### PR TITLE
webhooks: Support HEADERS and BODY in WITH ( ... )

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -857,8 +857,7 @@ impl Coordinator {
                     let validator = validation.as_ref().map(|v| {
                         let validation = v.clone();
                         AppendWebhookValidator::new(
-                            validation.expression,
-                            validation.secrets,
+                            validation,
                             coord.caching_secrets_reader.clone(),
                         )
                     });

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -193,6 +193,10 @@ impl From<AppendWebhookError> for WebhookError {
         match err {
             AppendWebhookError::MissingSecret => WebhookError::SecretMissing,
             AppendWebhookError::ValidationError => WebhookError::ValidationError,
+            AppendWebhookError::NonUtf8Body => WebhookError::InvalidBody {
+                ty: ScalarType::String,
+                msg: "invalid".to_string(),
+            },
             AppendWebhookError::InternalError => {
                 WebhookError::Internal(anyhow::anyhow!("failed to run validation"))
             }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -719,13 +719,28 @@ impl_display_t!(CreateWebhookSourceCheck);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CreateWebhookSourceCheckOptions<T: AstInfo> {
     pub secrets: Vec<CreateWebhookSourceSecret<T>>,
+    pub headers: Vec<CreateWebhookSourceHeader>,
+    pub bodies: Vec<CreateWebhookSourceBody>,
 }
 
 impl<T: AstInfo> AstDisplay for CreateWebhookSourceCheckOptions<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("WITH (");
 
-        f.write_node(&display::comma_separated(&self.secrets[..]));
+        let mut delim = "";
+        if !self.headers.is_empty() {
+            f.write_node(&display::comma_separated(&self.headers[..]));
+            delim = ", ";
+        }
+        if !self.bodies.is_empty() {
+            f.write_str(delim);
+            f.write_node(&display::comma_separated(&self.bodies[..]));
+            delim = ", ";
+        }
+        if !self.secrets.is_empty() {
+            f.write_str(delim);
+            f.write_node(&display::comma_separated(&self.secrets[..]));
+        }
 
         f.write_str(")");
     }
@@ -758,6 +773,54 @@ impl<T: AstInfo> AstDisplay for CreateWebhookSourceSecret<T> {
 }
 
 impl_display_t!(CreateWebhookSourceSecret);
+
+/// `HEADER [AS ...] [BYTES]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateWebhookSourceHeader {
+    pub alias: Option<Ident>,
+    pub use_bytes: bool,
+}
+
+impl AstDisplay for CreateWebhookSourceHeader {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("HEADERS");
+
+        if let Some(alias) = &self.alias {
+            f.write_str(" AS ");
+            f.write_node(alias);
+        }
+
+        if self.use_bytes {
+            f.write_str(" BYTES");
+        }
+    }
+}
+
+impl_display!(CreateWebhookSourceHeader);
+
+/// `BODY [AS ...] [BYTES]`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CreateWebhookSourceBody {
+    pub alias: Option<Ident>,
+    pub use_bytes: bool,
+}
+
+impl AstDisplay for CreateWebhookSourceBody {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_str("BODY");
+
+        if let Some(alias) = &self.alias {
+            f.write_str(" AS ");
+            f.write_node(alias);
+        }
+
+        if self.use_bytes {
+            f.write_str(" BYTES");
+        }
+    }
+}
+
+impl_display!(CreateWebhookSourceBody);
 
 /// `CREATE SOURCE`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]

--- a/src/sql-parser/tests/testdata/create
+++ b/src/sql-parser/tests/testdata/create
@@ -342,7 +342,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -357,7 +357,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -372,7 +372,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS foo, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("foo")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -402,7 +402,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET test_key AS bar, SECRET other_key) headers['signature'] = 'test')
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("test_key")])), alias: Some(Ident("bar")), use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: None, use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Value(String("test"))) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -414,7 +414,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: None, use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -426,7 +426,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: false }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -438,7 +438,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET bytes_key AS bytes BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("bytes_key")])), alias: Some(Ident("bytes")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -450,7 +450,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
 ----
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT JSON CHECK (WITH (SECRET secret_key, SECRET other_key AS foo BYTES) headers['signature'] = bytes_key)
 =>
-CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_json")]), if_not_exists: false, body_format: Json, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("secret_key")])), alias: None, use_bytes: false }, CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("other_key")])), alias: Some(Ident("foo")), use_bytes: true }], headers: [], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("bytes_key")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
 
 parse-statement
 CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -481,7 +481,7 @@ CREATE SOURCE webhook_json IN CLUSTER webhook_cluster FROM WEBHOOK
     BODY FORMAT JSON
     CHECK ( WITH ( SECRET test_key, ) )
 ----
-error: Expected one of SECRET, found right parenthesis
+error: Expected one of SECRET or HEADERS or BODY, found right parenthesis
     CHECK ( WITH ( SECRET test_key, ) )
                                     ^
 
@@ -505,6 +505,90 @@ CREATE SOURCE webhook_validation_no_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK 
 error: Expected IN CLUSTER, found FROM
 CREATE SOURCE webhook_validation_no_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK ( headers['signature'] = 'test' )
                                             ^
+
+parse-statement
+CREATE SOURCE webhook_with_headers_and_body IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (HEADERS, BODY)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers_and_body IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS, BODY) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_and_body")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (HEADERS AS h1)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS h1) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (HEADERS AS h1, SECRET my_secret)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS h1, SECRET my_secret) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("my_secret")])), alias: None, use_bytes: false }], headers: [CreateWebhookSourceHeader { alias: Some(Ident("h1")), use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (BODY, BODY AS b2 BYTES)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (BODY, BODY AS b2 BYTES) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [], bodies: [CreateWebhookSourceBody { alias: None, use_bytes: false }, CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_with_headers_thrice IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (HEADERS AS headers_bytes BYTES, HEADERS AS other_headers, HEADERS)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers_thrice IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (HEADERS AS headers_bytes BYTES, HEADERS AS other_headers, HEADERS) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers_thrice")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [], headers: [CreateWebhookSourceHeader { alias: Some(Ident("headers_bytes")), use_bytes: true }, CreateWebhookSourceHeader { alias: Some(Ident("other_headers")), use_bytes: false }, CreateWebhookSourceHeader { alias: None, use_bytes: false }], bodies: [] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (SECRET kool_secret BYTES, BODY AS b2 BYTES)
+        headers['signature'] = body
+    )
+----
+CREATE SOURCE webhook_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT CHECK (WITH (BODY AS b2 BYTES, SECRET kool_secret BYTES) headers['signature'] = body)
+=>
+CreateWebhookSource(CreateWebhookSourceStatement { name: UnresolvedItemName([Ident("webhook_with_headers")]), if_not_exists: false, body_format: Text, include_headers: false, validate_using: Some(CreateWebhookSourceCheck { options: Some(CreateWebhookSourceCheckOptions { secrets: [CreateWebhookSourceSecret { secret: Name(UnresolvedItemName([Ident("kool_secret")])), alias: None, use_bytes: true }], headers: [], bodies: [CreateWebhookSourceBody { alias: Some(Ident("b2")), use_bytes: true }] }), using: Op { op: Op { namespace: None, op: "=" }, expr1: Subscript { expr: Identifier([Ident("headers")]), positions: [SubscriptPosition { start: Some(Value(String("signature"))), end: None, explicit_slice: false }] }, expr2: Some(Identifier([Ident("body")])) } }), in_cluster: Unresolved(Ident("webhook_cluster")) })
+
+parse-statement
+CREATE SOURCE webhook_invalid_with IN CLUSTER webhook_cluster FROM WEBHOOK
+    BODY FORMAT TEXT
+    CHECK (
+        WITH (SECRET kool_secret BODY)
+        headers['signature'] = body
+    )
+----
+error: Expected right parenthesis, found BODY
+        WITH (SECRET kool_secret BODY)
+                                 ^
 
 parse-statement
 CREATE DATABASE IF NOT EXISTS db

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1080,6 +1080,12 @@ pub struct Ingestion {
 pub struct WebhookValidation {
     /// The expression used to validate a request.
     pub expression: MirScalarExpr,
+    /// The column index to provide the request body and whether to provide it as bytes.
+    pub bodies: Vec<(usize, bool)>,
+    /// The column index to provide the request headers and whether to provide the values as bytes.
+    ///
+    /// TODO(parkmycar): Support filtering down to specific headers.
+    pub headers: Vec<(usize, bool)>,
     /// Any secrets that are used in that validation.
     pub secrets: Vec<WebhookValidationSecret>,
 }

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -378,7 +378,7 @@ simple conn=joe,user=joe
 CREATE SOURCE webhook_text_with_secret IN CLUSTER source_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_key BYTES )
+    WITH ( BODY, SECRET webhook_key )
     body = webhook_key
   )
 ----
@@ -388,7 +388,7 @@ simple conn=child,user=child
 CREATE SOURCE webhook_text_with_secret1 IN CLUSTER source_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_key BYTES )
+    WITH ( BODY, SECRET webhook_key )
     body = webhook_key
   )
 ----
@@ -403,7 +403,7 @@ simple conn=joe,user=joe
 CREATE SOURCE webhook_text_with_secret IN CLUSTER source_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_key BYTES )
+    WITH ( BODY, SECRET webhook_key )
     body = webhook_key
   )
 ----
@@ -413,7 +413,7 @@ simple conn=child,user=child
 CREATE SOURCE webhook_text_with_secret1 IN CLUSTER source_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_key BYTES )
+    WITH ( BODY, SECRET webhook_key )
     body = webhook_key
   )
 ----
@@ -428,7 +428,7 @@ simple conn=joe,user=joe
 CREATE SOURCE webhook_text_with_secret IN CLUSTER source_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_key BYTES )
+    WITH ( BODY, SECRET webhook_key )
     body = webhook_key
   )
 ----

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -113,13 +113,15 @@ statement ok
 CREATE SOURCE webhook_bad_validation_expr IN CLUSTER webhook_cluster FROM WEBHOOK
     BODY FORMAT TEXT
     CHECK (
-        decode(headers->'signature', 'base64') = hmac(headers->'timestamp' || '.' || convert_from(body, 'utf-8'), 'key', 'sha256')
+        WITH (HEADERS, BODY)
+        decode(headers->'signature', 'base64') = hmac(headers->'timestamp' || '.' || body, 'key', 'sha256')
     )
 
 statement ok
 CREATE SOURCE webhook_buildkite IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT JSON
   CHECK (
+    WITH (HEADERS, BODY BYTES)
     decode(split_part(headers->'x-buildkite-signature', 'signature=', 1), 'hex') = hmac(
       split_part(split_part(headers->'x-buildkite-signature', 'timestamp=', 1), ',', 1) || '.' || convert_from(body, 'utf-8'),
       'test_key',
@@ -131,6 +133,7 @@ statement error column "field_that_does_not_exist" does not exist
 CREATE SOURCE webhook_bad_validation_expr IN CLUSTER webhook_cluster FROM WEBHOOK
     BODY FORMAT TEXT
     CHECK (
+        WITH (HEADERS)
         decode(headers->'signature', 'base64') = hmac(field_that_does_not_exist, 'key', 'sha256')
     )
 
@@ -147,22 +150,34 @@ CREATE SOURCE webhook_json_with_validation IN CLUSTER webhook_cluster FROM WEBHO
 statement error CHECK does not allow subqueries
 CREATE SOURCE webhook_validation_with_subquery IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
-  CHECK ( headers->'signature' IN (select * from mz_tables) )
+  CHECK (
+    WITH (HEADERS)
+    headers->'signature' IN (select * from mz_tables)
+  )
 
 statement error expression provided in CHECK is not deterministic
 CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
-  CHECK ( headers->'signature' = to_char(now(), 'YYYY/MM/DD HH12:MM:SS') )
+  CHECK (
+    WITH (HEADERS)
+    headers->'signature' = to_char(now(), 'YYYY/MM/DD HH12:MM:SS')
+  )
 
 statement error expression provided in CHECK is not deterministic
 CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
-  CHECK ( headers->'signature' = mz_now()::text )
+  CHECK (
+    WITH (HEADERS)
+    headers->'signature' = mz_now()::text
+  )
 
 statement error expression provided in CHECK is not deterministic
 CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
-  CHECK ( headers->'signature' = current_timestamp()::text )
+  CHECK (
+    WITH (HEADERS)
+    headers->'signature' = current_timestamp()::text
+  )
 
 statement error unknown cluster 'i_do_not_exist'
 CREATE SOURCE webhook_cluster_does_not_exist IN CLUSTER i_do_not_exist FROM WEBHOOK
@@ -181,7 +196,7 @@ statement ok
 CREATE SOURCE webhook_with_secret IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
-    WITH ( SECRET webhook_shared_secret )
+    WITH ( HEADERS, SECRET webhook_shared_secret )
     headers->'signature' = webhook_shared_secret
   )
 
@@ -189,9 +204,9 @@ statement ok
 CREATE SOURCE webhook_buildkite2 IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT JSON
   CHECK (
-    WITH ( SECRET webhook_shared_secret )
+    WITH ( HEADERS, BODY, SECRET webhook_shared_secret )
     decode(split_part(headers->'x-buildkite-signature', 'signature=', 1), 'hex') = hmac(
-      split_part(split_part(headers->'x-buildkite-signature', 'timestamp=', 1), ',', 1) || '.' || convert_from(body, 'utf-8'),
+      split_part(split_part(headers->'x-buildkite-signature', 'timestamp=', 1), ',', 1) || '.' || body,
       webhook_shared_secret,
       'sha256'
     )
@@ -205,6 +220,7 @@ CREATE SOURCE webhook_with_two_secrets IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
     WITH (
+      HEADERS, BODY BYTES,
       SECRET webhook_shared_secret AS key,
       SECRET other_secret BYTES
     )
@@ -216,8 +232,9 @@ CREATE SOURCE webhook_with_unknown_second_secret IN CLUSTER webhook_cluster FROM
   BODY FORMAT BYTES
   CHECK (
     WITH (
+      HEADERS, BODY,
       SECRET webhook_shared_secret AS key,
-      SECRET non_existent_secret BYTES
+      SECRET non_existent_secret
     )
     headers->'signature' = key AND body = non_existent_secret
   )
@@ -227,10 +244,48 @@ CREATE SOURCE webhook_with_duplicate_secret_names IN CLUSTER webhook_cluster FRO
   BODY FORMAT BYTES
   CHECK (
     WITH (
+      HEADERS, BODY,
       SECRET webhook_shared_secret AS other_secret,
-      SECRET other_secret BYTES
+      SECRET other_secret
     )
     headers->'signature' = other_secret AND body = other_secret
+  )
+
+statement ok
+CREATE SOURCE webhook_with_headers_and_body_alias IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  CHECK (
+    WITH (
+      HEADERS AS h1 BYTES,
+      HEADERS,
+      BODY AS b1,
+      BODY BYTES
+    )
+    headers->'signature' = convert_from(h1->'signature', 'utf-8') AND b1 = convert_from(body, 'utf-8')
+  )
+
+statement error column reference "headers" is ambiguous
+CREATE SOURCE webhook_with_headers_duplicates IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  CHECK (
+    WITH (HEADERS, HEADERS)
+    HEADERS->'signature' = '42'
+  )
+
+statement error column reference "body" is ambiguous
+CREATE SOURCE webhook_with_body_duplicates IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  CHECK (
+    WITH (BODY, BODY)
+    length(body) > 0
+  )
+
+statement error column reference "x" is ambiguous
+CREATE SOURCE webhook_with_duplicate_aliases IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  CHECK (
+    WITH (HEADERS as x, BODY as x)
+    length(x) > 0
   )
 
 # Try creating a webhook source in a compute cluster.

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -130,7 +130,10 @@ null
 
 > CREATE SOURCE webhook_bytes_with_validation IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
-  CHECK ( headers->'signature' = 'test' );
+  CHECK (
+    WITH (HEADERS)
+    headers->'signature' = 'test'
+  );
 
 $ webhook-append database=materialize schema=public name=webhook_bytes_with_validation signature=test
 123
@@ -141,7 +144,8 @@ $ webhook-append database=materialize schema=public name=webhook_bytes_with_vali
 > CREATE SOURCE webhook_bytes_with_hmac IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
-    decode(headers->'x-signature', 'base64') = hmac('body=' || convert_from(body, 'utf-8'), 'test_key', 'sha256')
+    WITH (HEADERS, BODY)
+    decode(headers->'x-signature', 'base64') = hmac('body=' || body, 'test_key', 'sha256')
   );
 
 $ webhook-append name=webhook_bytes_with_hmac x-signature=HA0rQdPkCiNNNAladA0eTI8x5WZp5z8rBawQHiywznI=
@@ -162,7 +166,7 @@ did_not_include_necessary_header
 > CREATE SOURCE webhook_bytes_with_secret IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
-    WITH ( SECRET webhook_secret BYTES )
+    WITH ( HEADERS, BODY BYTES, SECRET webhook_secret BYTES )
     decode(headers->'x-signature', 'base64') = hmac(body, webhook_secret, 'sha256')
   )
 
@@ -175,9 +179,10 @@ using an mz secret
 > CREATE SOURCE webhook_buildkite IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   CHECK (
+    WITH (HEADERS, BODY)
     decode(split_part(headers->'x-buildkite-signature', 'signature::', 2), 'hex')
       =
-    hmac(split_part(split_part(headers->'x-buildkite-signature', 'timestamp::', 2), ',', 1) || '.' || convert_from(body, 'utf-8'), 'test_key', 'sha256')
+    hmac(split_part(split_part(headers->'x-buildkite-signature', 'timestamp::', 2), ',', 1) || '.' || body, 'test_key', 'sha256')
   );
 
 $ webhook-append name=webhook_buildkite x-buildkite-signature=timestamp::42,signature::b610a43432fe965eb8e2a3ce4939a6bafaad3f35583c596e2f7271125a346d95
@@ -188,7 +193,7 @@ i hope this works
 
 > CREATE SOURCE webhook_hex IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
-  CHECK ( decode(convert_from(body, 'utf-8'), 'hex') = '\x42' );
+  CHECK ( WITH (BODY) decode(body, 'hex') = '\x42' );
 
 $ webhook-append name=webhook_hex status=400
 # 'z' is an invalid character in hex which causes an evaluation failure.
@@ -204,7 +209,10 @@ ALTER SYSTEM SET enable_unstable_dependencies = true;
 # Note: if you change the message in the panic, then you need to update ci_logged_errors_detect.py.
 > CREATE SOURCE webhook_validation_panic IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
-  CHECK ( mz_internal.mz_panic('webhook panic test') = headers::text );
+  CHECK (
+    WITH (HEADERS)
+    mz_internal.mz_panic('webhook panic test') = headers::text
+  );
 
 $ webhook-append name=webhook_validation_panic status=500
 abc
@@ -217,6 +225,8 @@ abc
   BODY FORMAT TEXT
   CHECK (
     WITH (
+      HEADERS,
+      BODY BYTES,
       SECRET webhook_secret,
       SECRET webhook_secret_bytes BYTES
     )


### PR DESCRIPTION
This PR updates webhook sources to support the `HEADERS` and `BODY` keywords inside of `CHECK`, i.e.

```
CREATE SOURCE events IN CLUSTER foo FROM WEBHOOK
  BODY FORMAT TEXT
  CHECK (
    WITH (
      HEADERS [AS <alias>] [BYTES],
      BODY [AS <alias>] [BYTES],
      ...
  )
```

Previously we provided the body of a request to validation as raw bytes, now we default to text because it's easier to work with. Users can opt to have it provided as raw bytes if need be, for example, if the body of their request is protobuf or avro.

### Motivation

We recently refined the design for validating/checking webhook requests, see https://github.com/MaterializeInc/materialize/pull/20727 for details.

### Tips for reviewer

This PR is broken into three separate commits which can be reviewed independently:

1. Changes to the SQL parser to support the new `HEADERS` and `BODY` keywords
2. Updates to planning and HTTP handlers to plumb the `headers` and `body` of a request appropriately
3. Updates to tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a the "webhook source" feature is currently gated
