### PR TITLE
adapter: support explicit single statement transactions

### DIFF
--- a/doc/developer/design/20230720_single_statement_explitic_transaction.md
+++ b/doc/developer/design/20230720_single_statement_explitic_transaction.md
@@ -1,0 +1,105 @@
+# Single-Statement Explicit Transactions
+
+- Associated: https://github.com/MaterializeInc/materialize/issues/20426
+
+## Context
+
+Many kinds of statements (importantly all DDL `CREATE` statements) can only be executed in an implied single-statement transaction.
+These are transactions without a `BEGIN` (hence implied) and known to be exactly one statement long.
+DDLs are disallowed because we cannot prospectively execute them until a commit.
+
+Many GUI and other tools however always wrap their statements with `BEGIN` and `COMMIT`,
+thus creating an explicit transaction, and are thus prevented from ever executing DDL or other prohibited statements.
+
+## Goals
+
+- Allow many more kinds of statements to execute in explicit transactions,
+  as long as there is exactly one statement in the transaction: `BEGIN; <stmt>; COMMIT`.
+
+## Non-Goals
+
+- Multiple DDLs in a single transaction.
+- Supporting all statements in this form.
+
+## Overview
+
+Add a new transaction op that holds onto a single `Statement` but does not execute it.
+The statements tag is generated and returned as if it did execute.
+We can thus only execute statements that can generate their tag from a `Statement` or `Plan` without execution.
+If any statement attempts to execute after that, the op will fail to add it, thus enforcing a single statement in the transaction.
+On `COMMIT`, the statement executes, returning any errors as normal.
+
+## Detailed description
+
+Many statements cannot be executed without observable side effects to other sessions, for example all DDLs.
+However, these and many other statements do have a known `ExecuteResponse` that can be determined without execution (as opposed to statements that return a row count).
+We will add a new transaction operation mode called `SingleStatement`.
+Currently those modes are `Peeks`, `Writes`, and `Subscribe`.
+`SingleStatement` will record the statement, then generate and return to the user an `ExecuteResponse` that assummes success.
+This mode can only be entered in explicit transactions (must start with `BEGIN`).
+If the next statement is `COMMIT`, the coordinator sets the session's transaction status to `InTransactionImplicit`, which is a status that can execute any statement, then executes the statement.
+If any other statement beside `COMMIT` or `ROLLBACK` is executed after the first, the transaction fails.
+
+### Session Transaction State Machine
+
+Here we describe the state machine and invariants for a single session's transaction before this design was implemented.
+We will then describe how this design modifies that state machine but still meets all invariants.
+
+Each `Session` has a `tranasction` property of type `enum TransactionStatus`.
+It is the responsibility of the various protocol handlers (pgwire, http, ws) to correctly manage this.
+A `TransactionStatus` is an enum with variants:
+
+- `Default`
+- `Started`
+- `InTransaction`
+- `InTransactionImplicit`
+- `Failed`
+
+`Default` is the initial state, and also the state when there is no in-progress transaction.
+In order for a session to execute a statement, the protocol handler must set this to one of the other states then end the transaction with a commit or rollback.
+`Started` is used for a single statement, so an immediate and implied commit follows.
+`InTransaction` is used when a user explicitly types `BEGIN`, and can only be exited when a user sends `COMMIT` or `ROLLBACK`.
+`InTransactionImplicit` is used when a user sends multiple statements in the same query (`SELECT 1; SELECT 2`), and an implicit `BEGIN` and `COMMIT` wrap it.
+`Failed` can only be entered when a statement in a transaction has error'd from the `InTransaction` state.
+If failures occur in the other in-progress states, an implicit `ROLLBACK` must be sent by the handler.
+
+All status except `Default` have an inner `Transaction` object that tracks what operations have happened in a transaction determined by the first statement.
+These operations are: `Peeks`, `Subscribe`, `Writes`, `None`.
+`None` is the default and can transition to any other operation.
+The other operations can be merged with like operations, except `Subscribe` which supports only a single `SUBSCRIBE`.
+
+The `ReadyForQuery` message is sent by the server when it is ready to receive new queries, and it includes the current transaction status code: `Idle`, `InTransaction`, or `Failed`.
+`InTransaction` and `Failed` correspond to the similarly named variants above and can only appear in explicit transactions.
+`Idle` is return in the `Default` state, because all other transaction states implicitly close and should never be active when deciding the status code.
+
+The pgwire, http, and ws handlers enforce these requirements and state changes.
+
+#### Changes from this design
+
+This design adds a new operation to the inner transaction: `SingleStatement`.
+This operation records a single statement that is later retrieved and executed during `COMMIT`.
+
+This design also adds what is essentially a new handler: the coordinator itself.
+When a transaction is being committed and its inner operation is `SingleStatement`, the inner statement is queued in the coordinator for execution by a new method that is serving as a handler: `sequence_execute_single_statement_transaction`.
+This method:
+1. Ensures the session's transaction is in `Default`, which should be a side effect of running it through `sequence_end_transaction` from the `COMMIT`.
+2. Puts the session's transaction into `Started` (single-statement, implicit transaction).
+3. Executes the inner statement, without sending the result to the user.
+4. Commits the transaction.
+5. The transaction should again be in `Default`.
+
+## Alternatives
+
+The simple query protocol allows passing multiple statements in a single query string.
+We could parse that and examine it for the `BEGIN; <stmt>; COMMIT` form.
+We could then execute *any* statement instead of only ones whose tag we can generate without execution.
+This is limited because it would not work for:
+- psql
+- drivers or APIs that use the extended protocol
+- http or websocket endpoints
+However, this alternative is not at odds with the above design, and could still be done if we discover any drivers or tools using this wrapped simple format.
+
+## Open questions
+
+1. Proving this doesn't have correctness errors in the code is difficult.
+   There are a lot of fiddly parts of session and transaction handling, and this design re-implements a few parts of them without much help from a compiler or existing handlers to enforce anything.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -526,8 +526,6 @@ pub enum ExecuteResponse {
     CreatedWebhookSource,
     /// The requested source was created.
     CreatedSource,
-    /// The requested sources were created.
-    CreatedSources,
     /// The requested table was created.
     CreatedTable,
     /// The requested view was created.
@@ -613,6 +611,77 @@ pub enum ExecuteResponse {
     ValidatedConnection,
 }
 
+impl TryInto<ExecuteResponse> for ExecuteResponseKind {
+    type Error = ();
+
+    /// Attempts to convert into an ExecuteResponse. Returns an error if not possible without
+    /// actually executing a statement.
+    fn try_into(self) -> Result<ExecuteResponse, Self::Error> {
+        match self {
+            ExecuteResponseKind::AlteredDefaultPrivileges => {
+                Ok(ExecuteResponse::AlteredDefaultPrivileges)
+            }
+            ExecuteResponseKind::AlteredObject => Err(()),
+            ExecuteResponseKind::AlteredIndexLogicalCompaction => {
+                Ok(ExecuteResponse::AlteredIndexLogicalCompaction)
+            }
+            ExecuteResponseKind::AlteredRole => Ok(ExecuteResponse::AlteredRole),
+            ExecuteResponseKind::AlteredSystemConfiguration => {
+                Ok(ExecuteResponse::AlteredSystemConfiguration)
+            }
+            ExecuteResponseKind::Canceled => Ok(ExecuteResponse::Canceled),
+            ExecuteResponseKind::ClosedCursor => Ok(ExecuteResponse::ClosedCursor),
+            ExecuteResponseKind::CopyTo => Err(()),
+            ExecuteResponseKind::CopyFrom => Err(()),
+            ExecuteResponseKind::CreatedConnection => Ok(ExecuteResponse::CreatedConnection),
+            ExecuteResponseKind::CreatedDatabase => Ok(ExecuteResponse::CreatedDatabase),
+            ExecuteResponseKind::CreatedSchema => Ok(ExecuteResponse::CreatedSchema),
+            ExecuteResponseKind::CreatedRole => Ok(ExecuteResponse::CreatedRole),
+            ExecuteResponseKind::CreatedCluster => Ok(ExecuteResponse::CreatedCluster),
+            ExecuteResponseKind::CreatedClusterReplica => {
+                Ok(ExecuteResponse::CreatedClusterReplica)
+            }
+            ExecuteResponseKind::CreatedIndex => Ok(ExecuteResponse::CreatedIndex),
+            ExecuteResponseKind::CreatedSecret => Ok(ExecuteResponse::CreatedSecret),
+            ExecuteResponseKind::CreatedSink => Ok(ExecuteResponse::CreatedSink),
+            ExecuteResponseKind::CreatedWebhookSource => Ok(ExecuteResponse::CreatedWebhookSource),
+            ExecuteResponseKind::CreatedSource => Ok(ExecuteResponse::CreatedSource),
+            ExecuteResponseKind::CreatedTable => Ok(ExecuteResponse::CreatedTable),
+            ExecuteResponseKind::CreatedView => Ok(ExecuteResponse::CreatedView),
+            ExecuteResponseKind::CreatedViews => Ok(ExecuteResponse::CreatedViews),
+            ExecuteResponseKind::CreatedMaterializedView => {
+                Ok(ExecuteResponse::CreatedMaterializedView)
+            }
+            ExecuteResponseKind::CreatedType => Ok(ExecuteResponse::CreatedType),
+            ExecuteResponseKind::Deallocate => Err(()),
+            ExecuteResponseKind::DeclaredCursor => Ok(ExecuteResponse::DeclaredCursor),
+            ExecuteResponseKind::Deleted => Err(()),
+            ExecuteResponseKind::DiscardedTemp => Ok(ExecuteResponse::DiscardedTemp),
+            ExecuteResponseKind::DiscardedAll => Ok(ExecuteResponse::DiscardedAll),
+            ExecuteResponseKind::DroppedObject => Err(()),
+            ExecuteResponseKind::DroppedOwned => Ok(ExecuteResponse::DroppedOwned),
+            ExecuteResponseKind::EmptyQuery => Ok(ExecuteResponse::EmptyQuery),
+            ExecuteResponseKind::Fetch => Err(()),
+            ExecuteResponseKind::GrantedPrivilege => Ok(ExecuteResponse::GrantedPrivilege),
+            ExecuteResponseKind::GrantedRole => Ok(ExecuteResponse::GrantedRole),
+            ExecuteResponseKind::Inserted => Err(()),
+            ExecuteResponseKind::Prepare => Ok(ExecuteResponse::Prepare),
+            ExecuteResponseKind::Raised => Ok(ExecuteResponse::Raised),
+            ExecuteResponseKind::ReassignOwned => Ok(ExecuteResponse::ReassignOwned),
+            ExecuteResponseKind::RevokedPrivilege => Ok(ExecuteResponse::RevokedPrivilege),
+            ExecuteResponseKind::RevokedRole => Ok(ExecuteResponse::RevokedRole),
+            ExecuteResponseKind::SendingRows => Err(()),
+            ExecuteResponseKind::SetVariable => Err(()),
+            ExecuteResponseKind::StartedTransaction => Ok(ExecuteResponse::StartedTransaction),
+            ExecuteResponseKind::Subscribing => Err(()),
+            ExecuteResponseKind::TransactionCommitted => Err(()),
+            ExecuteResponseKind::TransactionRolledBack => Err(()),
+            ExecuteResponseKind::Updated => Err(()),
+            ExecuteResponseKind::ValidatedConnection => Ok(ExecuteResponse::ValidatedConnection),
+        }
+    }
+}
+
 impl ExecuteResponse {
     pub fn tag(&self) -> Option<String> {
         use ExecuteResponse::*;
@@ -637,7 +706,6 @@ impl ExecuteResponse {
             CreatedSink { .. } => Some("CREATE SINK".into()),
             CreatedWebhookSource { .. } => Some("CREATE SOURCE".into()),
             CreatedSource { .. } => Some("CREATE SOURCE".into()),
-            CreatedSources => Some("CREATE SOURCES".into()),
             CreatedTable { .. } => Some("CREATE TABLE".into()),
             CreatedView { .. } => Some("CREATE VIEW".into()),
             CreatedViews { .. } => Some("CREATE VIEWS".into()),
@@ -719,7 +787,7 @@ impl ExecuteResponse {
             CreateRole => vec![CreatedRole],
             CreateCluster => vec![CreatedCluster],
             CreateClusterReplica => vec![CreatedClusterReplica],
-            CreateSource | CreateSources => vec![CreatedSource, CreatedSources],
+            CreateSource | CreateSources => vec![CreatedSource],
             CreateSecret => vec![CreatedSecret],
             CreateSink => vec![CreatedSink],
             CreateTable => vec![CreatedTable],

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -226,6 +226,11 @@ pub enum Message<T = mz_repr::Timestamp> {
     RetireExecute {
         data: ExecuteContextExtra,
     },
+    ExecuteSingleStatementTransaction {
+        ctx: ExecuteContext,
+        stmt: Statement<Raw>,
+        params: mz_sql::plan::Params,
+    },
 }
 
 #[derive(Derivative)]

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -44,7 +44,7 @@ use crate::coord::peek::PendingPeek;
 use crate::coord::{ConnMeta, Coordinator, Message, PendingTxn, PurifiedStatementReady};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
-use crate::session::{Session, TransactionStatus};
+use crate::session::{Session, TransactionOps, TransactionStatus};
 use crate::util::{ClientTransmitter, ResultExt};
 use crate::{catalog, metrics, rbac, ExecuteContext};
 
@@ -445,7 +445,7 @@ impl Coordinator {
     ) {
         // Verify that this statement type can be executed in the current
         // transaction state.
-        match ctx.session().transaction() {
+        match ctx.session_mut().transaction_mut() {
             // By this point we should be in a running transaction.
             TransactionStatus::Default => unreachable!(),
 
@@ -489,7 +489,8 @@ impl Coordinator {
             // transactions can do unless there's some additional checking to make sure
             // something disallowed in explicit transactions did not previously take place
             // in the implicit portion.
-            TransactionStatus::InTransactionImplicit(_) | TransactionStatus::InTransaction(_) => {
+            txn @ TransactionStatus::InTransactionImplicit(_)
+            | txn @ TransactionStatus::InTransaction(_) => {
                 match stmt {
                     // Statements that are safe in a transaction. We still need to verify that we
                     // don't interleave reads and writes since we can't perform those serializably.
@@ -531,47 +532,72 @@ impl Coordinator {
                     // Statements below must by run singly (in Started).
                     Statement::AlterCluster(_)
                     | Statement::AlterConnection(_)
+                    | Statement::AlterDefaultPrivileges(_)
                     | Statement::AlterIndex(_)
+                    | Statement::AlterObjectRename(_)
+                    | Statement::AlterOwner(_)
+                    | Statement::AlterRole(_)
                     | Statement::AlterSecret(_)
                     | Statement::AlterSink(_)
                     | Statement::AlterSource(_)
-                    | Statement::AlterObjectRename(_)
-                    | Statement::AlterRole(_)
-                    | Statement::AlterSystemSet(_)
                     | Statement::AlterSystemReset(_)
                     | Statement::AlterSystemResetAll(_)
-                    | Statement::AlterOwner(_)
+                    | Statement::AlterSystemSet(_)
+                    | Statement::CreateCluster(_)
+                    | Statement::CreateClusterReplica(_)
                     | Statement::CreateConnection(_)
                     | Statement::CreateDatabase(_)
                     | Statement::CreateIndex(_)
+                    | Statement::CreateMaterializedView(_)
                     | Statement::CreateRole(_)
-                    | Statement::CreateCluster(_)
-                    | Statement::CreateClusterReplica(_)
                     | Statement::CreateSchema(_)
                     | Statement::CreateSecret(_)
                     | Statement::CreateSink(_)
-                    | Statement::CreateWebhookSource(_)
                     | Statement::CreateSource(_)
                     | Statement::CreateSubsource(_)
                     | Statement::CreateTable(_)
                     | Statement::CreateType(_)
                     | Statement::CreateView(_)
-                    | Statement::CreateMaterializedView(_)
+                    | Statement::CreateWebhookSource(_)
                     | Statement::Delete(_)
                     | Statement::DropObjects(_)
                     | Statement::DropOwned(_)
                     | Statement::GrantPrivileges(_)
                     | Statement::GrantRole(_)
                     | Statement::Insert(_)
+                    | Statement::ReassignOwned(_)
                     | Statement::RevokePrivileges(_)
-                    | Statement::AlterDefaultPrivileges(_)
                     | Statement::RevokeRole(_)
                     | Statement::Update(_)
-                    | Statement::ValidateConnection(_)
-                    | Statement::ReassignOwned(_) => {
+                    | Statement::ValidateConnection(_) => {
+                        // Statements whose tag is trivial (known only from an unexecuted statement) can
+                        // be run in a special single-statement explicit mode. In this mode (`BEGIN;
+                        // <stmt>; COMMIT`), we generate the expected tag from a successful <stmt>, but
+                        // delay execution until `COMMIT`.
+                        let mut resp_kind = Plan::generated_from((&stmt).into())
+                            .into_iter()
+                            .map(ExecuteResponse::generated_from)
+                            .flatten()
+                            .map(|r| r.try_into())
+                            .collect::<Vec<Result<ExecuteResponse, _>>>();
+                        // If we're in an implicit transaction and we could generate exactly one
+                        // valid ExecuteResponse, we can delay execution until commit.
+                        if !txn.is_implicit() && resp_kind.len() == 1 {
+                            if let Ok(resp) = resp_kind.swap_remove(0) {
+                                if let Err(err) =
+                                    txn.add_ops(TransactionOps::SingleStatement { stmt, params })
+                                {
+                                    ctx.retire(Err(err));
+                                    return;
+                                }
+                                ctx.retire(Ok(resp));
+                                return;
+                            }
+                        }
+
                         return ctx.retire(Err(AdapterError::OperationProhibitsTransaction(
                             stmt.to_string(),
-                        )))
+                        )));
                     }
                 }
             }
@@ -594,21 +620,22 @@ impl Coordinator {
             // `CREATE SOURCE` statements must be purified off the main
             // coordinator thread of control.
             stmt @ (Statement::CreateSource(_) | Statement::AlterSource(_)) => {
-                // Checks if the session is authorized to purify a statement. Usually
-                // authorization is checked after planning, however purification happens before
-                // planning, which may require the use of some connections and secrets.
-                if let Err(e) = rbac::check_item_usage(&catalog, ctx.session(), &resolved_ids) {
-                    return ctx.retire(Err(e));
-                }
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let conn_id = ctx.session().conn_id().clone();
-
                 let catalog = self.owned_catalog();
                 let now = self.now();
                 let connection_context = self.connection_context.clone();
                 let otel_ctx = OpenTelemetryContext::obtain();
                 task::spawn(|| format!("purify:{conn_id}"), async move {
                     let catalog = catalog.for_session(ctx.session());
+
+                    // Checks if the session is authorized to purify a statement. Usually
+                    // authorization is checked after planning, however purification happens before
+                    // planning, which may require the use of some connections and secrets.
+                    if let Err(e) = rbac::check_item_usage(&catalog, ctx.session(), &resolved_ids) {
+                        return ctx.retire(Err(e));
+                    }
+
                     let result =
                         mz_sql::pure::purify_statement(catalog, now, stmt, connection_context)
                             .await
@@ -637,7 +664,7 @@ impl Coordinator {
             ))),
 
             // All other statements are handled immediately.
-            _ => match self.plan_statement(ctx.session_mut(), stmt, &params) {
+            _ => match self.plan_statement(ctx.session(), stmt, &params) {
                 Ok(plan) => self.sequence_plan(ctx, plan, resolved_ids).await,
                 Err(e) => ctx.retire(Err(e)),
             },

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -580,7 +580,7 @@ impl Coordinator {
                             .flatten()
                             .map(|r| r.try_into())
                             .collect::<Vec<Result<ExecuteResponse, _>>>();
-                        // If we're in an implicit transaction and we could generate exactly one
+                        // If we're not in an implicit transaction and we could generate exactly one
                         // valid ExecuteResponse, we can delay execution until commit.
                         if !txn.is_implicit() && resp_kind.len() == 1 {
                             if let Ok(resp) = resp_kind.swap_remove(0) {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -21,17 +21,19 @@ use mz_sql::catalog::CatalogCluster;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CopyRowsPlan, CreateRolePlan, CreateSourcePlans,
-    FetchPlan, Plan, PlanKind, RaisePlan, RotateKeysPlan,
+    FetchPlan, Params, Plan, PlanKind, RaisePlan, RotateKeysPlan,
 };
+use mz_sql_parser::ast::{Raw, Statement};
+use tokio::sync::oneshot;
 use tracing::{event, Level};
 
-use crate::command::ExecuteResponse;
+use crate::command::{Command, ExecuteResponse, Response};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::{introspection, Coordinator, Message};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
 use crate::session::{EndTransactionAction, Session, TransactionStatus};
-use crate::util::send_immediate_rows;
+use crate::util::{send_immediate_rows, ClientTransmitter};
 use crate::{rbac, ExecuteContext};
 
 // DO NOT make this visible in any way, i.e. do not add any version of
@@ -516,6 +518,65 @@ impl Coordinator {
                 });
             }
         }
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(crate) async fn sequence_execute_single_statement_transaction(
+        &mut self,
+        ctx: ExecuteContext,
+        stmt: Statement<Raw>,
+        params: Params,
+    ) {
+        // Put the session into single statement implicit so anything can execute.
+        let (tx, internal_cmd_tx, mut session, extra) = ctx.into_parts();
+        assert!(matches!(session.transaction(), TransactionStatus::Default));
+        session.start_transaction_implicit(self.now_datetime(), 1);
+        let conn_id = session.conn_id().unhandled();
+
+        // Execute the saved statement in a temp transmitter so we can run COMMIT.
+        let (sub_tx, sub_rx) = oneshot::channel();
+        let sub_ct = ClientTransmitter::new(sub_tx, self.internal_cmd_tx.clone());
+        let sub_ctx = ExecuteContext::from_parts(sub_ct, internal_cmd_tx, session, extra);
+        self.handle_execute_inner(stmt, params, sub_ctx).await;
+
+        // The response can need off-thread processing. Wait for it elsewhere so the coordinator can
+        // continue processing.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        mz_ore::task::spawn(
+            || format!("execute_single_statement:{conn_id}"),
+            async move {
+                let Ok(Response { result, session }) = sub_rx.await else {
+                    // Coordinator went away.
+                    return;
+                };
+                let (sub_tx, sub_rx) = oneshot::channel();
+                let _ = internal_cmd_tx.send(Message::Command(Command::Commit {
+                    action: EndTransactionAction::Commit,
+                    session,
+                    tx: sub_tx,
+                }));
+                let Ok(commit_response) = sub_rx.await else {
+                    // Coordinator went away.
+                    return;
+                };
+                assert!(matches!(
+                    commit_response.session.transaction(),
+                    TransactionStatus::Default
+                ));
+                // The fake, generated response was already sent to the user and we don't need to
+                // ever send an `Ok(result)` to the user, because they are expecting a response from
+                // a `COMMIT`. So, always send the `COMMIT`'s result if the original statement
+                // succeeded. If it failed, we can send an error and don't need to wrap it or send a
+                // later COMMIT or ROLLBACK.
+                let result = match (result, commit_response.result) {
+                    (Ok(_), commit) => commit,
+                    (Err(result), _) => Err(result),
+                };
+                // We ignore the resp.result because it's not clear what to do if it failed since we
+                // can only send a single ExecuteResponse to tx.
+                tx.send(result, commit_response.session);
+            },
+        );
     }
 
     /// Creates a role during connection startup.

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -530,7 +530,7 @@ impl Coordinator {
         // Put the session into single statement implicit so anything can execute.
         let (tx, internal_cmd_tx, mut session, extra) = ctx.into_parts();
         assert!(matches!(session.transaction(), TransactionStatus::Default));
-        session.start_transaction_implicit(self.now_datetime(), 1);
+        session.start_transaction_single_stmt(self.now_datetime());
         let conn_id = session.conn_id().unhandled();
 
         // Execute the saved statement in a temp transmitter so we can run COMMIT.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1816,6 +1816,12 @@ impl Coordinator {
                     .expect("sending to strict_serializable_reads_tx cannot fail");
                 return;
             }
+            Ok((Some(TransactionOps::SingleStatement { stmt, params }), _)) => {
+                self.internal_cmd_tx
+                    .send(Message::ExecuteSingleStatementTransaction { ctx, stmt, params })
+                    .expect("must send");
+                return;
+            }
             Ok((_, _)) => (response, action),
             Err(err) => (Err(err), EndTransactionAction::Rollback),
         };

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -24,8 +24,8 @@ use crate::{metrics, AdapterError, ExecuteContext, ExecuteResponse};
 
 impl Coordinator {
     pub(crate) fn plan_statement(
-        &mut self,
-        session: &mut Session,
+        &self,
+        session: &Session,
         stmt: mz_sql::ast::Statement<Aug>,
         params: &mz_sql::plan::Params,
     ) -> Result<mz_sql::plan::Plan, AdapterError> {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -401,7 +401,7 @@ impl AdapterError {
             AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
-            AdapterError::SingleStatementTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
+            AdapterError::SingleStatementTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::StatementTimeout => SqlState::QUERY_CANCELED,
             AdapterError::Canceled => SqlState::QUERY_CANCELED,
             AdapterError::IdleInTransactionSessionTimeout => {

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -202,6 +202,8 @@ pub enum AdapterError {
     WriteOnlyTransaction,
     /// The transaction only supports single table writes
     MultiTableWriteTransaction,
+    /// The transaction can only execute a single statement.
+    SingleStatementTransaction,
     /// An error occurred in the storage layer
     Storage(mz_storage_client::controller::StorageError),
     /// An error occurred in the compute layer
@@ -399,6 +401,7 @@ impl AdapterError {
             AdapterError::PreparedStatementExists(_) => SqlState::DUPLICATE_PSTATEMENT,
             AdapterError::ReadOnlyTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::ReadWriteUnavailable => SqlState::INVALID_TRANSACTION_STATE,
+            AdapterError::SingleStatementTransaction => SqlState::READ_ONLY_SQL_TRANSACTION,
             AdapterError::StatementTimeout => SqlState::QUERY_CANCELED,
             AdapterError::Canceled => SqlState::QUERY_CANCELED,
             AdapterError::IdleInTransactionSessionTimeout => {
@@ -536,6 +539,9 @@ impl fmt::Display for AdapterError {
                 write!(f, "prepared statement {} already exists", name.quoted())
             }
             AdapterError::ReadOnlyTransaction => f.write_str("transaction in read-only mode"),
+            AdapterError::SingleStatementTransaction => {
+                f.write_str("this transaction can only execute a single statement")
+            }
             AdapterError::ReadWriteUnavailable => {
                 f.write_str("transaction read-write mode must be set before any query")
             }

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -309,6 +309,11 @@ impl<T: TimestampManipulation> Session<T> {
         }
     }
 
+    /// Starts a single statement transaction, but only if no transaction has been started already.
+    pub fn start_transaction_single_stmt(&mut self, wall_time: DateTime<Utc>) {
+        self.start_transaction_implicit(wall_time, 1);
+    }
+
     /// Clears a transaction, setting its state to Default and destroying all
     /// portals. Returned are:
     /// - sinks that were started in this transaction and need to be dropped

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -246,7 +246,9 @@ impl<T: TimestampManipulation> Session<T> {
                 TransactionOps::Peeks(_) | TransactionOps::Subscribe => {
                     txn.access == Some(TransactionAccessMode::ReadOnly)
                 }
-                TransactionOps::None | TransactionOps::Writes(_) => false,
+                TransactionOps::None
+                | TransactionOps::Writes(_)
+                | TransactionOps::SingleStatement { .. } => false,
             };
 
             if read_write_prohibited && access == Some(TransactionAccessMode::ReadWrite) {
@@ -342,6 +344,11 @@ impl<T: TimestampManipulation> Session<T> {
         &self.transaction
     }
 
+    /// Returns the current transaction status.
+    pub fn transaction_mut(&mut self) -> &mut TransactionStatus<T> {
+        &mut self.transaction
+    }
+
     /// Returns the session's transaction code.
     pub fn transaction_code(&self) -> TransactionCode {
         self.transaction().into()
@@ -351,83 +358,7 @@ impl<T: TimestampManipulation> Session<T> {
     /// they cannot be merged (i.e., a timestamp-dependent read cannot be
     /// merged to an insert).
     pub fn add_transaction_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
-        match &mut self.transaction {
-            TransactionStatus::Started(Transaction { ops, access, .. })
-            | TransactionStatus::InTransaction(Transaction { ops, access, .. })
-            | TransactionStatus::InTransactionImplicit(Transaction { ops, access, .. }) => {
-                match ops {
-                    TransactionOps::None => {
-                        if matches!(access, Some(TransactionAccessMode::ReadOnly))
-                            && matches!(add_ops, TransactionOps::Writes(_))
-                        {
-                            return Err(AdapterError::ReadOnlyTransaction);
-                        }
-                        *ops = add_ops;
-                    }
-                    TransactionOps::Peeks(determination) => match add_ops {
-                        TransactionOps::Peeks(add_timestamp_determination) => {
-                            match (
-                                &determination.timestamp_context,
-                                &add_timestamp_determination.timestamp_context,
-                            ) {
-                                (
-                                    TimestampContext::TimelineTimestamp(txn_timeline, txn_ts),
-                                    TimestampContext::TimelineTimestamp(add_timeline, add_ts),
-                                ) => {
-                                    assert_eq!(txn_timeline, add_timeline);
-                                    assert_eq!(txn_ts, add_ts);
-                                }
-                                (TimestampContext::NoTimestamp, _) => {
-                                    *determination = add_timestamp_determination
-                                }
-                                (_, TimestampContext::NoTimestamp) => {}
-                            };
-                        }
-                        // Iff peeks thus far do not have a timestamp (i.e.
-                        // they are constant), we can switch to a write
-                        // transaction.
-                        writes @ TransactionOps::Writes(..)
-                            if !determination.timestamp_context.contains_timestamp() =>
-                        {
-                            *ops = writes;
-                        }
-                        _ => return Err(AdapterError::ReadOnlyTransaction),
-                    },
-                    TransactionOps::Subscribe => {
-                        return Err(AdapterError::SubscribeOnlyTransaction)
-                    }
-                    TransactionOps::Writes(txn_writes) => match add_ops {
-                        TransactionOps::Writes(mut add_writes) => {
-                            // We should have already checked the access above, but make sure we don't miss
-                            // it anyway.
-                            assert!(!matches!(access, Some(TransactionAccessMode::ReadOnly)));
-                            txn_writes.append(&mut add_writes);
-
-                            if txn_writes
-                                .iter()
-                                .map(|op| op.id)
-                                .collect::<BTreeSet<_>>()
-                                .len()
-                                > 1
-                            {
-                                return Err(AdapterError::MultiTableWriteTransaction);
-                            }
-                        }
-                        // Iff peeks do not have a timestamp (i.e. they are
-                        // constant), we can permit them.
-                        TransactionOps::Peeks(determination)
-                            if !determination.timestamp_context.contains_timestamp() => {}
-                        _ => {
-                            return Err(AdapterError::WriteOnlyTransaction);
-                        }
-                    },
-                }
-            }
-            TransactionStatus::Default | TransactionStatus::Failed(_) => {
-                unreachable!()
-            }
-        }
-        Ok(())
+        self.transaction.add_ops(add_ops)
     }
 
     /// Returns a channel on which to send notices to the session.
@@ -923,7 +854,7 @@ pub enum TransactionStatus<T> {
     Failed(Transaction<T>),
 }
 
-impl<T> TransactionStatus<T> {
+impl<T: TimestampManipulation> TransactionStatus<T> {
     /// Extracts the inner transaction ops and write lock guard if not failed.
     pub fn into_ops_and_lock_guard(
         self,
@@ -1022,6 +953,92 @@ impl<T> TransactionStatus<T> {
             None => false,
         }
     }
+
+    /// Adds operations to the current transaction. An error is produced if
+    /// they cannot be merged (i.e., a timestamp-dependent read cannot be
+    /// merged to an insert).
+    pub fn add_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
+        match self {
+            TransactionStatus::Started(Transaction { ops, access, .. })
+            | TransactionStatus::InTransaction(Transaction { ops, access, .. })
+            | TransactionStatus::InTransactionImplicit(Transaction { ops, access, .. }) => {
+                match ops {
+                    TransactionOps::None => {
+                        if matches!(access, Some(TransactionAccessMode::ReadOnly))
+                            && matches!(add_ops, TransactionOps::Writes(_))
+                        {
+                            return Err(AdapterError::ReadOnlyTransaction);
+                        }
+                        *ops = add_ops;
+                    }
+                    TransactionOps::Peeks(determination) => match add_ops {
+                        TransactionOps::Peeks(add_timestamp_determination) => {
+                            match (
+                                &determination.timestamp_context,
+                                &add_timestamp_determination.timestamp_context,
+                            ) {
+                                (
+                                    TimestampContext::TimelineTimestamp(txn_timeline, txn_ts),
+                                    TimestampContext::TimelineTimestamp(add_timeline, add_ts),
+                                ) => {
+                                    assert_eq!(txn_timeline, add_timeline);
+                                    assert_eq!(txn_ts, add_ts);
+                                }
+                                (TimestampContext::NoTimestamp, _) => {
+                                    *determination = add_timestamp_determination
+                                }
+                                (_, TimestampContext::NoTimestamp) => {}
+                            };
+                        }
+                        // Iff peeks thus far do not have a timestamp (i.e.
+                        // they are constant), we can switch to a write
+                        // transaction.
+                        writes @ TransactionOps::Writes(..)
+                            if !determination.timestamp_context.contains_timestamp() =>
+                        {
+                            *ops = writes;
+                        }
+                        _ => return Err(AdapterError::ReadOnlyTransaction),
+                    },
+                    TransactionOps::Subscribe => {
+                        return Err(AdapterError::SubscribeOnlyTransaction)
+                    }
+                    TransactionOps::Writes(txn_writes) => match add_ops {
+                        TransactionOps::Writes(mut add_writes) => {
+                            // We should have already checked the access above, but make sure we don't miss
+                            // it anyway.
+                            assert!(!matches!(access, Some(TransactionAccessMode::ReadOnly)));
+                            txn_writes.append(&mut add_writes);
+
+                            if txn_writes
+                                .iter()
+                                .map(|op| op.id)
+                                .collect::<BTreeSet<_>>()
+                                .len()
+                                > 1
+                            {
+                                return Err(AdapterError::MultiTableWriteTransaction);
+                            }
+                        }
+                        // Iff peeks do not have a timestamp (i.e. they are
+                        // constant), we can permit them.
+                        TransactionOps::Peeks(determination)
+                            if !determination.timestamp_context.contains_timestamp() => {}
+                        _ => {
+                            return Err(AdapterError::WriteOnlyTransaction);
+                        }
+                    },
+                    TransactionOps::SingleStatement { .. } => {
+                        return Err(AdapterError::SingleStatementTransaction)
+                    }
+                }
+            }
+            TransactionStatus::Default | TransactionStatus::Failed(_) => {
+                unreachable!()
+            }
+        }
+        Ok(())
+    }
 }
 
 /// An abstraction allowing us to identify different transactions.
@@ -1067,7 +1084,8 @@ impl<T> Transaction<T> {
             TransactionOps::Peeks(_)
             | TransactionOps::None
             | TransactionOps::Subscribe
-            | TransactionOps::Writes(_) => None,
+            | TransactionOps::Writes(_)
+            | TransactionOps::SingleStatement { .. } => None,
         }
     }
 
@@ -1137,13 +1155,23 @@ pub enum TransactionOps<T> {
     /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must
     /// only do other writes, or reads whose timestamp is None (i.e. constants).
     Writes(Vec<WriteOp>),
+    /// This transaction has a prospective statement that will execute during commit.
+    SingleStatement {
+        /// The prospective statement.
+        stmt: Statement<Raw>,
+        /// The statement params.
+        params: mz_sql::plan::Params,
+    },
 }
 
 impl<T> TransactionOps<T> {
     fn timestamp_determination(self) -> Option<TimestampDetermination<T>> {
         match self {
             TransactionOps::Peeks(determination) => Some(determination),
-            TransactionOps::None | TransactionOps::Subscribe | TransactionOps::Writes(_) => None,
+            TransactionOps::None
+            | TransactionOps::Subscribe
+            | TransactionOps::Writes(_)
+            | TransactionOps::SingleStatement { .. } => None,
         }
     }
 }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -994,7 +994,6 @@ async fn execute_stmt<S: ResultSender>(
         | ExecuteResponse::CreatedIndex { .. }
         | ExecuteResponse::CreatedSecret { .. }
         | ExecuteResponse::CreatedSource { .. }
-        | ExecuteResponse::CreatedSources
         | ExecuteResponse::CreatedSink { .. }
         | ExecuteResponse::CreatedView { .. }
         | ExecuteResponse::CreatedViews { .. }

--- a/src/environmentd/tests/testdata/http/ws
+++ b/src/environmentd/tests/testdata/http/ws
@@ -183,7 +183,7 @@ ws-text
 {"query": "CREATE VIEW v AS SELECT 1"}
 ----
 {"type":"CommandStarting","payload":{"has_rows":false,"is_streaming":false}}
-{"type":"Error","payload":{"message":"CREATE VIEW v AS SELECT 1 cannot be run inside a transaction block","code":"25001"}}
+{"type":"Error","payload":{"message":"transaction in read-only mode","code":"25006","detail":"SELECT queries cannot be combined with other query types, including SUBSCRIBE."}}
 {"type":"ReadyForQuery","payload":"E"}
 
 ws-text

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1499,7 +1499,6 @@ where
             | ExecuteResponse::CreatedSecret { .. }
             | ExecuteResponse::CreatedSink { .. }
             | ExecuteResponse::CreatedSource { .. }
-            | ExecuteResponse::CreatedSources
             | ExecuteResponse::CreatedTable { .. }
             | ExecuteResponse::CreatedType
             | ExecuteResponse::CreatedView { .. }

--- a/test/sqllogictest/privileges_pg.slt
+++ b/test/sqllogictest/privileges_pg.slt
@@ -129,7 +129,7 @@ COMPLETE 0
 simple conn=regress_priv_user3,user=regress_priv_user3
 REVOKE regress_priv_user2 FROM regress_priv_user4;
 ----
-db error: ERROR: REVOKE regress_priv_user2 FROM regress_priv_user4 cannot be run inside a transaction block
+COMPLETE 0
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 ROLLBACK;
@@ -144,7 +144,7 @@ COMPLETE 0
 simple conn=regress_priv_user3,user=regress_priv_user3
 GRANT regress_priv_user2 TO regress_priv_user4;
 ----
-db error: ERROR: GRANT regress_priv_user2 TO regress_priv_user4 cannot be run inside a transaction block
+COMPLETE 0
 
 simple conn=regress_priv_user3,user=regress_priv_user3
 ROLLBACK;

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -167,42 +167,6 @@ DROP ROLE PUBLIC
 statement error role name "public" is reserved
 ALTER ROLE public INHERIT
 
-statement ok
-BEGIN
-
-statement error cannot be run inside a transaction block
-CREATE ROLE bad
-
-statement ok
-ROLLBACK
-
-statement ok
-BEGIN
-
-statement error cannot be run inside a transaction block
-GRANT foo TO foo
-
-statement ok
-ROLLBACK
-
-statement ok
-BEGIN
-
-statement error cannot be run inside a transaction block
-REVOKE foo FROM foo
-
-statement ok
-ROLLBACK
-
-statement ok
-BEGIN
-
-statement error cannot be run inside a transaction block
-DROP ROLE bad
-
-statement ok
-ROLLBACK
-
 query T
 SELECT pg_get_userbyid((SELECT oid FROM mz_roles WHERE name = 'materialize'))
 ----

--- a/test/sqllogictest/secret.slt
+++ b/test/sqllogictest/secret.slt
@@ -160,15 +160,6 @@ create secret secret_512 as REPEAT('x', 1024 * 512)::bytea;
 statement error secrets can not be bigger than 512KiB
 create secret secret_1024 as REPEAT('x', 1024 * 1024)::bytea;
 
-statement OK
-START TRANSACTION
-
-statement error CREATE SECRET t_secret AS 'text' cannot be run inside a transaction block
-CREATE SECRET t_secret AS 'text'
-
-statement OK
-ROLLBACK
-
 # Test dropping multiple secrets in a single operation
 statement OK
 create schema to_be_dropped

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -694,3 +694,84 @@ RESET TRANSACTION_ISOLATION
 
 statement ok
 ROLLBACK
+
+# Test explicit single statement transactions.
+
+reset-server
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE t (i INT)
+
+# Should not have executed.
+simple conn=c1
+SHOW tables
+----
+COMPLETE 0
+
+statement ok
+COMMIT
+
+simple conn=c1
+SHOW tables
+----
+t
+COMPLETE 1
+
+statement ok
+BEGIN
+
+# No error yet because we didn't try to execute.
+statement ok
+CREATE TABLE t (i INT)
+
+statement error db error: ERROR: table "materialize\.public\.t" already exists
+COMMIT
+
+statement ok
+BEGIN
+
+# No error yet because we didn't try to execute.
+statement ok
+CREATE TABLE t (i INT)
+
+statement error db error: ERROR: this transaction can only execute a single statement
+SELECT 1
+
+statement ok
+ROLLBACK
+
+# Test CREATE SOURCE for its off thread purify.
+statement ok
+BEGIN
+
+statement ok
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER
+
+statement ok
+COMMIT
+
+simple
+SHOW SOURCES
+----
+s,load-generator,1
+s_progress,progress,NULL
+COMPLETE 2
+
+# Test a statement that doesn't work even in this mode because of ambiguous responses.
+statement ok
+CREATE DEFAULT INDEX ON s
+
+statement ok
+BEGIN
+
+statement error db error: ERROR: ALTER INDEX s_primary_idx SET \(LOGICAL COMPACTION WINDOW = 0\) cannot be run inside a transaction block
+ALTER INDEX s_primary_idx SET (LOGICAL COMPACTION WINDOW = 0)
+
+query error db error: ERROR: current transaction is aborted, commands ignored until end of transaction block
+SELECT 1
+
+statement ok
+ROLLBACK


### PR DESCRIPTION
See included design doc. Add a new transaction operation for delayed statement execution.

Fixes #20426

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support most single statements in explicit transactions: `BEGIN; CREATE <x>; COMMIT;`.