### PR TITLE
platform-checks: Do not run the DebeziumPostgres check if restarting …

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -539,7 +539,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
-          args: [--scenario=RestartSourcePostgres, --check=DebeziumPostgres, --check=PgCdc]
+          args: [--scenario=RestartSourcePostgres, --check=PgCdc]
 
   - id: cloudtest
     label: Cloudtest %n

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -122,12 +122,6 @@ class DebeziumPostgres(Check):
         return Testdrive(
             dedent(
                 """
-                # Restart Debezium in case the Scenario in which this Check is being run restarts Postgres
-                # The Debezium connector is unable to handle all Postgres restarts -- it will stop replicating
-                # and require a manual restart via its REST API in order to continue.
-                $ http-request method=POST url=http://debezium:8083/connectors/psql-connector/restart content-type=application/json accept-additional-status-codes=409
-                { }
-
                 > SELECT * FROM debezium_view1;
                 A 5 16000
                 B 5 16000


### PR DESCRIPTION
…Postgres

Debezium is unable to cleanly handle restarts of the source Postgres database. The Debezium server remains in limbo and manual action is required to restart replication.

This causes sporadic test failures that are not related to Materialize.

### Motivation

Per-push CI was failing due to no fault of Materialize.
