### PR TITLE
platform checks: Fix the "Parallel" scenarios

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -392,7 +392,7 @@ steps:
     label: "Checks parallel + DROP/CREATE replica"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -403,7 +403,7 @@ steps:
     label: "Checks parallel + restart compute clusterd"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -414,7 +414,7 @@ steps:
     label: "Checks parallel + restart of the entire Mz"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -425,7 +425,7 @@ steps:
     label: "Checks parallel + restart of environmentd & storage clusterd"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -436,7 +436,7 @@ steps:
     label: "Checks parallel + kill storage clusterd"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -447,7 +447,7 @@ steps:
     label: "Checks parallel + restart Redpanda & Debezium"
     timeout_in_minutes: 300
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -70,15 +70,17 @@ class Scenario:
         # Configure implicitly for cloud scenarios
         if not isinstance(actions[0], StartMz):
             actions.insert(0, ConfigureMz(self))
-        for action in actions:
-            action.execute(self.executor)
-            action.join(self.executor)
+
+        for index, action in enumerate(actions):
             # Implicitly call configure to raise version-dependent limits
             if isinstance(action, StartMz) or isinstance(
                 action, ReplaceEnvironmentdStatefulSet
             ):
-                ConfigureMz(self).execute(self.executor)
-                ConfigureMz(self).join(self.executor)
+                actions.insert(index + 1, ConfigureMz(self))
+
+        for action in actions:
+            action.execute(self.executor)
+            action.join(self.executor)
 
 
 class NoRestartNoUpgrade(Scenario):


### PR DESCRIPTION
Previously, a ConfigureMz() action was instantiated twice, which caused the join() method to bork. For some reason, even though mzcompose returned a non-zero value, the CI remained green.

Fixed by making sure we instantiate only one ConfigureMz() action so that the join() method always has a Threading handle to operate on.

Furthermore, give those scenarios larger CI machines to avoid OOMs

### Motivation

All the "parallel" scenarios in the Nightly CI were failing right away with an assertion that was masked by an unrelated mzcompose bug.