### PR TITLE
platform-checks: Fix scenarios involving Sleep()

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -22,7 +22,8 @@ class Action:
         assert False
 
     def join(self, e: Executor) -> None:
-        assert False
+        print(f"Action {self} does not implement join()")
+        raise NotImplementedError
 
 
 class Testdrive(Action):
@@ -49,6 +50,9 @@ class Sleep(Action):
     def execute(self, e: Executor) -> None:
         print(f"Sleeping for {self.interval} seconds")
         time.sleep(self.interval)
+
+    def join(self, e: Executor) -> None:
+        pass
 
 
 class Initialize(Action):


### PR DESCRIPTION
The Sleep() action was missing a join() method

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The 2 scenarios in Nightly that involved the Sleep() action were asserting mid-way.