### PR TITLE
mzcompose: Properly handle message-less asserts

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -590,6 +590,7 @@ To see the available workflows, run:
 
             # Upload test report to Buildkite Test Analytics.
             junit_suite = junit_xml.TestSuite(composition.name)
+
             for (name, result) in composition.test_results.items():
                 test_case = junit_xml.TestCase(name, composition.name, result.duration)
                 if result.error:
@@ -600,7 +601,9 @@ To see the available workflows, run:
                 junit_xml.to_xml_report_file(f, [junit_suite])
             ci_util.upload_junit_report("mzcompose", junit_report)
 
-            if any(result.error for result in composition.test_results.values()):
+            if any(
+                result.error is not None for result in composition.test_results.values()
+            ):
                 raise UIError("at least one test case failed")
 
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -419,11 +419,10 @@ class Composition:
             yield
             ui.header(f"mzcompose: test case {name} succeeded")
         except Exception as e:
-            error = str(e)
-            if isinstance(e, UIError):
-                print(f"mzcompose: test case {name} failed: {e}", file=sys.stderr)
-            else:
-                print(f"mzcompose: test case {name} failed:", file=sys.stderr)
+            error = f"{str(type(e))}: {e}"
+            print(f"mzcompose: test case {name} failed: {error}", file=sys.stderr)
+
+            if not isinstance(e, UIError):
                 traceback.print_exc()
         elapsed = time.time() - start_time
         self.test_results[name] = Composition.TestResult(elapsed, error)


### PR DESCRIPTION
A message-less assert stringifies to the empty string, which caused such asserts to be ignored by mzcompose, resulting in green CI builds where there were actual failures.

Fix this in two ways:
- stringify each exception, including AssertionException by pre-pended with the exception class name, so that there are never empty error stringifications.

- treat empty error strings as failures nevertheless. Only if the error is None can a test be considered a success.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
