### PR TITLE
launchdarkly: improve observability into wedged connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ checksum = "2eac3c0b9fa6eb75255ebb42c0ba3e2210d102a66d2795afef6fed668f373311"
 [[package]]
 name = "eventsource-client"
 version = "0.11.0"
-source = "git+https://github.com/MaterializeInc/rust-eventsource-client#7189b690cbfa7ff5be2e943fbce83b8a8b67b928"
+source = "git+https://github.com/MaterializeInc/rust-eventsource-client#fb749fde693a9757289238ee71d4e9b3590fb24b"
 dependencies = [
  "futures",
  "hyper",
@@ -2934,7 +2934,7 @@ dependencies = [
 [[package]]
 name = "launchdarkly-server-sdk"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk#5c36592edc75b620482a92e6991147aee7baf2d8"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk#fb0eaf5bee43f9a590a237705d190e6650d9ecd8"
 dependencies = [
  "built",
  "chrono",


### PR DESCRIPTION
Pick up changes from

* [x] https://github.com/MaterializeInc/rust-eventsource-client/pull/1
* [x] https://github.com/MaterializeInc/rust-server-sdk/pull/2
* [x] https://github.com/MaterializeInc/rust-server-sdk/pull/3

in `main`.

### Motivation

  * This PR adds a known-desirable feature.

We hope that his will help improve wedged connections.

### Tips for reviewer

This needs to be tested manually on `staging` before we can merge this and backport the changes to `v0.62.x`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
