### PR TITLE
webhooks: HTTP routing

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -398,9 +398,7 @@ impl InternalHttpServer {
                 ready_to_promote,
             })));
 
-        let router = router
-            .merge(leader_router)
-            .apply_default_layers(metrics);
+        let router = router.merge(leader_router).apply_default_layers(metrics);
 
         InternalHttpServer { router }
     }

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -19,23 +19,18 @@ use mz_repr::{ColumnType, Datum, Row, ScalarType};
 use mz_storage_client::controller::StorageError;
 
 use anyhow::Context;
-use axum::extract::Path;
+use axum::extract::{Path, State};
 use axum::response::IntoResponse;
-use axum::Extension;
 use bytes::Bytes;
 use http::StatusCode;
 use thiserror::Error;
 
-use crate::http::Delayed;
-
 pub async fn handle_webhook(
-    Extension(client): Extension<Delayed<mz_adapter::Client>>,
+    State(client): State<mz_adapter::Client>,
     Path((database, schema, name)): Path<(String, String, String)>,
     headers: http::HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
-    // Get our adapter client.
-    let client = client.await.context("receiving client")?;
     let conn_id = client.new_conn_id().context("allocate connection id")?;
 
     // Collect headers into a map, while converting them into strings.


### PR DESCRIPTION
This PR does two things:

1. Moves the `/api/webhook/...` route outside of the `base_router()` to avoid CORS and auth issues.
2. Moves the Prometheus metrics and max request size layers outside of the `base_router()` to apply for all routes.

### Motivation

  * This PR fixes a previously unreported bug.

The `base_router()` has a CORS layer and auth (Frontegg) layer applied to it, which we cannot enforce for webhooks, because external systems unknown to us will be pushing data to webhook sources. Note, webhook sources have their own validation step to make sure requests are from a trusted source.

### Tips for reviewer

Hide whitespace

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
