### PR TITLE
clusters: use topologySpreadConstraints instead of fixed, randomly-chosen availability zones

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4923,6 +4923,7 @@ dependencies = [
  "mz-interchange",
  "mz-kafka-util",
  "mz-lowertest",
+ "mz-orchestrator",
  "mz-ore",
  "mz-persist-client",
  "mz-pgcopy",

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -156,23 +156,33 @@ nodes:
     labels:
       materialize.cloud/disk: false
       materialize.cloud/availability-zone: "1"
+      topology.kubernetes.io/zone: "1"
   - role: worker
     labels:
       materialize.cloud/disk: false
       materialize.cloud/availability-zone: "2"
+      topology.kubernetes.io/zone: "2"
   - role: worker
     labels:
       materialize.cloud/disk: false
       materialize.cloud/availability-zone: "3"
+      topology.kubernetes.io/zone: "3"
+
+  # disk
   - role: worker
     labels:
       materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
+      topology.kubernetes.io/zone: "1"
+
+  # others
   - role: worker
     labels:
-      materialize.cloud/disk: true
-      materialize.cloud/availability-zone: "2"
-  - role: worker
-    labels:
-      materialize.cloud/disk: true
+      materialize.cloud/disk: false
       materialize.cloud/availability-zone: "3"
+      topology.kubernetes.io/zone: "3"
+  - role: worker
+    labels:
+      materialize.cloud/disk: false
+      materialize.cloud/availability-zone: "3"
+      topology.kubernetes.io/zone: "3"

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1775,6 +1775,8 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("cluster_id", ScalarType::String.nullable(false))
         .with_column("size", ScalarType::String.nullable(true))
+        // `NULL` for un-orchestrated clusters and for replicas where the user
+        // hasn't specified them.
         .with_column("availability_zone", ScalarType::String.nullable(true))
         .with_column("owner_id", ScalarType::String.nullable(false))
         .with_column("disk", ScalarType::Bool.nullable(true)),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -1739,7 +1739,15 @@ pub static MZ_CLUSTERS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("managed", ScalarType::Bool.nullable(false))
         .with_column("size", ScalarType::String.nullable(true))
         .with_column("replication_factor", ScalarType::UInt32.nullable(true))
-        .with_column("disk", ScalarType::Bool.nullable(true)),
+        .with_column("disk", ScalarType::Bool.nullable(true))
+        .with_column(
+            "availability_zones",
+            ScalarType::List {
+                element_type: Box::new(ScalarType::String),
+                custom_id: None,
+            }
+            .nullable(true),
+        ),
     is_retained_metrics_object: false,
 });
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -246,6 +246,12 @@ impl CatalogState {
                 allocation: _,
                 disk,
             }) => (Some(&**size), Some(*disk), Some(az.as_str())),
+            ReplicaLocation::Managed(ManagedReplicaLocation {
+                size,
+                availability_zones: _,
+                allocation: _,
+                disk,
+            }) => (Some(&**size), Some(*disk), None),
             _ => (None, None, None),
         };
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -227,6 +227,9 @@ impl CatalogState {
             ReplicaLocation::Managed(ManagedReplicaLocation {
                 size,
                 availability_zone,
+                // This is filled in durin concretization, and is exposed on the cluster
+                // in `mz_clusters`.
+                allowed_availability_zones: _,
                 allocation: _,
                 disk,
             }) => (Some(&**size), Some(*disk), availability_zone.as_deref()),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -227,10 +227,9 @@ impl CatalogState {
             ReplicaLocation::Managed(ManagedReplicaLocation {
                 size,
                 availability_zone,
-                az_user_specified: _,
                 allocation: _,
                 disk,
-            }) => (Some(&**size), Some(*disk), Some(availability_zone.as_str())),
+            }) => (Some(&**size), Some(*disk), availability_zone.as_deref()),
             ReplicaLocation::Unmanaged(_) => (None, None, None),
         };
 

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -155,8 +155,7 @@ fn builtin_cluster_replica_config(bootstrap_args: &BootstrapArgs) -> SerializedR
     SerializedReplicaConfig {
         location: SerializedReplicaLocation::Managed {
             size: bootstrap_args.builtin_cluster_replica_size.clone(),
-            availability_zone: bootstrap_args.default_availability_zone.clone(),
-            az_user_specified: false,
+            availability_zone: None,
             disk: false,
         },
         logging: default_logging_config(),
@@ -175,7 +174,6 @@ fn default_logging_config() -> SerializedReplicaLogging {
 pub struct BootstrapArgs {
     pub default_cluster_replica_size: String,
     pub builtin_cluster_replica_size: String,
-    pub default_availability_zone: String,
     pub bootstrap_role: Option<String>,
 }
 

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -371,12 +371,10 @@ impl RustType<proto::replica_config::Location> for SerializedReplicaLocation {
             SerializedReplicaLocation::Managed {
                 size,
                 availability_zone,
-                az_user_specified,
                 disk,
             } => proto::replica_config::Location::Managed(proto::replica_config::ManagedLocation {
                 size: size.to_string(),
-                availability_zone: availability_zone.to_string(),
-                az_user_specified: *az_user_specified,
+                availability_zone: availability_zone.clone(),
                 disk: *disk,
             }),
         }
@@ -397,7 +395,6 @@ impl RustType<proto::replica_config::Location> for SerializedReplicaLocation {
                 Ok(SerializedReplicaLocation::Managed {
                     size: location.size,
                     availability_zone: location.availability_zone,
-                    az_user_specified: location.az_user_specified,
                     disk: location.disk,
                 })
             }

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -864,8 +864,7 @@ fn default_replica_config(args: &BootstrapArgs) -> proto::ReplicaConfig {
         location: Some(proto::replica_config::Location::Managed(
             proto::replica_config::ManagedLocation {
                 size: args.default_cluster_replica_size.to_string(),
-                availability_zone: args.default_availability_zone.to_string(),
-                az_user_specified: false,
+                availability_zone: None,
                 disk: false,
             },
         )),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -885,6 +885,10 @@ impl Coordinator {
         self.controller.compute.update_configuration(compute_config);
         let storage_config = flags::storage_config(self.catalog().system_config());
         self.controller.storage.update_configuration(storage_config);
+        let orchestrator_scheduling_config =
+            flags::orchestrator_scheduling_config(self.catalog().system_config());
+        self.controller
+            .update_orchestrator_scheduling_config(orchestrator_scheduling_config);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         //

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1704,7 +1704,7 @@ pub async fn serve(
         cluster_replica_sizes,
         default_storage_cluster_size,
         system_parameter_defaults,
-        mut availability_zones,
+        availability_zones,
         connection_context,
         storage_usage_client,
         storage_usage_collection_interval,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -180,10 +180,6 @@ pub const DEFAULT_LOGICAL_COMPACTION_WINDOW: Duration =
 pub const DEFAULT_LOGICAL_COMPACTION_WINDOW_TS: mz_repr::Timestamp =
     Timestamp::new(DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS);
 
-/// A dummy availability zone to use when no availability zones are explicitly
-/// specified.
-pub const DUMMY_AVAILABILITY_ZONE: &str = "";
-
 #[derive(Debug)]
 pub enum Message<T = mz_repr::Timestamp> {
     Command(Command),
@@ -1731,12 +1727,6 @@ pub async fn serve(
     // Validate and process availability zones.
     if !availability_zones.iter().all_unique() {
         coord_bail!("availability zones must be unique");
-    }
-    // Later on, we choose an AZ for every replica, so we need to have at least
-    // one. If we're using an orchestrator that doesn't have the notion of AZs,
-    // just create a fake, blank one.
-    if availability_zones.is_empty() {
-        availability_zones.push(DUMMY_AVAILABILITY_ZONE.into());
     }
 
     let aws_principal_context = if aws_account_id.is_some()

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -847,7 +847,8 @@ impl Coordinator {
                     if let Some(az) = &location.availability_zone {
                         if !new_availability_zones.contains(az) {
                             coord_bail!(
-                                "unmanaged replica has az {az} which is not in managed {new_availability_zones:?}"
+                                "unmanaged replica has availability zone {az} which is not \
+                                in managed {new_availability_zones:?}"
                             )
                         }
                     }

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{
-    ClusterId, CreateReplicaConfig, ReplicaConfig, ReplicaId, ReplicaLocation, ReplicaLogging,
-    DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
+    ClusterId, CreateReplicaConfig, ManagedReplicaAvailabilityZones, ReplicaConfig, ReplicaId,
+    ReplicaLocation, ReplicaLogging, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS,
 };
 use mz_ore::cast::CastFrom;
 use mz_repr::role_id::RoleId;
@@ -844,7 +844,9 @@ impl Coordinator {
                     sizes.insert(location.size.clone());
                     disks.insert(location.disk);
 
-                    if let Some(az) = &location.availability_zone {
+                    if let ManagedReplicaAvailabilityZones::FromReplica(Some(az)) =
+                        &location.availability_zones
+                    {
                         if !new_availability_zones.contains(az) {
                             coord_bail!(
                                 "unmanaged replica has availability zone {az} which is not \

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -25,7 +25,6 @@ use mz_sql::plan::SourceSinkClusterConfig;
 use crate::catalog::{
     self, ClusterConfig, ClusterVariant, SerializedReplicaLocation, LINKED_CLUSTER_REPLICA_NAME,
 };
-use crate::coord::sequencer::cluster::AzHelper;
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 use crate::session::Session;
@@ -94,6 +93,7 @@ impl Coordinator {
                 .catalog()
                 .system_config()
                 .allowed_cluster_replica_sizes(),
+            None,
         )?;
         let logging = {
             ReplicaLogging {

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -83,14 +83,9 @@ impl Coordinator {
         ops: &mut Vec<catalog::Op>,
         owner_id: RoleId,
     ) -> Result<(), AdapterError> {
-        let availability_zone = {
-            let azs = self.catalog().state().availability_zones();
-            AzHelper::new(azs).choose_az()
-        };
         let location = SerializedReplicaLocation::Managed {
             size: size.to_string(),
-            availability_zone,
-            az_user_specified: false,
+            availability_zone: None,
             disk,
         };
         let location = self.catalog().concretize_replica_location(

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -10,6 +10,7 @@
 use std::time::Duration;
 
 use mz_compute_client::protocol::command::ComputeParameters;
+use mz_orchestrator::scheduling_config::{ServiceSchedulingConfig, ServiceTopologySpreadConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_persist_client::cfg::{PersistParameters, RetryParameters};
@@ -148,5 +149,20 @@ fn grpc_client_config(config: &SystemVars) -> GrpcClientParameters {
         connect_timeout: Some(config.grpc_connect_timeout()),
         http2_keep_alive_interval: Some(config.grpc_client_http2_keep_alive_interval()),
         http2_keep_alive_timeout: Some(config.grpc_client_http2_keep_alive_timeout()),
+    }
+}
+
+pub fn orchestrator_scheduling_config(config: &SystemVars) -> ServiceSchedulingConfig {
+    ServiceSchedulingConfig {
+        multi_pod_az_affinity_weight: config.cluster_multi_process_replica_az_affinity_weight(),
+        soften_replication_anti_affinity: config.cluster_soften_replication_anti_affinity(),
+        soft_replication_anti_affinity_weight: config
+            .cluster_soften_replication_anti_affinity_weight(),
+        topology_spread: ServiceTopologySpreadConfig {
+            enabled: config.cluster_enable_topology_spread(),
+            ignore_non_singular_scale: config.cluster_topology_spread_ignore_non_singular_scale(),
+            max_skew: config.cluster_topology_spread_max_skew(),
+            soft: config.cluster_topology_spread_soft(),
+        },
     }
 }

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -156,7 +156,7 @@ pub fn orchestrator_scheduling_config(config: &SystemVars) -> ServiceSchedulingC
     ServiceSchedulingConfig {
         multi_pod_az_affinity_weight: config.cluster_multi_process_replica_az_affinity_weight(),
         soften_replication_anti_affinity: config.cluster_soften_replication_anti_affinity(),
-        soft_replication_anti_affinity_weight: config
+        soften_replication_anti_affinity_weight: config
             .cluster_soften_replication_anti_affinity_weight(),
         topology_spread: ServiceTopologySpreadConfig {
             enabled: config.cluster_enable_topology_spread(),
@@ -164,5 +164,7 @@ pub fn orchestrator_scheduling_config(config: &SystemVars) -> ServiceSchedulingC
             max_skew: config.cluster_topology_spread_max_skew(),
             soft: config.cluster_topology_spread_soft(),
         },
+        soften_az_affinity: config.cluster_soften_az_affinity(),
+        soften_az_affinity_weight: config.cluster_soften_az_affinity_weight(),
     }
 }

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -133,6 +133,6 @@ pub use crate::coord::timestamp_selection::{
 };
 pub use crate::coord::ExecuteContext;
 pub use crate::coord::ExecuteContextExtra;
-pub use crate::coord::{serve, Config, DUMMY_AVAILABILITY_ZONE};
+pub use crate::coord::{serve, Config};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -118,7 +118,7 @@ impl ReplicaLocation {
     pub fn availability_zone(&self) -> Option<&str> {
         match self {
             ReplicaLocation::Unmanaged(_) => None,
-            ReplicaLocation::Managed(m) => Some(&m.availability_zone),
+            ReplicaLocation::Managed(m) => m.availability_zone.as_deref(),
         }
     }
 
@@ -176,11 +176,8 @@ pub struct ManagedReplicaLocation {
     pub allocation: ReplicaAllocation,
     /// SQL size parameter used for allocation
     pub size: String,
-    /// The replica's availability zone
-    pub availability_zone: String,
-    /// `true` if the AZ was specified by the user and must be respected;
-    /// `false` if it was picked arbitrarily by Materialize.
-    pub az_user_specified: bool,
+    /// The replica's availability zone, if specified.
+    pub availability_zone: Option<String>,
     /// Whether the replica needs scratch disk space.
     pub disk: bool,
 }
@@ -551,11 +548,7 @@ where
                         ("workers".into(), location.allocation.workers.to_string()),
                         ("size".into(), location.size.to_string()),
                     ]),
-                    availability_zone: if location.az_user_specified {
-                        Some(location.availability_zone)
-                    } else {
-                        None
-                    },
+                    availability_zone: location.availability_zone,
                     // This provides the orchestrator with some label selectors that
                     // are used to constraint the scheduling of replicas, based on
                     // its internal configuration.

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -164,11 +164,11 @@ pub struct UnmanagedReplicaLocation {
 #[derive(Clone, Debug)]
 pub enum ManagedReplicaAvailabilityZones {
     /// Specified if the `Replica` is from `MANAGED` cluster,
-    /// and specifies if their is an `AVAILABILITY ZONES`
-    /// constraint. Empty list's are represented as `None`.
+    /// and specifies if there is an `AVAILABILITY ZONES`
+    /// constraint. Empty lists are represented as `None`.
     FromCluster(Option<Vec<String>>),
     /// Specified if the `Replica` is from a non-`MANAGED` cluster,
-    /// and specifies if their is a specific `AVAILABILITY ZONE`.
+    /// and specifies if there is a specific `AVAILABILITY ZONE`.
     FromReplica(Option<String>),
 }
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -59,7 +59,7 @@ pub type ClusterStatus = mz_orchestrator::ServiceStatus;
 pub type ReplicaId = mz_cluster_client::ReplicaId;
 
 /// Configures a cluster replica.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ReplicaConfig {
     /// The location of the replica.
     pub location: ReplicaLocation,
@@ -104,7 +104,7 @@ fn test_replica_allocation_deserialization() {
 }
 
 /// Configures the location of a cluster replica.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub enum ReplicaLocation {
     /// An unmanaged replica.
     Unmanaged(UnmanagedReplicaLocation),
@@ -161,7 +161,7 @@ pub struct UnmanagedReplicaLocation {
 }
 
 /// The location of a managed replica.
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ManagedReplicaLocation {
     /// The resource allocation for the replica.
     pub allocation: ReplicaAllocation,
@@ -174,6 +174,7 @@ pub struct ManagedReplicaLocation {
     ///
     /// This is placed here during replica concretization for convenience.
     /// It is never serialized anywhere.
+    #[serde(skip)]
     pub allowed_availability_zones: Option<Vec<String>>,
     /// Whether the replica needs scratch disk space.
     pub disk: bool,

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -542,7 +542,6 @@ where
                         ("cluster-id".into(), cluster_id.to_string()),
                         ("type".into(), "cluster".into()),
                         ("replica-role".into(), role_label.into()),
-                        ("scale".into(), location.allocation.scale.to_string()),
                         ("workers".into(), location.allocation.workers.to_string()),
                         ("size".into(), location.size.to_string()),
                     ]),
@@ -574,36 +573,6 @@ where
                             value: cluster_id.to_string(),
                         },
                     }],
-                    replicas_selector_ignoring_scale: vec![
-                        LabelSelector {
-                            label_name: "cluster-id".to_string(),
-                            logic: LabelSelectionLogic::Eq {
-                                value: cluster_id.to_string(),
-                            },
-                        },
-                        // Ignoring replicas with more than 1 pod.
-                        LabelSelector {
-                            label_name: "scale".into(),
-                            logic: LabelSelectionLogic::Eq {
-                                value: "1".to_string(),
-                            },
-                        },
-                    ],
-                    horizontal_scale_selector: vec![
-                        LabelSelector {
-                            label_name: "cluster-id".to_string(),
-                            logic: LabelSelectionLogic::Eq {
-                                value: cluster_id.to_string(),
-                            },
-                        },
-                        // Select specifically pods in the same replica.
-                        LabelSelector {
-                            label_name: "replica-id".into(),
-                            logic: LabelSelectionLogic::Eq {
-                                value: replica_id.to_string(),
-                            },
-                        },
-                    ],
                     disk_limit: location.allocation.disk_limit,
                     disk: location.disk,
                 },

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -249,6 +249,12 @@ where
     T: Timestamp + Lattice,
     ComputeGrpcClient: ComputeClient<T>,
 {
+    pub fn update_orchestrator_scheduling_config(
+        &mut self,
+        config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
+    ) {
+        self.orchestrator.update_scheduling_config(config);
+    }
     /// Marks the end of any initialization commands.
     ///
     /// The implementor may wait for this method to be called before implementing prior commands,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -398,7 +398,6 @@ impl Listeners {
                         builtin_cluster_replica_size: config
                             .bootstrap_builtin_cluster_replica_size
                             .clone(),
-                        default_availability_zone: mz_adapter::DUMMY_AVAILABILITY_ZONE.into(),
                         bootstrap_role: config.bootstrap_role.clone(),
                     },
                     None,
@@ -452,14 +451,6 @@ impl Listeners {
             &BootstrapArgs {
                 default_cluster_replica_size: config.bootstrap_default_cluster_replica_size,
                 builtin_cluster_replica_size: config.bootstrap_builtin_cluster_replica_size,
-                // TODO(benesch, brennan): remove this after v0.27.0-alpha.4 has
-                // shipped to cloud since all clusters will have had a default
-                // availability zone installed.
-                default_availability_zone: config
-                    .availability_zones
-                    .choose(&mut rand::thread_rng())
-                    .cloned()
-                    .unwrap_or_else(|| mz_adapter::DUMMY_AVAILABILITY_ZONE.into()),
                 bootstrap_role: config.bootstrap_role,
             },
             config.deploy_generation,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -108,7 +108,6 @@ use mz_sql::catalog::EnvironmentId;
 use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::types::connections::ConnectionContext;
 use openssl::ssl::{SslAcceptor, SslFiletype, SslMethod};
-use rand::seq::SliceRandom;
 use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::RecvError;
 use tower_http::cors::AllowOrigin;

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -472,6 +472,13 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             }
         })
     }
+
+    fn update_scheduling_config(
+        &self,
+        _config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
+    ) {
+        // This orchestrator ignores scheduling constraints.
+    }
 }
 
 impl NamespacedProcessOrchestrator {

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -340,8 +340,12 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             cpu_limit: _,
             scale,
             labels,
+            // Scheduling constraints are entirely ignored by the process orchestrator.
             availability_zone: _,
-            anti_affinity: _,
+            other_replicas_selector: _,
+            replicas_selector: _,
+            replicas_selector_ignoring_scale: _,
+            horizontal_scale_selector: _,
             disk,
             disk_limit: _,
         }: ServiceConfig<'_>,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -341,7 +341,7 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             scale,
             labels,
             // Scheduling constraints are entirely ignored by the process orchestrator.
-            availability_zone: _,
+            availability_zones: _,
             other_replicas_selector: _,
             replicas_selector: _,
             replicas_selector_ignoring_scale: _,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -344,8 +344,6 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             availability_zones: _,
             other_replicas_selector: _,
             replicas_selector: _,
-            replicas_selector_ignoring_scale: _,
-            horizontal_scale_selector: _,
             disk,
             disk_limit: _,
         }: ServiceConfig<'_>,

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -478,6 +478,13 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
     fn watch_services(&self) -> BoxStream<'static, Result<ServiceEvent, anyhow::Error>> {
         self.inner.watch_services()
     }
+
+    fn update_scheduling_config(
+        &self,
+        config: mz_orchestrator::scheduling_config::ServiceSchedulingConfig,
+    ) {
+        self.inner.update_scheduling_config(config)
+    }
 }
 
 /// Specifies the format of a stderr log message.

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -286,17 +286,6 @@ pub struct ServiceConfig<'a> {
     ///
     /// The orchestrator backend may or may not actually implement placement spread functionality.
     pub replicas_selector: Vec<LabelSelector>,
-    /// Similar to `replicas_selector`, but skipping services that have `scale`
-    /// greater than 1. This may be used to weaken spread constraints, increasing
-    /// availability.
-    pub replicas_selector_ignoring_scale: Vec<LabelSelector>,
-    /// A set of label selectors selecting all services that are horizontally scaled
-    /// parts of this service.
-    ///
-    /// This may be used to co-locate these services in the same zone.
-    ///
-    /// The orchestrator backend may or may not actually implement collocation functionality.
-    pub horizontal_scale_selector: Vec<LabelSelector>,
 
     /// Whether scratch disk space should be allocated for the service.
     pub disk: bool,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -492,8 +492,7 @@ pub mod scheduling_config {
         ///
         /// Defaults to `Some(100)`.
         pub multi_pod_az_affinity_weight: Option<i32>,
-        // TODO(guswynn): soften az node selector config
-        /// If `true`, make the node-level anti-affinity between
+        /// If `true`, make the node-scope anti-affinity between
         /// replicated services a preference over a constraint.
         ///
         /// Defaults to `false`.
@@ -501,9 +500,17 @@ pub mod scheduling_config {
         /// The weight for `soften_replication_anti_affinity.
         ///
         /// Defaults to `100`.
-        pub soft_replication_anti_affinity_weight: i32,
+        pub soften_replication_anti_affinity_weight: i32,
         /// Configuration for `TopologySpreadConstraint`'s
         pub topology_spread: ServiceTopologySpreadConfig,
+        /// If `true`, make the az-scope node affinity soft.
+        ///
+        /// Defaults to `false`.
+        pub soften_az_affinity: bool,
+        /// The weight for `soften_replication_anti_affinity.
+        ///
+        /// Defaults to `100`.
+        pub soften_az_affinity_weight: i32,
     }
 
     pub const DEFAULT_POD_AZ_AFFINITY_WEIGHT: Option<i32> = Some(100);
@@ -515,12 +522,15 @@ pub mod scheduling_config {
     pub const DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW: i32 = 1;
     pub const DEFAULT_TOPOLOGY_SPREAD_SOFT: bool = false;
 
+    pub const DEFAULT_SOFTEN_AZ_AFFINITY: bool = false;
+    pub const DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT: i32 = 100;
+
     impl Default for ServiceSchedulingConfig {
         fn default() -> Self {
             ServiceSchedulingConfig {
                 multi_pod_az_affinity_weight: DEFAULT_POD_AZ_AFFINITY_WEIGHT,
                 soften_replication_anti_affinity: DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
-                soft_replication_anti_affinity_weight:
+                soften_replication_anti_affinity_weight:
                     DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT,
                 topology_spread: ServiceTopologySpreadConfig {
                     enabled: DEFAULT_TOPOLOGY_SPREAD_ENABLED,
@@ -528,6 +538,8 @@ pub mod scheduling_config {
                     max_skew: DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
                     soft: DEFAULT_TOPOLOGY_SPREAD_SOFT,
                 },
+                soften_az_affinity: DEFAULT_SOFTEN_AZ_AFFINITY,
+                soften_az_affinity_weight: DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
             }
         }
     }

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -269,12 +269,32 @@ pub struct ServiceConfig<'a> {
     /// The availability zone the service should be run in. If no availability
     /// zone is specified, the orchestrator is free to choose one.
     pub availability_zone: Option<String>,
-    /// A set of label selectors declaring anti-affinity. If _all_ such selectors
+    /// A set of label selectors selecting all _other_ services that are replicas of this one.
+    ///
+    /// This may be used to implement anti-affinity. If _all_ such selectors
     /// match for a given service, this service should not be co-scheduled on
     /// a machine with that service.
     ///
     /// The orchestrator backend may or may not actually implement anti-affinity functionality.
-    pub anti_affinity: Option<Vec<LabelSelector>>,
+    pub other_replicas_selector: Vec<LabelSelector>,
+    /// A set of label selectors selecting all services that are replicas of this one,
+    /// including itself.
+    ///
+    /// This may be used to implement placement spread.
+    ///
+    /// The orchestrator backend may or may not actually implement placement spread functionality.
+    pub replicas_selector: Vec<LabelSelector>,
+    /// Similar to `replicas_selector`, but skipping services that have `scale`
+    /// greater than 1. This may be used to weaken spread constraints, increasing
+    /// availability.
+    pub replicas_selector_ignoring_scale: Vec<LabelSelector>,
+    /// A set of label selectors selecting all services that are horizontally scaled
+    /// parts of this service.
+    ///
+    /// This may be used to co-locate these services in the same zone.
+    ///
+    /// The orchestrator backend may or may not actually implement collocation functionality.
+    pub horizontal_scale_selector: Vec<LabelSelector>,
 
     /// Whether scratch disk space should be allocated for the service.
     pub disk: bool,

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -266,9 +266,9 @@ pub struct ServiceConfig<'a> {
     ///
     /// The orchestrator backend may apply a prefix to the key if appropriate.
     pub labels: BTreeMap<String, String>,
-    /// The availability zone the service should be run in. If no availability
-    /// zone is specified, the orchestrator is free to choose one.
-    pub availability_zone: Option<String>,
+    /// The availability zones the service can be run in. If no availability
+    /// zones are specified, the orchestrator is free to choose one.
+    pub availability_zones: Option<Vec<String>>,
     /// A set of label selectors selecting all _other_ services that are replicas of this one.
     ///
     /// This may be used to implement anti-affinity. If _all_ such selectors

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -26,6 +26,7 @@ mz-controller = { path = "../controller" }
 mz-expr = { path = "../expr" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
+mz-orchestrator = { path = "../orchestrator" }
 mz-ore = { path = "../ore", features = ["chrono", "async"] }
 mz-persist-client = { path = "../persist-client" }
 mz-pgcopy = { path = "../pgcopy" }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2847,6 +2847,10 @@ pub fn plan_create_cluster(
         let replication_factor = replication_factor.unwrap_or(1);
         let availability_zones = availability_zones.unwrap_or_default();
 
+        if !availability_zones.is_empty() {
+            scx.require_feature_flag(&vars::ENABLE_MANAGED_AVAILABILITY_ZONES)?;
+        }
+
         let disk_default = scx.catalog.system_vars().disk_cluster_replicas_default();
         let disk = disk.unwrap_or(disk_default);
         if disk {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2848,7 +2848,7 @@ pub fn plan_create_cluster(
         let availability_zones = availability_zones.unwrap_or_default();
 
         if !availability_zones.is_empty() {
-            scx.require_feature_flag(&vars::ENABLE_MANAGED_AVAILABILITY_ZONES)?;
+            scx.require_feature_flag(&vars::ENABLE_MANAGED_CLUSTER_AVAILABILITY_ZONES)?;
         }
 
         let disk_default = scx.catalog.system_vars().disk_cluster_replicas_default();

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1386,6 +1386,10 @@ feature_flags!(
         enable_dangerous_functions,
         "executing potentially dangerous functions"
     ),
+    (
+        enable_managed_availability_zones,
+        "MANAGED, AVAILABILITY ZONES syntax"
+    )
 );
 
 /// Represents the input to a variable.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1175,7 +1175,8 @@ mod cluster_scheduling {
         ServerVar {
             name: UncasedStr::new("cluster_multi_process_replica_az_affinity_weight"),
             value: &DEFAULT_POD_AZ_AFFINITY_WEIGHT,
-            description: "Whether or to add an availability zone affinity between instances of \
+            description:
+                "Whether or not to add an availability zone affinity between instances of \
             multi-process replicas. Either an affinity weight or empty (off) (Materialize).",
             internal: true,
         };
@@ -1183,7 +1184,7 @@ mod cluster_scheduling {
     pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: ServerVar<bool> = ServerVar {
         name: UncasedStr::new("cluster_soften_replication_anti_affinity"),
         value: &DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
-        description: "Whether or to turn the node-level anti affinity between replicas \
+        description: "Whether or not to turn the node-scope anti affinity between replicas \
             in the same cluster into a preference (Materialize).",
         internal: true,
     };
@@ -1223,6 +1224,21 @@ mod cluster_scheduling {
         name: UncasedStr::new("cluster_topology_spread_soft"),
         value: &DEFAULT_TOPOLOGY_SPREAD_SOFT,
         description: "If true, soften the topology spread constraints for replicas (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_AZ_AFFINITY: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_soften_az_affinity"),
+        value: &DEFAULT_SOFTEN_AZ_AFFINITY,
+        description: "Whether or not to turn the az-scope node affinity for replicas. \
+            Note this could violate requests from the user (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_soften_az_affinity_weight"),
+        value: &DEFAULT_SOFTEN_AZ_AFFINITY_WEIGHT,
+        description: "The preference weight for `cluster_soften_az_affinity` (Materialize).",
         internal: true,
     };
 }
@@ -2060,7 +2076,10 @@ impl SystemVars {
             .with_var(&cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD)
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE)
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW)
-            .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT);
+            .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
+            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY)
+            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT);
+
         vars.refresh_internal_state();
         vars
     }
@@ -2657,6 +2676,14 @@ impl SystemVars {
 
     pub fn cluster_topology_spread_soft(&self) -> bool {
         *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
+    }
+
+    pub fn cluster_soften_az_affinity(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY)
+    }
+
+    pub fn cluster_soften_az_affinity_weight(&self) -> i32 {
+        *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
     }
 }
 
@@ -4076,6 +4103,8 @@ pub fn is_cluster_scheduling_var(name: &str) -> bool {
         || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE.name()
         || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW.name()
         || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT.name()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1403,7 +1403,7 @@ feature_flags!(
         "executing potentially dangerous functions"
     ),
     (
-        enable_managed_availability_zones,
+        enable_managed_cluster_availability_zones,
         "MANAGED, AVAILABILITY ZONES syntax"
     )
 );

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1166,6 +1166,67 @@ mod grpc_client {
     };
 }
 
+/// Configuration for how cluster replicas are scheduled.
+mod cluster_scheduling {
+    use super::*;
+    use mz_orchestrator::scheduling_config::*;
+
+    pub const CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT: ServerVar<Option<i32>> =
+        ServerVar {
+            name: UncasedStr::new("cluster_multi_process_replica_az_affinity_weight"),
+            value: &DEFAULT_POD_AZ_AFFINITY_WEIGHT,
+            description: "Whether or to add an availability zone affinity between instances of \
+            multi-process replicas. Either an affinity weight or empty (off) (Materialize).",
+            internal: true,
+        };
+
+    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_soften_replication_anti_affinity"),
+        value: &DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY,
+        description: "Whether or to turn the node-level anti affinity between replicas \
+            in the same cluster into a preference (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_soften_replication_anti_affinity_weight"),
+        value: &DEFAULT_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT,
+        description:
+            "The preference weight for `cluster_soften_replication_anti_affinity` (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_ENABLE_TOPOLOGY_SPREAD: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_enable_topology_spread"),
+        value: &DEFAULT_TOPOLOGY_SPREAD_ENABLED,
+        description:
+            "Whether or not to add topology spread constraints among replicas in the same cluster (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_ignore_non_singular_scale"),
+        value: &DEFAULT_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE,
+        description:
+            "If true, ignore replicas with more than 1 process when adding topology spread constraints (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW: ServerVar<i32> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_max_skew"),
+        value: &DEFAULT_TOPOLOGY_SPREAD_MAX_SKEW,
+        description: "The `maxSkew` for replica topology spread constraints (Materialize).",
+        internal: true,
+    };
+
+    pub const CLUSTER_TOPOLOGY_SPREAD_SOFT: ServerVar<bool> = ServerVar {
+        name: UncasedStr::new("cluster_topology_spread_soft"),
+        value: &DEFAULT_TOPOLOGY_SPREAD_SOFT,
+        description: "If true, soften the topology spread constraints for replicas (Materialize).",
+        internal: true,
+    };
+}
+
 /// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
 /// availability of features.
 ///
@@ -1988,7 +2049,14 @@ impl SystemVars {
             .with_var(&WEBHOOKS_SECRETS_CACHING_TTL_SECS)
             .with_var(&grpc_client::CONNECT_TIMEOUT)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_INTERVAL)
-            .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT);
+            .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
+            .with_var(&cluster_scheduling::CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT)
+            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY)
+            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT)
+            .with_var(&cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD)
+            .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE)
+            .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW)
+            .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT);
         vars.refresh_internal_state();
         vars
     }
@@ -2557,6 +2625,34 @@ impl SystemVars {
 
     pub fn grpc_connect_timeout(&self) -> Duration {
         *self.expect_value(&grpc_client::CONNECT_TIMEOUT)
+    }
+
+    pub fn cluster_multi_process_replica_az_affinity_weight(&self) -> Option<i32> {
+        *self.expect_value(&cluster_scheduling::CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT)
+    }
+
+    pub fn cluster_soften_replication_anti_affinity(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY)
+    }
+
+    pub fn cluster_soften_replication_anti_affinity_weight(&self) -> i32 {
+        *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT)
+    }
+
+    pub fn cluster_enable_topology_spread(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD)
+    }
+
+    pub fn cluster_topology_spread_ignore_non_singular_scale(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE)
+    }
+
+    pub fn cluster_topology_spread_max_skew(&self) -> i32 {
+        *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW)
+    }
+
+    pub fn cluster_topology_spread_soft(&self) -> bool {
+        *self.expect_value(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
     }
 }
 
@@ -3965,6 +4061,17 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_FILTER_ENABLED.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
+}
+
+/// Returns whether the named variable is a cluster scheduling config
+pub fn is_cluster_scheduling_var(name: &str) -> bool {
+    name == cluster_scheduling::CLUSTER_MULTI_PROCESS_REPLICA_AZ_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY.name()
+        || name == cluster_scheduling::CLUSTER_SOFTEN_REPLICATION_ANTI_AFFINITY_WEIGHT.name()
+        || name == cluster_scheduling::CLUSTER_ENABLE_TOPOLOGY_SPREAD.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_IGNORE_NON_SINGULAR_SCALE.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW.name()
+        || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -87,7 +87,6 @@ use anyhow::Context;
 use clap::Parser;
 use mz_adapter::catalog::storage::{self as catalog, BootstrapArgs};
 use mz_adapter::catalog::{Catalog, ClusterReplicaSizeMap, Config};
-use mz_adapter::DUMMY_AVAILABILITY_ZONE;
 use mz_build_info::{build_info, BuildInfo};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
@@ -472,7 +471,6 @@ impl Usage {
             &BootstrapArgs {
                 default_cluster_replica_size: "1".into(),
                 builtin_cluster_replica_size: "1".into(),
-                default_availability_zone: DUMMY_AVAILABILITY_ZONE.into(),
                 bootstrap_role: None,
             },
             None,

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "e8e7f4ec34697eefd908e9ce40bbf763"
+    "md5": "caeba871ee4c70243741bb5efa474b9e"
   },
   {
     "name": "objects_v15.proto",
@@ -70,5 +70,9 @@
   {
     "name": "objects_v31.proto",
     "md5": "e78e005dc9ddef0dd00cd5a580d222c6"
+  },
+  {
+    "name": "objects_v32.proto",
+    "md5": "5cedf06f7ee9f15a6ada28067907639b"
   }
 ]

--- a/src/stash/protos/objects_v32.proto
+++ b/src/stash/protos/objects_v32.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v32;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -106,7 +106,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 31;
+pub const STASH_VERSION: u64 = 32;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -924,6 +924,7 @@ impl Stash {
                             28 => upgrade::v28_to_v29::upgrade(&mut tx).await?,
                             29 => upgrade::v29_to_v30::upgrade(),
                             30 => upgrade::v30_to_v31::upgrade(),
+                            31 => upgrade::v31_to_v32::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -62,6 +62,7 @@ pub(crate) mod v27_to_v28;
 pub(crate) mod v28_to_v29;
 pub(crate) mod v29_to_v30;
 pub(crate) mod v30_to_v31;
+pub(crate) mod v31_to_v32;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v31_to_v32.rs
+++ b/src/stash/src/upgrade/v31_to_v32.rs
@@ -1,0 +1,353 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v31 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v31.rs"));
+}
+pub mod objects_v32 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v32.rs"));
+}
+
+/// Remove randomly selected az's.
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    pub const CLUSTER_REPLICA_COLLECTION: TypedCollection<
+        objects_v31::ClusterReplicaKey,
+        objects_v31::ClusterReplicaValue,
+    > = TypedCollection::new("compute_replicas");
+
+    CLUSTER_REPLICA_COLLECTION
+        .migrate_to(tx, |entries| {
+            let mut updates = Vec::new();
+
+            for (key, value) in entries {
+                let new_key: objects_v32::ClusterReplicaKey = key.clone().into();
+                let new_value: objects_v32::ClusterReplicaValue = value.clone().into();
+                updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+            }
+
+            updates
+        })
+        .await?;
+
+    Ok(())
+}
+
+impl From<objects_v31::ClusterReplicaKey> for objects_v32::ClusterReplicaKey {
+    fn from(key: objects_v31::ClusterReplicaKey) -> Self {
+        objects_v32::ClusterReplicaKey {
+            id: key
+                .id
+                .map(|key| objects_v32::ReplicaId { value: key.value }),
+        }
+    }
+}
+
+impl From<objects_v31::RoleId> for objects_v32::RoleId {
+    fn from(id: objects_v31::RoleId) -> Self {
+        let value = match id.value {
+            None => None,
+            Some(objects_v31::role_id::Value::User(id)) => {
+                Some(objects_v32::role_id::Value::User(id))
+            }
+            Some(objects_v31::role_id::Value::System(id)) => {
+                Some(objects_v32::role_id::Value::System(id))
+            }
+            Some(objects_v31::role_id::Value::Public(_)) => {
+                Some(objects_v32::role_id::Value::Public(Default::default()))
+            }
+        };
+        objects_v32::RoleId { value }
+    }
+}
+
+impl From<objects_v31::ClusterId> for objects_v32::ClusterId {
+    fn from(cluster_id: objects_v31::ClusterId) -> Self {
+        let value = match cluster_id.value {
+            None => None,
+            Some(objects_v31::cluster_id::Value::System(id)) => {
+                Some(objects_v32::cluster_id::Value::System(id))
+            }
+            Some(objects_v31::cluster_id::Value::User(id)) => {
+                Some(objects_v32::cluster_id::Value::User(id))
+            }
+        };
+        Self { value }
+    }
+}
+
+impl From<objects_v31::Duration> for objects_v32::Duration {
+    fn from(duration: objects_v31::Duration) -> Self {
+        Self {
+            secs: duration.secs,
+            nanos: duration.nanos,
+        }
+    }
+}
+
+impl From<objects_v31::ReplicaLogging> for objects_v32::ReplicaLogging {
+    fn from(logging: objects_v31::ReplicaLogging) -> Self {
+        Self {
+            log_logging: logging.log_logging,
+            interval: logging.interval.map(Into::into),
+        }
+    }
+}
+
+impl From<objects_v31::ReplicaMergeEffort> for objects_v32::ReplicaMergeEffort {
+    fn from(effort: objects_v31::ReplicaMergeEffort) -> Self {
+        Self {
+            effort: effort.effort,
+        }
+    }
+}
+
+impl From<objects_v31::ReplicaConfig> for objects_v32::ReplicaConfig {
+    fn from(config: objects_v31::ReplicaConfig) -> Self {
+        let location = match config.location {
+            Some(objects_v31::replica_config::Location::Unmanaged(
+                objects_v31::replica_config::UnmanagedLocation {
+                    storagectl_addrs,
+                    storage_addrs,
+                    computectl_addrs,
+                    compute_addrs,
+                    workers,
+                },
+            )) => Some(objects_v32::replica_config::Location::Unmanaged(
+                objects_v32::replica_config::UnmanagedLocation {
+                    storagectl_addrs,
+                    storage_addrs,
+                    computectl_addrs,
+                    compute_addrs,
+                    workers,
+                },
+            )),
+            Some(objects_v31::replica_config::Location::Managed(
+                objects_v31::replica_config::ManagedLocation {
+                    size,
+                    availability_zone,
+                    az_user_specified,
+                    disk,
+                },
+            )) => Some(objects_v32::replica_config::Location::Managed(
+                objects_v32::replica_config::ManagedLocation {
+                    size,
+                    // This is the core migration.
+                    availability_zone: if az_user_specified {
+                        Some(availability_zone)
+                    } else {
+                        None
+                    },
+                    disk,
+                },
+            )),
+            None => None,
+        };
+
+        Self {
+            logging: config.logging.map(Into::into),
+            idle_arrangement_merge_effort: config.idle_arrangement_merge_effort.map(Into::into),
+            location,
+        }
+    }
+}
+
+impl From<objects_v31::ClusterReplicaValue> for objects_v32::ClusterReplicaValue {
+    fn from(config: objects_v31::ClusterReplicaValue) -> Self {
+        Self {
+            cluster_id: config.cluster_id.map(Into::into),
+            name: config.name,
+            config: config.config.map(Into::into),
+            owner_id: config.owner_id.map(Into::into),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::upgrade;
+
+    use crate::upgrade::v31_to_v32::{objects_v31, objects_v32};
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        // Connect to the Stash.
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        // Insert a cluster.
+        let cluster_replica_v31: TypedCollection<
+            objects_v31::ClusterReplicaKey,
+            objects_v31::ClusterReplicaValue,
+        > = TypedCollection::new("compute_replicas");
+
+        // Test that we can correctly migrate unmanaged, and both cases of managed replicas.
+        for (key, location) in [
+            (
+                10,
+                objects_v31::replica_config::Location::Managed(
+                    objects_v31::replica_config::ManagedLocation {
+                        size: "s".to_string(),
+                        availability_zone: "z".to_string(),
+                        az_user_specified: true,
+                        disk: true,
+                    },
+                ),
+            ),
+            (
+                11,
+                objects_v31::replica_config::Location::Managed(
+                    objects_v31::replica_config::ManagedLocation {
+                        size: "s".to_string(),
+                        availability_zone: "z".to_string(),
+                        az_user_specified: false,
+                        disk: true,
+                    },
+                ),
+            ),
+            (
+                12,
+                objects_v31::replica_config::Location::Unmanaged(
+                    objects_v31::replica_config::UnmanagedLocation {
+                        storagectl_addrs: vec!["one".to_string()],
+                        storage_addrs: vec!["two".to_string()],
+                        computectl_addrs: vec!["three".to_string()],
+                        compute_addrs: vec!["four".to_string()],
+                        workers: 50,
+                    },
+                ),
+            ),
+        ] {
+            cluster_replica_v31
+                .insert_without_overwrite(
+                    &mut stash,
+                    vec![(
+                        objects_v31::ClusterReplicaKey {
+                            id: Some(objects_v31::ReplicaId { value: key }),
+                        },
+                        objects_v31::ClusterReplicaValue {
+                            cluster_id: Some(objects_v31::ClusterId {
+                                value: Some(objects_v31::cluster_id::Value::User(1)),
+                            }),
+                            name: "gus".to_string(),
+                            config: Some(objects_v31::ReplicaConfig {
+                                location: Some(location),
+                                idle_arrangement_merge_effort: Some(
+                                    objects_v31::ReplicaMergeEffort { effort: 1 },
+                                ),
+                                logging: Some(objects_v31::ReplicaLogging {
+                                    log_logging: true,
+                                    interval: Some(objects_v31::Duration {
+                                        secs: 1,
+                                        nanos: 100,
+                                    }),
+                                }),
+                            }),
+                            owner_id: Some(objects_v31::RoleId {
+                                value: Some(objects_v31::role_id::Value::User(100)),
+                            }),
+                        },
+                    )],
+                )
+                .await
+                .unwrap();
+        }
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        let cluster_replica_v32: TypedCollection<
+            objects_v32::ClusterReplicaKey,
+            objects_v32::ClusterReplicaValue,
+        > = TypedCollection::new("compute_replicas");
+        let cluster_replicas = cluster_replica_v32.iter(&mut stash).await.unwrap();
+
+        let cluster_replicas: BTreeMap<_, _> = cluster_replicas
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect();
+
+        for (key, location) in [
+            (
+                10,
+                objects_v32::replica_config::Location::Managed(
+                    objects_v32::replica_config::ManagedLocation {
+                        size: "s".to_string(),
+                        availability_zone: Some("z".to_string()),
+                        disk: true,
+                    },
+                ),
+            ),
+            (
+                11,
+                objects_v32::replica_config::Location::Managed(
+                    objects_v32::replica_config::ManagedLocation {
+                        size: "s".to_string(),
+                        availability_zone: None,
+                        disk: true,
+                    },
+                ),
+            ),
+            (
+                12,
+                objects_v32::replica_config::Location::Unmanaged(
+                    objects_v32::replica_config::UnmanagedLocation {
+                        storagectl_addrs: vec!["one".to_string()],
+                        storage_addrs: vec!["two".to_string()],
+                        computectl_addrs: vec!["three".to_string()],
+                        compute_addrs: vec!["four".to_string()],
+                        workers: 50,
+                    },
+                ),
+            ),
+        ] {
+            assert_eq!(
+                cluster_replicas[&objects_v32::ClusterReplicaKey {
+                    id: Some(objects_v32::ReplicaId { value: key })
+                }],
+                objects_v32::ClusterReplicaValue {
+                    cluster_id: Some(objects_v32::ClusterId {
+                        value: Some(objects_v32::cluster_id::Value::User(1)),
+                    }),
+                    name: "gus".to_string(),
+                    config: Some(objects_v32::ReplicaConfig {
+                        location: Some(location),
+                        idle_arrangement_merge_effort: Some(objects_v32::ReplicaMergeEffort {
+                            effort: 1
+                        },),
+                        logging: Some(objects_v32::ReplicaLogging {
+                            log_logging: true,
+                            interval: Some(objects_v32::Duration {
+                                secs: 1,
+                                nanos: 100,
+                            }),
+                        }),
+                    }),
+                    owner_id: Some(objects_v32::RoleId {
+                        value: Some(objects_v32::role_id::Value::User(100)),
+                    }),
+                }
+            )
+        }
+    }
+}

--- a/test/cloudtest/test_antiaffinity.py
+++ b/test/cloudtest/test_antiaffinity.py
@@ -17,7 +17,9 @@ from materialize.cloudtest.wait import wait
 
 
 def zones_used(
-    mz: MaterializeApplication, replica_names: Optional[list[str]] = None
+    mz: MaterializeApplication,
+    replica_names: Optional[list[str]] = None,
+    cluster_name: str = "antiaffinity_cluster1",
 ) -> int:
     if replica_names is None:
         replica_names = [
@@ -28,9 +30,16 @@ def zones_used(
     nodes = {}
 
     for replica_name in replica_names:
-        cluster_id, replica_id = mz.environmentd.sql_query(
-            f"SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = '{replica_name}'"
-        )[0]
+
+        cluster_id = mz.environmentd.sql_query(
+            f"SELECT id FROM mz_clusters WHERE name = '{cluster_name}'"
+        )[0][0]
+        assert cluster_id is not None
+
+        replica_id = mz.environmentd.sql_query(
+            "SELECT id FROM mz_cluster_replicas "
+            f"WHERE cluster_id = '{cluster_id}' AND name = '{replica_name}'"
+        )[0][0]
         assert replica_id is not None
 
         cluster_pod = cluster_pod_name(cluster_id, replica_id)
@@ -124,12 +133,7 @@ def test_managed_set_azs(mz: MaterializeApplication) -> None:
     """Test that the AVAILABILITY ZONE argument to CREATE CLUSTER REPLICA is observed."""
 
     mz.environmentd.sql(
-        "ALTER SYSTEM SET enable_managed_clusters = true",
-        port="internal",
-        user="mz_system",
-    )
-    mz.environmentd.sql(
-        "ALTER SYSTEM SET enable_managed_availability_zones = true",
+        "ALTER SYSTEM SET enable_managed_cluster_availability_zones = true",
         port="internal",
         user="mz_system",
     )

--- a/test/cloudtest/test_antiaffinity.py
+++ b/test/cloudtest/test_antiaffinity.py
@@ -7,15 +7,18 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import pytest
 from typing import Optional
+
+import pytest
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.k8s import cluster_pod_name
 from materialize.cloudtest.wait import wait
 
 
-def zones_used(mz: MaterializeApplication, replica_names: Optional[list[str]] = None ) -> int:
+def zones_used(
+    mz: MaterializeApplication, replica_names: Optional[list[str]] = None
+) -> int:
     if replica_names is None:
         replica_names = [
             "antiaffinity_replica1",
@@ -132,14 +135,17 @@ def test_managed_set_azs(mz: MaterializeApplication) -> None:
         """
     )
 
-    assert zones_used(
-        mz,
-        replica_names=[
-            "r1",
-            "r2",
-            "r3",
-        ]
-    ) == 2
+    assert (
+        zones_used(
+            mz,
+            replica_names=[
+                "r1",
+                "r2",
+                "r3",
+            ],
+        )
+        == 2
+    )
 
     mz.environmentd.sql("DROP CLUSTER antiaffinity_cluster1 CASCADE")
 

--- a/test/cloudtest/test_antiaffinity.py
+++ b/test/cloudtest/test_antiaffinity.py
@@ -128,6 +128,11 @@ def test_managed_set_azs(mz: MaterializeApplication) -> None:
         port="internal",
         user="mz_system",
     )
+    mz.environmentd.sql(
+        "ALTER SYSTEM SET enable_managed_availability_zones = true",
+        port="internal",
+        user="mz_system",
+    )
 
     mz.environmentd.sql(
         """

--- a/test/cloudtest/test_managed_cluster.py
+++ b/test/cloudtest/test_managed_cluster.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from textwrap import dedent
+
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.k8s import cluster_pod_name
 from materialize.cloudtest.wait import wait
@@ -35,12 +37,15 @@ def test_managed_cluster_sizing(mz: MaterializeApplication) -> None:
     assert check is not None
     assert check == True
 
-    try:
-        mz.environmentd.sql("ALTER CLUSTER sized1 SET (AVAILABILITY ZONES ('4'))")
-    except:
-        pass
-    else:
-        assert False, "We shouldn't be able to set az's to an unknown az"
+    mz.testdrive.run(
+        input=dedent(
+            """
+            ! ALTER CLUSTER sized1 SET (AVAILABILITY ZONES ('4'))
+            exact:unknown cluster replica availability zone 4
+            """
+        ),
+        no_reset=True,
+    )
 
     replicas = mz.environmentd.sql_query(
         "SELECT mz_cluster_replicas.name, mz_cluster_replicas.id FROM mz_cluster_replicas JOIN mz_clusters ON mz_cluster_replicas.cluster_id = mz_clusters.id WHERE mz_clusters.name = 'sized1' ORDER BY 1"

--- a/test/cloudtest/test_system_clusters.py
+++ b/test/cloudtest/test_system_clusters.py
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import json
+
+from materialize.cloudtest.app.materialize_application import MaterializeApplication
+
+
+def assert_pod_properties(mz: MaterializeApplication, pod_name: str) -> None:
+    pod_desc = json.loads(mz.kubectl("get", "-o", "json", "pod", pod_name))
+    node_selector = pod_desc["spec"]["nodeSelector"]
+
+    assert any(
+        "disk" in k and v == "false" for k, v in node_selector.items()
+    ), f"pod {pod_name} does not have the disk=false selector"
+    assert not any(
+        "availability-zone" in k for k in node_selector.keys()
+    ), f"pod {pod_name} has a availability-zone selector"
+
+
+def test_system_clusters(mz: MaterializeApplication) -> None:
+    """Confirm that the system clusters have the expected labels and selectors"""
+    mz.wait_replicas()
+
+    assert_pod_properties(mz, "cluster-s1-replica-2-0")
+    assert_pod_properties(mz, "cluster-s2-replica-3-0")

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -78,6 +78,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 6  size  text
 7  replication_factor  uint4
 8  disk  boolean
+9  availability_zones  list
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_columns' ORDER BY position

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -216,8 +216,8 @@ ORDER BY r.id;
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#5]
-    Project (#0..=#3, #5, #13)
-      Join on=(#0 = #12 AND #2 = #4) type=differential
+    Project (#0..=#3, #5, #14)
+      Join on=(#0 = #13 AND #2 = #4) type=differential
         ArrangeBy keys=[[#2]]
           Project (#0..=#3)
             Get mz_catalog.mz_cluster_replicas


### PR DESCRIPTION
This pr implements the constraints as decided on here: https://www.notion.so/materialize/Top-down-replica-topology-constraints-038ebdf80e304e7daf987a1e8b0798f2

I recommend reviewing per-commit, described below. The commits that are related to the constraints themselves are the 1st and 3rd commit. 

@benesch where do we want to express the constraints to users? just not it in a notion doc for communication? or actually on the website?

### Motivation

  * This PR adds a known-desirable feature.

Closes: https://github.com/MaterializeInc/materialize/issues/20659

### Tips for reviewer

1st commit: scheduling constraints
2nd commit: fix and migrate the replica configs in stash
3rd commit: represent `MANAGED AVAILABILITY ZONES` as node affinities
4th commit: add `availability_zones` to `mz_clusters`
5th commit: configure scheduling constraints with LD
6th commit: fix some tests
7th commit: dd feature flag for `MANAGED AVAILABILITY ZONES`. _Note that this can be added backwards compatibly because we dont write cluster and replica sql down_. Existing clusters with `AVAILABILITY ZONES` configured can be checked for in prod once the 4th commit is pushed
8th commit: add soften node affinity flag

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - there will be a doc pr afterwards
  - adds `availability_zones` to `mz_clusters`
  - nullifies `availability_zone` in `mz_cluster_replicas` for non-user-specified ones
