### PR TITLE
adapter: dump most catalog state

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -12,6 +12,7 @@
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::net::Ipv4Addr;
+use std::ops::{Deref, DerefMut};
 use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -169,30 +170,55 @@ impl Clone for Catalog {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct CatalogState {
     database_by_name: BTreeMap<String, DatabaseId>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     database_by_id: BTreeMap<DatabaseId, Database>,
+    #[serde(serialize_with = "skip_temp_items")]
     entry_by_id: BTreeMap<GlobalId, CatalogEntry>,
     ambient_schemas_by_name: BTreeMap<String, SchemaId>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     ambient_schemas_by_id: BTreeMap<SchemaId, Schema>,
+    #[serde(skip)]
     temporary_schemas: BTreeMap<ConnectionId, Schema>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     clusters_by_id: BTreeMap<ClusterId, Cluster>,
     clusters_by_name: BTreeMap<String, ClusterId>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     clusters_by_linked_object_id: BTreeMap<GlobalId, ClusterId>,
     roles_by_name: BTreeMap<String, RoleId>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     roles_by_id: BTreeMap<RoleId, Role>,
+    #[serde(skip)]
     config: mz_sql::catalog::CatalogConfig,
+    #[serde(skip)]
     oid_counter: u32,
     cluster_replica_sizes: ClusterReplicaSizeMap,
+    #[serde(skip)]
     default_storage_cluster_size: Option<String>,
+    #[serde(skip)]
     availability_zones: Vec<String>,
+    #[serde(skip)]
     system_configuration: SystemVars,
     egress_ips: Vec<Ipv4Addr>,
     aws_principal_context: Option<AwsPrincipalContext>,
     aws_privatelink_availability_zones: Option<BTreeSet<String>>,
     default_privileges: DefaultPrivileges,
     system_privileges: PrivilegeMap,
+}
+
+fn skip_temp_items<S>(
+    entries: &BTreeMap<GlobalId, CatalogEntry>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    mz_ore::serde::map_key_to_string(
+        entries.iter().filter(|(_k, v)| v.conn_id().is_none()),
+        serializer,
+    )
 }
 
 impl CatalogState {
@@ -1508,15 +1534,15 @@ impl CatalogState {
     /// There are no guarantees about the format of the serialized state, except
     /// that the serialized state for two identical catalogs will compare
     /// identically.
-    pub fn dump(&self) -> String {
-        // Note: database_by_id is a Map whose keys are not Strings, but serializing
-        // a Map to JSON requires the keys be strings, hence the mapping here.
-        let database_by_str: BTreeMap<String, _> = self
-            .database_by_id
-            .iter()
-            .map(|(key, value)| (key.to_string(), value.debug_json()))
-            .collect();
-        serde_json::to_string(&database_by_str).expect("serialization cannot fail")
+    pub fn dump(&self) -> Result<String, Error> {
+        serde_json::to_string_pretty(&self).map_err(|e| {
+            Error::new(ErrorKind::Unstructured(format!(
+                // Don't panic here because we don't have compile-time failures for maps with
+                // non-string keys.
+                "internal error: could not dump catalog: {}",
+                e
+            )))
+        })
     }
 
     pub fn availability_zones(&self) -> &[String] {
@@ -1736,40 +1762,20 @@ impl ConnCatalog<'_> {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub struct Database {
     pub name: String,
     pub id: DatabaseId,
     #[serde(skip)]
     pub oid: u32,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     pub schemas_by_id: BTreeMap<SchemaId, Schema>,
     pub schemas_by_name: BTreeMap<String, SchemaId>,
     pub owner_id: RoleId,
     pub privileges: PrivilegeMap,
 }
 
-impl Database {
-    /// Returns a `Database` formatted as a `serde_json::Value` that is suitable for debugging. For
-    /// example `CatalogState::dump`.
-    fn debug_json(&self) -> serde_json::Value {
-        let schemas_by_str: BTreeMap<String, _> = self
-            .schemas_by_id
-            .iter()
-            .map(|(key, value)| (key.to_string(), value.debug_json()))
-            .collect();
-
-        serde_json::json!({
-            "name": self.name,
-            "id": self.id,
-            "schemas_by_id": schemas_by_str,
-            "schemas_by_name": self.schemas_by_name,
-            "owner_id": self.owner_id,
-            "privileges": self.privileges.debug_json(),
-        })
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
+#[derive(Debug, Serialize, Clone)]
 pub struct Schema {
     pub name: QualifiedSchemaName,
     pub id: SchemaSpecifier,
@@ -1779,21 +1785,6 @@ pub struct Schema {
     pub functions: BTreeMap<String, GlobalId>,
     pub owner_id: RoleId,
     pub privileges: PrivilegeMap,
-}
-
-impl Schema {
-    /// Returns a `Schema` formatted as a `serde_json::Value` that is suitable for debugging. For
-    /// example `CatalogState::dump`.
-    fn debug_json(&self) -> serde_json::Value {
-        serde_json::json!({
-            "name": self.name,
-            "id": self.id,
-            "items": self.items,
-            "functions": self.functions,
-            "owner_id": self.owner_id,
-            "privileges": self.privileges.debug_json(),
-        })
-    }
 }
 
 #[derive(Debug, Serialize, Clone)]
@@ -1862,12 +1853,14 @@ pub struct Cluster {
     pub name: String,
     pub id: ClusterId,
     pub config: ClusterConfig,
+    #[serde(skip)]
     pub log_indexes: BTreeMap<LogVariant, GlobalId>,
     pub linked_object_id: Option<GlobalId>,
     /// Objects bound to this cluster. Does not include introspection source
     /// indexes.
     pub bound_objects: BTreeSet<GlobalId>,
     pub replica_id_by_name: BTreeMap<String, ReplicaId>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
     pub replicas_by_id: BTreeMap<ReplicaId, ClusterReplica>,
     pub owner_id: RoleId,
     pub privileges: PrivilegeMap,
@@ -1898,6 +1891,7 @@ pub struct ClusterReplica {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
     pub config: ReplicaConfig,
+    #[serde(skip)]
     pub process_status: BTreeMap<ProcessId, ClusterReplicaProcessStatus>,
     pub owner_id: RoleId,
 }
@@ -1931,11 +1925,13 @@ pub struct ClusterReplicaProcessStatus {
     pub time: DateTime<Utc>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct CatalogEntry {
     item: CatalogItem,
+    #[serde(skip)]
     used_by: Vec<GlobalId>,
     id: GlobalId,
+    #[serde(skip)]
     oid: u32,
     name: QualifiedItemName,
     owner_id: RoleId,
@@ -1963,6 +1959,7 @@ pub struct Table {
     pub desc: RelationDesc,
     #[serde(skip)]
     pub defaults: Vec<Expr<Aug>>,
+    #[serde(skip)]
     pub conn_id: Option<ConnectionId>,
     pub resolved_ids: ResolvedIds,
     pub custom_logical_compaction_window: Option<Duration>,
@@ -2040,6 +2037,8 @@ impl DataSourceDesc {
 #[derive(Debug, Clone, Serialize)]
 pub struct Source {
     pub create_sql: String,
+    // TODO: Unskip: currently blocked on some inner BTreeMap<X, _> problems.
+    #[serde(skip)]
     pub data_source: DataSourceDesc,
     pub desc: RelationDesc,
     pub timeline: Timeline,
@@ -2228,6 +2227,7 @@ pub struct Sink {
     pub from: GlobalId,
     // TODO(benesch): this field duplicates information that could be derived
     // from the connection ID. Too hard to fix at the moment.
+    #[serde(skip)]
     pub connection: StorageSinkConnectionState,
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
@@ -2871,16 +2871,31 @@ struct AllocatedBuiltinSystemIds<T> {
     migrated_builtins: Vec<GlobalId>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Default)]
 pub struct DefaultPrivileges {
-    privileges: BTreeMap<DefaultPrivilegeObject, BTreeMap<RoleId, DefaultPrivilegeAclItem>>,
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
+    privileges: BTreeMap<DefaultPrivilegeObject, RoleDefaultPrivileges>,
 }
 
-impl Default for DefaultPrivileges {
-    fn default() -> DefaultPrivileges {
-        DefaultPrivileges {
-            privileges: Default::default(),
-        }
+// Use a new type here because otherwise we have two levels of BTreeMap, both needing
+// map_key_to_string.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Default)]
+struct RoleDefaultPrivileges(
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")]
+    BTreeMap<RoleId, DefaultPrivilegeAclItem>,
+);
+
+impl Deref for RoleDefaultPrivileges {
+    type Target = BTreeMap<RoleId, DefaultPrivilegeAclItem>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for RoleDefaultPrivileges {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
     }
 }
 
@@ -7476,8 +7491,8 @@ impl Catalog {
     /// There are no guarantees about the format of the serialized state, except
     /// that the serialized state for two identical catalogs will compare
     /// identically.
-    pub fn dump(&self) -> CatalogDump {
-        CatalogDump::new(self.state.dump())
+    pub fn dump(&self) -> Result<CatalogDump, Error> {
+        Ok(CatalogDump::new(self.state.dump()?))
     }
 
     pub fn config(&self) -> &mz_sql::catalog::CatalogConfig {

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -23,7 +23,7 @@ use mz_repr::GlobalId;
 use mz_secrets::SecretsReader;
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::session::vars::ConnectionCounter;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::catalog::storage;
 use crate::config::SystemParameterFrontend;
@@ -80,7 +80,7 @@ pub struct Config<'a> {
     pub active_connection_count: Arc<std::sync::Mutex<ConnectionCounter>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterReplicaSizeMap(pub BTreeMap<String, ReplicaAllocation>);
 
 impl Default for ClusterReplicaSizeMap {
@@ -185,7 +185,7 @@ impl Default for ClusterReplicaSizeMap {
 ///
 /// In the case of AWS PrivateLink connections, Materialize will connect to the
 /// VPC endpoint as the AWS Principal generated via this context.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AwsPrincipalContext {
     pub aws_account_id: String,
     pub aws_external_id_prefix: AwsExternalIdPrefix,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -166,7 +166,7 @@ impl Coordinator {
 
             Command::DumpCatalog { session, tx } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
-                tx.send(Ok(self.catalog().dump()), session);
+                tx.send(self.catalog().dump().map_err(AdapterError::from), session);
             }
 
             Command::CopyRows {

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -133,6 +133,8 @@ pub mod result;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]
 #[cfg(feature = "async")]
 pub mod retry;
+#[cfg(feature = "serde")]
+pub mod serde;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "stack")))]
 #[cfg(feature = "stack")]
 pub mod stack;

--- a/src/ore/src/serde.rs
+++ b/src/ore/src/serde.rs
@@ -1,0 +1,34 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Serde utilities.
+
+/// Used to serialize fields of Maps whose key type is not a native string. Annotate the field with
+/// `#[serde(serialize_with = mz_ore::serde::map_key_to_string)]`.
+pub fn map_key_to_string<'a, I, K, V, S>(map: I, serializer: S) -> Result<S::Ok, S::Error>
+where
+    I: IntoIterator<Item = (&'a K, &'a V)>,
+    K: std::fmt::Display + 'a,
+    V: serde::Serialize + 'a,
+    S: serde::Serializer,
+{
+    use serde::ser::SerializeMap;
+
+    let mut s = serializer.serialize_map(None)?;
+    for (key, value) in map {
+        s.serialize_entry(&key.to_string(), value)?;
+    }
+    s.end()
+}

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -519,7 +519,9 @@ impl Columnation for AclItem {
 
 /// A container of [`MzAclItem`]s that is optimized to look up an [`MzAclItem`] by the grantee.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize, Serialize)]
-pub struct PrivilegeMap(BTreeMap<RoleId, Vec<MzAclItem>>);
+pub struct PrivilegeMap(
+    #[serde(serialize_with = "mz_ore::serde::map_key_to_string")] BTreeMap<RoleId, Vec<MzAclItem>>,
+);
 
 impl PrivilegeMap {
     /// Creates a new empty `PrivilegeMap`.

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -1447,7 +1447,7 @@ impl Display for ErrorMessageObjectDescription {
 }
 
 /// Specification for objects that will be affected by a default privilege.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct DefaultPrivilegeObject {
     /// The role id that created the object.
     pub role_id: RoleId,
@@ -1476,8 +1476,15 @@ impl DefaultPrivilegeObject {
     }
 }
 
+impl std::fmt::Display for DefaultPrivilegeObject {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        // TODO: Don't just wrap Debug.
+        write!(f, "{self:?}")
+    }
+}
+
 /// Specification for the privileges that will be granted from default privileges.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize)]
 pub struct DefaultPrivilegeAclItem {
     /// The role that will receive the privileges.
     pub grantee: RoleId,

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -80,7 +80,7 @@ impl From<FullItemName> for UnresolvedItemName {
 
 /// A fully-qualified non-human readable name of an item in the catalog using IDs for the database
 /// and schema.
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
 pub struct QualifiedItemName {
     pub qualifiers: ItemQualifiers,
     pub item: String,
@@ -386,7 +386,7 @@ impl From<SchemaSpecifier> for SchemaId {
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Copy, Clone, Default)]
 pub struct Aug;
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 pub struct ItemQualifiers {
     pub database_spec: ResolvedDatabaseSpecifier,
     pub schema_spec: SchemaSpecifier,


### PR DESCRIPTION
Use serde to dump nearly all of the CatalogState struct. This provides much broader testdrive verification and also doesn't rely on humans to remember to add serialization when dependent structs change.

One risk is that the serialization is not roundtrippable, and that's not obvious to programmers who may assume they can add a `Deserialize` trait to many of these objects and it'll work as expected.

Fixes #20811

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
