### PR TITLE
mz_join_core: Do not flush on every iteration

### DIFF
--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -422,9 +422,8 @@ where
 
         let flush = |data: &mut Vec<_>, session: &mut Session<_, _, _>| {
             let old_len = data.len();
-            // TODO: This consolidation is optional, and it may not be very
-            //       helpful. We might try harder to understand whether we
-            //       should do this work here, or downstream at consumers.
+            // Consolidating here is important when the join closure produces data that
+            // consolidates well, for example when projecting columns.
             consolidate_updates(data);
             let recovered = old_len - data.len();
             session.give_iterator(data.drain(..));

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -478,7 +478,7 @@ where
         }
 
         if !temp.is_empty() {
-            flush(temp, &mut session);
+            *fuel += flush(temp, &mut session);
         }
 
         // We only get here after having iterated through all keys.


### PR DESCRIPTION
### Motivation

Collect output of `mz_join_core` across values on the left side of the inputs before passing the data to downstream operators. Specifically, only flush the data once we're running out of fuel or done. This has two benefits: We're sending data downstream less eagerly giving Timely the chance to collect fuller batches, and we consolidate larger batches of data, which can improve the effectivity and reduce the number of records passed to the downstream operator.

The implementation in this PR always consolidates before sending the data downstream. A different policy would be to only send the data downstream when consolidation yields no significant reduction in length. It's harder to track this reliably, risking a situation where we're repeatedly consolidating data, which is costly. This simpler policy should work fine, because we have a relatively large fuel of 1M elements.

[Slack for context](https://materializeinc.slack.com/archives/C05JJGG13EJ/p1690584257216499).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
