### PR TITLE
ci: Follow-up fixes from #20500

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -38,7 +38,8 @@ steps:
           - { value: zippy-postgres-cdc }
           - { value: zippy-cluster-replicas }
           - { value: zippy-crdb-latest }
-          - { value: secrets }
+          - { value: secrets-aws-secrets-manager }
+          - { value: secrets-local-file }
           - { value: checks-restart-cockroach }
           - { value: checks-restart-entire-mz }
           - { value: checks-parallel-drop-create-default-replica }
@@ -354,15 +355,25 @@ steps:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=55m]
 
-  - id: secrets
-    label: "Secrets"
+  - id: secrets-aws-secrets-manager
+    label: "Secrets AWS"
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
-          composition: secrets
+          composition: secrets-aws-secrets-manager
+
+  - id: secrets-local-file
+    label: "Secrets Local File"
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: secrets-local-file
 
   - id: checks-restart-cockroach
     label: "Checks + restart Cockroach"

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -154,7 +154,6 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             f"--persist-blob-url=s3://minio:minio123@persist/persist?endpoint={s3_endpoint}&region=minio",
             "--orchestrator=kubernetes",
             "--orchestrator-kubernetes-image-pull-policy=if-not-present",
-            "--secrets-controller=kubernetes",
             "--persist-consensus-url=postgres://root@cockroach.default:26257?options=--search_path=consensus",
             "--adapter-stash-url=postgres://root@cockroach.default:26257?options=--search_path=adapter",
             "--storage-stash-url=postgres://root@cockroach.default:26257?options=--search_path=storage",


### PR DESCRIPTION
- the two new tests that were introduced were not configured to run in CI
- a environmentd command-line option was used that is not valid for old versions
### Motivation

Nightly CI was failing.