### PR TITLE
slt: Fortify test/sqllogictest/regex.slt

### DIFF
--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -113,7 +113,7 @@ SELECT regexp_match('ABC', 'a.*', 'ci');
 ----
 {ABC}
 
-query error db error: ERROR: invalid regular expression: regex parse error:
+query error invalid regular expression: regex parse error:
 SELECT 'abs' ~ '\';
 
 # Case-insensitive vs. case-sensitive regexes when there is no full const folding, but MirScalarExpr::reduce changes


### PR DESCRIPTION
The query returns an error with a different prefix depending on whether it was executed stand-alone or as part of a materialized view.

Fix by having SLT match only on the common part of the two error messages.


### Motivation

Nightly SLT, which runs each SELECT both stand-alone and as a materialized view reported that the two different executions return different error messages:

```
materialize=>     SELECT 'abs' ~ '\';
ERROR:  invalid regular expression: regex parse error:
    \
    ^
error: incomplete escape sequence, reached end of pattern prematurely
materialize=>     CREATE VIEW "v5752706b431d4d15a28d2d56413ac5d1" AS SELECT 'abs' ~ '\';
CREATE VIEW
materialize=>     CREATE DEFAULT INDEX ON "v5752706b431d4d15a28d2d56413ac5d1";
CREATE INDEX
materialize=>     SELECT * FROM "v5752706b431d4d15a28d2d56413ac5d1";
ERROR:  Evaluation error: invalid regular expression: regex parse error:
    \
    ^
```
The second error has an "Evaluation error" prefix, but the stand-alone SELECT invocation does not have it.