### PR TITLE
Enable memory.slt

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -32,6 +32,7 @@ tests=(
     test/sqllogictest/introspection/*.slt \
     test/sqllogictest/explain/*.slt \
     test/sqllogictest/transform/*.slt \
+    test/sqllogictest/special/* \
 )
 tests_without_views=(
     # errors:


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/20826. This tries to enable `memory.slt`.

Execution of SQL logic tests: https://buildkite.com/materialize/sql-logic-tests/builds/5628 ✅ 