### PR TITLE
cloud-api: handle successful request with no content

### DIFF
--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -17,7 +17,7 @@
 //! Frontegg client is used to request and manage the access token.
 use std::sync::Arc;
 
-use reqwest::{Method, RequestBuilder, Url};
+use reqwest::{Method, RequestBuilder, Url, StatusCode};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 
@@ -125,7 +125,11 @@ impl Client {
         let res = req.send().await?;
         let status_code = res.status();
         if status_code.is_success() {
-            Ok(res.json().await?)
+            if status_code == StatusCode::NO_CONTENT {
+                Err(Error::SuccesfullButNoContent)
+            } else {
+                Ok(res.json().await?)
+            }
         } else {
             match res.json::<ErrorResponse>().await {
                 Ok(e) => {

--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -17,7 +17,7 @@
 //! Frontegg client is used to request and manage the access token.
 use std::sync::Arc;
 
-use reqwest::{Method, RequestBuilder, Url, StatusCode};
+use reqwest::{Method, RequestBuilder, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 

--- a/src/cloud-api/src/client/region.rs
+++ b/src/cloud-api/src/client/region.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use reqwest::Method;
-use serde::{Deserialize, Serialize, Deserializer};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::client::cloud_provider::CloudProvider;
 use crate::client::{Client, Error};
@@ -51,7 +51,6 @@ pub struct RegionInfo {
     pub enabled_at: Option<DateTime<Utc>>,
 }
 
-
 impl Client {
     /// Get a customer region in a partciular cloud region for the current user.
     pub async fn get_region(&self, provider: CloudProvider) -> Result<Region, Error> {
@@ -61,12 +60,8 @@ impl Client {
             .await?;
 
         match self.send_request(req).await {
-            Ok(region) => {
-                Ok(region)
-            },
-            Err(Error::SuccesfullButNoContent) => {
-                Err(Error::EmptyRegion)
-            }
+            Ok(region) => Ok(region),
+            Err(Error::SuccesfullButNoContent) => Err(Error::EmptyRegion),
             Err(e) => Err(e),
         }
     }

--- a/src/cloud-api/src/client/region.rs
+++ b/src/cloud-api/src/client/region.rs
@@ -18,8 +18,8 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use reqwest::{Method, StatusCode};
-use serde::{Deserialize, Serialize};
+use reqwest::Method;
+use serde::{Deserialize, Serialize, Deserializer};
 
 use crate::client::cloud_provider::CloudProvider;
 use crate::client::{Client, Error};
@@ -51,12 +51,6 @@ pub struct RegionInfo {
     pub enabled_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Debug, Deserialize, Clone)]
-#[serde(untagged)]
-enum APIResponse {
-    Empty,
-    Region(Region),
-}
 
 impl Client {
     /// Get a customer region in a partciular cloud region for the current user.
@@ -66,14 +60,12 @@ impl Client {
             .build_region_request(Method::GET, ["api", "region"], &provider)
             .await?;
 
-        match self.send_request::<APIResponse>(req).await {
-            Ok(APIResponse::Region(region)) => Ok(region),
-            Ok(APIResponse::Empty) => Err(Error::EmptyRegion),
-            Err(Error::Api(err)) => {
-                if err.status_code == StatusCode::NOT_FOUND {
-                    return Err(Error::EmptyRegion);
-                }
-                Err(Error::Api(err))
+        match self.send_request(req).await {
+            Ok(region) => {
+                Ok(region)
+            },
+            Err(Error::SuccesfullButNoContent) => {
+                Err(Error::EmptyRegion)
             }
             Err(e) => Err(e),
         }
@@ -141,6 +133,20 @@ impl Client {
     /// A request returning a 202 indicates that
     /// no region is available to delete (the delete request is complete.)
     pub async fn delete_region(&self, cloud_provider: CloudProvider) -> Result<(), Error> {
+        /// A struct that deserializes nothing.
+        ///
+        /// Useful for deserializing empty response bodies.
+        struct Empty;
+
+        impl<'de> Deserialize<'de> for Empty {
+            fn deserialize<D>(_: D) -> Result<Empty, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                Ok(Empty)
+            }
+        }
+
         // We need to continuously try to delete the environment
         // until it succeeds (Status code: 202) or an unexpected error occurs.
         let mut loops = 0;
@@ -154,7 +160,7 @@ impl Client {
             // This timeout corresponds to the same in our cloud services tests.
             let req = req.timeout(Duration::from_secs(305));
 
-            match self.send_request::<APIResponse>(req).await {
+            match self.send_request::<Empty>(req).await {
                 Ok(_) => break Ok(()), // The request was successful, no environment is available to delete anymore.
                 Err(Error::Api(err)) => {
                     if err.status_code != 504 {

--- a/src/cloud-api/src/error.rs
+++ b/src/cloud-api/src/error.rs
@@ -89,7 +89,7 @@ pub enum Error {
     #[error("Timeout reached.")]
     TimeoutError,
     /// Indicates that the request was executed successfully but returns no content (204).
-    /// E.g.: It happens when the region is enabled but not ready yet.
+    /// E.g.: It happens when trying to request information from a not enabled region.
     #[error("Succesfull but no content.")]
     SuccesfullButNoContent,
 }

--- a/src/cloud-api/src/error.rs
+++ b/src/cloud-api/src/error.rs
@@ -91,5 +91,5 @@ pub enum Error {
     /// Indicates that the request was executed successfully but returns no content (204).
     /// E.g.: It happens when the region is enabled but not ready yet.
     #[error("Succesfull but no content.")]
-    SuccesfullButNoContent
+    SuccesfullButNoContent,
 }

--- a/src/cloud-api/src/error.rs
+++ b/src/cloud-api/src/error.rs
@@ -88,4 +88,8 @@ pub enum Error {
     /// Indicates that a timeout has been reached.
     #[error("Timeout reached.")]
     TimeoutError,
+    /// Indicates that the request was executed successfully but returns no content (204).
+    /// E.g.: It happens when the region is enabled but not ready yet.
+    #[error("Succesfull but no content.")]
+    SuccesfullButNoContent
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds a little logic to return an error (`SuccesfullButNoContent`) and avoids parsing the JSON content for `204 (No Content)` requests.

The old approach tries to parse the content and produces a parsing error, even when using an `Empty` struct with a custom `Deserialize` implementation to "parse nothing". It seems that `No Content` != `Empty Content`.

This change only affects the `GET` method for `/api/regions/`. The `DELETE` method ha no problem accepting the `Empty` struct.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
