### PR TITLE
[persist] Infrastructure for streaming consolidation

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -62,6 +62,9 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # reduce CRDB load as we are struggling with it in CI:
     "persist_next_listen_batch_retryer_clamp": "100ms",
     "persist_next_listen_batch_retryer_initial_backoff": "1200ms",
+    # Advance coverage on some Persist internals changes
+    "persist_streaming_compaction_enabled": "true",
+    "persist_streaming_snapshot_and_fetch_enabled": "true",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -164,6 +164,7 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
         pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
         rollup_threshold: Some(config.persist_rollup_threshold()),
+        feature_flags: config.persist_flags(),
     }
 }
 

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -32,6 +32,7 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
     optional uint64 stats_budget_bytes = 17;
     optional ProtoUntrimmableColumns stats_untrimmable_columns = 18;
+    map<string, bool> feature_flags = 19;
 }
 
 message ProtoRetryParameters {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -484,6 +484,10 @@ impl DynamicConfig {
         self.feature_flags[flag.name].load(DynamicConfig::LOAD_ORDERING)
     }
 
+    pub fn set_flag(&self, flag: PersistFlag, to: bool) {
+        self.feature_flags[flag.name].store(to, DynamicConfig::STORE_ORDERING);
+    }
+
     /// The maximum number of parts (s3 blobs) that [crate::batch::BatchBuilder]
     /// will pipeline before back-pressuring [crate::batch::BatchBuilder::add]
     /// calls on previous ones finishing.
@@ -1066,7 +1070,7 @@ impl PersistParameters {
         }
         for flag in PersistFlag::ALL {
             if let Some(value) = feature_flags.get(flag.name) {
-                cfg.dynamic.feature_flags[flag.name].store(*value, DynamicConfig::STORE_ORDERING);
+                cfg.dynamic.set_flag(*flag, *value);
             }
         }
     }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -35,7 +35,7 @@ use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
 use crate::cfg::{MiB, PersistFlag};
-use crate::fetch::{fetch_batch_part, Cursor, EncodedPart};
+use crate::fetch::{fetch_batch_part, Cursor, EncodedPart, FetchBatchFilter};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
 use crate::internal::machine::{retry_external, Machine};
@@ -684,7 +684,12 @@ where
             true,
         );
 
-        let mut consolidator = Consolidator::new(desc.since().clone(), prefetch_budget_bytes);
+        let mut consolidator = Consolidator::new(
+            FetchBatchFilter::Compaction {
+                since: desc.since().clone(),
+            },
+            prefetch_budget_bytes,
+        );
 
         for (desc, parts) in runs {
             consolidator.enqueue_run(

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -34,7 +34,7 @@ use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
-use crate::cfg::{MiB, PersistFlag};
+use crate::cfg::{MiB, PersistFeatureFlag};
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart, FetchBatchFilter};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
@@ -87,7 +87,9 @@ impl CompactConfig {
             compaction_yield_after_n_updates: value.compaction_yield_after_n_updates,
             version: value.build_version.clone(),
             batch: BatchBuilderConfig::new(value, writer_id),
-            streaming_compact: value.dynamic.enabled(PersistFlag::STREAMING_COMPACTION),
+            streaming_compact: value
+                .dynamic
+                .enabled(PersistFeatureFlag::STREAMING_COMPACTION),
         }
     }
 }

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -34,7 +34,7 @@ use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
-use crate::cfg::MiB;
+use crate::cfg::{MiB, PersistFlag};
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
@@ -42,6 +42,7 @@ use crate::internal::machine::{retry_external, Machine};
 use crate::internal::metrics::ShardMetrics;
 use crate::internal::state::{HollowBatch, HollowBatchPart};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
+use crate::iter::Consolidator;
 use crate::{Metrics, PersistConfig, ShardId, WriterId};
 
 /// A request for compaction.
@@ -75,6 +76,7 @@ pub struct CompactConfig {
     pub(crate) compaction_yield_after_n_updates: usize,
     pub(crate) version: semver::Version,
     pub(crate) batch: BatchBuilderConfig,
+    pub(crate) streaming_compact: bool,
 }
 
 impl CompactConfig {
@@ -85,6 +87,7 @@ impl CompactConfig {
             compaction_yield_after_n_updates: value.compaction_yield_after_n_updates,
             version: value.build_version.clone(),
             batch: BatchBuilderConfig::new(value, writer_id),
+            streaming_compact: value.dynamic.enabled(PersistFlag::STREAMING_COMPACTION),
         }
     }
 }
@@ -634,6 +637,88 @@ where
         ordered_runs
     }
 
+    async fn compact_runs_streaming<'a>(
+        // note: 'a cannot be elided due to https://github.com/rust-lang/rust/issues/63033
+        cfg: &'a CompactConfig,
+        shard_id: &'a ShardId,
+        desc: &'a Description<T>,
+        runs: Vec<(&'a Description<T>, &'a [HollowBatchPart])>,
+        blob: Arc<dyn Blob + Send + Sync>,
+        metrics: Arc<Metrics>,
+        shard_metrics: Arc<ShardMetrics>,
+        isolated_runtime: Arc<IsolatedRuntime>,
+        real_schemas: Schemas<K, V>,
+    ) -> Result<HollowBatch<T>, anyhow::Error> {
+        // TODO: Figure out a more principled way to allocate our memory budget.
+        // Currently, we give any excess budget to write parallelism. If we had
+        // to pick between 100% towards writes vs 100% towards reads, then reads
+        // is almost certainly better, but the ideal is probably somewhere in
+        // between the two.
+        //
+        // For now, invent some some extra budget out of thin air for prefetch.
+        let prefetch_budget_bytes = 2 * cfg.batch.blob_target_size;
+
+        let timings = Timings::default();
+
+        // Old style compaction operates on the encoded bytes and doesn't need
+        // the real schema, so we synthesize one. We use the real schema for
+        // stats though (see below).
+        let fake_compaction_schema = Schemas {
+            key: Arc::new(VecU8Schema),
+            val: Arc::new(VecU8Schema),
+        };
+
+        let mut batch = BatchBuilderInternal::<Vec<u8>, Vec<u8>, T, D>::new(
+            cfg.batch.clone(),
+            Arc::clone(&metrics),
+            Arc::clone(&shard_metrics),
+            fake_compaction_schema,
+            metrics.compaction.batch.clone(),
+            desc.lower().clone(),
+            Arc::clone(&blob),
+            isolated_runtime,
+            shard_id.clone(),
+            cfg.version.clone(),
+            desc.since().clone(),
+            Some(desc.upper().clone()),
+            true,
+        );
+
+        let mut consolidator = Consolidator::new(desc.since().clone(), prefetch_budget_bytes);
+
+        for (desc, parts) in runs {
+            consolidator.enqueue_run(
+                *shard_id,
+                &blob,
+                &metrics,
+                |m| &m.compaction,
+                &shard_metrics,
+                desc,
+                parts,
+            );
+        }
+
+        let remaining_budget = consolidator.start_prefetches();
+        if remaining_budget.is_none() {
+            metrics.compaction.not_all_prefetched.inc();
+        }
+
+        while let Some(updates) = consolidator.next().await {
+            for (k, v, t, d) in updates.take(cfg.compaction_yield_after_n_updates) {
+                batch
+                    .add(&real_schemas, &k.to_vec(), &v.to_vec(), &t, &d)
+                    .await?;
+            }
+            tokio::task::yield_now().await;
+        }
+        let batch = batch.finish(&real_schemas, desc.upper().clone()).await?;
+        let hollow_batch = batch.into_hollow_batch();
+
+        timings.record(&metrics);
+
+        Ok(hollow_batch)
+    }
+
     /// Compacts runs together. If the input runs are sorted, a single run will be created as output
     ///
     /// Maximum possible memory usage is `(# runs + 2) * [crate::PersistConfig::blob_target_size]`
@@ -649,6 +734,20 @@ where
         isolated_runtime: Arc<IsolatedRuntime>,
         real_schemas: Schemas<K, V>,
     ) -> Result<HollowBatch<T>, anyhow::Error> {
+        if cfg.streaming_compact {
+            return Self::compact_runs_streaming(
+                cfg,
+                shard_id,
+                desc,
+                runs,
+                blob,
+                metrics,
+                shard_metrics,
+                isolated_runtime,
+                real_schemas,
+            )
+            .await;
+        }
         // TODO: Figure out a more principled way to allocate our memory budget.
         // Currently, we give any excess budget to write parallelism. If we had
         // to pick between 100% towards writes vs 100% towards reads, then reads

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1032,6 +1032,7 @@ pub mod datadriven {
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
     };
+    use crate::cfg::PersistFlag;
     use crate::fetch::{fetch_batch_part, Cursor};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
@@ -1069,6 +1070,14 @@ pub mod datadriven {
                 .cfg
                 .dynamic
                 .set_blob_target_size(PersistConfig::DEFAULT_BLOB_TARGET_SIZE);
+            client
+                .cfg
+                .dynamic
+                .set_flag(PersistFlag::STREAMING_COMPACTION, true);
+            client
+                .cfg
+                .dynamic
+                .set_flag(PersistFlag::STREAMING_SNAPSHOT_AND_FETCH, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1032,7 +1032,7 @@ pub mod datadriven {
     use crate::batch::{
         validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
     };
-    use crate::cfg::PersistFlag;
+    use crate::cfg::PersistFeatureFlag;
     use crate::fetch::{fetch_batch_part, Cursor};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
     use crate::internal::datadriven::DirectiveArgs;
@@ -1073,11 +1073,11 @@ pub mod datadriven {
             client
                 .cfg
                 .dynamic
-                .set_flag(PersistFlag::STREAMING_COMPACTION, true);
+                .set_feature_flag(PersistFeatureFlag::STREAMING_COMPACTION, true);
             client
                 .cfg
                 .dynamic
-                .set_flag(PersistFlag::STREAMING_SNAPSHOT_AND_FETCH, true);
+                .set_feature_flag(PersistFeatureFlag::STREAMING_SNAPSHOT_AND_FETCH, true);
             let state_versions = Arc::new(StateVersions::new(
                 client.cfg.clone(),
                 Arc::clone(&client.consensus),

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1150,6 +1150,7 @@ pub struct ShardsMetrics {
     blob_gets: mz_ore::metrics::IntCounterVec,
     blob_sets: mz_ore::metrics::IntCounterVec,
     live_writers: mz_ore::metrics::UIntGaugeVec,
+    unconsolidated_snapshot: mz_ore::metrics::IntCounterVec,
     // We hand out `Arc<ShardMetrics>` to read and write handles, but store it
     // here as `Weak`. This allows us to discover if it's no longer in use and
     // so we can remove it from the map.
@@ -1312,6 +1313,11 @@ impl ShardsMetrics {
                 help: "number of writers that have recently appended updates to this shard",
                 var_labels: ["shard", "name"],
             )),
+            unconsolidated_snapshot: registry.register(metric!(
+                name: "mz_persist_shard_unconsolidated_snapshot",
+                help: "in snapshot_and_read, the number of times consolidating the raw data wasn't enough to produce consolidated output",
+                var_labels: ["shard", "name"],
+            )),
             shards,
         }
     }
@@ -1384,6 +1390,7 @@ pub struct ShardMetrics {
     pub blob_gets: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub blob_sets: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub live_writers: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
+    pub unconsolidated_snapshot: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
 
 impl ShardMetrics {
@@ -1474,7 +1481,10 @@ impl ShardMetrics {
                 .get_delete_on_drop_counter(vec![shard.clone(), name.to_string()]),
             live_writers: shards_metrics
                 .live_writers
-                .get_delete_on_drop_gauge(vec![shard, name.to_string()]),
+                .get_delete_on_drop_gauge(vec![shard.clone(), name.to_string()]),
+            unconsolidated_snapshot: shards_metrics
+                .unconsolidated_snapshot
+                .get_delete_on_drop_counter(vec![shard, name.to_string()]),
         }
     }
 

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -1,0 +1,738 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Code for iterating through one or more parts, including streaming consolidation.
+
+use std::cmp::Reverse;
+use std::collections::binary_heap::PeekMut;
+use std::collections::{BinaryHeap, VecDeque};
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use differential_dataflow::consolidation::consolidate_updates;
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
+use futures_util::stream::FuturesUnordered;
+use futures_util::StreamExt;
+use mz_persist::location::Blob;
+use mz_persist_types::Codec64;
+use timely::progress::{Antichain, Timestamp};
+use tokio::task::JoinHandle;
+use tracing::{debug_span, Instrument};
+
+use crate::fetch::{fetch_batch_part, Cursor, EncodedPart};
+use crate::internal::metrics::{BatchPartReadMetrics, ReadMetrics, ShardMetrics};
+use crate::internal::paths::PartialBatchKey;
+use crate::internal::state::HollowBatchPart;
+use crate::metrics::Metrics;
+use crate::ShardId;
+
+type Tuple<T, D> = ((Vec<u8>, Vec<u8>), T, D);
+type TupleRef<'a, T, D> = (&'a [u8], &'a [u8], T, D);
+
+fn borrow_tuple<T: Clone, D: Clone>(((k, v), t, d): &Tuple<T, D>) -> TupleRef<T, D> {
+    (k.as_slice(), v.as_slice(), t.clone(), d.clone())
+}
+
+fn clone_tuple<T, D>((k, v, t, d): TupleRef<T, D>) -> Tuple<T, D> {
+    ((k.to_vec(), v.to_vec()), t, d)
+}
+
+/// The data needed to fetch a batch part, bundled up to make it easy
+/// to send between threads.
+#[derive(Debug)]
+pub(crate) struct FetchData<T> {
+    shard_id: ShardId,
+    blob: Arc<dyn Blob + Send + Sync>,
+    metrics: Arc<Metrics>,
+    read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
+    shard_metrics: Arc<ShardMetrics>,
+    part_key: PartialBatchKey,
+    part_desc: Description<T>,
+}
+
+impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
+    async fn fetch(self) -> anyhow::Result<EncodedPart<T>> {
+        let Self {
+            shard_id,
+            blob,
+            metrics,
+            read_metrics,
+            shard_metrics,
+            part_key,
+            part_desc,
+        } = self;
+        metrics.compaction.parts_prefetched.inc();
+        fetch_batch_part(
+            &shard_id,
+            &*blob,
+            &metrics,
+            &shard_metrics,
+            read_metrics(&metrics.read),
+            &part_key,
+            &part_desc,
+        )
+        .await
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ConsolidationPart<T, D> {
+    Queued {
+        data: Option<FetchData<T>>,
+    },
+    Prefetched {
+        handle: JoinHandle<anyhow::Result<EncodedPart<T>>>,
+        metrics: Arc<Metrics>,
+    },
+    Encoded {
+        part: EncodedPart<T>,
+        cursor: Cursor,
+    },
+    Sorted {
+        data: Vec<((Vec<u8>, Vec<u8>), T, D)>,
+        index: usize,
+    },
+}
+
+impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> ConsolidationPart<T, D> {
+    pub(crate) fn from_encoded(part: EncodedPart<T>, as_of: &Antichain<T>) -> Self {
+        let mut cursor = Cursor::default();
+        if part.maybe_unconsolidated() {
+            Self::from_iter(ConsolidationPartIter::encoded(&part, &mut cursor, as_of))
+        } else {
+            ConsolidationPart::Encoded { part, cursor }
+        }
+    }
+
+    pub(crate) fn from_iter(data: impl IntoIterator<Item = TupleRef<'a, T, D>>) -> Self
+    where
+        D: Semigroup,
+    {
+        let mut data: Vec<_> = data.into_iter().map(clone_tuple).collect();
+        consolidate_updates(&mut data);
+        Self::Sorted { data, index: 0 }
+    }
+
+    async fn join(&mut self, as_of: &Antichain<T>) -> anyhow::Result<()> {
+        match self {
+            ConsolidationPart::Queued { data } => {
+                let data = data.take().expect("unfetched");
+                data.metrics.compaction.parts_waited.inc();
+                *self = Self::from_encoded(data.fetch().await?, as_of);
+            }
+            ConsolidationPart::Prefetched { handle, metrics } => {
+                metrics.compaction.parts_waited.inc();
+                *self = Self::from_encoded(handle.await??, as_of);
+            }
+            ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
+        }
+        Ok(())
+    }
+
+    /// This requires a mutable pointer because the cursor may need to scan ahead to find the next
+    /// valid record.
+    pub(crate) fn is_empty(&mut self) -> bool {
+        match self {
+            ConsolidationPart::Encoded { part, cursor, .. } => cursor.peek(part).is_none(),
+            ConsolidationPart::Sorted { data, index } => data.len() <= *index,
+            ConsolidationPart::Queued { .. } | ConsolidationPart::Prefetched { .. } => false,
+        }
+    }
+}
+
+/// A tool for incrementally consolidating a persist shard.
+///
+/// The naive way to consolidate a Persist shard would be to fetch every part, then consolidate
+/// the whole thing. We'd like to improve on that in two ways:
+/// - Concurrency: we'd like to be able to start consolidating and returning results before every
+///   part is fetched. (And continue fetching while we're doing other work.)
+/// - Memory usage: we'd like to limit the number of parts we have in memory at once, dropping
+///   parts that are fully consolidated and fetching parts just a little before they're needed.
+///
+/// This interface supports this by consolidating in multiple steps. Each call to [Self::next]
+/// will do some housekeeping work -- prefetching needed parts, dropping any unneeded parts -- and
+/// return  an iterator over a consolidated subset of the data. To read an entire dataset, the
+/// client should call `next` until it returns `None`, which signals all data has been returned...
+/// but it's also free to abandon the instance at any time if it eg. only needs a few entries.
+#[derive(Debug)]
+pub(crate) struct Consolidator<T, D> {
+    runs: Vec<VecDeque<(ConsolidationPart<T, D>, usize)>>,
+    as_of: Antichain<T>,
+    budget: usize,
+    // NB: this is the tricky part!
+    // One hazard of streaming consolidation is that we may start consolidating a particular KVT,
+    // but not be able to finish, because some other part that might also contain the same KVT
+    // (and thus consolidate) may not have been fetched yet. Let's call such a KVT an "incomplete"
+    // tuple. These two fields are used to "carry over" incomplete tuples between calls
+    // to `next`: `initial_state` is used to pass an incomplete tuple to the next round of
+    // consolidation, and `drop_stash` is used to stow any incomplete tuple when the consolidating
+    // iter is dropped.
+    initial_state: Option<Tuple<T, D>>,
+    drop_stash: Option<Tuple<T, D>>,
+}
+
+impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D> {
+    /// Create a new [Self] instance with the given prefetch budget. This budget is a "soft limit"
+    /// on the size of the parts that the consolidator will fetch... we'll try and stay below the
+    /// limit, but may burst above it if that's necessary to make progress.
+    pub fn new(as_of: Antichain<T>, prefetch_budget_bytes: usize) -> Self {
+        Self {
+            runs: vec![],
+            as_of,
+            budget: prefetch_budget_bytes,
+            initial_state: None,
+            drop_stash: None,
+        }
+    }
+
+    /// Add another run of data to be consolidated.
+    ///
+    /// To ensure consolidation, every tuple in this run should be larger than any tuple already
+    /// returned from the iterator. At the moment, this invariant is not checked. The simplest way
+    /// to ensure this is to enqueue every run before any calls to next.
+    // TODO(bkirwi): enforce this invariant, either by forcing all runs to be pre-registered or with an assert.
+    // TODO(bkirwi): try moving some of these params into the constructor when the dust settles.
+    pub fn enqueue_run<'a>(
+        &mut self,
+        shard_id: ShardId,
+        blob: &Arc<dyn Blob + Send + Sync>,
+        metrics: &Arc<Metrics>,
+        read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
+        shard_metrics: &Arc<ShardMetrics>,
+        desc: &Description<T>,
+        parts: impl IntoIterator<Item = &'a HollowBatchPart>,
+    ) {
+        let run = parts
+            .into_iter()
+            .map(|part: &HollowBatchPart| {
+                let c_part = ConsolidationPart::Queued {
+                    data: Some(FetchData {
+                        shard_id,
+                        blob: Arc::clone(blob),
+                        metrics: Arc::clone(metrics),
+                        read_metrics,
+                        shard_metrics: Arc::clone(shard_metrics),
+                        part_key: part.key.clone(),
+                        part_desc: desc.clone(),
+                    }),
+                };
+                let size = part.encoded_size_bytes;
+                (c_part, size)
+            })
+            .collect();
+        self.runs.push(run);
+    }
+
+    /// Tidy up: discard any empty parts, and discard any runs that have no parts left.
+    fn trim(&mut self) {
+        self.runs.retain_mut(|run| {
+            while run.front_mut().map_or(false, |(part, _)| part.is_empty()) {
+                run.pop_front();
+            }
+            !run.is_empty()
+        });
+
+        // Some budget may have just been freed up: start prefetching.
+        self.start_prefetches();
+    }
+
+    /// Return an iterator over the next consolidated chunk of output, if there's any left.
+    ///
+    /// Requirement: at least the first part of each run should be fetched and nonempty.
+    fn iter(&mut self) -> Option<ConsolidatingIter<T, D>> {
+        // At this point, the `initial_state` of the previously-returned iterator has either been
+        // fully consolidated and returned, or put back into `drop_stash`. In either case, this is
+        // safe to overwrite.
+        self.initial_state = self.drop_stash.take();
+        if self.initial_state.is_none() && self.runs.is_empty() {
+            return None;
+        }
+
+        let mut iter = ConsolidatingIter::new(
+            self.initial_state.as_ref().map(borrow_tuple),
+            &mut self.drop_stash,
+        );
+
+        for run in &mut self.runs {
+            let last_in_run = run.len() < 2;
+            if let Some((part, _)) = run.front_mut() {
+                let part_iter = match part {
+                    ConsolidationPart::Encoded { part, cursor } => {
+                        ConsolidationPartIter::encoded(part, cursor, &self.as_of)
+                    }
+                    ConsolidationPart::Sorted { data, index } => {
+                        ConsolidationPartIter::Sorted { data, index }
+                    }
+                    ConsolidationPart::Queued { .. } | ConsolidationPart::Prefetched { .. } => {
+                        // Unreachable from the public API: we always join on the first part of every
+                        // run in `next`, so we should never encounter an unfetched part here.
+                        // TODO: when we have lower bounds on keys in the stats, we could insert a
+                        // placeholder here instead.
+                        panic!("trying to create an interator from an unfetched part!")
+                    }
+                };
+                iter.push(part_iter, last_in_run);
+            }
+        }
+
+        Some(iter)
+    }
+
+    /// Wait until the next part in every run is available, then return an iterator over the next
+    /// consolidated chunk of output. If this method returns `None`, that all the data has been
+    /// exhausted and the full consolidated dataset has been returned.
+    pub(crate) async fn next(&mut self) -> Option<ConsolidatingIter<T, D>> {
+        self.trim();
+        let futures: FuturesUnordered<_> = self
+            .runs
+            .iter_mut()
+            .map(|run| async {
+                run.front_mut()
+                    .expect("trimmed run should be nonempty")
+                    .0
+                    .join(&self.as_of)
+                    .await
+                    .expect("fetching data to succeed")
+            })
+            .collect();
+        let () = futures.collect().await;
+        self.iter()
+    }
+
+    /// The size of the data that we _might_ be holding concurrently in memory. While this is
+    /// normally kept less than the budget, it may burst over it temporarily, since we need at
+    /// least one part in every run to continue making progress.
+    fn live_bytes(&self) -> usize {
+        self.runs
+            .iter()
+            .flat_map(|run| {
+                run.iter().map(|(part, size)| match part {
+                    ConsolidationPart::Queued { .. } => 0,
+                    ConsolidationPart::Prefetched { .. }
+                    | ConsolidationPart::Encoded { .. }
+                    | ConsolidationPart::Sorted { .. } => *size,
+                })
+            })
+            .sum()
+    }
+
+    /// Returns None if the budget was exhausted, or Some(remaining_bytes) if it is not.
+    pub(crate) fn start_prefetches(&mut self) -> Option<usize> {
+        let mut prefetch_budget_bytes = self.budget;
+
+        let mut check_budget = |size| {
+            // Subtract the amount from the budget, returning None if the budget is exhausted.
+            prefetch_budget_bytes
+                .checked_sub(size)
+                .map(|remaining| prefetch_budget_bytes = remaining)
+        };
+
+        // First account for how much budget has already been used
+        let live_bytes = self.live_bytes();
+        check_budget(live_bytes)?;
+        // Iterate through parts in a certain order (attempting to match the
+        // order in which they'll be fetched), prefetching until we run out of
+        // budget.
+        //
+        // The order used here is the first part of each run, then the second, etc.
+        // There's a bunch of heuristics we could use here, but we'd get it exactly
+        // correct if we stored on HollowBatchPart the actual kv bounds of data
+        // contained in each part and go in sorted order of that. This information
+        // would also be useful for pushing MFP down into persist reads, so it seems
+        // like we might want to do it at some point. As a result, don't think too
+        // hard about this heuristic at first.
+        let max_run_len = self.runs.iter().map(|x| x.len()).max().unwrap_or_default();
+        for idx in 0..max_run_len {
+            for run in self.runs.iter_mut() {
+                let Some((c_part, size)) = run.get_mut(idx) else {
+                    continue;
+                };
+
+                if let ConsolidationPart::Queued { data } = c_part {
+                    check_budget(*size)?;
+                    let data = data.take().expect("unfetched");
+                    let metrics = Arc::clone(&data.metrics);
+                    let span = debug_span!("compaction::prefetch");
+                    let handle = mz_ore::task::spawn(
+                        || "persist::compaction::prefetch",
+                        async move { data.fetch().await }.instrument(span),
+                    );
+                    *c_part = ConsolidationPart::Prefetched { handle, metrics };
+                }
+            }
+        }
+
+        Some(prefetch_budget_bytes)
+    }
+}
+
+/// The mutable references in this iterator (the [Cursor] for an encoded part, or the index for a
+/// sorted one) point to state that outlives this iterator, and we take care not to advance them
+/// too eagerly.
+/// In particular, we only advance the cursor past a tuple when that tuple has been returned from
+/// a call to `next`.
+#[derive(Debug)]
+pub(crate) enum ConsolidationPartIter<'a, T: Timestamp, D> {
+    Encoded {
+        part: &'a EncodedPart<T>,
+        cursor: &'a mut Cursor,
+        as_of: &'a Antichain<T>,
+        // The tuple that would be returned by the next call to `cursor.peek`, with the timestamp
+        // advanced to the as-of.
+        next: Option<TupleRef<'a, T, D>>,
+    },
+    Sorted {
+        data: &'a [((Vec<u8>, Vec<u8>), T, D)],
+        index: &'a mut usize,
+    },
+}
+
+impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64> ConsolidationPartIter<'a, T, D> {
+    fn encoded(
+        part: &'a EncodedPart<T>,
+        cursor: &'a mut Cursor,
+        as_of: &'a Antichain<T>,
+    ) -> ConsolidationPartIter<'a, T, D> {
+        let mut iter = Self::Encoded {
+            part,
+            cursor,
+            as_of,
+            next: None,
+        };
+        iter.next(); // Advance to the next valid entry in the part
+        iter
+    }
+    fn peek(&self) -> Option<TupleRef<'a, T, D>> {
+        match self {
+            Self::Encoded { next, .. } => next.clone(),
+            Self::Sorted { data, index } => Some(borrow_tuple(data.get(**index)?)),
+        }
+    }
+}
+
+impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64> Iterator
+    for ConsolidationPartIter<'a, T, D>
+{
+    type Item = TupleRef<'a, T, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            ConsolidationPartIter::Encoded {
+                part,
+                cursor,
+                as_of,
+                next,
+            } => {
+                let out = next.take();
+                if out.is_some() {
+                    cursor.advance(part);
+                }
+                *next = cursor.peek(part).map(|(k, v, mut t, d)| {
+                    t.advance_by(as_of.borrow());
+                    (k, v, t, D::decode(d))
+                });
+                out
+            }
+            ConsolidationPartIter::Sorted { data, index } => {
+                let tuple = data.get(**index)?;
+                **index += 1;
+                Some(borrow_tuple(tuple))
+            }
+        }
+    }
+}
+
+/// This is used as a max-heap entry: the ordering of the fields is important!
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq)]
+struct PartRef<'a, T: Timestamp, D> {
+    /// The smallest KVT that might be emitted from this run in the future.
+    /// This is reverse-sorted: Nones will sort largest (and be popped first on the heap)
+    /// and smaller keys will be popped before larger keys.
+    next_kvt: Reverse<Option<(&'a [u8], &'a [u8], T)>>,
+    /// The index of the corresponding iterator.
+    index: usize,
+    /// Whether / not the iterator for the part is the last in its run, or whether there may be
+    /// iterators for the same part in the future.
+    last_in_run: bool,
+    _phantom: PhantomData<D>,
+}
+
+impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> PartRef<'a, T, D> {
+    fn update_peek(&mut self, iter: &mut ConsolidationPartIter<'a, T, D>) {
+        let peek = iter.peek();
+        self.next_kvt = Reverse(peek.map(|(k, v, t, _)| (k, v, t)));
+    }
+
+    fn pop(&mut self, from: &mut [ConsolidationPartIter<'a, T, D>]) -> Option<TupleRef<'a, T, D>> {
+        let iter = &mut from[self.index];
+        let popped = iter.next();
+        self.update_peek(iter);
+        popped
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct ConsolidatingIter<'a, T: Timestamp, D> {
+    parts: Vec<ConsolidationPartIter<'a, T, D>>,
+    heap: BinaryHeap<PartRef<'a, T, D>>,
+    state: Option<TupleRef<'a, T, D>>,
+    drop_stash: &'a mut Option<Tuple<T, D>>,
+}
+
+impl<'a, T, D> ConsolidatingIter<'a, T, D>
+where
+    T: Timestamp + Codec64 + Lattice,
+    D: Codec64 + Semigroup,
+{
+    pub fn new(
+        init_state: Option<TupleRef<'a, T, D>>,
+        drop_stash: &'a mut Option<Tuple<T, D>>,
+    ) -> Self {
+        Self {
+            parts: vec![],
+            heap: BinaryHeap::new(),
+            state: init_state,
+            drop_stash,
+        }
+    }
+
+    fn push(&mut self, mut iter: ConsolidationPartIter<'a, T, D>, last_in_run: bool) {
+        let mut part_ref = PartRef {
+            next_kvt: Reverse(None),
+            index: self.parts.len(),
+            last_in_run,
+            _phantom: Default::default(),
+        };
+        part_ref.update_peek(&mut iter);
+        self.parts.push(iter);
+        self.heap.push(part_ref);
+    }
+
+    /// Attempt to consolidate as much into the current state as possible.
+    fn consolidate(&mut self) -> Option<TupleRef<'a, T, D>> {
+        loop {
+            let Some(mut part) = self.heap.peek_mut() else {
+                break;
+            };
+            match part.next_kvt.0.as_ref() {
+                None => {
+                    if part.last_in_run {
+                        PeekMut::pop(part);
+                    } else {
+                        // NB: this is the only case this method exits without returning the current state:
+                        // there may be more instances of the KVT in a later part of the same run.
+                        return None;
+                    }
+                }
+                Some((k1, v1, t1)) => match &mut self.state {
+                    None => {
+                        self.state = part.pop(&mut self.parts);
+                    }
+                    Some((k0, v0, t0, d0)) => {
+                        if (*k0, *v0, &*t0) == (*k1, *v1, t1) {
+                            let (_, _, _, d1) = part
+                                .pop(&mut self.parts)
+                                .expect("popping from a non-empty iterator");
+                            d0.plus_equals(&d1);
+                        } else {
+                            break;
+                        }
+                    }
+                },
+            }
+        }
+        self.state.take()
+    }
+}
+
+impl<'a, T, D> Iterator for ConsolidatingIter<'a, T, D>
+where
+    T: Timestamp + Codec64 + Lattice,
+    D: Codec64 + Semigroup,
+{
+    type Item = TupleRef<'a, T, D>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            match self.consolidate() {
+                Some((_, _, _, d)) if d.is_zero() => continue,
+                other => break other,
+            }
+        }
+    }
+}
+
+impl<'a, T: Timestamp, D> Drop for ConsolidatingIter<'a, T, D> {
+    fn drop(&mut self) {
+        // Make sure to stash any incomplete state in a place where we'll pick it up on the next run.
+        // See the comment on `Consolidator` for more on why this is necessary.
+        *self.drop_stash = self.state.take().map(clone_tuple);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+
+    use differential_dataflow::trace::Description;
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+    use timely::progress::Antichain;
+
+    use mz_ore::metrics::MetricsRegistry;
+    use mz_persist::location::Blob;
+    use mz_persist::mem::{MemBlob, MemBlobConfig};
+
+    use crate::cfg::PersistConfig;
+    use crate::internal::paths::PartialBatchKey;
+    use crate::internal::state::HollowBatchPart;
+    use crate::metrics::Metrics;
+    use crate::ShardId;
+
+    #[mz_ore::test]
+    fn consolidation() {
+        // Check that output consolidated via this logic matches output consolidated via timely's!
+        type Part = Vec<((Vec<u8>, Vec<u8>), u64, i64)>;
+
+        fn check(parts: Vec<(Part, usize)>) {
+            let original = {
+                let mut rows = parts
+                    .iter()
+                    .flat_map(|(p, _)| p.clone())
+                    .collect::<Vec<_>>();
+                consolidate_updates(&mut rows);
+                rows
+            };
+            let streaming = {
+                // Toy compaction loop!
+                let mut consolidator = Consolidator {
+                    // Generated runs of data that are sorted, but not necessarily consolidated.
+                    // This is because timestamp-advancement may cause us to have duplicate KVTs,
+                    // including those that span runs.
+                    runs: parts
+                        .into_iter()
+                        .map(|(mut part, cut)| {
+                            part.sort();
+                            let part_2 = part.split_off(cut.min(part.len()));
+                            [part, part_2]
+                                .into_iter()
+                                .map(|part| {
+                                    (
+                                        ConsolidationPart::from_iter(part.iter().map(borrow_tuple)),
+                                        0,
+                                    )
+                                })
+                                .collect::<VecDeque<_>>()
+                        })
+                        .collect::<Vec<_>>(),
+                    as_of: Antichain::from_elem(0),
+                    budget: 0,
+                    initial_state: None,
+                    drop_stash: None,
+                };
+
+                let mut out = vec![];
+                loop {
+                    consolidator.trim();
+                    let Some(iter) = consolidator.iter() else {
+                        break;
+                    };
+                    out.extend(iter.map(clone_tuple));
+                }
+                out
+            };
+
+            assert_eq!(original, streaming);
+        }
+
+        // Restricting the ranges to help make sure we have frequent collisions
+        let key_gen = (0..4usize).prop_map(|i| i.to_string().into_bytes()).boxed();
+        let part_gen = vec(
+            ((key_gen.clone(), key_gen.clone()), 0..10u64, -3..=3i64),
+            0..10,
+        );
+        let run_gen = vec((part_gen, 0..10usize), 0..5);
+        proptest!(|(state in run_gen)| {
+            check(state)
+        });
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn prefetches() {
+        fn check(budget: usize, runs: Vec<Vec<usize>>) {
+            let desc = Description::new(
+                Antichain::from_elem(0u64),
+                Antichain::new(),
+                Antichain::from_elem(0u64),
+            );
+
+            let total_size: usize = runs.iter().flat_map(|run| run.iter().map(|p| *p)).sum();
+
+            let shard_id = ShardId::new();
+            let blob: Arc<dyn Blob + Send + Sync> =
+                Arc::new(MemBlob::open(MemBlobConfig::default()));
+            let metrics = Arc::new(Metrics::new(
+                &PersistConfig::new_for_tests(),
+                &MetricsRegistry::new(),
+            ));
+            let shard_metrics = metrics.shards.shard(&shard_id, "");
+
+            let mut consolidator: Consolidator<u64, i64> =
+                Consolidator::new(desc.since().clone(), budget);
+
+            for run in runs {
+                let parts: Vec<_> = run
+                    .into_iter()
+                    .map(|encoded_size_bytes| HollowBatchPart {
+                        key: PartialBatchKey("".into()),
+                        encoded_size_bytes,
+                        key_lower: vec![],
+                        stats: None,
+                    })
+                    .collect();
+                consolidator.enqueue_run(
+                    shard_id,
+                    &blob,
+                    &metrics,
+                    |m| &m.batch_fetcher,
+                    &shard_metrics,
+                    &desc,
+                    &parts,
+                )
+            }
+
+            // No matter what, the budget should be respected.
+            let remaining = consolidator.start_prefetches();
+            let live_bytes = consolidator.live_bytes();
+            assert!(live_bytes <= budget, "budget should be respected");
+            match remaining {
+                None => assert!(live_bytes < total_size, "not all parts fetched"),
+                Some(remaining) => assert_eq!(
+                    live_bytes + remaining,
+                    budget,
+                    "remaining should match budget"
+                ),
+            }
+
+            // If we up the budget to match the total size, we should prefetch everything.
+            consolidator.budget = total_size;
+            assert!(consolidator.start_prefetches() == Some(0));
+        }
+
+        let run_gen = vec(vec(0..20usize, 0..5usize), 0..5usize);
+        proptest!(|(budget in 0..20usize, state in run_gen)| {
+            check(budget, state)
+        });
+    }
+}

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -140,6 +140,7 @@ pub mod operators {
     //! [timely] operators for reading and writing persist Shards.
     pub mod shard_source;
 }
+pub mod iter;
 pub mod read;
 pub mod rpc;
 pub mod stats;

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -34,7 +34,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug, debug_span, instrument, trace_span, warn, Instrument};
 use uuid::Uuid;
 
-use crate::cfg::PersistFlag;
+use crate::cfg::PersistFeatureFlag;
 use crate::fetch::{
     fetch_leased_part, BatchFetcher, FetchBatchFilter, FetchedPart, LeasedBatchPart,
     SerdeLeasedBatchPart, SerdeLeasedBatchPartMetadata,
@@ -1041,7 +1041,7 @@ where
             .applier
             .cfg
             .dynamic
-            .enabled(PersistFlag::STREAMING_SNAPSHOT_AND_FETCH)
+            .enabled(PersistFeatureFlag::STREAMING_SNAPSHOT_AND_FETCH)
         {
             return self.snapshot_and_fetch_streaming(as_of).await;
         }

--- a/src/persist-client/tests/machine/compaction_bounded
+++ b/src/persist-client/tests/machine/compaction_bounded
@@ -42,21 +42,19 @@ part 0
 # most importantly, we expect there to be a single run, as each input has a single run of ordered parts
 compact output=b0_1 inputs=(b0,b1) lower=0 upper=6 since=6 target_size=50 memory_bound=10000
 ----
-parts=3 len=4
+parts=2 len=4
 
 fetch-batch input=b0_1
 ----
 <part 0>
 a 6 2
-<part 1>
 b 6 2
-<part 2>
+<part 1>
 c 6 1
 d 6 1
 <run 0>
 part 0
 part 1
-part 2
 
 write-batch output=b2 lower=6 upper=9 target_size=0 parts_size_override=25
 a 8 1
@@ -83,32 +81,25 @@ f 8 1
 part 0
 
 # compact b0, b1, b2 with enough memory for all runs, but a target size that can only hold 2 keys in mem at a time.
-# we expect `aaaa` to appear twice because we calculate part size by unconsolidated updates.
 compact output=b0_1_2 inputs=(b0,b1,b2) lower=0 upper=9 since=8 target_size=50 memory_bound=1000
 ----
-parts=5 len=8
+parts=3 len=6
 
 fetch-batch input=b0_1_2
 ----
 <part 0>
-a 8 2
+a 8 3
+b 8 2
 <part 1>
-a 8 1
-b 8 1
-<part 2>
-b 8 1
 c 8 1
-<part 3>
 d 8 1
+<part 2>
 e 8 1
-<part 4>
 f 8 1
 <run 0>
 part 0
 part 1
 part 2
-part 3
-part 4
 
 # compact b0, b1, b2 with enough memory for all keys, but only 2 runs at a time. this means
 # b0 and b1 will be physically compacted together, but b2 will be compacted in isolation.
@@ -164,29 +155,27 @@ ok
 
 compact output=b0_1_2 inputs=(b0,b1,b2) lower=0 upper=9 since=8 target_size=50 memory_bound=200
 ----
-parts=5 len=7
+parts=4 len=7
 
 fetch-batch input=b0_1_2
 ----
 <part 0>
 a 8 2
-<part 1>
 b 8 2
-<part 2>
+<part 1>
 c 8 1
 d 8 1
-<part 3>
+<part 2>
 a 8 1
 e 8 1
-<part 4>
+<part 3>
 f 8 1
 <run 0>
 part 0
 part 1
-part 2
 <run 1>
+part 2
 part 3
-part 4
 
 # compact b0, b1, b2 even though our memory isn't enough to hold any 2 runs at a time. this is an edge case
 # where we still force 2 runs to be merged together when possible, even at the expense of our memory requirement.
@@ -206,29 +195,27 @@ ok
 
 compact output=b0_1_2 inputs=(b0,b1,b2) lower=0 upper=9 since=8 target_size=50 memory_bound=200
 ----
-parts=5 len=7
+parts=4 len=7
 
 fetch-batch input=b0_1_2
 ----
 <part 0>
 a 8 2
-<part 1>
 b 8 2
-<part 2>
+<part 1>
 c 8 1
 d 8 1
-<part 3>
+<part 2>
 a 8 1
 e 8 1
-<part 4>
+<part 3>
 f 8 1
 <run 0>
 part 0
 part 1
-part 2
 <run 1>
+part 2
 part 3
-part 4
 
 # for good measure, repeatedly compacting a single batch of several runs should eventually
 # converge to 1 run even if there isn't enough memory to hold more than 2 runs at a time
@@ -246,8 +233,8 @@ fetch-batch input=b0_1_2_iter1
 a 8 3
 b 8 2
 c 8 1
-<part 1>
 d 8 1
+<part 1>
 e 8 1
 f 8 1
 <run 0>

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -136,7 +136,7 @@ pub trait Codec: Sized + 'static {
 
 /// Encoding and decoding operations for a type usable as a persisted timestamp
 /// or diff.
-pub trait Codec64: Sized + 'static {
+pub trait Codec64: Sized + Clone + 'static {
     /// Name of the codec.
     ///
     /// This name is stored for the timestamp and diff when a stream is first

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -80,7 +80,7 @@ use mz_ore::cast;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_persist_client::batch::UntrimmableColumns;
-use mz_persist_client::cfg::{PersistConfig, PersistFlag};
+use mz_persist_client::cfg::{PersistConfig, PersistFeatureFlag};
 use mz_repr::adt::numeric::Numeric;
 use mz_sql_parser::ast::TransactionIsolationLevel;
 use mz_tracing::CloneableEnvFilter;
@@ -2313,7 +2313,7 @@ impl SystemVars {
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
             );
 
-        for flag in PersistFlag::ALL {
+        for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
         }
 
@@ -2856,7 +2856,7 @@ impl SystemVars {
     }
 
     pub fn persist_flags(&self) -> BTreeMap<String, bool> {
-        PersistFlag::ALL
+        PersistFeatureFlag::ALL
             .iter()
             .map(|f| (f.name.to_owned(), *self.expect_value(&f.into())))
             .collect()
@@ -3128,8 +3128,8 @@ where
     }
 }
 
-impl From<&'static PersistFlag> for ServerVar<bool> {
-    fn from(value: &'static PersistFlag) -> Self {
+impl From<&'static PersistFeatureFlag> for ServerVar<bool> {
+    fn from(value: &'static PersistFeatureFlag) -> Self {
         Self {
             name: UncasedStr::new(value.name),
             // Awkward dance to get a static reference to a boolean...
@@ -4529,7 +4529,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_UNTRIMMABLE_COLUMNS.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
-        || PersistFlag::ALL.iter().any(|f| f.name == name)
+        || PersistFeatureFlag::ALL.iter().any(|f| f.name == name)
 }
 
 /// Returns whether the named variable is a cluster scheduling config

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -80,7 +80,7 @@ use mz_ore::cast;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
 use mz_persist_client::batch::UntrimmableColumns;
-use mz_persist_client::cfg::PersistConfig;
+use mz_persist_client::cfg::{PersistConfig, PersistFlag};
 use mz_repr::adt::numeric::Numeric;
 use mz_sql_parser::ast::TransactionIsolationLevel;
 use mz_tracing::CloneableEnvFilter;
@@ -1533,6 +1533,14 @@ feature_flags!(
         enable_multi_worker_storage_persist_sink,
         "multi-worker storage persist sink"
     ),
+    (
+        enable_persist_streaming_snapshot_and_fetch,
+        "use the new streaming consolidate for snapshot_and_fetch"
+    ),
+    (
+        enable_persist_streaming_compaction,
+        "use the new streaming consolidate for compaction"
+    ),
     (enable_raise_statement, "RAISE statement"),
     (enable_repeat_row, "the repeat_row function"),
     (
@@ -2305,11 +2313,15 @@ impl SystemVars {
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
             );
 
+        for flag in PersistFlag::ALL {
+            vars = vars.with_var(&flag.into())
+        }
+
         vars.refresh_internal_state();
         vars
     }
 
-    fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
+    fn with_var<V>(mut self, var: &ServerVar<V>) -> Self
     where
         V: Value + Debug + PartialEq + Clone + 'static,
         V::Owned: Debug + Send + Clone + Sync,
@@ -2843,6 +2855,13 @@ impl SystemVars {
         *self.expect_value(&PERSIST_ROLLUP_THRESHOLD)
     }
 
+    pub fn persist_flags(&self) -> BTreeMap<String, bool> {
+        PersistFlag::ALL
+            .iter()
+            .map(|f| (f.name.to_owned(), *self.expect_value(&f.into())))
+            .collect()
+    }
+
     /// Returns the `metrics_retention` configuration parameter.
     pub fn metrics_retention(&self) -> Duration {
         *self.expect_value(&METRICS_RETENTION)
@@ -3060,6 +3079,19 @@ where
     internal: bool,
 }
 
+// ServerVar is mostly just a bundle of static refs, so cloning is cheap and does not require
+// cloning the value.
+impl<V: Debug + 'static> Clone for ServerVar<V> {
+    fn clone(&self) -> Self {
+        Self {
+            name: self.name,
+            value: self.value,
+            description: self.description,
+            internal: self.internal,
+        }
+    }
+}
+
 impl<V> Var for ServerVar<V>
 where
     V: Value + Debug + PartialEq + 'static,
@@ -3096,6 +3128,18 @@ where
     }
 }
 
+impl From<&'static PersistFlag> for ServerVar<bool> {
+    fn from(value: &'static PersistFlag) -> Self {
+        Self {
+            name: UncasedStr::new(value.name),
+            // Awkward dance to get a static reference to a boolean...
+            value: &value.default,
+            description: value.description,
+            internal: true,
+        }
+    }
+}
+
 /// A `SystemVar` is persisted on disk value for a configuration parameter. If unset,
 /// the server default is used instead.
 #[derive(Debug)]
@@ -3106,7 +3150,7 @@ where
 {
     persisted_value: Option<V::Owned>,
     dynamic_default: Option<V::Owned>,
-    parent: &'static ServerVar<V>,
+    parent: ServerVar<V>,
     constraints: Vec<ValueConstraint<V>>,
 }
 
@@ -3120,7 +3164,7 @@ where
         SystemVar {
             persisted_value: self.persisted_value.clone(),
             dynamic_default: self.dynamic_default.clone(),
-            parent: self.parent,
+            parent: self.parent.clone(),
             constraints: self.constraints.clone(),
         }
     }
@@ -3131,11 +3175,11 @@ where
     V: Value + Debug + PartialEq + 'static,
     V::Owned: Debug + Clone + Send + Sync,
 {
-    fn new(parent: &'static ServerVar<V>) -> SystemVar<V> {
+    fn new(parent: &ServerVar<V>) -> SystemVar<V> {
         SystemVar {
             persisted_value: None,
             dynamic_default: None,
-            parent,
+            parent: parent.clone(),
             constraints: vec![],
         }
     }
@@ -4485,6 +4529,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_UNTRIMMABLE_COLUMNS.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
+        || PersistFlag::ALL.iter().any(|f| f.name == name)
 }
 
 /// Returns whether the named variable is a cluster scheduling config


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This work was done as support for #20708, but it's a generally useful capability that we may need for #18244 and similar projects.

### Tips for reviewer

This PR also switches some existing code to use the new thing:
- Compaction! In theory this should be more efficient (O(n) instead of O(n log n)) and require fewer small allocations. In the future, we could consider even removing the consolidate_updates call in the buffer itself.
- `snapshot_and_fetch`. This is now concurrent, configured similarly to compaction.
   - Since we'll generally have at least one part per run fetched at a time, this may use more memory than before. However, it might also use less memory than before, since generally rows will consolidate out immediately instead of hanging out in the buffer. So far it seems okay?

I wanted to include these, because if we couldn't use this new thing to implement them than something was wrong. But I suspect this is too much for a initial PR, especially out from behind a feature flag. Tell me how you feel!

Since not all historical data that was supposed to be consolidated is actually consolidated -- see https://github.com/MaterializeInc/materialize/pull/21182 and https://github.com/MaterializeInc/materialize/pull/21029 -- it is possible that our output is also not consolidated. Right now this doesn't really impact anything, since the data ends up getting consolidated again later in both cases, but we'll need to think about it before relying on a guarantee. (Tentative idea: pick a version after which we expect all data to be consolidated and explicitly sort any data from earlier than that we encounter, once it's rare enough that the cost isn't prohibitive.)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
