### PR TITLE
ci: Do not report a panic deliberately caused in a test

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -57,6 +57,8 @@ ERROR_RE = re.compile(
     (?!.*aborting\ because\ propagate_crashes\ is\ enabled)
     # Emitted by webhook source tests that explicitly panic the validation.
     (?!.*webhook\ panic\ test')
+    # Emitted by unit test at src/persist-client/src/cache.rs:765
+    (?!.*thread\ 'cache::tests::state_cache'\ panicked\ at\ 'boom')
     """,
     re.VERBOSE,
 )


### PR DESCRIPTION
A rust unit test causes a deliberate panic which should not be reported as an "unknown error" in the CI.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Nightly CI was reporting a false positive.