### PR TITLE
miri: Skip tests that are no longer compatible

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -879,6 +879,7 @@ mod tests {
     use super::*;
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn batch_builder_flushing() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -971,6 +972,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn batch_builder_keys() {
         let cache = PersistClientCache::new_no_metrics();
         // Set blob_target_size to 0 so that each row gets forced into its own batch part
@@ -1012,6 +1014,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn batch_builder_partial_order() {
         let cache = PersistClientCache::new_no_metrics();
         // Set blob_target_size to 0 so that each row gets forced into its own batch part

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -659,6 +659,7 @@ mod tests {
     use super::*;
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn client_cache() {
         let cache = PersistClientCache::new(
             PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
@@ -726,6 +727,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn state_cache() {
         mz_ore::test::init_logging();
         fn new_state<K, V, T, D>(shard_id: ShardId) -> TypedState<K, V, T, D>

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -377,6 +377,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn rate_limit() {
         let client = crate::tests::new_test_client().await;
 
@@ -408,6 +409,7 @@ mod tests {
 
     // Verifies that the handle updates its view of the opaque token correctly
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn handle_opaque_token() {
         let client = new_test_client().await;
         let shard_id = ShardId::new();

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1015,6 +1015,7 @@ mod tests {
     // made it to main) where batches written by compaction would always have a
     // since of the minimum timestamp.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn regression_minimum_since() {
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),
@@ -1081,6 +1082,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn compaction_partial_order() {
         let data = vec![
             (
@@ -1165,6 +1167,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn prefetches() {
         let desc = Description::new(
             Antichain::from_elem(0u64),

--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -1392,6 +1392,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn state_diff_migration_rollups() {
         let r1_rollup = HollowRollup {
             key: PartialRollupKey("foo".to_owned()),

--- a/src/persist-client/src/internal/state_versions.rs
+++ b/src/persist-client/src/internal/state_versions.rs
@@ -1022,6 +1022,7 @@ mod tests {
     /// Regression test for (part of) #17752, where an interrupted
     /// `bin/environmentd --reset` resulted in panic in persist usage code.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn fetch_all_live_states_regression_uninitialized() {
         let client = new_test_client().await;
         let state_versions = StateVersions::new(

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -274,6 +274,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn state_watch_listen_snapshot() {
         mz_ore::test::init_logging();
         let waker = noop_waker();

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -880,6 +880,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn sanity_check() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -927,6 +928,7 @@ mod tests {
 
     // Sanity check that the open_reader and open_writer calls work.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn open_reader_writer() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1238,6 +1240,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn multiple_shards() {
         let data1 = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1278,6 +1281,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn fetch_upper() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1309,6 +1313,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn append_with_invalid_upper() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1372,6 +1377,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn compare_and_append() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1428,6 +1434,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn overlapping_append() {
         mz_ore::test::init_logging_default("info");
 
@@ -1478,6 +1485,7 @@ mod tests {
     // Appends need to be contiguous for a shard, meaning the lower of an appended batch must not
     // be in advance of the current shard upper.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn contiguous_append() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1525,6 +1533,7 @@ mod tests {
     // Per-writer appends can be non-contiguous, as long as appends to the shard from all writers
     // combined are contiguous.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn noncontiguous_append_per_writer() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1567,6 +1576,7 @@ mod tests {
     // Compare_and_appends need to be contiguous for a shard, meaning the lower of an appended
     // batch needs to match the current shard upper.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn contiguous_compare_and_append() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1613,6 +1623,7 @@ mod tests {
     // Per-writer compare_and_appends can be non-contiguous, as long as appends to the shard from
     // all writers combined are contiguous.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn noncontiguous_compare_and_append_per_writer() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -1820,6 +1831,7 @@ mod tests {
     // immediately return the data currently available instead of waiting for
     // upper to advance past as_of.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn regression_blocking_reads() {
         let waker = noop_waker();
         let mut cx = Context::from_waker(&waker);
@@ -1891,6 +1903,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn heartbeat_task_shutdown() {
         // Verify that the ReadHandle and WriteHandle background heartbeat tasks
         // shut down cleanly after the handle is expired.
@@ -1920,6 +1933,7 @@ mod tests {
     /// maybe_heartbeat_writer or maybe_heartbeat_reader on a "tombstone" shard
     /// would panic.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn regression_16743_heartbeat_tombstone() {
         const EMPTY: &[(((), ()), u64, i64)] = &[];
         let (mut write, mut read) = new_test_client()

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -639,6 +639,7 @@ mod tests {
     /// NOTE: This test is weird: if everything is good it will pass. If we
     /// break the assumption that we test this will time out and we will notice.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_implicit_initial_as_of() {
         let (persist_clients, location) = new_test_client_cache_and_location();
 
@@ -707,6 +708,7 @@ mod tests {
     /// NOTE: This test is weird: if everything is good it will pass. If we
     /// break the assumption that we test this will time out and we will notice.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_explicit_initial_as_of() {
         let (persist_clients, location) = new_test_client_cache_and_location();
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1168,6 +1168,7 @@ mod tests {
 
     // Verifies `Subscribe` can be dropped while holding snapshot batches.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn drop_unused_subscribe() {
         let data = vec![
             (("0".to_owned(), "zero".to_owned()), 0, 1),

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -528,6 +528,7 @@ impl StorageUsageClient {
     ///
     /// Can be safely called within retry_external to ensure it succeeds
     #[cfg(test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn size(
         &self,
         prefix: BlobKeyPrefix<'_>,
@@ -741,6 +742,7 @@ mod tests {
     use super::*;
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn size() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -911,6 +913,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn usage_referenced() {
         mz_ore::test::init_logging();
 
@@ -1228,6 +1231,7 @@ mod tests {
     /// initial rollup is written for a shard, but the initial CaS hasn't yet
     /// succeeded.
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn usage_regression_shard_in_blob_not_consensus() {
         let client = new_test_client().await;
         let shard_id = ShardId::new();

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -732,6 +732,7 @@ mod tests {
     use super::*;
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn empty_batches() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -771,6 +772,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn compare_and_append_batch_multi() {
         let data0 = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),
@@ -838,6 +840,7 @@ mod tests {
     }
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn hollow_batch_roundtrip() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),


### PR DESCRIPTION
Those tests all fail to run under miri with:

error: unsupported operation: returning ready events from epoll_wait is not yet implemented

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
