### PR TITLE
doc: discuss second statements in single stmt txn doc

### DIFF
--- a/doc/developer/design/20230720_single_statement_explitic_transaction.md
+++ b/doc/developer/design/20230720_single_statement_explitic_transaction.md
@@ -82,6 +82,7 @@ The pgwire, http, and ws handlers enforce these requirements and state changes.
 
 This design adds a new operation to the inner transaction: `SingleStatement`.
 This operation records a single statement.
+If a second statement is added to the transaction with this operation, the transaction fails.
 The post processing for this operation enqueues to the Coordinator a message containing the statement and session, which is processed by a new `sequence_execute_single_statement_transaction` method.
 This method:
 1. Asserts the session's transaction is in `Default`, which should be a side effect of running it through `sequence_end_transaction` from the `COMMIT`.


### PR DESCRIPTION
Requested followup from original PR.

### Motivation

  * This PR improves a design doc.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a