### PR TITLE
adapter: stop LD client when `ENABLE_LAUNCHDARKLY = off`

### DIFF
--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -26,7 +26,7 @@ use mz_sql::session::vars::ConnectionCounter;
 use serde::{Deserialize, Serialize};
 
 use crate::catalog::storage;
-use crate::config::SystemParameterFrontend;
+use crate::config::SystemParameterSyncConfig;
 
 /// Configures a catalog.
 #[derive(Debug)]
@@ -66,7 +66,7 @@ pub struct Config<'a> {
     /// A optional frontend used to pull system parameters for initial sync in
     /// Catalog::open. A `None` value indicates that the initial sync should be
     /// skipped.
-    pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
+    pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
     /// How long to retain storage usage records
     pub storage_usage_retention_period: Option<Duration>,
     /// Needed only for migrating PG source column metadata. If `None`, will

--- a/src/adapter/src/config/frontend.rs
+++ b/src/adapter/src/config/frontend.rs
@@ -88,6 +88,14 @@ impl SystemParameterFrontend {
     }
 }
 
+impl Drop for SystemParameterFrontend {
+    fn drop(&mut self) {
+        tracing::info!("closing LaunchDarkly client");
+        self.ld_client.close();
+        tracing::info!("closed LaunchDarkly client");
+    }
+}
+
 fn ld_config(sync_config: &SystemParameterSyncConfig) -> ld::Config {
     ld::ConfigBuilder::new(&sync_config.ld_sdk_key)
         .event_processor(ld::EventProcessorBuilder::new().on_success({

--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -7,60 +7,82 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::sync::Arc;
-use std::time::Duration;
+use std::collections::BTreeMap;
 
-use mz_sql::session::vars::{Value, Var, VarInput, ENABLE_LAUNCHDARKLY};
-use tokio::time;
+use mz_ore::metric;
+use mz_ore::metrics::{MetricsRegistry, UIntGauge};
+use mz_ore::now::NowFn;
+use mz_sql::catalog::EnvironmentId;
+use prometheus::IntCounter;
 
 mod backend;
 mod frontend;
 mod params;
+mod sync;
 
 pub use backend::SystemParameterBackend;
 pub use frontend::SystemParameterFrontend;
 pub use params::{ModifiedParameter, SynchronizedParameters};
+pub use sync::system_parameter_sync;
 
-/// Run a loop that periodically pulls system parameters defined in the
-/// LaunchDarkly-backed [SystemParameterFrontend] and pushes modified values to the
-/// `ALTER SYSTEM`-backed [SystemParameterBackend].
-pub async fn system_parameter_sync(
-    frontend: Arc<SystemParameterFrontend>,
-    mut backend: SystemParameterBackend,
-    tick_interval: Option<Duration>,
-) -> Result<(), anyhow::Error> {
-    let tick_interval = match tick_interval {
-        Some(tick_interval) => tick_interval,
-        None => {
-            tracing::info!("skipping system parameter sync as tick_interval = None");
-            return Ok(());
+/// A factory for [SystemParameterFrontend] instances.
+#[derive(Clone, Debug)]
+pub struct SystemParameterSyncConfig {
+    /// The environment ID that should identify connected clients.
+    env_id: EnvironmentId,
+    /// Parameter sync metrics.
+    metrics: Metrics,
+    /// Function to return the current time.
+    now_fn: NowFn,
+    /// The SDK key.
+    ld_sdk_key: String,
+    /// A map from parameter names to LaunchDarkly feature keys
+    /// to use when populating the the [SynchronizedParameters]
+    /// instance in [SystemParameterFrontend::pull].
+    ld_key_map: BTreeMap<String, String>,
+}
+
+impl SystemParameterSyncConfig {
+    /// Construct a new [SystemParameterFrontend] instance.
+    pub fn new(
+        env_id: EnvironmentId,
+        registry: &MetricsRegistry,
+        now_fn: NowFn,
+        ld_sdk_key: String,
+        ld_key_map: BTreeMap<String, String>,
+    ) -> Self {
+        Self {
+            env_id,
+            metrics: Metrics::register_into(registry),
+            now_fn,
+            ld_sdk_key,
+            ld_key_map,
         }
-    };
+    }
+}
 
-    // Ensure the frontend client is initialized.
-    frontend.ensure_initialized().await;
+#[derive(Debug, Clone)]
+pub(super) struct Metrics {
+    pub last_cse_time_seconds: UIntGauge,
+    pub last_sse_time_seconds: UIntGauge,
+    pub params_changed: IntCounter,
+}
 
-    // Run the synchronization loop.
-    tracing::info!(
-        "synchronizing system parameter values every {} seconds",
-        tick_interval.as_secs()
-    );
-
-    // Tick every `tick_duration` ms, skipping missed ticks.
-    let mut interval = time::interval(tick_interval);
-    interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
-
-    let mut params = SynchronizedParameters::default();
-    loop {
-        interval.tick().await;
-        backend.pull(&mut params).await;
-        let launchdarkly_enabled = <bool as Value>::parse(
-            &ENABLE_LAUNCHDARKLY,
-            VarInput::Flat(&params.get(ENABLE_LAUNCHDARKLY.name())),
-        )
-        .expect("This is known to be a bool");
-        if launchdarkly_enabled && frontend.pull(&mut params) {
-            backend.push(&mut params).await;
+impl Metrics {
+    pub(super) fn register_into(registry: &MetricsRegistry) -> Self {
+        Self {
+            last_cse_time_seconds: registry.register(metric!(
+                name: "mz_parameter_frontend_last_cse_time_seconds",
+                help: "The last known time when the LaunchDarkly client sent an event to the LaunchDarkly server (as unix timestamp).",
+            )),
+            last_sse_time_seconds: registry.register(metric!(
+                name: "mz_parameter_frontend_last_sse_time_seconds",
+                help: "The last known time when the LaunchDarkly client received an event from the LaunchDarkly server (as unix timestamp).",
+            )),
+            params_changed: registry.register(metric!(
+                name: "mz_parameter_frontend_params_changed",
+                help: "The number of parameter changes pulled from the LaunchDarkly frontend.",
+            )),
         }
     }
 }

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -9,7 +9,7 @@
 
 use std::collections::BTreeSet;
 
-use mz_sql::session::vars::{SystemVars, VarInput};
+use mz_sql::session::vars::{SystemVars, Value, Var, VarInput, ENABLE_LAUNCHDARKLY};
 
 /// A struct that defines the system parameters that should be synchronized
 pub struct SynchronizedParameters {
@@ -130,6 +130,12 @@ impl SynchronizedParameters {
             tracing::error!("cannot modify unsynchronized system parameter {}", name);
             false
         }
+    }
+
+    pub fn enable_launchdarkly(&self) -> bool {
+        let var_name = self.get(ENABLE_LAUNCHDARKLY.name());
+        let var_input = VarInput::Flat(&var_name);
+        bool::parse(&ENABLE_LAUNCHDARKLY, var_input).expect("This is known to be a bool")
     }
 }
 

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -1,0 +1,61 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::time::Duration;
+
+use mz_sql::session::vars::{Value, Var, VarInput, ENABLE_LAUNCHDARKLY};
+use tokio::time;
+
+use crate::config::{
+    SynchronizedParameters, SystemParameterBackend, SystemParameterFrontend,
+    SystemParameterSyncConfig,
+};
+use crate::Client;
+
+/// Run a loop that periodically pulls system parameters defined in the
+/// LaunchDarkly-backed [SystemParameterFrontend] and pushes modified values to the
+/// `ALTER SYSTEM`-backed [SystemParameterBackend].
+pub async fn system_parameter_sync(
+    sync_config: SystemParameterSyncConfig,
+    adapter_client: Client,
+    tick_interval: Option<Duration>,
+) -> Result<(), anyhow::Error> {
+    let Some(tick_interval) = tick_interval else {
+        tracing::info!("skipping system parameter sync as tick_interval = None");
+        return Ok(());
+    };
+
+    // Ensure the frontend client is initialized.
+    let frontend = SystemParameterFrontend::from(&sync_config).await?;
+    let mut backend = SystemParameterBackend::new(adapter_client).await?;
+
+    // Run the synchronization loop.
+    tracing::info!(
+        "synchronizing system parameter values every {} seconds",
+        tick_interval.as_secs()
+    );
+
+    // Tick every `tick_duration` ms, skipping missed ticks.
+    let mut interval = time::interval(tick_interval);
+    interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+    let mut params = SynchronizedParameters::default();
+    loop {
+        interval.tick().await;
+        backend.pull(&mut params).await;
+        let launchdarkly_enabled = <bool as Value>::parse(
+            &ENABLE_LAUNCHDARKLY,
+            VarInput::Flat(&params.get(ENABLE_LAUNCHDARKLY.name())),
+        )
+        .expect("This is known to be a bool");
+        if launchdarkly_enabled && frontend.pull(&mut params) {
+            backend.push(&mut params).await;
+        }
+    }
+}

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -126,7 +126,7 @@ use crate::catalog::{
 };
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
-use crate::config::SystemParameterFrontend;
+use crate::config::SystemParameterSyncConfig;
 use crate::coord::appends::{Deferred, PendingWriteTxn};
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
@@ -466,7 +466,7 @@ pub struct Config {
     pub storage_usage_retention_period: Option<Duration>,
     pub segment_client: Option<mz_segment::Client>,
     pub egress_ips: Vec<Ipv4Addr>,
-    pub system_parameter_frontend: Option<Arc<SystemParameterFrontend>>,
+    pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
     pub aws_account_id: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
@@ -1651,7 +1651,7 @@ pub async fn serve(
         egress_ips,
         aws_account_id,
         aws_privatelink_availability_zones,
-        system_parameter_frontend,
+        system_parameter_sync_config,
         active_connection_count,
         tracing_handle,
     }: Config,
@@ -1709,7 +1709,7 @@ pub async fn serve(
             egress_ips,
             aws_principal_context,
             aws_privatelink_availability_zones,
-            system_parameter_frontend,
+            system_parameter_sync_config,
             storage_usage_retention_period,
             connection_context: Some(connection_context.clone()),
             active_connection_count,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -92,7 +92,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use mz_adapter::catalog::storage::{stash, BootstrapArgs};
 use mz_adapter::catalog::ClusterReplicaSizeMap;
-use mz_adapter::config::{system_parameter_sync, SystemParameterBackend, SystemParameterFrontend};
+use mz_adapter::config::{system_parameter_sync, SystemParameterSyncConfig};
 use mz_build_info::{build_info, BuildInfo};
 use mz_cloud_resources::CloudResourceController;
 use mz_controller::ControllerConfig;
@@ -480,29 +480,14 @@ impl Listeners {
         let controller = mz_controller::Controller::new(config.controller, envd_epoch).await;
 
         // Initialize the system parameter frontend if `launchdarkly_sdk_key` is set.
-        let system_parameter_frontend = if let Some(ld_sdk_key) = config.launchdarkly_sdk_key {
-            let ld_key_map = config.launchdarkly_key_map;
-            let env_id = config.environment_id.clone();
-            let metrics_registry = config.metrics_registry.clone();
-            let now = config.now.clone();
-            // The `SystemParameterFrontend::new` call needs to be wrapped in a
-            // spawn_blocking call because the LaunchDarkly SDK initialization uses
-            // `reqwest::blocking::client`. This should be revisited after the SDK
-            // is updated to 1.0.0.
-            let system_parameter_frontend = task::spawn_blocking(
-                || "SystemParameterFrontend::new",
-                move || {
-                    SystemParameterFrontend::new(
-                        env_id,
-                        &metrics_registry,
-                        ld_sdk_key.as_str(),
-                        ld_key_map,
-                        now,
-                    )
-                },
-            )
-            .await??;
-            Some(Arc::new(system_parameter_frontend))
+        let system_parameter_sync_config = if let Some(ld_sdk_key) = config.launchdarkly_sdk_key {
+            Some(SystemParameterSyncConfig::new(
+                config.environment_id.clone(),
+                &config.metrics_registry,
+                config.now.clone(),
+                ld_sdk_key,
+                config.launchdarkly_key_map,
+            ))
         } else {
             None
         };
@@ -530,7 +515,7 @@ impl Listeners {
             storage_usage_retention_period: config.storage_usage_retention_period,
             segment_client: segment_client.clone(),
             egress_ips: config.egress_ips,
-            system_parameter_frontend: system_parameter_frontend.clone(),
+            system_parameter_sync_config: system_parameter_sync_config.clone(),
             aws_account_id: config.aws_account_id,
             aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             active_connection_count: Arc::clone(&active_connection_count),
@@ -605,15 +590,14 @@ impl Listeners {
             });
         }
 
-        // If system_parameter_frontend and config_sync_loop_interval are present,
+        // If system_parameter_sync_config and config_sync_loop_interval are present,
         // start the system_parameter_sync loop.
-        if let Some(system_parameter_frontend) = system_parameter_frontend {
-            let system_parameter_backend = SystemParameterBackend::new(adapter_client).await?;
+        if let Some(system_parameter_sync_config) = system_parameter_sync_config {
             task::spawn(
                 || "system_parameter_sync",
                 AssertUnwindSafe(system_parameter_sync(
-                    system_parameter_frontend,
-                    system_parameter_backend,
+                    system_parameter_sync_config,
+                    adapter_client,
                     config.config_sync_loop_interval,
                 ))
                 .ore_catch_unwind(),

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -497,7 +497,7 @@ impl Usage {
             egress_ips: vec![],
             aws_principal_context: None,
             aws_privatelink_availability_zones: None,
-            system_parameter_frontend: None,
+            system_parameter_sync_config: None,
             storage_usage_retention_period: None,
             connection_context: None,
             active_connection_count: Arc::new(Mutex::new(ConnectionCounter::new(0))),


### PR DESCRIPTION
Implements the behavior suggested [in this comment](https://github.com/MaterializeInc/materialize/pull/20806#issuecomment-1654924142):

> Then, I think we should change the implementation of the `launchdarkly_enabled` configuration variable. Right now, setting that variable to false just breaks the connection between the frontend and the backend:
> 
> https://github.com/MaterializeInc/materialize/blob/64c3e5af19e030bbb35b31afaf705abb8d89426e/src/adapter/src/config/mod.rs#L57-L62
> 
> Instead, I think setting that variable to false should _turn off_ the entire LD sync task. Then setting it to true will start the sync from scratch. That will give us a really nice remediation if somehow the LD sync task gets wedged in a way we don't expect. We can manually log in to the environment and toggle the flag.

Once this lands in production we should update our runbooks to advertise the new functionality.

![images](https://github.com/MaterializeInc/materialize/assets/1071946/7625b465-7b30-4559-9407-32b1528e6ac6)

### Motivation

  * This PR adds a known-desirable feature.

See the referenced comment from #20806 for details.

### Tips for reviewer

- The first commit refactors code in preparation of the next one.
- The second commit actually changes the behavior.
- The third commit extends the existing `mzcompose` workflow to test the new behavior.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
