### PR TITLE
cloudtests: change context to kind-mzcloud

### DIFF
--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -12,6 +12,7 @@
 set -euo pipefail
 
 . misc/shlib/shlib.bash
+. test/cloudtest/config.bash
 
 run_args=(
     "--junitxml=junit_cloudtest_$BUILDKITE_JOB_ID.xml"
@@ -40,7 +41,7 @@ bin/ci-builder run stable test/cloudtest/reset
 rm -f kubectl-*.log
 
 ci_collapsed_heading "kail: Start a new instance"
-NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context kind-mzcloud --log-level info
+NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context "$K8S_CONTEXT" --log-level info
 
 ci_uncollapsed_heading "cloudtest: Running \`bin/pytest ${run_args[*]}\`"
 bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log

--- a/ci/plugins/cloudtest/hooks/command
+++ b/ci/plugins/cloudtest/hooks/command
@@ -40,7 +40,7 @@ bin/ci-builder run stable test/cloudtest/reset
 rm -f kubectl-*.log
 
 ci_collapsed_heading "kail: Start a new instance"
-NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context kind-cloudtest --log-level info
+NO_COLOR=1 bin/ci-builder run stable --detach --name "kail" kail --context kind-mzcloud --log-level info
 
 ci_uncollapsed_heading "cloudtest: Running \`bin/pytest ${run_args[*]}\`"
 bin/ci-builder run stable bin/pytest "${run_args[@]}" |& tee run.log

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -14,7 +14,7 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 kubectl() {
-    bin/ci-builder run stable kubectl --context=kind-cloudtest "$@"
+    bin/ci-builder run stable kubectl --context=kind-mzcloud "$@"
 }
 
 export_cov() {

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -12,9 +12,10 @@
 set -euo pipefail
 
 . misc/shlib/shlib.bash
+. test/cloudtest/config.bash
 
 kubectl() {
-    bin/ci-builder run stable kubectl --context=kind-mzcloud "$@"
+    bin/ci-builder run stable kubectl --context="$K8S_CONTEXT" "$@"
 }
 
 export_cov() {

--- a/misc/python/materialize/cloudtest/__init__.py
+++ b/misc/python/materialize/cloudtest/__init__.py
@@ -6,3 +6,6 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+
+DEFAULT_K8S_CLUSTER_NAME = "mzcloud"
+DEFAULT_K8S_CONTEXT_NAME = f"kind-{DEFAULT_K8S_CLUSTER_NAME}"

--- a/misc/python/materialize/cloudtest/app/application.py
+++ b/misc/python/materialize/cloudtest/app/application.py
@@ -54,4 +54,7 @@ class Application:
             raise e
 
     def context(self) -> str:
-        return "kind-cloudtest"
+        return f"kind-{self.cluster_name()}"
+
+    def cluster_name(self) -> str:
+        return "mzcloud"

--- a/misc/python/materialize/cloudtest/app/application.py
+++ b/misc/python/materialize/cloudtest/app/application.py
@@ -12,6 +12,7 @@ from textwrap import dedent
 from typing import List, Optional
 
 from materialize import ui
+from materialize.cloudtest import DEFAULT_K8S_CLUSTER_NAME, DEFAULT_K8S_CONTEXT_NAME
 from materialize.cloudtest.k8s import K8sResource
 
 
@@ -54,7 +55,7 @@ class Application:
             raise e
 
     def context(self) -> str:
-        return f"kind-{self.cluster_name()}"
+        return DEFAULT_K8S_CONTEXT_NAME
 
     def cluster_name(self) -> str:
-        return "mzcloud"
+        return DEFAULT_K8S_CLUSTER_NAME

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -120,7 +120,7 @@ class MaterializeApplication(Application):
                         "kind",
                         "load",
                         "docker-image",
-                        "--name=cloudtest",
+                        f"--name={self.cluster_name()}",
                         dep.spec(),
                     ]
                 )

--- a/misc/python/materialize/cloudtest/exists.py
+++ b/misc/python/materialize/cloudtest/exists.py
@@ -11,14 +11,15 @@
 import subprocess
 
 from materialize import ui
+from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
 from materialize.ui import UIError
 
 
-def exists(resource: str, context: str = "kind-mzcloud") -> None:
+def exists(resource: str, context: str = DEFAULT_K8S_CONTEXT_NAME) -> None:
     _exists(resource, True, context)
 
 
-def not_exists(resource: str, context: str = "kind-mzcloud") -> None:
+def not_exists(resource: str, context: str = DEFAULT_K8S_CONTEXT_NAME) -> None:
     _exists(resource, False, context)
 
 

--- a/misc/python/materialize/cloudtest/exists.py
+++ b/misc/python/materialize/cloudtest/exists.py
@@ -14,15 +14,15 @@ from materialize import ui
 from materialize.ui import UIError
 
 
-def exists(resource: str, context: str = "kind-cloudtest") -> None:
+def exists(resource: str, context: str = "kind-mzcloud") -> None:
     _exists(resource, True, context)
 
 
-def not_exists(resource: str, context: str = "kind-cloudtest") -> None:
+def not_exists(resource: str, context: str = "kind-mzcloud") -> None:
     _exists(resource, False, context)
 
 
-def _exists(resource: str, should_exist: bool, context: str = "kind-cloudtest") -> None:
+def _exists(resource: str, should_exist: bool, context: str) -> None:
     cmd = ["kubectl", "get", "--output", "name", resource, "--context", context]
     ui.progress(f'running {" ".join(cmd)} ... ')
 

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -31,6 +31,7 @@ from kubernetes.config import new_client_from_config  # type: ignore
 from pg8000 import Connection, Cursor
 
 from materialize import ROOT, mzbuild, ui
+from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
 
 
 class K8sResource:
@@ -65,7 +66,7 @@ class K8sResource:
         return RbacAuthorizationV1Api(api_client)
 
     def context(self) -> str:
-        return "kind-mzcloud"
+        return DEFAULT_K8S_CONTEXT_NAME
 
     def namespace(self) -> str:
         return "default"

--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -65,7 +65,7 @@ class K8sResource:
         return RbacAuthorizationV1Api(api_client)
 
     def context(self) -> str:
-        return "kind-cloudtest"
+        return "kind-mzcloud"
 
     def namespace(self) -> str:
         return "default"

--- a/misc/python/materialize/cloudtest/util/print_pods.py
+++ b/misc/python/materialize/cloudtest/util/print_pods.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 
 def print_pods(
-    context: str = "kind-cloudtest",
+    context: str = "kind-mzcloud",
     label: Optional[str] = None,
 ) -> None:
     cmd = [

--- a/misc/python/materialize/cloudtest/util/print_pods.py
+++ b/misc/python/materialize/cloudtest/util/print_pods.py
@@ -11,9 +11,11 @@
 import subprocess
 from typing import Optional
 
+from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
+
 
 def print_pods(
-    context: str = "kind-mzcloud",
+    context: str = DEFAULT_K8S_CONTEXT_NAME,
     label: Optional[str] = None,
 ) -> None:
     cmd = [

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -20,7 +20,7 @@ def wait(
     condition: str,
     resource: str,
     timeout_secs: int = 300,
-    context: str = "kind-cloudtest",
+    context: str = "kind-mzcloud",
     *,
     label: Optional[str] = None,
 ) -> None:

--- a/misc/python/materialize/cloudtest/wait.py
+++ b/misc/python/materialize/cloudtest/wait.py
@@ -12,6 +12,7 @@ import subprocess
 from typing import Optional
 
 from materialize import ui
+from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
 from materialize.cloudtest.util.print_pods import print_pods
 from materialize.ui import UIError
 
@@ -20,7 +21,7 @@ def wait(
     condition: str,
     resource: str,
     timeout_secs: int = 300,
-    context: str = "kind-mzcloud",
+    context: str = DEFAULT_K8S_CONTEXT_NAME,
     *,
     label: Optional[str] = None,
 ) -> None:

--- a/test/cloudtest/config.bash
+++ b/test/cloudtest/config.bash
@@ -11,10 +11,5 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")/../.."
-
-. misc/shlib/shlib.bash
-. test/cloudtest/config.bash
-
-run kubectl --context="$K8S_CONTEXT" delete all --all
-run kubectl --context="$K8S_CONTEXT" delete pvc --all
+K8S_CLUSTER_NAME="${K8S_CLUSTER_NAME:=mzcloud}"
+K8S_CONTEXT="${K8S_CONTEXT:=kind-"$K8S_CLUSTER_NAME"}"

--- a/test/cloudtest/reset
+++ b/test/cloudtest/reset
@@ -15,5 +15,7 @@ cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
 
-run kubectl --context=kind-cloudtest delete all --all
-run kubectl --context=kind-cloudtest delete pvc --all
+CONTEXT="${CONTEXT:=kind-mzcloud}"
+
+run kubectl --context="$CONTEXT" delete all --all
+run kubectl --context="$CONTEXT" delete pvc --all

--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -14,15 +14,14 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
+. test/cloudtest/config.bash
 
-CONTEXT="${CONTEXT:=kind-mzcloud}"
-
-if ! kind get clusters | grep -q mzcloud; then
-    run kind create cluster --name=mzcloud --config=misc/kind/cluster.yaml --wait=60s
+if ! kind get clusters | grep -q "$K8S_CLUSTER_NAME"; then
+    run kind create cluster --name="$K8S_CLUSTER_NAME" --config=misc/kind/cluster.yaml --wait=60s
 fi
 
 for f in misc/kind/configmaps/*; do
-    run kubectl --context="$CONTEXT" apply -f "$f"
+    run kubectl --context="$K8S_CONTEXT" apply -f "$f"
 done
 
-run kubectl --context="$CONTEXT" rollout restart -n kube-system deployment/coredns
+run kubectl --context="$K8S_CONTEXT" rollout restart -n kube-system deployment/coredns

--- a/test/cloudtest/setup
+++ b/test/cloudtest/setup
@@ -15,12 +15,14 @@ cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
 
-if ! kind get clusters | grep -q cloudtest; then
-    run kind create cluster --name=cloudtest --config=misc/kind/cluster.yaml --wait=60s
+CONTEXT="${CONTEXT:=kind-mzcloud}"
+
+if ! kind get clusters | grep -q mzcloud; then
+    run kind create cluster --name=mzcloud --config=misc/kind/cluster.yaml --wait=60s
 fi
 
 for f in misc/kind/configmaps/*; do
-    run kubectl --context=kind-cloudtest apply -f "$f"
+    run kubectl --context="$CONTEXT" apply -f "$f"
 done
 
-run kubectl --context=kind-cloudtest rollout restart -n kube-system deployment/coredns
+run kubectl --context="$CONTEXT" rollout restart -n kube-system deployment/coredns

--- a/test/cloudtest/teardown
+++ b/test/cloudtest/teardown
@@ -15,4 +15,4 @@ cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
 
-run kind delete cluster --name=cloudtest
+run kind delete cluster --name=mzcloud

--- a/test/cloudtest/teardown
+++ b/test/cloudtest/teardown
@@ -14,5 +14,6 @@ set -euo pipefail
 cd "$(dirname "$0")/../.."
 
 . misc/shlib/shlib.bash
+. test/cloudtest/config.bash
 
-run kind delete cluster --name=mzcloud
+run kind delete cluster --name="$K8S_CLUSTER_NAME"


### PR DESCRIPTION
As part of https://github.com/MaterializeInc/materialize/issues/19626, I will need to align the cloudtests' K8s context between both repos. Changing it in this repo seemed way easier.

Nightly: https://buildkite.com/materialize/nightlies/builds/2979