### PR TITLE
webhooks: Add concurrency limit to endpoint

### DIFF
--- a/doc/developer/design/20230615_webhook_source.md
+++ b/doc/developer/design/20230615_webhook_source.md
@@ -264,16 +264,16 @@ evaluate each request. This evaluation will happen off the main coordinator thre
 ### Request Limits
 [request_limits]: #request_limits
 
-To start we'll aim to support at least 100 requests per second, in other words, 10 sources could
-receive 10 requests per second. We can probably scale further, but this seems like a sensible limit
-to start at. Also we'll add an [`axum::middleware`](https://docs.rs/axum/latest/axum/middleware/index.html)
-that enforces rate limiting on our new endpoint. This should be a pretty easy way to prevent a
+To start we'll aim to support at least 100 concurrent requests, in other words, 10 sources could
+at one time be processing 10 requests each. We can probably scale further, but this seems like a
+sensible limit to start at. We'll do this by adding an [`axum::middleware`](https://docs.rs/axum/latest/axum/middleware/index.html)
+to enforce this limit on our new endpoint. This should be a pretty easy way to prevent a
 misbehaving source from taking down all of `environmentd`.
 
 We'll also introduce a maximum size the body of each request can be, the default limit will be
-16KiB.
+2MB.
 
-Both the maximum number of requests per second, and max body size, will be configurable via
+Both the maximum number of concurrent requests, and max body size, will be configurable via
 LaunchDarkly, and later we can introduce SQL syntax so the user can `ALTER` these parameters on a
 per-source basis.
 

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -83,7 +83,7 @@ tokio = { version = "1.24.2", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }
-tower = "0.4.13"
+tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -960,6 +960,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 tls,
                 frontegg,
                 cors_allowed_origin,
+                concurrent_webhook_req_count: None,
                 adapter_stash_url: args.adapter_stash_url,
                 controller,
                 secrets_controller,

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -25,6 +25,13 @@ use bytes::Bytes;
 use http::StatusCode;
 use thiserror::Error;
 
+/// The number of concurrent requests we allow at once for webhook sources.
+///
+/// TODO(parkmycar): Make this configurable via LaunchDarkly and/or as a setting on each webhook
+/// source. The blocker for doing this today is an `axum` layer that allows us to __reduce__ the
+/// concurrency limit, the current one only allows you to increase it.
+pub const CONCURRENCY_LIMIT: usize = 100;
+
 pub async fn handle_webhook(
     State(client): State<mz_adapter::Client>,
     Path((database, schema, name)): Path<(String, String, String)>,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -588,7 +588,9 @@ impl Listeners {
                 adapter_client: adapter_client.clone(),
                 allowed_origin: config.cors_allowed_origin,
                 active_connection_count: Arc::clone(&active_connection_count),
-                concurrent_webhook_req_count: config.concurrent_webhook_req_count,
+                concurrent_webhook_req_count: config
+                    .concurrent_webhook_req_count
+                    .unwrap_or(http::WEBHOOK_CONCURRENCY_LIMIT),
                 metrics: http_metrics,
             });
             server::serve(http_conns, http_server)

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -143,6 +143,8 @@ pub struct Config {
     pub tls: Option<TlsConfig>,
     /// Frontegg JWT authentication configuration.
     pub frontegg: Option<FronteggAuthentication>,
+    /// Number of concurrent requests accepted for webhooks, `None` indicates a default limit.
+    pub concurrent_webhook_req_count: Option<usize>,
 
     // === Connection options. ===
     /// Configuration for source and sink connections created by the storage
@@ -586,6 +588,7 @@ impl Listeners {
                 adapter_client: adapter_client.clone(),
                 allowed_origin: config.cors_allowed_origin,
                 active_connection_count: Arc::clone(&active_connection_count),
+                concurrent_webhook_req_count: config.concurrent_webhook_req_count,
                 metrics: http_metrics,
             });
             server::serve(http_conns, http_server)

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -142,6 +142,7 @@ pub struct Config {
     bootstrap_role: Option<String>,
     deploy_generation: Option<u64>,
     system_parameter_defaults: BTreeMap<String, String>,
+    concurrent_webhook_req_count: Option<usize>,
 }
 
 impl Default for Config {
@@ -163,6 +164,7 @@ impl Default for Config {
             bootstrap_role: Some("materialize".into()),
             deploy_generation: None,
             system_parameter_defaults: BTreeMap::new(),
+            concurrent_webhook_req_count: None,
         }
     }
 }
@@ -255,6 +257,11 @@ impl Config {
 
     pub fn with_system_parameter_default(mut self, param: String, value: String) -> Self {
         self.system_parameter_defaults.insert(param, value);
+        self
+    }
+
+    pub fn with_concurrent_webhook_req_count(mut self, limit: usize) -> Self {
+        self.concurrent_webhook_req_count = Some(limit);
         self
     }
 }
@@ -418,6 +425,7 @@ impl Listeners {
                     cloud_resource_controller: None,
                     tls: config.tls,
                     frontegg: config.frontegg,
+                    concurrent_webhook_req_count: config.concurrent_webhook_req_count,
                     unsafe_mode: config.unsafe_mode,
                     all_features: false,
                     metrics_registry: metrics_registry.clone(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -984,6 +984,7 @@ impl<'a> RunnerInner<'a> {
             tls: None,
             frontegg: None,
             cors_allowed_origin: AllowOrigin::list([]),
+            concurrent_webhook_req_count: None,
             unsafe_mode: true,
             all_features: false,
             metrics_registry,

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -102,7 +102,7 @@ tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
+tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
@@ -204,7 +204,7 @@ tokio = { version = "1.27.0", features = ["full", "test-util", "tracing"] }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", features = ["serde", "with-chrono-0_4", "with-serde_json-1", "with-uuid-1"] }
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
-tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
+tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
 tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }


### PR DESCRIPTION
This PR uses the `tower::ConcurrencyLimit` and `tower::LoadShed` layers to enforce a maximum number of concurrent requests for the `/api/webhook/...` endpoint. The current limit is 100 concurrent requests.

It also adds a Rust test where we assert that once we pass this limit, we start rejecting requests with `429 Too Many Requests`.

### Motivation

  * This PR adds a known-desirable feature: https://github.com/MaterializeInc/materialize/issues/20227

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Request limits for the currently gated Webhook sources feature
