### PR TITLE
sql: Justify output of timestamp subtraction

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -871,11 +871,19 @@ fn age_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, EvalErro
 }
 
 fn sub_timestamp<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    Datum::from(a.unwrap_timestamp() - b.unwrap_timestamp())
+    let diff = a.unwrap_timestamp() - b.unwrap_timestamp();
+    Datum::from(
+        justify_hours(diff.into())
+            .expect("timestamps are not large enough to overflow an interval"),
+    )
 }
 
 fn sub_timestamptz<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {
-    Datum::from(a.unwrap_timestamptz() - b.unwrap_timestamptz())
+    let diff = a.unwrap_timestamptz() - b.unwrap_timestamptz();
+    Datum::from(
+        justify_hours(diff.into())
+            .expect("timestamps are not large enough to overflow an interval"),
+    )
 }
 
 fn sub_date<'a>(a: Datum<'a>, b: Datum<'a>) -> Datum<'a> {

--- a/src/repr/src/adt/interval.rs
+++ b/src/repr/src/adt/interval.rs
@@ -91,6 +91,14 @@ impl std::str::FromStr for Interval {
     }
 }
 
+impl From<chrono::Duration> for Interval {
+    #[inline]
+    fn from(duration: chrono::Duration) -> Interval {
+        let micros = duration.num_microseconds().unwrap_or(0);
+        Interval::new(0, 0, micros)
+    }
+}
+
 static MONTH_OVERFLOW_ERROR: Lazy<String> = Lazy::new(|| {
     format!(
         "Overflows maximum months; cannot exceed {}/{} microseconds",

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -1145,8 +1145,7 @@ impl<'a> From<OrderedDecimal<Numeric>> for Datum<'a> {
 impl<'a> From<chrono::Duration> for Datum<'a> {
     #[inline]
     fn from(duration: chrono::Duration) -> Datum<'a> {
-        let micros = duration.num_microseconds().unwrap_or(0);
-        Datum::Interval(Interval::new(0, 0, micros))
+        Datum::Interval(duration.into())
     }
 }
 

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -368,6 +368,18 @@ SELECT DATE '2001-01-01' + INTERVAL '3' YEAR
 ----
 2004-01-01 00:00:00
 
+# Date-time arithmetic with timestamps
+
+query T
+select '2023-07-27 14:00:00+00'::timestamp - '2023-07-23 09:00:00+00'::timestamp
+----
+4 days 05:00:00
+
+query T
+select '2023-07-27 14:00:00+00'::timestamptz - '2023-07-23 09:00:00+00'::timestamptz
+----
+4 days 05:00:00
+
 # Check Comparisons
 
 query T


### PR DESCRIPTION
PostgreSQL automatically justifies the hours in the interval output of
timestamp and timestamptz subtraction. In other words, all hours in
excess of 24 are converted to days. This commit updates our timestamp
and timestamptz subtraction to match the semantics of PostgreSQL.

Fixes #20852

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Justify the hours of the interval result from timestamp subtraction.
