### PR TITLE
storage: add stats logging interval configs vars for rocksdb

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -71,6 +71,8 @@ pub fn storage_config(
                 config.upsert_rocksdb_bottommost_compression_type(),
                 config.upsert_rocksdb_batch_size(),
                 config.upsert_rocksdb_retry_duration(),
+                config.upsert_rocksdb_stats_log_interval_seconds(),
+                config.upsert_rocksdb_stats_persist_interval_seconds(),
             ) {
                 Ok(u) => u,
                 Err(e) => {

--- a/src/rocksdb-types/src/config.proto
+++ b/src/rocksdb-types/src/config.proto
@@ -41,4 +41,6 @@ message ProtoRocksDbTuningParameters {
     ProtoCompressionType bottommost_compression_type = 7;
     uint64 batch_size = 8;
     mz_proto.ProtoDuration retry_max_duration = 9;
+    uint32 stats_log_interval_seconds = 10;
+    uint32 stats_persist_interval_seconds = 11;
 }

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -59,6 +59,8 @@ pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) 
         compression_type,
         bottommost_compression_type,
         retry_max_duration: _,
+        stats_log_interval_seconds,
+        stats_persist_interval_seconds,
         dynamic: _,
     } = config;
 
@@ -96,4 +98,7 @@ pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) 
             .expect("More than 3 billion cores")
     };
     options.increase_parallelism(parallelism);
+
+    options.set_stats_dump_period_sec(*stats_log_interval_seconds);
+    options.set_stats_persist_period_sec(*stats_persist_interval_seconds);
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -748,6 +748,23 @@ mod upsert_rocksdb {
             "The upsert in-memory state size threshold in bytes after which it will spill to disk",
         internal: true,
     };
+
+    pub static UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_stats_log_interval_seconds"),
+        value: &mz_rocksdb_types::defaults::DEFAULT_STATS_LOG_INTERVAL_S,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
+    pub static UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS: ServerVar<u32> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_stats_persist_interval_seconds"),
+        value: &mz_rocksdb_types::defaults::DEFAULT_STATS_PERSIST_INTERVAL_S,
+        description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+        internal: true,
+    };
 }
 
 /// Controls the connect_timeout setting when connecting to PG via replication.
@@ -1869,6 +1886,8 @@ impl SystemVars {
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
@@ -2257,6 +2276,14 @@ impl SystemVars {
 
     pub fn upsert_rocksdb_retry_duration(&self) -> Duration {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION)
+    }
+
+    pub fn upsert_rocksdb_stats_log_interval_seconds(&self) -> u32 {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS)
+    }
+
+    pub fn upsert_rocksdb_stats_persist_interval_seconds(&self) -> u32 {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.
@@ -3831,6 +3858,8 @@ fn is_upsert_rocksdb_config_var(name: &str) -> bool {
         || name == upsert_rocksdb::UPSERT_ROCKSDB_COMPRESSION_TYPE.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_BOTTOMMOST_COMPRESSION_TYPE.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS.name()
 }
 
 /// Returns whether the named variable is a persist configuration parameter.


### PR DESCRIPTION
These don't actually eat up THAT much disk space, but we should have the ability to turn them off, especially for small replicas, if we miss releases and collect a bunch of logs

### Motivation


  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
