### PR TITLE
ci/test: don't attempt to set priority of wait steps

### DIFF
--- a/ci/test/mkpipeline.py
+++ b/ci/test/mkpipeline.py
@@ -152,8 +152,8 @@ def prioritize_pipeline(pipeline: Any) -> None:
 
     if priority is not None:
         for config in pipeline["steps"]:
-            if "trigger" in config:
-                # Trigger steps do not allow priorities.
+            if "trigger" in config or "wait" in config:
+                # Trigger and Wait steps do not allow priorities.
                 continue
             config["priority"] = config.get("priority", 0) + priority
 


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
