### PR TITLE
ci: Fix npm release ci build

### DIFF
--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -53,7 +53,7 @@ def generate_version(
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
         assert (
-            buildkite_tag == node_version
+            buildkite_tag.lstrip('v') == node_version
         ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
     return Version(rust=crate_version, node=node_version, is_development=is_development)
 

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -52,8 +52,9 @@ def generate_version(
         is_development = True
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
+        # buildkite_tag starts with a 'v'.
         assert (
-            buildkite_tag.lstrip("v") == node_version
+            buildkite_tag == f"v{node_version}"
         ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
     return Version(rust=crate_version, node=node_version, is_development=is_development)
 

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -53,7 +53,7 @@ def generate_version(
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
         assert (
-            buildkite_tag.lstrip('v') == node_version
+            buildkite_tag.lstrip("v") == node_version
         ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
     return Version(rust=crate_version, node=node_version, is_development=is_development)
 

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -52,7 +52,7 @@ def generate_version(
         is_development = True
     else:
         buildkite_tag = os.environ.get("BUILDKITE_TAG")
-        # buildkite_tag starts with a 'v'.
+        # buildkite_tag starts with a 'v' and node_version does not.
         assert (
             buildkite_tag == f"v{node_version}"
         ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"


### PR DESCRIPTION
This commit fixes the npm CI build so that it correctly compares the Buildkite tag with the NPM version. The buildkite tag starts with a 'v' that needs to be stripped and the npm version does not.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
