### PR TITLE
[TEST] compute: unbatch `ComputeCommand::AllowCompaction`

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1013,7 +1013,6 @@ where
 
         // Translate our net compute actions into `AllowCompaction` commands
         // and a list of collections that are potentially ready to be dropped
-        let mut compaction_commands = Vec::new();
         let mut dropped_collection_ids = Vec::new();
         for (id, change) in compute_net.iter_mut() {
             let frontier = self
@@ -1026,12 +1025,9 @@ where
             }
             if !change.is_empty() {
                 let frontier = frontier.to_owned();
-                compaction_commands.push((*id, frontier));
+                self.compute
+                    .send(ComputeCommand::AllowCompaction { id: *id, frontier });
             }
-        }
-        if !compaction_commands.is_empty() {
-            self.compute
-                .send(ComputeCommand::AllowCompaction(compaction_commands));
         }
         if !dropped_collection_ids.is_empty() {
             self.update_dropped_collections(dropped_collection_ids);

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -366,7 +366,7 @@ impl<M> CommandMetrics<M> {
             InitializationComplete => &self.initialization_complete,
             UpdateConfiguration(_) => &self.update_configuration,
             CreateDataflows(_) => &self.create_dataflows,
-            AllowCompaction(_) => &self.allow_compaction,
+            AllowCompaction { .. } => &self.allow_compaction,
             Peek(_) => &self.peek,
             CancelPeeks { .. } => &self.cancel_peeks,
         }

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -44,7 +44,7 @@ message ProtoComputeCommand {
         ProtoCreateTimely create_timely = 1;
         logging.ProtoLoggingConfig create_instance = 2;
         ProtoCreateDataflows create_dataflows = 3;
-        mz_storage_client.client.ProtoAllowCompaction allow_compaction = 4;
+        mz_storage_client.client.ProtoCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
         ProtoCancelPeeks cancel_peeks = 6;
         google.protobuf.Empty initialization_complete = 7;

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -123,10 +123,8 @@ where
                 ComputeCommand::CreateDataflows(dataflows) => {
                     live_dataflows.extend(dataflows);
                 }
-                ComputeCommand::AllowCompaction(frontiers) => {
-                    for (id, frontier) in frontiers {
-                        final_frontiers.insert(id, frontier.clone());
-                    }
+                ComputeCommand::AllowCompaction { id, frontier } => {
+                    final_frontiers.insert(id, frontier.clone());
                 }
                 ComputeCommand::Peek(peek) => {
                     live_peeks.push(peek);
@@ -213,10 +211,8 @@ where
             });
         }
         // Allow compaction only after emmitting peek commands.
-        if !final_frontiers.is_empty() {
-            self.push_inner(ComputeCommand::AllowCompaction(
-                final_frontiers.into_iter().collect(),
-            ));
+        for (id, frontier) in final_frontiers {
+            self.push_inner(ComputeCommand::AllowCompaction { id, frontier });
         }
         if initialization_complete {
             self.push_inner(ComputeCommand::InitializationComplete);

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -502,10 +502,8 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             old_dataflows.insert(export_ids, dataflow);
                         }
                     }
-                    ComputeCommand::AllowCompaction(frontiers) => {
-                        for (id, frontier) in frontiers.iter() {
-                            old_frontiers.insert(id, frontier);
-                        }
+                    ComputeCommand::AllowCompaction { id, frontier } => {
+                        old_frontiers.insert(id, frontier);
                     }
                     _ => {
                         // Nothing to do in these cases.
@@ -600,12 +598,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
             }
-            if !old_compaction.is_empty() {
-                let compactions = old_compaction
-                    .iter()
-                    .map(|(k, v)| (*k, v.clone()))
-                    .collect();
-                todo_commands.insert(0, ComputeCommand::AllowCompaction(compactions));
+            for (&id, frontier) in &old_compaction {
+                let frontier = frontier.clone();
+                todo_commands.insert(0, ComputeCommand::AllowCompaction { id, frontier });
             }
 
             // Clean up worker-local state.


### PR DESCRIPTION
This is a test to check the effect batching has on the compute protocol's efficiency.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
