### PR TITLE
test: Fix Zippy replica tests

### DIFF
--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -85,8 +85,15 @@ class CreateReplica(Action):
 
     def run(self, c: Composition) -> None:
         if self.new_replica:
+            # Default cluster is not owned by materialize, thus can't have a replica
+            # added if enable_rbac_checks is on.
             c.testdrive(
-                f"> CREATE CLUSTER REPLICA default.{self.replica.name} SIZE '{self.replica.size}'"
+                dedent(
+                    f"""
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                CREATE CLUSTER REPLICA default.{self.replica.name} SIZE '{self.replica.size}'
+                """
+                )
             )
 
     def provides(self) -> List[Capability]:
@@ -115,4 +122,13 @@ class DropReplica(Action):
 
     def run(self, c: Composition) -> None:
         if self.replica is not None:
-            c.testdrive(f"> DROP CLUSTER REPLICA IF EXISTS default.{self.replica.name}")
+            # Default cluster is not owned by materialize, thus can't have a replica
+            # removed if enable_rbac_checks is on.
+            c.testdrive(
+                dedent(
+                    f"""
+                $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                DROP CLUSTER REPLICA IF EXISTS default.{self.replica.name}
+                """
+                )
+            )


### PR DESCRIPTION
Commit ab3a145c9265d0a96589d8d40983bf9a071d62c7 updated the privileges for creating a cluster replica such that a user must own the cluster to add replicas to it. This commit updates the Zippy tests to work with these new privilege requirements.

### Motivation
Fixes a test.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
