### PR TITLE
Fixes to #20711

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2020,11 +2020,7 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| Bui
         .with_column("sample_rate", ScalarType::Float64.nullable(false))
         .with_column(
             "params",
-            ScalarType::List {
-                element_type: Box::new(ScalarType::String),
-                custom_id: None,
-            }
-            .nullable(false),
+            ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
         )
         .with_column("began_at", ScalarType::TimestampTz.nullable(false))
         .with_column("finished_at", ScalarType::TimestampTz.nullable(true))

--- a/src/repr/src/statement_logging.rs
+++ b/src/repr/src/statement_logging.rs
@@ -47,7 +47,7 @@ impl StatementExecutionStrategy {
 pub enum StatementEndedExecutionReason {
     Success {
         rows_returned: Option<u64>,
-        execution_strategy: StatementExecutionStrategy,
+        execution_strategy: Option<StatementExecutionStrategy>,
     },
     Canceled,
     Errored {
@@ -79,4 +79,13 @@ pub enum StatementLoggingEvent {
     Prepared(StatementPreparedRecord),
     BeganExecution(StatementBeganExecutionRecord),
     EndedExecution(StatementEndedExecutionRecord),
+    BeganSession(SessionHistoryEvent),
+}
+
+#[derive(Clone, Debug)]
+pub struct SessionHistoryEvent {
+    pub id: Uuid,
+    pub connected_at: EpochMillis,
+    pub application_name: String,
+    pub authenticated_user: String,
 }


### PR DESCRIPTION
Fixes to #20711: Make `SessionHistoryEvent` a struct, make `execution_strategy` optional, use array instead of list. 

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None