### PR TITLE
Non-persistent statement logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8903,6 +8903,7 @@ dependencies = [
  "prost-types",
  "quote",
  "rand",
+ "rand_chacha",
  "rdkafka-sys",
  "regex",
  "regex-syntax",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3441,6 +3441,7 @@ dependencies = [
  "prost",
  "qcell",
  "rand",
+ "rand_chacha",
  "rdkafka",
  "regex",
  "reqwest",

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -59,6 +59,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # reduce CRDB load as we are struggling with it in CI:
     "persist_next_listen_batch_retryer_clamp": "100ms",
     "persist_next_listen_batch_retryer_initial_backoff": "1200ms",
+    "statement_logging_max_sample_rate": "1.0",
+    "statement_logging_default_sample_rate": "1.0",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -57,6 +57,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 qcell = "0.5"
 rand = "0.8.5"
+rand_chacha = "0.3"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = "1.7.0"
 reqwest = "0.11.13"

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1446,17 +1446,13 @@ impl CatalogState {
         packer.extend([
             // finished_at
             Datum::Null,
-            // was_successful
-            Datum::Null,
-            // was_canceled
-            Datum::Null,
-            // was_aborted
+            // finished_status
             Datum::Null,
             // error_message
             Datum::Null,
             // rows_returned
             Datum::Null,
-            // was_fast_path
+            // execution_status
             Datum::Null,
         ]);
         BuiltinTableUpdate {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -149,6 +149,9 @@ impl Client {
     pub async fn startup(
         &self,
         session: Session,
+        // keys of settings that were set on statup, and thus should not be
+        // overridden by defaults.
+        set_setting_keys: Vec<String>,
     ) -> Result<(SessionClient, StartupResponse), AdapterError> {
         // Cancellation works by creating a watch channel (which remembers only
         // the last value sent to it) and sharing it between the coordinator and
@@ -172,6 +175,7 @@ impl Client {
                 session,
                 cancel_tx,
                 tx,
+                set_setting_keys,
             })
             .await;
         match response {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -204,7 +204,7 @@ impl Client {
         // Connect to the coordinator.
         let conn_id = self.new_conn_id()?;
         let session = self.new_session(conn_id, SUPPORT_USER.clone());
-        let (mut session_client, _) = self.startup(session).await?;
+        let (mut session_client, _) = self.startup(session, vec![]).await?;
 
         // Parse the SQL statement.
         let stmts = mz_sql::parse::parse(sql)?;

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -25,6 +25,7 @@ use mz_ore::now::{to_datetime, EpochMillis, NowFn};
 use mz_ore::task::{AbortOnDropHandle, JoinHandleExt};
 use mz_ore::thread::JoinOnDropHandle;
 use mz_ore::tracing::OpenTelemetryContext;
+use mz_repr::statement_logging::StatementEndedExecutionReason;
 use mz_repr::{GlobalId, Row, ScalarType};
 use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
@@ -214,7 +215,7 @@ impl Client {
             .declare(EMPTY_PORTAL.into(), stmt, sql.to_string(), vec![])
             .await?;
         match session_client
-            .execute(EMPTY_PORTAL.into(), futures::future::pending())
+            .execute(EMPTY_PORTAL.into(), futures::future::pending(), None)
             .await?
         {
             (ExecuteResponse::SendingRows { future, span: _ }, _) => match future.await {
@@ -418,6 +419,7 @@ impl SessionClient {
         &mut self,
         portal_name: String,
         cancel_future: impl Future<Output = std::io::Error> + Send,
+        outer_ctx_extra: Option<ExecuteContextExtra>,
     ) -> Result<(ExecuteResponse, Instant), AdapterError> {
         let execute_started = Instant::now();
         let response = self
@@ -427,6 +429,7 @@ impl SessionClient {
                     session,
                     tx,
                     span: tracing::Span::current(),
+                    outer_ctx_extra,
                 },
                 cancel_future,
             )
@@ -485,6 +488,19 @@ impl SessionClient {
     pub async fn dump_catalog(&mut self) -> Result<CatalogDump, AdapterError> {
         self.send(|tx, session| Command::DumpCatalog { session, tx })
             .await
+    }
+
+    /// Tells the coordinator a statement has finished execution, in the cases
+    /// where we have no other reason to communicate with the coordinator.
+    pub fn retire_execute(
+        &mut self,
+        data: ExecuteContextExtra,
+        reason: StatementEndedExecutionReason,
+    ) {
+        if !data.is_trivial() {
+            let cmd = Command::RetireExecute { data, reason };
+            self.inner_mut().send(cmd);
+        }
     }
 
     /// Inserts a set of rows into the given table.
@@ -596,7 +612,8 @@ impl SessionClient {
                 | Command::CopyRows { .. }
                 | Command::GetSystemVars { .. }
                 | Command::SetSystemVars { .. }
-                | Command::Terminate { .. } => {}
+                | Command::Terminate { .. }
+                | Command::RetireExecute { .. } => {}
             };
             cmd
         });

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -893,7 +893,7 @@ impl ExecuteResponse {
             GrantPrivileges => vec![GrantedPrivilege],
             GrantRole => vec![GrantedRole],
             CopyRows => vec![Inserted],
-            Insert => vec![Inserted, SendingRows, SendingRowsImmediate],
+            Insert => vec![Inserted, SendingRowsImmediate],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
             PlanKind::Raise => vec![ExecuteResponseKind::Raised],
             PlanKind::ReassignOwned => vec![ExecuteResponseKind::ReassignOwned],
@@ -904,7 +904,7 @@ impl ExecuteResponse {
             }
             PlanKind::Subscribe => vec![Subscribing, CopyTo],
             StartTransaction => vec![StartedTransaction],
-            SideEffectingFunc => vec![SendingRows, SendingRowsImmediate],
+            SideEffectingFunc => vec![SendingRowsImmediate],
             ValidateConnection => vec![ExecuteResponseKind::ValidatedConnection],
         }
     }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -50,6 +50,9 @@ pub enum Command {
         session: Session,
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Response<StartupResponse>>,
+        /// keys of settings that were set on statup, and thus should not be
+        /// overridden by defaults.
+        set_setting_keys: Vec<String>,
     },
 
     Declare {

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -25,6 +25,7 @@ use mz_ore::soft_assert;
 use mz_ore::str::StrExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
+use mz_repr::statement_logging::StatementEndedExecutionReason;
 use mz_repr::{ColumnType, Datum, GlobalId, Row, RowArena, ScalarType};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsReader;
@@ -79,6 +80,7 @@ pub enum Command {
         portal_name: String,
         session: Session,
         tx: oneshot::Sender<Response<ExecuteResponse>>,
+        outer_ctx_extra: Option<ExecuteContextExtra>,
         span: tracing::Span,
     },
 
@@ -138,6 +140,17 @@ pub enum Command {
         session: Session,
         tx: Option<oneshot::Sender<Response<()>>>,
     },
+
+    /// Performs any cleanup and logging actions necessary for
+    /// finalizing a statement execution.
+    ///
+    /// Only used for cases that terminate in the protocol layer and
+    /// otherwise have no reason to hand control back to the coordinator.
+    /// In other cases, we piggy-back on another command.
+    RetireExecute {
+        data: ExecuteContextExtra,
+        reason: StatementEndedExecutionReason,
+    },
 }
 
 impl Command {
@@ -155,8 +168,9 @@ impl Command {
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
             Command::CancelRequest { .. }
+            | Command::PrivilegedCancelRequest { .. }
             | Command::AppendWebhook { .. }
-            | Command::PrivilegedCancelRequest { .. } => None,
+            | Command::RetireExecute { .. } => None,
         }
     }
 
@@ -174,8 +188,9 @@ impl Command {
             | Command::SetSystemVars { session, .. }
             | Command::Terminate { session, .. } => Some(session),
             Command::CancelRequest { .. }
+            | Command::PrivilegedCancelRequest { .. }
             | Command::AppendWebhook { .. }
-            | Command::PrivilegedCancelRequest { .. } => None,
+            | Command::RetireExecute { .. } => None,
         }
     }
 }
@@ -568,6 +583,7 @@ pub enum ExecuteResponse {
         count: Option<FetchDirection>,
         /// How long to wait for results to arrive.
         timeout: ExecuteTimeout,
+        ctx_extra: ExecuteContextExtra,
     },
     /// The requested privilege was granted.
     GrantedPrivilege,
@@ -592,6 +608,13 @@ pub enum ExecuteResponse {
         #[derivative(Debug = "ignore")]
         span: tracing::Span,
     },
+    /// Like `SendingRows`, but the rows are known to be available
+    /// immediately, and thus the execution is considered ended in the coordinator.
+    SendingRowsImmediate {
+        rows: Vec<Row>,
+        #[derivative(Debug = "ignore")]
+        span: tracing::Span,
+    },
     /// The specified variable was set to a new value.
     SetVariable {
         name: String,
@@ -602,7 +625,10 @@ pub enum ExecuteResponse {
     StartedTransaction,
     /// Updates to the requested source or view will be streamed to the
     /// contained receiver.
-    Subscribing { rx: RowBatchStream },
+    Subscribing {
+        rx: RowBatchStream,
+        ctx_extra: ExecuteContextExtra,
+    },
     /// The active transaction committed.
     TransactionCommitted {
         /// Session parameters that changed because the transaction ended.
@@ -726,6 +752,7 @@ impl TryInto<ExecuteResponse> for ExecuteResponseKind {
             ExecuteResponseKind::TransactionRolledBack => Err(()),
             ExecuteResponseKind::Updated => Err(()),
             ExecuteResponseKind::ValidatedConnection => Ok(ExecuteResponse::ValidatedConnection),
+            ExecuteResponseKind::SendingRowsImmediate => Err(()),
         }
     }
 }
@@ -785,7 +812,7 @@ impl ExecuteResponse {
             ReassignOwned => Some("REASSIGN OWNED".into()),
             RevokedPrivilege => Some("REVOKE".into()),
             RevokedRole => Some("REVOKE ROLE".into()),
-            SendingRows { .. } => None,
+            SendingRows { .. } | SendingRowsImmediate { .. } => None,
             SetVariable { reset: true, .. } => Some("RESET".into()),
             SetVariable { reset: false, .. } => Some("SET".into()),
             StartedTransaction { .. } => Some("BEGIN".into()),
@@ -853,14 +880,20 @@ impl ExecuteResponse {
             DropOwned => vec![DroppedOwned],
             PlanKind::EmptyQuery => vec![ExecuteResponseKind::EmptyQuery],
             Explain | Select | ShowAllVariables | ShowCreate | ShowVariable | InspectShard => {
-                vec![CopyTo, SendingRows]
+                vec![CopyTo, SendingRows, SendingRowsImmediate]
             }
-            Execute | ReadThenWrite => vec![Deleted, Inserted, SendingRows, Updated],
+            Execute | ReadThenWrite => vec![
+                Deleted,
+                Inserted,
+                SendingRows,
+                SendingRowsImmediate,
+                Updated,
+            ],
             PlanKind::Fetch => vec![ExecuteResponseKind::Fetch],
             GrantPrivileges => vec![GrantedPrivilege],
             GrantRole => vec![GrantedRole],
             CopyRows => vec![Inserted],
-            Insert => vec![Inserted, SendingRows],
+            Insert => vec![Inserted, SendingRows, SendingRowsImmediate],
             PlanKind::Prepare => vec![ExecuteResponseKind::Prepare],
             PlanKind::Raise => vec![ExecuteResponseKind::Raised],
             PlanKind::ReassignOwned => vec![ExecuteResponseKind::ReassignOwned],
@@ -871,7 +904,7 @@ impl ExecuteResponse {
             }
             PlanKind::Subscribe => vec![Subscribing, CopyTo],
             StartTransaction => vec![StartedTransaction],
-            SideEffectingFunc => vec![SendingRows],
+            SideEffectingFunc => vec![SendingRows, SendingRowsImmediate],
             ValidateConnection => vec![ExecuteResponseKind::ValidatedConnection],
         }
     }

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -27,7 +27,7 @@ impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_id = client.new_conn_id()?;
         let session = client.new_session(conn_id, SYSTEM_USER.clone());
-        let (session_client, _) = client.startup(session).await?;
+        let (session_client, _) = client.startup(session, vec![]).await?;
         Ok(Self { session_client })
     }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -656,6 +656,7 @@ impl PendingRead {
 /// coordinator for retirement. To enforce this, we assert in the
 /// `Drop` implementation.
 #[derive(Debug, Default)]
+#[must_use]
 pub struct ExecuteContextExtra {
     statement_uuid: Option<StatementLoggingId>,
 }
@@ -671,6 +672,7 @@ impl ExecuteContextExtra {
     /// Take responsibility for the contents.  This should only be
     /// called from code that knows what to do to finish up logging
     /// based on the inner value.
+    #[must_use]
     fn retire(mut self) -> Option<StatementLoggingId> {
         let Self { statement_uuid } = &mut self;
         statement_uuid.take()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -101,7 +101,7 @@ use mz_repr::explain::ExplainFormat;
 use mz_repr::role_id::RoleId;
 use mz_repr::statement_logging::{
     SessionHistoryEvent, StatementBeganExecutionRecord, StatementEndedExecutionReason,
-    StatementExecutionStrategy, StatementLoggingEvent,
+    StatementExecutionStrategy,
 };
 use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
@@ -1030,11 +1030,6 @@ pub struct Coordinator {
     /// Only used by tests; otherwise, `rand::thread_rng()` is used.
     /// Controlled by the system var `statement_logging_use_reproducible_rng`.
     statement_logging_reproducible_rng: rand_chacha::ChaCha8Rng,
-
-    /// Statement logging events that have been recorded in `mz_prepared_statement_history`
-    /// or `mz_statement_execution_history` but not
-    /// durably in the stash.
-    statement_logging_pending_events: Vec<StatementLoggingEvent>,
 }
 
 impl Coordinator {
@@ -2022,7 +2017,6 @@ pub async fn serve(
                 tracing_handle,
                 statement_logging_executions_begun: BTreeMap::new(),
                 statement_logging_reproducible_rng: rand_chacha::ChaCha8Rng::seed_from_u64(42),
-                statement_logging_pending_events: Vec::new(),
                 statement_logging_unlogged_sessions: BTreeMap::new(),
             };
             let bootstrap = handle.block_on(async {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -99,10 +99,7 @@ use mz_ore::{soft_assert_or_log, stack, task};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
 use mz_repr::role_id::RoleId;
-use mz_repr::statement_logging::{
-    SessionHistoryEvent, StatementBeganExecutionRecord, StatementEndedExecutionReason,
-    StatementExecutionStrategy,
-};
+use mz_repr::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use mz_repr::{Datum, GlobalId, RelationType, Row, Timestamp};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsController;
@@ -119,7 +116,6 @@ use mz_storage_client::types::sinks::StorageSinkConnection;
 use mz_storage_client::types::sources::Timeline;
 use mz_transform::Optimizer;
 use timely::progress::Antichain;
-use rand::SeedableRng;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
@@ -149,7 +145,7 @@ use crate::util::{ClientTransmitter, CompletedClientTransmitter, ComputeSinkId, 
 use crate::{flags, AdapterNotice, TimestampProvider};
 
 pub(crate) mod dataflows;
-use self::statement_logging::StatementLoggingId;
+use self::statement_logging::{StatementLogging, StatementLoggingId};
 
 pub(crate) mod id_bundle;
 pub(crate) mod peek;
@@ -1015,23 +1011,8 @@ pub struct Coordinator {
     /// Tracing handle.
     tracing_handle: TracingHandle,
 
-    /// Information about statement executions that have been logged
-    /// but not finished.
-    ///
-    /// This map needs to have enough state left over to later retract
-    /// the system table entries (so that we can update them when the
-    /// execution finished.)
-    statement_logging_executions_begun: BTreeMap<Uuid, StatementBeganExecutionRecord>,
-
-    /// Information about sessions that have been started, but which
-    /// have not yet been logged in `mz_session_history`.
-    /// They may be logged as part of a statement being executed (and chosen for logging).
-    statement_logging_unlogged_sessions: BTreeMap<Uuid, SessionHistoryEvent>,
-
-    /// A reproducible RNG for deciding whether to sample statement executions.
-    /// Only used by tests; otherwise, `rand::thread_rng()` is used.
-    /// Controlled by the system var `statement_logging_use_reproducible_rng`.
-    statement_logging_reproducible_rng: rand_chacha::ChaCha8Rng,
+    /// Data used by the statement logging feature.
+    statement_logging: StatementLogging,
 }
 
 impl Coordinator {
@@ -2017,9 +1998,7 @@ pub async fn serve(
                 segment_client,
                 metrics,
                 tracing_handle,
-                statement_logging_executions_begun: BTreeMap::new(),
-                statement_logging_reproducible_rng: rand_chacha::ChaCha8Rng::seed_from_u64(42),
-                statement_logging_unlogged_sessions: BTreeMap::new(),
+                statement_logging: StatementLogging::new(),
             };
             let bootstrap = handle.block_on(async {
                 coord

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1849,8 +1849,7 @@ impl Coordinator {
         &self.active_conns
     }
 
-    // XXX rename this?
-    pub(crate) fn retire_peek(
+    pub(crate) fn retire_execution(
         &mut self,
         reason: StatementEndedExecutionReason,
         ctx_extra: ExecuteContextExtra,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -122,7 +122,7 @@ impl Coordinator {
                     .await;
             }
 
-            Command::RetireExecute { data, reason } => self.retire_execute(data, reason),
+            Command::RetireExecute { data, reason } => self.retire_execution(reason, data),
 
             Command::Declare {
                 name,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -369,7 +369,7 @@ impl Coordinator {
             },
         );
         let update = self.catalog().state().pack_session_update(&session, 1);
-        self.begin_session(&session);
+        self.begin_session_for_statement_logging(&session);
         self.send_builtin_table_updates(vec![update]).await;
 
         ClientTransmitter::new(tx, self.internal_cmd_tx.clone())
@@ -866,6 +866,7 @@ impl Coordinator {
             .dec();
         self.active_conns.remove(session.conn_id());
         self.cancel_pending_peeks(session.conn_id());
+        self.end_session_for_statement_logging(session.uuid());
         let update = self.catalog().state().pack_session_update(session, -1);
         self.send_builtin_table_updates(vec![update]).await;
     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -360,12 +360,19 @@ impl Coordinator {
             .iter()
             .any(|k| k == STATEMENT_LOGGING_SAMPLE_RATE.name())
         {
-            // let default = catalog.state().system_config().statem
-            session.vars_mut().set(
-                None,
-                STATEMENT_LOGGING_SAMPLE_RATE.name(),
-                VarInput::Flat(&default),
-            );
+            let default = catalog
+                .state()
+                .system_config()
+                .statement_logging_default_sample_rate();
+            session
+                .vars_mut()
+                .set(
+                    None,
+                    STATEMENT_LOGGING_SAMPLE_RATE.name(),
+                    VarInput::Flat(&default.to_string()),
+                    false,
+                )
+                .expect("constrained to be valid");
             session
                 .vars_mut()
                 .end_transaction(EndTransactionAction::Commit);

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -51,10 +51,6 @@ use crate::{catalog, metrics, rbac, ExecuteContext};
 use super::ExecuteContextExtra;
 
 impl Coordinator {
-    pub(crate) fn retire_execute(&mut self, _data: ExecuteContextExtra) {
-        // Do nothing, for now.
-        // In the future this is where we will log that statement execution finished.
-    }
     fn send_error(&mut self, cmd: Command, e: AdapterError) {
         fn send<T>(tx: oneshot::Sender<Response<T>>, session: Session, e: AdapterError) {
             let _ = tx.send(Response::<T> {
@@ -83,6 +79,7 @@ impl Coordinator {
                     send(tx, session, e)
                 }
             }
+            Command::RetireExecute { .. } => panic!("Command::RetireExecute is infallible"),
         }
     }
 
@@ -110,19 +107,18 @@ impl Coordinator {
                 session,
                 tx,
                 span,
+                outer_ctx_extra,
             } => {
                 let tx = ClientTransmitter::new(tx, self.internal_cmd_tx.clone());
-                let ctx = ExecuteContext::from_parts(
-                    tx,
-                    self.internal_cmd_tx.clone(),
-                    session,
-                    ExecuteContextExtra,
-                );
-
                 let span = span
                     .in_scope(|| tracing::debug_span!("message_command (execute)").or_current());
-                self.handle_execute(portal_name, ctx).instrument(span).await;
+
+                self.handle_execute(portal_name, session, tx, outer_ctx_extra)
+                    .instrument(span)
+                    .await;
             }
+
+            Command::RetireExecute { data, reason } => self.retire_execute(data, reason),
 
             Command::Declare {
                 name,
@@ -373,6 +369,7 @@ impl Coordinator {
             },
         );
         let update = self.catalog().state().pack_session_update(&session, 1);
+        self.begin_session(&session);
         self.send_builtin_table_updates(vec![update]).await;
 
         ClientTransmitter::new(tx, self.internal_cmd_tx.clone())
@@ -381,42 +378,80 @@ impl Coordinator {
 
     /// Handles an execute command.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn handle_execute(&mut self, portal_name: String, mut ctx: ExecuteContext) {
-        if ctx.session().vars().emit_trace_id_notice() {
+    pub(crate) async fn handle_execute(
+        &mut self,
+        portal_name: String,
+        mut session: Session,
+        tx: ClientTransmitter<ExecuteResponse>,
+        // If this command was part of another execute command
+        // (for example, executing a `FETCH` statement causes an execute to be
+        //  issued for the cursor it references),
+        // then `outer_context` should be `Some`.
+        // This instructs the coordinator that the
+        // outer execute should be considered finished once the inner one is.
+        outer_context: Option<ExecuteContextExtra>,
+    ) {
+        if session.vars().emit_trace_id_notice() {
             let span_context = tracing::Span::current()
                 .context()
                 .span()
                 .span_context()
                 .clone();
             if span_context.is_valid() {
-                ctx.session().add_notice(AdapterNotice::QueryTrace {
+                session.add_notice(AdapterNotice::QueryTrace {
                     trace_id: span_context.trace_id(),
                 });
             }
         }
 
-        if let Err(err) = self.verify_portal(ctx.session_mut(), &portal_name) {
+        if let Err(err) = self.verify_portal(&mut session, &portal_name) {
+            // If statement logging hasn't started yet, we don't need
+            // to add any "end" event, so just make up a no-op
+            // `ExecuteContextExtra` here, via `Default::default`.
+            //
+            // It's a bit unfortunate because the edge case of failed
+            // portal verifications won't show up in statement
+            // logging, but there seems to be nothing else we can do,
+            // because we need access to the portal to begin logging.
+            //
+            // Another option would be to log a begin and end event, but just fill in NULLs
+            // for everything we get from the portal (prepared statement id, params).
+            let extra = outer_context.unwrap_or_else(Default::default);
+            let ctx = ExecuteContext::from_parts(tx, self.internal_cmd_tx.clone(), session, extra);
             return ctx.retire(Err(err));
         }
 
-        let portal = ctx
-            .session()
-            .get_portal_unverified(&portal_name)
-            .expect("known to exist");
+        // The reference to `portal` can't outlive `session`, which we
+        // use to construct the context, so scope the reference to this block where we
+        // get everything we need from the portal for later.
+        let (stmt, ctx, params) = {
+            let portal = session
+                .get_portal_unverified(&portal_name)
+                .expect("known to exist");
+            let params = portal.parameters.clone();
+            let stmt = portal.stmt.clone();
+            let logging = Arc::clone(&portal.logging);
 
-        let stmt = match &portal.stmt {
-            Some(stmt) => stmt.clone(),
-            None => return ctx.retire(Ok(ExecuteResponse::EmptyQuery)),
+            let extra = if let Some(extra) = outer_context {
+                // We are executing in the context of another SQL statement, so we don't
+                // want to begin statement logging anew. The context of the actual statement
+                // being executed is the one that should be retired once this finishes.
+                extra
+            } else {
+                // This is a new statement, log it and return the context
+                let maybe_uuid =
+                    self.begin_statement_execution(&mut session, params.clone(), &logging);
+
+                ExecuteContextExtra::new(maybe_uuid)
+            };
+            let ctx = ExecuteContext::from_parts(tx, self.internal_cmd_tx.clone(), session, extra);
+            (stmt, ctx, params)
         };
 
-        let logging = Arc::clone(&portal.logging);
-
-        self.begin_statement_execution(ctx.session_mut(), &logging);
-
-        let portal = ctx
-            .session()
-            .get_portal_unverified(&portal_name)
-            .expect("known to exist");
+        let stmt = match stmt {
+            Some(stmt) => stmt,
+            None => return ctx.retire(Ok(ExecuteResponse::EmptyQuery)),
+        };
 
         let session_type = metrics::session_type_label_value(ctx.session().user());
         let stmt_type = metrics::statement_type_label_value(&stmt);
@@ -441,7 +476,6 @@ impl Coordinator {
             _ => {}
         }
 
-        let params = portal.parameters.clone();
         self.handle_execute_inner(stmt, params, ctx).await
     }
 
@@ -792,6 +826,11 @@ impl Coordinator {
                 conn_id: _,
                 cluster_id: _,
                 depends_on: _,
+                // We take responsibility for retiring the
+                // peek in `self.cancel_pending_peeks`,
+                // so we don't need to do anything with `ctx_extra` here.
+                ctx_extra: _,
+                is_fast_path: _,
             } in self.cancel_pending_peeks(&conn_id)
             {
                 // Cancel messages can be sent after the connection has hung

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -19,12 +19,13 @@ use mz_controller::ControllerResponse;
 use mz_ore::now::EpochMillis;
 use mz_ore::task;
 use mz_persist_client::usage::ShardsUsageReferenced;
+use mz_repr::statement_logging::StatementEndedExecutionReason;
 use mz_sql::ast::Statement;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{CreateSourcePlans, Plan};
 use mz_storage_client::controller::CollectionMetadata;
 use rand::{rngs, Rng, SeedableRng};
-use tracing::{event, warn, Instrument, Level};
+use tracing::{event, warn, Level};
 
 use crate::client::ConnectionId;
 use crate::command::{Command, ExecuteResponse};
@@ -35,7 +36,7 @@ use crate::coord::{
     SinkConnectionReady,
 };
 use crate::util::{ComputeSinkId, ResultExt};
-use crate::{catalog, AdapterNotice, TimestampContext};
+use crate::{catalog, AdapterNotice, ExecuteContextExtra, TimestampContext};
 
 impl Coordinator {
     pub(crate) async fn handle_message(&mut self, msg: Message) {
@@ -58,14 +59,6 @@ impl Coordinator {
                 self.message_create_connection_validation_ready(ready).await
             }
             Message::SinkConnectionReady(ready) => self.message_sink_connection_ready(ready).await,
-            Message::Execute {
-                portal_name,
-                ctx,
-                span,
-            } => {
-                let span = tracing::debug_span!(parent: &span, "message (execute)");
-                self.handle_execute(portal_name, ctx).instrument(span).await;
-            }
             Message::WriteLockGrant(write_lock_guard) => {
                 self.message_write_lock_grant(write_lock_guard).await;
             }
@@ -101,8 +94,8 @@ impl Coordinator {
                 self.message_real_time_recency_timestamp(conn_id, real_time_recency_ts, validity)
                     .await;
             }
-            Message::RetireExecute { data } => {
-                self.retire_execute(data);
+            Message::RetireExecute { data, reason } => {
+                self.retire_execute(data, reason);
             }
             Message::ExecuteSingleStatementTransaction { ctx, stmt, params } => {
                 self.sequence_execute_single_statement_transaction(ctx, stmt, params)
@@ -111,6 +104,15 @@ impl Coordinator {
             Message::PeekStageReady { ctx, stage } => {
                 self.sequence_peek_stage(ctx, stage).await;
             }
+        }
+    }
+    pub(crate) fn retire_execute(
+        &mut self,
+        ctx_extra: ExecuteContextExtra,
+        reason: StatementEndedExecutionReason,
+    ) {
+        if let Some(statement_uuid) = ctx_extra.retire() {
+            self.end_statement_execution(statement_uuid, reason)
         }
     }
 
@@ -739,7 +741,7 @@ impl Coordinator {
                 id_bundle,
             } => {
                 let result = self.sequence_explain_timestamp_finish(
-                    ctx.session_mut(),
+                    &mut ctx,
                     format,
                     cluster_id,
                     optimized_plan,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -25,7 +25,7 @@ use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{CreateSourcePlans, Plan};
 use mz_storage_client::controller::CollectionMetadata;
 use rand::{rngs, Rng, SeedableRng};
-use tracing::{event, warn, Level};
+use tracing::{event, warn, Instrument, Level};
 
 use crate::client::ConnectionId;
 use crate::command::{Command, ExecuteResponse};

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -359,7 +359,7 @@ impl crate::coord::Coordinator {
                     StatementEndedExecutionReason::Errored { error },
                 ),
             };
-            self.retire_peek(reason, std::mem::take(ctx_extra));
+            self.retire_execution(reason, std::mem::take(ctx_extra));
             return ret;
         }
 
@@ -536,7 +536,7 @@ impl crate::coord::Coordinator {
                 .collect::<Vec<_>>();
             for peek in &mut ret {
                 let ctx_extra = std::mem::take(&mut peek.ctx_extra);
-                self.retire_peek(StatementEndedExecutionReason::Canceled, ctx_extra);
+                self.retire_execution(StatementEndedExecutionReason::Canceled, ctx_extra);
             }
             ret
         } else {
@@ -569,7 +569,7 @@ impl crate::coord::Coordinator {
                         execution_strategy: Some(if is_fast_path {
                             StatementExecutionStrategy::FastPath
                         } else {
-                            StatementExecutionStrategy::Constant
+                            StatementExecutionStrategy::Standard
                         }),
                     }
                 }
@@ -578,7 +578,7 @@ impl crate::coord::Coordinator {
                 }
                 PeekResponse::Canceled => StatementEndedExecutionReason::Canceled,
             };
-            self.retire_peek(reason, ctx_extra);
+            self.retire_execution(reason, ctx_extra);
             otel_ctx.attach_as_parent();
             // Peek cancellations are best effort, so we might still
             // receive a response, even though the recipient is gone.

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -29,6 +29,7 @@ use mz_ore::str::{separated, Indent, StrExt};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{CompactScalarSeq, ExprHumanizer, Indices};
+use mz_repr::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use mz_repr::{Diff, GlobalId, RelationType, Row};
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
@@ -36,9 +37,10 @@ use tokio::sync::oneshot;
 use uuid::Uuid;
 
 use crate::client::ConnectionId;
+
 use crate::coord::timestamp_selection::TimestampDetermination;
-use crate::util::{send_immediate_rows, ResultExt};
-use crate::AdapterError;
+use crate::util::ResultExt;
+use crate::{AdapterError, ExecuteContextExtra, ExecuteResponse};
 
 #[derive(Debug)]
 pub(crate) struct PendingPeek {
@@ -47,6 +49,10 @@ pub(crate) struct PendingPeek {
     pub(crate) cluster_id: ClusterId,
     /// All `GlobalId`s that the peek depend on.
     pub(crate) depends_on: BTreeSet<GlobalId>,
+    /// Context about the execute that produced this peek,
+    /// needed by the coordinator for retiring it.
+    pub(crate) ctx_extra: ExecuteContextExtra,
+    pub(crate) is_fast_path: bool,
 }
 
 /// The response from a `Peek`, with row multiplicities represented in unary.
@@ -294,6 +300,7 @@ impl crate::coord::Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn implement_peek_plan(
         &mut self,
+        ctx_extra: &mut ExecuteContextExtra,
         plan: PlannedPeek,
         finishing: RowSetFinishing,
         compute_instance: ComputeInstanceId,
@@ -336,10 +343,24 @@ impl crate::coord::Coordinator {
                 }
             }
             let results = finishing.finish(results, max_result_size);
-            return match results {
-                Ok(rows) => Ok(send_immediate_rows(rows)),
-                Err(e) => Err(AdapterError::ResultSize(e)),
+            let (ret, reason) = match results {
+                Ok(rows) => {
+                    let rows_returned = u64::cast_from(rows.len());
+                    (
+                        Ok(Self::send_immediate_rows(rows)),
+                        StatementEndedExecutionReason::Success {
+                            rows_returned: Some(rows_returned),
+                            execution_strategy: Some(StatementExecutionStrategy::Constant),
+                        },
+                    )
+                }
+                Err(error) => (
+                    Err(AdapterError::ResultSize(error.clone())),
+                    StatementEndedExecutionReason::Errored { error },
+                ),
             };
+            self.retire_peek(reason, std::mem::take(ctx_extra));
+            return ret;
         }
 
         let timestamp = determination.timestamp_context.timestamp_or_default();
@@ -350,7 +371,7 @@ impl crate::coord::Coordinator {
         // differently.
 
         // If we must build the view, ship the dataflow.
-        let (peek_command, drop_dataflow) = match fast_path {
+        let (peek_command, drop_dataflow, is_fast_path) = match fast_path {
             PeekPlan::FastPath(FastPathPlan::PeekExisting(
                 id,
                 literal_constraints,
@@ -358,6 +379,7 @@ impl crate::coord::Coordinator {
             )) => (
                 (id, literal_constraints, timestamp, map_filter_project),
                 None,
+                true,
             ),
             PeekPlan::SlowPath(PeekDataflowPlan {
                 desc: dataflow,
@@ -406,6 +428,7 @@ impl crate::coord::Coordinator {
                         map_filter_project,
                     ),
                     Some(index_id),
+                    false,
                 )
             }
             _ => {
@@ -432,6 +455,8 @@ impl crate::coord::Coordinator {
                 conn_id: conn_id.clone(),
                 cluster_id: compute_instance,
                 depends_on: source_ids,
+                ctx_extra: std::mem::take(ctx_extra),
+                is_fast_path,
             },
         );
         self.client_pending_peeks
@@ -505,10 +530,15 @@ impl crate::coord::Coordinator {
                 }
             }
 
-            uuids
+            let mut ret = uuids
                 .iter()
                 .filter_map(|(uuid, _)| self.pending_peeks.remove(uuid))
-                .collect()
+                .collect::<Vec<_>>();
+            for peek in &mut ret {
+                let ctx_extra = std::mem::take(&mut peek.ctx_extra);
+                self.retire_peek(StatementEndedExecutionReason::Canceled, ctx_extra);
+            }
+            ret
         } else {
             Vec::new()
         }
@@ -527,8 +557,28 @@ impl crate::coord::Coordinator {
             conn_id: _,
             cluster_id: _,
             depends_on: _,
+            ctx_extra,
+            is_fast_path,
         }) = self.remove_pending_peek(&uuid)
         {
+            let reason = match &response {
+                PeekResponse::Rows(r) => {
+                    let rows_returned: u64 = r.iter().map(|(_, n)| u64::cast_from(n.get())).sum();
+                    StatementEndedExecutionReason::Success {
+                        rows_returned: Some(rows_returned),
+                        execution_strategy: Some(if is_fast_path {
+                            StatementExecutionStrategy::FastPath
+                        } else {
+                            StatementExecutionStrategy::Constant
+                        }),
+                    }
+                }
+                PeekResponse::Error(e) => {
+                    StatementEndedExecutionReason::Errored { error: e.clone() }
+                }
+                PeekResponse::Canceled => StatementEndedExecutionReason::Canceled,
+            };
+            self.retire_peek(reason, ctx_extra);
             otel_ctx.attach_as_parent();
             // Peek cancellations are best effort, so we might still
             // receive a response, even though the recipient is gone.
@@ -552,6 +602,16 @@ impl crate::coord::Coordinator {
             }
         }
         pending_peek
+    }
+
+    /// Constructs an [`ExecuteResponse`] that that will send some rows to the
+    /// client immediately, as opposed to asking the dataflow layer to send along
+    /// the rows after some computation.
+    pub(crate) fn send_immediate_rows(rows: Vec<Row>) -> ExecuteResponse {
+        ExecuteResponse::SendingRowsImmediate {
+            rows,
+            span: tracing::Span::none(),
+        }
     }
 }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -34,7 +34,7 @@ use crate::coord::{introspection, Coordinator, Message};
 use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
 use crate::session::{EndTransactionAction, Session, TransactionStatus};
-use crate::util::{send_immediate_rows, ClientTransmitter};
+use crate::util::ClientTransmitter;
 use crate::{rbac, ExecuteContext, ExecuteResponseKind};
 
 // DO NOT make this visible in any way, i.e. do not add any version of
@@ -271,7 +271,7 @@ impl Coordinator {
             }
             Plan::Subscribe(plan) => {
                 let result = self
-                    .sequence_subscribe(ctx.session_mut(), plan, target_cluster)
+                    .sequence_subscribe(&mut ctx, plan, target_cluster)
                     .await;
                 ctx.retire(result);
             }
@@ -279,7 +279,7 @@ impl Coordinator {
                 ctx.retire(self.sequence_side_effecting_func(plan));
             }
             Plan::ShowCreate(plan) => {
-                ctx.retire(Ok(send_immediate_rows(vec![plan.row])));
+                ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
             }
             Plan::CopyFrom(plan) => {
                 let (tx, _, session, ctx_extra) = ctx.into_parts();
@@ -412,10 +412,12 @@ impl Coordinator {
                 count,
                 timeout,
             }) => {
+                let ctx_extra = std::mem::take(ctx.extra_mut());
                 ctx.retire(Ok(ExecuteResponse::Fetch {
                     name,
                     count,
                     timeout,
+                    ctx_extra,
                 }));
             }
             Plan::Close(plan) => {
@@ -447,12 +449,15 @@ impl Coordinator {
             Plan::Execute(plan) => {
                 match self.sequence_execute(ctx.session_mut(), plan) {
                     Ok(portal_name) => {
+                        let (tx, _, session, extra) = ctx.into_parts();
                         self.internal_cmd_tx
-                            .send(Message::Execute {
+                            .send(Message::Command(Command::Execute {
                                 portal_name,
-                                ctx,
+                                session,
+                                tx: tx.take(),
+                                outer_ctx_extra: Some(extra),
                                 span: tracing::Span::none(),
-                            })
+                            }))
                             .expect("sending to self.internal_cmd_tx cannot fail");
                     }
                     Err(err) => ctx.retire(Err(err)),
@@ -601,7 +606,7 @@ impl Coordinator {
 
     pub(crate) fn sequence_explain_timestamp_finish(
         &mut self,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
         format: ExplainFormat,
         cluster_id: ClusterId,
         optimized_plan: OptimizedMirRelationExpr,
@@ -609,7 +614,7 @@ impl Coordinator {
         real_time_recency_ts: Option<Timestamp>,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.sequence_explain_timestamp_finish_inner(
-            session,
+            ctx.session_mut(),
             format,
             cluster_id,
             optimized_plan,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -103,9 +103,7 @@ use crate::notice::AdapterNotice;
 use crate::rbac::{self, is_rbac_enabled_for_session};
 use crate::session::{EndTransactionAction, Session, TransactionOps, TransactionStatus, WriteOp};
 use crate::subscribe::ActiveSubscribe;
-use crate::util::{
-    send_immediate_rows, viewable_variables, ClientTransmitter, ComputeSinkId, ResultExt,
-};
+use crate::util::{viewable_variables, ClientTransmitter, ComputeSinkId, ResultExt};
 use crate::{guard_write_critical_section, PeekResponseUnary, TimestampExplanation};
 
 /// Attempts to evaluate an expression. If an error is returned then the error is sent
@@ -1547,7 +1545,7 @@ impl Coordinator {
             .map(|v| (v.name(), v.value(), v.description()))
             .collect::<Vec<_>>();
         rows.sort_by_cached_key(|(name, _, _)| name.to_lowercase());
-        Ok(send_immediate_rows(
+        Ok(Self::send_immediate_rows(
             rows.into_iter()
                 .map(|(name, val, desc)| {
                     Row::pack_slice(&[
@@ -1561,7 +1559,7 @@ impl Coordinator {
     }
 
     pub(super) fn sequence_show_variable(
-        &self,
+        &mut self,
         session: &Session,
         plan: plan::ShowVariablePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
@@ -1576,7 +1574,7 @@ impl Coordinator {
                         .name()
                         .schema;
                     let row = Row::pack_slice(&[Datum::String(schema_name)]);
-                    Ok(send_immediate_rows(vec![row]))
+                    Ok(Self::send_immediate_rows(vec![row]))
                 }
                 None => {
                     session.add_notice(AdapterNotice::NoResolvableSearchPathSchema {
@@ -1587,7 +1585,9 @@ impl Coordinator {
                             .map(|schema| schema.to_string())
                             .collect(),
                     });
-                    Ok(send_immediate_rows(vec![Row::pack_slice(&[Datum::Null])]))
+                    Ok(Self::send_immediate_rows(vec![Row::pack_slice(&[
+                        Datum::Null,
+                    ])]))
                 }
             };
         }
@@ -1619,7 +1619,7 @@ impl Coordinator {
             let name = variable.value();
             session.add_notice(AdapterNotice::ClusterDoesNotExist { name });
         }
-        Ok(send_immediate_rows(vec![row]))
+        Ok(Self::send_immediate_rows(vec![row]))
     }
 
     pub(super) async fn sequence_inspect_shard(
@@ -1642,7 +1642,7 @@ impl Coordinator {
             .inspect_persist_state(plan.id)
             .await?;
         let jsonb = Jsonb::from_serde_json(state)?;
-        Ok(send_immediate_rows(vec![jsonb.into_row()]))
+        Ok(Self::send_immediate_rows(vec![jsonb.into_row()]))
     }
 
     pub(super) fn sequence_set_variable(
@@ -1882,7 +1882,7 @@ impl Coordinator {
                 } else {
                     Datum::False
                 };
-                Ok(send_immediate_rows(vec![Row::pack_slice(&[res])]))
+                Ok(Self::send_immediate_rows(vec![Row::pack_slice(&[res])]))
             }
         }
     }
@@ -1946,7 +1946,7 @@ impl Coordinator {
                     None => return,
                 },
                 PeekStage::Finish(stage) => {
-                    let res = self.peek_stage_finish(ctx.session_mut(), stage).await;
+                    let res = self.peek_stage_finish(&mut ctx, stage).await;
                     ctx.retire(res);
                     return;
                 }
@@ -2258,7 +2258,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     async fn peek_stage_finish(
         &mut self,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
         PeekStageFinish {
             validity: _,
             finishing,
@@ -2283,7 +2283,7 @@ impl Coordinator {
         });
         let peek_plan = self.plan_peek(
             dataflow,
-            session,
+            ctx.session_mut(),
             &when,
             cluster_id,
             view_id,
@@ -2299,12 +2299,13 @@ impl Coordinator {
         let determination = peek_plan.determination.clone();
 
         let max_query_result_size = std::cmp::min(
-            session.vars().max_query_result_size(),
+            ctx.session().vars().max_query_result_size(),
             self.catalog().system_config().max_result_size(),
         );
         // Implement the peek, and capture the response.
         let resp = self
             .implement_peek_plan(
+                ctx.extra_mut(),
                 peek_plan,
                 finishing,
                 cluster_id,
@@ -2313,10 +2314,11 @@ impl Coordinator {
             )
             .await?;
 
-        if session.vars().emit_timestamp_notice() {
+        if ctx.session().vars().emit_timestamp_notice() {
             let explanation =
-                self.explain_timestamp(session, cluster_id, &id_bundle, determination);
-            session.add_notice(AdapterNotice::QueryTimestamp { explanation });
+                self.explain_timestamp(ctx.session(), cluster_id, &id_bundle, determination);
+            ctx.session()
+                .add_notice(AdapterNotice::QueryTimestamp { explanation });
         }
 
         match copy_to {
@@ -2526,7 +2528,7 @@ impl Coordinator {
 
     pub(super) async fn sequence_subscribe(
         &mut self,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
         plan: plan::SubscribePlan,
         target_cluster: TargetCluster,
     ) -> Result<ExecuteResponse, AdapterError> {
@@ -2542,10 +2544,10 @@ impl Coordinator {
 
         let cluster = self
             .catalog()
-            .resolve_target_cluster(target_cluster, session)?;
+            .resolve_target_cluster(target_cluster, ctx.session())?;
         let cluster_id = cluster.id;
 
-        let target_replica_name = session.vars().cluster_replica();
+        let target_replica_name = ctx.session().vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {
                 cluster.replica_id_by_name.get(name).copied().ok_or(
@@ -2562,7 +2564,8 @@ impl Coordinator {
         if when == QueryWhen::Immediately {
             // If this isn't a SUBSCRIBE AS OF, the SUBSCRIBE can be in a transaction if it's the
             // only operation.
-            session.add_transaction_ops(TransactionOps::Subscribe)?;
+            ctx.session_mut()
+                .add_transaction_ops(TransactionOps::Subscribe)?;
         }
 
         // Determine the frontier of updates to subscribe *from*.
@@ -2574,7 +2577,14 @@ impl Coordinator {
             .sufficient_collections(&depends_on);
         let timeline = self.validate_timeline_context(id_bundle.iter())?;
         let as_of = self
-            .determine_timestamp(session, &id_bundle, &when, cluster_id, &timeline, None)?
+            .determine_timestamp(
+                ctx.session(),
+                &id_bundle,
+                &when,
+                cluster_id,
+                &timeline,
+                None,
+            )?
             .timestamp_context
             .timestamp_or_default();
 
@@ -2606,12 +2616,12 @@ impl Coordinator {
                     .desc(
                         &self
                             .catalog()
-                            .resolve_full_name(from.name(), Some(session.conn_id())),
+                            .resolve_full_name(from.name(), Some(ctx.session().conn_id())),
                     )
                     .expect("subscribes can only be run on items with descs")
                     .into_owned();
                 let sink_id = self.allocate_transient_id()?;
-                let sink_desc = make_sink_desc(self, session, from_id, from_desc)?;
+                let sink_desc = make_sink_desc(self, ctx.session_mut(), from_id, from_desc)?;
                 let sink_name = format!("subscribe-{}", sink_id);
                 self.dataflow_builder(cluster_id)
                     .build_sink_dataflow(sink_name, sink_id, sink_desc)?
@@ -2620,7 +2630,7 @@ impl Coordinator {
                 let id = self.allocate_transient_id()?;
                 let expr = self.view_optimizer.optimize(expr)?;
                 let desc = RelationDesc::new(expr.typ(), desc.iter_names());
-                let sink_desc = make_sink_desc(self, session, id, desc)?;
+                let sink_desc = make_sink_desc(self, ctx.session_mut(), id, desc)?;
                 let mut dataflow = DataflowDesc::new(format!("subscribe-{}", id));
                 let mut dataflow_builder = self.dataflow_builder(cluster_id);
                 dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;
@@ -2638,8 +2648,8 @@ impl Coordinator {
             .expect("subscribes have a single sink export");
         let (tx, rx) = mpsc::unbounded_channel();
         let active_subscribe = ActiveSubscribe {
-            user: session.user().clone(),
-            conn_id: session.conn_id().clone(),
+            user: ctx.session().user().clone(),
+            conn_id: ctx.session().conn_id().clone(),
             channel: tx,
             emit_progress,
             as_of,
@@ -2668,7 +2678,7 @@ impl Coordinator {
         }
 
         self.active_conns
-            .get_mut(session.conn_id())
+            .get_mut(ctx.session().conn_id())
             .expect("must exist for active sessions")
             .drop_sinks
             .push(ComputeSinkId {
@@ -2676,7 +2686,10 @@ impl Coordinator {
                 global_id: sink_id,
             });
 
-        let resp = ExecuteResponse::Subscribing { rx };
+        let resp = ExecuteResponse::Subscribing {
+            rx,
+            ctx_extra: std::mem::take(ctx.extra_mut()),
+        };
         match copy_to {
             None => Ok(resp),
             Some(format) => Ok(ExecuteResponse::CopyTo {
@@ -2696,7 +2709,7 @@ impl Coordinator {
             ExplainStage::Timestamp => self.sequence_explain_timestamp_begin(ctx, plan),
             _ => {
                 let result = self
-                    .sequence_explain_plan(ctx.session_mut(), plan, target_cluster)
+                    .sequence_explain_plan(&mut ctx, plan, target_cluster)
                     .await;
                 ctx.retire(result);
             }
@@ -2705,7 +2718,7 @@ impl Coordinator {
 
     async fn sequence_explain_plan(
         &mut self,
-        session: &mut Session,
+        ctx: &mut ExecuteContext,
         plan: plan::ExplainPlan,
         target_cluster: TargetCluster,
     ) -> Result<ExecuteResponse, AdapterError> {
@@ -2724,8 +2737,10 @@ impl Coordinator {
         let cluster_id = {
             let catalog = self.catalog();
             let cluster = match explainee {
-                Explainee::Dataflow(_) => catalog.active_cluster(session)?,
-                Explainee::Query => catalog.resolve_target_cluster(target_cluster, session)?,
+                Explainee::Dataflow(_) => catalog.active_cluster(ctx.session())?,
+                Explainee::Query => {
+                    catalog.resolve_target_cluster(target_cluster, ctx.session())?
+                }
             };
             cluster.id
         };
@@ -2738,9 +2753,15 @@ impl Coordinator {
         };
 
         let pipeline_result = {
-            self.sequence_explain_plan_pipeline(explainee, raw_plan, no_errors, cluster_id, session)
-                .with_subscriber(&optimizer_trace)
-                .await
+            self.sequence_explain_plan_pipeline(
+                explainee,
+                raw_plan,
+                no_errors,
+                cluster_id,
+                ctx.session_mut(),
+            )
+            .with_subscriber(&optimizer_trace)
+            .await
         };
 
         let (used_indexes, fast_path_plan) = match pipeline_result {
@@ -2762,7 +2783,7 @@ impl Coordinator {
         let trace = optimizer_trace.drain_all(
             format,
             config,
-            self.catalog().for_session(session),
+            self.catalog().for_session(ctx.session()),
             row_set_finishing,
             used_indexes,
             fast_path_plan,
@@ -2804,7 +2825,7 @@ impl Coordinator {
             }
         };
 
-        Ok(send_immediate_rows(rows))
+        Ok(Self::send_immediate_rows(rows))
     }
 
     #[tracing::instrument(level = "info", name = "optimize", skip_all)]
@@ -3176,7 +3197,7 @@ impl Coordinator {
             explanation.to_string()
         };
         let rows = vec![Row::pack_slice(&[Datum::from(s.as_str())])];
-        Ok(send_immediate_rows(rows))
+        Ok(Self::send_immediate_rows(rows))
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
@@ -3237,7 +3258,7 @@ impl Coordinator {
                 project: (0..plan.returning[0].0.iter().count()).collect(),
             };
             return match finishing.finish(plan.returning, plan.max_result_size) {
-                Ok(rows) => Ok(send_immediate_rows(rows)),
+                Ok(rows) => Ok(Self::send_immediate_rows(rows)),
                 Err(e) => Err(AdapterError::ResultSize(e)),
             };
         }
@@ -3482,6 +3503,17 @@ impl Coordinator {
         let (peek_tx, peek_rx) = oneshot::channel();
         let peek_client_tx = ClientTransmitter::new(peek_tx, self.internal_cmd_tx.clone());
         let (tx, _, session, extra) = ctx.into_parts();
+        // We construct a new execute context for the peek, with a trivial (`Default::default()`)
+        // execution context, because this peek does not directly correspond to an execute,
+        // and so we don't need to take any action on its retirement.
+        // TODO[btv]: we might consider extending statement logging to log the inner
+        // statement separately, here. That would require us to plumb through the SQL of the inner statement,
+        // and mint a new "real" execution context here. We'd also have to add some logic to
+        // make sure such "sub-statements" are always sampled when the top-level statement is
+        //
+        // It's debatable whether this makes sense conceptually,
+        // because the inner fragment here is not actually a
+        // "statement" in its own right.
         let peek_ctx = ExecuteContext::from_parts(
             peek_client_tx,
             self.internal_cmd_tx.clone(),
@@ -3523,7 +3555,49 @@ impl Coordinator {
             };
             let mut ctx = ExecuteContext::from_parts(tx, internal_cmd_tx.clone(), session, extra);
             let timeout_dur = *ctx.session().vars().statement_timeout();
-            let arena = RowArena::new();
+            let make_diffs = move |rows: Vec<Row>| -> Result<Vec<(Row, Diff)>, AdapterError> {
+                let arena = RowArena::new();
+                // Use 2x row len incase there's some assignments.
+                let mut diffs = Vec::with_capacity(rows.len() * 2);
+                let mut datum_vec = mz_repr::DatumVec::new();
+                for row in rows {
+                    if !assignments.is_empty() {
+                        assert!(
+                            matches!(kind, MutationKind::Update),
+                            "only updates support assignments"
+                        );
+                        let mut datums = datum_vec.borrow_with(&row);
+                        let mut updates = vec![];
+                        for (idx, expr) in &assignments {
+                            let updated = match expr.eval(&datums, &arena) {
+                                Ok(updated) => updated,
+                                Err(e) => return Err(AdapterError::Unstructured(anyhow!(e))),
+                            };
+                            updates.push((*idx, updated));
+                        }
+                        for (idx, new_value) in updates {
+                            datums[idx] = new_value;
+                        }
+                        let updated = Row::pack_slice(&datums);
+                        diffs.push((updated, 1));
+                    }
+                    match kind {
+                        // Updates and deletes always remove the
+                        // current row. Updates will also add an
+                        // updated value.
+                        MutationKind::Update | MutationKind::Delete => diffs.push((row, -1)),
+                        MutationKind::Insert => diffs.push((row, 1)),
+                    }
+                }
+                for (row, diff) in &diffs {
+                    if *diff > 0 {
+                        for (idx, datum) in row.iter().enumerate() {
+                            desc.constraints_met(idx, &datum)?;
+                        }
+                    }
+                }
+                Ok(diffs)
+            };
             let diffs = match peek_response {
                 ExecuteResponse::SendingRows {
                     future: batch,
@@ -3535,56 +3609,7 @@ impl Coordinator {
                     // clusters.
                     match tokio::time::timeout(timeout_dur, batch).await {
                         Ok(res) => match res {
-                            PeekResponseUnary::Rows(rows) => {
-                                |rows: Vec<Row>| -> Result<Vec<(Row, Diff)>, AdapterError> {
-                                    // Use 2x row len incase there's some assignments.
-                                    let mut diffs = Vec::with_capacity(rows.len() * 2);
-                                    let mut datum_vec = mz_repr::DatumVec::new();
-                                    for row in rows {
-                                        if !assignments.is_empty() {
-                                            assert!(
-                                                matches!(kind, MutationKind::Update),
-                                                "only updates support assignments"
-                                            );
-                                            let mut datums = datum_vec.borrow_with(&row);
-                                            let mut updates = vec![];
-                                            for (idx, expr) in &assignments {
-                                                let updated = match expr.eval(&datums, &arena) {
-                                                    Ok(updated) => updated,
-                                                    Err(e) => {
-                                                        return Err(AdapterError::Unstructured(
-                                                            anyhow!(e),
-                                                        ))
-                                                    }
-                                                };
-                                                updates.push((*idx, updated));
-                                            }
-                                            for (idx, new_value) in updates {
-                                                datums[idx] = new_value;
-                                            }
-                                            let updated = Row::pack_slice(&datums);
-                                            diffs.push((updated, 1));
-                                        }
-                                        match kind {
-                                            // Updates and deletes always remove the
-                                            // current row. Updates will also add an
-                                            // updated value.
-                                            MutationKind::Update | MutationKind::Delete => {
-                                                diffs.push((row, -1))
-                                            }
-                                            MutationKind::Insert => diffs.push((row, 1)),
-                                        }
-                                    }
-                                    for (row, diff) in &diffs {
-                                        if *diff > 0 {
-                                            for (idx, datum) in row.iter().enumerate() {
-                                                desc.constraints_met(idx, &datum)?;
-                                            }
-                                        }
-                                    }
-                                    Ok(diffs)
-                                }(rows)
-                            }
+                            PeekResponseUnary::Rows(rows) => make_diffs(rows),
                             PeekResponseUnary::Canceled => Err(AdapterError::Canceled),
                             PeekResponseUnary::Error(e) => {
                                 Err(AdapterError::Unstructured(anyhow!(e)))
@@ -3605,6 +3630,7 @@ impl Coordinator {
                         }
                     }
                 }
+                ExecuteResponse::SendingRowsImmediate { rows, span: _ } => make_diffs(rows),
                 resp @ ExecuteResponse::Canceled => {
                     ctx.retire(Ok(resp));
                     return;

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -9,13 +9,19 @@
 
 use std::sync::Arc;
 
+use bytes::BytesMut;
 use mz_ore::{cast::CastFrom, now::EpochMillis};
+use mz_repr::statement_logging::{
+    SessionHistoryEvent, StatementBeganExecutionRecord, StatementEndedExecutionReason,
+    StatementEndedExecutionRecord, StatementLoggingEvent, StatementPreparedRecord,
+};
+use mz_sql::plan::Params;
 use qcell::QCell;
+use rand::{distributions::Bernoulli, prelude::Distribution, thread_rng};
 use uuid::Uuid;
 
+use crate::coord::Coordinator;
 use crate::session::Session;
-
-use super::Coordinator;
 
 /// Metadata required for logging a prepared statement.
 #[derive(Debug)]
@@ -23,9 +29,6 @@ pub enum PreparedStatementLoggingInfo {
     /// The statement has already been logged; we don't need to log it
     /// again if a future execution hits the sampling rate; we merely
     /// need to reference the corresponding UUID.
-    ///
-    /// In this PR, this variant is never instantiated, because we are not
-    /// actually logging the prepared statements yet.
     AlreadyLogged { uuid: Uuid },
     /// The statement has not yet been logged; if a future execution
     /// hits the sampling rate, we need to log it at that point.
@@ -43,13 +46,117 @@ pub enum PreparedStatementLoggingInfo {
     },
 }
 
+#[derive(Debug, Ord, Eq, PartialOrd, PartialEq)]
+pub struct StatementLoggingId(Uuid);
+
 impl Coordinator {
-    /// Record metrics related to the future "statement logging" feature.
-    pub fn begin_statement_execution(
+    /// Returns any statement logging events needed for a particular
+    /// prepared statement. Possibly mutates the `PreparedStatementLoggingInfo` metadata.
+    ///
+    /// This function does not do a sampling check, and assumes we did so in a higher layer.
+    pub(crate) fn log_prepared_statement(
         &mut self,
         session: &mut Session,
         logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
+    ) -> (Option<StatementPreparedRecord>, Uuid) {
+        let logging = session.qcell_rw(&*logging);
+        let mut out = None;
+
+        let uuid = match logging {
+            PreparedStatementLoggingInfo::AlreadyLogged { uuid } => *uuid,
+            PreparedStatementLoggingInfo::StillToLog {
+                sql,
+                prepared_at,
+                name,
+                session_id,
+                accounted,
+            } => {
+                assert!(
+                    *accounted,
+                    "accounting for logging should be done in `begin_statement_execution`"
+                );
+                let uuid = Uuid::new_v4();
+                out = Some(StatementPreparedRecord {
+                    id: uuid,
+                    sql: std::mem::take(sql),
+                    name: std::mem::take(name),
+                    session_id: *session_id,
+                    prepared_at: *prepared_at,
+                });
+
+                *logging = PreparedStatementLoggingInfo::AlreadyLogged { uuid };
+                uuid
+            }
+        };
+        (out, uuid)
+    }
+    /// The rate at which statement execution should be sampled.
+    /// This is the value of the session var `statement_logging_sample_rate`,
+    /// constrained by the system var `statement_logging_max_sample_rate`.
+    pub fn statement_execution_sample_rate(&self, session: &Session) -> f64 {
+        let system: f64 = self
+            .catalog()
+            .system_config()
+            .statement_logging_max_sample_rate()
+            .try_into()
+            .expect("value constrained to be convertible to f64");
+        let user: f64 = session
+            .vars()
+            .get_statement_logging_sample_rate()
+            .try_into()
+            .expect("value constrained to be convertible to f64");
+        f64::min(system, user)
+    }
+
+    /// Record the end of statement execution for a statement whose beginning was logged.
+    /// It is an error to call this function for a statement whose beginning was not logged
+    /// (because it was not sampled). Requiring the opaque `StatementLoggingId` type,
+    /// which is only instantiated by `begin_statement_execution` if the statement is actually logged,
+    /// should prevent this.
+    pub fn end_statement_execution(
+        &mut self,
+        StatementLoggingId(id): StatementLoggingId,
+        reason: StatementEndedExecutionReason,
     ) {
+        let now = self.now_datetime();
+        let now_millis = now.timestamp_millis().try_into().expect("sane system time");
+        let ended_record = StatementEndedExecutionRecord {
+            id,
+            reason,
+            ended_at: now_millis,
+        };
+        self.statement_logging_pending_events
+            .push(StatementLoggingEvent::EndedExecution(ended_record.clone()));
+        let began_record = self.statement_logging_executions_begun.remove(&id).expect(
+            "matched `begin_statement_execution` and `end_statement_execution` invocations",
+        );
+        let updates = self
+            .catalog
+            .state()
+            .pack_statement_ended_execution_updates(&began_record, &ended_record);
+        self.buffer_builtin_table_updates(updates);
+    }
+    /// Possibly record the beginning of statement execution, depending on a randomly-chosen value.
+    /// If the execution beginning was indeed logged, returns a `StatementLoggingId` that must be
+    /// passed to `end_statement_execution` to record when it ends.
+    pub fn begin_statement_execution(
+        &mut self,
+        session: &mut Session,
+        params: Params,
+        logging: &Arc<QCell<PreparedStatementLoggingInfo>>,
+    ) -> Option<StatementLoggingId> {
+        let sample_rate = self.statement_execution_sample_rate(session);
+
+        let distribution = Bernoulli::new(sample_rate).expect("rate must be in range [0, 1]");
+        let sample = if self
+            .catalog()
+            .system_config()
+            .statement_logging_use_reproducible_rng()
+        {
+            distribution.sample(&mut self.statement_logging_reproducible_rng)
+        } else {
+            distribution.sample(&mut thread_rng())
+        };
         if let Some((sql, accounted)) = match session.qcell_rw(logging) {
             PreparedStatementLoggingInfo::AlreadyLogged { .. } => None,
             PreparedStatementLoggingInfo::StillToLog { sql, accounted, .. } => {
@@ -61,8 +168,85 @@ impl Coordinator {
                     .statement_logging_unsampled_bytes
                     .with_label_values(&[])
                     .inc_by(u64::cast_from(sql.len()));
+                if sample {
+                    self.metrics
+                        .statement_logging_actual_bytes
+                        .with_label_values(&[])
+                        .inc_by(u64::cast_from(sql.len()));
+                }
                 *accounted = true;
             }
         }
+        if !sample {
+            return None;
+        }
+
+        let (ps_record, ps_uuid) = self.log_prepared_statement(session, logging);
+
+        let ev_id = Uuid::new_v4();
+        let params = std::iter::zip(params.types.iter(), params.datums.iter())
+            .map(|(r#type, datum)| {
+                mz_pgrepr::Value::from_datum(datum, r#type).map(|val| {
+                    let mut buf = BytesMut::new();
+                    val.encode_text(&mut buf);
+                    String::from_utf8(Into::<Vec<u8>>::into(buf))
+                        .expect("Serialization shouldn't produce non-UTF-8 strings.")
+                })
+            })
+            .collect();
+        let record = StatementBeganExecutionRecord {
+            id: ev_id,
+            prepared_statement_id: ps_uuid,
+            sample_rate,
+            params,
+            began_at: self.now(),
+        };
+        self.statement_logging_pending_events
+            .push(StatementLoggingEvent::BeganExecution(record.clone()));
+        let ev = self
+            .catalog
+            .state()
+            .pack_statement_began_execution_update(&record, 1);
+        self.statement_logging_executions_begun
+            .insert(ev_id, record);
+        let updates = if let Some(ps_record) = ps_record {
+            self.statement_logging_pending_events
+                .push(StatementLoggingEvent::Prepared(ps_record.clone()));
+            let ps_ev = self
+                .catalog
+                .state()
+                .pack_statement_prepared_update(&ps_record);
+            if let Some(sh) = self
+                .statement_logging_unlogged_sessions
+                .remove(&ps_record.session_id)
+            {
+                let sh_ev = self.catalog.state().pack_session_history_update(&sh);
+                self.statement_logging_pending_events
+                    .push(StatementLoggingEvent::BeganSession(sh));
+                vec![sh_ev, ps_ev, ev]
+            } else {
+                vec![ps_ev, ev]
+            }
+        } else {
+            vec![ev]
+        };
+        self.buffer_builtin_table_updates(updates);
+        Some(StatementLoggingId(ev_id))
+    }
+
+    /// Record a new connection event
+    pub fn begin_session(&mut self, session: &Session) {
+        let id = session.uuid();
+        let connected_at = session.connect_time();
+        let application_name = session.application_name().to_owned();
+        let session_role = session.session_role_id();
+        let authenticated_user = self.catalog.get_role(session_role).name.clone();
+        let event = SessionHistoryEvent {
+            id,
+            connected_at,
+            application_name,
+            authenticated_user,
+        };
+        self.statement_logging_unlogged_sessions.insert(id, event);
     }
 }

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -263,7 +263,7 @@ impl Coordinator {
     }
 
     /// Record a new connection event
-    pub fn begin_session(&mut self, session: &Session) {
+    pub fn begin_session_for_statement_logging(&mut self, session: &Session) {
         let id = session.uuid();
         let connected_at = session.connect_time();
         let application_name = session.application_name().to_owned();
@@ -276,5 +276,9 @@ impl Coordinator {
             authenticated_user,
         };
         self.statement_logging.unlogged_sessions.insert(id, event);
+    }
+
+    pub fn end_session_for_statement_logging(&mut self, uuid: Uuid) {
+        self.statement_logging.unlogged_sessions.remove(&uuid);
     }
 }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -31,6 +31,7 @@ pub struct Metrics {
     pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub introspection_logins: IntCounter,
+    pub statement_logging_actual_bytes: IntCounterVec,
 }
 
 impl Metrics {
@@ -106,6 +107,10 @@ impl Metrics {
                 name: "mz_introspection_logins",
                 help: "Number of times mz_introspection used the psql interface",
             )),
+            statement_logging_actual_bytes: registry.register(metric!(
+                name: "mz_statement_logging_actual_bytes",
+                help: "The total amount of SQL text that was logged by statement logging.",
+            ))
         }
     }
 }

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -146,7 +146,8 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::GetSystemVars { .. }
         | Command::SetSystemVars { .. }
         | Command::AppendWebhook { .. }
-        | Command::Terminate { .. } => Ok(()),
+        | Command::Terminate { .. }
+        | Command::RetireExecute { .. } => Ok(()),
     }
 }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -491,7 +491,6 @@ impl<T: TimestampManipulation> Session<T> {
         &mut self,
         name: String,
         stmt: Option<Statement<Raw>>,
-        // TODO[btv] - This will be used by statement logging
         sql: String,
         desc: StatementDesc,
         catalog_revision: u64,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -457,7 +457,7 @@ impl AuthedClient {
         let drop_connection = DropConnection::new_connection(&user, active_connection_count)?;
         let conn_id = adapter_client.new_conn_id()?;
         let session = adapter_client.new_session(conn_id, user);
-        let (adapter_client, _) = adapter_client.startup(session).await?;
+        let (adapter_client, _) = adapter_client.startup(session, vec![]).await?;
         Ok(AuthedClient {
             client: adapter_client,
             drop_connection,

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -970,7 +970,7 @@ async fn execute_stmt<S: ResultSender>(
         .expect("unnamed portal should be present");
 
     let (res, execute_started) = match client
-        .execute(EMPTY_PORTAL.into(), futures::future::pending())
+        .execute(EMPTY_PORTAL.into(), futures::future::pending(), None)
         .await
     {
         Ok(res) => res,
@@ -1071,11 +1071,23 @@ async fn execute_stmt<S: ResultSender>(
             let tag = format!("SELECT {}", sql_rows.len());
             SqlResult::rows(client, tag, sql_rows, desc).into()
         }
-        ExecuteResponse::Subscribing { rx }  => {
+        ExecuteResponse::SendingRowsImmediate { rows, span: _} => {
+            let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
+            let mut datum_vec = mz_repr::DatumVec::new();
+            let desc = desc.relation_desc.expect("RelationDesc must exist");
+            let types = &desc.typ().column_types;
+            for row in rows {
+                let datums = datum_vec.borrow_with(&row);
+                sql_rows.push(datums.iter().enumerate().map(|(i, d)| TypedDatum::new(*d, &types[i]).json()).collect());
+            }
+            let tag = format!("SELECT {}", sql_rows.len());
+            SqlResult::rows(client, tag, sql_rows, desc).into()
+        }
+        ExecuteResponse::Subscribing { rx, ctx_extra: _ }  => {
             StatementResult::Subscribe {
-                tag: "SUBSCRIBE".into(),
+                tag:"SUBSCRIBE".into(),
                 desc: desc.relation_desc.unwrap(),
-                rx: RecordFirstRowStream::new(Box::new(UnboundedReceiverStream::new(rx)), execute_started, client),
+                rx: RecordFirstRowStream::new(Box::new(UnboundedReceiverStream::new(rx)), execute_started, client)
             }
         },
         res @ (ExecuteResponse::Fetch { .. }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -238,10 +238,6 @@ fn test_statement_logging_immediate() {
         "SHOW application_name",
     ];
 
-    client
-        .execute("SET statement_logging_sample_rate=1.0", &[])
-        .unwrap();
-
     for &statement in successful_immediates {
         client.execute(statement, &[]).unwrap();
     }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -197,10 +197,23 @@ fn test_persistence() {
     );
 }
 
+fn setup_statement_logging() -> (util::Server, postgres::Client) {
+    let server = util::start_server(util::Config::default().with_system_parameter_default(
+        "statement_logging_max_sample_rate".to_string(),
+        "1.0".to_string(),
+    ))
+    .unwrap();
+    let mut client = server.connect(postgres::NoTls).unwrap();
+    client
+        .execute("SET statement_logging_sample_rate=1.0", &[])
+        .unwrap();
+    (server, client)
+}
+
 #[mz_ore::test]
 // Test that we log various kinds of statement whose execution terminates in the coordinator.
 fn test_statement_logging_immediate() {
-    let (_server, mut client) = setup_statement_logging(util::Config::default());
+    let (_server, mut client) = setup_statement_logging();
     let successful_immediates: &[&str] = &[
         "CREATE VIEW v AS SELECT 1;",
         "CREATE DEFAULT INDEX i ON v;",
@@ -243,7 +256,7 @@ SELECT
     mseh.sample_rate,
     mseh.began_at,
     mseh.finished_at,
-    mseh.was_successful,
+    mseh.finished_status,
     mpsh.sql,
     mpsh.prepared_at
 FROM
@@ -260,7 +273,7 @@ ORDER BY mseh.began_at;",
         sample_rate: f64,
         began_at: DateTime<Utc>,
         finished_at: DateTime<Utc>,
-        was_successful: bool,
+        finished_status: String,
         sql: String,
         prepared_at: DateTime<Utc>,
     }
@@ -270,7 +283,7 @@ ORDER BY mseh.began_at;",
             sample_rate: r.get(0),
             began_at: r.get(1),
             finished_at: r.get(2),
-            was_successful: r.get(3),
+            finished_status: r.get(3),
             sql: r.get(4),
             prepared_at: r.get(5),
         };
@@ -279,7 +292,7 @@ ORDER BY mseh.began_at;",
             r.sql,
             stmt.chars().filter(|&ch| ch != ';').collect::<String>()
         );
-        assert!(r.was_successful);
+        assert_eq!(r.finished_status, "success");
         assert!(r.prepared_at <= r.began_at);
         assert!(r.began_at <= r.finished_at);
         // NB[btv] -- It would be a bit nicer if we could separately mock
@@ -290,35 +303,23 @@ ORDER BY mseh.began_at;",
     }
 }
 
-fn setup_statement_logging(cfg: util::Config) -> (util::Server, postgres::Client) {
-    let server = util::start_server(cfg.with_system_parameter_default(
-        "statement_logging_max_sample_rate".to_string(),
-        "1.0".to_string(),
-    ))
-    .unwrap();
-    let mut client = server.connect(postgres::NoTls).unwrap();
-    client
-        .execute("SET statement_logging_sample_rate=1.0", &[])
-        .unwrap();
-    (server, client)
-}
-
 #[mz_ore::test]
 fn test_statement_logging_selects() {
-    let (_server, mut client) = setup_statement_logging(util::Config::default());
+    let (_server, mut client) = setup_statement_logging();
     client.execute("SELECT 1", &[]).unwrap();
     // We test that queries of this view execute on a cluster.
     // If we ever change the threshold for constant folding such that
     // this gets to run on environmentd, change this query.
     client
         .execute(
-            "CREATE VIEW v AS SELECT count(*) FROM generate_series(1, 10001)",
+            "CREATE VIEW v AS SELECT * FROM generate_series(1, 10001)",
             &[],
         )
         .unwrap();
-    client.execute("SELECT count(*) FROM v", &[]).unwrap();
+    client.execute("SELECT * FROM v", &[]).unwrap();
     client.execute("CREATE DEFAULT INDEX i ON v", &[]).unwrap();
-    client.execute("SELECT count(*) FROM v", &[]).unwrap();
+    client.execute("SELECT * FROM v", &[]).unwrap();
+    let _ = client.execute("SELECT 1/0", &[]);
 
     // Statement logging happens async, give it a chance to catch up
     thread::sleep(Duration::from_secs(5));
@@ -328,10 +329,11 @@ fn test_statement_logging_selects() {
         sample_rate: f64,
         began_at: DateTime<Utc>,
         finished_at: DateTime<Utc>,
-        was_successful: bool,
+        finished_status: String,
+        error_message: Option<String>,
         prepared_at: DateTime<Utc>,
-        was_fast_path: bool,
-        // rows_returned: u64,
+        execution_strategy: Option<String>,
+        rows_returned: Option<i64>,
     }
 
     let sl_selects = client
@@ -340,10 +342,11 @@ fn test_statement_logging_selects() {
     mseh.sample_rate,
     mseh.began_at,
     mseh.finished_at,
-    mseh.was_successful,
+    mseh.finished_status,
+    mseh.error_message,
     mpsh.prepared_at,
-    mseh.was_fast_path
---    , mseh.rows_returned
+    mseh.execution_strategy,
+    mseh.rows_returned
 FROM
     mz_internal.mz_statement_execution_history AS mseh
         LEFT JOIN
@@ -359,33 +362,49 @@ ORDER BY mseh.began_at",
             sample_rate: r.get(0),
             began_at: r.get(1),
             finished_at: r.get(2),
-            was_successful: r.get(3),
-            prepared_at: r.get(4),
-            was_fast_path: r.get(5),
-            // rows_returned: r.get(6),
+            finished_status: r.get(3),
+            error_message: r.get(4),
+            prepared_at: r.get(5),
+            execution_strategy: r.get(6),
+            rows_returned: r.get(7),
         })
         .collect::<Vec<_>>();
-    assert_eq!(sl_selects.len(), 3);
+    assert_eq!(sl_selects.len(), 4);
     for r in &sl_selects {
         assert_eq!(r.sample_rate, 1.0);
         assert!(r.prepared_at <= r.began_at);
         assert!(r.began_at <= r.finished_at);
-        assert!(r.was_successful);
     }
-    assert!(sl_selects[0].was_fast_path);
-    // assert_eq!(sl_selects[0].rows_returned, 1);
-    assert!(sl_selects[1].was_fast_path);
-    // assert_eq!(sl_selects[1].rows_returned, 10002);
-    assert!(!sl_selects[2].was_fast_path);
-    // assert_eq!(sl_selects[2].rows_returned, 10002);
+    assert_eq!(sl_selects[0].rows_returned, Some(1));
+    assert_eq!(sl_selects[0].finished_status, "success");
+    assert_eq!(
+        sl_selects[0].execution_strategy.as_ref().unwrap(),
+        "constant"
+    );
+    assert_eq!(sl_selects[1].rows_returned, Some(10001));
+    assert_eq!(sl_selects[1].finished_status, "success");
+    assert_eq!(
+        sl_selects[1].execution_strategy.as_ref().unwrap(),
+        "standard"
+    );
+    assert_eq!(sl_selects[2].rows_returned, Some(10001));
+    assert_eq!(sl_selects[2].finished_status, "success");
+    assert_eq!(
+        sl_selects[2].execution_strategy.as_ref().unwrap(),
+        "fast-path"
+    );
+    assert_eq!(sl_selects[3].finished_status, "error");
+    assert!(sl_selects[3]
+        .error_message
+        .as_ref()
+        .unwrap()
+        .contains("division by zero"));
+    assert!(sl_selects[3].rows_returned.is_none());
 }
 
 #[mz_ore::test]
 fn test_statement_logging_subscribes() {
-    let data_dir = tempfile::tempdir().unwrap();
-    let config = util::Config::default().data_directory(data_dir.path());
-
-    let (server, mut client) = setup_statement_logging(config.clone());
+    let (server, mut client) = setup_statement_logging();
     let cancel_token = client.cancel_token();
 
     // This should finish
@@ -408,29 +427,17 @@ fn test_statement_logging_subscribes() {
     }
     handle.join().unwrap();
 
-    // let mut client = server.connect(postgres::NoTls).unwrap();
-    // client.execute("SET statement_logging_sample_rate=1.0", &[]).unwrap();
-    // let handle = thread::spawn(move || {
-    //     // This should be aborted.
-    //     let _ = client.execute("SUBSCRIBE TO (SELECT * FROM t)", &[]);
-    // });
     // Statement logging happens async, give it a chance to catch up
     thread::sleep(Duration::from_secs(5));
-    // // Drop the old server, to make the running subscribe abort.
-
-    // // Restart the server. We should pick up the aborted query on restart.
-    // let server = util::start_server(config).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     struct Record {
         sample_rate: f64,
         began_at: DateTime<Utc>,
         finished_at: DateTime<Utc>,
-        was_successful: bool,
-        was_canceled: bool,
-        was_aborted: bool,
+        finished_status: String,
         prepared_at: DateTime<Utc>,
-        was_fast_path: Option<bool>,
+        execution_strategy: Option<String>,
     }
     let sl_subscribes = client
         .query(
@@ -438,11 +445,9 @@ fn test_statement_logging_subscribes() {
     mseh.sample_rate,
     mseh.began_at,
     mseh.finished_at,
-    mseh.was_successful,
-    mseh.was_canceled,
-    mseh.was_aborted,
+    mseh.finished_status,
     mpsh.prepared_at,
-    mseh.was_fast_path
+    mseh.execution_strategy
 FROM
     mz_internal.mz_statement_execution_history AS mseh
         LEFT JOIN
@@ -458,11 +463,9 @@ ORDER BY mseh.began_at",
             sample_rate: r.get(0),
             began_at: r.get(1),
             finished_at: r.get(2),
-            was_successful: r.get(3),
-            was_canceled: r.get(4),
-            was_aborted: r.get(5),
-            prepared_at: r.get(6),
-            was_fast_path: r.get(7),
+            finished_status: r.get(3),
+            prepared_at: r.get(4),
+            execution_strategy: r.get(5),
         })
         .collect::<Vec<_>>();
     assert_eq!(
@@ -473,19 +476,10 @@ ORDER BY mseh.began_at",
         assert_eq!(r.sample_rate, 1.0);
         assert!(r.prepared_at <= r.began_at);
         assert!(r.began_at <= r.finished_at);
+        assert!(r.execution_strategy.is_none());
     }
-    assert!(sl_subscribes[0].was_successful);
-    assert!(!sl_subscribes[0].was_canceled);
-    assert!(!sl_subscribes[0].was_aborted);
-    assert_eq!(sl_subscribes[0].was_fast_path, Some(false));
-    assert!(!sl_subscribes[1].was_successful);
-    assert!(sl_subscribes[1].was_canceled);
-    assert!(!sl_subscribes[1].was_aborted);
-    assert_eq!(sl_subscribes[1].was_fast_path, None);
-    // assert!(!sl_subscribes[2].was_successful);
-    // assert!(!sl_subscribes[2].was_canceled);
-    // assert!(sl_subscribes[2].was_aborted);
-    // assert_eq!(sl_subscribes[2].was_fast_path, None);
+    assert_eq!(sl_subscribes[0].finished_status, "success");
+    assert_eq!(sl_subscribes[1].finished_status, "canceled");
 }
 
 #[mz_ore::test]
@@ -521,12 +515,11 @@ fn test_statement_logging_unsampled_metrics() {
 
     let named_prepared_inner = "SELECT 42";
     let named_prepared_outer = format!("PREPARE p AS {named_prepared_inner};EXECUTE p;");
-    let named_prepared_total = named_prepared_inner.len()
-        + named_prepared_outer
-            .as_bytes()
-            .iter()
-            .filter(|&&ch| ch != b';')
-            .count();
+    let named_prepared_outer_len = named_prepared_outer
+        .as_bytes()
+        .iter()
+        .filter(|&&ch| ch != b';')
+        .count();
 
     for q in batch_queries {
         client.batch_execute(q).unwrap();
@@ -546,7 +539,7 @@ fn test_statement_logging_unsampled_metrics() {
     // This should NOT be logged, since we never actually execute it.
     client.prepare("SELECT 'Hello, not counted!'").unwrap();
 
-    let expected_total = batch_total + single_total + prepared_total + named_prepared_total;
+    let expected_total = batch_total + single_total + prepared_total + named_prepared_outer_len;
     let metric_value = server
         .metrics_registry
         .gather()

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1026,7 +1026,6 @@ where
                     // in bind. We don't do it in bind because I'm not sure what purpose it would
                     // serve us (i.e., I'm not aware of a pgtest that would differ between us and
                     // Postgres).
-                    println!("[btv] Portal state: NotStarted");
                     self.start_transaction(Some(1));
                     match self
                         .adapter_client
@@ -1116,7 +1115,6 @@ where
                 // we must remember the number of rows that were returned. Use this tag to
                 // remember that information and return it.
                 PortalState::Completed(Some(tag)) => {
-                    println!("[btv] Portal state: Completed with tag {tag}");
                     let tag = tag.to_string();
                     if let Some(outer_ctx_extra) = outer_ctx_extra {
                         self.adapter_client.retire_execute(

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -244,6 +244,7 @@ where
         (session, is_expired)
     };
 
+    let mut setting_keys = vec![];
     for (name, value) in params {
         let settings = match name.as_str() {
             "options" => match parse_options(&value) {
@@ -272,6 +273,8 @@ where
                     name: key,
                     reason: err.to_string(),
                 });
+            } else {
+                setting_keys.push(key);
             }
         }
     }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1026,6 +1026,7 @@ where
                     // in bind. We don't do it in bind because I'm not sure what purpose it would
                     // serve us (i.e., I'm not aware of a pgtest that would differ between us and
                     // Postgres).
+                    println!("[btv] Portal state: NotStarted");
                     self.start_transaction(Some(1));
                     match self
                         .adapter_client
@@ -1059,17 +1060,54 @@ where
                 }
                 PortalState::InProgress(rows) => {
                     let rows = rows.take().expect("InProgress rows must be populated");
-                    self.send_rows(
-                        row_desc.expect("portal missing row desc on resumption"),
-                        portal_name,
-                        rows,
-                        max_rows,
-                        get_response,
-                        fetch_portal_name,
-                        timeout,
-                    )
-                    .await
-                    .map(|(state, _)| state)
+                    let (result, statement_ended_execution_reason) = match self
+                        .send_rows(
+                            row_desc.expect("portal missing row desc on resumption"),
+                            portal_name,
+                            rows,
+                            max_rows,
+                            get_response,
+                            fetch_portal_name,
+                            timeout,
+                        )
+                        .await
+                    {
+                        Err(e) => {
+                            // This is an error communicating with the connection.
+                            // We consider that to be a cancelation, rather than a query error.
+                            (Err(e), StatementEndedExecutionReason::Canceled)
+                        }
+                        Ok((ok, SendRowsEndedReason::Canceled)) => {
+                            (Ok(ok), StatementEndedExecutionReason::Canceled)
+                        }
+                        // NOTE: For now the `rows_returned` in
+                        // fetches is a bit confusing.  We record
+                        // `Some(n)` for the first fetch, where `n` is
+                        // the number of rows returned by the inner
+                        // execute (regardless of how many rows the
+                        // fetch fetched) , and `None` for subsequent fetches.
+                        //
+                        // This arguably makes sense since the rows
+                        // returned measures how much work the compute
+                        // layer had to do to satisfy the query, but
+                        // we should revisit it if/when we start
+                        // logging the inner execute separately.
+                        Ok((ok, SendRowsEndedReason::Success { rows_returned: _ })) => (
+                            Ok(ok),
+                            StatementEndedExecutionReason::Success {
+                                rows_returned: None,
+                                execution_strategy: None,
+                            },
+                        ),
+                        Ok((ok, SendRowsEndedReason::Errored { error })) => {
+                            (Ok(ok), StatementEndedExecutionReason::Errored { error })
+                        }
+                    };
+                    if let Some(outer_ctx_extra) = outer_ctx_extra {
+                        self.adapter_client
+                            .retire_execute(outer_ctx_extra, statement_ended_execution_reason);
+                    }
+                    result
                 }
                 // FETCH is an awkward command for our current architecture. In Postgres it
                 // will extract <count> rows from the target portal, cache them, and return
@@ -1078,17 +1116,36 @@ where
                 // we must remember the number of rows that were returned. Use this tag to
                 // remember that information and return it.
                 PortalState::Completed(Some(tag)) => {
+                    println!("[btv] Portal state: Completed with tag {tag}");
                     let tag = tag.to_string();
+                    if let Some(outer_ctx_extra) = outer_ctx_extra {
+                        self.adapter_client.retire_execute(
+                            outer_ctx_extra,
+                            StatementEndedExecutionReason::Success {
+                                rows_returned: None,
+                                execution_strategy: None,
+                            },
+                        );
+                    }
                     self.send(BackendMessage::CommandComplete { tag }).await?;
                     Ok(State::Ready)
                 }
                 PortalState::Completed(None) => {
+                    let error = format!(
+                        "portal {} cannot be run",
+                        Ident::new(portal_name).to_ast_string_stable()
+                    );
+                    if let Some(outer_ctx_extra) = outer_ctx_extra {
+                        self.adapter_client.retire_execute(
+                            outer_ctx_extra,
+                            StatementEndedExecutionReason::Errored {
+                                error: error.clone(),
+                            },
+                        );
+                    }
                     self.error(ErrorResponse::error(
                         SqlState::OBJECT_NOT_IN_PREREQUISITE_STATE,
-                        format!(
-                            "portal {} cannot be run",
-                            Ident::new(portal_name).to_ast_string_stable()
-                        ),
+                        error,
                     ))
                     .await
                 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -29,6 +29,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::netio::AsyncReady;
 use mz_ore::str::StrExt;
 use mz_pgcopy::CopyFormatParams;
+use mz_repr::statement_logging::StatementEndedExecutionReason;
 use mz_repr::{Datum, GlobalId, RelationDesc, RelationType, Row, RowArena, ScalarType};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::{FetchDirection, Ident, Raw, Statement};
@@ -436,6 +437,15 @@ struct StateMachine<'a, A> {
     adapter_client: mz_adapter::SessionClient,
 }
 
+enum SendRowsEndedReason {
+    Success { rows_returned: u64 },
+    Errored { error: String },
+    Canceled,
+}
+
+const ABORTED_TXN_MSG: &str =
+    "current transaction is aborted, commands ignored until end of transaction block";
+
 impl<'a, A> StateMachine<'a, A>
 where
     A: AsyncRead + AsyncWrite + AsyncReady + Send + Sync + Unpin + 'a,
@@ -534,6 +544,7 @@ where
                         portal_exec_message,
                         None,
                         ExecuteTimeout::None,
+                        None,
                     )
                     .instrument(execute_root_span)
                     .await?;
@@ -627,7 +638,7 @@ where
 
         let result = match self
             .adapter_client
-            .execute(EMPTY_PORTAL.to_string(), self.conn.wait_closed())
+            .execute(EMPTY_PORTAL.to_string(), self.conn.wait_closed(), None)
             .await
         {
             Ok((response, execute_started)) => {
@@ -968,6 +979,7 @@ where
         get_response: GetResponse,
         fetch_portal_name: Option<String>,
         timeout: ExecuteTimeout,
+        outer_ctx_extra: Option<ExecuteContextExtra>,
     ) -> BoxFuture<'_, Result<State, io::Error>> {
         async move {
             let aborted_txn = self.is_aborted_txn();
@@ -980,11 +992,15 @@ where
             {
                 Some(portal) => portal,
                 None => {
+                    let msg = format!("portal {} does not exist", portal_name.quoted());
+                    if let Some(outer_ctx_extra) = outer_ctx_extra {
+                        self.adapter_client.retire_execute(
+                            outer_ctx_extra,
+                            StatementEndedExecutionReason::Errored { error: msg.clone() },
+                        );
+                    }
                     return self
-                        .error(ErrorResponse::error(
-                            SqlState::INVALID_CURSOR_NAME,
-                            format!("portal {} does not exist", portal_name.quoted()),
-                        ))
+                        .error(ErrorResponse::error(SqlState::INVALID_CURSOR_NAME, msg))
                         .await;
                 }
             };
@@ -992,6 +1008,14 @@ where
             // In an aborted transaction, reject all commands except COMMIT/ROLLBACK.
             let txn_exit_stmt = is_txn_exit_stmt(portal.stmt.as_ref());
             if aborted_txn && !txn_exit_stmt {
+                if let Some(outer_ctx_extra) = outer_ctx_extra {
+                    self.adapter_client.retire_execute(
+                        outer_ctx_extra,
+                        StatementEndedExecutionReason::Errored {
+                            error: ABORTED_TXN_MSG.to_string(),
+                        },
+                    );
+                }
                 return self.aborted_txn_error().await;
             }
 
@@ -1005,7 +1029,11 @@ where
                     self.start_transaction(Some(1));
                     match self
                         .adapter_client
-                        .execute(portal_name.clone(), self.conn.wait_closed())
+                        .execute(
+                            portal_name.clone(),
+                            self.conn.wait_closed(),
+                            outer_ctx_extra,
+                        )
                         .await
                     {
                         Ok((response, execute_started)) => {
@@ -1041,6 +1069,7 @@ where
                         timeout,
                     )
                     .await
+                    .map(|(state, _)| state)
                 }
                 // FETCH is an awkward command for our current architecture. In Postgres it
                 // will extract <count> rows from the target portal, cache them, and return
@@ -1150,6 +1179,7 @@ where
         max_rows: ExecuteCount,
         fetch_portal_name: Option<String>,
         timeout: ExecuteTimeout,
+        ctx_extra: ExecuteContextExtra,
     ) -> Result<State, io::Error> {
         // Unlike Execute, no count specified in FETCH returns 1 row, and 0 means 0
         // instead of All.
@@ -1171,21 +1201,29 @@ where
             (ExecuteCount::Count(max_rows), FetchDirection::ForwardCount(count)) => {
                 let count = usize::cast_from(count);
                 if max_rows < count {
+                    let msg = "Execute with max_rows < a FETCH's count is not supported";
+                    self.adapter_client.retire_execute(
+                        ctx_extra,
+                        StatementEndedExecutionReason::Errored {
+                            error: msg.to_string(),
+                        },
+                    );
                     return self
-                        .error(ErrorResponse::error(
-                            SqlState::FEATURE_NOT_SUPPORTED,
-                            "Execute with max_rows < a FETCH's count is not supported",
-                        ))
+                        .error(ErrorResponse::error(SqlState::FEATURE_NOT_SUPPORTED, msg))
                         .await;
                 }
                 ExecuteCount::Count(count)
             }
             (ExecuteCount::Count(_), FetchDirection::ForwardAll) => {
+                let msg = "Execute with max_rows of a FETCH ALL is not supported";
+                self.adapter_client.retire_execute(
+                    ctx_extra,
+                    StatementEndedExecutionReason::Errored {
+                        error: msg.to_string(),
+                    },
+                );
                 return self
-                    .error(ErrorResponse::error(
-                        SqlState::FEATURE_NOT_SUPPORTED,
-                        "Execute with max_rows of a FETCH ALL is not supported",
-                    ))
+                    .error(ErrorResponse::error(SqlState::FEATURE_NOT_SUPPORTED, msg))
                     .await;
             }
             (ExecuteCount::All, FetchDirection::ForwardAll) => ExecuteCount::All,
@@ -1200,6 +1238,7 @@ where
             fetch_message,
             fetch_portal_name,
             timeout,
+            Some(ctx_extra),
         )
         .await
     }
@@ -1344,6 +1383,7 @@ where
                 name,
                 count,
                 timeout,
+                ctx_extra,
             } => {
                 self.fetch(
                     name,
@@ -1351,6 +1391,7 @@ where
                     max_rows,
                     Some(portal_name.to_string()),
                     timeout,
+                    ctx_extra,
                 )
                 .await
             }
@@ -1376,6 +1417,31 @@ where
                 )
                 .instrument(span)
                 .await
+                .map(|(state, _)| state)
+            }
+            ExecuteResponse::SendingRowsImmediate { rows, span } => {
+                let row_desc = row_desc
+                    .expect("missing row description for ExecuteResponse::SendingRowsImmediate");
+
+                let span = tracing::debug_span!(parent: &span, "send_execute_response");
+                let stream =
+                    futures::stream::once(futures::future::ready(PeekResponseUnary::Rows(rows)));
+                self.send_rows(
+                    row_desc,
+                    portal_name,
+                    InProgressRows::new(RecordFirstRowStream::new(
+                        Box::new(stream),
+                        execute_started,
+                        &self.adapter_client,
+                    )),
+                    max_rows,
+                    get_response,
+                    fetch_portal_name,
+                    timeout,
+                )
+                .instrument(span)
+                .await
+                .map(|(state, _)| state)
             }
             ExecuteResponse::SetVariable { name, .. } => {
                 // This code is somewhat awkwardly structured because we
@@ -1397,7 +1463,7 @@ where
                 }
                 command_complete!()
             }
-            ExecuteResponse::Subscribing { rx } => {
+            ExecuteResponse::Subscribing { rx, ctx_extra } => {
                 if fetch_portal_name.is_none() {
                     let mut msg = ErrorResponse::notice(
                         SqlState::WARNING,
@@ -1414,30 +1480,128 @@ where
                 }
                 let row_desc =
                     row_desc.expect("missing row description for ExecuteResponse::Subscribing");
-                self.send_rows(
-                    row_desc,
-                    portal_name,
-                    InProgressRows::new(RecordFirstRowStream::new(
-                        Box::new(UnboundedReceiverStream::new(rx)),
-                        execute_started,
-                        &self.adapter_client,
-                    )),
-                    max_rows,
-                    get_response,
-                    fetch_portal_name,
-                    timeout,
-                )
-                .await
+                let (result, statement_ended_execution_reason) = match self
+                    .send_rows(
+                        row_desc,
+                        portal_name,
+                        InProgressRows::new(RecordFirstRowStream::new(
+                            Box::new(UnboundedReceiverStream::new(rx)),
+                            execute_started,
+                            &self.adapter_client,
+                        )),
+                        max_rows,
+                        get_response,
+                        fetch_portal_name,
+                        timeout,
+                    )
+                    .await
+                {
+                    Err(e) => {
+                        // This is an error communicating with the connection.
+                        // We consider that to be a cancelation, rather than a query error.
+                        (Err(e), StatementEndedExecutionReason::Canceled)
+                    }
+                    Ok((ok, SendRowsEndedReason::Canceled)) => {
+                        (Ok(ok), StatementEndedExecutionReason::Canceled)
+                    }
+                    Ok((ok, SendRowsEndedReason::Success { rows_returned })) => (
+                        Ok(ok),
+                        StatementEndedExecutionReason::Success {
+                            rows_returned: Some(rows_returned),
+                            execution_strategy: None,
+                        },
+                    ),
+                    Ok((ok, SendRowsEndedReason::Errored { error })) => {
+                        (Ok(ok), StatementEndedExecutionReason::Errored { error })
+                    }
+                };
+                self.adapter_client
+                    .retire_execute(ctx_extra, statement_ended_execution_reason);
+                return result;
             }
             ExecuteResponse::CopyTo { format, resp } => {
                 let row_desc =
                     row_desc.expect("missing row description for ExecuteResponse::CopyTo");
-                let rows = match *resp {
-                    ExecuteResponse::Subscribing { rx } => rx,
+                match *resp {
+                    ExecuteResponse::Subscribing { rx, ctx_extra } => {
+                        let (result, statement_ended_execution_reason) = match self
+                            .copy_rows(
+                                format,
+                                row_desc,
+                                RecordFirstRowStream::new(
+                                    Box::new(UnboundedReceiverStream::new(rx)),
+                                    execute_started,
+                                    &self.adapter_client,
+                                ),
+                            )
+                            .await
+                        {
+                            Err(e) => {
+                                // This is an error communicating with the connection.
+                                // We consider that to be a cancelation, rather than a query error.
+                                (Err(e), StatementEndedExecutionReason::Canceled)
+                            }
+                            Ok((state, SendRowsEndedReason::Success { rows_returned })) => (
+                                Ok(state),
+                                StatementEndedExecutionReason::Success {
+                                    rows_returned: Some(rows_returned),
+                                    execution_strategy: None,
+                                },
+                            ),
+                            Ok((state, SendRowsEndedReason::Errored { error })) => {
+                                (Ok(state), StatementEndedExecutionReason::Errored { error })
+                            }
+                            Ok((state, SendRowsEndedReason::Canceled)) => {
+                                (Ok(state), StatementEndedExecutionReason::Canceled)
+                            }
+                        };
+                        self.adapter_client
+                            .retire_execute(ctx_extra, statement_ended_execution_reason);
+                        return result;
+                    }
                     ExecuteResponse::SendingRows {
                         future: rows_rx,
                         span,
-                    } => self.row_future_to_stream(&span, rows_rx).await?,
+                    } => {
+                        let rows = self.row_future_to_stream(&span, rows_rx).await?;
+                        // We don't need to finalize execution here;
+                        // it was already done in the
+                        // coordinator. Just extract the state and
+                        // return that.
+                        return self
+                            .copy_rows(
+                                format,
+                                row_desc,
+                                RecordFirstRowStream::new(
+                                    Box::new(UnboundedReceiverStream::new(rows)),
+                                    execute_started,
+                                    &self.adapter_client,
+                                ),
+                            )
+                            .await
+                            .map(|(state, _)| state);
+                    }
+                    ExecuteResponse::SendingRowsImmediate { rows, span: _ } => {
+                        let rows = futures::stream::once(futures::future::ready(
+                            PeekResponseUnary::Rows(rows),
+                        ));
+                        // We don't need to finalize execution here;
+                        // it was already done in the
+                        // coordinator. Just extract the state and
+                        // return that.
+                        return self
+                            .copy_rows(
+                                format,
+                                row_desc,
+                                RecordFirstRowStream::new(
+                                    Box::new(rows),
+                                    execute_started,
+                                    &self.adapter_client,
+                                ),
+                            )
+                            .await
+                            .map(|(state, _)| state);
+                    }
                     _ => {
                         return self
                             .error(ErrorResponse::error(
@@ -1447,16 +1611,6 @@ where
                             .await;
                     }
                 };
-                self.copy_rows(
-                    format,
-                    row_desc,
-                    RecordFirstRowStream::new(
-                        Box::new(UnboundedReceiverStream::new(rows)),
-                        execute_started,
-                        &self.adapter_client,
-                    ),
-                )
-                .await
             }
             ExecuteResponse::CopyFrom {
                 id,
@@ -1548,7 +1702,7 @@ where
         get_response: GetResponse,
         fetch_portal_name: Option<String>,
         timeout: ExecuteTimeout,
-    ) -> Result<State, io::Error> {
+    ) -> Result<(State, SendRowsEndedReason), io::Error> {
         // If this portal is being executed from a FETCH then we need to use the result
         // format type of the outer portal.
         let result_format_portal_name: &str = if let Some(ref name) = fetch_portal_name {
@@ -1628,28 +1782,31 @@ where
                         let datums = row.unpack();
                         let col_types = &row_desc.typ().column_types;
                         if datums.len() != col_types.len() {
-                            return self
-                                .error(ErrorResponse::error(
-                                    SqlState::INTERNAL_ERROR,
-                                    format!(
+                            let msg = format!(
                                         "internal error: row descriptor has {} columns but row has {} columns",
                                         col_types.len(),
                                         datums.len(),
-                                    ),
-                                ))
-                                .await;
+                                    );
+                            return self
+                                .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, msg.clone()))
+                                .await
+                                .map(|state| (state, SendRowsEndedReason::Errored { error: msg }));
                         }
                         for (i, (d, t)) in datums.iter().zip(col_types).enumerate() {
                             if !d.is_instance_of(t) {
+                                let msg = format!(
+                                    "internal error: column {} is not of expected type {:?}: {:?}",
+                                    i, t, d
+                                );
                                 return self
                                     .error(ErrorResponse::error(
                                         SqlState::INTERNAL_ERROR,
-                                            format!(
-                                            "internal error: column {} is not of expected type {:?}: {:?}",
-                                            i, t, d
-                                        ),
+                                        msg.clone(),
                                     ))
-                                    .await;
+                                    .await
+                                    .map(|state| {
+                                        (state, SendRowsEndedReason::Errored { error: msg })
+                                    });
                             }
                         }
                     }
@@ -1687,8 +1844,9 @@ where
                 }
                 FetchResult::Error(text) => {
                     return self
-                        .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text))
-                        .await;
+                        .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text.clone()))
+                        .await
+                        .map(|state| (state, SendRowsEndedReason::Errored { error: text }));
                 }
                 FetchResult::Canceled => {
                     return self
@@ -1696,7 +1854,8 @@ where
                             SqlState::QUERY_CANCELED,
                             "canceling statement due to user request",
                         ))
-                        .await;
+                        .await
+                        .map(|state| (state, SendRowsEndedReason::Canceled));
                 }
             }
         }
@@ -1719,16 +1878,21 @@ where
         });
         let response_message = get_response(max_rows, total_sent_rows, fetch_portal);
         self.send(response_message).await?;
-        Ok(State::Ready)
+        Ok((
+            State::Ready,
+            SendRowsEndedReason::Success {
+                rows_returned: u64::cast_from(total_sent_rows),
+            },
+        ))
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, stream))]
     async fn copy_rows(
         &mut self,
         format: CopyFormat,
         row_desc: RelationDesc,
         mut stream: RecordFirstRowStream,
-    ) -> Result<State, io::Error> {
+    ) -> Result<(State, SendRowsEndedReason), io::Error> {
         let (encode_fn, encode_format): (
             fn(Row, &RelationType, &mut Vec<u8>) -> Result<(), std::io::Error>,
             mz_pgrepr::Format,
@@ -1736,12 +1900,14 @@ where
             CopyFormat::Text => (mz_pgcopy::encode_copy_row_text, mz_pgrepr::Format::Text),
             CopyFormat::Binary => (mz_pgcopy::encode_copy_row_binary, mz_pgrepr::Format::Binary),
             _ => {
+                let msg = format!("COPY TO format {:?} not supported", format);
                 return self
                     .error(ErrorResponse::error(
                         SqlState::FEATURE_NOT_SUPPORTED,
-                        format!("COPY TO format {:?} not supported", format),
+                        msg.clone(),
                     ))
                     .await
+                    .map(|state| (state, SendRowsEndedReason::Errored { error: msg }));
             }
         };
 
@@ -1780,21 +1946,22 @@ where
                             SqlState::QUERY_CANCELED,
                             "canceling statement due to user request",
                         ))
-                    .await;
+                    .await.map(|state| (state, SendRowsEndedReason::Canceled));
                 },
                 batch = stream.recv() => match batch {
                     None => break,
                     Some(PeekResponseUnary::Error(text)) => {
                         return self
-                            .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text))
-                            .await;
+                            .error(ErrorResponse::error(SqlState::INTERNAL_ERROR, text.clone()))
+                        .await
+                        .map(|state| (state, SendRowsEndedReason::Errored { error: text }));
                     }
                     Some(PeekResponseUnary::Canceled) => {
                         return self.error(ErrorResponse::error(
                                 SqlState::QUERY_CANCELED,
                                 "canceling statement due to user request",
                             ))
-                            .await;
+                            .await.map(|state| (state, SendRowsEndedReason::Canceled));
                     }
                     Some(PeekResponseUnary::Rows(rows)) => {
                         count += rows.len();
@@ -1825,7 +1992,12 @@ where
         let tag = format!("COPY {}", count);
         self.send(BackendMessage::CopyDone).await?;
         self.send(BackendMessage::CommandComplete { tag }).await?;
-        Ok(State::Ready)
+        Ok((
+            State::Ready,
+            SendRowsEndedReason::Success {
+                rows_returned: u64::cast_from(count),
+            },
+        ))
     }
 
     /// Handles the copy-in mode of the postgres protocol from transferring
@@ -1836,7 +2008,41 @@ where
         columns: Vec<usize>,
         params: CopyFormatParams<'_>,
         row_desc: RelationDesc,
-        ctx_extra: ExecuteContextExtra,
+        mut ctx_extra: ExecuteContextExtra,
+    ) -> Result<State, io::Error> {
+        let res = self
+            .copy_from_inner(id, columns, params, row_desc, &mut ctx_extra)
+            .await;
+        match &res {
+            Ok(State::Done) => {
+                // The connection closed gracefully without sending us a `CopyDone`,
+                // causing us to just drop the copy request.
+                // For the purposes of statement logging, we count this as a cancellation.
+                self.adapter_client
+                    .retire_execute(ctx_extra, StatementEndedExecutionReason::Canceled);
+            }
+            Err(e) => {
+                self.adapter_client.retire_execute(
+                    ctx_extra,
+                    StatementEndedExecutionReason::Errored {
+                        error: format!("{e}"),
+                    },
+                );
+            }
+            _ => {
+                assert!(ctx_extra.is_trivial())
+            }
+        }
+        res
+    }
+
+    async fn copy_from_inner(
+        &mut self,
+        id: GlobalId,
+        columns: Vec<usize>,
+        params: CopyFormatParams<'_>,
+        row_desc: RelationDesc,
+        ctx_extra: &mut ExecuteContextExtra,
     ) -> Result<State, io::Error> {
         let typ = row_desc.typ();
         let column_formats = vec![mz_pgrepr::Format::Text; typ.column_types.len()];
@@ -1848,32 +2054,38 @@ where
         self.conn.flush().await?;
 
         let mut data = Vec::new();
-        let mut next_state = State::Ready;
         loop {
             let message = self.conn.recv().await?;
             match message {
                 Some(FrontendMessage::CopyData(buf)) => data.extend(buf),
                 Some(FrontendMessage::CopyDone) => break,
                 Some(FrontendMessage::CopyFail(err)) => {
+                    self.adapter_client.retire_execute(
+                        std::mem::take(ctx_extra),
+                        StatementEndedExecutionReason::Canceled,
+                    );
                     return self
                         .error(ErrorResponse::error(
                             SqlState::QUERY_CANCELED,
                             format!("COPY from stdin failed: {}", err),
                         ))
-                        .await
+                        .await;
                 }
                 Some(FrontendMessage::Flush) | Some(FrontendMessage::Sync) => {}
                 Some(_) => {
+                    let msg = "unexpected message type during COPY from stdin";
+                    self.adapter_client.retire_execute(
+                        std::mem::take(ctx_extra),
+                        StatementEndedExecutionReason::Errored {
+                            error: msg.to_string(),
+                        },
+                    );
                     return self
-                        .error(ErrorResponse::error(
-                            SqlState::PROTOCOL_VIOLATION,
-                            "unexpected message type during COPY from stdin",
-                        ))
-                        .await
+                        .error(ErrorResponse::error(SqlState::PROTOCOL_VIOLATION, msg))
+                        .await;
                 }
-                _ => {
-                    next_state = State::Done;
-                    break;
+                None => {
+                    return Ok(State::Done);
                 }
             }
         }
@@ -1885,36 +2097,46 @@ where
             .map(mz_pgrepr::Type::from)
             .collect::<Vec<mz_pgrepr::Type>>();
 
-        if let State::Ready = next_state {
-            let rows = match mz_pgcopy::decode_copy_format(&data, &column_types, params) {
-                Ok(rows) => rows,
-                Err(e) => {
-                    return self
-                        .error(ErrorResponse::error(
-                            SqlState::BAD_COPY_FILE_FORMAT,
-                            format!("{}", e),
-                        ))
-                        .await
-                }
-            };
-
-            let count = rows.len();
-
-            if let Err(e) = self
-                .adapter_client
-                .insert_rows(id, columns, rows, ctx_extra)
-                .await
-            {
+        let rows = match mz_pgcopy::decode_copy_format(&data, &column_types, params) {
+            Ok(rows) => rows,
+            Err(e) => {
+                self.adapter_client.retire_execute(
+                    std::mem::take(ctx_extra),
+                    StatementEndedExecutionReason::Errored {
+                        error: e.to_string(),
+                    },
+                );
                 return self
-                    .error(ErrorResponse::from_adapter_error(Severity::Error, e))
+                    .error(ErrorResponse::error(
+                        SqlState::BAD_COPY_FILE_FORMAT,
+                        format!("{}", e),
+                    ))
                     .await;
             }
+        };
 
-            let tag = format!("COPY {}", count);
-            self.send(BackendMessage::CommandComplete { tag }).await?;
+        let count = rows.len();
+
+        if let Err(e) = self
+            .adapter_client
+            .insert_rows(id, columns, rows, std::mem::take(ctx_extra))
+            .await
+        {
+            self.adapter_client.retire_execute(
+                std::mem::take(ctx_extra),
+                StatementEndedExecutionReason::Errored {
+                    error: e.to_string(),
+                },
+            );
+            return self
+                .error(ErrorResponse::from_adapter_error(Severity::Error, e))
+                .await;
         }
 
-        Ok(next_state)
+        let tag = format!("COPY {}", count);
+        self.send(BackendMessage::CommandComplete { tag }).await?;
+
+        Ok(State::Ready)
     }
 
     async fn send_pending_notices(&mut self) -> Result<(), io::Error> {
@@ -1968,7 +2190,7 @@ where
     async fn aborted_txn_error(&mut self) -> Result<State, io::Error> {
         self.send(BackendMessage::ErrorResponse(ErrorResponse::error(
             SqlState::IN_FAILED_SQL_TRANSACTION,
-            "current transaction is aborted, commands ignored until end of transaction block",
+            ABORTED_TXN_MSG,
         )))
         .await?;
         Ok(State::Drain)

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -312,7 +312,7 @@ where
     conn.flush().await?;
 
     // Register session with adapter.
-    let (adapter_client, startup) = match adapter_client.startup(session).await {
+    let (adapter_client, startup) = match adapter_client.startup(session, setting_keys).await {
         Ok(startup) => startup,
         Err(e) => {
             return conn

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1236,7 +1236,7 @@ impl QueryWhen {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Copy, Clone)]
 pub enum MutationKind {
     Insert,
     Update,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -67,6 +67,7 @@ use std::any::Any;
 use std::borrow::Borrow;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
+use std::ops::RangeBounds;
 use std::str::FromStr;
 use std::string::ToString;
 use std::sync::{Arc, Mutex};
@@ -1096,6 +1097,17 @@ pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
+static DEFAULT_STATEMENT_LOGGING_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.0.into());
+pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
+    ServerVar {
+    name: UncasedStr::new("statement_logging_sample_rate"),
+    value: &DEFAULT_STATEMENT_LOGGING_SAMPLE_RATE,
+    description: "User-facing session variable indicating how many statement executions should be \
+    logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize).",
+    internal: false,
+}
+});
+
 /// Whether compute rendering should use Materialize's custom linear join implementation rather
 /// than the one from Differential Dataflow.
 const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
@@ -1114,6 +1126,15 @@ pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
         "LD facing global boolean flag that allows turning default connection validation off for everyone (Materialize).",
     internal: true,
 };
+
+static DEFAULT_STATEMENT_LOGGING_MAX_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.0.into());
+pub static STATEMENT_LOGGING_MAX_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("statement_logging_max_sample_rate"),
+    value: &DEFAULT_STATEMENT_LOGGING_MAX_SAMPLE_RATE,
+    description: "The maximum rate at which statements may be logged. If this value is less than \
+that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
+    internal: false,
+});
 
 pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("auto_route_introspection_queries"),
@@ -1447,7 +1468,11 @@ feature_flags!(
         enable_arrangement_size_logging,
         "arrangement size logging",
         true
-    )
+    ),
+    (
+        statement_logging_use_reproducible_rng,
+        "statement logging with reproducible RNG"
+    ),
 );
 
 /// Represents the input to a variable.
@@ -1545,6 +1570,10 @@ impl SessionVars {
             )
             .with_var(&MAX_QUERY_RESULT_SIZE)
             .with_var(&MAX_IDENTIFIER_LENGTH)
+            .with_value_constrained_var(
+                &STATEMENT_LOGGING_SAMPLE_RATE,
+                ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
+            )
     }
 
     fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
@@ -1938,6 +1967,10 @@ impl SessionVars {
         self.set(None, CLUSTER.name(), VarInput::Flat(&cluster), false)
             .expect("setting cluster from string succeeds");
     }
+
+    pub fn get_statement_logging_sample_rate(&self) -> Numeric {
+        *self.expect_value(&STATEMENT_LOGGING_SAMPLE_RATE)
+    }
 }
 
 #[derive(Debug, Copy, Clone)]
@@ -2123,6 +2156,11 @@ impl SystemVars {
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
             .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY)
             .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT);
+            .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
+            .with_value_constrained_var(
+                &STATEMENT_LOGGING_MAX_SAMPLE_RATE,
+                ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
+            );
 
         vars.refresh_internal_state();
         vars
@@ -2737,6 +2775,11 @@ impl SystemVars {
 
     pub fn cluster_soften_az_affinity_weight(&self) -> i32 {
         *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
+    }
+
+    /// Returns the `statement_logging_max_sample_rate` configuration parameter.
+    pub fn statement_logging_max_sample_rate(&self) -> Numeric {
+        *self.expect_value(&STATEMENT_LOGGING_MAX_SAMPLE_RATE)
     }
 }
 
@@ -3446,6 +3489,22 @@ impl Value for usize {
     }
 }
 
+impl Value for f64 {
+    fn type_name() -> String {
+        "double-precision floating-point number".to_string()
+    }
+
+    fn parse<'a>(param: &'a (dyn Var + Send + Sync), input: VarInput) -> Result<f64, VarError> {
+        let s = extract_single_value(param, input)?;
+        s.parse()
+            .map_err(|_| VarError::InvalidParameterType(param.into()))
+    }
+
+    fn format(&self) -> String {
+        self.to_string()
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 struct NumericNonNegNonNan;
 
@@ -3456,6 +3515,44 @@ impl DomainConstraint<Numeric> for NumericNonNegNonNan {
                 parameter: var.into(),
                 values: vec![n.to_string()],
                 reason: "only supports non-negative, non-NaN numeric values".to_string(),
+            })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+struct NumericInRange<R>(R);
+
+impl<R> DomainConstraint<Numeric> for NumericInRange<R>
+where
+    R: RangeBounds<f64> + std::fmt::Debug + Send + Sync,
+{
+    fn check(&self, var: &(dyn Var + Send + Sync), n: &Numeric) -> Result<(), VarError> {
+        let n: f64 = (*n)
+            .try_into()
+            .map_err(|_e| VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                // This first check can fail if the value is NaN, out of range,
+                // OR if it underflows (i.e. is very close to 0 without actually being 0, and the closest
+                // representable float is 0).
+                //
+                // The underflow case is very unlikely to be accidentally hit by a user, so let's
+                // not make the error message more confusing by talking about it, even though that makes
+                // the error message slightly inaccurate.
+                //
+                // If the user tries to set the paramater to 0.000<hundreds more zeros>001
+                // and gets the message "only supports values in range [0.0..=1.0]", I think they will
+                // understand, or at least accept, what's going on.
+                reason: format!("only supports values in range {:?}", self.0),
+            })?;
+        if !self.0.contains(&n) {
+            Err(VarError::InvalidParameterValue {
+                parameter: var.into(),
+                values: vec![n.to_string()],
+                reason: format!("only supports values in range {:?}", self.0),
             })
         } else {
             Ok(())

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1097,7 +1097,7 @@ pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
-static DEFAULT_STATEMENT_LOGGING_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.0.into());
+static DEFAULT_STATEMENT_LOGGING_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.1.into());
 pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
     ServerVar {
     name: UncasedStr::new("statement_logging_sample_rate"),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1136,6 +1136,16 @@ that of `statement_logging_sample_rate`, the latter is ignored (Materialize).",
     internal: false,
 });
 
+static DEFAULT_STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.0.into());
+pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<ServerVar<Numeric>> =
+    Lazy::new(|| ServerVar {
+        name: UncasedStr::new("statement_logging_default_sample_rate"),
+        value: &DEFAULT_STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE,
+        description:
+            "The default value of `statement_logging_sample_rate` for new sessions (Materialize).",
+        internal: false,
+    });
+
 pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("auto_route_introspection_queries"),
     value: &true,
@@ -2160,6 +2170,10 @@ impl SystemVars {
             .with_value_constrained_var(
                 &STATEMENT_LOGGING_MAX_SAMPLE_RATE,
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
+            )
+            .with_value_constrained_var(
+                &STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE,
+                ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
             );
 
         vars.refresh_internal_state();
@@ -2780,6 +2794,11 @@ impl SystemVars {
     /// Returns the `statement_logging_max_sample_rate` configuration parameter.
     pub fn statement_logging_max_sample_rate(&self) -> Numeric {
         *self.expect_value(&STATEMENT_LOGGING_MAX_SAMPLE_RATE)
+    }
+
+    /// Returns the `statement_logging_default_sample_rate` configuration parameter.
+    pub fn statement_logging_default_sample_rate(&self) -> Numeric {
+        *self.expect_value(&STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE)
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2155,7 +2155,7 @@ impl SystemVars {
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_MAX_SKEW)
             .with_var(&cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT)
             .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY)
-            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT);
+            .with_var(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
             .with_value_constrained_var(
                 &STATEMENT_LOGGING_MAX_SAMPLE_RATE,

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -79,6 +79,7 @@ prost-reflect = { version = "0.11.4", default-features = false, features = ["ser
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
+rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
@@ -180,6 +181,7 @@ prost-reflect = { version = "0.11.4", default-features = false, features = ["ser
 prost-types = { version = "0.11.9" }
 quote = { version = "1.0.28" }
 rand = { version = "0.8.5", features = ["small_rng"] }
+rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -58,6 +58,8 @@ server_version                      9.5.0                   "Shows the PostgreSQ
 server_version_num                  90500                   "Shows the PostgreSQL compatible server version as an integer (PostgreSQL)."
 sql_safe_updates                    off                     "Prohibits SQL statements that may be overly destructive (CockroachDB)."
 standard_conforming_strings         on                      "Causes '...' strings to treat backslashes literally (PostgreSQL)."
+statement_logging_max_sample_rate   0                       "The maximum rate at which statements may be logged. If this value is less than that of `statement_logging_sample_rate`, the latter is ignored (Materialize)."
+statement_logging_sample_rate       0                       "User-facing session variable indicating how many statement executions should be logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize)."
 statement_timeout                   "10 s"                  "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. If this value is specified without units, it is taken as milliseconds."
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -13,7 +13,7 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_rbac_checks = true;
 
-$ set-regex match="cluster1|default|v\d+\.\d+\.\d+(-[a-z0-9]+)? \([a-f0-9]{9}\)" replacement=<VARIES>
+$ set-regex match="cluster1|^default$|v\d+\.\d+\.\d+(-[a-z0-9]+)? \([a-f0-9]{9}\)" replacement=<VARIES>
 
 > SHOW ALL
 allowed_cluster_replica_sizes       ""                      "The allowed sizes when creating a new cluster replica (Materialize)."
@@ -58,8 +58,9 @@ server_version                      9.5.0                   "Shows the PostgreSQ
 server_version_num                  90500                   "Shows the PostgreSQL compatible server version as an integer (PostgreSQL)."
 sql_safe_updates                    off                     "Prohibits SQL statements that may be overly destructive (CockroachDB)."
 standard_conforming_strings         on                      "Causes '...' strings to treat backslashes literally (PostgreSQL)."
-statement_logging_max_sample_rate   0                       "The maximum rate at which statements may be logged. If this value is less than that of `statement_logging_sample_rate`, the latter is ignored (Materialize)."
-statement_logging_sample_rate       0                       "User-facing session variable indicating how many statement executions should be logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize)."
+statement_logging_default_sample_rate 1.0                   "The default value of `statement_logging_sample_rate` for new sessions (Materialize)."
+statement_logging_max_sample_rate   1.0                     "The maximum rate at which statements may be logged. If this value is less than that of `statement_logging_sample_rate`, the latter is ignored (Materialize)."
+statement_logging_sample_rate       1.0                     "User-facing session variable indicating how many statement executions should be logged, subject to constraint by the system variable `statement_logging_max_sample_rate` (Materialize)."
 statement_timeout                   "10 s"                  "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. If this value is specified without units, it is taken as milliseconds."
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -189,3 +189,6 @@ contains:invalid value for parameter "IntervalStyle": "postgres-legacy"
 
 ! SET cluster_replica = 1, 2
 contains:parameter "cluster_replica" cannot have value "1","2": expects a single value
+
+! SET statement_logging_sample_rate = 1.1
+contains:parameter "statement_logging_sample_rate" cannot have value "1.1": only supports values in range 0.0..=1.0

--- a/test/testdrive/statement-logging.td
+++ b/test/testdrive/statement-logging.td
@@ -1,0 +1,109 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# These just test that statement
+# logging is set up in CI. The values
+# in prod won't necessarily be the same.
+
+> SHOW statement_logging_max_sample_rate
+statement_logging_max_sample_rate
+----
+1.0
+
+> SHOW statement_logging_sample_rate
+statement_logging_sample_rate
+----
+1.0
+
+# Later, we need to ignore everything
+# that happened before the real test started. Sleep here,
+# so we can be sure that their `began_at` is different.
+> SELECT mz_internal.mz_sleep(1)
+<null>
+
+# Now the real test begins
+
+> SELECT 'beginning real test!'
+"beginning real test!"
+
+> PREPARE p AS values ($1)
+
+> EXECUTE p('hello world')
+"hello world"
+
+> CREATE TABLE t(f int)
+
+> INSERT INTO t VALUES (1)
+
+! SELECT f/0 FROM t
+contains: division by zero
+
+> CREATE DEFAULT INDEX i ON t
+
+> SELECT * FROM t
+1
+
+> SELECT count(*) FROM t
+1
+
+# This one does not show up in the results. See
+# point "(2)" in the comment below.
+! SELECT f_nonexistent FROM t
+contains: column "f_nonexistent" does not exist
+
+> BEGIN
+
+> DECLARE c CURSOR FOR VALUES (1), (2)
+
+> FETCH c
+1
+
+> FETCH c
+2
+
+> FETCH c
+
+> COMMIT
+
+# Assumptions encoded here:
+# (1) "Inner" statement executions are not logged. For example,
+#     if SQL-level `PREPARE` and `EXECUTE` are used, those statements will
+#     be logged, but not the statements they reference.
+# (2) We don't have a way to log errors that happen during statement preparation,
+#     but only during statement execution.
+# (3) SQL-level statements always use a prepared statement with a useless name beginning with 's'
+# (4) `FETCH` has the somewhat confusing behavior of reporting the `rows_returned`
+#     of the *total* result set in the first `FETCH`, and null thereafter.
+#
+# All of these (except (3), which is just how the postgres library TD uses works) are working as designed.
+# However, we recognize that they are confusing, so we will work on making them
+# less confusing as follow-ups.
+#
+# When we do so, we will need to change this test to encode the improved behavior.
+
+> WITH all_stmts AS (SELECT * FROM mz_internal.mz_statement_execution_history mseh RIGHT JOIN mz_internal.mz_prepared_statement_history mpsh ON mseh.prepared_statement_id = mpsh.id),
+       test_begin AS (SELECT began_at FROM all_stmts WHERE sql = 'SELECT ''beginning real test!''' ORDER BY began_at DESC LIMIT 1)
+  SELECT all_stmts.sample_rate, all_stmts.params, all_stmts.finished_status, all_stmts.error_message, all_stmts.rows_returned, all_stmts.execution_strategy, all_stmts.name LIKE 's%', all_stmts.sql
+  FROM all_stmts, test_begin WHERE all_stmts.began_at >= test_begin.began_at AND all_stmts.sql NOT LIKE '%sduiahsdfuoiahsdf%' --ignore this statement, in case we have to re-run it
+  ORDER BY all_stmts.sql, all_statements.rows_returned
+1 {} error "Evaluation error: division by zero" <null> <null> true "SELECT f/0 FROM t"
+1 {} success <null> 1 constant true "EXECUTE p('hello world')"
+1 {} success <null> 1 constant true "SELECT 'beginning real test!'"
+1 {} success <null> 1 fast-path true "SELECT * FROM t"
+1 {} success <null> 1 standard true "SELECT count(*) FROM t"
+1 {} success <null> 2 constant true "FETCH c"
+1 {} success <null> <null> <null> true BEGIN
+1 {} success <null> <null> <null> true COMMIT
+1 {} success <null> <null> <null> true "CREATE DEFAULT INDEX i ON t"
+1 {} success <null> <null> <null> true "CREATE TABLE t(f int)"
+1 {} success <null> <null> <null> true "DECLARE c CURSOR FOR VALUES (1), (2)"
+1 {} success <null> <null> <null> true "FETCH c"
+1 {} success <null> <null> <null> true "FETCH c"
+1 {} success <null> <null> <null> true "INSERT INTO t VALUES (1)"
+1 {} success <null> <null> <null> true "PREPARE p AS values ($1)"


### PR DESCRIPTION
This PR causes a log of statements to be maintained but not persisted, in the tables `mz_prepared_statement_history` and `mz_statement_execution_history`. Logging is controlled by the session variable `statement_logging_sample_rate`, constrained by the system variable `statement_logging_max_sample_rate`.

It works by emitting a "begin" event when the statement begins executing, and an "end" event when it ends. What it means for statement execution to "end" is determined by the type of statement. For most statements, it is the moment when control of the session is given back to the protocol layer. However, for some other statements (notably non-constant `SELECT`s, and `SUBSCRIBE`s), a more complex notion is needed; for example, a `SELECT` is only considered finished after the cluster has returned results, whereas a non-constant `SUBSCRIBE` is never finished unless it errors or the client cancels it.

Thus, we need to pipe the statement logging ID through the various commands and responses that implement these more complex protocols. This is done by adding that ID to the `ExecuteContextExtra` struct. We also make that struct log an error if it's dropped anywhere other than in the coordinator code that handles finishing logging, to ensure that we don't forget somewhere to end a statement.

A follow-up PR will persist the log in the stash, which we may later decide to replace with storing it directly in Persist. In this PR the log is in a built-in table, which is cleared on restart.