### PR TITLE
platform-checks: Fix the Webhook Check

### DIFF
--- a/misc/python/materialize/checks/webhook.py
+++ b/misc/python/materialize/checks/webhook.py
@@ -115,8 +115,6 @@ class Webhook(Check):
                 \\\\x00\\x00\\x00\\x00
                 \\\\x01
                 \\\\x01\\x02\\x03\\x04
-
-                > DROP CLUSTER webhook_cluster CASCADE;
            """
             )
         )


### PR DESCRIPTION
The validate() phase should be idempotent as it runs more than once. Therefore, it can not contain a `DROP CLUSTER`.


### Motivation

Nightly was failing. @ParkMyCar FYI.