### PR TITLE
feature-benchmark: Use generate_series to populate MFPPushdown

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -43,7 +43,7 @@ class FastPathFilterNoIndex(FastPath):
             self.table_ten(),
             TdAction(
                 f"""
-> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT {self.unique_values()} AS f1, 1 AS f2 FROM {self.join()}
+> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT generate_series AS f1, 1 AS f2 FROM generate_series(1, {self.n()});
 
 > CREATE DEFAULT INDEX ON v1;
 
@@ -73,7 +73,7 @@ class MFPPushdown(Scenario):
             self.table_ten(),
             TdAction(
                 f"""
-> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT {self.unique_values()} AS f1, 1 AS f2 FROM {self.join()}
+> CREATE MATERIALIZED VIEW v1 (f1, f2) AS SELECT generate_series AS f1, 1 AS f2 FROM generate_series(1, {self.n()});
 
 > SELECT COUNT(*) = {self.n()} FROM v1;
 true


### PR DESCRIPTION
Previously, the MFPPushdown scenario used the legacy table population method which involved a seven-table cross join. This is causing OOMs, so replace with a generate_series query.


### Motivation

Release Qualification was failing.