### PR TITLE
Avoid large import in sequencer inner

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -49,6 +49,7 @@ use mz_sql::names::{
     ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds, ResolvedItemName,
     SchemaSpecifier, SystemObjectId,
 };
+// Import `plan` module, but only import select elements to avoid merge conflicts on use statements.
 use mz_sql::plan;
 use mz_sql::plan::{
     AlterOptionParameter, IndexOption, MaterializedView, MutationKind, OptimizerConfig, Params,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -49,19 +49,10 @@ use mz_sql::names::{
     ObjectId, QualifiedItemName, ResolvedDatabaseSpecifier, ResolvedIds, ResolvedItemName,
     SchemaSpecifier, SystemObjectId,
 };
+use mz_sql::plan;
 use mz_sql::plan::{
-    AlterDefaultPrivilegesPlan, AlterIndexResetOptionsPlan, AlterIndexSetOptionsPlan,
-    AlterItemRenamePlan, AlterOptionParameter, AlterOwnerPlan, AlterRolePlan, AlterSecretPlan,
-    AlterSinkPlan, AlterSourceAction, AlterSourcePlan, AlterSystemResetAllPlan,
-    AlterSystemResetPlan, AlterSystemSetPlan, CreateConnectionPlan, CreateDatabasePlan,
-    CreateIndexPlan, CreateMaterializedViewPlan, CreateRolePlan, CreateSchemaPlan,
-    CreateSecretPlan, CreateSinkPlan, CreateSourcePlans, CreateTablePlan, CreateTypePlan,
-    CreateViewPlan, DropObjectsPlan, DropOwnedPlan, ExecutePlan, ExplainPlan, GrantPrivilegesPlan,
-    GrantRolePlan, IndexOption, InsertPlan, InspectShardPlan, MaterializedView, MutationKind,
-    OptimizerConfig, Params, Plan, QueryWhen, ReadThenWritePlan, ReassignOwnedPlan,
-    ResetVariablePlan, RevokePrivilegesPlan, RevokeRolePlan, SelectPlan, SendDiffsPlan,
-    SetTransactionPlan, SetVariablePlan, ShowVariablePlan, SideEffectingFunc,
-    SourceSinkClusterConfig, SubscribeFrom, SubscribePlan, UpdatePrivilege, VariableValue,
+    AlterOptionParameter, IndexOption, MaterializedView, MutationKind, OptimizerConfig, Params,
+    Plan, QueryWhen, SideEffectingFunc, SourceSinkClusterConfig, SubscribeFrom, UpdatePrivilege,
 };
 use mz_sql::session::vars::{
     IsolationLevel, OwnedVarInput, Var, VarInput, CLUSTER_VAR_NAME, DATABASE_VAR_NAME,
@@ -83,7 +74,7 @@ use tracing::instrument::WithSubscriber;
 use tracing::{event, warn, Level};
 
 use crate::catalog::{
-    self, Catalog, CatalogItem, Cluster, ConnCatalog, Connection, DataSourceDesc, Op,
+    self, Catalog, CatalogItem, Cluster, ConnCatalog, Connection, DataSourceDesc,
     StorageSinkConnectionState, UpdatePrivilegeVariant,
 };
 use crate::command::{ExecuteResponse, Response};
@@ -134,7 +125,7 @@ struct DropOps {
 
 // A bundle of values returned from create_source_inner
 struct CreateSourceInner {
-    ops: Vec<Op>,
+    ops: Vec<catalog::Op>,
     sources: Vec<(GlobalId, catalog::Source)>,
     if_not_exists_ids: BTreeMap<GlobalId, QualifiedItemName>,
 }
@@ -143,7 +134,7 @@ impl Coordinator {
     async fn create_source_inner(
         &mut self,
         session: &mut Session,
-        plans: Vec<CreateSourcePlans>,
+        plans: Vec<plan::CreateSourcePlans>,
     ) -> Result<CreateSourceInner, AdapterError> {
         let mut ops = vec![];
         let mut sources = vec![];
@@ -151,7 +142,7 @@ impl Coordinator {
         let if_not_exists_ids = plans
             .iter()
             .filter_map(
-                |CreateSourcePlans {
+                |plan::CreateSourcePlans {
                      source_id,
                      plan,
                      resolved_ids: _,
@@ -165,7 +156,7 @@ impl Coordinator {
             )
             .collect::<BTreeMap<_, _>>();
 
-        for CreateSourcePlans {
+        for plan::CreateSourcePlans {
             source_id,
             plan,
             resolved_ids,
@@ -212,7 +203,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_source(
         &mut self,
         session: &mut Session,
-        plans: Vec<CreateSourcePlans>,
+        plans: Vec<plan::CreateSourcePlans>,
     ) -> Result<ExecuteResponse, AdapterError> {
         let CreateSourceInner {
             ops,
@@ -288,7 +279,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_connection(
         &mut self,
         mut ctx: ExecuteContext,
-        mut plan: CreateConnectionPlan,
+        mut plan: plan::CreateConnectionPlan,
         resolved_ids: ResolvedIds,
     ) {
         let connection_gid = match self.catalog_mut().allocate_user_id().await {
@@ -369,7 +360,7 @@ impl Coordinator {
         &mut self,
         session: &mut Session,
         connection_gid: GlobalId,
-        plan: CreateConnectionPlan,
+        plan: plan::CreateConnectionPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
         let connection_oid = self.catalog_mut().allocate_oid()?;
@@ -443,7 +434,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_database(
         &mut self,
         session: &mut Session,
-        plan: CreateDatabasePlan,
+        plan: plan::CreateDatabasePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let db_oid = self.catalog_mut().allocate_oid()?;
         let schema_oid = self.catalog_mut().allocate_oid()?;
@@ -470,7 +461,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_schema(
         &mut self,
         session: &mut Session,
-        plan: CreateSchemaPlan,
+        plan: plan::CreateSchemaPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateSchema {
@@ -498,7 +489,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_role(
         &mut self,
         session: &Session,
-        CreateRolePlan { name, attributes }: CreateRolePlan,
+        plan::CreateRolePlan { name, attributes }: plan::CreateRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let oid = self.catalog_mut().allocate_oid()?;
         let op = catalog::Op::CreateRole {
@@ -515,10 +506,10 @@ impl Coordinator {
     pub(super) async fn sequence_create_table(
         &mut self,
         session: &mut Session,
-        plan: CreateTablePlan,
+        plan: plan::CreateTablePlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let CreateTablePlan {
+        let plan::CreateTablePlan {
             name,
             table,
             if_not_exists,
@@ -601,9 +592,9 @@ impl Coordinator {
     pub(super) async fn sequence_create_secret(
         &mut self,
         session: &mut Session,
-        plan: CreateSecretPlan,
+        plan: plan::CreateSecretPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let CreateSecretPlan {
+        let plan::CreateSecretPlan {
             name,
             mut secret,
             if_not_exists,
@@ -655,10 +646,10 @@ impl Coordinator {
     pub(super) async fn sequence_create_sink(
         &mut self,
         ctx: ExecuteContext,
-        plan: CreateSinkPlan,
+        plan: plan::CreateSinkPlan,
         resolved_ids: ResolvedIds,
     ) {
-        let CreateSinkPlan {
+        let plan::CreateSinkPlan {
             name,
             sink,
             with_snapshot,
@@ -833,7 +824,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_view(
         &mut self,
         session: &mut Session,
-        plan: CreateViewPlan,
+        plan: plan::CreateViewPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
         let if_not_exists = plan.if_not_exists;
@@ -857,13 +848,13 @@ impl Coordinator {
     async fn generate_view_ops(
         &mut self,
         session: &Session,
-        CreateViewPlan {
+        plan::CreateViewPlan {
             name,
             view,
             drop_ids,
             ambiguous_columns,
             ..
-        }: &CreateViewPlan,
+        }: &plan::CreateViewPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<Vec<catalog::Op>, AdapterError> {
         // Validate any references in the view's expression. We do this on the
@@ -911,10 +902,10 @@ impl Coordinator {
     pub(super) async fn sequence_create_materialized_view(
         &mut self,
         session: &mut Session,
-        plan: CreateMaterializedViewPlan,
+        plan: plan::CreateMaterializedViewPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let CreateMaterializedViewPlan {
+        let plan::CreateMaterializedViewPlan {
             name,
             materialized_view:
                 MaterializedView {
@@ -1056,10 +1047,10 @@ impl Coordinator {
     pub(super) async fn sequence_create_index(
         &mut self,
         session: &mut Session,
-        plan: CreateIndexPlan,
+        plan: plan::CreateIndexPlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let CreateIndexPlan {
+        let plan::CreateIndexPlan {
             name,
             index,
             options,
@@ -1132,7 +1123,7 @@ impl Coordinator {
     pub(super) async fn sequence_create_type(
         &mut self,
         session: &Session,
-        plan: CreateTypePlan,
+        plan: plan::CreateTypePlan,
         resolved_ids: ResolvedIds,
     ) -> Result<ExecuteResponse, AdapterError> {
         let typ = catalog::Type {
@@ -1161,11 +1152,11 @@ impl Coordinator {
     pub(super) async fn sequence_drop_objects(
         &mut self,
         session: &mut Session,
-        DropObjectsPlan {
+        plan::DropObjectsPlan {
             drop_ids,
             object_type,
             referenced_ids: _,
-        }: DropObjectsPlan,
+        }: plan::DropObjectsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let DropOps {
             ops,
@@ -1357,7 +1348,7 @@ impl Coordinator {
     pub(super) async fn sequence_drop_owned(
         &mut self,
         session: &mut Session,
-        plan: DropOwnedPlan,
+        plan: plan::DropOwnedPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         for role_id in &plan.role_ids {
             self.catalog().ensure_not_reserved_role(role_id)?;
@@ -1564,7 +1555,7 @@ impl Coordinator {
     pub(super) fn sequence_show_variable(
         &self,
         session: &Session,
-        plan: ShowVariablePlan,
+        plan: plan::ShowVariablePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         if &plan.name == SCHEMA_ALIAS {
             let schemas = self.catalog.resolve_search_path(session);
@@ -1626,7 +1617,7 @@ impl Coordinator {
     pub(super) async fn sequence_inspect_shard(
         &self,
         session: &Session,
-        plan: InspectShardPlan,
+        plan: plan::InspectShardPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         // TODO: Not thrilled about this rbac special case here, but probably
         // sufficient for now.
@@ -1649,7 +1640,7 @@ impl Coordinator {
     pub(super) fn sequence_set_variable(
         &self,
         session: &mut Session,
-        plan: SetVariablePlan,
+        plan: plan::SetVariablePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let (name, local) = (plan.name, plan.local);
         if &name == TRANSACTION_ISOLATION_VAR_NAME {
@@ -1658,8 +1649,8 @@ impl Coordinator {
 
         let vars = session.vars_mut();
         let values = match plan.value {
-            VariableValue::Default => None,
-            VariableValue::Values(values) => Some(values),
+            plan::VariableValue::Default => None,
+            plan::VariableValue::Values(values) => Some(values),
         };
 
         match values {
@@ -1709,7 +1700,7 @@ impl Coordinator {
     pub(super) fn sequence_reset_variable(
         &self,
         session: &mut Session,
-        plan: ResetVariablePlan,
+        plan: plan::ResetVariablePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let name = plan.name;
         if &name == TRANSACTION_ISOLATION_VAR_NAME {
@@ -1724,7 +1715,7 @@ impl Coordinator {
     pub(super) fn sequence_set_transaction(
         &self,
         session: &mut Session,
-        plan: SetTransactionPlan,
+        plan: plan::SetTransactionPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         // TODO(jkosh44) Only supports isolation levels for now.
         for mode in plan.modes {
@@ -1898,7 +1889,7 @@ impl Coordinator {
     pub(super) async fn sequence_peek(
         &mut self,
         ctx: ExecuteContext,
-        plan: SelectPlan,
+        plan: plan::SelectPlan,
         target_cluster: TargetCluster,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
@@ -1967,7 +1958,7 @@ impl Coordinator {
             target_cluster,
         }: PeekStageValidate,
     ) -> Result<PeekStageOptimize, AdapterError> {
-        let SelectPlan {
+        let plan::SelectPlan {
             source,
             when,
             finishing,
@@ -2491,10 +2482,10 @@ impl Coordinator {
     pub(super) async fn sequence_subscribe(
         &mut self,
         session: &mut Session,
-        plan: SubscribePlan,
+        plan: plan::SubscribePlan,
         target_cluster: TargetCluster,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let SubscribePlan {
+        let plan::SubscribePlan {
             from,
             with_snapshot,
             when,
@@ -2653,7 +2644,7 @@ impl Coordinator {
     pub(super) async fn sequence_explain(
         &mut self,
         mut ctx: ExecuteContext,
-        plan: ExplainPlan,
+        plan: plan::ExplainPlan,
         target_cluster: TargetCluster,
     ) {
         match plan.stage {
@@ -2670,12 +2661,12 @@ impl Coordinator {
     async fn sequence_explain_plan(
         &mut self,
         session: &mut Session,
-        plan: ExplainPlan,
+        plan: plan::ExplainPlan,
         target_cluster: TargetCluster,
     ) -> Result<ExecuteResponse, AdapterError> {
         use ExplainStage::*;
 
-        let ExplainPlan {
+        let plan::ExplainPlan {
             raw_plan,
             row_set_finishing,
             stage,
@@ -2943,7 +2934,11 @@ impl Coordinator {
         Ok((used_indexes, fast_path_plan))
     }
 
-    fn sequence_explain_timestamp_begin(&mut self, mut ctx: ExecuteContext, plan: ExplainPlan) {
+    fn sequence_explain_timestamp_begin(
+        &mut self,
+        mut ctx: ExecuteContext,
+        plan: plan::ExplainPlan,
+    ) {
         let (format, source_ids, optimized_plan, cluster_id, id_bundle) = return_if_err!(
             self.sequence_explain_timestamp_begin_inner(ctx.session(), plan),
             ctx
@@ -2998,7 +2993,7 @@ impl Coordinator {
     fn sequence_explain_timestamp_begin_inner(
         &mut self,
         session: &Session,
-        plan: ExplainPlan,
+        plan: plan::ExplainPlan,
     ) -> Result<
         (
             ExplainFormat,
@@ -3009,7 +3004,7 @@ impl Coordinator {
         ),
         AdapterError,
     > {
-        let ExplainPlan {
+        let plan::ExplainPlan {
             raw_plan, format, ..
         } = plan;
 
@@ -3132,7 +3127,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     fn sequence_send_diffs(
         session: &mut Session,
-        mut plan: SendDiffsPlan,
+        mut plan: plan::SendDiffsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let affected_rows = {
             let mut affected_rows = Diff::from(0);
@@ -3198,7 +3193,11 @@ impl Coordinator {
         })
     }
 
-    pub(super) async fn sequence_insert(&mut self, mut ctx: ExecuteContext, plan: InsertPlan) {
+    pub(super) async fn sequence_insert(
+        &mut self,
+        mut ctx: ExecuteContext,
+        plan: plan::InsertPlan,
+    ) {
         let optimized_mir = if let Some(..) = &plan.values.as_const() {
             // We don't perform any optimizations on an expression that is already
             // a constant for writes, as we want to maximize bulk-insert throughput.
@@ -3253,7 +3252,7 @@ impl Coordinator {
                     project: (0..desc_arity).collect(),
                 };
 
-                let read_then_write_plan = ReadThenWritePlan {
+                let read_then_write_plan = plan::ReadThenWritePlan {
                     id: plan.id,
                     selection,
                     finishing,
@@ -3294,7 +3293,7 @@ impl Coordinator {
                         desc.constraints_met(i, &datum)?;
                     }
                 }
-                let diffs_plan = SendDiffsPlan {
+                let diffs_plan = plan::SendDiffsPlan {
                     id,
                     updates: rows,
                     kind: MutationKind::Insert,
@@ -3349,13 +3348,13 @@ impl Coordinator {
     pub(super) async fn sequence_read_then_write(
         &mut self,
         mut ctx: ExecuteContext,
-        plan: ReadThenWritePlan,
+        plan: plan::ReadThenWritePlan,
     ) {
         let mut source_ids = plan.selection.depends_on();
         source_ids.insert(plan.id);
         guard_write_critical_section!(self, ctx, Plan::ReadThenWrite(plan), source_ids);
 
-        let ReadThenWritePlan {
+        let plan::ReadThenWritePlan {
             id,
             kind,
             selection,
@@ -3436,7 +3435,7 @@ impl Coordinator {
         );
         self.sequence_peek(
             peek_ctx,
-            SelectPlan {
+            plan::SelectPlan {
                 source: selection,
                 when: QueryWhen::Freshest,
                 finishing,
@@ -3649,7 +3648,7 @@ impl Coordinator {
                 Ok(diffs) => {
                     let result = Self::sequence_send_diffs(
                         ctx.session_mut(),
-                        SendDiffsPlan {
+                        plan::SendDiffsPlan {
                             id,
                             updates: diffs,
                             kind,
@@ -3669,7 +3668,7 @@ impl Coordinator {
     pub(super) async fn sequence_alter_item_rename(
         &mut self,
         session: &Session,
-        plan: AlterItemRenamePlan,
+        plan: plan::AlterItemRenamePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let op = catalog::Op::RenameItem {
             id: plan.id,
@@ -3684,7 +3683,7 @@ impl Coordinator {
 
     pub(super) fn sequence_alter_index_set_options(
         &mut self,
-        plan: AlterIndexSetOptionsPlan,
+        plan: plan::AlterIndexSetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.set_index_options(plan.id, plan.options)?;
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
@@ -3692,7 +3691,7 @@ impl Coordinator {
 
     pub(super) fn sequence_alter_index_reset_options(
         &mut self,
-        plan: AlterIndexResetOptionsPlan,
+        plan: plan::AlterIndexResetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let mut options = Vec::with_capacity(plan.options.len());
         for o in plan.options {
@@ -3741,11 +3740,11 @@ impl Coordinator {
     pub(super) async fn sequence_alter_role(
         &mut self,
         session: &Session,
-        AlterRolePlan {
+        plan::AlterRolePlan {
             id,
             name,
             attributes,
-        }: AlterRolePlan,
+        }: plan::AlterRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let catalog = self.catalog().for_session(session);
         let role = catalog.get_role(&id);
@@ -3763,9 +3762,9 @@ impl Coordinator {
     pub(super) async fn sequence_alter_secret(
         &mut self,
         session: &Session,
-        plan: AlterSecretPlan,
+        plan: plan::AlterSecretPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let AlterSecretPlan { id, mut secret_as } = plan;
+        let plan::AlterSecretPlan { id, mut secret_as } = plan;
 
         let payload = self.extract_secret(session, &mut secret_as)?;
 
@@ -3777,7 +3776,7 @@ impl Coordinator {
     pub(super) async fn sequence_alter_sink(
         &mut self,
         session: &Session,
-        AlterSinkPlan { id, size }: AlterSinkPlan,
+        plan::AlterSinkPlan { id, size }: plan::AlterSinkPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let cluster_config = alter_storage_cluster_config(size);
         if let Some(cluster_config) = cluster_config {
@@ -3797,12 +3796,12 @@ impl Coordinator {
     pub(super) async fn sequence_alter_source(
         &mut self,
         session: &mut Session,
-        AlterSourcePlan { id, action }: AlterSourcePlan,
-        to_create_subsources: Vec<CreateSourcePlans>,
+        plan::AlterSourcePlan { id, action }: plan::AlterSourcePlan,
+        to_create_subsources: Vec<plan::CreateSourcePlans>,
     ) -> Result<ExecuteResponse, AdapterError> {
         assert!(
             to_create_subsources.is_empty()
-                || matches!(action, AlterSourceAction::AddSubsourceExports { .. }),
+                || matches!(action, plan::AlterSourceAction::AddSubsourceExports { .. }),
             "cannot include subsources with {:?}",
             action
         );
@@ -3839,7 +3838,7 @@ impl Coordinator {
         };
 
         match action {
-            AlterSourceAction::Resize(size) => {
+            plan::AlterSourceAction::Resize(size) => {
                 let cluster_config = alter_storage_cluster_config(size);
                 if let Some(cluster_config) = cluster_config {
                     let mut ops = self.alter_linked_cluster_ops(id, &cluster_config).await?;
@@ -3852,7 +3851,7 @@ impl Coordinator {
                     self.maybe_alter_linked_cluster(id).await;
                 }
             }
-            AlterSourceAction::DropSubsourceExports { to_drop } => {
+            plan::AlterSourceAction::DropSubsourceExports { to_drop } => {
                 mz_ore::soft_assert!(!to_drop.is_empty());
 
                 const ALTER_SOURCE: &str = "ALTER SOURCE...DROP TABLES";
@@ -4045,7 +4044,7 @@ impl Coordinator {
                 );
 
                 // Redefine source.
-                ops.push(Op::UpdateItem {
+                ops.push(catalog::Op::UpdateItem {
                     id,
                     // Look this up again so we don't have to hold an immutable reference to the
                     // entry for so long.
@@ -4062,7 +4061,7 @@ impl Coordinator {
                     .await
                     .expect("altering collection after txn must succeed");
             }
-            AlterSourceAction::AddSubsourceExports {
+            plan::AlterSourceAction::AddSubsourceExports {
                 subsources,
                 details,
                 options,
@@ -4239,7 +4238,7 @@ impl Coordinator {
                 );
 
                 // Redefine source.
-                ops.push(Op::UpdateItem {
+                ops.push(catalog::Op::UpdateItem {
                     id,
                     // Look this up again so we don't have to hold an immutable reference to the
                     // entry for so long.
@@ -4355,15 +4354,15 @@ impl Coordinator {
     pub(super) async fn sequence_alter_system_set(
         &mut self,
         session: &Session,
-        AlterSystemSetPlan { name, value }: AlterSystemSetPlan,
+        plan::AlterSystemSetPlan { name, value }: plan::AlterSystemSetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session, Some(&name))?;
         let op = match value {
-            VariableValue::Values(values) => catalog::Op::UpdateSystemConfiguration {
+            plan::VariableValue::Values(values) => catalog::Op::UpdateSystemConfiguration {
                 name,
                 value: OwnedVarInput::SqlSet(values),
             },
-            VariableValue::Default => catalog::Op::ResetSystemConfiguration { name },
+            plan::VariableValue::Default => catalog::Op::ResetSystemConfiguration { name },
         };
         self.catalog_transact(Some(session), vec![op]).await?;
         Ok(ExecuteResponse::AlteredSystemConfiguration)
@@ -4372,7 +4371,7 @@ impl Coordinator {
     pub(super) async fn sequence_alter_system_reset(
         &mut self,
         session: &Session,
-        AlterSystemResetPlan { name }: AlterSystemResetPlan,
+        plan::AlterSystemResetPlan { name }: plan::AlterSystemResetPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session, Some(&name))?;
         let op = catalog::Op::ResetSystemConfiguration { name };
@@ -4383,7 +4382,7 @@ impl Coordinator {
     pub(super) async fn sequence_alter_system_reset_all(
         &mut self,
         session: &Session,
-        _: AlterSystemResetAllPlan,
+        _: plan::AlterSystemResetAllPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.is_user_allowed_to_alter_system(session, None)?;
         let op = catalog::Op::ResetAllSystemConfiguration;
@@ -4432,7 +4431,7 @@ impl Coordinator {
     pub(super) fn sequence_execute(
         &mut self,
         session: &mut Session,
-        plan: ExecutePlan,
+        plan: plan::ExecutePlan,
     ) -> Result<String, AdapterError> {
         // Verify the stmt is still valid.
         Self::verify_prepared_statement(self.catalog(), session, &plan.name)?;
@@ -4449,10 +4448,10 @@ impl Coordinator {
     pub(super) async fn sequence_grant_privileges(
         &mut self,
         session: &mut Session,
-        GrantPrivilegesPlan {
+        plan::GrantPrivilegesPlan {
             update_privileges,
             grantees,
-        }: GrantPrivilegesPlan,
+        }: plan::GrantPrivilegesPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.sequence_update_privileges(
             session,
@@ -4466,10 +4465,10 @@ impl Coordinator {
     pub(super) async fn sequence_revoke_privileges(
         &mut self,
         session: &mut Session,
-        RevokePrivilegesPlan {
+        plan::RevokePrivilegesPlan {
             update_privileges,
             revokees,
-        }: RevokePrivilegesPlan,
+        }: plan::RevokePrivilegesPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         self.sequence_update_privileges(
             session,
@@ -4591,11 +4590,11 @@ impl Coordinator {
     pub(super) async fn sequence_alter_default_privileges(
         &mut self,
         session: &mut Session,
-        AlterDefaultPrivilegesPlan {
+        plan::AlterDefaultPrivilegesPlan {
             privilege_objects,
             privilege_acl_items,
             is_grant,
-        }: AlterDefaultPrivilegesPlan,
+        }: plan::AlterDefaultPrivilegesPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let mut ops = Vec::with_capacity(privilege_objects.len() * privilege_acl_items.len());
         let variant = if is_grant {
@@ -4622,7 +4621,7 @@ impl Coordinator {
             for privilege_acl_item in &privilege_acl_items {
                 self.catalog()
                     .ensure_not_system_role(&privilege_acl_item.grantee)?;
-                ops.push(Op::UpdateDefaultPrivilege {
+                ops.push(catalog::Op::UpdateDefaultPrivilege {
                     privilege_object: privilege_object.clone(),
                     privilege_acl_item: privilege_acl_item.clone(),
                     variant,
@@ -4637,11 +4636,11 @@ impl Coordinator {
     pub(super) async fn sequence_grant_role(
         &mut self,
         session: &mut Session,
-        GrantRolePlan {
+        plan::GrantRolePlan {
             role_ids,
             member_ids,
             grantor_id,
-        }: GrantRolePlan,
+        }: plan::GrantRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let catalog = self.catalog();
         let mut ops = Vec::with_capacity(role_ids.len() * member_ids.len());
@@ -4681,11 +4680,11 @@ impl Coordinator {
     pub(super) async fn sequence_revoke_role(
         &mut self,
         session: &mut Session,
-        RevokeRolePlan {
+        plan::RevokeRolePlan {
             role_ids,
             member_ids,
             grantor_id,
-        }: RevokeRolePlan,
+        }: plan::RevokeRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let catalog = self.catalog();
         let mut ops = Vec::with_capacity(role_ids.len() * member_ids.len());
@@ -4725,13 +4724,13 @@ impl Coordinator {
     pub(super) async fn sequence_alter_owner(
         &mut self,
         session: &mut Session,
-        AlterOwnerPlan {
+        plan::AlterOwnerPlan {
             id,
             object_type,
             new_owner,
-        }: AlterOwnerPlan,
+        }: plan::AlterOwnerPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let mut ops = vec![Op::UpdateOwner {
+        let mut ops = vec![catalog::Op::UpdateOwner {
             id: id.clone(),
             new_owner,
         }];
@@ -4755,7 +4754,7 @@ impl Coordinator {
                     .used_by()
                     .into_iter()
                     .filter(|id| self.catalog().get_entry(id).is_index())
-                    .map(|id| Op::UpdateOwner {
+                    .map(|id| catalog::Op::UpdateOwner {
                         id: ObjectId::Item(*id),
                         new_owner,
                     });
@@ -4764,12 +4763,15 @@ impl Coordinator {
                 // Alter owner cascades down to linked clusters and replicas.
                 if let Some(cluster) = self.catalog().get_linked_cluster(*global_id) {
                     let linked_cluster_replica_ops =
-                        cluster.replicas_by_id.keys().map(|id| Op::UpdateOwner {
-                            id: ObjectId::ClusterReplica((cluster.id(), *id)),
-                            new_owner,
-                        });
+                        cluster
+                            .replicas_by_id
+                            .keys()
+                            .map(|id| catalog::Op::UpdateOwner {
+                                id: ObjectId::ClusterReplica((cluster.id(), *id)),
+                                new_owner,
+                            });
                     ops.extend(linked_cluster_replica_ops);
-                    ops.push(Op::UpdateOwner {
+                    ops.push(catalog::Op::UpdateOwner {
                         id: ObjectId::Cluster(cluster.id()),
                         new_owner,
                     });
@@ -4777,10 +4779,13 @@ impl Coordinator {
 
                 // Alter owner cascades down to sub-sources and progress collections.
                 let dependent_subsources =
-                    entry.subsources().into_iter().map(|id| Op::UpdateOwner {
-                        id: ObjectId::Item(id),
-                        new_owner,
-                    });
+                    entry
+                        .subsources()
+                        .into_iter()
+                        .map(|id| catalog::Op::UpdateOwner {
+                            id: ObjectId::Item(id),
+                            new_owner,
+                        });
                 ops.extend(dependent_subsources);
             }
             ObjectId::Cluster(cluster_id) => {
@@ -4790,7 +4795,7 @@ impl Coordinator {
                     cluster
                         .replicas_by_id
                         .keys()
-                        .map(|replica_id| Op::UpdateOwner {
+                        .map(|replica_id| catalog::Op::UpdateOwner {
                             id: ObjectId::ClusterReplica((cluster.id(), *replica_id)),
                             new_owner,
                         });
@@ -4807,11 +4812,11 @@ impl Coordinator {
     pub(super) async fn sequence_reassign_owned(
         &mut self,
         session: &mut Session,
-        ReassignOwnedPlan {
+        plan::ReassignOwnedPlan {
             old_roles,
             new_role,
             reassign_ids,
-        }: ReassignOwnedPlan,
+        }: plan::ReassignOwnedPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         for role_id in old_roles.iter().chain(iter::once(&new_role)) {
             self.catalog().ensure_not_reserved_role(role_id)?;
@@ -4819,7 +4824,7 @@ impl Coordinator {
 
         let ops = reassign_ids
             .into_iter()
-            .map(|id| Op::UpdateOwner {
+            .map(|id| catalog::Op::UpdateOwner {
                 id,
                 new_owner: new_role,
             })


### PR DESCRIPTION
### Motivation

Avoids some merge conflicts in `Plan` imports in `inner.rs`. Unfortunately, I don't think there's a good way to prevent future changes from again importing the plans directly.

This is not a functional change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
