### PR TITLE
Expose lexer keywords to WASM32 targets

### DIFF
--- a/src/sql-lexer/src/keywords.rs
+++ b/src/sql-lexer/src/keywords.rs
@@ -23,6 +23,13 @@ use std::str::FromStr;
 
 use uncased::UncasedStr;
 
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(typescript_custom_section)]
+const KEYWORDS_TS_DEF: &'static str = r#"export function getKeywords(): string[];"#;
+
 // The `Keyword` type and the keyword constants are automatically generated from
 // the list in keywords.txt by the crate's build script.
 //
@@ -138,4 +145,15 @@ impl fmt::Display for Keyword {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         f.write_str(self.as_str())
     }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen(js_name = getKeywords, skip_typescript)]
+// #[wasm_bindgen] cannot be applied directly to KEYWORDS, only to functions, structs, enums,
+// impls, or extern blocks. Wrap this in a function.
+pub fn get_keywords() -> Vec<JsValue> {
+    KEYWORDS
+        .keys()
+        .map(|k| JsValue::from(k.to_string()))
+        .collect()
 }


### PR DESCRIPTION


<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.
 
It is useful for external consumers to know what keywords Materialize understands. For example, the SQL Shell can use this to apply accurate syntax highlighting to SQL commands.

Unfortunately we cannot apply the wasm-bindgen proc macro directly to the `KEYWORDS` const as the macro only works with functions, structs, enums, impls, and extern blocks. As a result, this introduces a new WASM-only function to expose the keywords to WASM32 consumers.

Touches MaterializeInc/database-issues#11046
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
