### PR TITLE
feature-benchmark: Detect regressions based on dataflow message counts

### DIFF
--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -75,12 +75,12 @@ class TdAction(Action):
     ) -> None:
         executor = executor or self._executor
         assert executor
-        td_output = executor.Td(self._td_str)
-
         # Print each query once so that it is easier to reproduce regressions
         # based on just the logs from CI
         if executor.add_known_fragment(self._td_str):
-            print(td_output)
+            print(self._td_str)
+
+        executor.Td(self._td_str)
 
 
 class DummyAction(Action):

--- a/misc/python/materialize/feature_benchmark/aggregation.py
+++ b/misc/python/materialize/feature_benchmark/aggregation.py
@@ -23,7 +23,10 @@ class Aggregation:
         self._data.append(measurement.value)
 
     def aggregate(self) -> Any:
-        return self.func()([*self._data])
+        if len(self._data) == 0:
+            return None
+        else:
+            return self.func()([*self._data])
 
     def func(self) -> Callable:
         assert False

--- a/misc/python/materialize/feature_benchmark/benchmark.py
+++ b/misc/python/materialize/feature_benchmark/benchmark.py
@@ -38,6 +38,7 @@ class Benchmark:
         self._filter = filter
         self._termination_conditions = termination_conditions
         self._performance_aggregation = aggregation_class()
+        self._messages_aggregation = aggregation_class()
 
         if measure_memory:
             self._memory_aggregation = aggregation_class()
@@ -117,6 +118,14 @@ class Benchmark:
                 print(f"{i} {performance_measurement}")
                 self._performance_aggregation.append(performance_measurement)
 
+            messages = self._executor.Messages()
+            if messages is not None:
+                messages_measurement = Measurement(
+                    type=MeasurementType.MESSAGES, value=messages
+                )
+                print(f"{i}: {messages_measurement}")
+                self._messages_aggregation.append(messages_measurement)
+
             if self._memory_aggregation:
                 memory_measurement = Measurement(
                     type=MeasurementType.MEMORY,
@@ -130,7 +139,11 @@ class Benchmark:
 
             for termination_condition in self._termination_conditions:
                 if termination_condition.terminate(performance_measurement):
-                    return [self._performance_aggregation, self._memory_aggregation]
+                    return [
+                        self._performance_aggregation,
+                        self._messages_aggregation,
+                        self._memory_aggregation,
+                    ]
 
         assert False, "unreachable"
 
@@ -147,14 +160,14 @@ class Report:
 
     def dump(self) -> None:
         print(
-            f"{'NAME':<35} | {'TYPE':<10} | {'THIS':^11} | {'OTHER':^11} | {'Regression?':^13} | 'THIS' is:"
+            f"{'NAME':<35} | {'TYPE':<9} | {'THIS':^15} | {'OTHER':^15} | {'Regression?':^13} | 'THIS' is:"
         )
         print("-" * 100)
 
         for comparison in self._comparisons:
             regression = "!!YES!!" if comparison.is_regression() else "no"
             print(
-                f"{comparison.name:<35} | {comparison.type:<10} | {comparison.this():>11.3f} | {comparison.other():>11.3f} | {regression:^13} | {comparison.human_readable()}"
+                f"{comparison.name:<35} | {comparison.type:<9} | {comparison.this_as_str():>15} | {comparison.other_as_str():>15} | {regression:^13} | {comparison.human_readable()}"
             )
 
 

--- a/misc/python/materialize/feature_benchmark/measurement.py
+++ b/misc/python/materialize/feature_benchmark/measurement.py
@@ -13,6 +13,7 @@ from enum import Enum, auto
 class MeasurementType(Enum):
     WALLCLOCK = auto()
     MEMORY = auto()
+    MESSAGES = auto()
 
     def __str__(self) -> str:
         return self.name.lower()

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -24,6 +24,7 @@ from scenarios_concurrency import *  # noqa: F401 F403
 from scenarios_customer import *  # noqa: F401 F403
 from scenarios_optbench import *  # noqa: F401 F403
 from scenarios_scale import *  # noqa: F401 F403
+from scenarios_skew import *  # noqa: F401 F403
 from scenarios_subscribe import *  # noqa: F401 F403
 
 from materialize.feature_benchmark.aggregation import Aggregation, MinAggregation
@@ -110,9 +111,10 @@ def run_one_scenario(
     name = scenario.__name__
     print(f"--- Now benchmarking {name} ...")
 
-    measurement_types = [MeasurementType.WALLCLOCK]
+    measurement_types = [MeasurementType.WALLCLOCK, MeasurementType.MESSAGES]
     if args.measure_memory:
         measurement_types.append(MeasurementType.MEMORY)
+
     comparators = [make_comparator(name=name, type=t) for t in measurement_types]
 
     common_seed = round(time.time())

--- a/test/feature-benchmark/scenarios_skew.py
+++ b/test/feature-benchmark/scenarios_skew.py
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from math import floor
+from textwrap import dedent
+from typing import List
+
+from materialize.feature_benchmark.action import Action, TdAction
+from materialize.feature_benchmark.measurement_source import MeasurementSource, Td
+from materialize.feature_benchmark.scenario import Scenario
+
+
+def create_skewed_table(scale: int) -> str:
+    count = 10**scale
+    return (
+        dedent(
+            f"""
+       > CREATE TABLE skewed_table(f1 INTEGER);
+       # Make sure 0 is overepresented
+       > INSERT INTO skewed_table (f1) SELECT 0 FROM generate_series(1, {count});
+       """
+        )
+        + "\n".join(
+            [
+                f"> INSERT INTO skewed_table (f1) SELECT MOD(generate_series, POW(10, {i})) FROM generate_series(1, {count} / {scale});"
+                for i in range(scale)
+            ]
+        )
+    )
+
+
+def create_uniform_table(scale: int) -> str:
+    count = 10**scale
+    return dedent(
+        f"""
+        > CREATE TABLE uniform_table (f1 INTEGER);
+        > INSERT INTO uniform_table (f1) SELECT generate_series FROM generate_series(0, {count-1});
+        """
+    )
+
+
+class SkewedJoin(Scenario):
+    def init(self) -> List[Action]:
+        return [
+            TdAction(
+                create_skewed_table(floor(self.scale()))
+                + create_uniform_table(floor(self.scale()))
+            )
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            dedent(
+                """
+                > DROP MATERIALIZED VIEW IF EXISTS v1;
+
+                > CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) > 0 FROM skewed_table JOIN uniform_table USING (f1)
+                  /* A */
+
+                > SELECT * FROM v1
+                  /* B */
+                true
+                """
+            )
+        )


### PR DESCRIPTION
Measure the total number of messages in the system in order to detect regressions in low-level operations that only manifest that way.

Add a scenario that creates a join dataflow over an input with a skewed distribution.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
