### PR TITLE
stash: Clean up public interface

### DIFF
--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -30,7 +30,7 @@ hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes", "smallvec", "stack", "test"] }
+mz-ore = { path = "../ore", features = ["bytes", "smallvec", "stack", "test", "serde"] }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 num-traits = "0.2.15"

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -77,22 +77,21 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::convert::Infallible;
 use std::time::Duration;
 
+use crate::{
+    AppendBatch, Data, Stash, StashCollection, StashError, StashFactory, TableTransaction,
+    Timestamp, TypedCollection, INSERT_BATCH_SPLIT_SIZE,
+};
 use futures::Future;
 use mz_ore::assert_contains;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::spawn;
-use mz_stash::{
-    AppendBatch, Data, Stash, StashCollection, StashError, StashFactory, TableTransaction,
-    Timestamp, TypedCollection, INSERT_BATCH_SPLIT_SIZE,
-};
 use postgres_openssl::MakeTlsConnector;
 use timely::progress::Antichain;
 use tokio::sync::oneshot;
 use tokio_postgres::Config;
 
-pub static C1: TypedCollection<i64, i64> = TypedCollection::new("c1");
-pub static C2: TypedCollection<i64, i64> = TypedCollection::new("c2");
-pub static C_SAVEPOINT: TypedCollection<i64, i64> = TypedCollection::new("c_savepoint");
+static C1: TypedCollection<i64, i64> = TypedCollection::new("c1");
+static C_SAVEPOINT: TypedCollection<i64, i64> = TypedCollection::new("c_savepoint");
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
@@ -638,8 +637,8 @@ where
                     ],
                     None,
                 )
-                .await
-                .unwrap();
+                    .await
+                    .unwrap();
                 tx.seal(orders.id, Antichain::from_elem(3), None)
                     .await
                     .unwrap();

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -63,7 +63,6 @@ pub(crate) mod v28_to_v29;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.
-    #[allow(dead_code)]
     Delete(K1),
     /// Inserts the provided key-value pair. The key must not currently exist!
     Insert(K2, V2),


### PR DESCRIPTION
This commit cleans up the stash public interface by doing the following:

- Add some doc-comments to `pub` methods.
- Move the stash integration tests into unit tests. Integration tests can only access `pub` methods. This required us to expose some stash implementation details via `pub` methods that were only used in the integration tests. Moving the integration tests to unit tests allows us to remove the `pub` modifier.
- Remove `pub` modifier or convert to `pub(crate)` for all methods that were only used within the stash crate.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
