### PR TITLE
webhooks: Add upgrade test

### DIFF
--- a/test/upgrade/check-from-v0.63.0-webhook-source.td
+++ b/test/upgrade/check-from-v0.63.0-webhook-source.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SELECT body FROM my_webhook_source;
+"using an mz secret"

--- a/test/upgrade/create-in-v0.27.0-secrets.td
+++ b/test/upgrade/create-in-v0.27.0-secrets.td
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> CREATE SECRET secret1 AS 'secret';
+# Note: Also used for creating a webhook source.
+> CREATE SECRET secret1 AS 'shared_key';
 
 > CREATE SECRET secret2 AS 'secret';

--- a/test/upgrade/create-in-v0.63.0-webhook-source.td
+++ b/test/upgrade/create-in-v0.63.0-webhook-source.td
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_webhook_sources = true
+
+> CREATE SECRET IF NOT EXISTS webhook_shared_secret AS 'shared_key'
+> CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
+
+> CREATE SOURCE my_webhook_source IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  INCLUDE HEADERS
+  CHECK (
+    WITH(HEADERS, BODY, SECRET webhook_shared_secret)
+    decode(headers->'x-signature', 'base64') = hmac(body, webhook_secret, 'sha256')
+  )
+
+$ webhook-append name=my_webhook_source x-signature=VNCe6bTKrlFO46GfiUYR/xFpeZ2H/KbLfR9oJKYAwkc=
+using an mz secret
+
+$ webhook-append name=my_webhook_source x-signature=invalid_signature status=400
+this should not get appended

--- a/test/upgrade/create-in-v0.63.0-webhook-source.td
+++ b/test/upgrade/create-in-v0.63.0-webhook-source.td
@@ -10,15 +10,14 @@
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_webhook_sources = true
 
-> CREATE SECRET IF NOT EXISTS webhook_shared_secret AS 'shared_key'
 > CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
 
 > CREATE SOURCE my_webhook_source IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT
   INCLUDE HEADERS
   CHECK (
-    WITH(HEADERS, BODY, SECRET webhook_shared_secret)
-    decode(headers->'x-signature', 'base64') = hmac(body, webhook_secret, 'sha256')
+    WITH(HEADERS, BODY, SECRET secret1)
+    decode(headers->'x-signature', 'base64') = hmac(body, secret1, 'sha256')
   )
 
 $ webhook-append name=my_webhook_source x-signature=VNCe6bTKrlFO46GfiUYR/xFpeZ2H/KbLfR9oJKYAwkc=


### PR DESCRIPTION
This PR adds a test to `/test/upgrade` that creates a webhook source, appends some data to it, then checks in a newer version that we can read back that data.

### Motivation

Fixes: https://github.com/MaterializeInc/materialize/issues/20502

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
