### PR TITLE
webhooks: Rate limit writes to persist

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2159,7 +2159,7 @@ fn webhook_concurrent_actions() {
     });
 
     // Let the posting threads run for a bit.
-    std::thread::sleep(std::time::Duration::from_secs(4));
+    std::thread::sleep(std::time::Duration::from_secs(5));
 
     // We should see at least this many successes.
     let expected_success = expected_success.load(std::sync::atomic::Ordering::Relaxed);
@@ -2186,7 +2186,7 @@ fn webhook_concurrent_actions() {
     // count before we dropped the source.
     for _ in 0..expected_success {
         let status = results.next().expect("element");
-        assert!(status.is_success())
+        assert!(status.is_success(), "status: {status:?}")
     }
     // We should have seen at least 100 successes.
     assert!(expected_success > 100);
@@ -2198,6 +2198,9 @@ fn webhook_concurrent_actions() {
         }
     }
     assert!(saw_atleast_one_success_after_close);
+
+    // Best effort cleanup.
+    let _ = client.execute("DROP CLUSTER webhook_cluster CASCADE", &[]);
 }
 
 #[mz_ore::test]

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2186,7 +2186,11 @@ fn webhook_concurrent_actions() {
     // count before we dropped the source.
     for _ in 0..expected_success {
         let status = results.next().expect("element");
-        assert!(status.is_success(), "status: {status:?}")
+        // Note it's possible we get rate limited as we append.
+        assert!(
+            status.is_success() || status == StatusCode::TOO_MANY_REQUESTS,
+            "status: {status:?}"
+        )
     }
     // We should have seen at least 100 successes.
     assert!(expected_success > 100);

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -56,7 +56,7 @@ serde_json = { version = "1.0.89" }
 static_assertions = "1.1"
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tonic = "0.8.2"

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -26,7 +26,7 @@ use tracing::debug;
 use crate::client::TimestamplessUpdate;
 use crate::controller::{persist_handles, StorageError};
 
-// Note(parkmycar): The capacity here was chosen randomly.
+// Note(parkmycar): The capacity here was chosen arbitrarily.
 const CHANNEL_CAPACITY: usize = 256;
 // We only append data once per-second.
 const DEFAULT_APPEND_CADANCE: Duration = Duration::from_secs(1);

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -20,10 +20,16 @@ use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, Row, TimestampManipulation};
 use timely::progress::Timestamp;
 use tokio::sync::{mpsc, oneshot};
+use tokio::time::{Duration, Instant};
 use tracing::debug;
 
 use crate::client::TimestamplessUpdate;
 use crate::controller::{persist_handles, StorageError};
+
+// Note(parkmycar): The capacity here was chosen randomly.
+const CHANNEL_CAPACITY: usize = 256;
+// We only append data once per-second.
+const DEFAULT_APPEND_CADANCE: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone)]
 pub struct CollectionManager {
@@ -55,12 +61,11 @@ impl CollectionManager {
         let collections: Arc<Mutex<BTreeSet<GlobalId>>> = Arc::new(Mutex::new(BTreeSet::new()));
         let collections_outer = Arc::clone(&collections);
 
-        // Note(parkmycar): The capacity here was chosen randomly.
         let (tx, mut rx) = mpsc::channel::<(
             GlobalId,
             Vec<(Row, Diff)>,
             oneshot::Sender<Result<(), StorageError>>,
-        )>(256);
+        )>(CHANNEL_CAPACITY);
 
         // Allows callers to wait until we finish any in-progress work.
         //
@@ -74,7 +79,8 @@ impl CollectionManager {
         let notifies_outer = Arc::clone(&notifies);
 
         mz_ore::task::spawn(|| "ControllerManagedCollectionWriter", async move {
-            let mut interval = tokio::time::interval(tokio::time::Duration::from_millis(1_000));
+            let mut interval = tokio::time::interval(Duration::from_millis(1_000));
+
             loop {
                 // Notify any waiters.
                 notifies
@@ -111,8 +117,12 @@ impl CollectionManager {
                             }
                         }
                     },
-                    cmd = rx.recv_many(64) => {
+                    cmd = rx.recv_many(CHANNEL_CAPACITY) => {
                         if let Some(batch) = cmd {
+                            // To rate limit appends to persist we add artifical latency, and will
+                            // finish no sooner than this instant.
+                            let min_time_to_complete = Instant::now() + DEFAULT_APPEND_CADANCE;
+
                             // Group all of our updates based on ID.
                             let mut updates: BTreeMap<GlobalId, UpdateRequest> = BTreeMap::new();
                             for (id, rows, notif) in batch {
@@ -205,6 +215,12 @@ impl CollectionManager {
                                     }
                                 }
                             }
+
+                            // Wait until our artificial latency has completed.
+                            //
+                            // Note: if writing to persist took longer than `DEFAULT_APPEND_CADANCE`
+                            // this await will resolve immediately.
+                            tokio::time::sleep_until(min_time_to_complete).await;
                         }
                     }
                 }


### PR DESCRIPTION
### Motivation

This PR adds some rate limiting to the `CollectionManager`, which webhook sources use to append data. After merging the MVP for webhook sources and running a multi-day test, I chatted with the persist folks ([Slack](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1690816652002909)) to make sure things were relatively stable. They were, but webhook sources were allowed to append as fast as persist could handle and currently they were appending ~14 times per second. This causes a lot of CRDB writes, so we're going to rate limit appends to ~1 per second, which is the same cadence as our other sources.

Instead of just sleeping for 1 second after each append, before an append runs we get an `Instant` that is 1 second in the future, run the append, and then wait for this `Instant` to pass. This essentially adds fake latency and makes it appear as though writes are taking at least 1 second.

We also refactor the concurrency test to use async, otherwise the threads spawned for requests would wait until the request resolved, which is ~1 second. So in the 4 seconds we waited we'd only get ~12 requests. Using async we can run hundreds of tasks concurrently and get ~450 requests.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
