### PR TITLE
[persist] Consolidate opportunistically when fetching a part

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -520,6 +520,11 @@ where
                 d.plus_equals(&D::decode(d_next));
             }
 
+            // If multiple updates consolidate out entirely, drop the record.
+            if d.is_zero() {
+                continue;
+            }
+
             let k = self.metrics.codecs.key.decode(|| K::decode(k));
             let v = self.metrics.codecs.val.decode(|| V::decode(v));
             return Some(((k, v), t, d));


### PR DESCRIPTION
This requires splitting out a new `Cursor` abstraction, so that we can avoid holding on to a mutable pointer to `encoded_part` in `FetchedPart::next()`.

### Motivation

Did the work as part of #20708 prototyping, and it's a TODO in the code, so why not send the PR?

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
