### PR TITLE
stash: Remove timestamps from public API

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -1791,8 +1791,7 @@ impl<'a> Transaction<'a> {
                 return Ok(());
             }
             let collection = typed.from_tx(tx).await?;
-            let upper = tx.upper(collection.id).await?;
-            let mut batch = collection.make_batch_lower(upper)?;
+            let mut batch = collection.make_batch_tx(tx).await?;
             for (k, v, diff) in changes {
                 collection.append_to_batch(&mut batch, k, v, *diff);
             }

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -334,8 +334,8 @@ pub struct AppendBatch {
 }
 
 impl<K, V> StashCollection<K, V> {
-    /// Returns whether the collection is initialized. Collections that haven't been written to at
-    /// least once will panic if they're read from.
+    /// Returns whether the collection is initialized, i.e. has been written to at least once.
+    /// Collections that haven't been written to at least once cannot be read.
     pub async fn is_initialized(&self, tx: &Transaction<'_>) -> Result<bool, StashError> {
         let upper = tx.upper(self.id).await?;
         Ok(upper.elements() != [Timestamp::MIN])

--- a/src/stash/src/transaction.rs
+++ b/src/stash/src/transaction.rs
@@ -225,7 +225,10 @@ impl<'a> Transaction<'a> {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn upper(&self, collection_id: Id) -> Result<Antichain<Timestamp>, StashError> {
+    pub(crate) async fn upper(
+        &self,
+        collection_id: Id,
+    ) -> Result<Antichain<Timestamp>, StashError> {
         // We can't use .entry here because that would require holding the
         // MutexGuard across the .await.
         if let Some(entry) = self.uppers.lock().unwrap().get(&collection_id) {

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1033,8 +1033,8 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             .await
             .expect("could not connect to postgres storage stash");
 
-        // Ensure all collections are initialized, otherwise they panic if
-        // they're read before being written to.
+        // Ensure all collections are initialized, otherwise they cannot
+        // be read.
         async fn maybe_get_init_batch<'tx, K, V>(
             tx: &'tx mz_stash::Transaction<'tx>,
             typed: &TypedCollection<K, V>,

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -1047,14 +1047,15 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
                 .collection::<K, V>(typed.name())
                 .await
                 .expect("named collection must exist");
-            let upper = tx
-                .upper(collection.id)
+            if !collection
+                .is_initialized(tx)
                 .await
-                .expect("collection known to exist");
-            if upper.elements() == [mz_stash::Timestamp::MIN] {
+                .expect("collection known to exist")
+            {
                 Some(
                     collection
-                        .make_batch_lower(upper)
+                        .make_batch_tx(tx)
+                        .await
                         .expect("stash operation must succeed"),
                 )
             } else {


### PR DESCRIPTION
Internally the stash is implemented using timestamps for every key value pair inserted/removed. Consumers of the stash treat the stash as a key-value store and completely ignore the timestamps except for the following scenarios:

- Checking if a stash collection is initialized by comparing the collection's upper to `Timestamp::MIN`.
- Writing an empty batch to a stash collection at its upper to initialize it.
- Dumping the raw contents of a stash collection for the stash-debug tool.

While we may one day want to expose the Time Varying Collection (TVC) internals of the stash, the current usage of timestamps by consumers, other than the stash-debug tool, feels more like an abstraction leak than a feature. Therefore, this commit updates consumers, other than the stash-debug tool, to not use timestamps, and remove the `pub` visibility of the stash's timestamp internals.

The `TypedCollection::iter` method is the only method left that exposes timestamps.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
