### PR TITLE
storage: add config var to only turn on backpressure for disk upsert sources

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -79,6 +79,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             max_inflight_bytes_default: config.storage_dataflow_max_inflight_bytes(),
             max_inflight_bytes_cluster_size_percent: config
                 .storage_dataflow_max_inflight_bytes_to_cluster_size_percent(),
+            disk_only: config.storage_dataflow_max_inflight_bytes_disk_only(),
         },
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -902,6 +902,14 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Opt
         internal: true,
     };
 
+const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("storage_dataflow_max_inflight_bytes_disk_only"),
+    value: &true,
+    description: "Whether or not `storage_dataflow_max_inflight_bytes` applies only to \
+        upsert dataflows using disks. Defaults to true (Materialize).",
+    internal: true,
+};
+
 /// Controls [`mz_persist_client::cfg::PersistConfig::sink_minimum_batch_updates`].
 const PERSIST_SINK_MINIMUM_BATCH_UPDATES: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("persist_sink_minimum_batch_updates"),
@@ -1898,6 +1906,7 @@ impl SystemVars {
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
+            .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
@@ -2374,6 +2383,11 @@ impl SystemVars {
     /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_percent` configuration parameter.
     pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_percent(&self) -> Option<usize> {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
+    }
+
+    /// Returns the `storage_dataflow_max_inflight_bytes_disk_only` configuration parameter.
+    pub fn storage_dataflow_max_inflight_bytes_disk_only(&self) -> bool {
+        *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
     }
 
     /// Returns the `persist_sink_minimum_batch_updates` configuration parameter.
@@ -3839,6 +3853,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == PG_REPLICATION_TCP_USER_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT.name()
+        || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
         || is_upsert_rocksdb_config_var(name)
         || is_persist_config_var(name)
         || is_tracing_var(name)

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -44,6 +44,8 @@ message ProtoUpsertAutoSpillConfig {
 }
 
 message ProtoStorageMaxInflightBytesConfig {
+    reserved 3;
     optional uint64 max_in_flight_bytes_default = 1;
     optional uint64 max_in_flight_bytes_cluster_size_percent = 2;
+    bool disk_only = 4;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -45,13 +45,25 @@ pub struct StorageParameters {
     pub storage_dataflow_max_inflight_bytes_config: StorageMaxInflightBytesConfig,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub struct StorageMaxInflightBytesConfig {
     /// The default value for the max in-flight bytes
     pub max_inflight_bytes_default: Option<usize>,
     /// Specified percentage which will be used to calculate the max in-flight from the
     /// memory limit of the cluster in use.
     pub max_inflight_bytes_cluster_size_percent: Option<usize>,
+    /// Whether or not the above configs only apply to disk-using dataflows.
+    pub disk_only: bool,
+}
+
+impl Default for StorageMaxInflightBytesConfig {
+    fn default() -> Self {
+        Self {
+            max_inflight_bytes_default: Default::default(),
+            max_inflight_bytes_cluster_size_percent: Default::default(),
+            disk_only: true,
+        }
+    }
 }
 
 impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesConfig {
@@ -61,6 +73,7 @@ impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesCon
             max_in_flight_bytes_cluster_size_percent: self
                 .max_inflight_bytes_cluster_size_percent
                 .map(u64::cast_from),
+            disk_only: self.disk_only,
         }
     }
     fn from_proto(proto: ProtoStorageMaxInflightBytesConfig) -> Result<Self, TryFromProtoError> {
@@ -69,6 +82,7 @@ impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesCon
             max_inflight_bytes_cluster_size_percent: proto
                 .max_in_flight_bytes_cluster_size_percent
                 .map(usize::cast_from),
+            disk_only: proto.disk_only,
         })
     }
 }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -171,6 +171,7 @@ def workflow_rehydration(c: Composition) -> None:
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",
+                    "storage_dataflow_max_inflight_bytes_disk_only": "false",
                 },
                 environment_extra=materialized_environment_extra,
             ),
@@ -193,6 +194,7 @@ def workflow_rehydration(c: Composition) -> None:
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",
+                    "storage_dataflow_max_inflight_bytes_disk_only": "false",
                 },
                 environment_extra=materialized_environment_extra,
             ),


### PR DESCRIPTION
I noticed we might want this to safely roll backpressure out.

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
