### PR TITLE
storage: Fix stash usage in finalize_shards

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2990,7 +2990,6 @@ where
     }
 
     /// Attempts to close all shards marked for finalization.
-    #[allow(dead_code)]
     async fn finalize_shards(&mut self) {
         let shards = self
             .state
@@ -3001,13 +3000,13 @@ where
                         .collection::<ProtoShardId, ()>(command_wals::SHARD_FINALIZATION.name())
                         .await
                         .expect("named collection must exist");
-                    tx.peek(collection).await
+                    tx.peek_one(collection).await
                 })
             })
             .await
             .expect("stash operation succeeds")
             .into_iter()
-            .map(|(shard, _, _)| ShardId::from_proto(shard).expect("invalid ShardId"));
+            .map(|(shard, _)| ShardId::from_proto(shard).expect("invalid ShardId"));
 
         // Open a persist client to delete unused shards.
         let persist_client = self


### PR DESCRIPTION
Shard finalization reads a list of shard IDs from the stash and attempts to close all the shards returned.

Previously, the IDs were read from the stash using the `Transaction::peek` method, which returns an unconsolidated list of (key, value, diff) triples. The diffs were all ignored and the code would attempt to close each key. As a result it was possible to attempt to close the same shard twice and attempt to close an already closed shard.

The shard finalization code looks like it correctly handles duplicate and already closed shards. However, it's likely not the intent of shard finalization to read unconsolidated stash data.

This commit updates shard finalization to use the
`Transaction::peek_one` method, which returns a consolidated list of (key, value) pairs.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
