### PR TITLE
storage: support float percents for backpressure configuration

### DIFF
--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -218,7 +218,7 @@ try_cast_from!(u64, f64);
 
 /// A trait for potentially-lossy casts. Typically useful when converting from integers
 /// to floating point, and you want the nearest floating-point number to your integer
-/// when your integer is large.
+/// when your integer is large, or vice versa.
 pub trait CastLossy<T> {
     /// Perform the lossy cast.
     fn cast_lossy(from: T) -> Self;
@@ -231,10 +231,24 @@ impl CastLossy<usize> for f64 {
     }
 }
 
+impl CastLossy<f64> for usize {
+    #[allow(clippy::as_conversions)]
+    fn cast_lossy(from: f64) -> Self {
+        from as usize
+    }
+}
+
 impl CastLossy<u64> for f64 {
     #[allow(clippy::as_conversions)]
     fn cast_lossy(from: u64) -> Self {
         from as f64
+    }
+}
+
+impl CastLossy<f64> for u64 {
+    #[allow(clippy::as_conversions)]
+    fn cast_lossy(from: f64) -> Self {
+        from as u64
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -891,7 +891,7 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
 /// in-flight bytes emitted by persist_sources feeding storage dataflows.
 /// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
 /// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
-const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Option<usize>> =
+const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Option<Numeric>> =
     ServerVar {
         name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_percent"),
         value: &None,
@@ -2381,7 +2381,7 @@ impl SystemVars {
     }
 
     /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_percent` configuration parameter.
-    pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_percent(&self) -> Option<usize> {
+    pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_percent(&self) -> Option<Numeric> {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
     }
 

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -44,8 +44,8 @@ message ProtoUpsertAutoSpillConfig {
 }
 
 message ProtoStorageMaxInflightBytesConfig {
-    reserved 3;
+    reserved 2, 3;
     optional uint64 max_in_flight_bytes_default = 1;
-    optional uint64 max_in_flight_bytes_cluster_size_percent = 2;
+    optional double max_in_flight_bytes_cluster_size_percent = 5;
     bool disk_only = 4;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -24,7 +24,7 @@ include!(concat!(
 ///
 /// Parameters can be set (`Some`) or unset (`None`).
 /// Unset parameters should be interpreted to mean "use the previous value".
-#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default, PartialEq)]
 pub struct StorageParameters {
     /// Persist client configuration.
     pub persist: PersistParameters,
@@ -45,13 +45,13 @@ pub struct StorageParameters {
     pub storage_dataflow_max_inflight_bytes_config: StorageMaxInflightBytesConfig,
 }
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct StorageMaxInflightBytesConfig {
     /// The default value for the max in-flight bytes
     pub max_inflight_bytes_default: Option<usize>,
     /// Specified percentage which will be used to calculate the max in-flight from the
     /// memory limit of the cluster in use.
-    pub max_inflight_bytes_cluster_size_percent: Option<usize>,
+    pub max_inflight_bytes_cluster_size_percent: Option<f64>,
     /// Whether or not the above configs only apply to disk-using dataflows.
     pub disk_only: bool,
 }
@@ -70,18 +70,14 @@ impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesCon
     fn into_proto(&self) -> ProtoStorageMaxInflightBytesConfig {
         ProtoStorageMaxInflightBytesConfig {
             max_in_flight_bytes_default: self.max_inflight_bytes_default.map(u64::cast_from),
-            max_in_flight_bytes_cluster_size_percent: self
-                .max_inflight_bytes_cluster_size_percent
-                .map(u64::cast_from),
+            max_in_flight_bytes_cluster_size_percent: self.max_inflight_bytes_cluster_size_percent,
             disk_only: self.disk_only,
         }
     }
     fn from_proto(proto: ProtoStorageMaxInflightBytesConfig) -> Result<Self, TryFromProtoError> {
         Ok(Self {
             max_inflight_bytes_default: proto.max_in_flight_bytes_default.map(usize::cast_from),
-            max_inflight_bytes_cluster_size_percent: proto
-                .max_in_flight_bytes_cluster_size_percent
-                .map(usize::cast_from),
+            max_inflight_bytes_cluster_size_percent: proto.max_in_flight_bytes_cluster_size_percent,
             disk_only: proto.disk_only,
         })
     }


### PR DESCRIPTION
We need more than integer precision here.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
