### PR TITLE
doc: correct load generator docs

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-load-generator.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="667" height="803">
+<svg xmlns="http://www.w3.org/2000/svg" width="667" height="819">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -98,135 +98,135 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="548" y="261">)</text>
-   <rect x="45" y="441" width="138" height="32" rx="10"/>
+   <rect x="45" y="457" width="138" height="32" rx="10"/>
    <rect x="43"
-         y="439"
+         y="455"
          width="138"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="459">FOR ALL TABLES</text>
-   <rect x="45" y="529" width="106" height="32" rx="10"/>
+   <text class="terminal" x="53" y="475">FOR ALL TABLES</text>
+   <rect x="45" y="545" width="106" height="32" rx="10"/>
    <rect x="43"
-         y="527"
+         y="543"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="547">FOR TABLES</text>
-   <rect x="171" y="529" width="26" height="32" rx="10"/>
+   <text class="terminal" x="53" y="563">FOR TABLES</text>
+   <rect x="171" y="545" width="26" height="32" rx="10"/>
    <rect x="169"
-         y="527"
+         y="543"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="179" y="547">(</text>
-   <rect x="237" y="529" width="96" height="32"/>
-   <rect x="235" y="527" width="96" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="245" y="547">table_name</text>
-   <rect x="373" y="561" width="40" height="32" rx="10"/>
+   <text class="terminal" x="179" y="563">(</text>
+   <rect x="237" y="545" width="96" height="32"/>
+   <rect x="235" y="543" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="245" y="563">table_name</text>
+   <rect x="373" y="577" width="40" height="32" rx="10"/>
    <rect x="371"
-         y="559"
+         y="575"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="381" y="579">AS</text>
-   <rect x="433" y="561" width="106" height="32"/>
-   <rect x="431" y="559" width="106" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="441" y="579">subsrc_name</text>
-   <rect x="237" y="485" width="24" height="32" rx="10"/>
+   <text class="terminal" x="381" y="595">AS</text>
+   <rect x="433" y="577" width="106" height="32"/>
+   <rect x="431" y="575" width="106" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="595">subsrc_name</text>
+   <rect x="237" y="501" width="24" height="32" rx="10"/>
    <rect x="235"
-         y="483"
+         y="499"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="245" y="503">,</text>
-   <rect x="599" y="529" width="26" height="32" rx="10"/>
+   <text class="terminal" x="245" y="519">,</text>
+   <rect x="599" y="545" width="26" height="32" rx="10"/>
    <rect x="597"
-         y="527"
+         y="543"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="607" y="547">)</text>
-   <rect x="101" y="643" width="76" height="32" rx="10"/>
+   <text class="terminal" x="607" y="563">)</text>
+   <rect x="101" y="659" width="76" height="32" rx="10"/>
    <rect x="99"
-         y="641"
+         y="657"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="109" y="661">EXPOSE</text>
-   <rect x="197" y="643" width="96" height="32" rx="10"/>
+   <text class="terminal" x="109" y="677">EXPOSE</text>
+   <rect x="197" y="659" width="96" height="32" rx="10"/>
    <rect x="195"
-         y="641"
+         y="657"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="205" y="661">PROGRESS</text>
-   <rect x="313" y="643" width="40" height="32" rx="10"/>
+   <text class="terminal" x="205" y="677">PROGRESS</text>
+   <rect x="313" y="659" width="40" height="32" rx="10"/>
    <rect x="311"
-         y="641"
+         y="657"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="321" y="661">AS</text>
-   <rect x="373" y="643" width="196" height="32"/>
-   <rect x="371" y="641" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="381" y="661">progress_subsource_name</text>
-   <rect x="255" y="753" width="58" height="32" rx="10"/>
+   <text class="terminal" x="321" y="677">AS</text>
+   <rect x="373" y="659" width="196" height="32"/>
+   <rect x="371" y="657" width="196" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="381" y="677">progress_subsource_name</text>
+   <rect x="255" y="769" width="58" height="32" rx="10"/>
    <rect x="253"
-         y="751"
+         y="767"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="263" y="771">WITH</text>
-   <rect x="333" y="753" width="26" height="32" rx="10"/>
+   <text class="terminal" x="263" y="787">WITH</text>
+   <rect x="333" y="769" width="26" height="32" rx="10"/>
    <rect x="331"
-         y="751"
+         y="767"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="341" y="771">(</text>
-   <rect x="399" y="753" width="48" height="32"/>
-   <rect x="397" y="751" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="407" y="771">field</text>
-   <rect x="467" y="753" width="28" height="32" rx="10"/>
+   <text class="terminal" x="341" y="787">(</text>
+   <rect x="399" y="769" width="48" height="32"/>
+   <rect x="397" y="767" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="787">field</text>
+   <rect x="467" y="769" width="28" height="32" rx="10"/>
    <rect x="465"
-         y="751"
+         y="767"
          width="28"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="475" y="771">=</text>
-   <rect x="515" y="753" width="38" height="32"/>
-   <rect x="513" y="751" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="523" y="771">val</text>
-   <rect x="399" y="709" width="24" height="32" rx="10"/>
+   <text class="terminal" x="475" y="787">=</text>
+   <rect x="515" y="769" width="38" height="32"/>
+   <rect x="513" y="767" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="523" y="787">val</text>
+   <rect x="399" y="725" width="24" height="32" rx="10"/>
    <rect x="397"
-         y="707"
+         y="723"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="407" y="727">,</text>
-   <rect x="593" y="753" width="26" height="32" rx="10"/>
+   <text class="terminal" x="407" y="743">,</text>
+   <rect x="593" y="769" width="26" height="32" rx="10"/>
    <rect x="591"
-         y="751"
+         y="767"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="601" y="771">)</text>
+   <text class="terminal" x="601" y="787">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-406 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m88 0 h10 m0 0 h16 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m60 0 h10 m0 0 h44 m40 -132 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-605 198 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m138 0 h10 m0 0 h442 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-608 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="657 767 665 763 665 771"/>
-   <polygon points="657 767 649 763 649 771"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-406 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m20 -32 h10 m196 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-539 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m86 0 h10 m0 0 h18 m-144 0 h20 m124 0 h20 m-164 0 q10 0 10 10 m144 0 q0 -10 10 -10 m-154 10 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m88 0 h10 m0 0 h16 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m104 0 h10 m-134 -10 v20 m144 0 v-20 m-144 20 v24 m144 0 v-24 m-144 24 q0 10 10 10 m124 0 q10 0 10 -10 m-134 10 h10 m60 0 h10 m0 0 h44 m40 -132 h10 m26 0 h10 m20 0 h10 m166 0 h10 m-206 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m186 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-186 0 h10 m24 0 h10 m0 0 h142 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m22 -34 l2 0 m2 0 l2 0 m2 0 l2 0 m-605 182 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h590 m-620 0 h20 m600 0 h20 m-640 0 q10 0 10 10 m620 0 q0 -10 10 -10 m-630 10 v12 m620 0 v-12 m-620 12 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m138 0 h10 m0 0 h442 m-610 -10 v20 m620 0 v-20 m-620 20 v68 m620 0 v-68 m-620 68 q0 10 10 10 m600 0 q10 0 10 -10 m-610 10 h10 m106 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m96 0 h10 m20 0 h10 m0 0 h176 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v12 m206 0 v-12 m-206 12 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m40 0 h10 m0 0 h10 m106 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m342 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-342 0 h10 m24 0 h10 m0 0 h298 m20 44 h10 m26 0 h10 m22 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-608 202 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-398 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="657 783 665 779 665 787"/>
+   <polygon points="657 783 649 779 649 787"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -135,7 +135,7 @@ create_source_load_generator ::=
   ('(' (load_generator_option) ( ( ',' load_generator_option ) )* ')')?
   (
     'FOR ALL TABLES' |
-    'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')
+    'FOR TABLES' '(' table_name ('AS' subsrc_name)?  (',' table_name ('AS' subsrc_name)? )* ')')?
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?
   ('WITH' '(' ( field '=' val ) ( ( ',' field '=' val ) )* ')')?
 load_generator_option ::=


### PR DESCRIPTION
They don't always require TABLES.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a