### PR TITLE
persist: replace incorrect MB name with correct MiB in cfg constant

### DIFF
--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -142,7 +142,7 @@ impl PersistConfig {
                 compaction_heuristic_min_inputs: AtomicUsize::new(8),
                 compaction_heuristic_min_parts: AtomicUsize::new(8),
                 compaction_heuristic_min_updates: AtomicUsize::new(1024),
-                compaction_memory_bound_bytes: AtomicUsize::new(1024 * MB),
+                compaction_memory_bound_bytes: AtomicUsize::new(1024 * MiB),
                 compaction_minimum_timeout: RwLock::new(Self::DEFAULT_COMPACTION_MINIMUM_TIMEOUT),
                 consensus_connection_pool_ttl: RwLock::new(Self::DEFAULT_CONSENSUS_CONNPOOL_TTL),
                 consensus_connection_pool_ttl_stagger: RwLock::new(
@@ -221,11 +221,12 @@ impl PersistConfig {
     }
 }
 
-pub(crate) const MB: usize = 1024 * 1024;
+#[allow(non_upper_case_globals)]
+pub(crate) const MiB: usize = 1024 * 1024;
 
 impl PersistConfig {
     /// Default value for [`DynamicConfig::blob_target_size`].
-    pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MB;
+    pub const DEFAULT_BLOB_TARGET_SIZE: usize = 128 * MiB;
     /// Default value for [`DynamicConfig::compaction_minimum_timeout`].
     pub const DEFAULT_COMPACTION_MINIMUM_TIMEOUT: Duration = Duration::from_secs(90);
     /// Default value for [`DynamicConfig::consensus_connect_timeout`].

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -34,7 +34,7 @@ use tracing::{debug, debug_span, trace, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::batch::{BatchBuilderConfig, BatchBuilderInternal};
-use crate::cfg::MB;
+use crate::cfg::MiB;
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
@@ -294,12 +294,12 @@ where
             // either our minimum timeout
             cfg.dynamic.compaction_minimum_timeout(),
             // or 1s per MB of input data
-            Duration::from_secs(u64::cast_from(total_input_bytes / MB)),
+            Duration::from_secs(u64::cast_from(total_input_bytes / MiB)),
         );
 
         trace!(
             "compaction request for {}MBs ({} bytes), with timeout of {}s.",
-            total_input_bytes / MB,
+            total_input_bytes / MiB,
             total_input_bytes,
             timeout.as_secs_f64()
         );


### PR DESCRIPTION

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
