### PR TITLE
test/replica-isolation: restore compaction validation

### DIFF
--- a/test/replica-isolation/mzcompose.py
+++ b/test/replica-isolation/mzcompose.py
@@ -28,7 +28,11 @@ SERVICES = [
     Kafka(),
     SchemaRegistry(),
     Localstack(),
-    Materialized(),
+    Materialized(
+        additional_system_parameter_defaults={
+            "log_filter": "mz_cluster::server=debug,info",
+        },
+    ),
     Testdrive(),
 ]
 
@@ -453,9 +457,7 @@ def run_test(c: Composition, disruption: Disruption, id: int) -> None:
             disruption.disruption(c)
 
             validate(c)
-
-            # Currently failing, see #20818
-            # validate_introspection_compaction(c, disruption.compaction_checks)
+            validate_introspection_compaction(c, disruption.compaction_checks)
 
         cleanup_list = ["materialized", "testdrive", *[n.name for n in nodes]]
         c.kill(*cleanup_list)


### PR DESCRIPTION
I think long ago I made this log line into a `debug!` one instead, so we just needed to restore it!

### Motivation

  * This PR fixes a recognized bug.

Closes: #20818


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
