### PR TITLE
platform-checks: Perform validate() twice in the CI

### DIFF
--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -539,14 +539,6 @@ class Owners(Check):
                 owner_kafka_conn9  owner_role_01=U/owner_role_01
                 """
             )
-            + self._drop_objects("owner_role_01", 1, expensive=True)
-            + self._drop_objects("other_owner", 2, expensive=True)
-            + self._drop_objects("owner_role_01", 3)
-            + self._drop_objects("other_owner", 4)
-            + self._drop_objects("owner_role_01", 5)
-            + self._drop_objects("other_owner", 6)
-            + self._drop_objects("owner_role_02", 7)
-            + self._drop_objects("other_owner", 8)
             + self._drop_objects("owner_role_01", 9)
             + self._drop_objects("owner_role_02", 10)
             + self._drop_objects("owner_role_03", 11)

--- a/misc/python/materialize/checks/privileges.py
+++ b/misc/python/materialize/checks/privileges.py
@@ -299,8 +299,5 @@ class Privileges(Check):
                 privilege_kafka_conn4  role_1=U/materialize
                 """
             )
-            + self._drop_objects(1, expensive=True)
-            + self._drop_objects(2)
-            + self._drop_objects(3)
             + self._drop_objects(4)
         )

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -162,6 +162,9 @@ class RestartEnvironmentdClusterdStorage(Scenario):
             KillMz(),
             StartMz(),
             Validate(self),
+            # Validate again so that introducing non-idempotent validate()s
+            # will cause the CI to fail.
+            Validate(self),
         ]
 
 


### PR DESCRIPTION
Make sure at least one step in the per-push CI performs validate() twice. This will weed out any validate()s that are not idempotent.

Previously, multiple validate() calls were only present in Nightly.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Nightly CI was failing if non-idempotent validate()s are introduced.