### PR TITLE
Avoid a temporary allocation when reporting frontiers

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -432,8 +432,11 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
     pub fn report_compute_frontiers(&mut self) {
         let mut new_uppers = Vec::new();
 
+        // Maintain a single allocation for `new_frontier` to avoid allocating on every iteration.
+        let mut new_frontier = Antichain::new();
+
         for (&id, collection) in self.compute_state.collections.iter_mut() {
-            let mut new_frontier = Antichain::new();
+            new_frontier.clear();
             if let Some(traces) = self.compute_state.traces.get_mut(&id) {
                 assert!(
                     collection.sink_write_frontier.is_none(),
@@ -478,7 +481,7 @@ impl<'a, A: Allocate> ActiveComputeState<'a, A> {
                 }
             }
 
-            new_uppers.push((id, new_frontier));
+            new_uppers.push((id, new_frontier.clone()));
             collection.set_reported_frontier(new_reported_frontier);
         }
 


### PR DESCRIPTION

### Motivation

Fixes an unreported issue. We're allocating a new `Antichain` for every maintained collection when reporting frontiers. With this PR, we re-use the allocation, avoiding a significant number of temporary allocations.

It's hard to say what performance impact this has, but it's good habit to avoid allocations if it's easy to do.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
