### PR TITLE
sql: add UpdateItem to audit log

### DIFF
--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -326,6 +326,7 @@ pub enum EventDetails {
     IdNameV1(IdNameV1),
     SchemaV1(SchemaV1),
     SchemaV2(SchemaV2),
+    UpdateItemV1(UpdateItemV1),
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
@@ -949,6 +950,31 @@ impl RustType<proto::audit_log_event_v1::SchemaV2> for SchemaV2 {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, PartialOrd, PartialEq, Eq, Ord, Hash, Arbitrary)]
+pub struct UpdateItemV1 {
+    pub id: String,
+    #[serde(flatten)]
+    pub name: FullNameV1,
+}
+
+impl RustType<proto::audit_log_event_v1::UpdateItemV1> for UpdateItemV1 {
+    fn into_proto(&self) -> proto::audit_log_event_v1::UpdateItemV1 {
+        proto::audit_log_event_v1::UpdateItemV1 {
+            id: self.id.to_string(),
+            name: Some(self.name.into_proto()),
+        }
+    }
+
+    fn from_proto(
+        proto: proto::audit_log_event_v1::UpdateItemV1,
+    ) -> Result<Self, TryFromProtoError> {
+        Ok(UpdateItemV1 {
+            id: proto.id,
+            name: proto.name.into_rust_if_some("UpdateItemV1::name")?,
+        })
+    }
+}
+
 impl EventDetails {
     pub fn as_json(&self) -> serde_json::Value {
         match self {
@@ -980,6 +1006,7 @@ impl EventDetails {
                 serde_json::to_value(v).expect("must serialize")
             }
             EventDetails::UpdateOwnerV1(v) => serde_json::to_value(v).expect("must serialize"),
+            EventDetails::UpdateItemV1(v) => serde_json::to_value(v).expect("must serialize"),
         }
     }
 }
@@ -1017,6 +1044,7 @@ impl RustType<proto::audit_log_event_v1::Details> for EventDetails {
             EventDetails::IdNameV1(details) => IdNameV1(details.into_proto()),
             EventDetails::SchemaV1(details) => SchemaV1(details.into_proto()),
             EventDetails::SchemaV2(details) => SchemaV2(details.into_proto()),
+            EventDetails::UpdateItemV1(details) => UpdateItemV1(details.into_proto()),
         }
     }
 
@@ -1056,6 +1084,7 @@ impl RustType<proto::audit_log_event_v1::Details> for EventDetails {
             IdNameV1(details) => Ok(EventDetails::IdNameV1(details.into_rust()?)),
             SchemaV1(details) => Ok(EventDetails::SchemaV1(details.into_rust()?)),
             SchemaV2(details) => Ok(EventDetails::SchemaV2(details.into_rust()?)),
+            UpdateItemV1(details) => Ok(EventDetails::UpdateItemV1(details.into_rust()?)),
         }
     }
 }

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "90079ca1764e2402cccdc2cd983e3942"
+    "md5": "e8e7f4ec34697eefd908e9ce40bbf763"
   },
   {
     "name": "objects_v15.proto",
@@ -66,5 +66,9 @@
   {
     "name": "objects_v30.proto",
     "md5": "85e44d81055146392f272df16d40e92e"
+  },
+  {
+    "name": "objects_v31.proto",
+    "md5": "e78e005dc9ddef0dd00cd5a580d222c6"
   }
 ]

--- a/src/stash/protos/objects_v31.proto
+++ b/src/stash/protos/objects_v31.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v31;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -106,7 +106,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 30;
+pub const STASH_VERSION: u64 = 31;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -923,6 +923,7 @@ impl Stash {
                             27 => upgrade::v27_to_v28::upgrade(&mut tx).await?,
                             28 => upgrade::v28_to_v29::upgrade(&mut tx).await?,
                             29 => upgrade::v29_to_v30::upgrade(),
+                            30 => upgrade::v30_to_v31::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -61,6 +61,7 @@ pub(crate) mod v26_to_v27;
 pub(crate) mod v27_to_v28;
 pub(crate) mod v28_to_v29;
 pub(crate) mod v29_to_v30;
+pub(crate) mod v30_to_v31;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v30_to_v31.rs
+++ b/src/stash/src/upgrade/v30_to_v31.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for adding events for updating items (e.g. `ALTER SOURCE`).
+pub fn upgrade() {}


### PR DESCRIPTION
Add `UpdateItem` events to the audit log. We need these to identify when we've executed an `ALTER SOURCE...(ADD|DROP) SUBSOURCE` in our telemetry systems.

### Motivation

This PR adds a known-desirable feature. Tracking for events where we add or remove subsources.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
