### PR TITLE
webhooks: Add test to assert we support / in source names

### DIFF
--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -241,6 +241,19 @@ materialize space monkey
 > SELECT * FROM webhook_double_validation;
 "materialize space monkey"
 
+# Webhooks should support special characters like a /
+
+> CREATE SOURCE "webhook_with_/" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT;
+
+$ webhook-append name=webhook_with_/ status=404
+wont_work
+
+$ webhook-append name=webhook_with_%2F
+will_work
+
+> SELECT * FROM "webhook_with_/"
+"will_work"
+
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id


### PR DESCRIPTION
At the time of design we were unsure how a webhook source name that contained a special character, e.g. a `/` would behave with the `/api/webhook` endpoint. This PR adds a test to assert the when the special character is URL encoded, we're able to resolve the source and append.

### Motivation

Closes https://github.com/MaterializeInc/materialize/issues/20226

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
