### PR TITLE
persist: add snapshot_and_stream that streams out updates in bounded mem

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -641,7 +641,7 @@ pub struct BatchPartReadMetrics {
     pub(crate) compaction: ReadMetrics,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ReadMetrics {
     pub(crate) part_bytes: IntCounter,
     pub(crate) part_goodbytes: IntCounter,

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1102,12 +1102,11 @@ where
                     schemas.clone(),
                 )
                 .await;
+                lease_returner.return_leased_part(part);
 
                 while let Some(next) = fetched_part.next() {
                     yield next;
                 }
-
-                lease_returner.return_leased_part(part);
             }
         };
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1184,6 +1184,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::pin;
     use std::str::FromStr;
 
     use mz_build_info::DUMMY_BUILD_INFO;
@@ -1194,6 +1195,7 @@ mod tests {
     use mz_persist::unreliable::{UnreliableConsensus, UnreliableHandle};
     use serde::{Deserialize, Serialize};
     use serde_json::json;
+    use tokio_stream::StreamExt;
 
     use crate::async_runtime::IsolatedRuntime;
     use crate::cache::StateCache;
@@ -1282,6 +1284,44 @@ mod tests {
             updates,
             &[((Ok("k".to_owned()), Ok("v".to_owned())), 4u64, 3i64)],
         )
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn snapshot_and_stream() {
+        let data = &mut [
+            (("k1".to_owned(), "v1".to_owned()), 0, 1),
+            (("k2".to_owned(), "v2".to_owned()), 1, 1),
+            (("k3".to_owned(), "v3".to_owned()), 2, 1),
+            (("k4".to_owned(), "v4".to_owned()), 2, 1),
+            (("k5".to_owned(), "v5".to_owned()), 3, 1),
+        ];
+
+        let (mut write, mut read) = {
+            let client = new_test_client().await;
+            client.cfg.dynamic.set_blob_target_size(0); // split batches across multiple parts
+            client
+                .expect_open::<String, String, u64, i64>(crate::ShardId::new())
+                .await
+        };
+
+        write.expect_compare_and_append(&data[0..2], 0, 2).await;
+        write.expect_compare_and_append(&data[2..4], 2, 3).await;
+        write.expect_compare_and_append(&data[4..], 3, 4).await;
+
+        let as_of = Antichain::from_elem(3);
+        let mut snapshot = pin::pin!(read.snapshot_and_stream(as_of.clone()).await.unwrap());
+
+        let mut snapshot_rows = vec![];
+        while let Some(((k, v), t, d)) = snapshot.next().await {
+            snapshot_rows.push(((k.expect("valid key"), v.expect("valid key")), t, d));
+        }
+
+        for ((_k, _v), t, _d) in data.as_mut_slice() {
+            t.advance_by(as_of.borrow());
+        }
+
+        assert_eq!(data.as_slice(), snapshot_rows.as_slice());
     }
 
     // Verifies the semantics of `SeqNo` leases + checks dropping `LeasedBatchPart` semantics.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adds a new `snapshot_and_stream` fn that can stream out a snapshot in bounded memory (1 part at a time). This will be initially used by the statement log, which needs to read the snapshot at startup and write out retractions. 

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
