### PR TITLE
Deprecate some old join code with a `soft_panic_or_log`

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -124,7 +124,7 @@ where
                     writeln!(f, "{}Map ({})", ctx.as_mut(), scalars)?;
                     *ctx.as_mut() += 1;
                 }
-                MirRelationExpr::fmt_indexed_filter(f, ctx, id, literal_constraints.clone())?;
+                MirRelationExpr::fmt_indexed_filter(f, ctx, id, literal_constraints.clone(), None)?;
                 writeln!(f)?;
                 ctx.as_mut().reset();
                 Ok(())

--- a/src/transform/src/literal_constraints.rs
+++ b/src/transform/src/literal_constraints.rs
@@ -155,9 +155,12 @@ impl LiteralConstraints {
                             // common here, so we explicitly add it.)
                             keys: vec![(0..key.len()).collect()],
                         },
-                    };
+                    }
+                    .arrange_by(&[(0..key.len()).map(MirScalarExpr::Column).collect_vec()]);
 
                     *relation = MirRelationExpr::Join {
+                        // It's important to keep the `filter_list` in the second position.
+                        // Both the lowering and EXPLAIN depends on this.
                         inputs: vec![relation.clone().arrange_by(&[key.clone()]), filter_list],
                         equivalences: key
                             .iter()

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -1241,7 +1241,7 @@ SELECT x * 5 FROM cte WHERE x = 5
                                     }
                                   },
                                   "forms": {
-                                    "raw": false,
+                                    "raw": true,
                                     "arranged": [
                                       [
                                         [

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -312,7 +312,7 @@ Explained Query:
               raw=false
               arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
             ArrangeBy
-              raw=false
+              raw=true
               arrangements[0]={ key=[#0], permutation=id, thinning=() }
               Constant
                 - (5)

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -194,21 +194,27 @@ EXPLAIN WITH(arity, join_impls) SELECT l_partkey AS col24843 , l_orderkey AS col
   AND l_extendedprice = MOD (o_totalprice , 5 ) ;
 ----
 Explained Query:
-  Project (#1, #0, #1) // { arity: 3 }
-    Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
-      implementation
-        %1:orders[#0, #1]KKef » %0:lineitem[#2, #3]KKef » %2:customer[×]ef
-      ArrangeBy keys=[[#2, #3]] // { arity: 4 }
-        Project (#0, #1, #4, #6) // { arity: 4 }
-          Filter (#4 = (#4 % 5)) // { arity: 8 }
-            Get materialize.public.lineitem // { arity: 8 }
-      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-        Project (#2, #3) // { arity: 2 }
-          Filter (#2 = (#2 % 5)) // { arity: 5 }
-            ReadExistingIndex materialize.public.orders lookup_value=(134) // { arity: 5 }
-      ArrangeBy keys=[[]] // { arity: 0 }
-        Project () // { arity: 0 }
-          ReadExistingIndex materialize.public.customer lookup_value=(134) // { arity: 4 }
+  Return // { arity: 3 }
+    Project (#1, #0, #1) // { arity: 3 }
+      Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 6 }
+        implementation
+          %1:orders[#0, #1]KKef » %0:lineitem[#2, #3]KKef » %2:customer[×]ef
+        ArrangeBy keys=[[#2, #3]] // { arity: 4 }
+          Project (#0, #1, #4, #6) // { arity: 4 }
+            Filter (#4 = (#4 % 5)) // { arity: 8 }
+              Get materialize.public.lineitem // { arity: 8 }
+        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+          Project (#2, #3) // { arity: 2 }
+            Filter (#2 = (#2 % 5)) // { arity: 5 }
+              ReadExistingIndex materialize.public.orders lookup_values=<Get l0> // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 0 }
+          Project () // { arity: 0 }
+            ReadExistingIndex materialize.public.customer lookup_values=<Get l0> // { arity: 4 }
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Constant // { arity: 1 }
+          - (134)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey
@@ -226,19 +232,25 @@ EXPLAIN WITH(arity, join_impls) SELECT *
   AND l_shipDATE = o_orderdate;
 ----
 Explained Query:
-  Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
-    Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 15 }
-      implementation
-        %1:orders[#2, #3]KKe » %0:lineitem[#4, #5]KKef » %2:customer[×]ef
-      ArrangeBy keys=[[#4, #5]] // { arity: 8 }
-        Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
-          Get materialize.public.lineitem // { arity: 8 }
-      ArrangeBy keys=[[#2, #3]] // { arity: 4 }
-        Project (#0..=#3) // { arity: 4 }
-          ReadExistingIndex materialize.public.orders lookup_value=(229) // { arity: 5 }
-      ArrangeBy keys=[[]] // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
-          ReadExistingIndex materialize.public.customer lookup_value=(229) // { arity: 4 }
+  Return // { arity: 15 }
+    Project (#0..=#9, #4, #5, #12..=#14) // { arity: 15 }
+      Join on=(#4 = #10 AND #5 = #11) type=differential // { arity: 15 }
+        implementation
+          %1:orders[#2, #3]KKe » %0:lineitem[#4, #5]KKef » %2:customer[×]ef
+        ArrangeBy keys=[[#4, #5]] // { arity: 8 }
+          Filter (date_to_timestamp(#7) = (#5 + 6 days)) // { arity: 8 }
+            Get materialize.public.lineitem // { arity: 8 }
+        ArrangeBy keys=[[#2, #3]] // { arity: 4 }
+          Project (#0..=#3) // { arity: 4 }
+            ReadExistingIndex materialize.public.orders lookup_values=<Get l0> // { arity: 5 }
+        ArrangeBy keys=[[]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            ReadExistingIndex materialize.public.customer lookup_values=<Get l0> // { arity: 4 }
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]] // { arity: 1 }
+        Constant // { arity: 1 }
+          - (229)
 
 Used Indexes:
   - materialize.public.pk_customer_custkey

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -196,7 +196,7 @@ Explained Query:
             raw=false
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
           ArrangeBy
-            raw=false
+            raw=true
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
             Constant
               - (2, "l2")


### PR DESCRIPTION
This is just a minor PR as a preparation for the [EXPLAIN "Used indexes"](https://github.com/MaterializeInc/materialize/issues/15242) improvements. At the moment, I'm not 100% sure whether we should do the [moving of the "Used indexes" to LIR](https://github.com/MaterializeInc/materialize/issues/16598) now, or the current MIR-based approach can be just smartened enough for now. This PR brings us closer to the answer by adding a `soft_panic_or_log` for a situation whose existence used to suggest that the MIR-based approach is not precise enough, but shouldn't actually occur nowadays. Specifically, I added a `soft_panic_or_log` for the situation when a non-delta join doesn't have an MIR `ArrangeBy` that it would need. I added code comments to explain why this was happening before but shouldn't be happening anymore.

To support the above, I also added an `ArrangeBy` on the constant input of a Join that was created for a literal constraint (i.e., an `IndexedFilter` join). This was not possible to do before https://github.com/MaterializeInc/materialize/pull/16351, because the `ArrangeBy` would have been const-folded away. This has some very minor effects on plans, as can be seen in the slt rewrite:
- When the same const input in an `IndexedFilter` join occurs multiple times, CSE will now pull out the arrangement creation. (This looks somewhat weird, as the `Get` for that CTE is not visible, as it is hidden by the explain code turning an `IndexedFilter` into a special `ReadExistingIndex` print.)
- The LIR `ArrangeBy` will have `raw=true`, whereas earlier it was `false`. This shouldn't have any actual effect on the rendered dataflow, because the `ArrangeBy` won't do any work to create the raw form (just forward what is already there), and the subsequent join won't be requesting the `raw` form of the collection. (@vmarcos, FYI, here is one more reason that we shouldn't mess with the raw collections coming out of LIR `ArrangeBy`s...)

So, the point of the PR is that this soft panic (hopefully) not occurring in either nightly or sentry will inform us next week when we are thinking about the "Used indexes" stuff. (And if it does occur, that would mean that we might also be missing some index reuses, so then we need some bugfixing to do around `JoinImplementation`.)

Additionally, I added a comment to the old LIR literal constraints handling logic to explain its continued existence despite the `LiteralConstraints` MIR transform taking away most of its job. (I wanted to add a `soft_panic_or_log` also there, but it turned out there are still some legitimate uses of that code occurring even in our slts.)

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
