### PR TITLE
clusters: populate `disk_usage` from kubernetes

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1167,6 +1167,7 @@ impl CatalogState {
                 ServiceProcessMetrics {
                     cpu_nano_cores,
                     memory_bytes,
+                    disk_usage_bytes,
                 },
             )| {
                 Row::pack_slice(&[
@@ -1174,8 +1175,7 @@ impl CatalogState {
                     u64::cast_from(process_id).into(),
                     (*cpu_nano_cores).into(),
                     (*memory_bytes).into(),
-                    // TODO(guswynn): disk usage will be filled in later.
-                    Datum::Null,
+                    (*disk_usage_bytes).into(),
                 ])
             },
         );

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -558,6 +558,7 @@ where
         }
 
         // Process pending replica metrics responses
+        // TODO(guswynn): remove the `replica_metrics`, field, its unused.
         if let Some((replica_id, metrics)) = self.compute.replica_metrics.pop_first() {
             return Some(ComputeControllerResponse::ReplicaMetrics(
                 replica_id, metrics,

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -321,6 +321,8 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
             metrics.push(ServiceProcessMetrics {
                 cpu_nano_cores,
                 memory_bytes,
+                // Process orchestrator does not support this right now.
+                disk_usage_bytes: None,
             });
         }
         Ok(metrics)

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -199,6 +199,7 @@ pub trait Service: fmt::Debug + Send + Sync {
 pub struct ServiceProcessMetrics {
     pub cpu_nano_cores: Option<u64>,
     pub memory_bytes: Option<u64>,
+    pub disk_usage_bytes: Option<u64>,
 }
 
 /// A simple language for describing assertions about a label's existence and value.


### PR DESCRIPTION
Finally populates `disk_usage` using the `custom.metrics.k8s.io` endpoint

### Motivation


  * This PR adds a known-desirable feature.

### Tips for reviewer

`MetricValuesList` is quite weird, context here: https://discord.com/channels/500028886025895936/1131417884594278450

Testing has been done manually, by me, in my personal stack. This change is required for `spill2disk`, but too onerous to test for now: https://materializeinc.slack.com/archives/CL68GT3AT/p1689130297513229?thread_ts=1689103346.796849&cid=CL68GT3AT

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
