### PR TITLE
persist,adapter: opt small, select operations into INFO-level spans

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -118,7 +118,7 @@ use timely::progress::Antichain;
 use tokio::runtime::Handle as TokioHandle;
 use tokio::select;
 use tokio::sync::{mpsc, oneshot, watch, OwnedMutexGuard};
-use tracing::{debug_span, info, span, warn, Instrument, Level, Span};
+use tracing::{info, info_span, span, warn, Instrument, Level, Span};
 use uuid::Uuid;
 
 use crate::catalog::builtin::{BUILTINS, MZ_VIEW_FOREIGN_KEYS, MZ_VIEW_KEYS};
@@ -1617,7 +1617,7 @@ impl Coordinator {
                 // `tick()` on `Interval` is cancel-safe:
                 // https://docs.rs/tokio/1.19.2/tokio/time/struct.Interval.html#cancel-safety
                 _ = self.advance_timelines_interval.tick() => {
-                    let span = debug_span!(parent: None, "advance_timelines_interval");
+                    let span = info_span!(parent: None, "advance_timelines_interval");
                     span.follows_from(Span::current());
                     Message::GroupCommitInitiate(span)
                 },

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -484,7 +484,7 @@ where
         let next_state = match message {
             Some(FrontendMessage::Query { sql }) => {
                 let query_root_span =
-                    tracing::debug_span!(parent: None, "advance_ready", otel.name = message_name);
+                    tracing::info_span!(parent: None, "advance_ready", otel.name = message_name);
                 query_root_span.follows_from(tracing::Span::current());
                 self.query(sql).instrument(query_root_span).await?
             }
@@ -518,7 +518,7 @@ where
                     Ok(n) => ExecuteCount::Count(n),
                 };
                 let execute_root_span =
-                    tracing::debug_span!(parent: None, "advance_ready", otel.name = message_name);
+                    tracing::info_span!(parent: None, "advance_ready", otel.name = message_name);
                 execute_root_span.follows_from(tracing::Span::current());
                 let state = self
                     .execute(


### PR DESCRIPTION
We'd like to start defaulting to some small, select amount of always on tracing. One per each external operation run on behalf of persist, one for each action requested by the user via pgwire, and one for the periodic timeline advancement seems like a nice place to start getting a sense for what sort of volume our tracing infra will support.

Note that we default opentelemetry_filter to "off" not "info", so we can use LD to control the effect of this PR once it is deployed.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
