### PR TITLE
platform-checks: Fix the scenarios around managed clusters

### DIFF
--- a/misc/python/materialize/checks/managed_cluster.py
+++ b/misc/python/materialize/checks/managed_cluster.py
@@ -18,6 +18,16 @@ class CreateManagedCluster(Check):
     def _can_run(self) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $[version<=6300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_managed_clusters = true
+                """
+            )
+        )
+
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))
@@ -69,6 +79,16 @@ class CreateManagedCluster(Check):
 class DropManagedCluster(Check):
     def _can_run(self) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $[version<=6300] postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+                ALTER SYSTEM SET enable_managed_clusters = true
+                """
+            )
+        )
 
     def manipulate(self) -> List[Testdrive]:
         return [


### PR DESCRIPTION
Managed clusters are on by default in the main branch, but still need to be explicitly enabled if old versions of Mz are used, as is the case with the upgrade tests.


### Motivation

Nightly CI was failing.