### PR TITLE
Set enable_managed_clusters for older versions of Materialize

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -113,6 +113,13 @@ class ConfigureMz(MzcomposeAction):
             )
             system_settings.add("GRANT CREATE ON CLUSTER default TO materialize;")
 
+        if (
+            MzVersion.parse("0.58.0-dev")
+            <= e.current_mz_version
+            <= MzVersion.parse("0.63.0-dev")
+        ):
+            system_settings.add("ALTER SYSTEM SET enable_managed_clusters = on;")
+
         system_settings = system_settings - e.system_settings
 
         if system_settings:

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -7,8 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import operator
 import urllib.parse
-from typing import Dict, Optional
+from typing import Callable, Dict, Optional
 
 from kubernetes.client import (
     V1Container,
@@ -211,6 +212,9 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             ]
         if self._meets_minimum_version("0.63.0-dev"):
             args += ["--secrets-controller=kubernetes"]
+        if self._meets_maximum_version("0.63.99"):
+            args += ["--system-parameter-default=enable_managed_clusters=true"]
+
         container = V1Container(
             name="environmentd",
             image=self.image(
@@ -261,23 +265,21 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             ),
         )
 
-    def _meets_minimum_version(self, minimum: str) -> bool:
-        """Determine whether environmentd is at least the `minimum` version.
+    def _meets_version(self, version: str, operator: Callable, default: bool) -> bool:
+        """Determine whether environmentd matches a given version based on a comparison operator"""
 
-        This function matches the function of the same name in MaterializeInc/cloud.
-        """
-
-        # Assume that unstable and development versions, as indicated by a
-        # missing or unparseable tag, are always recent enough to support all
-        # features.
-        #
-        # TODO: learn how to do real feature detection on arbitrary versions.
         if self.tag is None:
-            return True
+            return default
         try:
             tag_version = Version.parse(self.tag.removeprefix("v"))
         except ValueError:
-            return True
+            return default
 
-        minimum_version = Version.parse(minimum)
-        return tag_version >= minimum_version
+        version = Version.parse(version)
+        return bool(operator(tag_version, version))
+
+    def _meets_minimum_version(self, version: str) -> bool:
+        return self._meets_version(version=version, operator=operator.ge, default=True)
+
+    def _meets_maximum_version(self, version: str) -> bool:
+        return self._meets_version(version=version, operator=operator.le, default=False)


### PR DESCRIPTION
### Motivation

Fix upgrade tests broken by #20399.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
