### PR TITLE
compute: adjust reconciliation metrics

### DIFF
--- a/doc/developer/design/20230531_compute_metrics.md
+++ b/doc/developer/design/20230531_compute_metrics.md
@@ -249,13 +249,13 @@ All metrics in this list have a `worker_id` label identifying the Timely worker.
     * **Labels**: `worker_id`
     * **Description**: A histogram of dataflow shutdown durations since restart.
     * **Export Type**: prometheus-exporter, through the `mz_dataflow_shutdown_durations_histogram` introspection source
-  * [ ] `mz_dataflow_frontiers`
+  * [x] `mz_dataflow_frontiers`
     * **Type**: gauge
     * **Labels**: `worker_id`, `collection_id`
     * **Description**: The frontiers of dataflows.
     * **Export Type**: prometheus-exporter, through the `mz_compute_frontiers` introspection source
     * **Notes**: To reduce the cardinality of this metric, we limit it to non-transient dataflows.
-  * [ ] `mz_dataflow_import_frontiers`
+  * [x] `mz_dataflow_import_frontiers`
     * **Type**: gauge
     * **Labels**: `worker_id`, `collection_id`
     * **Description**: The import frontiers of dataflows.
@@ -297,16 +297,16 @@ All metrics in this list have a `worker_id` label identifying the Timely worker.
     * **Notes**: This metric exists already, with an extra label `arrangement_id`.
                  Proposing to remove the `arrangement_id` label, because it blows up the cardinality of this metric.
 * Reconciliation
-  * [ ] `mz_compute_reconciliation_reused_dataflows_count_total`
+  * [x] `mz_compute_reconciliation_reused_dataflows_count_total`
     * **Type**: counter
     * **Labels**: `worker_id`
     * **Description**: The total number of dataflows that were reused during compute reconciliation.
     * **Export Type**: direct
     * **Notes**: This metric exists already as `mz_compute_reconciliation_reused_dataflows`.
                  Proposing to rename to follow the Prometheus naming conventions, and adding a worker label.
-  * [ ] `mz_compute_reconciliation_replaced_dataflows_count_total`
+  * [x] `mz_compute_reconciliation_replaced_dataflows_count_total`
     * **Type**: counter
-    * **Labels**: `worker_id`
+    * **Labels**: `worker_id`, `reason`
     * **Description**: The total number of dataflows that were replaced during compute reconciliation.
     * **Export Type**: direct
     * **Notes**: This metric exists already as `mz_compute_reconciliation_replaced_dataflows`.

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -559,6 +559,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
                                 }
 
                                 compute_state.metrics.record_dataflow_reconciliation(
+                                    self.timely_worker.index(),
                                     compatible,
                                     uncompacted,
                                     subscribe_free,

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1607,9 +1607,13 @@ def workflow_test_compute_reconciliation_reuse(c: Composition) -> None:
         reused = 0
         replaced = 0
         for metric in metrics.splitlines():
-            if metric.startswith("mz_compute_reconciliation_reused_dataflows"):
+            if metric.startswith(
+                "mz_compute_reconciliation_reused_dataflows_count_total"
+            ):
                 reused += int(metric.split()[1])
-            elif metric.startswith("mz_compute_reconciliation_replaced_dataflows"):
+            elif metric.startswith(
+                "mz_compute_reconciliation_replaced_dataflows_count_total"
+            ):
                 replaced += int(metric.split()[1])
 
         return reused, replaced


### PR DESCRIPTION
This PR makes two adjustments to the compute reconciliation metrics, as proposed in the [design doc](https://github.com/MaterializeInc/materialize/pull/19717).
 * renames them to bring them in line with the Prometheus naming conventions
 * adds a `worker_id` label to bring them in line with the other metrics exported by replicas

### Motivation

  * This PR adds a known-desirable feature.

Part of #18745.

### Tips for reviewer

This includes a metrics rename, so it can potentially break existing metrics. I doubt that any dashboard uses reconciliation metrics currently, but I will find a way to verify this.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A