### PR TITLE
compute: refactor trace metrics

### DIFF
--- a/doc/developer/design/20230531_compute_metrics.md
+++ b/doc/developer/design/20230531_compute_metrics.md
@@ -289,7 +289,7 @@ All metrics in this list have a `worker_id` label identifying the Timely worker.
     * **Labels**: `worker_id`
     * **Description**: The size of all arrangements in all dataflows.
     * **Export Type**: prometheus-exporter, through the `mz_arrangement_sizes` introspection source
-  * [ ] `mz_arrangement_maintenance_seconds_total`
+  * [x] `mz_arrangement_maintenance_seconds_total`
     * **Type**: counter
     * **Labels**: `worker_id`
     * **Description**: The total time maintaining arrangements.

--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -16,97 +16,25 @@ use std::time::Instant;
 
 use differential_dataflow::lattice::antichain_join;
 use differential_dataflow::trace::TraceReader;
-use mz_ore::metric;
-use mz_ore::metrics::{
-    CounterVec, CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt,
-    MetricsRegistry, UIntGaugeVec,
-};
 use mz_repr::{GlobalId, Timestamp};
-use prometheus::core::{AtomicF64, AtomicU64};
 use timely::progress::frontier::{Antichain, AntichainRef};
 
+use crate::metrics::TraceMetrics;
 use crate::typedefs::{ErrsHandle, KeysValsHandle};
-
-/// Base metrics for arrangements.
-#[derive(Clone, Debug)]
-pub struct TraceMetrics {
-    total_maintenance_time: CounterVec,
-    doing_maintenance: UIntGaugeVec,
-}
-
-impl TraceMetrics {
-    /// TODO(undocumented)
-    pub fn register_with(registry: &MetricsRegistry) -> Self {
-        Self {
-            total_maintenance_time: registry.register(metric!(
-                name: "mz_arrangement_maintenance_seconds_total",
-                help: "The total time spent maintaining an arrangement",
-                var_labels: ["worker_id", "arrangement_id"],
-            )),
-            doing_maintenance: registry.register(metric!(
-                name: "mz_arrangement_maintenance_active_info",
-                help: "Whether or not maintenance is currently occurring",
-                var_labels: ["worker_id"],
-            )),
-        }
-    }
-
-    fn maintenance_time_metric(
-        &self,
-        worker_id: usize,
-        id: GlobalId,
-    ) -> DeleteOnDropCounter<'static, AtomicF64, Vec<String>> {
-        self.total_maintenance_time
-            .get_delete_on_drop_counter(vec![worker_id.to_string(), id.to_string()])
-    }
-
-    fn maintenance_flag_metric(
-        &self,
-        worker_id: usize,
-    ) -> DeleteOnDropGauge<'static, AtomicU64, Vec<String>> {
-        self.doing_maintenance
-            .get_delete_on_drop_gauge(vec![worker_id.to_string()])
-    }
-}
-
-struct MaintenanceMetrics {
-    /// total time spent doing maintenance. More useful in the general case.
-    total_maintenance_time: DeleteOnDropCounter<'static, AtomicF64, Vec<String>>,
-}
-
-impl MaintenanceMetrics {
-    fn new(metrics: &TraceMetrics, worker_id: usize, arrangement_id: GlobalId) -> Self {
-        MaintenanceMetrics {
-            total_maintenance_time: metrics.maintenance_time_metric(worker_id, arrangement_id),
-        }
-    }
-}
 
 /// A `TraceManager` stores maps from global identifiers to the primary arranged
 /// representation of that collection.
 pub struct TraceManager {
     pub(crate) traces: BTreeMap<GlobalId, TraceBundle>,
-    worker_id: usize,
-    maintenance_metrics: BTreeMap<GlobalId, MaintenanceMetrics>,
-    /// 1 if this worker is currently doing maintenance.
-    ///
-    /// If maintenance turns out to take a very long time, this will allow us
-    /// to gain a sense that materialize is stuck on maintenance before the
-    /// maintenance completes
-    doing_maintenance: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     metrics: TraceMetrics,
 }
 
 impl TraceManager {
     /// TODO(undocumented)
-    pub fn new(metrics: TraceMetrics, worker_id: usize) -> Self {
-        let doing_maintenance = metrics.maintenance_flag_metric(worker_id);
+    pub fn new(metrics: TraceMetrics) -> Self {
         TraceManager {
             traces: BTreeMap::new(),
-            worker_id,
             metrics,
-            maintenance_metrics: BTreeMap::new(),
-            doing_maintenance,
         }
     }
 
@@ -118,27 +46,20 @@ impl TraceManager {
     /// of differential dataflow, which requires users to perform this explicitly; if that changes we may
     /// be able to remove this code.
     pub fn maintenance(&mut self) {
+        let start = Instant::now();
+        self.metrics.maintenance_active_info.set(1);
+
         let mut antichain = Antichain::new();
-        for (arrangement_id, bundle) in self.traces.iter_mut() {
-            // Update maintenance metrics
-            // Entry is guaranteed to exist as it gets created when we initialize the partition.
-            let maintenance_metrics = self.maintenance_metrics.get_mut(arrangement_id).unwrap();
-
-            // signal that maintenance is happening
-            self.doing_maintenance.set(1);
-            let now = Instant::now();
-
+        for bundle in self.traces.values_mut() {
             bundle.oks.read_upper(&mut antichain);
             bundle.oks.set_physical_compaction(antichain.borrow());
             bundle.errs.read_upper(&mut antichain);
             bundle.errs.set_physical_compaction(antichain.borrow());
-
-            maintenance_metrics
-                .total_maintenance_time
-                .inc_by(now.elapsed().as_secs_f64());
-            // signal that maintenance has ended
-            self.doing_maintenance.set(0);
         }
+
+        let duration = start.elapsed().as_secs_f64();
+        self.metrics.maintenance_seconds_total.inc_by(duration);
+        self.metrics.maintenance_active_info.set(0);
     }
 
     /// Enables compaction of traces associated with the identifier.
@@ -167,22 +88,16 @@ impl TraceManager {
 
     /// Binds the arrangement for `id` to `trace`.
     pub fn set(&mut self, id: GlobalId, trace: TraceBundle) {
-        self.maintenance_metrics.insert(
-            id,
-            MaintenanceMetrics::new(&self.metrics, self.worker_id, id),
-        );
         self.traces.insert(id, trace);
     }
 
     /// Removes the trace for `id`.
     pub fn del_trace(&mut self, id: &GlobalId) -> bool {
-        self.maintenance_metrics.remove(id);
         self.traces.remove(id).is_some()
     }
 
     /// Removes all managed traces.
     pub fn del_all_traces(&mut self) {
-        self.maintenance_metrics.clear();
         self.traces.clear();
     }
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -90,11 +90,12 @@ pub struct ComputeState {
 impl ComputeState {
     /// Construct a new `ComputeState`.
     pub fn new(
-        traces: TraceManager,
+        worker_id: usize,
         persist_clients: Arc<PersistClientCache>,
         metrics: ComputeMetrics,
         tracing_handle: Arc<TracingHandle>,
     ) -> Self {
+        let traces = TraceManager::new(metrics.for_traces(worker_id));
         let command_history = ComputeCommandHistory::new(metrics.for_history());
 
         Self {

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -84,5 +84,3 @@ pub(crate) mod render;
 pub mod server;
 pub(crate) mod sink;
 mod typedefs;
-
-pub use arrangement::manager::{TraceManager, TraceMetrics};

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -11,20 +11,25 @@ use mz_compute_client::metrics::{CommandMetrics, HistoryMetrics};
 use mz_ore::metric;
 use mz_ore::metrics::{raw, DeleteOnDropGauge, GaugeVec, GaugeVecExt, MetricsRegistry, UIntGauge};
 use mz_repr::GlobalId;
-use prometheus::core::AtomicF64;
+use prometheus::core::{AtomicF64, GenericCounter};
 
+/// Metrics exposed by compute replicas.
 #[derive(Clone, Debug)]
 pub struct ComputeMetrics {
     // command history
-    pub history_command_count: raw::UIntGaugeVec,
-    pub history_dataflow_count: UIntGauge,
+    history_command_count: raw::UIntGaugeVec,
+    history_dataflow_count: UIntGauge,
 
     // reconciliation
-    pub reconciliation_reused_dataflows_count_total: raw::IntCounterVec,
-    pub reconciliation_replaced_dataflows_count_total: raw::IntCounterVec,
+    reconciliation_reused_dataflows_count_total: raw::IntCounterVec,
+    reconciliation_replaced_dataflows_count_total: raw::IntCounterVec,
 
     // dataflow state
-    pub dataflow_initial_output_duration_seconds: GaugeVec,
+    dataflow_initial_output_duration_seconds: GaugeVec,
+
+    // arrangements
+    arrangement_maintenance_seconds_total: raw::CounterVec,
+    arrangement_maintenance_active_info: raw::UIntGaugeVec,
 }
 
 impl ComputeMetrics {
@@ -54,6 +59,16 @@ impl ComputeMetrics {
                 help: "The time from dataflow installation up to when the first output was produced.",
                 var_labels: ["worker_id", "collection_id"],
             )),
+            arrangement_maintenance_seconds_total: registry.register(metric!(
+                name: "mz_arrangement_maintenance_seconds_total",
+                help: "The total time spent maintaining arrangements.",
+                var_labels: ["worker_id"],
+            )),
+            arrangement_maintenance_active_info: registry.register(metric!(
+                name: "mz_arrangement_maintenance_active_info",
+                help: "Whether maintenance is currently occuring.",
+                var_labels: ["worker_id"],
+            )),
         }
     }
 
@@ -68,6 +83,21 @@ impl ComputeMetrics {
         HistoryMetrics {
             command_counts,
             dataflow_count,
+        }
+    }
+
+    pub fn for_traces(&self, worker_id: usize) -> TraceMetrics {
+        let worker = worker_id.to_string();
+        let maintenance_seconds_total = self
+            .arrangement_maintenance_seconds_total
+            .with_label_values(&[&worker]);
+        let maintenance_active_info = self
+            .arrangement_maintenance_active_info
+            .with_label_values(&[&worker]);
+
+        TraceMetrics {
+            maintenance_seconds_total,
+            maintenance_active_info,
         }
     }
 
@@ -130,4 +160,15 @@ impl ComputeMetrics {
 /// Metrics maintained per compute collection.
 pub struct CollectionMetrics {
     pub initial_output_duration_seconds: DeleteOnDropGauge<'static, AtomicF64, Vec<String>>,
+}
+
+/// Metrics maintained by the trace manager.
+pub struct TraceMetrics {
+    pub maintenance_seconds_total: GenericCounter<AtomicF64>,
+    /// 1 if this worker is currently doing maintenance.
+    ///
+    /// If maintenance turns out to take a very long time, this will allow us
+    /// to gain a sense that Materialize is stuck on maintenance before the
+    /// maintenance completes
+    pub maintenance_active_info: UIntGauge,
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -39,17 +39,14 @@ use tokio::sync::mpsc;
 use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
 use crate::logging::compute::ComputeEvent;
 use crate::metrics::ComputeMetrics;
-use crate::{TraceManager, TraceMetrics};
 
 /// Configures the server with compute-specific metrics.
 #[derive(Debug, Clone)]
 pub struct Config {
-    /// Metrics about traces.
-    pub trace_metrics: TraceMetrics,
-    /// Metrics about command histories and dataflows.
+    /// Metrics exposed by compute replicas.
     // TODO(guswynn): cluster-unification: ensure these stats
     // also work for storage when merging.
-    pub compute_metrics: ComputeMetrics,
+    pub metrics: ComputeMetrics,
 }
 
 /// Initiates a timely dataflow computation, processing compute commands.
@@ -62,14 +59,8 @@ pub fn serve(
     ),
     Error,
 > {
-    // Various metrics related things.
-    let trace_metrics = TraceMetrics::register_with(&config.metrics_registry);
-    let compute_metrics = ComputeMetrics::register_with(&config.metrics_registry);
-
-    let compute_config = Config {
-        trace_metrics,
-        compute_metrics,
-    };
+    let metrics = ComputeMetrics::register_with(&config.metrics_registry);
+    let compute_config = Config { metrics };
 
     let (timely_container, client_builder) = mz_cluster::server::serve::<
         Config,
@@ -138,10 +129,8 @@ struct Worker<'w, A: Allocate> {
     /// are delivered.
     client_rx: crossbeam_channel::Receiver<(CommandReceiver, ResponseSender, ActivatorSender)>,
     compute_state: Option<ComputeState>,
-    /// Trace metrics.
-    trace_metrics: TraceMetrics,
     /// Compute metrics.
-    compute_metrics: ComputeMetrics,
+    metrics: ComputeMetrics,
     /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
     /// This is intentionally shared between workers
     persist_clients: Arc<PersistClientCache>,
@@ -165,8 +154,7 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
         Worker {
             timely_worker,
             client_rx,
-            trace_metrics: config.trace_metrics,
-            compute_metrics: config.compute_metrics,
+            metrics: config.metrics,
             persist_clients,
             compute_state: None,
             tracing_handle,
@@ -391,12 +379,10 @@ impl<'w, A: Allocate> Worker<'w, A> {
     fn handle_command(&mut self, response_tx: &mut ResponseSender, cmd: ComputeCommand) {
         match &cmd {
             ComputeCommand::CreateInstance(_) => {
-                let traces =
-                    TraceManager::new(self.trace_metrics.clone(), self.timely_worker.index());
                 self.compute_state = Some(ComputeState::new(
-                    traces,
+                    self.timely_worker.index(),
                     Arc::clone(&self.persist_clients),
-                    self.compute_metrics.clone(),
+                    self.metrics.clone(),
                     Arc::clone(&self.tracing_handle),
                 ));
             }
@@ -692,8 +678,7 @@ impl<'w, A: Allocate> Worker<'w, A> {
         // Overwrite `self.command_history` to reflect `new_commands`.
         // It is possible that there still isn't a compute state yet.
         if let Some(compute_state) = &mut self.compute_state {
-            let mut command_history =
-                ComputeCommandHistory::new(self.compute_metrics.for_history());
+            let mut command_history = ComputeCommandHistory::new(self.metrics.for_history());
             for command in new_commands.iter() {
                 command_history.push(command.clone(), &compute_state.pending_peeks);
             }


### PR DESCRIPTION
This commit refactors the way trace metrics are handled in compute.

It includes one functional change: `mz_arrangement_maintenance_seconds_total` loses its `arrangement_id` label. We determined that having this label blows up the cardinality of this metric too much (currently it produces ~15k timeseries in production) to be defensible.

The larger refactor moves the definition of trace metrics into the `ComputeMetrics` type. This makes all replica metrics defined at the same place and simplifies the metrics plumbing done during initialization.

### Motivation

  * This PR adds a known-desirable feature.

Part of #18745.
Design doc: #19717.

### Tips for reviewer

I thought about adding a `collection_id` label to `mz_arrangement_maintenance_seconds_total`. However, implementing this seems difficult, as the `TraceManager` would have to learn about the arrangement -> collection mapping. Given that we will have additional metrics showing us row and batch counts per collection, I think we should be able to derive the likely sources of changed maintenance times without a `collection_id` label on this specific metric. LMK if anyone feels strongly the other way!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A