### PR TITLE
Explicitly disallow aggregates and window funcs in the ORDER BY of a set expression

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1245,13 +1245,13 @@ fn plan_query_inner(
             let (expr, scope) = plan_set_expr(qcx, &q.body)?;
             let ecx = &ExprContext {
                 qcx,
-                name: "ORDER BY clause",
+                name: "ORDER BY clause of a set expression",
                 scope: &scope,
                 relation_type: &qcx.relation_type(&expr),
-                allow_aggregates: true,
+                allow_aggregates: false,
                 allow_subqueries: true,
                 allow_parameters: true,
-                allow_windows: true,
+                allow_windows: false,
             };
             let output_columns: Vec<_> = scope.column_names().enumerate().collect();
             let (order_by, map_exprs) = plan_order_by_exprs(ecx, &q.order_by, &output_columns)?;

--- a/test/sqllogictest/cockroach/order_by.slt
+++ b/test/sqllogictest/cockroach/order_by.slt
@@ -233,7 +233,6 @@ CREATE TABLE abc (
 statement ok
 INSERT INTO abc VALUES (1, 2, 3, 'one'), (4, 5, 6, 'Two')
 
-skipif postgresql # TODO(benesch): support lower.
 query T
 SELECT d FROM abc ORDER BY lower(d)
 ----

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -91,6 +91,102 @@ SELECT DISTINCT a FROM foo ORDER BY a + 1
 query error column "b" does not exist
 (SELECT a FROM foo) UNION (SELECT a FROM foo) ORDER BY b
 
+# We should pick up the column name from the first input of UNION.
+query I
+(SELECT a FROM foo)
+UNION
+(SELECT a-3 FROM foo)
+ORDER BY a;
+----
+-3
+-2
+-1
+0
+1
+2
+
+query I
+(SELECT a FROM foo)
+UNION
+(SELECT a FROM foo)
+ORDER BY a;
+----
+0
+1
+2
+
+query error ERROR: column "a" does not exist
+(SELECT a-3 FROM foo)
+UNION
+(SELECT a FROM foo)
+ORDER BY a;
+
+# We support complex expressions in the ORDER BY of a set expression (Postgres doesn't).
+query I
+(SELECT a FROM foo)
+UNION
+(SELECT a-3 FROM foo)
+ORDER BY -2*a+3;
+----
+2
+1
+0
+-1
+-2
+-3
+
+# But we don't support aggregations in the ORDER BY of a set expression (same in Postgres)
+query error db error: ERROR: aggregate functions are not allowed in ORDER BY clause of a set expression \(function pg_catalog\.sum\)
+(SELECT a FROM foo)
+UNION
+(SELECT a-3 FROM foo)
+ORDER BY sum(a);
+
+# ... or window functions (same in Postgres).
+query error db error: ERROR: window functions are not allowed in ORDER BY clause of a set expression \(function pg_catalog\.lag\)
+(SELECT a FROM foo)
+UNION
+(SELECT a-3 FROM foo)
+ORDER BY lag(a) OVER ();
+
+# We support window functions in a normal ORDER BY, though
+query I
+SELECT a FROM foo
+ORDER BY lag(a) OVER (ORDER BY a) NULLS LAST;
+----
+1
+2
+0
+
+query I
+SELECT a FROM foo
+ORDER BY lag(a) OVER (ORDER BY -a NULLS FIRST) DESC NULLS LAST;
+----
+1
+0
+2
+
+# We support subqueries in ORDER BY
+query IT
+SELECT a, b FROM foo
+ORDER BY a IN (SELECT length(b)-1 FROM foo), -a;
+----
+1  one
+0  zero
+2  two
+
+# ... even for a set expression
+query I
+(SELECT a FROM foo)
+UNION
+(SELECT a+1 FROM foo)
+ORDER BY a IN (SELECT length(b)-1 FROM foo), -a;
+----
+1
+0
+3
+2
+
 # Using a column twice and referring to it by its alias in the ORDER BY should
 # work.
 query II


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/20902 as discussed in https://github.com/MaterializeInc/materialize/issues/20902#issuecomment-1662252383

We still need to run `stash-debug upgrade-check` to verify that no customer has a window function in the ORDER BY of a set expression, such as UNION! Edit: Verified in a different way that there are no window functions in any ORDER BY.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/20902

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
