### PR TITLE
config: don't sync the `enable_launchdarkly` SystemVar

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2038,6 +2038,7 @@ impl SystemVars {
     pub fn iter_synced(&self) -> impl Iterator<Item = &dyn Var> {
         self.iter()
             .filter(|v| v.name() != CONFIG_HAS_SYNCED_ONCE.name)
+            .filter(|v| v.name() != ENABLE_LAUNCHDARKLY.name)
     }
 
     /// Returns a [`Var`] representing the configuration parameter with the


### PR DESCRIPTION
Adds a guard to the `iter_synced` result in order to guard us against the unlikely scenario where somebody adds an `enable_launchdarkly` flag to LaunchDarkly and sets the default value to `false`.

If this happens, at the moment we will close all connections and it will be a pain to bring LD sync back to life.

### Motivation

  * This PR fixes a previously unreported bug.

Something that @antiguru pointed out and I think we were protecting against, but until this PR we didn't.

### Tips for reviewer

Observe that `iter_synced()` is used to populate the set of `synchronized` values in the `SynchronizedParameters` constructor:

https://github.com/MaterializeInc/materialize/blob/76f59e16df67d28f75642dd2e5b059b3d5eca3ec/src/adapter/src/config/params.rs#L37-L47

Removing `enable_launchdarkly` from the `iter_synced()` result should therefore guard us against the unlikely scenario where we shoot ourselves in the foot.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
