### PR TITLE
stash: ensure objects and latest version protos have matching hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5010,6 +5010,7 @@ dependencies = [
  "prost-build",
  "protobuf-src",
  "rand",
+ "regex",
  "serde",
  "serde_json",
  "similar-asserts",

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -52,6 +52,7 @@ anyhow = "1.0.66"
 md-5 = "0.10.5"
 protobuf-src = "1.1.0"
 prost-build = "0.11.9"
+regex = "1.7.0"
 serde = "1.0.152"
 serde_json = "1.0.89"
 

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,42 +1,42 @@
 [
   {
-    "name": "objects.proto",
-    "md5": "caeba871ee4c70243741bb5efa474b9e"
-  },
-  {
     "name": "objects_v25.proto",
-    "md5": "0a055b56539327ccbb8e23f209843cf2"
+    "md5": "6f150aab3fa095b00753500ab4950af6"
   },
   {
     "name": "objects_v26.proto",
-    "md5": "bffd4936bea8f4f894662fcea12e4a5d"
+    "md5": "20b96b75360de55bf3233548b6e3c649"
   },
   {
     "name": "objects_v27.proto",
-    "md5": "7ccd2c67b302d72cc4c94be892c7cfc1"
+    "md5": "57275dc806e67834d5ebcfb04001c50d"
   },
   {
     "name": "objects_v28.proto",
-    "md5": "891db1de528b10e073463cb8108556e0"
+    "md5": "57275dc806e67834d5ebcfb04001c50d"
   },
   {
     "name": "objects_v29.proto",
-    "md5": "a79ba1c1f4536c945ac6ee26fcc38946"
+    "md5": "57275dc806e67834d5ebcfb04001c50d"
   },
   {
     "name": "objects_v30.proto",
-    "md5": "85e44d81055146392f272df16d40e92e"
+    "md5": "90079ca1764e2402cccdc2cd983e3942"
   },
   {
     "name": "objects_v31.proto",
-    "md5": "e78e005dc9ddef0dd00cd5a580d222c6"
+    "md5": "e8e7f4ec34697eefd908e9ce40bbf763"
   },
   {
     "name": "objects_v32.proto",
-    "md5": "5cedf06f7ee9f15a6ada28067907639b"
+    "md5": "caeba871ee4c70243741bb5efa474b9e"
   },
   {
     "name": "objects_v33.proto",
-    "md5": "b5f70889965589369efc18ec36e8cbd8"
+    "md5": "caeba871ee4c70243741bb5efa474b9e"
+  },
+  {
+    "name": "objects.proto",
+    "md5": "caeba871ee4c70243741bb5efa474b9e"
   }
 ]


### PR DESCRIPTION
I noticed there is nothing ensuring the objects hash matches the latest versioned files hash. This is because it has a different package name. This pr edits the file in memory to ensure the hashes match.

It also asserts this equivalence, and maintains the order of the hashes file.

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
