### PR TITLE
ci: Run Nightly on PRs that may cause Nightly to break

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -695,6 +695,47 @@ steps:
     if: build.tag != "" && build.branch =~ /^v.*\..*\$/
     coverage: skip
 
+  - id: nightly-if-risky
+    label: Nightly for risky PRs
+    depends_on: devel-docker-tags
+    trigger: nightlies
+    async: true
+    build:
+      commit: "$BUILDKITE_COMMIT"
+      branch: "$BUILDKITE_BRANCH"
+      env:
+        BUILDKITE_TAG: "$BUILDKITE_TAG"
+        BUILDKITE_PULL_REQUEST: "${BUILDKITE_PULL_REQUEST}"
+        BUILDKITE_PULL_REQUEST_BASE_BRANCH: "${BUILDKITE_PULL_REQUEST_BASE_BRANCH}"
+        BUILDKITE_PULL_REQUEST_REPO: "${BUILDKITE_PULL_REQUEST_REPO}"
+    if: build.tag != "" && build.branch != "main" && build.branch !~ /^v.*\..*\$/
+
+    inputs:
+      # Changes to the SQL syntax
+      - src/sql-parser/src
+      - src/expr-parser/src
+      # Changes to feature flags and other settings
+      - src/adapter/src/flags.rs
+      - src/persist-client/src/cfg*
+      - src/compute-client/src/protocol/command*
+      - src/sql/src/session/vars.rs
+      # Changes to command-line options
+      - src/environmentd/src/bin/environmentd/
+      - src/clusterd/src/bin/
+      # Changes to test frameworks
+      - src/testdrive/src
+      - misc/python/materialize
+      - test/feature-benchmark
+      - test/limits
+      # Changes to the CI inputs
+      - "**/Dockerfile"
+      - misc/images
+      - ci/builder
+      - bin/ci-builder
+      - ci/nightly
+      - ci/plugins
+    coverage: skip
+
   - wait: ~
     continue_on_failure: true
 


### PR DESCRIPTION
Run Nightly on PRs that may cause Nightly to break.

PRs that modify any of the files listed in the respective section of pipeline.template.yml will trigger Nightly. See the documentation in pipeline.template.yml for the justification of individual rules.

### Motivation

Changes in certain areas of the product are more likely to break Nightly, requiring follow-up fixes to either the product or the tests. It is best to catch those in the PR phase.