### PR TITLE
stash: Remove serde traits

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -84,7 +84,6 @@ use std::sync::Arc;
 
 use mz_ore::soft_assert;
 use mz_proto::{RustType, TryFromProtoError};
-use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
 
 pub mod objects;
@@ -131,14 +130,8 @@ pub(crate) type Id = i64;
 
 /// A common trait for uses of K and V to express in a single place all of the
 /// traits required by async_trait and StashCollection.
-pub trait Data:
-    prost::Message + Default + Ord + Send + Sync + Serialize + for<'de> Deserialize<'de>
-{
-}
-impl<T: prost::Message + Default + Ord + Send + Sync + Serialize + for<'de> Deserialize<'de>> Data
-    for T
-{
-}
+pub trait Data: prost::Message + Default + Ord + Send + Sync {}
+impl<T: prost::Message + Default + Ord + Send + Sync> Data for T {}
 
 /// `StashCollection` is like a differential dataflow [`Collection`], but the
 /// state of the collection is durable.


### PR DESCRIPTION
### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
