### PR TITLE
config: relax `synchronized` guards  in `SystemParameterBackend`

### DIFF
--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -60,9 +60,7 @@ impl SystemParameterBackend {
         match self.session_client.get_system_vars().await {
             Ok(vars) => {
                 for (name, value) in vars {
-                    if params.is_synchronized(&name) {
-                        params.modify(&name, &value);
-                    }
+                    params.modify(&name, &value);
                 }
             }
             Err(error) => {

--- a/src/adapter/src/config/params.rs
+++ b/src/adapter/src/config/params.rs
@@ -60,7 +60,10 @@ impl SynchronizedParameters {
     }
 
     /// Return a vector of [ModifiedParameter] instances that need to be pushed
-    /// to the backend and reset this set to the empty set.
+    /// to the backend and reset this set to the empty set for future calls.
+    ///
+    /// The set will start growing again as soon as we modify a parameter from
+    /// the `synchronized` set with a [SynchronizedParameters::modify] call.
     pub fn modified(&mut self) -> Vec<ModifiedParameter> {
         let mut modified = BTreeSet::new();
         std::mem::swap(&mut self.modified, &mut modified);
@@ -93,42 +96,45 @@ impl SynchronizedParameters {
             .value()
     }
 
-    /// Try to modify the in-memory `value` for `name` backing this
-    /// [SynchronizedParameters] instace, calling `SystemVars::reset` iff
-    /// `value` is the default for this `name` and `SystemVars::set` otherwise.
+    /// Try to modify the in-memory entry for `name` in the SystemVars backing
+    /// this [SynchronizedParameters] instace.
+    ///
+    /// This will call `SystemVars::reset` iff `value` is the default for this
+    /// `name` and `SystemVars::set` otherwise.
+    ///
+    /// As a side effect, the modified set will be changed to contain `name` iff
+    /// the in-memory entry for `name` was modified **and** `name` is in the
+    /// `synchronized` set.
     ///
     /// Return `true` iff the backing in-memory value for this `name` has
     /// changed.
     pub fn modify(&mut self, name: &str, value: &str) -> bool {
-        // Resolve name to &'static str and assert that the system parameter can
-        // be indeed modified.
-        if let Some(name) = self.synchronized.get(name) {
-            // It's OK to call `unwrap_or(false)` here because for fixed `name`
-            // and `value` an error in `self.is_default(name, value)` implies
-            // the same error in `self.system_vars.set(name, value)`.
-            let value = VarInput::Flat(value);
-            let modified = if self.system_vars.is_default(name, value).unwrap_or(false) {
-                self.system_vars.reset(name)
-            } else {
-                self.system_vars.set(name, value)
-            };
-            match modified {
-                Ok(true) => {
-                    self.modified.insert(name);
-                    true
-                }
-                Ok(false) => {
-                    // The value was the same as the current one.
-                    false
-                }
-                Err(e) => {
-                    tracing::error!("cannot modify system parameter {}: {}", name, e);
-                    false
-                }
-            }
+        // It's OK to call `unwrap_or(false)` here because for fixed `name`
+        // and `value` an error in `self.is_default(name, value)` implies
+        // the same error in `self.system_vars.set(name, value)`.
+        let value = VarInput::Flat(value);
+        let modified = if self.system_vars.is_default(name, value).unwrap_or(false) {
+            self.system_vars.reset(name)
         } else {
-            tracing::error!("cannot modify unsynchronized system parameter {}", name);
-            false
+            self.system_vars.set(name, value)
+        };
+
+        match modified {
+            Ok(true) => {
+                // Track modified parameters from the "synchronized" set.
+                if let Some(name) = self.synchronized.get(name) {
+                    self.modified.insert(name);
+                }
+                true
+            }
+            Ok(false) => {
+                // The value was the same as the current one.
+                false
+            }
+            Err(e) => {
+                tracing::error!("cannot modify system parameter {}: {}", name, e);
+                false
+            }
         }
     }
 

--- a/test/launchdarkly/mzcompose.py
+++ b/test/launchdarkly/mzcompose.py
@@ -183,13 +183,15 @@ def workflow_default(c: Composition) -> None:
         assert "stopping system parameter frontend" not in logs.stdout
         # (2) Turn the kill switch on
         sys("ALTER SYSTEM SET enable_launchdarkly=off")
-        sys("ALTER SYSTEM SET max_result_size=1234")
-        # (3) The new value should not be replaced, even after 15 seconds
-        sleep(15)
-        c.testdrive("\n".join(["> SHOW max_result_size", "1234"]))
-        # (4) The logs should report that the frontend was stopped at least once
+        sleep(10)
+        # (3) The logs should report that the frontend was stopped at least once
         logs = c.invoke("logs", "materialized", capture=True)
         assert "stopping system parameter frontend" in logs.stdout
+        # (4) After that, it should be safe to alter a value directly.
+        #     The new value should not be replaced, even after 15 seconds
+        sys("ALTER SYSTEM SET max_result_size=1234")
+        sleep(15)
+        c.testdrive("\n".join(["> SHOW max_result_size", "1234"]))
         # (5) The value should be reset after we turn the kill switch back off
         sys("ALTER SYSTEM SET enable_launchdarkly=on")
         c.testdrive("\n".join(["> SHOW max_result_size", "4294967295"]))


### PR DESCRIPTION
I broke the kill switch behavior after merging #20947, as witnessed by [some failing LaunchDarkly tests on Nightly](https://buildkite.com/materialize/nightlies/builds/3014).


### Motivation

  * This PR fixes a previously unreported bug.

@philip-stoev observed that LaunchDarkly tests on `main` started failing after I merged the one-liner change from #20947.

### Tips for reviewer

* The first commit just rewrites the LaunchDarkly `mzcompose` test to make it a bit more robust against race conditions.
* The second commit actually fixes the bug. See the commit message for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered. [BuildKite custom-triggered tests](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Adont_sync_enable_ld)
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
