### PR TITLE
Remove AWS secrets migration code

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -787,7 +787,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     sc
                 }
                 SecretsControllerKind::AwsSecretsManager => {
-                    let aws_secrets_controller = Arc::new(
+                    Arc::new(
                         runtime.block_on(AwsSecretsController::new(
                             args.environment_id.cloud_provider_region(),
                             // TODO [Alex Hunt] move this to a shared function that can be imported by the
@@ -799,11 +799,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                                 .map(|tag| (tag.key, tag.value))
                                 .collect(),
                         )),
-                    );
-                    // One-time migrate any existing kubernetes secrets
-                    // TODO [Alex Hunt] Remove after all customers have been migrated.
-                    runtime.block_on(aws_secrets_controller.migrate_from(&*orchestrator))?;
-                    aws_secrets_controller
+                    )
                 }
                 SecretsControllerKind::LocalFile => bail!(
                     "SecretsControllerKind::LocalFile is not compatible with Orchestrator::Kubernetes."
@@ -863,7 +859,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                     "SecretsControllerKind::Kubernetes is not compatible with Orchestrator::Process."
                 ),
                 SecretsControllerKind::AwsSecretsManager => {
-                    let aws_secrets_controller = Arc::new(
+                    Arc::new(
                         runtime.block_on(AwsSecretsController::new(
                             args.environment_id.cloud_provider_region(),
                             &aws_secrets_controller_prefix(&args.environment_id),
@@ -873,11 +869,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                                 .map(|tag| (tag.key, tag.value))
                                 .collect(),
                         )),
-                    );
-                    // One-time migrate any existing kubernetes secrets
-                    // TODO [Alex Hunt] Remove after all customers have been migrated.
-                    runtime.block_on(aws_secrets_controller.migrate_from(&*orchestrator))?;
-                    aws_secrets_controller
+                    )
                 }
                 SecretsControllerKind::LocalFile => {
                     let sc = Arc::clone(&orchestrator);


### PR DESCRIPTION
Removes AWS secrets migration code now that all customers have been migrated.

### Motivation

* This PR removes no longer useful code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user facing changes.
