### PR TITLE
Use 'adapter' team instead of 'surfaces' in CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,10 +18,10 @@
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage
 /misc/dbt-materialize               @MaterializeInc/devex
-/src/adapter                        @MaterializeInc/surfaces
+/src/adapter                        @MaterializeInc/adapter
 /src/adapter/src/flags.rs
 /src/alloc                          @benesch
-/src/audit-log                      @MaterializeInc/surfaces
+/src/audit-log                      @MaterializeInc/adapter
 /src/avro                           @umanwizard
 /src/avro-derive                    @umanwizard
 /src/build-id                       @umanwizard
@@ -34,18 +34,18 @@
 /src/compute                        @MaterializeInc/compute
 /src/compute-client                 @MaterializeInc/compute
 /src/controller                     @MaterializeInc/compute @MaterializeInc/storage
-/src/environmentd                   @MaterializeInc/surfaces
+/src/environmentd                   @MaterializeInc/adapter
 /src/expr                           @MaterializeInc/compute
 /src/expr-test-util                 @MaterializeInc/compute
-/src/frontegg-auth                  @MaterializeInc/surfaces
-/src/http-util                      @MaterializeInc/surfaces
+/src/frontegg-auth                  @MaterializeInc/adapter
+/src/http-util                      @MaterializeInc/adapter
 /src/interchange                    @MaterializeInc/storage
 /src/kafka-util                     @MaterializeInc/storage
 /src/kinesis-util                   @MaterializeInc/storage
 /src/lowertest                      @MaterializeInc/compute
 /src/lowertest-derive               @MaterializeInc/compute
 /src/metabase                       @benesch
-/src/mz                             @MaterializeInc/surfaces @MaterializeInc/devex
+/src/mz                             @MaterializeInc/adapter @MaterializeInc/devex
 /src/npm                            @benesch
 /src/orchestrator                   @benesch
 /src/orchestrator-kubernetes        @benesch
@@ -55,10 +55,10 @@
 /src/persist                        @MaterializeInc/persist
 /src/persist-client                 @MaterializeInc/persist
 /src/persist-types                  @MaterializeInc/persist
-/src/pgcopy                         @MaterializeInc/surfaces
-/src/pgrepr                         @MaterializeInc/surfaces
-/src/pgtest                         @MaterializeInc/surfaces
-/src/pgwire                         @MaterializeInc/surfaces
+/src/pgcopy                         @MaterializeInc/adapter
+/src/pgrepr                         @MaterializeInc/adapter
+/src/pgtest                         @MaterializeInc/adapter
+/src/pgwire                         @MaterializeInc/adapter
 /src/pid-file                       @benesch
 /src/postgres-util                  @MaterializeInc/storage
 /src/prof                           @umanwizard
@@ -71,20 +71,20 @@
 /src/secrets                        @MaterializeInc/cloud
 /src/segment                        @benesch
 /src/service                        @MaterializeInc/storage @MaterializeInc/compute
-/src/sql                            @MaterializeInc/surfaces
+/src/sql                            @MaterializeInc/adapter
 /src/sql/src/session/vars.rs
 # HirRelationExpr is the boundary between the `sql` crate and the compute
 # layer, and is jointly owned by the two teams.
-/src/sql/src/plan/expr.rs           @MaterializeInc/surfaces @MaterializeInc/compute
+/src/sql/src/plan/expr.rs           @MaterializeInc/adapter @MaterializeInc/compute
 # The lowering of HirRelationExpr to MirRelationExpr is part of the compute
 # layer, despite being located in the `sql` crate.
 /src/sql/src/plan/lowering.rs       @MaterializeInc/compute
-/src/sql-lexer                      @MaterializeInc/surfaces
-/src/sql-parser                     @MaterializeInc/surfaces
-/src/sqllogictest                   @MaterializeInc/surfaces
+/src/sql-lexer                      @MaterializeInc/adapter
+/src/sql-parser                     @MaterializeInc/adapter
+/src/sqllogictest                   @MaterializeInc/adapter
 /src/ssh-util                       @MaterializeInc/storage
-/src/stash                          @MaterializeInc/surfaces
-/src/stash-debug                    @MaterializeInc/surfaces
+/src/stash                          @MaterializeInc/adapter
+/src/stash-debug                    @MaterializeInc/adapter
 /src/storage                        @MaterializeInc/storage
 /src/storage-client                 @MaterializeInc/storage
 /src/test-macro                     @MaterializeInc/qa


### PR DESCRIPTION
 so that reviews are assigned to just the adapter sub-team.
The adapter team already has round-robin auto assignment set up for PRs.

Replaced all assignments to @MaterializeInc/surfaces with @MaterializeInc/adapter .

Will wait until Monday to merge, when the whole team is in office.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
