### PR TITLE
[doc/user] Clarify insert select limitations

### DIFF
--- a/doc/user/content/sql/insert.md
+++ b/doc/user/content/sql/insert.md
@@ -33,7 +33,7 @@ The optional `RETURNING` clause causes `INSERT` to return values based on each i
 
 ### Known limitations
 
-* `INSERT ... SELECT` can reference [user-created tables](../create-table) but not [sources](../create-source).
+* `INSERT ... SELECT` can reference [user-created tables](../create-table) but not [sources](../create-source) _(or views, materialized views, and indexes that depend on sources)_.
 * **Low performance.** While processing an `INSERT ... SELECT` statement,
   Materialize cannot process other `INSERT`, `UPDATE`, or `DELETE` statements.
 


### PR DESCRIPTION
There is currently a limitation that prevents users from executing 

```sql
INSERT INTO my_table (cols) SELECT cols FROM <ANYTHING_THAT_READS_FROM_A_SOURCE>;
```

and the wording of this line in the docs:
>  `INSERT ... SELECT` can reference [user-created tables](../create-table) but not [sources](../create-source).

 tripped [a user](https://materializecommunity.slack.com/archives/C015KDVS7EV/p1691105465598029) up by making it seem like only SOURCES were an issue. 