### PR TITLE
platform-checks: Fix the managed cluster scenarios (take #2)

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -116,7 +116,7 @@ class ConfigureMz(MzcomposeAction):
         if (
             MzVersion.parse("0.58.0-dev")
             <= e.current_mz_version
-            <= MzVersion.parse("0.63.0-dev")
+            <= MzVersion.parse("0.63.99")
         ):
             system_settings.add("ALTER SYSTEM SET enable_managed_clusters = on;")
 


### PR DESCRIPTION
The enable_managed_clusters statement needs to run on v0.63.* as well.

Relates to #20399

### Motivation

Nightly CI kept failing.