### PR TITLE
adapter: allow ALTER and DROP in single stmt txns

### DIFF
--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -775,3 +775,27 @@ SELECT 1
 
 statement ok
 ROLLBACK
+
+# Test ALTER and DROP which go through separate paths to determine the correct response.
+statement ok
+BEGIN
+
+statement ok
+ALTER SOURCE s RENAME TO v
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+DROP SOURCE v
+
+statement ok
+COMMIT
+
+simple
+SHOW SOURCES
+----
+COMPLETE 0


### PR DESCRIPTION
These previously did not work because of the inner `ObjectType` enum that prevented an unambiguous ExecuteResponse being created from a Plan. Add some extra logic that checks a statement directly and is able to generate ExecuteResponses from those.

Fixes #20959

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow `DROP` and `ALTER` in explicit single-statement transactions.