### PR TITLE
Window functions vs. `CASE WHEN`

### DIFF
--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -63,6 +63,8 @@ ORDER BY -2*a;
 0
 
 # This looks a bit weird if we compare it with the previous two tests, but Postgres does the same
+# See https://www.postgresql.org/docs/current/queries-order.html
+# "Note that an output column name has to stand alone, that is, it cannot be used in an expression"
 query error db error: ERROR: column "d" does not exist
 SELECT 2*a as d
 FROM foo

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -45,9 +45,158 @@ SELECT a + 1 FROM foo ORDER BY a + 1
 3
 
 query I nosort
+SELECT 2*a as d
+FROM foo
+ORDER BY d;
+----
+0
+2
+4
+
+query I nosort
+SELECT 2*a as d
+FROM foo
+ORDER BY -2*a;
+----
+4
+2
+0
+
+# This looks a bit weird if we compare it with the previous two tests, but Postgres does the same
+query error db error: ERROR: column "d" does not exist
+SELECT 2*a as d
+FROM foo
+ORDER BY -d;
+
+query I nosort
 SELECT sum(a) FROM foo ORDER BY sum(a)
 ----
 3
+
+query error db error: ERROR: column "foo\.a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT a FROM foo ORDER BY sum(a);
+
+query error db error: ERROR: column "foo\.a" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT sum(a) FROM foo ORDER BY a;
+
+query error db error: ERROR: column "foo\.b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT sum(a) FROM foo ORDER BY sum(a), b;
+
+query error db error: ERROR: column "foo\.b" must appear in the GROUP BY clause or be used in an aggregate function
+SELECT sum(a), b FROM foo ORDER BY sum(a), b;
+
+query I nosort
+SELECT sum(a)
+FROM foo
+GROUP BY b
+ORDER BY sum(a), b;
+----
+0
+1
+2
+
+query I nosort
+SELECT sum(a)
+FROM foo
+GROUP BY b
+ORDER BY -sum(a), b;
+----
+2
+1
+0
+
+query I nosort
+SELECT right_a
+FROM foo LEFT JOIN (SELECT a as right_a FROM foo WHERE a<2) ON foo.a = right_a
+GROUP BY b, right_a
+ORDER BY -right_a, -sum(foo.a), b;
+----
+1
+0
+NULL
+
+query IIT nosort
+SELECT lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), -sum(foo.a), b
+FROM foo LEFT JOIN (SELECT a as right_a FROM foo WHERE a<2) ON foo.a = right_a
+GROUP BY b, right_a
+ORDER BY lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), -sum(foo.a), b;
+----
+3  -1  one
+NULL  -2  two
+NULL  0  zero
+
+query IT nosort
+SELECT -sum(foo.a), b
+FROM foo LEFT JOIN (SELECT a as right_a FROM foo WHERE a<2) ON foo.a = right_a
+GROUP BY b, right_a
+ORDER BY lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), -sum(foo.a), b;
+----
+-1  one
+-2  two
+0  zero
+
+query IIT nosort
+SELECT lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), sum(foo.a), length(b)
+FROM foo LEFT JOIN (SELECT a as right_a FROM foo WHERE a<2) ON foo.a = right_a
+GROUP BY b, right_a
+ORDER BY lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), -sum(foo.a)/10, length(b) DESC NULLS FIRST;
+----
+3  1  3
+NULL  0  4
+NULL  2  3
+
+query I nosort
+SELECT 10-sum(a)
+FROM foo
+GROUP BY b
+ORDER BY 1;
+----
+8
+9
+10
+
+query error db error: ERROR: column reference 2 in ORDER BY clause is out of range \(1 \- 1\)
+SELECT 10-sum(a)
+FROM foo
+GROUP BY b
+ORDER BY 2;
+
+query II nosort
+SELECT 10-sum(a), lag(sum(a)) OVER (ORDER BY sum(a))
+FROM foo
+GROUP BY b
+ORDER BY 2;
+----
+9  0
+8  1
+10  NULL
+
+query error db error: ERROR: column reference 3 in ORDER BY clause is out of range \(1 \- 2\)
+SELECT 10-sum(a), lag(sum(a)) OVER (ORDER BY sum(a))
+FROM foo
+GROUP BY b
+ORDER BY 3;
+
+query II
+SELECT a, lag(a) OVER (ORDER BY a) as d
+FROM foo
+ORDER BY d;
+----
+1  0
+2  1
+0  NULL
+
+# When an ORDER BY refers to an output column name, the column name can't be part of a bigger expression.
+# (This is the same in Postgres.)
+query error db error: ERROR: column "d" does not exist
+SELECT a, lag(a) OVER (ORDER BY a) as d
+FROM foo
+ORDER BY -d;
+
+query error db error: ERROR: column "d" does not exist
+SELECT a, 2*a as d
+FROM foo
+ORDER BY lag(d) OVER (ORDER BY d);
 
 query I nosort
 SELECT a FROM foo ORDER BY (0-a)

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -4921,3 +4921,822 @@ FROM t5
 GROUP BY f1
 ----
 1 NULL
+
+# Check some HIR plans to verify that the lifting of window functions to the top of Maps is actually happening.
+
+statement ok
+CREATE TABLE foo (
+    a int,
+    b text
+);
+
+statement ok
+INSERT INTO foo (a, b) VALUES (0, 'zero'), (1, 'one'), (2, 'two'), (3, 'three');
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT 3 + lag(a) OVER (ORDER BY a) + 5 + 27
+FROM foo;
+----
+Project (#3)
+  Map (lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), (((3 + #2) + 5) + 27))
+    Get materialize.public.foo
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT -lag(10*right_a+3) OVER (ORDER BY right_a NULLS FIRST), -sum(foo.a), b
+FROM foo LEFT JOIN (SELECT a AS right_a FROM foo WHERE a<2) ON foo.a = right_a
+GROUP BY b, right_a;
+----
+Project (#4, #5, #0)
+  Map (lag(row(((10 * #1) + 3), 1, null)) over (order by [#1 asc nulls_first]), -(#3), -(#2))
+    Reduce group_by=[#3, #4] aggregates=[sum(#0)]
+      Map (#1, #2)
+        LeftOuterJoin (#0 = #2)
+          Get materialize.public.foo
+          Project (#0)
+            Filter (#0 < 2)
+              Get materialize.public.foo
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT 3 + lag(a) OVER (ORDER BY a) AS o
+FROM foo
+ORDER BY o;
+----
+Finish order_by=[#0 asc nulls_last] output=[#0]
+  Project (#3)
+    Map (lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), (3 + #2))
+      Get materialize.public.foo
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT
+  a,
+  3 + lag(a) OVER (ORDER BY a),
+  3 + lag(a) OVER (ORDER BY a),
+  lag(a) OVER (ORDER BY a),
+  lead(a) OVER (ORDER BY a),
+  5 + lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+Finish order_by=[#0 asc nulls_last] output=[#0..=#5]
+  Project (#0, #4, #4, #2, #3, #5)
+    Map (lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), lead(row(#0, 1, null)) over (order by [#0 asc nulls_last]), (3 + #2), (5 + #2))
+      Get materialize.public.foo
+
+EOF
+
+query IIIIII nosort
+SELECT
+  a,
+  3 + lag(a) OVER (ORDER BY a),
+  3 + lag(a) OVER (ORDER BY a),
+  lag(a) OVER (ORDER BY a),
+  lead(a) OVER (ORDER BY a),
+  5 + lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  NULL  NULL  NULL  1  NULL
+1  3  3  0  2  5
+2  4  4  1  3  6
+3  5  5  2  NULL  7
+
+# Two window function calls in the same HirScalarExpr, but both calls are the same
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT a, b, lag(a) OVER (ORDER BY a) + lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
+  Project (#0, #1, #3)
+    Map (lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), (#2 + #2))
+      Get materialize.public.foo
+
+EOF
+
+query ITI nosort
+SELECT a, b, lag(a) OVER (ORDER BY a) + lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  0
+2  two  2
+3  three  4
+
+# Two window function calls in the same HirScalarExpr, and they are different
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT a, b, lag(a) OVER (ORDER BY a) + lead(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
+  Project (#0, #1, #4)
+    Map (lead(row(#0, 1, null)) over (order by [#0 asc nulls_last]), lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), (#3 + #2))
+      Get materialize.public.foo
+
+EOF
+
+query ITI nosort
+SELECT a, b, lag(a) OVER (ORDER BY a) + lead(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  2
+2  two  4
+3  three  NULL
+
+# Window function in DISTINCT ON
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT DISTINCT ON(1 + lag(a, 1, 0) OVER (ORDER BY a)) *
+FROM foo;
+----
+Project (#0, #1)
+  TopK group_by=[#3] limit=1
+    Map (lag(row(#0, 1, 0)) over (order by [#0 asc nulls_last]), (1 + #2))
+      Get materialize.public.foo
+
+EOF
+
+query IIT
+SELECT 1 + lag(a, 1, 0) OVER (ORDER BY a), *
+FROM foo;
+----
+1  1  one
+2  2  two
+1  0  zero
+3  3  three
+
+query IT
+SELECT DISTINCT ON(1 + lag(a, 1, 0) OVER (ORDER BY a)) *
+FROM foo;
+----
+2  two
+0  zero
+3  three
+
+query IIT nosort
+SELECT 1 + lag(a, 1, 0) OVER (ORDER BY a), *
+FROM foo
+ORDER BY 1 + lag(a, 1, 0) OVER (ORDER BY a), a ASC;
+----
+1  0  zero
+1  1  one
+2  2  two
+3  3  three
+
+query IT nosort
+SELECT DISTINCT ON(1 + lag(a, 1, 0) OVER (ORDER BY a)) *
+FROM foo
+ORDER BY 1 + lag(a, 1, 0) OVER (ORDER BY a), a ASC;
+----
+0  zero
+2  two
+3  three
+
+query error db error: ERROR: SELECT DISTINCT ON expressions must match initial ORDER BY expressions
+SELECT DISTINCT ON(1 + lag(a, 1, 0) OVER (ORDER BY a)) *
+FROM foo
+ORDER BY lag(a, 1, 0) OVER (ORDER BY a), a DESC;
+
+query IIIT nosort
+SELECT 1 + lag(a, 1, 0) OVER (ORDER BY a), lead(a) OVER (ORDER BY b) AS o, a, b
+FROM foo
+ORDER BY 1 + lag(a, 1, 0) OVER (ORDER BY a), o DESC;
+----
+1  NULL  0  zero
+1  3  1  one
+2  0  2  two
+3  2  3  three
+
+query IIT nosort
+SELECT DISTINCT ON(1 + lag(a, 1, 0) OVER (ORDER BY a)) lead(a) OVER (ORDER BY b) AS o, a, b
+FROM foo
+ORDER BY 1 + lag(a, 1, 0) OVER (ORDER BY a), o DESC;
+----
+NULL  0  zero
+0  2  two
+2  3  three
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT DISTINCT ON(5 + lag(a) OVER (ORDER BY a)) lead(a) OVER (ORDER BY b) AS o
+FROM foo
+ORDER BY 5 + lag(a) OVER (ORDER BY a), o;
+----
+Finish order_by=[#4 asc nulls_last, #3 asc nulls_last] output=[#3]
+  TopK group_by=[#4] order_by=[#3 asc nulls_last] limit=1
+    Map (lag(row(#0, 1, null)) over (order by [#0 asc nulls_last]), lead(row(#0, 1, null)) over (order by [#1 asc nulls_last]), (5 + #2))
+      Get materialize.public.foo
+
+EOF
+
+# Nested window function call in the argument of a window function call (Postgres doesn't allow this, but we do)
+
+query ITI nosort
+SELECT a, b, lag(lag(a) OVER (ORDER BY a)) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  0
+3  three  1
+
+query ITI nosort
+SELECT a, b, lag(lag(a) OVER (PARTITION BY length(b) ORDER BY a)) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  NULL
+3  three  1
+
+# The inner window function call also appears outside
+
+query ITII nosort
+SELECT a, b, lag(lag(a) OVER (ORDER BY a)) OVER (ORDER BY a), lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL  NULL
+1  one  NULL  0
+2  two  0  1
+3  three  1  2
+
+query ITII nosort
+SELECT a, b, lag(a) OVER (ORDER BY a), lag(lag(a) OVER (ORDER BY a)) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL  NULL
+1  one  0  NULL
+2  two  1  0
+3  three  2  1
+
+# Nested window function call in the PARTITION BY of a window function call (Postgres doesn't allow this, but we do)
+
+query ITII nosort
+SELECT a, b, lag(a) OVER (PARTITION BY lag(length(b)) OVER (ORDER BY a) ORDER BY a), lag(length(b)) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL  NULL
+1  one  NULL  4
+2  two  NULL  3
+3  three  2  3
+
+query ITI nosort
+SELECT a, b, lag(a) OVER (PARTITION BY lag(length(b)) OVER (ORDER BY a) ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  NULL
+3  three  2
+
+query ITII nosort
+SELECT a, b, row_number() OVER (PARTITION BY lag(length(b)) OVER (ORDER BY a) ORDER BY a), lag(length(b)) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  1  NULL
+1  one  1  4
+2  two  1  3
+3  three  2  3
+
+# Nested window function calls in both the argument and the PARTITION BY of a window function call (Postgres doesn't
+# allow this, but we do)
+
+query ITI nosort
+SELECT a, b, lead(lag(a) OVER (PARTITION BY lag(length(b)) OVER (ORDER BY a) ORDER BY a), 1, -5) OVER (ORDER BY a)
+FROM foo
+ORDER BY a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  2
+3  three  -5
+
+# Nested window function calls in the ORDER BY of a window function call (Postgres doesn't allow this, but we do)
+
+query ITII nosort
+SELECT a, b, lag(a) OVER (ORDER BY lag(a) OVER (ORDER BY a)), lag(a) OVER (ORDER BY a)
+FROM foo
+ORDER BY lag(a) OVER (ORDER BY a);
+----
+1  one  NULL  0
+2  two  1  1
+3  three  2  2
+0  zero  3  NULL
+
+query ITI
+SELECT a, b, lag(a) OVER (ORDER BY lag(a) OVER (ORDER BY a))
+FROM foo;
+----
+1  one  NULL
+2  two  1
+0  zero  3
+3  three  2
+
+# Window function inside CASE WHEN
+# Regression test for https://github.com/MaterializeInc/materialize/issues/20746
+
+statement ok
+CREATE TABLE bools(cond bool, x int);
+
+statement ok
+INSERT INTO bools VALUES (true, 0), (false, 1), (false, 2);
+
+# The window function call should be lifted outside of the If
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT
+  cond,
+  x,
+  CASE
+    WHEN cond THEN
+      first_value(x) OVER (ORDER BY x DESC)
+    ELSE
+      42
+    END
+FROM bools;
+----
+Project (#0, #1, #3)
+  Map (first_value(#1) over (order by [#1 desc nulls_first]), case when #0 then #2 else 42 end)
+    Get materialize.public.bools
+
+EOF
+
+query TII
+SELECT
+  cond,
+  x,
+  CASE
+    WHEN cond THEN
+      first_value(x) OVER (ORDER BY x DESC)
+    ELSE
+      42
+    END
+FROM bools;
+----
+false  1  42
+false  2  42
+true  0  2
+
+statement ok
+CREATE TABLE tcm(
+  chat_id int,
+  chat_message_id int,
+  message_tstamp date,
+  xxx_id int,
+  first_xxx_id int,
+  user_id int,
+  boolean_flag bool
+);
+
+statement ok
+INSERT INTO tcm VALUES
+  (
+    5814889,
+    78687406,
+    '2023-08-04'::DATE,
+    11111111,
+    null,
+    22222221,
+    true
+  ),
+  (
+    5814889,
+    78707836,
+    '2023-08-05'::DATE,
+    11111112,
+    923095,
+    22222222,
+    false
+  ),
+  (
+    5814889,
+    78708445,
+    '2023-08-06'::DATE,
+    11111113,
+    743482,
+    22222223,
+    false
+  ),
+  (
+    581488900,
+    78687406,
+    '2023-08-04'::DATE,
+    11111111,
+    null,
+    22222221,
+    true
+  ),
+  (
+    581488900,
+    78707836,
+    '2023-08-05'::DATE,
+    11111112,
+    923095,
+    22222222,
+    false
+  ),
+  (
+    581488900,
+    78708445,
+    '2023-08-06'::DATE,
+    11111113,
+    743482,
+    22222223,
+    true
+  );
+
+query IITIIIIT nosort
+SELECT
+  tcm.chat_id AS chat_id,
+  tcm.chat_message_id AS chat_message_id,
+  tcm.message_tstamp AS message_tstamp,
+  tcm.first_xxx_id AS first_xxx_id,
+  lead(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp) AS _lead,
+  lag(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp) AS _lag,
+  CASE
+    WHEN tcm.boolean_flag THEN
+      coalesce(
+          lead(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp),
+          lag(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp),
+          tcm.xxx_id
+      )
+    ELSE tcm.user_id end AS xxx_id,
+  tcm.boolean_flag AS boolean_flag
+FROM tcm
+ORDER BY chat_id, message_tstamp;
+----
+5814889  78687406  2023-08-04  NULL  923095  NULL  923095  true
+5814889  78707836  2023-08-05  923095  743482  NULL  22222222  false
+5814889  78708445  2023-08-06  743482  NULL  923095  22222223  false
+581488900  78687406  2023-08-04  NULL  923095  NULL  923095  true
+581488900  78707836  2023-08-05  923095  743482  NULL  22222222  false
+581488900  78708445  2023-08-06  743482  NULL  923095  923095  true
+
+query IITIIT nosort
+SELECT
+  tcm.chat_id AS chat_id,
+  tcm.chat_message_id AS chat_message_id,
+  tcm.message_tstamp AS message_tstamp,
+  tcm.first_xxx_id AS first_xxx_id,
+  CASE
+    WHEN tcm.boolean_flag THEN
+      coalesce(
+          lead(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp),
+          lag(tcm.first_xxx_id) ignore nulls over (partition by tcm.chat_id order by tcm.message_tstamp),
+          tcm.xxx_id
+      )
+    ELSE tcm.user_id end AS xxx_id,
+  tcm.boolean_flag AS boolean_flag
+FROM tcm
+ORDER BY chat_id, message_tstamp;
+----
+5814889  78687406  2023-08-04  NULL  923095  true
+5814889  78707836  2023-08-05  923095  22222222  false
+5814889  78708445  2023-08-06  743482  22222223  false
+581488900  78687406  2023-08-04  NULL  923095  true
+581488900  78707836  2023-08-05  923095  22222222  false
+581488900  78708445  2023-08-06  743482  923095  true
+
+# Window func with (non-windowed) aggregations
+
+query error db error: ERROR: window functions are not allowed in aggregate function \(function pg_catalog\.lag\)
+EXPLAIN RAW PLAN FOR
+SELECT sum(lag(a) OVER ())
+FROM foo;
+
+query III nosort
+SELECT length(b), sum(a), lag(sum(a)) OVER (ORDER BY sum(a))
+FROM foo
+GROUP BY length(b)
+ORDER BY sum(a), length(b);
+----
+4  0  NULL
+3  3  0
+5  3  3
+
+query III nosort
+SELECT length(b), sum(a), lag(sum(a)) OVER (ORDER BY length(b))
+FROM foo
+GROUP BY length(b)
+ORDER BY length(b);
+----
+3  3  NULL
+4  0  3
+5  3  0
+
+query III
+(SELECT length(b), sum(a), lag(sum(a)) OVER (ORDER BY sum(a))
+ FROM foo
+ GROUP BY length(b))
+UNION
+(SELECT length(b), sum(a), lag(sum(a)) OVER (ORDER BY length(b))
+ FROM foo
+ GROUP BY length(b));
+----
+3  3  NULL
+4  0  NULL
+3  3  0
+4  0  3
+5  3  0
+5  3  3
+
+query IIII nosort
+SELECT *, row_number() OVER (PARTITION BY len ORDER BY sum DESC, lag NULLS FIRST) as row_num FROM (
+    (SELECT length(b) AS len, sum(a) AS sum, lag(sum(a)) OVER (ORDER BY sum(a)) AS lag
+     FROM foo
+     GROUP BY length(b))
+    UNION
+    (SELECT length(b), -1 + sum(a) + row_number() OVER (ORDER BY length(b)), lag(sum(a)) OVER (ORDER BY length(b))
+     FROM foo
+     GROUP BY length(b))
+) AS sq
+ORDER BY len, row_num;
+----
+3  3  NULL  1
+3  3  0  2
+4  1  3  1
+4  0  NULL  2
+5  5  0  1
+5  3  3  2
+
+## Subqueries
+
+# Correlated scalar subquery in the 2nd argument of lag
+query ITI nosort
+SELECT *,
+    lag(
+        outer_a,
+        (SELECT count(*) FROM foo WHERE length(b) = length(outer_b))::integer
+    ) OVER (ORDER BY outer_a)
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  0
+3  three  2
+
+# Add a correlated IN subquery at the 3rd argument of lag
+query ITI nosort
+SELECT *,
+    lag(
+        outer_a,
+        (SELECT count(*) FROM foo WHERE length(b) = length(outer_b))::integer,
+        CASE WHEN outer_a - 1 IN (SELECT a FrOM foo) THEN 100 ELSE 500 END
+    ) OVER (ORDER BY outer_a)
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  500
+1  one  100
+2  two  0
+3  three  2
+
+# Correlated subquery in the PARTITION BY.
+# The same subquery is also present in the SELECT to make the output more human-friendly.
+query IITI nosort
+SELECT (SELECT count(*) FROM foo WHERE length(b) = length(outer_b)) as part, *,
+    lag(outer_a) OVER (
+        PARTITION BY (SELECT count(*) FROM foo WHERE length(b) = length(outer_b))
+        ORDER BY outer_a
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY part, outer_a;
+----
+1  0  zero  NULL
+1  3  three  0
+2  1  one  NULL
+2  2  two  1
+
+# Same query as the previous, but the subquery is not present in the SELECT
+query ITI nosort
+SELECT *,
+    lag(outer_a) OVER (
+        PARTITION BY (SELECT count(*) FROM foo WHERE length(b) = length(outer_b))
+        ORDER BY outer_a
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  NULL
+1  one  NULL
+2  two  1
+3  three  0
+
+# Correlated subquery in the ORDER BY of a window function.
+# The same subquery is also present in the SELECT to make the output more human-friendly.
+query IITI nosort
+SELECT (SELECT count(*) FROM foo WHERE length(outer_b) > a + 2) as ord, *,
+    lag(outer_a) OVER (
+        ORDER BY (SELECT count(*) FROM foo WHERE length(outer_b) > a + 2), outer_a
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY ord, outer_a;
+----
+1  1  one  NULL
+1  2  two  1
+2  0  zero  2
+3  3  three  0
+
+# Same query as the previous, but the subquery is not present in the SELECT
+query ITI nosort
+SELECT *,
+    lag(outer_a) OVER (
+        ORDER BY (SELECT count(*) FROM foo WHERE length(outer_b) > a + 2), outer_a
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  2
+1  one  NULL
+2  two  1
+3  three  0
+
+# Window func in a correlated subquery, but the correlating column reference is outside the window function
+query ITI nosort
+SELECT *,
+    (
+        SELECT sum(lead_a)
+        FROM (
+            SELECT lead(a) OVER (ORDER BY a) AS lead_a
+            FROM foo
+            WHERE a <= outer_a AND a < 3
+        ) as fsq2
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  NULL
+1  one  1
+2  two  3
+3  three  3
+
+# Similar to the previous one, but more window functions and aggregations
+query ITI nosort
+SELECT *,
+    (
+        SELECT sum(2 * w) + max(w)
+        FROM (
+            SELECT lead(a) OVER (ORDER BY a) + row_number() OVER (ORDER BY a) AS w
+            FROM foo
+            WHERE a <= outer_a AND a < 3
+        ) as fsq2
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  NULL
+1  one  6
+2  two  16
+3  three  16
+
+# Window func in a correlated subquery, and the window function argument refers to the outer query
+query ITI nosort
+SELECT *,
+    (
+        SELECT sum(lead_a)
+        FROM (
+            SELECT lead(outer_a + a) OVER (ORDER BY a) AS lead_a
+            FROM foo
+        ) as fsq2
+    )
+FROM (
+    SELECT a AS outer_a, b AS outer_b
+    FROM foo
+) as fsq
+ORDER BY outer_a;
+----
+0  zero  6
+1  one  9
+2  two  12
+3  three  15
+
+# Window func in a correlated subquery, and the window function's PARTITION BY refers to the outer query
+query ITI
+SELECT *,
+    (
+        SELECT sum(lead_a)
+        FROM (
+            SELECT 3 + lead(a) OVER (PARTITION BY 4 * a / (outer_a + length(outer_b)) ORDER BY a) AS lead_a
+            FROM foo
+        ) as fsq2
+    )
+FROM (
+    (SELECT a AS outer_a, b AS outer_b
+     FROM foo)
+    UNION
+    (SELECT a + 2 AS outer_a, b AS outer_b
+     FROM foo)
+    UNION
+    (SELECT a + 5 AS outer_a, b AS outer_b
+     FROM foo)
+) as fsq
+ORDER BY outer_a, outer_b;
+----
+0  zero  NULL
+1  one  NULL
+2  two  4
+2  zero  4
+3  one  4
+3  three  10
+4  two  10
+5  three  9
+5  zero  9
+6  one  9
+7  two  9
+8  three  15
+
+# Let's check the HIR plan for the above query to see if the window function is lifted out from behind the `3 +`
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT *,
+    (
+        SELECT sum(lead_a)
+        FROM (
+            SELECT 3 + lead(a) OVER (PARTITION BY 4 * a / (outer_a + length(outer_b)) ORDER BY a) AS lead_a
+            FROM foo
+        ) as fsq2
+    )
+FROM (
+    (SELECT a AS outer_a, b AS outer_b
+     FROM foo)
+    UNION
+    (SELECT a + 2 AS outer_a, b AS outer_b
+     FROM foo)
+    UNION
+    (SELECT a + 5 AS outer_a, b AS outer_b
+     FROM foo)
+) as fsq
+ORDER BY outer_a, outer_b;
+----
+Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#2]
+  Return
+    Map (select(Get l1))
+      Distinct
+        Union
+          Distinct
+            Union
+              Get materialize.public.foo
+              Project (#2, #1)
+                Map ((#0 + 2))
+                  Get materialize.public.foo
+          Project (#2, #1)
+            Map ((#0 + 5))
+              Get materialize.public.foo
+  With
+    cte l1 =
+      Reduce aggregates=[sum(#0)]
+        Project (#3)
+          Map (lead(row(#0, 1, null)) over (partition by [((4 * #0) / (#^0 + char_length(#^1)))] order by [#0 asc nulls_last]), (3 + #2))
+            Get materialize.public.foo
+
+EOF


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/20746 by approach 4. in the issue description. Later, I will  change this to approach 5. in a separate PR, but I would like to finish my window aggregations work first to avoid merge  conflicts with my window aggregations WIP branch.

It also adds a gazillion tests.

I have not yet added test queries that have both window functions and table functions. We'll need to do that as part of fixing https://github.com/MaterializeInc/materialize/issues/20979.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/20746

### Tips for reviewer

@mjibson, Could you please check the `type_as_any` call that I added? I'm not sure I completely understand this type coercion stuff.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
