### PR TITLE
adapter: fix `auto_run_on_introspection` for `EXPLAIN` plans

### DIFF
--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -239,7 +239,7 @@ http
 {"query":"EXPLAIN SELECT 1"}
 ----
 200 OK
-{"results":[{"tag":"SELECT 1","rows":[["Explained Query (fast path):\n  Constant\n    - (1)\n"]],"desc":{"columns":[{"name":"Optimized Plan","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[]}]}
+{"results":[{"tag":"SELECT 1","rows":[["Explained Query (fast path):\n  Constant\n    - (1)\n"]],"desc":{"columns":[{"name":"Optimized Plan","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[{"message":"query was automatically run on the \"mz_introspection\" cluster","severity":"debug"}]}]}
 
 http
 {"query":"SHOW VIEWS"}

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -1785,10 +1785,14 @@ impl MirRelationExpr {
         (size, max_depth)
     }
 
-    /// The MirRelationExpr is considered potentially expensive if and only if at least one of the
-    ///  following conditions is true:
+    /// The MirRelationExpr is considered potentially expensive if and only if
+    /// at least one of the following conditions is true:
+    ///
     ///  - It contains at least one FlatMap or a Reduce operator.
     ///  - It contains at least one MirScalarExpr with a function call.
+    ///
+    /// !!!WARNING!!!: this method has an HirRelationExpr counterpart. The two
+    /// should be kept in sync w.r.t. HIR ⇒ MIR lowering!
     pub fn could_run_expensive_function(&self) -> bool {
         let mut result = false;
         self.visit_pre(&mut |e: &MirRelationExpr| {
@@ -2020,6 +2024,8 @@ pub fn non_nullable_columns(predicates: &[MirScalarExpr]) -> BTreeSet<usize> {
 }
 
 impl CollectionPlan for MirRelationExpr {
+    // !!!WARNING!!!: this method has an MirRelationExpr counterpart. The two
+    // should be kept in sync w.r.t. HIR ⇒ MIR lowering!
     fn depends_on_into(&self, out: &mut BTreeSet<GlobalId>) {
         if let MirRelationExpr::Get {
             id: Id::Global(id), ..

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -71,6 +71,19 @@ Explained Query (fast path):
 
 EOF
 
+# Test introspection queries (index found based on cluster auto-routing).
+query T multiline
+EXPLAIN SELECT * FROM mz_internal.mz_source_status_history
+----
+Explained Query (fast path):
+  Project (#1, #0, #2..=#4)
+    ReadExistingIndex mz_internal.mz_source_status_history_ind
+
+Used Indexes:
+  - mz_internal.mz_source_status_history_ind
+
+EOF
+
 # Test basic linear chains (fast path).
 query T multiline
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -396,10 +396,12 @@ Explained Query:
               Map ("materialized-view") // { arity: 9 }
                 Get mz_catalog.mz_materialized_views // { arity: 8 }
 
-Source mz_catalog.mz_views
-  filter=(true)
 Source mz_catalog.mz_materialized_views
   filter=(true)
+
+Used Indexes:
+  - mz_internal.mz_show_schemas_ind
+  - mz_internal.mz_show_views_ind
 
 EOF
 

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -113,7 +113,7 @@ contains:cannot modify linked cluster "materialize_public_lg1"
 contains:cannot execute queries on cluster containing sources or sinks
 ! SUBSCRIBE v
 contains:cannot execute queries on cluster containing sources or sinks
-! EXPLAIN SELECT 1
+! EXPLAIN SELECT * FROM v
 contains:cannot execute queries on cluster containing sources or sinks
 > SET cluster = default
 


### PR DESCRIPTION
The `auto_run_on_introspection` method is missing a case for `EXPLAIN` plans consistent with the `SELECT` handling. Consequently, the `EXPLAIN` output for introspection queries does not consider indexes that are actually picked up during the actual execution.

Most probably this was introduced in #20372, but I didn't catch this when I was reviewing that PR.

### Motivation

  * This PR fixes a recognized bug.

The specific issue was reported by @benesch this morning.

More generally, this an instance of #18089 where the `SELECT` path (which is the only one that we try to faithfully mirror at the moment) diverged between `sequence_peek` and `sequence_explain_plan`.

### Tips for reviewer

The first PR fixes the issue, by adding a `Plan::Explain` case to `auto_run_on_introspection`. Note that due to the somewhat awkward boundary between the planner and the coordinator (all `Plan` variants except `Explain` wrap `Mir~` expressions), I had to re-define code that is currently defined for `MirRelationExpr` terms to `HirRelationExpr`. For faithful results, the two implementations should always be kept in sync. I've added comments on the corresponding `Hir~` and `Mir~` code to highlight this.

The second adds a test to the `explain/optimized_plan_as_text.slt` file.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - `EXPLAIN` output for `SELECT` queries that can be auto-routed to the `mz_introspection` cluster now reflects the indexes available in that cluster.
