### PR TITLE
Consolidate after a Union that has a Negated input

### DIFF
--- a/doc/developer/design/20230728_left_join_stack_consolidation.md
+++ b/doc/developer/design/20230728_left_join_stack_consolidation.md
@@ -128,6 +128,8 @@ How `consolidate` works is that it buffers up some data before it actually conso
 
 The total effect of the feature on memory usage will still be beneficial, as the unconsolidated records are currently consolidated several times when they go into joins (e.g., the 2 unconsolidated records coming from `l1` are currently consolidated both when forming the arrangement for the join in `l2` and also similarly in `l4`). One situation when we might have a net increase in memory usage is when there is only one LEFT JOIN, and there are no other operators downstream that would benefit from a consolidation, but this is probably not so common. Another situation when the consolidation is not helping much is if most records from the left side of a LEFT JOIN don't have a match on the right side.
 
+Also note that the ArrangeBy of the Join that the Union-Negate pattern feeds (e.g., the second usage of `l1`) will have a smaller memory usage after the consolidation.
+
 # Testing and Rollout
 [rollout]: #rollout
 

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -299,6 +299,9 @@ impl Coordinator {
             dataflow,
             self.catalog()
                 .system_config()
+                .enable_consolidate_after_union_negate(),
+            self.catalog()
+                .system_config()
                 .enable_monotonic_oneshot_selects(),
         )
         .map_err(AdapterError::Internal)

--- a/src/compute-client/src/explain/text.rs
+++ b/src/compute-client/src/explain/text.rs
@@ -330,8 +330,19 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 };
                 ctx.indented(|ctx| input.fmt_text(f, ctx))?;
             }
-            Union { inputs } => {
-                writeln!(f, "{}Union", ctx.indent)?;
+            Union {
+                inputs,
+                consolidate_output,
+            } => {
+                if *consolidate_output {
+                    writeln!(
+                        f,
+                        "{}Union consolidate_output={}",
+                        ctx.indent, consolidate_output
+                    )?;
+                } else {
+                    writeln!(f, "{}Union", ctx.indent)?;
+                }
                 ctx.indented(|ctx| {
                     for input in inputs.iter() {
                         input.fmt_text(f, ctx)?;

--- a/src/compute-client/src/plan.proto
+++ b/src/compute-client/src/plan.proto
@@ -133,6 +133,7 @@ message ProtoPlan {
 
    message ProtoPlanUnion {
         repeated ProtoPlan inputs = 1;
+        bool consolidate_output = 2;
    }
 
    message ProtoPlanArrangeBy {

--- a/src/compute-client/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-client/src/plan/interpret/physically_monotonic.rs
@@ -109,7 +109,7 @@ impl<T> Interpreter<T> for SingleTimeMonotonic<'_, T> {
         _keys: &AvailableCollections,
         _plan: &GetPlan,
     ) -> Self::Domain {
-        // A get operator yields physically monotonic output iff the correspoding
+        // A get operator yields physically monotonic output iff the corresponding
         // `Plan::Get` is on a local or global ID that is known to provide physically
         // monotonic input. The way this becomes know is through the interpreter itself
         // for non-recursive local IDs or through configuration for the global IDs of
@@ -213,9 +213,17 @@ impl<T> Interpreter<T> for SingleTimeMonotonic<'_, T> {
         PhysicallyMonotonic(!ctx.is_rec)
     }
 
-    fn union(&self, _ctx: &Context<Self::Domain>, inputs: Vec<Self::Domain>) -> Self::Domain {
+    fn union(
+        &self,
+        _ctx: &Context<Self::Domain>,
+        inputs: Vec<Self::Domain>,
+        _consolidate_output: bool,
+    ) -> Self::Domain {
         // Union just concatenates the inputs, so is physically monotonic iff
         // all inputs are physically monotonic.
+        // (Even when we do consolidation, we can't be certain that a negative diff from an input
+        // is actually cancelled out. For example, Union outputs negative diffs when it's part of
+        // the EXCEPT pattern.)
         PhysicallyMonotonic(inputs.iter().all(|monotonic| monotonic.0))
     }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1127,6 +1127,13 @@ const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_consolidate_after_union_negate"),
+    value: &true,
+    description: "consolidation after Unions that have a Negated input (Materialize).",
+    internal: false,
+};
+
 /// Configuration for gRPC client connections.
 mod grpc_client {
     use super::*;
@@ -1958,6 +1965,7 @@ impl SystemVars {
             .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
+            .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
             .with_var(&ENABLE_DEFAULT_CONNECTION_VALIDATION)
             .with_var(&LOGGING_FILTER)
             .with_var(&OPENTELEMETRY_FILTER)
@@ -2500,6 +2508,10 @@ impl SystemVars {
     /// Returns the `enable_storage_shard_finalization` configuration parameter.
     pub fn enable_storage_shard_finalization(&self) -> bool {
         *self.expect_value(&ENABLE_STORAGE_SHARD_FINALIZATION)
+    }
+
+    pub fn enable_consolidate_after_union_negate(&self) -> bool {
+        *self.expect_value(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
     }
 
     /// Returns the `enable_default_connection_validation` configuration parameter.

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -699,7 +699,8 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                         }
                       }
                     }
-                  ]
+                  ],
+                  "consolidate_output": true
                 }
               },
               "forms": {
@@ -955,7 +956,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                             }
                           }
                         }
-                      ]
+                      ],
+                      "consolidate_output": true
                     }
                   },
                   "forms": {
@@ -1143,7 +1145,8 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                     }
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -1338,7 +1341,8 @@ SELECT x * 5 FROM cte WHERE x = 5
                             }
                           }
                         }
-                      ]
+                      ],
+                      "consolidate_output": true
                     }
                   },
                   "forms": {
@@ -2000,7 +2004,8 @@ FROM t
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -2054,7 +2059,8 @@ FROM t
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -2466,7 +2472,8 @@ VIEW hierarchical_global
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -2512,7 +2519,8 @@ VIEW hierarchical_global
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -2726,7 +2734,8 @@ SELECT * FROM hierarchical_global
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -2772,7 +2781,8 @@ SELECT * FROM hierarchical_global
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -3713,7 +3723,8 @@ FROM t
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -3759,7 +3770,8 @@ FROM t
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -5346,7 +5358,8 @@ VIEW collated_global
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -5464,7 +5477,8 @@ VIEW collated_global
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }
@@ -6083,7 +6097,8 @@ SELECT * FROM collated_global
                               }
                             }
                           }
-                        ]
+                        ],
+                        "consolidate_output": true
                       }
                     },
                     "mfp": {
@@ -6201,7 +6216,8 @@ SELECT * FROM collated_global
                     "input_key_val": null
                   }
                 }
-              ]
+              ],
+              "consolidate_output": false
             }
           }
         }

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -222,7 +222,7 @@ Explained Query:
     ArrangeBy
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
-      Union
+      Union consolidate_output=true
         Get::Arrangement materialize.public.t
           project=(#0)
           key=#0
@@ -267,7 +267,7 @@ Explained Query:
         ArrangeBy
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=() }
-          Union
+          Union consolidate_output=true
             Get::Arrangement materialize.public.t
               project=(#0)
               key=#0
@@ -300,7 +300,7 @@ Explained Query:
       ArrangeBy
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
-        Union
+        Union consolidate_output=true
           Join::Linear
             linear_stage[0]
               closure
@@ -415,7 +415,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, 0)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -510,7 +510,7 @@ materialize.public.hierarchical_global:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -557,7 +557,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -637,7 +637,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -751,7 +751,7 @@ materialize.public.collated_global:
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -807,7 +807,7 @@ Explained Query:
       Mfp
         project=(#0..=#5)
         map=(0, null, null, null, null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -77,3 +77,138 @@ SELECT * FROM generate_series(1, 2), LATERAL (SELECT * FROM t1) _ NATURAL RIGHT 
 2 2 3    4
 1 5 NULL 7
 2 5 NULL 7
+
+statement ok
+create table left(x int, y int);
+
+statement ok
+create table right1_keyed(x int, y int);
+
+statement ok
+create table right2(x int, y int);
+
+statement ok
+insert into left values (0,0);
+
+statement ok
+insert into right2 values (0,0);
+
+# `consolidate_output` should be true when there is a negated input to a Union.
+query T multiline
+explain physical plan for
+select *
+from
+  left
+  LEFT JOIN right1_keyed ON left.x = right1_keyed.x
+  LEFT JOIN right2 ON left.x = right2.x;
+----
+Explained Query:
+  Return
+    Union
+      Mfp
+        project=(#0..=#5)
+        map=(null, null)
+        Union consolidate_output=true
+          Negate
+            Join::Linear
+              linear_stage[0]
+                lookup={ relation=0, key=[#0] }
+                stream={ key=[#0], thinning=() }
+              source={ relation=1, key=[#0] }
+              ArrangeBy
+                raw=true
+                arrangements[0]={ key=[#0], permutation=id, thinning=(#1..=#3) }
+                Get::PassArrangements l1
+                  raw=true
+              Reduce::Distinct
+                val_plan
+                  project=()
+                key_plan=id
+                Get::Collection l2
+                  project=(#0)
+                  raw=true
+          Get::PassArrangements l1
+            raw=true
+      Get::Collection l2
+        project=(#0..=#3, #0, #4)
+        raw=true
+  With
+    cte l2 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1..=#3) }
+        source={ relation=0, key=[#0] }
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1..=#3) }
+          Get::Collection l1
+            filter=((#0) IS NOT NULL)
+            raw=true
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          Get::Collection materialize.public.right2
+            raw=true
+    cte l1 =
+      Union
+        Mfp
+          project=(#0..=#3)
+          map=(null, null)
+          Union consolidate_output=true
+            Negate
+              Join::Linear
+                linear_stage[0]
+                  lookup={ relation=0, key=[#0] }
+                  stream={ key=[#0], thinning=() }
+                source={ relation=1, key=[#0] }
+                ArrangeBy
+                  raw=true
+                  arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+                  Get::PassArrangements materialize.public.left
+                    raw=true
+                Reduce::Distinct
+                  val_plan
+                    project=()
+                  key_plan=id
+                  Get::Collection l0
+                    project=(#0)
+                    raw=true
+            Get::PassArrangements materialize.public.left
+              raw=true
+        Get::Collection l0
+          project=(#0, #1, #0, #2)
+          raw=true
+    cte l0 =
+      Join::Linear
+        linear_stage[0]
+          lookup={ relation=1, key=[#0] }
+          stream={ key=[#0], thinning=(#1) }
+        source={ relation=0, key=[#0] }
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          Get::Collection materialize.public.left
+            filter=((#0) IS NOT NULL)
+            raw=true
+        ArrangeBy
+          raw=true
+          arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+          Get::Collection materialize.public.right1_keyed
+            raw=true
+
+Source materialize.public.right1_keyed
+  filter=((#0) IS NOT NULL)
+Source materialize.public.right2
+  filter=((#0) IS NOT NULL)
+
+EOF
+
+query IIIIII
+select *
+from
+  left
+  LEFT JOIN right1_keyed ON left.x = right1_keyed.x
+  LEFT JOIN right2 ON left.x = right2.x;
+----
+0  0  NULL  NULL  0  0

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -168,7 +168,7 @@ Explained Query:
       Mfp
         project=(#0)
         map=(0)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -62,7 +62,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -120,7 +120,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -178,7 +178,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -246,7 +246,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -317,7 +317,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -341,7 +341,7 @@ Explained Query:
           ArrangeBy
             raw=false
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
-            Union
+            Union consolidate_output=true
               Get::Collection materialize.public.t
                 filter=((1 = (#0 % 2)))
                 raw=true
@@ -402,7 +402,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l1
               project=()
@@ -502,7 +502,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -579,7 +579,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -638,7 +638,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -736,7 +736,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l1
               project=()
@@ -818,7 +818,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -878,7 +878,7 @@ Explained Query:
       Mfp
         project=(#0, #1)
         map=(null, null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -992,7 +992,7 @@ Explained Query:
       Mfp
         project=(#0)
         map=(null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -1058,7 +1058,7 @@ Explained Query:
       Mfp
         project=(#0)
         map=(null)
-        Union
+        Union consolidate_output=true
           Negate
             Get::Arrangement l0
               project=()
@@ -1124,7 +1124,7 @@ Explained Query:
         Mfp
           project=(#0)
           map=(null)
-          Union
+          Union consolidate_output=true
             Negate
               Get::Arrangement l1
                 project=()

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -60,6 +60,7 @@ standard_conforming_strings         on                      "Causes '...' string
 statement_timeout                   "10 s"                  "Sets the maximum allowed duration of INSERT...SELECT, UPDATE, and DELETE operations. If this value is specified without units, it is taken as milliseconds."
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."
+enable_consolidate_after_union_negate on                    "consolidation after Unions that have a Negated input (Materialize)."
 
 > SET application_name = 'foo'
 


### PR DESCRIPTION
This fixes the LEFT JOIN consolidation issue, as planned in the [design doc](https://github.com/MaterializeInc/materialize/blob/98d995eb4b91021fdd041117039272e87180d731/doc/developer/design/20230728_left_join_stack_consolidation.md).

It adds a feature flag, which will be `enabled` by default.

Edit:
I manually checked the record counts by looking at the hierarchical memory visualizer with the feature flag turned on and off, and they look good. I was not able to add a Testdrive test to check record counts, because they don't seem to be stable: if the insertion of the input data is still ongoing when the dataflow is created, then we get a bit large record counts.

### Motivation

  * This PR fixes a recognized bug: #20828

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date design doc: https://github.com/MaterializeInc/materialize/blob/98d995eb4b91021fdd041117039272e87180d731/doc/developer/design/20230728_left_join_stack_consolidation.md
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
