### PR TITLE
sql: Prevent users from executing dangerous funcs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -751,8 +751,6 @@
     unmaterializable: true
   - signature: 'mz_row_size(expr: Record) -> int'
     description: Returns the number of bytes used to store a row.
-  - signature: 'is_rbac_enabled() -> boolean'
-    description: Reports whether RBAC is enabled for the current session.
 
 - type: PostgreSQL compatibility
   description: |

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -53,6 +53,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_rbac_checks": "true",
     "enable_monotonic_oneshot_selects": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
+    "enable_dangerous_functions": "true",
     # Following values are set based on Load Test environment to
     # reduce CRDB load as we are struggling with it in CI:
     "persist_next_listen_batch_retryer_clamp": "100ms",

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -674,7 +674,7 @@ impl Coordinator {
             ))),
 
             // All other statements are handled immediately.
-            _ => match self.plan_statement(ctx.session(), stmt, &params) {
+            _ => match self.plan_statement(ctx.session(), stmt, &params, &resolved_ids) {
                 Ok(plan) => self.sequence_plan(ctx, plan, resolved_ids).await,
                 Err(e) => ctx.retire(Err(e)),
             },

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -383,6 +383,7 @@ impl Coordinator {
                 ctx.session(),
                 Statement::CreateSubsource(subsource_stmt),
                 &params,
+                &resolved_ids,
             ) {
                 Ok(Plan::CreateSource(plan)) => plan,
                 Ok(_) => {
@@ -407,7 +408,7 @@ impl Coordinator {
 
         let resolved_ids = mz_sql::names::visit_dependencies(&stmt);
 
-        match self.plan_statement(ctx.session(), stmt, &params) {
+        match self.plan_statement(ctx.session(), stmt, &params, &resolved_ids) {
             Ok(Plan::CreateSource(plan)) => {
                 let source_id = match self.catalog_mut().allocate_user_id().await {
                     Ok(id) => id,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4020,6 +4020,7 @@ impl Coordinator {
                     &catalog,
                     Statement::CreateSource(create_source_stmt),
                     &Params::empty(),
+                    &resolved_ids,
                 )
                 .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?
                 {
@@ -4232,6 +4233,7 @@ impl Coordinator {
                     &catalog,
                     Statement::CreateSource(create_source_stmt),
                     &Params::empty(),
+                    &resolved_ids,
                 )
                 .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?
                 {

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -11,7 +11,7 @@
 //! put in more meaningfully named modules.
 
 use mz_repr::{GlobalId, ScalarType};
-use mz_sql::names::Aug;
+use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::StatementDesc;
 use mz_sql_parser::ast::{Raw, Statement};
 
@@ -28,10 +28,11 @@ impl Coordinator {
         session: &Session,
         stmt: mz_sql::ast::Statement<Aug>,
         params: &mz_sql::plan::Params,
+        resolved_ids: &ResolvedIds,
     ) -> Result<mz_sql::plan::Plan, AdapterError> {
         let pcx = session.pcx();
         let catalog = self.catalog().for_session(session);
-        let plan = mz_sql::plan::plan(Some(pcx), &catalog, stmt, params)?;
+        let plan = mz_sql::plan::plan(Some(pcx), &catalog, stmt, params, resolved_ids)?;
         Ok(plan)
     }
 

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -579,6 +579,7 @@ fn test_pgtest_mz() {
         &[
             "enable_raise_statement",
             "enable_unmanaged_cluster_replicas",
+            "enable_dangerous_functions",
         ],
     );
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2011,6 +2011,7 @@ fn test_github_20262() {
 fn test_cancel_read_then_write() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
+    server.enable_feature_flags(&["enable_dangerous_functions"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     client
@@ -2266,7 +2267,11 @@ fn webhook_concurrency_limit() {
     let config = util::Config::default().with_concurrent_webhook_req_count(concurrency_limit);
     let server = util::start_server(config).unwrap();
     // Note: we need enable_unstable_dependencies to use mz_sleep.
-    server.enable_feature_flags(&["enable_webhook_sources", "enable_unstable_dependencies"]);
+    server.enable_feature_flags(&[
+        "enable_webhook_sources",
+        "enable_unstable_dependencies",
+        "enable_dangerous_functions",
+    ]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -320,6 +320,7 @@ fn test_drop_connection_race() {
 #[mz_ore::test]
 fn test_time() {
     let server = util::start_server(util::Config::default()).unwrap();
+    server.enable_feature_flags(&["enable_dangerous_functions"]);
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Confirm that `now()` and `current_timestamp()` both return a
@@ -1551,6 +1552,7 @@ fn test_utilization_hold() {
 fn test_github_12546() {
     let config = util::Config::default().with_propagate_crashes(false);
     let server = util::start_server(config).unwrap();
+    server.enable_feature_flags(&["enable_dangerous_functions"]);
 
     server
         .runtime
@@ -2200,6 +2202,7 @@ fn test_introspection_user_permissions() {
 fn test_idle_in_transaction_session_timeout() {
     let config = util::Config::default();
     let server = util::start_server(config).unwrap();
+    server.enable_feature_flags(&["enable_dangerous_functions"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     client

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -150,6 +150,9 @@ pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
     /// Gets all schemas.
     fn get_schemas(&self) -> Vec<&dyn CatalogSchema>;
 
+    /// Gets the mz_internal schema id.
+    fn get_mz_internal_schema_id(&self) -> &SchemaId;
+
     /// Returns true if `schema` is an internal system schema, false otherwise
     fn is_system_schema(&self, schema: &str) -> bool;
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1152,12 +1152,12 @@ mod grpc_client {
     };
 }
 
-// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
-// availability of features.
-//
-// Note that not all ServerVar<bool> are feature flags. Feature flags are for variables that:
-// - Belong to `SystemVars`, _not_ `SessionVars`
-// - Default to false and must be explicitly enabled
+/// Macro to simplify creating feature flags, i.e. boolean flags that we use to toggle the
+/// availability of features.
+///
+/// Note that not all `ServerVar<bool>` are feature flags. Feature flags are for variables that:
+/// - Belong to `SystemVars`, _not_ `SessionVars`
+/// - Default to false and must be explicitly enabled
 macro_rules! feature_flags {
     ($(($name:expr, $feature_desc:literal)),+ $(,)?) => {
         paste::paste!{
@@ -1306,7 +1306,11 @@ feature_flags!(
         enable_try_parse_monotonic_iso8601_timestamp,
         "the try_parse_monotonic_iso8601_timestamp function"
     ),
-    (enable_alter_set_cluster, "ALTER ... SET CLUSTER syntax")
+    (enable_alter_set_cluster, "ALTER ... SET CLUSTER syntax"),
+    (
+        enable_dangerous_functions,
+        "executing potentially dangerous functions"
+    ),
 );
 
 /// Represents the input to a variable.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1093,6 +1093,11 @@ impl<'a> RunnerInner<'a> {
                 )
                 .await?;
         }
+
+        // Dangerous functions are useful for tests so we enable it for all tests.
+        self.system_client
+            .execute("ALTER SYSTEM SET enable_dangerous_functions = on", &[])
+            .await?;
         Ok(())
     }
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -307,6 +307,12 @@ impl State {
             .await
             .context("resetting materialize state: ALTER SYSTEM RESET ALL")?;
 
+        // Dangerous functions are useful for tests so we enable it for all tests.
+        inner_client
+            .batch_execute("ALTER SYSTEM SET enable_dangerous_functions = on")
+            .await
+            .context("enabling dangerous functions")?;
+
         for row in inner_client
             .query("SHOW DATABASES", &[])
             .await

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1612,3 +1612,39 @@ query I
 SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
 ----
 -1
+
+# mz_internal functions can't be executed with the enable_dangerous_functions flag turned off
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_dangerous_functions = false
+----
+COMPLETE 0
+
+statement error executing potentially dangerous functions is not supported
+SELECT mz_internal.mz_sleep(10)
+
+statement error executing potentially dangerous functions is not supported
+SELECT mz_internal.mz_panic('hello')
+
+statement ok
+CREATE TABLE dangerous_table (a INT)
+
+statement ok
+INSERT INTO dangerous_table VALUES (1)
+
+statement error executing potentially dangerous functions is not supported
+SELECT mz_internal.mz_any(a) FROM dangerous_table
+
+statement ok
+DROP TABLE dangerous_table
+
+statement error executing potentially dangerous functions is not supported
+SELECT * FROM mz_internal.mz_resolve_object_name('t');
+
+statement error executing potentially dangerous functions is not supported
+SELECT mz_internal.mz_resolve_object_name('t');
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_dangerous_functions = true
+----
+COMPLETE 0

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1627,13 +1627,16 @@ statement error executing potentially dangerous functions is not supported
 SELECT mz_internal.mz_panic('hello')
 
 statement ok
-CREATE TABLE dangerous_table (a INT)
+CREATE TABLE dangerous_table (a INT, b TEXT)
 
 statement ok
-INSERT INTO dangerous_table VALUES (1)
+INSERT INTO dangerous_table (a) VALUES (1)
 
 statement error executing potentially dangerous functions is not supported
 SELECT mz_internal.mz_any(a) FROM dangerous_table
+
+statement error executing potentially dangerous functions is not supported
+INSERT INTO dangerous_table (b) VALUES (mz_internal.mz_panic('hello'))
 
 statement ok
 DROP TABLE dangerous_table


### PR DESCRIPTION
This commit prevents users from executing dangerous functions. For now,
a dangerous function is defined as any function found in the
mz_internal schema. In the future we could be more specific and add
attributes to each function to indicate if it's safe for a user to
evaluate.

Dangerous functions include functions that are only meant to be
executed in tests, such as mz_panic and mz_sleep, and functions
that are used to implement other functions/operators but don't
have well-defined semantics, such as mz_all and mz_any. If a user ever
executes one of these functions they would either get back
confusing/unhelpful results or crash part/all of their environment.

Fixes #15805
Fixes #18023
Fixes #18057


### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Prevent users from executing dangerous functions.
