### PR TITLE
Unbatch compute commands

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1209,11 +1209,10 @@ impl Coordinator {
                             .entry(idx.cluster_id)
                             .or_insert_with(Default::default)
                             .extend(dataflow.export_ids());
-                        let dataflow_plan =
-                            vec![self.must_finalize_dataflow(dataflow, idx.cluster_id)];
+                        let dataflow_plan = self.must_finalize_dataflow(dataflow, idx.cluster_id);
                         self.controller
                             .active_compute()
-                            .create_dataflows(idx.cluster_id, dataflow_plan)
+                            .create_dataflow(idx.cluster_id, dataflow_plan)
                             .unwrap_or_terminate("cannot fail to create dataflows");
                     }
                 }

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -137,7 +137,6 @@ impl Coordinator {
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
-    /// Utility method for the more general [`Self::must_ship_dataflows`]
     ///
     /// # Panics
     ///
@@ -147,65 +146,36 @@ impl Coordinator {
         dataflow: DataflowDesc,
         instance: ComputeInstanceId,
     ) {
-        self.must_ship_dataflows(vec![dataflow], instance).await
-    }
-
-    /// Finalizes a list of dataflows and then broadcasts it to all workers.
-    ///
-    /// # Panics
-    ///
-    /// Panics if any of the dataflows fail to ship.
-    async fn must_ship_dataflows(
-        &mut self,
-        dataflows: Vec<DataflowDesc>,
-        instance: ComputeInstanceId,
-    ) {
-        self.ship_dataflows(dataflows, instance)
+        self.ship_dataflow(dataflow, instance)
             .await
-            .expect("failed to ship dataflows");
+            .expect("failed to ship dataflow");
     }
 
     /// Finalizes a dataflow and then broadcasts it to all workers.
-    /// Utility method for the more general [`Self::ship_dataflows`]
     ///
     /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
     /// [`Self::must_ship_dataflow`].
     pub(crate) async fn ship_dataflow(
         &mut self,
-        dataflow: DataflowDesc,
+        mut dataflow: DataflowDesc,
         instance: ComputeInstanceId,
     ) -> Result<(), AdapterError> {
-        self.ship_dataflows(vec![dataflow], instance).await
-    }
-
-    /// Finalizes a list of dataflows and then broadcasts it to all workers.
-    ///
-    /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version
-    /// [`Self::must_ship_dataflows`].
-    async fn ship_dataflows(
-        &mut self,
-        dataflows: Vec<DataflowDesc>,
-        instance: ComputeInstanceId,
-    ) -> Result<(), AdapterError> {
-        let mut output_ids = Vec::new();
-        let mut dataflow_plans = Vec::with_capacity(dataflows.len());
-        for mut dataflow in dataflows.into_iter() {
-            output_ids.extend(dataflow.export_ids());
-            // If the only outputs of the dataflow are sinks, we might
-            // be able to turn off the computation early, if they all
-            // have non-trivial `up_to`s.
-            if dataflow.index_exports.is_empty() {
-                dataflow.until = Antichain::from_elem(Timestamp::MIN);
-                for (_, sink) in &dataflow.sink_exports {
-                    dataflow.until.join_assign(&sink.up_to);
-                }
+        // If the only outputs of the dataflow are sinks, we might
+        // be able to turn off the computation early, if they all
+        // have non-trivial `up_to`s.
+        if dataflow.index_exports.is_empty() {
+            dataflow.until = Antichain::from_elem(Timestamp::MIN);
+            for (_, sink) in &dataflow.sink_exports {
+                dataflow.until.join_assign(&sink.up_to);
             }
-            let plan = self.finalize_dataflow(dataflow, instance)?;
-            dataflow_plans.push(plan);
         }
+
+        let output_ids = dataflow.export_ids().collect();
+        let plan = self.finalize_dataflow(dataflow, instance)?;
+
         self.controller
             .active_compute()
-            .create_dataflows(instance, dataflow_plans)
+            .create_dataflow(instance, plan)
             .unwrap_or_terminate("dataflow creation cannot fail");
         self.initialize_compute_read_policies(
             output_ids,
@@ -939,7 +909,7 @@ fn role_oid_memberships_inner<'a>(
 impl Coordinator {
     #[allow(dead_code)]
     async fn verify_ship_dataflow_no_error(&mut self) {
-        // must_ship_dataflow, must_ship_dataflows, and must_finalize_dataflow are not allowed
+        // must_ship_dataflow and must_finalize_dataflow are not allowed
         // to have a `Result` return because these functions are called after
         // `catalog_transact`, after which no errors are allowed. This test exists to
         // prevent us from incorrectly teaching those functions how to return errors
@@ -951,9 +921,6 @@ impl Coordinator {
 
         let df = DataflowDesc::new("".into());
         let _: () = self.must_ship_dataflow(df.clone(), compute_instance).await;
-        let _: () = self
-            .must_ship_dataflows(vec![df.clone()], compute_instance)
-            .await;
         let _: DataflowDescription<mz_compute_client::plan::Plan> =
             self.must_finalize_dataflow(df, compute_instance);
     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -388,7 +388,7 @@ impl Coordinator {
                     if let Some(pending_peek) = self.remove_pending_peek(&uuid) {
                         self.controller
                             .active_compute()
-                            .cancel_peeks(pending_peek.cluster_id, vec![uuid].into_iter().collect())
+                            .cancel_peek(pending_peek.cluster_id, uuid)
                             .unwrap_or_terminate("unable to cancel peek");
                         // Client may have left.
                         let _ = pending_peek.sender.send(PeekResponse::Error(format!(

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -374,7 +374,7 @@ impl crate::coord::Coordinator {
                 // Very important: actually create the dataflow (here, so we can destructure).
                 self.controller
                     .active_compute()
-                    .create_dataflows(compute_instance, vec![dataflow])
+                    .create_dataflow(compute_instance, dataflow)
                     .unwrap_or_terminate("cannot fail to create dataflows");
                 self.initialize_compute_read_policies(
                     output_ids,
@@ -494,15 +494,15 @@ impl crate::coord::Coordinator {
             for (uuid, compute_instance) in &uuids {
                 inverse.entry(*compute_instance).or_default().insert(*uuid);
             }
+            let mut compute = self.controller.active_compute();
             for (compute_instance, uuids) in inverse {
                 // It's possible that this compute instance no longer exists because it was dropped
                 // while the peek was in progress. In this case we ignore the error and move on
                 // because the dataflow no longer exists.
                 // TODO(jkosh44) Dropping a cluster should actively cancel all pending queries.
-                let _ = self
-                    .controller
-                    .active_compute()
-                    .cancel_peeks(compute_instance, uuids);
+                for uuid in uuids {
+                    let _ = compute.cancel_peek(compute_instance, uuid);
+                }
             }
 
             uuids

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -19,7 +19,7 @@
 //!
 //! The state maintained for a compute instance can be viewed as a partial map from `GlobalId` to
 //! collection. It is an error to use an identifier before it has been "created" with
-//! `create_dataflows()`. Once created, the controller holds a read capability for each output
+//! `create_dataflow()`. Once created, the controller holds a read capability for each output
 //! collection of a dataflow, which is manipulated with `set_read_policy()`. Eventually, a
 //! collection is dropped with either `drop_collections()` or by allowing compaction to the empty
 //! frontier.
@@ -29,7 +29,7 @@
 //! from compacting beyond the allowed compaction of each of its outputs, ensuring that we can
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::num::NonZeroI64;
 use std::time::Duration;
 
@@ -449,12 +449,12 @@ where
     /// It installs read dependencies from the outputs to the inputs, so that the input read
     /// capabilities will be held back to the output read capabilities, ensuring that we are
     /// always able to return to a state that can serve the output read capabilities.
-    pub fn create_dataflows(
+    pub fn create_dataflow(
         &mut self,
         instance_id: ComputeInstanceId,
-        dataflows: Vec<DataflowDescription<crate::plan::Plan<T>, (), T>>,
+        dataflow: DataflowDescription<crate::plan::Plan<T>, (), T>,
     ) -> Result<(), DataflowCreationError> {
-        self.instance(instance_id)?.create_dataflows(dataflows)?;
+        self.instance(instance_id)?.create_dataflow(dataflow)?;
         Ok(())
     }
 
@@ -494,23 +494,21 @@ where
         Ok(())
     }
 
-    /// Cancel existing peek requests.
+    /// Cancel an existing peek request.
     ///
     /// Canceling a peek is best effort. The caller may see any of the following
     /// after canceling a peek request:
     ///
     ///   * A `PeekResponse::Rows` indicating that the cancellation request did
-    ///    not take effect in time and the query succeeded.
-    ///
+    ///     not take effect in time and the query succeeded.
     ///   * A `PeekResponse::Canceled` affirming that the peek was canceled.
-    ///
     ///   * No `PeekResponse` at all.
-    pub fn cancel_peeks(
+    pub fn cancel_peek(
         &mut self,
         instance_id: ComputeInstanceId,
-        uuids: BTreeSet<Uuid>,
+        uuid: Uuid,
     ) -> Result<(), InstanceMissing> {
-        self.instance(instance_id)?.cancel_peeks(uuids);
+        self.instance(instance_id)?.cancel_peek(uuid);
         Ok(())
     }
 

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -318,10 +318,10 @@ impl StatsCollector<ProtoComputeCommand, ProtoComputeResponse> for ReplicaMetric
 pub struct CommandMetrics<M> {
     create_timely: M,
     create_instance: M,
-    create_dataflows: M,
+    create_dataflow: M,
     allow_compaction: M,
     peek: M,
-    cancel_peeks: M,
+    cancel_peek: M,
     initialization_complete: M,
     update_configuration: M,
 }
@@ -334,10 +334,10 @@ impl<M> CommandMetrics<M> {
         Self {
             create_timely: build_metric("create_timely"),
             create_instance: build_metric("create_instance"),
-            create_dataflows: build_metric("create_dataflows"),
+            create_dataflow: build_metric("create_dataflow"),
             allow_compaction: build_metric("allow_compaction"),
             peek: build_metric("peek"),
-            cancel_peeks: build_metric("cancel_peeks"),
+            cancel_peek: build_metric("cancel_peek"),
             initialization_complete: build_metric("initialization_complete"),
             update_configuration: build_metric("update_configuration"),
         }
@@ -351,10 +351,10 @@ impl<M> CommandMetrics<M> {
         f(&self.create_instance);
         f(&self.initialization_complete);
         f(&self.update_configuration);
-        f(&self.create_dataflows);
+        f(&self.create_dataflow);
         f(&self.allow_compaction);
         f(&self.peek);
-        f(&self.cancel_peeks);
+        f(&self.cancel_peek);
     }
 
     pub fn for_command<T>(&self, command: &ComputeCommand<T>) -> &M {
@@ -365,10 +365,10 @@ impl<M> CommandMetrics<M> {
             CreateInstance(_) => &self.create_instance,
             InitializationComplete => &self.initialization_complete,
             UpdateConfiguration(_) => &self.update_configuration,
-            CreateDataflows(_) => &self.create_dataflows,
-            AllowCompaction(_) => &self.allow_compaction,
+            CreateDataflow(_) => &self.create_dataflow,
+            AllowCompaction { .. } => &self.allow_compaction,
             Peek(_) => &self.peek,
-            CancelPeeks { .. } => &self.cancel_peeks,
+            CancelPeek { .. } => &self.cancel_peek,
         }
     }
 
@@ -378,10 +378,10 @@ impl<M> CommandMetrics<M> {
         match proto.kind.as_ref().unwrap() {
             CreateTimely(_) => &self.create_timely,
             CreateInstance(_) => &self.create_instance,
-            CreateDataflows(_) => &self.create_dataflows,
+            CreateDataflow(_) => &self.create_dataflow,
             AllowCompaction(_) => &self.allow_compaction,
             Peek(_) => &self.peek,
-            CancelPeeks(_) => &self.cancel_peeks,
+            CancelPeek(_) => &self.cancel_peek,
             InitializationComplete(_) => &self.initialization_complete,
             UpdateConfiguration(_) => &self.update_configuration,
         }

--- a/src/compute-client/src/metrics.rs
+++ b/src/compute-client/src/metrics.rs
@@ -391,7 +391,7 @@ impl<M> CommandMetrics<M> {
 /// Metrics keyed by `ComputeResponse` type.
 #[derive(Debug)]
 struct ResponseMetrics<M> {
-    frontier_uppers: M,
+    frontier_upper: M,
     peek_response: M,
     subscribe_response: M,
 }
@@ -402,7 +402,7 @@ impl<M> ResponseMetrics<M> {
         F: Fn(&str) -> M,
     {
         Self {
-            frontier_uppers: build_metric("frontier_uppers"),
+            frontier_upper: build_metric("frontier_upper"),
             peek_response: build_metric("peek_response"),
             subscribe_response: build_metric("subscribe_response"),
         }
@@ -412,7 +412,7 @@ impl<M> ResponseMetrics<M> {
         use crate::protocol::response::proto_compute_response::Kind::*;
 
         match proto.kind.as_ref().unwrap() {
-            FrontierUppers(_) => &self.frontier_uppers,
+            FrontierUpper(_) => &self.frontier_upper,
             PeekResponse(_) => &self.peek_response,
             SubscribeResponse(_) => &self.subscribe_response,
         }

--- a/src/compute-client/src/protocol.rs
+++ b/src/compute-client/src/protocol.rs
@@ -21,15 +21,15 @@
 //! gracefully handle messages that don’t reflect the state of the world described by the messages
 //! they have previously sent. In other words, messages sent take effect only eventually. For
 //! example, after the compute controller has instructed the replica to cancel a peek (by sending a
-//! [`CancelPeeks`] command, it must still be ready to accept non-[`Canceled`] responses to the
-//! peek. Similarly, if a replica receives a [`CancelPeeks`] command for a peek it has already
+//! [`CancelPeek`] command, it must still be ready to accept non-[`Canceled`] responses to the
+//! peek. Similarly, if a replica receives a [`CancelPeek`] command for a peek it has already
 //! answered, it must handle that command gracefully (e.g., by ignoring it).
 //!
 //! While the protocol does not provide any guarantees about the delay between sending a message
 //! and it being received and processed, it does guarantee that messages are delivered in the same
 //! order they are sent in. For example, if the compute controller sends a [`Peek`] command
-//! followed by a [`CancelPeeks`] command, it is guaranteed that [`CancelPeeks`] is only received
-//! by the replica after the [`Peek`] command.
+//! followed by a [`CancelPeek`] command, it is guaranteed that [`CancelPeek`] is only received by
+//! the replica after the [`Peek`] command.
 //!
 //! # Message Transport and Encoding
 //!
@@ -85,15 +85,15 @@
 //!
 //! The compute controller may send any number of computation commands:
 //!
-//!   - [`CreateDataflows`]
+//!   - [`CreateDataflow`]
 //!   - [`AllowCompaction`]
 //!   - [`Peek`]
-//!   - [`CancelPeeks`]
+//!   - [`CancelPeek`]
 //!   - [`UpdateConfiguration`]
 //!
 //! The compute controller must respect dependencies between commands. For example, it must send a
-//! [`CreateDataflows`] command before it sends [`AllowCompaction`] or [`Peek`] commands that
-//! target the created dataflow.
+//! [`CreateDataflow`] command before it sends [`AllowCompaction`] or [`Peek`] commands that target
+//! the created dataflow.
 //!
 //! The replica must send the required responses to computation commands. This includes commands it
 //! has received in the initialization phase that have not already been responded to.
@@ -102,10 +102,10 @@
 //! [`CreateTimely`]: self::command::ComputeCommand::CreateTimely
 //! [`CreateInstance`]: self::command::ComputeCommand::CreateInstance
 //! [`InitializationComplete`]: self::command::ComputeCommand::InitializationComplete
-//! [`CreateDataflows`]: self::command::ComputeCommand::CreateDataflows
+//! [`CreateDataflow`]: self::command::ComputeCommand::CreateDataflow
 //! [`AllowCompaction`]: self::command::ComputeCommand::AllowCompaction
 //! [`Peek`]: self::command::ComputeCommand::Peek
-//! [`CancelPeeks`]: self::command::ComputeCommand::CancelPeeks
+//! [`CancelPeek`]: self::command::ComputeCommand::CancelPeek
 //! [`UpdateConfiguration`]: self::command::ComputeCommand::UpdateConfiguration
 //! [`ComputeResponse`]: self::response::ComputeResponse
 //! [`FrontierUppers`]: self::response::ComputeResponse::FrontierUppers

--- a/src/compute-client/src/protocol.rs
+++ b/src/compute-client/src/protocol.rs
@@ -108,7 +108,6 @@
 //! [`CancelPeek`]: self::command::ComputeCommand::CancelPeek
 //! [`UpdateConfiguration`]: self::command::ComputeCommand::UpdateConfiguration
 //! [`ComputeResponse`]: self::response::ComputeResponse
-//! [`FrontierUppers`]: self::response::ComputeResponse::FrontierUppers
 //! [`Canceled`]: self::response::PeekResponse::Canceled
 //! [`SubscribeResponse::DroppedAt`]: self::response::SubscribeResponse::DroppedAt
 

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -28,14 +28,6 @@ import "google/protobuf/empty.proto";
 package mz_compute_client.protocol.command;
 
 message ProtoComputeCommand {
-    message ProtoCreateDataflows {
-        repeated types.dataflows.ProtoDataflowDescription dataflows = 1;
-    }
-
-    message ProtoCancelPeeks {
-        repeated mz_proto.ProtoU128 uuids = 1;
-    }
-
     message ProtoCreateTimely {
         mz_cluster_client.client.ProtoTimelyConfig config = 1;
         mz_cluster_client.client.ProtoClusterStartupEpoch epoch = 2;
@@ -44,10 +36,10 @@ message ProtoComputeCommand {
     oneof kind {
         ProtoCreateTimely create_timely = 1;
         logging.ProtoLoggingConfig create_instance = 2;
-        ProtoCreateDataflows create_dataflows = 3;
-        mz_storage_client.client.ProtoAllowCompaction allow_compaction = 4;
+        types.dataflows.ProtoDataflowDescription create_dataflow = 3;
+        mz_storage_client.client.ProtoCompaction allow_compaction = 4;
         ProtoPeek peek = 5;
-        ProtoCancelPeeks cancel_peeks = 6;
+        mz_proto.ProtoU128 cancel_peek = 6;
         google.protobuf.Empty initialization_complete = 7;
         ProtoComputeParameters update_configuration = 8;
     }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -119,7 +119,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// should prefer panicking over producing incorrect results.
     ///
     /// After receiving a `CreateDataflow` command, if the created dataflow exports indexes or
-    /// storage sinks, the replica must produce [`FrontierUppers`] responses that report the
+    /// storage sinks, the replica must produce [`FrontierUpper`] responses that report the
     /// advancement of the `upper` frontiers of these compute collections.
     ///
     /// After receiving a `CreateDataflow` command, if the created dataflow exports subscribes, the
@@ -130,7 +130,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`source_imports`]: DataflowDescription::source_imports
     /// [`index_imports`]: DataflowDescription::index_imports
     /// [`as_of`]: DataflowDescription::as_of
-    /// [`FrontierUppers`]: super::response::ComputeResponse::FrontierUppers
+    /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     /// [Initialization Stage]: super#initialization-stage
     CreateDataflow(DataflowDescription<crate::plan::Plan<T>, CollectionMetadata, T>),
@@ -161,10 +161,10 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// compute collections.
     ///
     /// A replica that receives an `AllowCompaction` command with the empty frontier must
-    /// eventually respond with a [`FrontierUppers`] response reporting the empty frontier for the
+    /// eventually respond with a [`FrontierUpper`] response reporting the empty frontier for the
     /// same collection. ([#16275])
     ///
-    /// [`FrontierUppers`]: super::response::ComputeResponse::FrontierUppers
+    /// [`FrontierUpper`]: super::response::ComputeResponse::FrontierUpper
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     AllowCompaction {
         id: GlobalId,

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -9,8 +9,6 @@
 
 //! Compute protocol commands.
 
-use std::collections::BTreeSet;
-
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig};
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -18,8 +16,9 @@ use mz_persist_client::cfg::PersistParameters;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, Row};
 use mz_service::params::GrpcClientParameters;
-use mz_storage_client::client::ProtoAllowCompaction;
+use mz_storage_client::client::ProtoCompaction;
 use mz_storage_client::controller::CollectionMetadata;
+use mz_timely_util::progress::any_antichain;
 use mz_tracing::params::TracingParameters;
 use proptest::prelude::{any, Arbitrary};
 use proptest::strategy::{BoxedStrategy, Strategy, Union};
@@ -98,21 +97,16 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// rather than as [`ComputeParameters`].
     UpdateConfiguration(ComputeParameters),
 
-    /// `CreateDataflows` instructs the replica to create and start maintaining dataflows according
-    /// to the given [`DataflowDescription`]s.
+    /// `CreateDataflow` instructs the replica to create and start maintaining a dataflow according
+    /// to the given [`DataflowDescription`].
     ///
-    /// If a `CreateDataflows` command defines multiple dataflows, the list of
-    /// [`DataflowDescription`]s must be topologically ordered according to the dependency
-    /// relation.
-    ///
-    /// Each [`DataflowDescription`] must have the following properties:
+    /// The [`DataflowDescription`] must have the following properties:
     ///
     ///   * Dataflow imports are valid:
     ///     * Imported storage collections specified in [`source_imports`] exist and are readable by
     ///       the compute replica.
     ///     * Imported indexes specified in [`index_imports`] have been created on the replica
-    ///       previously, either by previous `CreateDataflows` commands, or by the same
-    ///       `CreateDataflows` command.
+    ///       previously, by previous `CreateDataflow` commands.
     ///   * Dataflow imports are readable at the specified [`as_of`]. In other words: The `since`s of
     ///     imported collections are not beyond the dataflow [`as_of`].
     ///   * Dataflow exports have unique IDs, i.e., the IDs of exports from dataflows a replica is
@@ -124,12 +118,12 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// exhibit undefined behavior, such as panicking or production of incorrect results. A replica
     /// should prefer panicking over producing incorrect results.
     ///
-    /// After receiving a `CreateDataflows` command, for created dataflows that export indexes or
+    /// After receiving a `CreateDataflow` command, if the created dataflow exports indexes or
     /// storage sinks, the replica must produce [`FrontierUppers`] responses that report the
     /// advancement of the `upper` frontiers of these compute collections.
     ///
-    /// After receiving a `CreateDataflows` command, for created dataflows that export subscribes,
-    /// the replica must produce [`SubscribeResponse`]s that report the progress and results of the
+    /// After receiving a `CreateDataflow` command, if the created dataflow exports subscribes, the
+    /// replica must produce [`SubscribeResponse`]s that report the progress and results of the
     /// subscribes.
     ///
     /// [`objects_to_build`]: DataflowDescription::objects_to_build
@@ -139,17 +133,17 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`FrontierUppers`]: super::response::ComputeResponse::FrontierUppers
     /// [`SubscribeResponse`]: super::response::ComputeResponse::SubscribeResponse
     /// [Initialization Stage]: super#initialization-stage
-    CreateDataflows(Vec<DataflowDescription<crate::plan::Plan<T>, CollectionMetadata, T>>),
+    CreateDataflow(DataflowDescription<crate::plan::Plan<T>, CollectionMetadata, T>),
 
     /// `AllowCompaction` informs the replica about the relaxation of external read capabilities on
-    /// the compute collections exported by the replica’s dataflow.
+    /// a compute collection exported by one of the replica’s dataflow.
     ///
-    /// Each entry in the vector names a collection and provides a frontier after which
-    /// accumulations must be correct. The replica gains the liberty of compacting the
-    /// corresponding maintained traces up through that frontier.
+    /// The command names a collection and provides a frontier after which accumulations must be
+    /// correct. The replica gains the liberty of compacting the corresponding maintained trace up
+    /// through that frontier.
     ///
-    /// It is invalid to send an `AllowCompaction` command that references compute collections that
-    /// were not created by a corresponding `CreateDataflows` command before. Doing so may cause
+    /// It is invalid to send an `AllowCompaction` command that references a compute collection
+    /// that was not created by a corresponding `CreateDataflow` command before. Doing so may cause
     /// the replica to exhibit undefined behavior.
     ///
     /// The `AllowCompaction` command only informs about external read requirements, not internal
@@ -157,7 +151,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// all times, so local dataflow inputs are not compacted beyond times at which they are still
     /// being read from.
     ///
-    /// The read frontiers transmitted through `AllowCompactions` may be beyond the corresponding
+    /// The read frontiers transmitted through `AllowCompaction`s may be beyond the corresponding
     /// collections' current `upper` frontiers. This signals that external readers are not
     /// interested in times up to the specified new read frontiers. Consequently, an empty read
     /// frontier signals that external readers are not interested in updates from the corresponding
@@ -172,13 +166,16 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     ///
     /// [`FrontierUppers`]: super::response::ComputeResponse::FrontierUppers
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
-    AllowCompaction(Vec<(GlobalId, Antichain<T>)>),
+    AllowCompaction {
+        id: GlobalId,
+        frontier: Antichain<T>,
+    },
 
     /// `Peek` instructs the replica to perform a peek at an index.
     ///
     /// The [`Peek`] description must have the following properties:
     ///
-    ///   * The target index has previously been created by a corresponding `CreateDataflows`
+    ///   * The target index has previously been created by a corresponding `CreateDataflow`
     ///     command.
     ///   * The [`Peek::uuid`] is unique, i.e., the UUIDs of peeks a replica gets instructed to
     ///     perform do not repeat (within a single protocol iteration).
@@ -203,25 +200,24 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// [`Canceled`]: super::response::PeekResponse::Canceled
     Peek(Peek<T>),
 
-    /// `CancelPeeks` instructs the replica to cancel the identified pending peeks.
+    /// `CancelPeek` instructs the replica to cancel the identified pending peek.
     ///
-    /// It is invalid to send a `CancelPeeks` command that references peeks that were not created
+    /// It is invalid to send a `CancelPeek` command that references a peek that was not created
     /// by a corresponding `Peek` command before. Doing so may cause the replica to exhibit
     /// undefined behavior.
     ///
-    /// If a replica cancels a peek in response to a `CancelPeeks` command, it must respond with a
+    /// If a replica cancels a peek in response to a `CancelPeek` command, it must respond with a
     /// [`PeekResponse::Canceled`]. The replica may also decide to fulfill the peek instead and
     /// return a different [`PeekResponse`], or it may already have returned a response to the
     /// specified peek. In these cases it must *not* return another [`PeekResponse`].
     ///
     /// [`PeekResponse`]: super::response::PeekResponse
     /// [`PeekResponse::Canceled`]: super::response::PeekResponse::Canceled
-    CancelPeeks {
-        /// The identifiers of the peek requests to cancel.
+    CancelPeek {
+        /// The identifier of the peek request to cancel.
         ///
-        /// Values in this set must match [`Peek::uuid`] values transmitted in previous `Peek`
-        /// commands.
-        uuids: BTreeSet<Uuid>,
+        /// This Value must match a [`Peek::uuid`] value transmitted in a previous `Peek` command.
+        uuid: Uuid,
     },
 }
 
@@ -240,20 +236,15 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
                 ComputeCommand::UpdateConfiguration(params) => {
                     UpdateConfiguration(params.into_proto())
                 }
-                ComputeCommand::CreateDataflows(dataflows) => {
-                    CreateDataflows(ProtoCreateDataflows {
-                        dataflows: dataflows.into_proto(),
-                    })
-                }
-                ComputeCommand::AllowCompaction(collections) => {
-                    AllowCompaction(ProtoAllowCompaction {
-                        collections: collections.into_proto(),
+                ComputeCommand::CreateDataflow(dataflow) => CreateDataflow(dataflow.into_proto()),
+                ComputeCommand::AllowCompaction { id, frontier } => {
+                    AllowCompaction(ProtoCompaction {
+                        id: Some(id.into_proto()),
+                        frontier: Some(frontier.into_proto()),
                     })
                 }
                 ComputeCommand::Peek(peek) => Peek(peek.into_proto()),
-                ComputeCommand::CancelPeeks { uuids } => CancelPeeks(ProtoCancelPeeks {
-                    uuids: uuids.into_proto(),
-                }),
+                ComputeCommand::CancelPeek { uuid } => CancelPeek(uuid.into_proto()),
             }),
         }
     }
@@ -275,15 +266,18 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
             Some(UpdateConfiguration(params)) => {
                 Ok(ComputeCommand::UpdateConfiguration(params.into_rust()?))
             }
-            Some(CreateDataflows(ProtoCreateDataflows { dataflows })) => {
-                Ok(ComputeCommand::CreateDataflows(dataflows.into_rust()?))
+            Some(CreateDataflow(dataflow)) => {
+                Ok(ComputeCommand::CreateDataflow(dataflow.into_rust()?))
             }
-            Some(AllowCompaction(ProtoAllowCompaction { collections })) => {
-                Ok(ComputeCommand::AllowCompaction(collections.into_rust()?))
+            Some(AllowCompaction(ProtoCompaction { id, frontier })) => {
+                Ok(ComputeCommand::AllowCompaction {
+                    id: id.into_rust_if_some("ProtoAllowCompaction::id")?,
+                    frontier: frontier.into_rust_if_some("ProtoAllowCompaction::frontier")?,
+                })
             }
             Some(Peek(peek)) => Ok(ComputeCommand::Peek(peek.into_rust()?)),
-            Some(CancelPeeks(ProtoCancelPeeks { uuids })) => Ok(ComputeCommand::CancelPeeks {
-                uuids: uuids.into_rust()?,
+            Some(CancelPeek(uuid)) => Ok(ComputeCommand::CancelPeek {
+                uuid: uuid.into_rust()?,
             }),
             None => Err(TryFromProtoError::missing_field(
                 "ProtoComputeCommand::kind",
@@ -298,47 +292,23 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         Union::new(vec![
-                any::<LoggingConfig>()
-                    .prop_map(ComputeCommand::CreateInstance)
-                    .boxed(),
-                any::<ComputeParameters>()
-                    .prop_map(ComputeCommand::UpdateConfiguration)
-                    .boxed(),
-                proptest::collection::vec(
-                    any::<
-                        DataflowDescription<
-                            crate::plan::Plan,
-                            CollectionMetadata,
-                            mz_repr::Timestamp,
-                        >,
-                    >(),
-                    1..4,
-                )
-                .prop_map(ComputeCommand::CreateDataflows)
+            any::<LoggingConfig>()
+                .prop_map(ComputeCommand::CreateInstance)
                 .boxed(),
-                proptest::collection::vec(
-                    (
-                        any::<GlobalId>(),
-                        proptest::collection::vec(any::<mz_repr::Timestamp>(), 1..4),
-                    ),
-                    1..4,
-                )
-                .prop_map(|collections| {
-                    ComputeCommand::AllowCompaction(
-                        collections
-                            .into_iter()
-                            .map(|(id, frontier_vec)| (id, Antichain::from(frontier_vec)))
-                            .collect(),
-                    )
-                })
+            any::<ComputeParameters>()
+                .prop_map(ComputeCommand::UpdateConfiguration)
                 .boxed(),
-                any::<Peek>().prop_map(ComputeCommand::Peek).boxed(),
-                proptest::collection::vec(any_uuid(), 1..6)
-                    .prop_map(|uuids| ComputeCommand::CancelPeeks {
-                        uuids: BTreeSet::from_iter(uuids.into_iter()),
-                    })
-                    .boxed(),
-            ])
+            any::<DataflowDescription<crate::plan::Plan, CollectionMetadata, mz_repr::Timestamp>>()
+                .prop_map(ComputeCommand::CreateDataflow)
+                .boxed(),
+            (any::<GlobalId>(), any_antichain())
+                .prop_map(|(id, frontier)| ComputeCommand::AllowCompaction { id, frontier })
+                .boxed(),
+            any::<Peek>().prop_map(ComputeCommand::Peek).boxed(),
+            any_uuid()
+                .prop_map(|uuid| ComputeCommand::CancelPeek { uuid })
+                .boxed(),
+        ])
     }
 }
 

--- a/src/compute-client/src/protocol/response.proto
+++ b/src/compute-client/src/protocol/response.proto
@@ -32,7 +32,7 @@ message ProtoComputeResponse {
     }
 
     oneof kind {
-        mz_storage_client.client.ProtoFrontierUppersKind frontier_uppers = 1;
+        mz_storage_client.client.ProtoTrace frontier_upper = 1;
         ProtoPeekResponseKind peek_response = 2;
         ProtoSubscribeResponseKind subscribe_response = 3;
     }

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -14,6 +14,7 @@ use std::num::NonZeroUsize;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_proto::{any_uuid, IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{Diff, GlobalId, Row};
+use mz_storage_client::client::ProtoTrace;
 use mz_timely_util::progress::any_antichain;
 use proptest::prelude::{any, Arbitrary, Just};
 use proptest::strategy::{BoxedStrategy, Strategy, Union};
@@ -34,17 +35,16 @@ include!(concat!(
 /// [`ComputeCommand`]: super::command::ComputeCommand
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ComputeResponse<T = mz_repr::Timestamp> {
-    /// `FrontierUppers` announces the advancement of the upper frontiers of the specified compute
-    /// collections. The response contains a mapping of collection IDs to their new upper
-    /// frontiers.
+    /// `FrontierUpper` announces the advancement of the upper frontier of the specified compute
+    /// collection. The response contain a collection ID and that collection's new upper frontier.
     ///
-    /// Upon receiving a `FrontierUppers` response, the controller may assume that the replica has
-    /// finished computing the given collections up to at least the given frontiers. It may also
-    /// assume that the replica has finished reading from the collections’ inputs up to those
-    /// frontiers.
+    /// Upon receiving a `FrontierUpper` response, the controller may assume that the replica has
+    /// finished computing the given collection up to at least the given frontier. It may also
+    /// assume that the replica has finished reading from the collection’s inputs up to that
+    /// frontier.
     ///
-    /// Replicas must send `FrontierUppers` responses for compute collections that are indexes or
-    /// storage sinks. Replicas must not send `FrontierUppers` responses for subscribes.
+    /// Replicas must send `FrontierUpper` responses for compute collections that are indexes or
+    /// storage sinks. Replicas must not send `FrontierUpper` responses for subscribes.
     ///
     /// Replicas must never report regressing frontiers. Specifically:
     ///
@@ -53,7 +53,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * Subsequent reported frontiers for a collection must not be less than any frontier
     ///     reported previously for the same collection.
     ///
-    /// Replicas must send a `FrontierUppers` response reporting advancement to the empty frontier
+    /// Replicas must send a `FrontierUpper` response reporting advancement to the empty frontier
     /// for a collection in two cases:
     ///
     ///   * The collection has advanced to the empty frontier (e.g. because its inputs have advanced
@@ -64,9 +64,9 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// Once a collection was reported to have been advanced to the empty upper frontier:
     ///
     ///   * It must no longer read from its inputs.
-    ///   * The replica must not send further `FrontierUppers` responses for that collection.
+    ///   * The replica must not send further `FrontierUpper` responses for that collection.
     ///
-    /// The replica must not send `FrontierUppers` responses for collections that have not
+    /// The replica must not send `FrontierUpper` responses for collections that have not
     /// been created previously by a [`CreateDataflow` command] or by a [`CreateInstance`
     /// command].
     ///
@@ -74,7 +74,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
-    FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
+    FrontierUpper { id: GlobalId, upper: Antichain<T> },
 
     /// `PeekResponse` reports the result of a previous [`Peek` command]. The peek is identified by
     /// a `Uuid` that matches the command's [`Peek::uuid`].
@@ -135,7 +135,10 @@ impl RustType<ProtoComputeResponse> for ComputeResponse<mz_repr::Timestamp> {
         use proto_compute_response::*;
         ProtoComputeResponse {
             kind: Some(match self {
-                ComputeResponse::FrontierUppers(traces) => FrontierUppers(traces.into_proto()),
+                ComputeResponse::FrontierUpper { id, upper } => FrontierUpper(ProtoTrace {
+                    id: Some(id.into_proto()),
+                    upper: Some(upper.into_proto()),
+                }),
                 ComputeResponse::PeekResponse(id, resp, otel_ctx) => {
                     PeekResponse(ProtoPeekResponseKind {
                         id: Some(id.into_proto()),
@@ -156,9 +159,10 @@ impl RustType<ProtoComputeResponse> for ComputeResponse<mz_repr::Timestamp> {
     fn from_proto(proto: ProtoComputeResponse) -> Result<Self, TryFromProtoError> {
         use proto_compute_response::Kind::*;
         match proto.kind {
-            Some(FrontierUppers(traces)) => {
-                Ok(ComputeResponse::FrontierUppers(traces.into_rust()?))
-            }
+            Some(FrontierUpper(trace)) => Ok(ComputeResponse::FrontierUpper {
+                id: trace.id.into_rust_if_some("ProtoTrace::id")?,
+                upper: trace.upper.into_rust_if_some("ProtoTrace::upper")?,
+            }),
             Some(PeekResponse(resp)) => Ok(ComputeResponse::PeekResponse(
                 resp.id.into_rust_if_some("ProtoPeekResponseKind::id")?,
                 resp.resp.into_rust_if_some("ProtoPeekResponseKind::resp")?,
@@ -183,8 +187,8 @@ impl Arbitrary for ComputeResponse<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         Union::new(vec![
-            proptest::collection::vec((any::<GlobalId>(), any_antichain()), 1..4)
-                .prop_map(ComputeResponse::FrontierUppers)
+            (any::<GlobalId>(), any_antichain())
+                .prop_map(|(id, upper)| ComputeResponse::FrontierUpper { id, upper })
                 .boxed(),
             (any_uuid(), any::<PeekResponse>())
                 .prop_map(|(id, resp)| {

--- a/src/compute-client/src/protocol/response.rs
+++ b/src/compute-client/src/protocol/response.rs
@@ -67,11 +67,11 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * The replica must not send further `FrontierUppers` responses for that collection.
     ///
     /// The replica must not send `FrontierUppers` responses for collections that have not
-    /// been created previously by a [`CreateDataflows` command] or by a [`CreateInstance`
+    /// been created previously by a [`CreateDataflow` command] or by a [`CreateInstance`
     /// command].
     ///
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
-    /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
+    /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`CreateInstance` command]: super::command::ComputeCommand::CreateInstance
     /// [#16275]: https://github.com/MaterializeInc/materialize/issues/16275
     FrontierUppers(Vec<(GlobalId, Antichain<T>)>),
@@ -81,15 +81,15 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///
     /// The replica must send exactly one `PeekResponse` for every [`Peek` command] it received.
     ///
-    /// If the replica did not receive a [`CancelPeeks` command] for a peek, it must not send a
-    /// [`Canceled`] response for that peek. If the replica did receive a [`CancelPeeks` command]
+    /// If the replica did not receive a [`CancelPeek` command] for a peek, it must not send a
+    /// [`Canceled`] response for that peek. If the replica did receive a [`CancelPeek` command]
     /// for a peek, it may send any of the three [`PeekResponse`] variants.
     ///
     /// The replica must not send `PeekResponse`s for peek IDs that were not previously specified
     /// in a [`Peek` command].
     ///
     /// [`Peek` command]: super::command::ComputeCommand::Peek
-    /// [`CancelPeeks` command]: super::command::ComputeCommand::CancelPeeks
+    /// [`CancelPeek` command]: super::command::ComputeCommand::CancelPeek
     /// [`Peek::uuid`]: super::command::Peek::uuid
     /// [`Canceled`]: PeekResponse::Canceled
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
@@ -97,7 +97,7 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     /// `SubscribeResponse` reports the results emitted by an active subscribe over some time
     /// interval.
     ///
-    /// For each subscribe that was installed by a previous [`CreateDataflows` command], the
+    /// For each subscribe that was installed by a previous [`CreateDataflow` command], the
     /// replica must emit [`Batch`] responses that cover the entire time interval from the
     /// minimum time until the subscribe advances to the empty frontier or is
     /// dropped. The time intervals of consecutive [`Batch`]es must be increasing, contiguous,
@@ -120,11 +120,11 @@ pub enum ComputeResponse<T = mz_repr::Timestamp> {
     ///   * The replica must not send further `SubscribeResponse`s for that subscribe.
     ///
     /// The replica must not send `SubscribeResponse`s for subscribes that have not been
-    /// created previously by a [`CreateDataflows` command].
+    /// created previously by a [`CreateDataflow` command].
     ///
     /// [`Batch`]: SubscribeResponse::Batch
     /// [`DroppedAt`]: SubscribeResponse::DroppedAt
-    /// [`CreateDataflows` command]: super::command::ComputeCommand::CreateDataflows
+    /// [`CreateDataflow` command]: super::command::ComputeCommand::CreateDataflow
     /// [`AllowCompaction` command]: super::command::ComputeCommand::AllowCompaction
     SubscribeResponse(GlobalId, SubscribeResponse<T>),
 }

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -182,43 +182,36 @@ impl<'w, A: Allocate> Worker<'w, A> {
         parts: usize,
     ) -> Vec<ComputeCommand<T>> {
         match command {
-            ComputeCommand::CreateDataflows(dataflows) => {
-                let mut dataflows_parts = vec![Vec::new(); parts];
-
-                for dataflow in dataflows {
-                    // A list of descriptions of objects for each part to build.
-                    let mut builds_parts = vec![Vec::new(); parts];
-                    // Partition each build description among `parts`.
-                    for build_desc in dataflow.objects_to_build {
-                        let build_part = build_desc.plan.partition_among(parts);
-                        for (plan, objects_to_build) in
-                            build_part.into_iter().zip(builds_parts.iter_mut())
-                        {
-                            objects_to_build.push(BuildDesc {
-                                id: build_desc.id,
-                                plan,
-                            });
-                        }
-                    }
-                    // Each list of build descriptions results in a dataflow description.
-                    for (dataflows_part, objects_to_build) in
-                        dataflows_parts.iter_mut().zip(builds_parts)
+            ComputeCommand::CreateDataflow(dataflow) => {
+                // A list of descriptions of objects for each part to build.
+                let mut builds_parts = vec![Vec::new(); parts];
+                // Partition each build description among `parts`.
+                for build_desc in dataflow.objects_to_build {
+                    let build_part = build_desc.plan.partition_among(parts);
+                    for (plan, objects_to_build) in
+                        build_part.into_iter().zip(builds_parts.iter_mut())
                     {
-                        dataflows_part.push(DataflowDescription {
-                            source_imports: dataflow.source_imports.clone(),
-                            index_imports: dataflow.index_imports.clone(),
-                            objects_to_build,
-                            index_exports: dataflow.index_exports.clone(),
-                            sink_exports: dataflow.sink_exports.clone(),
-                            as_of: dataflow.as_of.clone(),
-                            until: dataflow.until.clone(),
-                            debug_name: dataflow.debug_name.clone(),
+                        objects_to_build.push(BuildDesc {
+                            id: build_desc.id,
+                            plan,
                         });
                     }
                 }
-                dataflows_parts
+
+                // Each list of build descriptions results in a dataflow description.
+                builds_parts
                     .into_iter()
-                    .map(ComputeCommand::CreateDataflows)
+                    .map(|objects_to_build| DataflowDescription {
+                        source_imports: dataflow.source_imports.clone(),
+                        index_imports: dataflow.index_imports.clone(),
+                        objects_to_build,
+                        index_exports: dataflow.index_exports.clone(),
+                        sink_exports: dataflow.sink_exports.clone(),
+                        as_of: dataflow.as_of.clone(),
+                        until: dataflow.until.clone(),
+                        debug_name: dataflow.debug_name.clone(),
+                    })
+                    .map(ComputeCommand::CreateDataflow)
                     .collect()
             }
             command => vec![command; parts],
@@ -481,16 +474,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     ComputeCommand::CreateInstance(logging) => {
                         old_logging_config = Some(logging);
                     }
-                    ComputeCommand::CreateDataflows(dataflows) => {
-                        for dataflow in dataflows.iter() {
-                            let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
-                            old_dataflows.insert(export_ids, dataflow);
-                        }
+                    ComputeCommand::CreateDataflow(dataflow) => {
+                        let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
+                        old_dataflows.insert(export_ids, dataflow);
                     }
-                    ComputeCommand::AllowCompaction(frontiers) => {
-                        for (id, frontier) in frontiers.iter() {
-                            old_frontiers.insert(id, frontier);
-                        }
+                    ComputeCommand::AllowCompaction { id, frontier } => {
+                        old_frontiers.insert(id, frontier);
                     }
                     _ => {
                         // Nothing to do in these cases.
@@ -506,57 +495,49 @@ impl<'w, A: Allocate> Worker<'w, A> {
             // Traverse new commands, sorting out what remediation we can do.
             for command in new_commands.iter() {
                 match command {
-                    ComputeCommand::CreateDataflows(dataflows) => {
-                        // Track dataflow we must build anew.
-                        let mut new_dataflows = Vec::new();
+                    ComputeCommand::CreateDataflow(dataflow) => {
+                        // Attempt to find an existing match for the dataflow.
+                        let as_of = dataflow.as_of.as_ref().unwrap();
+                        let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
 
-                        // Attempt to find an existing match for each dataflow.
-                        for dataflow in dataflows.iter() {
-                            let as_of = dataflow.as_of.as_ref().unwrap();
-                            let export_ids = dataflow.export_ids().collect::<BTreeSet<_>>();
-
-                            if let Some(old_dataflow) = old_dataflows.get(&export_ids) {
-                                let compatible = old_dataflow.compatible_with(dataflow);
-                                let uncompacted = !export_ids
-                                    .iter()
-                                    .flat_map(|id| old_frontiers.get(id))
-                                    .any(|frontier| {
-                                        !timely::PartialOrder::less_equal(
-                                            *frontier,
-                                            dataflow.as_of.as_ref().unwrap(),
-                                        )
-                                    });
-                                // We cannot reconcile subscriptions at the moment, because the response buffer is shared,
-                                // and to a first approximation must be completely reformed.
-                                let subscribe_free = dataflow
-                                    .sink_exports
-                                    .iter()
-                                    .all(|(_id, sink)| !sink.connection.is_subscribe());
-                                if compatible && uncompacted && subscribe_free {
-                                    // Match found; remove the match from the deletion queue,
-                                    // and compact its outputs to the dataflow's `as_of`.
-                                    old_dataflows.remove(&export_ids);
-                                    for id in export_ids.iter() {
-                                        old_compaction.insert(*id, as_of.clone());
-                                    }
-                                    retain_ids.extend(export_ids);
-                                } else {
-                                    new_dataflows.push(dataflow.clone());
+                        if let Some(old_dataflow) = old_dataflows.get(&export_ids) {
+                            let compatible = old_dataflow.compatible_with(dataflow);
+                            let uncompacted = !export_ids
+                                .iter()
+                                .flat_map(|id| old_frontiers.get(id))
+                                .any(|frontier| {
+                                    !timely::PartialOrder::less_equal(
+                                        *frontier,
+                                        dataflow.as_of.as_ref().unwrap(),
+                                    )
+                                });
+                            // We cannot reconcile subscriptions at the moment, because the response buffer is shared,
+                            // and to a first approximation must be completely reformed.
+                            let subscribe_free = dataflow
+                                .sink_exports
+                                .iter()
+                                .all(|(_id, sink)| !sink.connection.is_subscribe());
+                            if compatible && uncompacted && subscribe_free {
+                                // Match found; remove the match from the deletion queue,
+                                // and compact its outputs to the dataflow's `as_of`.
+                                old_dataflows.remove(&export_ids);
+                                for id in export_ids.iter() {
+                                    old_compaction.insert(*id, as_of.clone());
                                 }
-
-                                compute_state.metrics.record_dataflow_reconciliation(
-                                    self.timely_worker.index(),
-                                    compatible,
-                                    uncompacted,
-                                    subscribe_free,
-                                );
+                                retain_ids.extend(export_ids);
                             } else {
-                                new_dataflows.push(dataflow.clone());
+                                todo_commands
+                                    .push(ComputeCommand::CreateDataflow(dataflow.clone()));
                             }
-                        }
 
-                        if !new_dataflows.is_empty() {
-                            todo_commands.push(ComputeCommand::CreateDataflows(new_dataflows));
+                            compute_state.metrics.record_dataflow_reconciliation(
+                                self.timely_worker.index(),
+                                compatible,
+                                uncompacted,
+                                subscribe_free,
+                            );
+                        } else {
+                            todo_commands.push(ComputeCommand::CreateDataflow(dataflow.clone()));
                         }
                     }
                     ComputeCommand::CreateInstance(logging) => {
@@ -586,12 +567,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
             }
-            if !old_compaction.is_empty() {
-                let compactions = old_compaction
-                    .iter()
-                    .map(|(k, v)| (*k, v.clone()))
-                    .collect();
-                todo_commands.insert(0, ComputeCommand::AllowCompaction(compactions));
+            for (&id, frontier) in &old_compaction {
+                let frontier = frontier.clone();
+                todo_commands.insert(0, ComputeCommand::AllowCompaction { id, frontier });
             }
 
             // Clean up worker-local state.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2116,12 +2116,12 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     assert count == 1, f"unexpected create_instance count: {count}"
     count = metrics.get_command_count("allow_compaction")
     assert count > 0, f"unexpected allow_compaction count: {count}"
-    count = metrics.get_command_count("create_dataflows")
-    assert count > 0, f"unexpected create_dataflows count: {count}"
+    count = metrics.get_command_count("create_dataflow")
+    assert count > 0, f"unexpected create_dataflow count: {count}"
     count = metrics.get_command_count("peek")
     assert count <= 2, f"unexpected peek count: {count}"
-    count = metrics.get_command_count("cancel_peeks")
-    assert count == 0, f"unexpected cancel_peeks count: {count}"
+    count = metrics.get_command_count("cancel_peek")
+    assert count == 0, f"unexpected cancel_peek count: {count}"
     count = metrics.get_command_count("initialization_complete")
     assert count == 0, f"unexpected initialization_complete count: {count}"
     count = metrics.get_command_count("update_configuration")


### PR DESCRIPTION
This PR removes the batching previously build into `ComputeCommand`s and `ComputeResponse`s. Any commands and responses that previously contained a collection of items now contain only a single item. Where applicable they have also been renamed from plural to singular.

The compute controller API is adjusted accordingly, to simplify the code a bit. This means that this change affects adapter code as well, but only slightly.

The unbatching generally improves readability and reduces complexity by removing loops over the batches. It also makes it easier to reason about command counts in the `ComputeCommandHistory`, which previously required thinking about "physical" and "logical" commands. Now these are the same.

### Network Traffic

This change could plausibly produce a regression in amount of network traffic produced. Our current best guess is that the batching was originally added to allow a more efficient network encoding. But even if this optimization was validated back then, we switched encodings in the meantime (from bitcode to protobuf). I claim that with protobuf, the difference in encoded size we get from batching compute commands and responses is negligible.

To show this, I spun up a TPC-H load generator source on my staging env and installed all the pk and fk indexes. Then I observed the bytes transmitted on main and with this PR. This is the result (notice the spikes in the graphs when the env was restarted between the two version):

![Screenshot 2023-08-07 at 13 56 32](https://github.com/MaterializeInc/materialize/assets/4521314/888b229c-c710-4ce3-b347-15c04386385e)

As expected, the number of commands and responses increases significantly, but the number of bytes transmitted stays roughly the same (and even seems to decrease slightly).

### Encoding

Finally, we can look at the protobuf encoding to convince ourselves that the new encoding doesn't use more space than the old one:

* **old encoding**
  The command `AllowCompaction([(User(1), Antichain { elements: [11111] }), (User(2), Antichain { elements: [22222] })])` serializes to 27 bytes:
  ```
  22 19                 tag: "allow_compaction", type: LEN(25)
     0a 0a              tag: "collections", type: LEN(10)
        0a 02           tag: "id", type: LEN(2)
           10           tag: "user", type: VARINT
           01           value: 1
        12 04           tag: "frontier", type: LEN(4)
           0a 02        tag: "elements", type: LEN(2)
              e7 56     value: [11111]
     0a 0b              tag: "collections", type: LEN(11)
        0a 02           tag: "id", type: LEN(2)
           10           tag: "user", type: VARINT
           02           value: 2
        12 05           tag: "frontier", type: LEN(5)
           0a 03        tag: "elements", type: LEN(3)
              ce ad 01  value: [22222]
  ```

* **new encoding**
  The commands `AllowCompaction { id: User(1), frontier: Antichain { elements: [11111] } }, AllowCompaction { id: User(2), frontier: Antichain { elements: [22222] } }` serialize to 25 bytes:
  ```
  22 0a                 tag: "allow_compaction", type: LEN(10)
     0a 02              tag: "id", type: LEN(2)
        10              tag: "user", type: VARINT
        01              value: 1
     12 04              tag: "frontier", type: LEN(4)
        0a 02           tag: "elements", type: LEN(2)
           e7 56        value: [11111]
  22 0b                 tag: "allow_compaction", type: LEN(10)
     0a 02              tag: "id", type: LEN(2)
        10              tag: "user", type: VARINT
        02              value: 2
     12 05              tag: "frontier", type: LEN(5)
        0a 03           tag: "elements", type: LEN(3)
           ce ad 01     value: [22222]
  ```

The new encoding adds one "allow_compaction" message tag (2 bytes) for each transmitted item but the first, but it also omits one "collections" message tag (2 bytes) per transmitted item. As a result, the new encoding is two bytes smaller than the old one. This should be true for each unbatched message type and for any number of transmitted items.

### Motivation

   * This PR refactors existing code.

Prepares for fixing #20242.
[Relevant discussion in Slack.](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1689847632229639)

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A