### PR TITLE
Add missing builtin sink indexes

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -4286,12 +4286,30 @@ ON mz_internal.mz_source_statuses (id)",
     is_retained_metrics_object: false,
 };
 
+pub const MZ_SINK_STATUSES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_sink_statuses_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_sink_statuses_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_sink_statuses (id)",
+    is_retained_metrics_object: false,
+};
+
 pub const MZ_SOURCE_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
     name: "mz_source_status_history_ind",
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE INDEX mz_source_status_history_ind
 IN CLUSTER mz_introspection
 ON mz_internal.mz_source_status_history (source_id)",
+    is_retained_metrics_object: false,
+};
+
+pub const MZ_SINK_STATUS_HISTORY_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_sink_status_history_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_sink_status_history_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_sink_status_history (sink_id)",
     is_retained_metrics_object: false,
 };
 
@@ -4715,6 +4733,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_CLUSTERS_IND),
         Builtin::Index(&MZ_SOURCE_STATUSES_IND),
         Builtin::Index(&MZ_SOURCE_STATUS_HISTORY_IND),
+        Builtin::Index(&MZ_SINK_STATUSES_IND),
+        Builtin::Index(&MZ_SINK_STATUS_HISTORY_IND),
         Builtin::Index(&MZ_SOURCE_STATISTICS_IND),
         Builtin::Index(&MZ_SINK_STATISTICS_IND),
         Builtin::Index(&MZ_CLUSTER_REPLICAS_IND),

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -407,7 +407,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-100
+102
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -415,7 +415,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-81
+83
 
 simple conn=mz_system,user=mz_system
 ALTER CLUSTER default OWNER TO materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -647,7 +647,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-81
+83
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -329,3 +329,5 @@ mz_sink_statistics_ind                                      mz_sink_statistics  
 mz_source_statistics_ind                                    mz_source_statistics                         mz_introspection    {id}
 mz_source_status_history_ind                                mz_source_status_history                     mz_introspection    {source_id}
 mz_source_statuses_ind                                      mz_source_statuses                           mz_introspection    {id}
+mz_sink_statuses_ind                                        mz_sink_statuses                             mz_introspection    {id}
+mz_sink_status_history_ind                                  mz_sink_status_history                       mz_introspection    {sink_id}

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -697,73 +697,80 @@ ReduceMinsMaxes
 > SET CLUSTER TO mz_introspection
 
 > SELECT mdo.name FROM mz_internal.mz_arrangement_sharing mash JOIN mz_internal.mz_dataflow_operators mdo ON mash.operator_id = mdo.id ORDER BY mdo.name;
-AccumulableErrorCheck
-ArrangeAccumulable
+"AccumulableErrorCheck"
+"ArrangeAccumulable"
 "ArrangeBy[[Column(0), Column(1), Column(2), Column(3)]]"
 "ArrangeBy[[Column(0), Column(1), Column(2), Column(3)]]-errors"
 "ArrangeBy[[Column(0), Column(2)]]"
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
-ArrangeBy[[Column(0)]]-errors
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
+"ArrangeBy[[Column(0)]]-errors"
 "ArrangeBy[[Column(1), Column(0)]]"
 "ArrangeBy[[Column(1), Column(3)]]"
 "ArrangeBy[[Column(1), Column(3)]]"
-ArrangeBy[[Column(1)]]
-ArrangeBy[[Column(1)]]
-ArrangeBy[[Column(1)]]
-ArrangeBy[[Column(1)]]-errors
-ArrangeBy[[Column(1)]]-errors
+"ArrangeBy[[Column(1)]]"
+"ArrangeBy[[Column(1)]]"
+"ArrangeBy[[Column(1)]]"
+"ArrangeBy[[Column(1)]]"
+"ArrangeBy[[Column(1)]]"
+"ArrangeBy[[Column(1)]]-errors"
+"ArrangeBy[[Column(1)]]-errors"
+"ArrangeBy[[Column(1)]]-errors"
 "ArrangeBy[[Column(2), Column(3)]]"
 "ArrangeBy[[Column(2), Column(3)]]-errors"
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(2)]]-errors
-ArrangeBy[[Column(3)]]
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(2)]]-errors"
+"ArrangeBy[[Column(3)]]"
 "ArrangeBy[[Column(4), Column(5), Column(6)]]"
 "ArrangeBy[[Column(4), Column(5), Column(6)]]-errors"
 "Arranged DistinctBy"
@@ -776,13 +783,29 @@ ArrangeBy[[Column(3)]]
 "Arranged TopK input"
 "Arranged TopK input"
 "Arranged TopK input"
-DistinctBy
-DistinctByErrorCheck
-JoinStage
-JoinStage
-ReduceAccumulable
-ReduceInaccumulable
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"Arranged TopK input"
+"DistinctBy"
+"DistinctByErrorCheck"
+"JoinStage"
+"JoinStage"
+"ReduceAccumulable"
+"ReduceInaccumulable"
 "ReduceInaccumulable Error Check"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
+"Reduced TopK input"
 "Reduced TopK input"
 "Reduced TopK input"
 "Reduced TopK input"


### PR DESCRIPTION
Adds indexes for `mz_sink_status_history` and `mz_sink_statuses`.

### Motivation


  * This PR adds a feature that has not yet been specified.

Make it fast!


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):

No user facing chages.
