### PR TITLE
tracing: introduce span_field_struct macro; use in persist GC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
  "mz-timely-util",
  "num_cpus",
  "num_enum",
+ "paste",
  "prometheus",
  "proptest",
  "proptest-derive",

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -44,6 +44,7 @@ mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }
+paste = "1.0.11"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -33,7 +33,7 @@ use crate::cache::StateCache;
 use crate::cli::inspect::StateArgs;
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
 use crate::internal::encoding::Schemas;
-use crate::internal::gc::{GarbageCollector, GcReq};
+use crate::internal::gc::{GarbageCollector, GcReq, GcSpanFields};
 use crate::internal::machine::Machine;
 use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
@@ -451,7 +451,8 @@ async fn force_gc(
         shard_id,
         new_seqno_since: machine.applier.seqno_since(),
     };
-    let (maintenance, _stats) = GarbageCollector::gc_and_truncate(&mut machine, gc_req).await;
+    let (maintenance, _stats) =
+        GarbageCollector::gc_and_truncate(&mut machine, gc_req, GcSpanFields::default()).await;
     if !maintenance.is_empty() {
         info!("ignoring non-empty requested maintenance: {maintenance:?}")
     }

--- a/src/persist-client/src/internal/gc.rs
+++ b/src/persist-client/src/internal/gc.rs
@@ -23,7 +23,7 @@ use prometheus::Counter;
 use timely::progress::Timestamp;
 use tokio::sync::mpsc::UnboundedSender;
 use tokio::sync::{mpsc, oneshot, Semaphore};
-use tracing::{debug, debug_span, error, warn, Instrument, Span};
+use tracing::{debug, debug_span, error, instrument, warn, Instrument, Span};
 
 use crate::async_runtime::IsolatedRuntime;
 use mz_ore::cast::CastFrom;
@@ -149,9 +149,6 @@ where
                     );
                 }
 
-                let gc_span = debug_span!(parent: None, "gc_and_truncate", shard_id=%consolidated_req.shard_id);
-                gc_span.follows_from(&Span::current());
-
                 let start = Instant::now();
                 machine.applier.metrics.gc.started.inc();
                 let (mut maintenance, _stats) = {
@@ -159,9 +156,12 @@ where
                     let mut machine = machine.clone();
                     isolated_runtime
                         .spawn_named(|| name, async move {
-                            Self::gc_and_truncate(&mut machine, consolidated_req)
-                                .instrument(gc_span)
-                                .await
+                            Self::gc_and_truncate(
+                                &mut machine,
+                                consolidated_req,
+                                GcSpanFields::default(),
+                            )
+                            .await
                         })
                         .await
                         .expect("gc_and_truncate failed")
@@ -215,10 +215,33 @@ where
         Some(gc_completed_receiver)
     }
 
+    #[instrument(
+        level = "debug",
+        parent = None,
+        skip_all,
+        fields(
+            gc_req_seqno_since,
+            gc_current_state_seqno,
+            gc_rollups_to_remove_count,
+            gc_batch_parts_deleted_from_blob_count,
+            gc_rollups_deleted_from_blob_count,
+            shard = %req.shard_id
+        )
+    )]
     pub(crate) async fn gc_and_truncate(
         machine: &mut Machine<K, V, T, D>,
         req: GcReq,
+        GcSpanFields {
+            gc_req_seqno_since: _,
+            gc_current_state_seqno: _,
+            gc_rollups_to_remove_count: _,
+            gc_batch_parts_deleted_from_blob_count: _,
+            gc_rollups_deleted_from_blob_count: _,
+            recorder,
+        }: GcSpanFields,
     ) -> (RoutineMaintenance, GcResults) {
+        let span = Span::current();
+
         let mut step_start = Instant::now();
         let mut report_step_timing = |counter: &Counter| {
             let now = Instant::now();
@@ -252,6 +275,10 @@ where
         report_step_timing(&machine.applier.metrics.gc.steps.find_removable_rollups);
 
         let mut gc_results = GcResults::default();
+
+        recorder.gc_current_state_seqno(&span, || machine.seqno().0);
+        recorder.gc_req_seqno_since(&span, || req.new_seqno_since.0);
+        recorder.gc_rollups_to_remove_count(&span, || rollups_to_remove_from_state.len());
 
         if rollups_to_remove_from_state.is_empty() {
             // If there are no rollups to remove from state (either the work has already
@@ -385,6 +412,11 @@ where
                 .steps
                 .post_gc_calculations_seconds,
         );
+
+        recorder.gc_rollups_deleted_from_blob_count(&span, || gc_results.rollups_deleted_from_blob);
+        recorder.gc_batch_parts_deleted_from_blob_count(&span, || {
+            gc_results.batch_parts_deleted_from_blob
+        });
 
         (maintenance, gc_results)
     }
@@ -672,3 +704,12 @@ impl GcRollups {
         }
     }
 }
+
+mz_ore::span_field_struct!(
+    GcSpanFields,
+    gc_req_seqno_since,
+    gc_current_state_seqno,
+    gc_rollups_to_remove_count,
+    gc_batch_parts_deleted_from_blob_count,
+    gc_rollups_deleted_from_blob_count,
+);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Introduces a new macro, `span_field_struct!` that allows for semi-structured access to span fields in `#[instrument]` and `(info|debug|trace)_span!` macros. This partially avoids the challenges of ensuring that the field name used in the macro matches 1:1 with the string passed in to `Span::record`, and additionally creates compilation errors if the fields are renamed or any left unset in the fn body. It's not currently possible to use const expressions for field names (https://discord.com/channels/500028886025895936/627649734592561152/1137023415136555028) so this is the best solution I could come up. The rustdoc example and PoC outlined for persist GC explain this better in code than I can in words.

Anyway, tl;dr, this PR helps reduce the footguns involved with turning 

```
mz_ore::span_field_struct!(
    GcSpanFields,
    gc_req_seqno_since,
    gc_current_state_seqno,
    gc_rollups_to_remove_count,
    gc_batch_parts_deleted_from_blob_count,
    gc_rollups_deleted_from_blob_count,
);
```

into

<img width="1721" alt="Screenshot 2023-08-04 at 12 30 58 PM" src="https://github.com/MaterializeInc/materialize/assets/785446/19dd78fd-7e58-49a7-a4fa-ddbeb29ef25b">

I am very, very far from a Rust expert, so please let me know if there are simpler / better / safer ways to structure field names!

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
