### PR TITLE
cloudtest: Cross-repo coordination for cloud tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -94,3 +94,4 @@
 /src/walkabout                      @benesch
 /src/workspace-hack                 @benesch
 /test
+/misc/python/materialize/cloudtest  @MaterializeInc/cloud @MaterializeInc/qa

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -52,7 +52,7 @@ Delete this section if no tips.
 - [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
   <!-- Reference the design in the description. -->
 - [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
-- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
+- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
   <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
 - [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
   - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->


### PR DESCRIPTION
Update the pull request template to reference cloud tests as well as
orchestration, and add the Cloud team as CODEOWNERS for the shared cloud
test code.

### Motivation

   * This PR refactors existing code.

   Not code so much as process :smile: