### PR TITLE
[optimizer] Avoid cardinality estimation panic in debug builds

### DIFF
--- a/src/transform/src/attribute/cardinality.rs
+++ b/src/transform/src/attribute/cardinality.rs
@@ -74,7 +74,7 @@ pub trait Factorizer {
     fn flat_map(&self, tf: &TableFunc, input: &SymExp) -> SymExp;
     /// Computes selectivity of the predicate `expr`, given that `unique_columns` are indexed/unique
     ///
-    /// The result should be in the range (0, 1.0]
+    /// The result should be in the range [0, 1.0]
     fn predicate(&self, expr: &MirScalarExpr, unique_columns: &BTreeSet<usize>) -> SymExp;
     /// Computes selectivity for a filter
     fn filter(
@@ -254,11 +254,11 @@ impl Factorizer for WorstCaseFactorizer {
         for expr in predicates {
             let predicate_scaling_factor = self.predicate(expr, &unique_columns);
 
-            // constant scaling factors should be in (0,1]
+            // constant scaling factors should be in [0,1]
             debug_assert!(match predicate_scaling_factor {
-                SymExp::Constant(OrderedFloat(n)) => 0.0 < n && n <= 1.0,
+                SymExp::Constant(OrderedFloat(n)) => 0.0 <= n && n <= 1.0,
                 _ => true,
-            });
+            }, "predicate scaling factor {predicate_scaling_factor} should be in the range [0,1]");
 
             factor = factor * predicate_scaling_factor;
         }

--- a/src/transform/src/attribute/cardinality.rs
+++ b/src/transform/src/attribute/cardinality.rs
@@ -255,10 +255,13 @@ impl Factorizer for WorstCaseFactorizer {
             let predicate_scaling_factor = self.predicate(expr, &unique_columns);
 
             // constant scaling factors should be in [0,1]
-            debug_assert!(match predicate_scaling_factor {
-                SymExp::Constant(OrderedFloat(n)) => 0.0 <= n && n <= 1.0,
-                _ => true,
-            }, "predicate scaling factor {predicate_scaling_factor} should be in the range [0,1]");
+            debug_assert!(
+                match predicate_scaling_factor {
+                    SymExp::Constant(OrderedFloat(n)) => 0.0 <= n && n <= 1.0,
+                    _ => true,
+                },
+                "predicate scaling factor {predicate_scaling_factor} should be in the range [0,1]"
+            );
 
             factor = factor * predicate_scaling_factor;
         }

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -195,3 +195,65 @@ Used Indexes:
   - materialize.public.tt_x
 
 EOF
+
+# regression test drawn from LDBC-BI query 15 for having a selectivity of 0
+# TODO(mgree): we could probably trim this down to be tighter, but the optimizer has been too clever for me
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_with_mutually_recursive TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE Person_knows_Person (
+    creationDate timestamp with time zone NOT NULL,
+    Person1id bigint NOT NULL,
+    Person2id bigint NOT NULL
+)
+
+statement ok
+CREATE INDEX Person_knows_Person_Person1id_Person2id ON Person_knows_Person (Person1id, Person2id)
+
+query T multiline
+EXPLAIN WITH MUTUALLY RECURSIVE
+  mm (src bigint, dst bigint, w bigint) AS (SELECT 3::bigint, 4::bigint, 5::bigint),
+  path (src bigint, dst bigint, w double precision) AS (
+      SELECT pp.person1id, pp.person2id, 10::double precision / (coalesce(w, 0) + 10)
+      FROM Person_knows_Person pp left join mm on least(pp.person1id, pp.person2id) = mm.src AND greatest(pp.person1id, pp.person2id) = mm.dst
+  ),
+  pexists (src bigint, dir bool) AS (
+      (
+          SELECT 1::bigint, true
+          UNION
+          SELECT 2::bigint, false
+      )
+      UNION
+      (
+          WITH
+          ss (src, dir) AS (SELECT src, dir FROM pexists),
+          ns (src, dir) AS (SELECT p.dst, ss.dir FROM ss, path p WHERE ss.src = p.src),
+          bb (src, dir) AS (SELECT src, dir FROM ns UNION ALL SELECT src, dir FROM ss),
+          found (found) AS (
+              SELECT 1 AS found
+              FROM bb b1, bb b2
+              WHERE b1.dir AND (NOT b2.dir) AND b1.src = b2.src
+          )
+          SELECT src, dir
+          FROM ns
+          WHERE NOT EXISTS (SELECT 1 FROM found)
+          UNION
+          SELECT -1, true
+          WHERE EXISTS (SELECT 1 FROM found)
+      )
+  ),
+  pathfound (c bool) AS (
+      SELECT true AS c
+      FROM pexists
+      WHERE src = -1 AND dir
+  )
+SELECT * FROM pexists;
+----
+Explained Query (fast path):
+  Constant <empty>
+
+EOF

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -253,7 +253,73 @@ EXPLAIN WITH MUTUALLY RECURSIVE
   )
 SELECT * FROM pexists;
 ----
-Explained Query (fast path):
-  Constant <empty>
+Explained Query:
+  Return
+    Get l4
+  With Mutually Recursive
+    cte l4 =
+      Distinct group_by=[#0, #1]
+        Union
+          Distinct group_by=[#0, #1]
+            Union
+              Project (#1, #0)
+                CrossJoin type=differential
+                  ArrangeBy keys=[[]]
+                    Get l1
+                  ArrangeBy keys=[[]]
+                    Union
+                      Negate
+                        Get l3
+                      Constant
+                        - ()
+              Project (#1, #0)
+                Map (true, -1)
+                  Get l3
+          Constant
+            - (1, true)
+            - (2, false)
+    cte l3 =
+      Distinct
+        Project ()
+          Join on=(#0 = #1) type=differential
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter #1
+                  Get l2
+            ArrangeBy keys=[[#0]]
+              Project (#0)
+                Filter NOT(#1)
+                  Get l2
+    cte l2 =
+      Union
+        Project (#1, #0)
+          Get l1
+        Get l4
+    cte l1 =
+      Project (#1, #3)
+        Join on=(#0 = #2) type=differential
+          ArrangeBy keys=[[#0]]
+            Get l4
+          ArrangeBy keys=[[#0]]
+            Union
+              Project (#1, #2)
+                Get l0
+              Project (#1, #2)
+                Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential
+                  ArrangeBy keys=[[#0..=#2]]
+                    Union
+                      Negate
+                        Distinct group_by=[#0..=#2]
+                          Get l0
+                      Distinct group_by=[#0..=#2]
+                        Get materialize.public.person_knows_person
+                  ArrangeBy keys=[[#0..=#2]]
+                    Get materialize.public.person_knows_person
+    cte l0 =
+      Filter (3 = least(#1, #2)) AND (4 = greatest(#1, #2))
+        Get materialize.public.person_knows_person
+
+Used Indexes:
+  - materialize.public.person_knows_person_person1id_person2id
 
 EOF


### PR DESCRIPTION
Cardinality estimation was checking that predicate selectivity was in the range (0,1], but it should allow the range [0,1], i.e., 0 is an acceptable selectivity.

It's tricky to write a query to that has a selectivity of 0 or 1---typically, the optimizer will get rid of these! But LDBC BI query (query #15) does exactly that; I've added a lightly minimized form of that as a regression test. (I tried to shrink it more, but gave up after 5min.) I also corrected documentation and improved the `debug_assert!` call to give more detail should it fail for a _good_ reason.

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR does not require a design.
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
