### PR TITLE
storage: ldbc load generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,8 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
+ "zstd",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -5376,6 +5378,7 @@ name = "mz-storage"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-compression",
  "async-stream",
  "async-trait",
  "axum",
@@ -5457,7 +5460,6 @@ dependencies = [
  "url",
  "uuid",
  "workspace-hack",
- "zstd",
 ]
 
 [[package]]
@@ -5564,6 +5566,7 @@ name = "mz-storage-types"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-credential-types",
  "aws-types",
@@ -7116,6 +7119,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -9409,6 +9413,7 @@ version = "0.0.0"
 dependencies = [
  "ahash",
  "anyhow",
+ "async-compression",
  "aws-credential-types",
  "aws-sdk-sts",
  "aws-sig-auth",
@@ -9573,18 +9578,18 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
+version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.6"
+version = "5.0.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
  "zstd-sys",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5177,6 +5177,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uncased",
+ "url",
  "uuid",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5385,12 +5385,14 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam-channel",
+ "csv",
  "csv-core",
  "datadriven",
  "dec",
  "differential-dataflow",
  "either",
  "fail",
+ "flate2",
  "futures",
  "globset",
  "http",
@@ -5414,6 +5416,7 @@ dependencies = [
  "mz-persist-client",
  "mz-persist-types",
  "mz-pgcopy",
+ "mz-pgrepr",
  "mz-pid-file",
  "mz-postgres-util",
  "mz-repr",
@@ -5434,11 +5437,13 @@ dependencies = [
  "rand",
  "rdkafka",
  "regex",
+ "reqwest",
  "rocksdb",
  "seahash",
  "serde",
  "serde_json",
  "sha2",
+ "tar",
  "tempfile",
  "thiserror",
  "timely",
@@ -5452,6 +5457,7 @@ dependencies = [
  "url",
  "uuid",
  "workspace-hack",
+ "zstd",
 ]
 
 [[package]]
@@ -9508,6 +9514,7 @@ dependencies = [
  "url",
  "uuid",
  "zeroize",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -9565,11 +9572,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+name = "zstd"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "6.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.8+zstd.1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5556e6ee25d32df2586c098bbfa278803692a20d0ab9565e049480d52707ec8c"
 dependencies = [
  "cc",
  "libc",
+ "pkg-config",
 ]

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -37,6 +37,7 @@ from materialize.checks.json_source import *  # noqa: F401 F403
 from materialize.checks.jsonb_type import *  # noqa: F401 F403
 from materialize.checks.kafka_formats import *  # noqa: F401 F403
 from materialize.checks.large_tables import *  # noqa: F401 F403
+from materialize.checks.ldbc_generator import *  # noqa: F401 F403
 from materialize.checks.like import *  # noqa: F401 F403
 from materialize.checks.managed_cluster import *  # noqa: F401 F403
 from materialize.checks.materialized_views import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/ldbc_generator.py
+++ b/misc/python/materialize/checks/ldbc_generator.py
@@ -1,0 +1,55 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
+
+
+class LdbcGenerator(Check):
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse("0.73.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            """
+            > CREATE SCHEMA ldbc_generator;
+            """
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(
+                """
+                > SET schema = ldbc_generator;
+                > CREATE SOURCE gen FROM LOAD GENERATOR LDBC (SCALE FACTOR 1) FOR ALL TABLES;
+                """,
+            ),
+            Testdrive(
+                """
+                # Do not burden the system with a second LDBC load generator, so do nothing in manipulate() #2
+                > SELECT 1;
+                1
+                """
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            """
+            > SET SCHEMA = ldbc_generator;
+
+            # Confirm that the sub-sources exist without actually trying to query them.
+            # Starting up the LDBC generator takes time and we can not afford to wait.
+            ? EXPLAIN SELECT * FROM tagclass;
+            Explained Query:
+              ReadStorage materialize.ldbc_generator.tagclass
+            """
+        )

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -203,6 +203,7 @@ Keys
 Last
 Lateral
 Latest
+Ldbc
 Leading
 Least
 Left

--- a/src/sql-parser/src/ast/defs/ddl.rs
+++ b/src/sql-parser/src/ast/defs/ddl.rs
@@ -1148,6 +1148,7 @@ pub enum LoadGenerator {
     Auction,
     Datums,
     Tpch,
+    Ldbc,
 }
 
 impl AstDisplay for LoadGenerator {
@@ -1158,6 +1159,7 @@ impl AstDisplay for LoadGenerator {
             Self::Auction => f.write_str("AUCTION"),
             Self::Datums => f.write_str("DATUMS"),
             Self::Tpch => f.write_str("TPCH"),
+            Self::Ldbc => f.write_str("LDBC"),
         }
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3117,11 +3117,12 @@ impl<'a> Parser<'a> {
             LOAD => {
                 self.expect_keyword(GENERATOR)?;
                 let generator = match self
-                    .expect_one_of_keywords(&[COUNTER, MARKETING, AUCTION, TPCH, DATUMS])?
+                    .expect_one_of_keywords(&[COUNTER, MARKETING, AUCTION, TPCH, DATUMS, LDBC])?
                 {
                     COUNTER => LoadGenerator::Counter,
                     AUCTION => LoadGenerator::Auction,
                     TPCH => LoadGenerator::Tpch,
+                    LDBC => LoadGenerator::Ldbc,
                     DATUMS => LoadGenerator::Datums,
                     MARKETING => LoadGenerator::Marketing,
                     _ => unreachable!(),

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -68,6 +68,7 @@ tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 uncased = "0.9.7"
+url = "2.3.1"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -216,6 +216,7 @@ pub enum PlanError {
     KafkaSourcePurification(KafkaSourcePurificationError),
     TestScriptSourcePurification(TestScriptSourcePurificationError),
     LoadGeneratorSourcePurification(LoadGeneratorSourcePurificationError),
+    UnsupportedLdbcScaleFactor,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -266,6 +267,7 @@ impl PlanError {
             Self::KafkaSourcePurification(e) => e.detail(),
             Self::TestScriptSourcePurification(e) => e.detail(),
             Self::LoadGeneratorSourcePurification(e) => e.detail(),
+            Self::UnsupportedLdbcScaleFactor=>Some("Supported scale factors: 1, 3, 10, 30, 100, 300".into()),
             _ => None,
         }
     }
@@ -340,6 +342,7 @@ impl PlanError {
             Self::KafkaSourcePurification(e) => e.hint(),
             Self::TestScriptSourcePurification(e) => e.hint(),
             Self::LoadGeneratorSourcePurification(e) => e.hint(),
+            Self::UnsupportedLdbcScaleFactor=> Some("See: https://github.com/ldbc/ldbc_snb_bi/blob/main/snb-bi-pre-generated-data-sets.md".into()),
             _ => None,
         }
     }
@@ -551,6 +554,7 @@ impl fmt::Display for PlanError {
             Self::MangedReplicaName(name) => {
                 write!(f, "{name} is reserved for replicas of managed clusters")
             }
+            Self::UnsupportedLdbcScaleFactor => write!(f, "unsupported scale factor"),
         }
     }
 }

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -62,6 +62,7 @@ use mz_storage_types::sources::{
     TestScriptSourceConnection, Timeline, UnplannedSourceEnvelope, UpsertStyle,
 };
 use prost::Message;
+use url::Url;
 
 use crate::ast::display::AstDisplay;
 use crate::ast::{
@@ -975,8 +976,11 @@ pub fn plan_create_source(
             (connection, encoding, Some(available_subsources))
         }
         CreateSourceConnection::LoadGenerator { generator, options } => {
-            let (load_generator, available_subsources) =
-                load_generator_ast_to_generator(generator, options)?;
+            let (load_generator, available_subsources) = load_generator_ast_to_generator(
+                generator,
+                options,
+                scx.catalog.system_vars().ldbc_url(),
+            )?;
             let available_subsources = available_subsources
                 .map(|a| BTreeMap::from_iter(a.into_iter().map(|(k, v)| (k, v.0))));
 
@@ -1462,6 +1466,7 @@ generate_extracted_config!(
 pub(crate) fn load_generator_ast_to_generator(
     loadgen: &mz_sql_parser::ast::LoadGenerator,
     options: &[LoadGeneratorOption<Aug>],
+    url_prefix: &str,
 ) -> Result<
     (
         LoadGenerator,
@@ -1485,13 +1490,13 @@ pub(crate) fn load_generator_ast_to_generator(
             // Default to 0.01 scale factor (=10MB).
             let sf: f64 = scale_factor.unwrap_or(0.01);
             if !sf.is_finite() || sf < 0.0 {
-                sql_bail!("unsupported scale factor {sf}");
+                return Err(PlanError::UnsupportedLdbcScaleFactor);
             }
 
             let f_to_i = |multiplier: f64| -> Result<i64, PlanError> {
                 let total = (sf * multiplier).floor();
                 let mut i = i64::try_cast_from(total)
-                    .ok_or_else(|| sql_err!("unsupported scale factor {sf}"))?;
+                    .ok_or_else(|| PlanError::UnsupportedLdbcScaleFactor)?;
                 if i < 1 {
                     i = 1;
                 }
@@ -1520,17 +1525,21 @@ pub(crate) fn load_generator_ast_to_generator(
                 None => 1,
                 Some(sf) => match i64::try_cast_from(sf) {
                     Some(i) => i,
-                    None => sql_bail!("unsupported scale factor: {sf}"),
+                    None => return Err(PlanError::UnsupportedLdbcScaleFactor),
                 },
             };
             // See https://github.com/ldbc/ldbc_snb_bi/blob/main/snb-bi-pre-generated-data-sets.md
             // for valid scale factors and URLs.
             match sf {
                 1 | 3 | 10 | 30 | 100 | 300 => {}
-                _ => sql_bail!("unsupported scale factor: {sf}"),
+                _ => return Err(PlanError::UnsupportedLdbcScaleFactor),
             }
-            let urls = vec![format!("https://pub-383410a98aef4cb686f0c7601eddd25f.r2.dev/bi-pre-audit/bi-sf{}-composite-merged-fk.tar.zst", sf)];
-            LoadGenerator::Ldbc { urls }
+            let url = Url::parse(url_prefix)
+                .and_then(|u| u.join(&format!("bi-sf{sf}-composite-merged-fk.tar.zst")))
+                .map_err(|e| sql_err!("could not generate LDBC url: {e}"))?;
+            LoadGenerator::Ldbc {
+                urls: vec![url.to_string()],
+            }
         }
     };
 

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -486,8 +486,11 @@ async fn purify_create_source(
         CreateSourceConnection::LoadGenerator { generator, options } => {
             let scx = StatementContext::new(None, &catalog);
 
-            let (_load_generator, available_subsources) =
-                load_generator_ast_to_generator(generator, options)?;
+            let (_load_generator, available_subsources) = load_generator_ast_to_generator(
+                generator,
+                options,
+                catalog.system_vars().ldbc_url(),
+            )?;
 
             let mut targeted_subsources = vec![];
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1186,6 +1186,20 @@ static REAL_TIME_RECENCY: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
+pub static DEFAULT_LDBC_URL: Lazy<String> =
+    Lazy::new(|| "https://pub-383410a98aef4cb686f0c7601eddd25f.r2.dev/bi-pre-audit/".to_string());
+
+/// Feature flag indicating whether real time recency is enabled. Not that
+/// unlike other feature flags, this is made available at the session level, so
+/// is additionally gated by a feature flag.
+static LDBC_URL: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("ldbc_url"),
+    value: &DEFAULT_LDBC_URL,
+    description:
+        "URL prefix that must end with `/` (`https://HOST/DIR/`) of LDBC files (Materialize).",
+    internal: true,
+});
+
 static EMIT_TIMESTAMP_NOTICE: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("emit_timestamp_notice"),
     value: &false,
@@ -2453,7 +2467,8 @@ impl SystemVars {
             .with_var(&TRUNCATE_STATEMENT_LOG)
             .with_var(&STATEMENT_LOGGING_RETENTION)
             .with_var(&OPTIMIZER_STATS_TIMEOUT)
-            .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT);
+            .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
+            .with_var(&LDBC_URL);
 
         for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
@@ -3196,6 +3211,10 @@ impl SystemVars {
     /// Returns the `optimizer_oneshot_stats_timeout` configuration parameter.
     pub fn optimizer_oneshot_stats_timeout(&self) -> Duration {
         *self.expect_value(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
+    }
+
+    pub fn ldbc_url(&self) -> &String {
+        self.expect_value(&LDBC_URL)
     }
 }
 

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1.68"
 aws-config = { version = "0.55", default-features = false, features = ["native-tls"] }
 aws-credential-types = { version = "0.55", features = ["hardcoded-credentials"] }
 aws-types = "0.55"

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -208,6 +208,7 @@ message ProtoLoadGeneratorSourceConnection {
         ProtoTpchLoadGenerator tpch = 4;
         google.protobuf.Empty datums = 5;
         google.protobuf.Empty marketing = 7;
+        ProtoLdbcLoadGenerator ldbc = 8;
     }
     optional uint64 tick_micros = 2;
 }
@@ -226,6 +227,10 @@ message ProtoTpchLoadGenerator {
     int64 count_customer = 3;
     int64 count_orders = 4;
     int64 count_clerk = 5;
+}
+
+message ProtoLdbcLoadGenerator {
+    repeated string urls = 1;
 }
 
 message ProtoCompression {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail};
+use async_trait::async_trait;
 use bytes::BufMut;
 use dec::OrderedDecimal;
 use itertools::EitherOrBoth::Both;
@@ -2525,9 +2526,10 @@ impl LoadGenerator {
     }
 }
 
+#[async_trait]
 pub trait Generator {
     /// Returns a function that produces rows and batch information.
-    fn by_seed(
+    async fn by_seed(
         &self,
         now: NowFn,
         seed: Option<u64>,

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -2215,6 +2215,9 @@ pub enum LoadGenerator {
         count_orders: i64,
         count_clerk: i64,
     },
+    Ldbc {
+        urls: Vec<String>,
+    },
 }
 
 impl LoadGenerator {
@@ -2248,6 +2251,7 @@ impl LoadGenerator {
             ),
             LoadGenerator::Marketing => DataEncodingInner::RowCodec(RelationDesc::empty()),
             LoadGenerator::Tpch { .. } => DataEncodingInner::RowCodec(RelationDesc::empty()),
+            LoadGenerator::Ldbc { .. } => DataEncodingInner::RowCodec(RelationDesc::empty()),
         }
     }
 
@@ -2494,6 +2498,15 @@ impl LoadGenerator {
                     ),
                 ]
             }
+            LoadGenerator::Ldbc { .. } => {
+                let mut descs = LDBC_DESCS.iter().collect::<Vec<_>>();
+                // Sort by output id.
+                descs.sort_by_key(|x| x.1 .0);
+                descs
+                    .into_iter()
+                    .map(|(name, (_output, desc))| (*name, desc.clone()))
+                    .collect()
+            }
         }
     }
 
@@ -2507,6 +2520,7 @@ impl LoadGenerator {
             LoadGenerator::Marketing => false,
             LoadGenerator::Datums => true,
             LoadGenerator::Tpch { .. } => false,
+            LoadGenerator::Ldbc { .. } => false,
         }
     }
 }
@@ -2545,6 +2559,9 @@ impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnect
                     count_orders: *count_orders,
                     count_clerk: *count_clerk,
                 }),
+                LoadGenerator::Ldbc { urls } => {
+                    ProtoGenerator::Ldbc(ProtoLdbcLoadGenerator { urls: urls.clone() })
+                }
                 LoadGenerator::Datums => ProtoGenerator::Datums(()),
             }),
             tick_micros: self.tick_micros,
@@ -2575,6 +2592,9 @@ impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnect
                     count_orders,
                     count_clerk,
                 },
+                ProtoGenerator::Ldbc(ProtoLdbcLoadGenerator { urls }) => {
+                    LoadGenerator::Ldbc { urls }
+                }
                 ProtoGenerator::Datums(()) => LoadGenerator::Datums,
             },
             tick_micros: proto.tick_micros,
@@ -2830,6 +2850,298 @@ impl Schema<SourceData> for RelationDesc {
         })
     }
 }
+
+const LDBC_ORGANISATION_OUTPUT: usize = 1;
+const LDBC_PLACE_OUTPUT: usize = 2;
+const LDBC_TAG_OUTPUT: usize = 3;
+const LDBC_TAGCLASS_OUTPUT: usize = 4;
+const LDBC_COMMENT_OUTPUT: usize = 5;
+const LDBC_FORUM_OUTPUT: usize = 6;
+const LDBC_POST_OUTPUT: usize = 7;
+const LDBC_PERSON_OUTPUT: usize = 8;
+const LDBC_COMMENT_HASTAG_TAG_OUTPUT: usize = 9;
+const LDBC_POST_HASTAG_TAG_OUTPUT: usize = 10;
+const LDBC_FORUM_HASMEMBER_PERSON_OUTPUT: usize = 11;
+const LDBC_FORUM_HASTAG_TAG_OUTPUT: usize = 12;
+const LDBC_PERSON_HASINTEREST_TAG_OUTPUT: usize = 13;
+const LDBC_PERSON_LIKES_COMMENT_OUTPUT: usize = 14;
+const LDBC_PERSON_LIKES_POST_OUTPUT: usize = 15;
+const LDBC_PERSON_STUDYAT_UNIVERSITY_OUTPUT: usize = 16;
+const LDBC_PERSON_WORKAT_COMPANY_OUTPUT: usize = 17;
+pub const LDBC_PERSON_KNOWS_PERSON_OUTPUT: usize = 18;
+
+pub static LDBC_DESCS: Lazy<BTreeMap<&'static str, (usize, RelationDesc)>> = Lazy::new(|| {
+    let identifier = ScalarType::Int64.nullable(false);
+    let identifier_nullable = ScalarType::Int64.nullable(true);
+
+    BTreeMap::from([
+        (
+            "organisation",
+            (
+                LDBC_ORGANISATION_OUTPUT,
+                RelationDesc::empty()
+                    .with_column("id", identifier.clone())
+                    .with_column("type", ScalarType::String.nullable(false))
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_column("url", ScalarType::String.nullable(false))
+                    .with_column("locationplaceid", identifier_nullable.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "place",
+            (
+                LDBC_PLACE_OUTPUT,
+                RelationDesc::empty()
+                    .with_column("id", identifier.clone())
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_column("url", ScalarType::String.nullable(false))
+                    .with_column("type", ScalarType::String.nullable(false))
+                    .with_column("partofplaceid", identifier_nullable.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "tag",
+            (
+                LDBC_TAG_OUTPUT,
+                RelationDesc::empty()
+                    .with_column("id", identifier.clone())
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_column("url", ScalarType::String.nullable(false))
+                    .with_column("typetagclassid", identifier.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "tagclass",
+            (
+                LDBC_TAGCLASS_OUTPUT,
+                RelationDesc::empty()
+                    .with_column("id", identifier.clone())
+                    .with_column("name", ScalarType::String.nullable(false))
+                    .with_column("url", ScalarType::String.nullable(false))
+                    .with_column("subclassoftagclassid", identifier_nullable.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "comment",
+            (
+                LDBC_COMMENT_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("id", identifier.clone())
+                    .with_column("locationip", ScalarType::String.nullable(false))
+                    .with_column("browserused", ScalarType::String.nullable(false))
+                    .with_column("content", ScalarType::String.nullable(true))
+                    .with_column("length", ScalarType::Int32.nullable(false))
+                    .with_column("creatorpersonid", identifier.clone())
+                    .with_column("locationcountryid", identifier.clone())
+                    .with_column("parentpostid", identifier_nullable.clone())
+                    .with_column("parentcommentid", identifier_nullable.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "forum",
+            (
+                LDBC_FORUM_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("id", identifier.clone())
+                    .with_column("title", ScalarType::String.nullable(false))
+                    .with_column("moderatorpersonid", identifier_nullable.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "post",
+            (
+                LDBC_POST_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("id", identifier.clone())
+                    .with_column("imagefile", ScalarType::String.nullable(true))
+                    .with_column("locationip", ScalarType::String.nullable(false))
+                    .with_column("browserused", ScalarType::String.nullable(false))
+                    .with_column("language", ScalarType::String.nullable(true))
+                    .with_column("content", ScalarType::String.nullable(true))
+                    .with_column("length", ScalarType::Int32.nullable(false))
+                    .with_column("creatorpersonid", identifier.clone())
+                    .with_column("containerforumid", identifier.clone())
+                    .with_column("locationcountryid", identifier.clone())
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "person",
+            (
+                LDBC_PERSON_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("id", identifier.clone())
+                    .with_column("firstname", ScalarType::String.nullable(false))
+                    .with_column("lastname", ScalarType::String.nullable(false))
+                    .with_column("gender", ScalarType::String.nullable(false))
+                    .with_column("birthday", ScalarType::Date.nullable(false))
+                    .with_column("locationip", ScalarType::String.nullable(false))
+                    .with_column("browserused", ScalarType::String.nullable(false))
+                    .with_column("locationcountryid", identifier.clone())
+                    // TODO: This should be an array split on ';'.
+                    .with_column("speaks", ScalarType::String.nullable(false))
+                    // TODO: This should be an array split on ';'.
+                    .with_column("email", ScalarType::String.nullable(false))
+                    .with_key(vec![0]),
+            ),
+        ),
+        (
+            "comment_hastag_tag",
+            (
+                LDBC_COMMENT_HASTAG_TAG_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("commentid", identifier.clone())
+                    .with_column("tagid", identifier.clone()),
+            ),
+        ),
+        (
+            "post_hastag_tag",
+            (
+                LDBC_POST_HASTAG_TAG_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("postid", identifier.clone())
+                    .with_column("tagid", identifier.clone()),
+            ),
+        ),
+        (
+            "forum_hasmember_person",
+            (
+                LDBC_FORUM_HASMEMBER_PERSON_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("forumid", identifier.clone())
+                    .with_column("personid", identifier.clone()),
+            ),
+        ),
+        (
+            "forum_hastag_tag",
+            (
+                LDBC_FORUM_HASTAG_TAG_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("forumid", identifier.clone())
+                    .with_column("tagid", identifier.clone()),
+            ),
+        ),
+        (
+            "person_hasinterest_tag",
+            (
+                LDBC_PERSON_HASINTEREST_TAG_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("personid", identifier.clone())
+                    .with_column("tagid", identifier.clone()),
+            ),
+        ),
+        (
+            "person_likes_comment",
+            (
+                LDBC_PERSON_LIKES_COMMENT_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("personid", identifier.clone())
+                    .with_column("commentid", identifier.clone()),
+            ),
+        ),
+        (
+            "person_likes_post",
+            (
+                LDBC_PERSON_LIKES_POST_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("personid", identifier.clone())
+                    .with_column("postid", identifier.clone()),
+            ),
+        ),
+        (
+            "person_studyat_university",
+            (
+                LDBC_PERSON_STUDYAT_UNIVERSITY_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("personid", identifier.clone())
+                    .with_column("universityid", identifier.clone())
+                    .with_column("classyear", ScalarType::Int32.nullable(false)),
+            ),
+        ),
+        (
+            "person_workat_company",
+            (
+                LDBC_PERSON_WORKAT_COMPANY_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("personid", identifier.clone())
+                    .with_column("companyid", identifier.clone())
+                    .with_column("workfrom", ScalarType::Int32.nullable(false)),
+            ),
+        ),
+        (
+            "person_knows_person",
+            (
+                LDBC_PERSON_KNOWS_PERSON_OUTPUT,
+                RelationDesc::empty()
+                    .with_column(
+                        "creationdate",
+                        ScalarType::TimestampTz { precision: None }.nullable(false),
+                    )
+                    .with_column("person1id", identifier.clone())
+                    .with_column("person2id", identifier.clone())
+                    .with_key(vec![1, 2]),
+            ),
+        ),
+    ])
+});
 
 #[cfg(test)]
 mod tests {

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -12,6 +12,7 @@ bench = false
 
 [dependencies]
 anyhow = "1.0.66"
+async-compression = { version = "0.3.15", features = ["tokio", "zstd"] }
 async-stream = "0.3.3"
 async-trait = "0.1.68"
 bytes = { version = "1.3.0", features = ["serde"] }
@@ -42,12 +43,7 @@ mz-expr = { path = "../expr" }
 mz-cluster = { path = "../cluster" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = [
-  "async",
-  "tracing_",
-  "chrono",
-  "bytes_",
-] }
+mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono"] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
@@ -69,27 +65,16 @@ postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { version = "0.29.0", features = [
-  "cmake-build",
-  "ssl-vendored",
-  "libz-static",
-  "zstd",
-] }
+rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 regex = { version = "1.7.0" }
-reqwest = { version = "0.11", features = ["blocking"] }
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = [
-  "snappy",
-  "zstd",
-  "lz4",
-] }
+reqwest = { version = "0.11", features = ["stream"] }
+rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = ["snappy", "zstd", "lz4"] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"
 tar = "0.4.38"
-timely = { version = "0.12.0", default-features = false, features = [
-  "bincode",
-] }
+timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
@@ -100,7 +85,6 @@ thiserror = { version = "1.0.37" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-zstd = "0.12.3"
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -20,11 +20,13 @@ bincode = "1"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 crossbeam-channel = "0.5.8"
+csv = "1.2.1"
 csv-core = { version = "0.1.10" }
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
 either = { version = "1.8.0", features = ["serde"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
+flate2 = "1.0.24"
 futures = "0.3.25"
 globset = { version = "0.4.9", features = ["serde1"] }
 http = "0.2.8"
@@ -40,11 +42,17 @@ mz-expr = { path = "../expr" }
 mz-cluster = { path = "../cluster" }
 mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
-mz-ore = { path = "../ore", features = ["async", "tracing_", "chrono"] }
+mz-ore = { path = "../ore", features = [
+  "async",
+  "tracing_",
+  "chrono",
+  "bytes_",
+] }
 mz-persist = { path = "../persist" }
 mz-persist-client = { path = "../persist-client" }
 mz-persist-types = { path = "../persist-types" }
 mz-pgcopy = { path = "../pgcopy" }
+mz-pgrepr = { path = "../pgrepr" }
 mz-pid-file = { path = "../pid-file" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-repr = { path = "../repr" }
@@ -61,14 +69,27 @@ postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = [
+  "cmake-build",
+  "ssl-vendored",
+  "libz-static",
+  "zstd",
+] }
 regex = { version = "1.7.0" }
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = ["snappy", "zstd", "lz4"] }
+reqwest = { version = "0.11", features = ["blocking"] }
+rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = [
+  "snappy",
+  "zstd",
+  "lz4",
+] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+tar = "0.4.38"
+timely = { version = "0.12.0", default-features = false, features = [
+  "bincode",
+] }
 tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
@@ -79,6 +100,7 @@ thiserror = { version = "1.0.37" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+zstd = "0.12.3"
 
 [build-dependencies]
 protobuf-src = "1.1.0"

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -31,12 +31,14 @@ use crate::source::{RawSourceCreationConfig, SourceMessage, SourceReaderError};
 mod auction;
 mod counter;
 mod datums;
+mod ldbc;
 mod marketing;
 mod tpch;
 
 pub use auction::Auction;
 pub use counter::Counter;
 pub use datums::Datums;
+pub use ldbc::Ldbc;
 pub use tpch::Tpch;
 
 use self::marketing::Marketing;
@@ -65,6 +67,7 @@ pub fn as_generator(g: &LoadGenerator, tick_micros: Option<u64>) -> Box<dyn Gene
             // completely.
             tick: Duration::from_micros(tick_micros.unwrap_or(0)),
         }),
+        LoadGenerator::Ldbc { urls } => Box::new(Ldbc { urls: urls.clone() }),
     }
 }
 

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -117,11 +117,9 @@ impl SourceRender for LoadGeneratorSourceConnection {
                 return;
             };
 
-            let mut rows = as_generator(&self.load_generator, self.tick_micros).by_seed(
-                mz_ore::now::SYSTEM_TIME.clone(),
-                None,
-                resume_offset,
-            );
+            let mut rows = as_generator(&self.load_generator, self.tick_micros)
+                .by_seed(mz_ore::now::SYSTEM_TIME.clone(), None, resume_offset)
+                .await;
 
             let tick = Duration::from_micros(self.tick_micros.unwrap_or(1_000_000));
 

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -10,6 +10,7 @@
 use std::collections::VecDeque;
 use std::iter;
 
+use async_trait::async_trait;
 use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{Datum, Row};
 use mz_storage_types::sources::{Generator, MzOffset};
@@ -70,8 +71,9 @@ const BIDS_OUTPUT: usize = 5;
 // Note that this generator never issues retractions; if you change this,
 // `mz_storage_types::sources::LoadGenerator::is_monotonic`
 // must be updated.
+#[async_trait]
 impl Generator for Auction {
-    fn by_seed(
+    async fn by_seed(
         &self,
         now: NowFn,
         seed: Option<u64>,

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use async_trait::async_trait;
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
 use mz_storage_types::sources::{Generator, MzOffset};
@@ -21,8 +22,9 @@ pub struct Counter {
     pub max_cardinality: Option<u64>,
 }
 
+#[async_trait]
 impl Generator for Counter {
-    fn by_seed(
+    async fn by_seed(
         &self,
         _now: NowFn,
         _seed: Option<u64>,

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -9,6 +9,7 @@
 
 use std::iter;
 
+use async_trait::async_trait;
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
 use mz_storage_types::sources::{Generator, MzOffset};
@@ -19,8 +20,9 @@ pub struct Datums {}
 // Note that this generator never issues retractions; if you change this,
 // `mz_storage_types::sources::LoadGenerator::is_monotonic`
 // must be updated.
+#[async_trait]
 impl Generator for Datums {
-    fn by_seed(
+    async fn by_seed(
         &self,
         _: NowFn,
         _seed: Option<u64>,

--- a/src/storage/src/source/generator/ldbc.rs
+++ b/src/storage/src/source/generator/ldbc.rs
@@ -1,0 +1,230 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::io::Read;
+use std::path::PathBuf;
+
+use bytes::{Buf, Bytes};
+use csv::{ReaderBuilder, StringRecord};
+use flate2::read::GzDecoder;
+use mz_ore::now::NowFn;
+use mz_repr::{Datum, RelationDesc, Row, RowArena};
+use mz_storage_types::sources::{Generator, MzOffset, LDBC_DESCS, LDBC_PERSON_KNOWS_PERSON_OUTPUT};
+use timely::dataflow::operators::to_stream::Event;
+use tracing::error;
+
+#[derive(Clone, Debug)]
+pub struct Ldbc {
+    pub urls: Vec<String>,
+}
+
+impl Generator for Ldbc {
+    fn by_seed(
+        &self,
+        _: NowFn,
+        _seed: Option<u64>,
+        _resume_offset: MzOffset,
+    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+        let bytes = match fetch_urls_compressed(&self.urls) {
+            Ok(bytes) => bytes,
+            Err(err) => {
+                error!("could not download file: {err}");
+                return Box::new(std::iter::empty());
+            }
+        };
+        let mut archive = tar::Archive::new(bytes.as_slice());
+        let entries = match archive.entries() {
+            Ok(entries) => entries,
+            Err(err) => {
+                error!("count not extract tar: {err}");
+                return Box::new(std::iter::empty());
+            }
+        };
+        let entries = entries
+            .map(|entry| {
+                let mut entry = entry.unwrap();
+                let path = entry.path().unwrap().into_owned();
+                let mut bytes = Vec::new();
+                entry.read_to_end(&mut bytes).unwrap();
+                (path, bytes)
+            })
+            .collect::<BTreeMap<_, _>>();
+        let ctx = Context {
+            entries: entries.into_iter(),
+            rdr: None,
+            record: StringRecord::new(),
+            arena: RowArena::new(),
+            offset: 0.into(),
+            pending: None,
+        };
+        Box::new(ctx)
+    }
+}
+
+struct CsvFile {
+    rdr: csv::Reader<bytes::buf::Reader<bytes::Bytes>>,
+    desc: &'static RelationDesc,
+    output: usize,
+}
+
+struct Context {
+    entries: std::collections::btree_map::IntoIter<PathBuf, Vec<u8>>,
+    rdr: Option<CsvFile>,
+    record: StringRecord,
+    arena: RowArena,
+    offset: MzOffset,
+    pending: Option<(usize, Row)>,
+}
+
+impl Context {
+    /// Opens the next file if `self.rdr` is `None`. `self.rdr` is set to `None` if there are no
+    /// more files to read.
+    fn next_file(&mut self) {
+        while self.rdr.is_none() {
+            let Some((mut path, mut entry)) = self.entries.next() else {
+                return;
+            };
+            // Gunzip gz files, removing the .gz extension.
+            if matches!(path.extension().and_then(|s| s.to_str()), Some("gz")) {
+                let mut buf = Vec::new();
+                if let Err(err) = GzDecoder::new(entry.as_slice()).read_to_end(&mut buf) {
+                    error!("error gunzipping inner ldbc file {:?}: {}", path, err);
+                    continue;
+                }
+                path = path.with_extension("");
+                entry = buf;
+            }
+            // Skip non-CSV files.
+            if !matches!(path.extension().and_then(|s| s.to_str()), Some("csv")) {
+                continue;
+            }
+            let parts = path.parent().and_then(|path| {
+                let mut parts = path.components().rev();
+                let Some(entity) = parts.next() else {
+                    return None;
+                };
+                let Some(entity) = entity.as_os_str().to_str() else {
+                    return None;
+                };
+                let Some(load) = parts.next() else {
+                    return None;
+                };
+                let Some(load) = load.as_os_str().to_str() else {
+                    return None;
+                };
+                Some((load, entity))
+            });
+            let (output, desc) = match parts {
+                Some(("static" | "dynamic", entity)) => {
+                    let entity = entity.to_lowercase();
+                    let Some((output, desc)) = LDBC_DESCS.get(entity.as_str()) else {
+                        error!("could not find ldbc relation: {entity}");
+                        continue;
+                    };
+                    (output, desc)
+                }
+                Some(_) => continue,
+                None => continue,
+            };
+            let reader = Bytes::from(entry).reader();
+            let rdr = ReaderBuilder::new().delimiter(b'|').from_reader(reader);
+            self.rdr = Some(CsvFile {
+                rdr,
+                desc,
+                output: *output,
+            });
+        }
+    }
+
+    /// Reads the next record out of `self.rdr`. Returns `None` if `self.rdr` is out of records.
+    fn next_record(&mut self) -> Option<(usize, Row)> {
+        self.rdr
+            .as_mut()
+            .and_then(|csv| match csv.rdr.read_record(&mut self.record) {
+                Ok(true) => {
+                    let row = Row::pack(self.record.iter().zip(csv.desc.iter_types()).map(
+                        |(field, typ)| {
+                            let pgtyp = mz_pgrepr::Type::from(&typ.scalar_type);
+                            match mz_pgrepr::Value::decode_text(&pgtyp, field.as_bytes()) {
+                                Ok(value) => value.into_datum(&self.arena, &pgtyp),
+                                Err(_) => {
+                                    if field.is_empty() && typ.nullable {
+                                       return Datum::Null;
+                                    }
+                                  error!("could not decode typ {typ:?} for value '{field}' in ldbc output {}", csv.output);
+                                    panic!("could not decode typ {typ:?} for value '{field}' in ldbc output {}", csv.output);
+                                }
+                            }
+                        },
+                    ));
+                    // Make symmetric.
+                    if csv.output == LDBC_PERSON_KNOWS_PERSON_OUTPUT {
+                        assert!(self.pending.is_none());
+                        let mut iter = row.iter();
+                        let creationdate = iter.next().expect("must exist");
+                        let person1id = iter.next().expect("must exist");
+                        let person2id = iter.next().expect("must exist");
+                        let swapped = Row::pack_slice(&[
+                            creationdate,
+                            person2id,
+                            person1id,
+                        ]);
+                        self.pending = Some((csv.output, swapped));
+                    }
+                    Some((csv.output, row))
+                }
+                Ok(false) => None,
+                Err(_) => None,
+            })
+    }
+}
+
+impl Iterator for Context {
+    type Item = (usize, Event<Option<MzOffset>, (Row, i64)>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some((output, row)) = self.pending.take() {
+            self.offset += 1;
+            return Some((output, Event::Message(self.offset, (row, 1))));
+        }
+        loop {
+            match self.next_record() {
+                Some((output, row)) => {
+                    self.offset += 1;
+                    return Some((output, Event::Message(self.offset, (row, 1))));
+                }
+                None => {
+                    // If we're out of records for this file, close the current file and its data.
+                    if let Some(csv) = self.rdr.take() {
+                        return Some((csv.output, Event::Progress(Some(self.offset))));
+                    }
+                    // Otherwise open the next file.
+                    self.next_file();
+                    // No more files.
+                    if self.rdr.is_none() {
+                        return None;
+                    }
+                    continue;
+                }
+            }
+        }
+    }
+}
+
+/// Fetches URLs whose bodies are zstd compressed and returns their response body uncompressed and
+/// concatenated.
+fn fetch_urls_compressed(urls: &[String]) -> Result<Vec<u8>, anyhow::Error> {
+    let mut buf = Vec::new();
+    for url in urls {
+        let resp = reqwest::blocking::get(url)?.error_for_status()?;
+        zstd::stream::copy_decode(resp, &mut buf)?;
+    }
+    Ok(buf)
+}

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -12,6 +12,7 @@ use std::{
     iter,
 };
 
+use async_trait::async_trait;
 use mz_ore::now::to_datetime;
 use mz_repr::{Datum, Row};
 use mz_storage_types::sources::{Generator, MzOffset};
@@ -33,8 +34,9 @@ pub struct Marketing {}
 // Note that this generator issues retractions; if you change this,
 // `mz_storage_types::sources::LoadGenerator::is_monotonic`
 // must be updated.
+#[async_trait]
 impl Generator for Marketing {
-    fn by_seed(
+    async fn by_seed(
         &self,
         now: mz_ore::now::NowFn,
         seed: Option<u64>,

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -13,6 +13,7 @@ use std::iter;
 use std::ops::RangeInclusive;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use chrono::NaiveDate;
 use dec::{Context as DecimalContext, OrderedDecimal};
 use mz_ore::now::NowFn;
@@ -46,8 +47,9 @@ const LINEITEM_OUTPUT: usize = 6;
 const NATION_OUTPUT: usize = 7;
 const REGION_OUTPUT: usize = 8;
 
+#[async_trait]
 impl Generator for Tpch {
-    fn by_seed(
+    async fn by_seed(
         &self,
         _: NowFn,
         seed: Option<u64>,

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -114,6 +114,7 @@ uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
+zstd-sys = { version = "2.0.8", features = ["std"] }
 
 [build-dependencies]
 ahash = { version = "0.8.0" }
@@ -218,6 +219,7 @@ uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }
 zeroize = { version = "1.5.7", features = ["serde"] }
+zstd-sys = { version = "2.0.8", features = ["std"] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 native-tls = { version = "0.2.11", default-features = false, features = ["vendored"] }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -16,6 +16,7 @@ publish = false
 [dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+async-compression = { version = "0.3.15", features = ["gzip", "tokio", "zstd"] }
 aws-credential-types = { version = "0.55.1", default-features = false, features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
@@ -84,7 +85,7 @@ rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
+reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
@@ -119,6 +120,7 @@ zstd-sys = { version = "2.0.8", features = ["std"] }
 [build-dependencies]
 ahash = { version = "0.8.0" }
 anyhow = { version = "1.0.66", features = ["backtrace"] }
+async-compression = { version = "0.3.15", features = ["gzip", "tokio", "zstd"] }
 aws-credential-types = { version = "0.55.1", default-features = false, features = ["hardcoded-credentials"] }
 aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["native-tls", "rt-tokio"] }
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
@@ -188,7 +190,7 @@ rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
+reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored", "stream"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }

--- a/test/ldbc-bi/ldbc.td
+++ b/test/ldbc-bi/ldbc.td
@@ -1,0 +1,75 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test the cardinality of LDBC tables.
+
+! CREATE SOURCE gen FROM LOAD GENERATOR LDBC
+contains: multi-output sources require a FOR TABLES (..) or FOR ALL TABLES statement
+
+! CREATE SOURCE gen FROM LOAD GENERATOR LDBC (SCALE FACTOR 2) FOR ALL TABLES
+contains: unsupported scale factor: 2
+
+! CREATE SOURCE gen FROM LOAD GENERATOR LDBC (SCALE FACTOR -1) FOR ALL TABLES
+contains: unsupported scale factor: -1
+
+> CREATE SOURCE gen FROM LOAD GENERATOR LDBC (SCALE FACTOR 1) FOR ALL TABLES
+
+> SELECT count(*) FROM comment
+1739438
+
+> SELECT count(*) FROM comment_hastag_tag
+2176131
+
+> SELECT count(*) FROM forum
+100827
+
+> SELECT count(*) FROM forum_hasmember_person
+2909768
+
+> SELECT count(*) FROM forum_hastag_tag
+328584
+
+> SELECT count(*) FROM organisation
+7954
+
+> SELECT count(*) FROM person
+10295
+
+> SELECT count(*) FROM person_hasinterest_tag
+238052
+
+> SELECT count(*) FROM person_knows_person
+346028
+
+> SELECT count(*) FROM person_likes_comment
+1109813
+
+> SELECT count(*) FROM person_likes_post
+760455
+
+> SELECT count(*) FROM person_studyat_university
+8309
+
+> SELECT count(*) FROM person_workat_company
+22044
+
+> SELECT count(*) FROM place
+1460
+
+> SELECT count(*) FROM post
+1121226
+
+> SELECT count(*) FROM post_hastag_tag
+751933
+
+> SELECT count(*) FROM tag
+16080
+
+> SELECT count(*) FROM tagclass
+71


### PR DESCRIPTION
This load generator downloads the LDBC datasets instead of generating them dynamically.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
