### PR TITLE
compute-client: remove leftover metrics infrastructure

### DIFF
--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -189,9 +189,6 @@ impl<T> From<ComputeControllerResponse<T>> for ControllerResponse<T> {
             ComputeControllerResponse::ReplicaHeartbeat(id, when) => {
                 ControllerResponse::ComputeReplicaHeartbeat(id, when)
             }
-            ComputeControllerResponse::ReplicaMetrics(id, metrics) => {
-                ControllerResponse::ComputeReplicaMetrics(id, metrics)
-            }
         }
     }
 }


### PR DESCRIPTION
This PR removes orchestrator metrics infrastructure in the compute controller that was left over after this kind of metrics collection was moved into the top-level controller in #17256 (specifically https://github.com/MaterializeInc/materialize/pull/17256/commits/1e16c2cc17ca794506a92da9913f4e675278e3dd).

### Motivation

   * This PR removes unused code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
