### PR TITLE
[persist] Thread time all the way through to BatchBuffer

### DIFF
--- a/src/persist-client/tests/machine/compaction_ordered
+++ b/src/persist-client/tests/machine/compaction_ordered
@@ -34,8 +34,8 @@ parts=1 len=2
 fetch-batch input=b0_advanced
 ----
 <part 0>
-a 257 -1
 a 2 1
+a 257 -1
 <run 0>
 part 0
 
@@ -67,5 +67,4 @@ a 2 1
 a 257 -1
 <run 0>
 part 0
-<run 1>
 part 1

--- a/src/persist-client/tests/machine/compaction_ordered
+++ b/src/persist-client/tests/machine/compaction_ordered
@@ -1,0 +1,71 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Ordering behaviour during compaction
+
+write-batch output=b0 lower=0 upper=1000 target_size=1000
+a 0 1
+a 257 -1
+----
+parts=1 len=2
+
+compact output=b0_unadvanced inputs=(b0) lower=0 upper=1000 since=0 target_size=1000 memory_bound=10000
+----
+parts=1 len=2
+
+fetch-batch input=b0_unadvanced
+----
+<part 0>
+a 0 1
+a 257 -1
+<run 0>
+part 0
+
+compact output=b0_advanced inputs=(b0) lower=0 upper=1000 since=2 target_size=1000 memory_bound=10000
+----
+parts=1 len=2
+
+fetch-batch input=b0_advanced
+----
+<part 0>
+a 257 -1
+a 2 1
+<run 0>
+part 0
+
+write-batch output=b1 lower=0 upper=1000 target_size=0
+a 0 1
+a 257 -1
+----
+parts=2 len=2
+
+fetch-batch input=b1
+----
+<part 0>
+a 0 1
+<part 1>
+a 257 -1
+<run 0>
+part 0
+part 1
+
+compact output=b1_advanced inputs=(b1) lower=0 upper=1000 since=2 target_size=1 memory_bound=10000
+----
+parts=2 len=2
+
+fetch-batch input=b1_advanced
+----
+<part 0>
+a 2 1
+<part 1>
+a 257 -1
+<run 0>
+part 0
+<run 1>
+part 1


### PR DESCRIPTION
This ensures any consolidated output is ordered by time.

### Motivation

One might imagine that since the KV ordering is based on the serialized bytes, and therefore somewhat arbitrary, fine to do the same for T. However, we often need to advance the timestamp to some frontier at read time, and it is very useful if that is an order-preserving operation.

### Tips for reviewer

#### Give me an example of this causing a problem.

Sure! Consider two timestamps `0x0001` (with serialized rep `"0100"`) and `0x0101` (with rep `"0101"`). Advancing the since frontier to `{0x0002}` will cause `0x0001` to advance to the frontier and have rep `"0200"` and leave the other timestamp unchanged. This reverses the order!

In practice we don't currently rely on total-orderedness for much, see below, so there's not a significant impact. (Though it does mean that our nice compaction-always-decreases-the-number-of-runs invariant is broken if a case like this happens at a part boundary, etc.)

#### Why is this safe to do without a migration?
After all, data that was sorted according to the old comparison will be unsorted by the new one. However, since advancing the timestamp was already destroying sortedness, and all readers advanced timestamps, nobody must be relying on this guarantee. (The effectiveness of compaction does rely on parts being _mostly-_ordered, but that should be true both before and after this change.)

#### Will we ever be able to rely on data being sorted?
We don't rewrite data on any fixed cadence, so I'm not sure! Though now that we keep the build-version number in the part key we can at least identify parts that are sufficiently new to have the guarantee.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
