### PR TITLE
deps: update kube to 0.85.0 and k8s-openapi to 0.19.0+v1_25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -57,6 +57,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,9 +700,9 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.18.0",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
@@ -755,6 +761,12 @@ name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -1133,7 +1145,7 @@ dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.1",
  "once_cell",
  "strsim",
  "termcolor",
@@ -1736,16 +1748,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
 name = "dirs-sys"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,17 +1757,6 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1955,6 +1946,12 @@ dependencies = [
  "quote",
  "syn 2.0.18",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -2233,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2243,9 +2240,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
 name = "futures-executor"
@@ -2260,38 +2257,38 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfb8ce053d86b91919aad980c220b1fb8401a9394410e1c289ed7e66b61835d"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2388,7 +2385,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 1.9.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2413,6 +2410,16 @@ version = "0.12.3"
 source = "git+https://github.com/MaterializeInc/hashbrown.git#6a3c48b1fadbcfb11cff2863dcc83e65b8f0ab0d"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
 ]
 
 [[package]]
@@ -2502,6 +2509,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+dependencies = [
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2684,8 +2700,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
  "serde",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -2761,9 +2787,9 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "0.3.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e712e62827c382a77b87f590532febb1f8b2fdbc3eefa1ee37fe7281687075ef"
+checksum = "1f54898088ccb91df1b492cc80029a6fdf1c48ca0db7c6822a8babad69c94658"
 dependencies = [
  "serde",
  "serde_json",
@@ -2811,11 +2837,11 @@ dependencies = [
 
 [[package]]
 name = "k8s-openapi"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9455388f4977de4d0934efa9f7d36296295537d774574113a20f6082de03da"
+checksum = "95578de7d6eac4fba42114bc751e38c59a739968769df1be56feba6f17fd148e"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "chrono",
  "http",
@@ -2828,9 +2854,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba77b857a9581e3d1cb1165f9cb1d1732d65ce52642498addae8fa2c6d5e037"
+checksum = "a189cb8721a47de68d883040713bbb9c956763d784fcf066828018d32c180b96"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -2841,16 +2867,16 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80db3ca107e89da5f7eae37ea5274e06cefdcf9689d0ebd5ec3575a6f983e4e"
+checksum = "98989b6e1f27695afe22aa29c94136fa06be5e8d28b91222e6dfbe5a460c803f"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.20.0",
  "bytes",
  "chrono",
- "dirs-next",
  "either",
  "futures",
+ "home",
  "http",
  "http-body",
  "hyper",
@@ -2869,18 +2895,18 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.0",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.4.0",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fce686d2fbdaf6cb18d19cdb0692e9485dd9945f79f944b8772bdb2a07e8d39d"
+checksum = "c24d23bf764ec9a5652f943442ff062b91fd52318ea6d2fc11115f19d8c84d13"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2896,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93ef49d30d03c5de8041e2ab5dc421d671d6225ffd53975571d4a5b18d5e50fb"
+checksum = "0bbec4da219dcb02bb32afd762a7ac4dffd47ed92b7e35ac9a7b961d21327117"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2909,14 +2935,16 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.77.0"
+version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acc59ede459fd8e944ab1e6ff798aca83188b08aeb44e8c3d6f028db2d74233c"
+checksum = "381224caa8a6fc16f8251cf1fd6d8678cdf5366f33000a923e4c54192e4b25b5"
 dependencies = [
  "ahash",
+ "async-trait",
  "backoff",
  "derivative",
  "futures",
+ "hashbrown 0.14.0",
  "json-patch",
  "k8s-openapi",
  "kube-client",
@@ -3185,7 +3213,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -4006,12 +4034,12 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.18.0",
  "url",
  "uuid",
  "workspace-hack",
@@ -4152,7 +4180,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "tracing-subscriber",
  "workspace-hack",
@@ -5031,7 +5059,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "uuid",
  "walkdir",
@@ -5144,7 +5172,7 @@ dependencies = [
  "globset",
  "http",
  "humantime",
- "indexmap",
+ "indexmap 1.9.1",
  "itertools",
  "maplit",
  "mz-avro",
@@ -5798,7 +5826,7 @@ dependencies = [
  "fnv",
  "futures-channel",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.1",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -5956,9 +5984,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a3b09a20e374558580a4914d3b7d89bd61b954a5a5e1dcbea98753addb1947"
+checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
 ]
@@ -5985,7 +6013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a13a2fa9d0b63e5f22328828741e523766fff0ee9e779316902290dff3f824f"
 dependencies = [
  "fixedbitset",
- "indexmap",
+ "indexmap 1.9.1",
 ]
 
 [[package]]
@@ -6281,7 +6309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
 dependencies = [
  "autocfg",
- "indexmap",
+ "indexmap 1.9.1",
 ]
 
 [[package]]
@@ -7103,9 +7131,9 @@ checksum = "0772c5c30e1a0d91f6834f8e545c69281c099dfa9a3ac58d96a9fd629c8d4898"
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "9e8c8cf938e98f769bc164923b06dce91cea1751522f46f8466461af04c9027d"
 dependencies = [
  "serde_derive",
 ]
@@ -7121,13 +7149,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "d9735b638ccc51c28bf6914d90a2e9725b377144fc612c49a611fddd1b631d68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -7143,11 +7171,11 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.89"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020ff22c755c2ed3f8cf162dbb41a7268d934702f3ed3631656ea597e08fc3db"
+checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
  "itoa",
  "ryu",
  "serde",
@@ -7202,7 +7230,7 @@ dependencies = [
  "base64 0.13.1",
  "chrono",
  "hex",
- "indexmap",
+ "indexmap 1.9.1",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -7223,14 +7251,15 @@ dependencies = [
 
 [[package]]
 name = "serde_yaml"
-version = "0.8.23"
+version = "0.9.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a521f2940385c165a24ee286aa8599633d162077a54bdcae2a6fd5a7bfa7a0"
+checksum = "1a49e178e4452f45cb61d0cd8cebc1b0fafd3e41929e996cef79aa3aca91f574"
 dependencies = [
- "indexmap",
+ "indexmap 2.0.0",
+ "itoa",
  "ryu",
  "serde",
- "yaml-rust",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -7681,22 +7710,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
 ]
 
 [[package]]
@@ -8020,7 +8049,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.18.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.20.0",
 ]
 
 [[package]]
@@ -8100,7 +8141,7 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 1.9.1",
  "pin-project",
  "pin-project-lite",
  "rand",
@@ -8128,6 +8169,27 @@ dependencies = [
  "http-range-header",
  "pin-project-lite",
  "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
+dependencies = [
+ "base64 0.20.0",
+ "bitflags",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-range-header",
+ "mime",
+ "pin-project-lite",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8292,6 +8354,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tungstenite"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
 name = "twox-hash"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8393,6 +8474,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "untrusted"
@@ -8856,9 +8943,9 @@ dependencies = [
  "futures-task",
  "futures-util",
  "globset",
- "hashbrown",
+ "hashbrown 0.12.3",
  "hyper",
- "indexmap",
+ "indexmap 1.9.1",
  "itertools",
  "k8s-openapi",
  "kube",
@@ -8915,11 +9002,11 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.3.5",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "tungstenite",
+ "tungstenite 0.18.0",
  "uncased",
  "url",
  "uuid",
@@ -8955,15 +9042,6 @@ name = "xmlparser"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d25c75bf9ea12c4040a97f829154768bbbce366287e2dc044af160cd79a13fd"
-
-[[package]]
-name = "yaml-rust"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
-dependencies = [
- "linked-hash-map",
-]
 
 [[package]]
 name = "yansi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,14 +672,14 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.7"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
 dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.21.0",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "futures-util",
  "headers",
@@ -700,18 +700,17 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.18.0",
+ "tokio-tungstenite",
  "tower",
- "tower-http 0.3.5",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -764,12 +763,6 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -791,17 +784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bdca834647821e0b13d9539a8634eb62d3501b6b6c2cec1722786ee6671b851"
 
 [[package]]
-name = "bigdecimal"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6aaf33151a6429fe9211d1b276eafdf70cdff28b071e76c0b0e1503221ea3744"
-dependencies = [
- "num-bigint",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -812,30 +794,11 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cexpr",
  "clang-sys",
  "lazy_static",
@@ -855,6 +818,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
 
 [[package]]
 name = "bitvec"
@@ -946,9 +915,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 dependencies = [
  "serde",
 ]
@@ -1142,7 +1111,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eef2b3ded6a26dfaec672a742c93c8cf6b689220324da509ec5caa20de55dc83"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "indexmap 1.9.1",
@@ -1234,8 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
-source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
@@ -1245,8 +1215,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
-source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1576,17 +1547,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
-dependencies = [
- "cfg-if",
- "num_cpus",
- "parking_lot",
 ]
 
 [[package]]
@@ -2138,70 +2098,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "frunk"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd67cf7d54b7e72d0ea76f3985c3747d74aee43e0218ad993b7903ba7a5395e"
-dependencies = [
- "frunk_core",
- "frunk_derives",
- "frunk_proc_macros",
-]
-
-[[package]]
-name = "frunk_core"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1246cf43ec80bf8b2505b5c360b8fb999c97dabd17dbb604d85558d5cbc25482"
-
-[[package]]
-name = "frunk_derives"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dbc4f084ec5a3f031d24ccedeb87ab2c3189a2f33b8d070889073837d5ea09e"
-dependencies = [
- "frunk_proc_macro_helpers",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "frunk_proc_macro_helpers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99f11257f106c6753f5ffcb8e601fb39c390a088017aaa55b70c526bff15f63e"
-dependencies = [
- "frunk_core",
- "proc-macro2",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
-name = "frunk_proc_macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a078bd8459eccbb85e0b007b8f756585762a72a9efc53f359b371c3b6351dbcc"
-dependencies = [
- "frunk_core",
- "frunk_proc_macros_impl",
- "proc-macro-hack",
-]
-
-[[package]]
-name = "frunk_proc_macros_impl"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ffba99f0fa4f57e42f57388fbb9a0ca863bc2b4261f3c5570fed579d5df6c32"
-dependencies = [
- "frunk_core",
- "frunk_proc_macro_helpers",
- "proc-macro-hack",
- "quote",
- "syn 1.0.107",
-]
-
-[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2407,10 +2303,8 @@ checksum = "74721d007512d0cb3338cd20f0654ac913920061a4c4d0d8708edb3f2a698c0c"
 [[package]]
 name = "hashbrown"
 version = "0.12.3"
-source = "git+https://github.com/MaterializeInc/hashbrown.git#6a3c48b1fadbcfb11cff2863dcc83e65b8f0ab0d"
-dependencies = [
- "ahash",
-]
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -2442,7 +2336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
 dependencies = [
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "headers-core",
  "http",
@@ -2778,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2815,7 +2709,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09f4f04699947111ec1733e71778d763555737579e44b85844cae8e1940a1828"
 dependencies = [
  "base64 0.13.1",
- "pem",
+ "pem 1.1.1",
  "ring",
  "serde",
  "serde_json",
@@ -2853,6 +2747,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyed_priority_queue"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d63b6407b66fc81fc539dccf3ddecb669f393c5101b6a2be3976c95099a06e8"
+dependencies = [
+ "indexmap 1.9.1",
+]
+
+[[package]]
 name = "kube"
 version = "0.85.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2868,10 +2771,9 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.85.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98989b6e1f27695afe22aa29c94136fa06be5e8d28b91222e6dfbe5a460c803f"
+source = "git+https://github.com/MaterializeInc/kube-rs.git#946c1f3a4b60bbb24292e7b06423c4c3a793d6d8"
 dependencies = [
- "base64 0.20.0",
+ "base64 0.21.0",
  "bytes",
  "chrono",
  "either",
@@ -2886,7 +2788,7 @@ dependencies = [
  "k8s-openapi",
  "kube-core",
  "openssl",
- "pem",
+ "pem 2.0.1",
  "pin-project",
  "rand",
  "secrecy",
@@ -2895,18 +2797,17 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "tokio",
- "tokio-tungstenite 0.20.0",
+ "tokio-tungstenite",
  "tokio-util",
  "tower",
- "tower-http 0.4.0",
+ "tower-http",
  "tracing",
 ]
 
 [[package]]
 name = "kube-core"
 version = "0.85.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c24d23bf764ec9a5652f943442ff062b91fd52318ea6d2fc11115f19d8c84d13"
+source = "git+https://github.com/MaterializeInc/kube-rs.git#946c1f3a4b60bbb24292e7b06423c4c3a793d6d8"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -2962,7 +2863,7 @@ dependencies = [
 [[package]]
 name = "launchdarkly-server-sdk"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/rust-server-sdk#fb0eaf5bee43f9a590a237705d190e6650d9ecd8"
+source = "git+https://github.com/MaterializeInc/rust-server-sdk#dcc193d9601086f4329bde3ec191e0e929da7170"
 dependencies = [
  "built",
  "chrono",
@@ -3115,7 +3016,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -3209,11 +3110,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.8.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
+checksum = "eedb2bdbad7e0634f83989bf596f497b070130daaa398ab22d84c39e266deec5"
 dependencies = [
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -3294,9 +3195,9 @@ dependencies = [
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mime_guess"
@@ -3385,9 +3286,8 @@ dependencies = [
 
 [[package]]
 name = "mysql_async"
-version = "0.31.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f9a46598da19a35a5637ee5510da39b3f07a8c53b621645e83a8959490a067"
+version = "0.32.2"
+source = "git+https://github.com/MaterializeInc/mysql_async.git#ce4066497b0b60598199e4c99d7c2a8968ee3c2e"
 dependencies = [
  "bytes",
  "crossbeam",
@@ -3395,22 +3295,20 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "futures-util",
+ "keyed_priority_queue",
  "lazy_static",
  "lru",
  "mio",
  "mysql_common",
- "native-tls",
  "once_cell",
- "pem",
+ "pem 2.0.1",
  "percent-encoding",
  "pin-project",
- "priority-queue",
  "serde",
  "serde_json",
- "socket2 0.4.9",
+ "socket2 0.5.3",
  "thiserror",
  "tokio",
- "tokio-native-tls",
  "tokio-util",
  "twox-hash",
  "url",
@@ -3418,14 +3316,13 @@ dependencies = [
 
 [[package]]
 name = "mysql_common"
-version = "0.29.2"
+version = "0.30.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9006c95034ccf7b903d955f210469119f6c3477fc9c9e7a7845ce38a3e665c2a"
+checksum = "57349d5a326b437989b6ee4dc8f2f34b0cc131202748414712a8e7d98952fc8c"
 dependencies = [
- "base64 0.13.1",
- "bigdecimal",
- "bindgen 0.59.2",
- "bitflags",
+ "base64 0.21.0",
+ "bindgen",
+ "bitflags 2.3.3",
  "bitvec",
  "byteorder",
  "bytes",
@@ -3433,14 +3330,12 @@ dependencies = [
  "cmake",
  "crc32fast",
  "flate2",
- "frunk",
  "lazy_static",
  "lexical",
  "num-bigint",
  "num-traits",
  "rand",
  "regex",
- "rust_decimal",
  "saturating",
  "serde",
  "serde_json",
@@ -3449,7 +3344,6 @@ dependencies = [
  "smallvec",
  "subprocess",
  "thiserror",
- "time",
  "uuid",
 ]
 
@@ -4034,12 +3928,12 @@ dependencies = [
  "tokio-postgres",
  "tokio-stream",
  "tower",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "tracing-core",
  "tracing-opentelemetry",
  "tracing-subscriber",
- "tungstenite 0.18.0",
+ "tungstenite",
  "url",
  "uuid",
  "workspace-hack",
@@ -4180,7 +4074,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "workspace-hack",
@@ -4734,7 +4628,7 @@ name = "mz-repr"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "chrono",
  "chrono-tz",
@@ -4932,7 +4826,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "aws-sdk-sts",
- "bitflags",
+ "bitflags 1.3.2",
  "chrono",
  "datadriven",
  "enum-kinds",
@@ -5059,7 +4953,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-postgres",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "uuid",
  "walkdir",
@@ -5092,7 +4986,7 @@ name = "mz-stash"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 1.3.2",
  "bytes",
  "criterion",
  "differential-dataflow",
@@ -5172,7 +5066,7 @@ dependencies = [
  "globset",
  "http",
  "humantime",
- "indexmap 1.9.1",
+ "indexmap 2.0.0",
  "itertools",
  "maplit",
  "mz-avro",
@@ -5492,7 +5386,7 @@ version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a58d1d356c6597d08cde02c2f09d785b09e28711837b1ed667dc652c08a694"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -5728,7 +5622,7 @@ version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -5778,9 +5672,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -5788,16 +5682,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
- "futures",
- "futures-util",
+ "futures-core",
  "http",
- "opentelemetry",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
@@ -5806,27 +5701,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
 dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
 dependencies = [
- "fnv",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
  "futures-channel",
  "futures-util",
  "indexmap 1.9.1",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -5835,21 +5738,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float",
  "percent-encoding",
  "rand",
+ "regex",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -5989,6 +5893,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
  "base64 0.13.1",
+]
+
+[[package]]
+name = "pem"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
+dependencies = [
+ "base64 0.21.0",
+ "serde",
 ]
 
 [[package]]
@@ -6303,23 +6217,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "priority-queue"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7685ca4cc0b3ad748c22ce6803e23b55b9206ef7715b965ebeaf41639238fdc"
-dependencies = [
- "autocfg",
- "indexmap 1.9.1",
-]
-
-[[package]]
 name = "proc-macro-crate"
-version = "1.0.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
- "thiserror",
- "toml",
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -6380,7 +6284,7 @@ name = "proptest"
 version = "1.0.0"
 source = "git+https://github.com/MaterializeInc/proptest.git#fc9660f0f45ad49949d42341f964597a44e5fce0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "lazy_static",
  "num-traits",
@@ -6507,7 +6411,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34f197a544b0c9ab3ae46c359a7ec9cbbb5c7bf97054266fecb7ead794a181d6"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "memchr",
  "unicase",
 ]
@@ -6653,7 +6557,7 @@ version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6662,7 +6566,7 @@ version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6801,17 +6705,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust_decimal"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0593ce4677e3800ddafb3de917e8397b1348e06e688128ade722d88fbe11ebf"
-dependencies = [
- "arrayvec",
- "num-traits",
- "serde",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6838,7 +6731,7 @@ version = "0.37.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0661814f891c57c930a610266415528da53c4933e6dea5fb350cbfe048a9ece"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -6967,7 +6860,7 @@ version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bc1bb97804af6631813c55739f771071e0f2ed33ee20b68c86ec505d906356c"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -7424,12 +7317,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc8d618c6641ae355025c449427f9e96b98abf99a772be3cef6708d15c77147a"
+checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7621,7 +7514,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed66d6a2ccbd656659289bc90767895b7abbdec897a0fc6031aca3ed1cb51d3e"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "enum-as-inner",
  "libc",
@@ -8010,7 +7903,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "serde",
- "socket2 0.5.1",
+ "socket2 0.5.3",
  "tokio",
  "tokio-util",
 ]
@@ -8042,18 +7935,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54319c93411147bced34cb5609a80e0a8e44c5999c93903a81cd866630ec0bfd"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.18.0",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b2dbec703c26b00d74844519606ef15d09a7d6857860f84ad223dec002ddea2"
@@ -8061,7 +7942,7 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite 0.20.0",
+ "tungstenite",
 ]
 
 [[package]]
@@ -8090,15 +7971,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.8.3"
+name = "toml_datetime"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
 dependencies = [
- "async-stream",
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "tonic"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
+dependencies = [
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8110,21 +8007,18 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
-source = "git+https://github.com/MaterializeInc/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
+version = "0.9.2"
+source = "git+https://github.com/MaterializeInc/tonic#f2892a068a0d7513aac570ae8a58fa48d84b5d45"
 dependencies = [
  "prettyplease 0.2.4",
  "proc-macro2",
@@ -8155,33 +8049,12 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
+checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
- "base64 0.13.1",
- "bitflags",
- "bytes",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-range-header",
- "pin-project-lite",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d1d42a9b3f3ec46ba828e8d376aec14592ea199f70a06a548587ecd1c4ab658"
-dependencies = [
- "base64 0.20.0",
- "bitflags",
+ "base64 0.21.0",
+ "bitflags 2.3.3",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8190,6 +8063,7 @@ dependencies = [
  "http-range-header",
  "mime",
  "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -8242,16 +8116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8264,8 +8128,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.19.0"
-source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#3c7e5779db371735c24394b03a6bd31f67214419"
+version = "0.20.0"
+source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#405437e84fa3b0f34b91b8655d45a229265a6f14"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -8335,26 +8199,6 @@ checksum = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"
 
 [[package]]
 name = "tungstenite"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ee6ab729cd4cf0fd55218530c4522ed30b7b6081752839b68fcec8d0960788"
-dependencies = [
- "base64 0.13.1",
- "byteorder",
- "bytes",
- "http",
- "httparse",
- "log",
- "native-tls",
- "rand",
- "sha1",
- "thiserror",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e862a1c4128df0112ab625f55cd5c934bcb4312ba80b39ae4b4835a3fd58e649"
@@ -8365,6 +8209,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
+ "native-tls",
  "rand",
  "sha1",
  "thiserror",
@@ -8622,9 +8467,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8632,16 +8477,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -8659,9 +8504,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8669,22 +8514,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
@@ -8895,6 +8740,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
+name = "winnow"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acaaa1190073b2b101e15083c38ee8ec891b5e05cbee516521e94ec008f61e64"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8915,7 +8769,7 @@ dependencies = [
  "aws-sigv4",
  "aws-smithy-http",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bstr",
  "byteorder",
  "bytes",
@@ -8933,8 +8787,6 @@ dependencies = [
  "digest",
  "either",
  "flate2",
- "frunk_core",
- "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -8943,7 +8795,7 @@ dependencies = [
  "futures-task",
  "futures-util",
  "globset",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.0",
  "hyper",
  "indexmap 1.9.1",
  "itertools",
@@ -8965,7 +8817,6 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "ordered-float",
- "parking_lot",
  "phf",
  "phf_shared",
  "postgres",
@@ -9002,11 +8853,11 @@ dependencies = [
  "tokio-stream",
  "tokio-util",
  "tower",
- "tower-http 0.3.5",
+ "tower-http",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
- "tungstenite 0.18.0",
+ "tungstenite",
  "uncased",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2771,7 +2771,7 @@ dependencies = [
 [[package]]
 name = "kube-client"
 version = "0.85.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git#946c1f3a4b60bbb24292e7b06423c4c3a793d6d8"
+source = "git+https://github.com/MaterializeInc/kube-rs.git?rev=838a7981483005e1af7c1338c48a4d0540a33ce4#838a7981483005e1af7c1338c48a4d0540a33ce4"
 dependencies = [
  "base64 0.21.0",
  "bytes",
@@ -2807,7 +2807,7 @@ dependencies = [
 [[package]]
 name = "kube-core"
 version = "0.85.0"
-source = "git+https://github.com/MaterializeInc/kube-rs.git#946c1f3a4b60bbb24292e7b06423c4c3a793d6d8"
+source = "git+https://github.com/MaterializeInc/kube-rs.git?rev=838a7981483005e1af7c1338c48a4d0540a33ce4#838a7981483005e1af7c1338c48a4d0540a33ce4"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -8018,13 +8018,13 @@ dependencies = [
 [[package]]
 name = "tonic-build"
 version = "0.9.2"
-source = "git+https://github.com/MaterializeInc/tonic#f2892a068a0d7513aac570ae8a58fa48d84b5d45"
+source = "git+https://github.com/MaterializeInc/tonic?rev=0d86e360ab45779770ca150c8487fe7940c299a9#0d86e360ab45779770ca150c8487fe7940c299a9"
 dependencies = [
- "prettyplease 0.2.4",
+ "prettyplease 0.1.25",
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.18",
+ "syn 1.0.107",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,11 +128,6 @@ timely_logging = { git = "https://github.com/MaterializeInc/timely-dataflow.git"
 differential-dataflow = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
 dogsdogsdogs = { git = "https://github.com/MaterializeInc/differential-dataflow.git" }
 
-# Waiting for hashlink, indexmap, and lru to upgrade to hashbrown v0.13,
-# which depends on ahash v0.8 instead of v0.7. In the meantime we've
-# backported the ahash v0.8 bump into hashbrown v0.12.
-hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git" }
-
 # Waiting on https://github.com/sfackler/rust-postgres/pull/752.
 postgres  = { git = "https://github.com/MaterializeInc/rust-postgres" }
 tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres" }
@@ -155,10 +150,6 @@ tonic-build = { git = "https://github.com/MaterializeInc/tonic" }
 # upstream.
 tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing-opentelemetry.git" }
 
-# Waiting on https://github.com/tokio-rs/console/pull/388.
-console-api = { git = "https://github.com/MaterializeInc/tokio-console.git" }
-console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git" }
-
 # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
 # it into a release.
 launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk" }
@@ -174,6 +165,13 @@ rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
 # Waiting on https://github.com/openssh-rust/openssh/pull/120 to make it into
 # a release.
 openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
+
+# Waiting for a new release of kube-client compatible with base64 0.21.0
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git" }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git" }
+
+# Waiting on `lru` dep to update to `0.11.0`
+mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git" }
 
 [patch."https://github.com/frankmcsherry/columnation"]
 # Projects that do not reliably release to crates.io.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,7 +144,7 @@ serde-value = { git = "https://github.com/MaterializeInc/serde-value.git" }
 vte = { git = "https://github.com/MaterializeInc/vte", rev = "45670c47cebd7af050def2f80a307bdeec7caba3" }
 
 # Waiting on https://github.com/hyperium/tonic/pull/1398.
-tonic-build = { git = "https://github.com/MaterializeInc/tonic" }
+tonic-build = { git = "https://github.com/MaterializeInc/tonic", rev = "0d86e360ab45779770ca150c8487fe7940c299a9" }
 
 # Waiting on https://github.com/MaterializeInc/tracing/pull/1 to be submitted
 # upstream.
@@ -167,8 +167,8 @@ rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git" }
 openssh = { git = "https://github.com/MaterializeInc/openssh.git" }
 
 # Waiting for a new release of kube-client compatible with base64 0.21.0
-kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git" }
-kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git" }
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4" }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4" }
 
 # Waiting on `lru` dep to update to `0.11.0`
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git" }

--- a/deny.toml
+++ b/deny.toml
@@ -38,13 +38,26 @@ skip = [
     { name = "hermit-abi", version = "0.2.6" },
     { name = "redox_syscall", version = "0.2.10" },
 
-    # Waiting for <https://github.com/blackbeam/rust_mysql_common/commit/2a6419aef2ff609cd35a5ce41a9eb48253a8214d>
-    # to be released.
-    { name = "bindgen", version = "0.59.2" },
-
     # Waiting on https://github.com/tokio-rs/prost/pull/833 to make it into a
     # release. (not yet in v0.11.9)
     { name = "prettyplease", version = "0.1.25" },
+
+    # Will require updating many crates
+    { name = "indexmap", version = "1.9.1" },
+    # Required by indexmap 1.9.1, which is depended on by many things
+    { name = "hashbrown", version = "0.12.3" },
+
+    # https://github.com/Keats/jsonwebtoken has already updated to `pem` version `2`
+    # on its main branch, but hasn't released a new version with that change yet
+    # TODO: Fork https://github.com/Keats/jsonwebtoken and cherry-pick the change from
+    # https://github.com/Keats/jsonwebtoken/pull/322
+    { name = "pem", version = "1.1.1" },
+
+    # Had to update `tower-http` to `0.4.3` to fix the `base64` duplicate version
+    # but this introduced a new dependency on `bitflags 2.3.3` but all the rest of
+    # our crates use `bitflags 1.3.2`
+    # TODO: fork `tower-http` and swap to use older bitflags
+    { name = "bitflags", version = "1.3.2" },
 ]
 
 # Use `tracing` instead.

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -50,7 +50,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-tracing = { path = "../tracing" }
 mz-transform = { path = "../transform" }
 mz-cloud-resources = { path = "../cloud-resources" }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
@@ -70,7 +70,7 @@ tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
-tracing-opentelemetry = { version = "0.19.0" }
+tracing-opentelemetry = { version = "0.20.0" }
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -9,8 +9,8 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 async-trait = "0.1.68"
-k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
-kube = { version = "0.77.0", features = ["derive", "openssl-tls", "ws"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
+kube = { version = "0.85.0", features = ["derive", "openssl-tls", "ws"] }
 mz-ore = { path = "../ore", features = [] }
 mz-repr = { path = "../repr" }
 schemars = { version = "0.8", features = ["uuid1"] }

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.89"
 thiserror = "1.0.37"
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -34,7 +34,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
-axum = "0.6.7"
+axum = "0.6.20"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -98,7 +98,7 @@ use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::{GrpcPubSubClient, PersistPubSubClient, PersistPubSubClientConfig};
 use mz_pid_file::PidFile;
 use mz_service::emit_boot_diagnostics;
-use mz_service::grpc::GrpcServer;
+use mz_service::grpc::{GrpcServer, MAX_GRPC_MESSAGE_SIZE};
 use mz_service::secrets::SecretsReaderCliArgs;
 use mz_storage::storage_state::StorageInstanceContext;
 use mz_storage_client::client::proto_storage_server::ProtoStorageServer;
@@ -342,7 +342,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             args.storage_controller_listen_addr,
             BUILD_INFO.semver_version(),
             storage_client,
-            ProtoStorageServer::new,
+            |svc| ProtoStorageServer::new(svc).max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
         ),
     );
 
@@ -363,7 +363,7 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             args.compute_controller_listen_addr,
             BUILD_INFO.semver_version(),
             compute_client,
-            ProtoComputeServer::new,
+            |svc| ProtoComputeServer::new(svc).max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE),
         ),
     );
 

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -51,7 +51,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 anyhow = "1.0.66"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 async-trait = "0.1.68"
-axum = { version = "0.6.7", features = ["headers", "ws"] }
+axum = { version = "0.6.20", features = ["headers", "ws"] }
 base64 = "0.13.1"
 bytes = "1.3.0"
 bytesize = "1.1.0"
@@ -63,7 +63,7 @@ nix = "0.26.1"
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false }
 rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
@@ -84,12 +84,12 @@ tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }
 tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
-tower-http = { version = "0.3.5", features = ["cors"] }
+tower-http = { version = "0.4.2", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { version = "0.19.0" }
+tracing-opentelemetry = { version = "0.20.0" }
 tracing-subscriber = "0.3.16"
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
+tungstenite = { version = "0.20.0", features = ["native-tls"] }
 url = "2.3.1"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -788,7 +788,7 @@ pub fn auth_with_ws(
     ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
     options: BTreeMap<String, String>,
 ) -> Result<Vec<WebSocketResponse>, anyhow::Error> {
-    ws.write_message(Message::Text(
+    ws.send(Message::Text(
         serde_json::to_string(&WebSocketAuth::Basic {
             user: "materialize".into(),
             password: "".into(),
@@ -799,7 +799,7 @@ pub fn auth_with_ws(
     // Wait for initial ready response.
     let mut msgs = Vec::new();
     loop {
-        let resp = ws.read_message()?;
+        let resp = ws.read()?;
         match resp {
             Message::Text(msg) => {
                 let msg: WebSocketResponse = serde_json::from_str(&msg).unwrap();

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
-axum = { version = "0.6.7", features = ["headers"] }
+axum = { version = "0.6.20", features = ["headers"] }
 headers = "0.3.8"
 http = "0.2.8"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
@@ -20,7 +20,7 @@ serde = "1.0.152"
 serde_json = { version = "1.0.89" }
 tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
-tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower-http = { version = "0.4.2", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -8,7 +8,7 @@ rust-version.workspace = true
 
 [dependencies]
 anyhow = "1.0.66"
-axum = { version = "0.6.7" }
+axum = { version = "0.6.20" }
 clap = { version = "3.2.24", features = [ "derive" ] }
 dirs = "5.0.0"
 indicatif = "0.17.2"

--- a/src/orchestrator-kubernetes/Cargo.toml
+++ b/src/orchestrator-kubernetes/Cargo.toml
@@ -18,8 +18,8 @@ mz-cloud-resources = { path = "../cloud-resources" }
 mz-orchestrator = { path = "../orchestrator" }
 mz-secrets = { path = "../secrets" }
 mz-repr = { path = "../repr" }
-k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
-kube = { version = "0.77.0", features = ["runtime", "ws"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
+kube = { version = "0.85.0", features = ["runtime", "ws"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 sha2 = "0.10.6"

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -93,7 +93,7 @@ use k8s_openapi::api::core::v1::{
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, LabelSelectorRequirement};
-use kube::api::{Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams};
+use kube::api::{Api, DeleteParams, ObjectMeta, Patch, PatchParams};
 use kube::client::Client;
 use kube::error::Error;
 use kube::runtime::{watcher, WatchStreamExt};
@@ -353,12 +353,12 @@ impl k8s_openapi::Metadata for MetricValueList {
 impl NamespacedKubernetesOrchestrator {
     /// Return a `ListParams` instance that limits results to the namespace
     /// assigned to this orchestrator.
-    fn list_pod_params(&self) -> ListParams {
+    fn list_pod_params(&self) -> watcher::Config {
         let ns_selector = format!(
             "environmentd.materialize.cloud/namespace={}",
             self.namespace
         );
-        ListParams::default().labels(&ns_selector)
+        watcher::Config::default().labels(&ns_selector)
     }
     /// Convert a higher-level label key to the actual one we
     /// will give to Kubernetes

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -351,9 +351,9 @@ impl k8s_openapi::Metadata for MetricValueList {
 }
 
 impl NamespacedKubernetesOrchestrator {
-    /// Return a `ListParams` instance that limits results to the namespace
+    /// Return a `wather::Config` instance that limits results to the namespace
     /// assigned to this orchestrator.
-    fn list_pod_params(&self) -> watcher::Config {
+    fn watch_pod_params(&self) -> watcher::Config {
         let ns_selector = format!(
             "environmentd.materialize.cloud/namespace={}",
             self.namespace
@@ -1317,7 +1317,7 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             })
         }
 
-        let stream = watcher(self.pod_api.clone(), self.list_pod_params())
+        let stream = watcher(self.pod_api.clone(), self.watch_pod_params())
             .touched_objects()
             .filter_map(|object| async move {
                 match object {

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -22,7 +22,7 @@ mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", default-features = false }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -20,7 +20,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"
-tonic-build = "0.8.0"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -49,15 +49,15 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 atty = { version = "0.2.14", optional = true }
 http = { version = "0.2.8", optional = true }
 tracing = { version = "0.1.37", optional = true }
-tracing-opentelemetry = { version = "0.19.0", optional = true }
-tonic = { version = "0.8.2", features = ["transport"], optional = true }
+tracing-opentelemetry = { version = "0.20.0", optional = true }
+tonic = { version = "0.9.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.11", features = ["alpn"], optional = true }
 hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"], optional = true }
-opentelemetry-otlp = { version = "0.12.0", optional = true }
-console-subscriber = { version = "0.1.8", optional = true }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.13.0", optional = true }
+console-subscriber = { version = "0.1.10", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -56,7 +56,7 @@ timely = { version = "0.12.0", default-features = false, features = ["bincode"] 
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -66,7 +66,7 @@ tokio-console = ["mz-ore/tokio-console"]
 
 [dev-dependencies]
 async-trait = "0.1.68"
-axum = { version = "0.6.7" }
+axum = { version = "0.6.20" }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 criterion = { version = "0.4.0", features = ["html_reports"] }
 datadriven = { version = "0.6.0", features = ["async"] }
@@ -83,7 +83,7 @@ tempfile = "3.2.0"
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/persist-client/src/rpc.rs
+++ b/src/persist-client/src/rpc.rs
@@ -942,8 +942,9 @@ impl PersistGrpcPubSubServer {
 
     /// Starts the gRPC server. Consumes `self` and runs until the task is cancelled.
     pub async fn serve(self, listen_addr: SocketAddr) -> Result<(), anyhow::Error> {
+        // Increase the default message decoding limit to avoid unnecessary panics
         tonic::transport::Server::builder()
-            .add_service(ProtoPersistPubSubServer::new(self))
+            .add_service(ProtoPersistPubSubServer::new(self).max_decoding_message_size(usize::MAX))
             .serve(listen_addr)
             .await?;
         Ok(())

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -35,7 +35,7 @@ privileges = ["postgres_array"]
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 askama = { version = "0.11.1", default-features = false, features = ["config", "serde-json"] }
 anyhow = "1.0.66"
-axum = { version = "0.6.7", features = ["headers"] }
+axum = { version = "0.6.20", features = ["headers"] }
 backtrace = "0.3.66"
 bytesize = "1.1.0"
 cfg-if = "1.0.0"

--- a/src/rocksdb-types/Cargo.toml
+++ b/src/rocksdb-types/Cargo.toml
@@ -21,7 +21,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -34,7 +34,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -34,7 +34,7 @@ sysinfo = "0.27.2"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tower = "0.4.13"
 tracing = "0.1.37"
 sentry-tracing = "0.29.1"
@@ -43,7 +43,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/service/src/grpc.rs
+++ b/src/service/src/grpc.rs
@@ -41,6 +41,9 @@ use crate::params::GrpcClientParameters;
 
 include!(concat!(env!("OUT_DIR"), "/mz_service.params.rs"));
 
+// Use with generated servers Server::new(Svc).max_decoding_message_size
+pub const MAX_GRPC_MESSAGE_SIZE: usize = usize::MAX;
+
 pub type ResponseStream<PR> = Pin<Box<dyn Stream<Item = Result<PR, Status>> + Send>>;
 
 pub type ClientTransport = InterceptedService<Channel, VersionAttachInterceptor>;
@@ -193,7 +196,9 @@ where
     where
         Self: Sized,
     {
-        let inner = tonic::client::Grpc::new(inner);
+        let inner = tonic::client::Grpc::new(inner)
+            .max_decoding_message_size(MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(MAX_GRPC_MESSAGE_SIZE);
         let codec = StatCodec::new(stats_collector);
         BidiProtoClient { inner, path, codec }
     }

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -42,7 +42,7 @@ time = "0.3.17"
 tracing = "0.1.37"
 tokio = "1.24.2"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
-tower-http = { version = "0.3.5", features = ["cors"] }
+tower-http = { version = "0.4.2", features = ["cors"] }
 uuid = "1.2.2"
 walkdir = "2.3.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -59,7 +59,7 @@ timely = { version = "0.12.0", default-features = false, features = ["bincode"] 
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = { version = "2.3.1", features = ["serde"] }
@@ -69,7 +69,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 itertools = "0.10.5"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -28,7 +28,7 @@ fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
 globset = { version = "0.4.9", features = ["serde1"] }
 http = "0.2.8"
-indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
+indexmap = { version = "2.0.0", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 maplit = "1.0.2"
 mz-avro = { path = "../avro", features = ["snappy"] }
@@ -80,11 +80,11 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 async-trait = "0.1.68"
-axum = { version = "0.6.7" }
+axum = { version = "0.6.20" }
 clap = { version = "3.2.24", features = ["derive", "env"] }
 datadriven = { version = "0.6.0", features = ["async"] }
 humantime = "2.1.0"

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -30,7 +30,7 @@ junit-report = "0.7.1"
 once_cell = "1.16.0"
 maplit = "1.0.2"
 md-5 = "0.10.5"
-mysql_async = "0.31.2"
+mysql_async = { version = "0.32.2",  default-features = false, features = ["minimal"] }
 mz-avro = { path = "../avro", features = ["snappy"] }
 mz-aws-s3-util = { path = "../aws-s3-util" }
 mz-ccsr = { path = "../ccsr" }

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -21,7 +21,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -53,8 +53,8 @@ indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
-kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.11.0" }
@@ -151,8 +151,8 @@ indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
-kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a7981483005e1af7c1338c48a4d0540a33ce4", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.11.0" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -53,10 +53,10 @@ hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features 
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
-kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
-kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
+kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
+kube-client = { version = "0.85.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.85.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.8.1" }
@@ -154,10 +154,10 @@ hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features 
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
-k8s-openapi = { version = "0.16.0", features = ["v1_24"] }
-kube = { version = "0.77.0", features = ["derive", "runtime", "ws"] }
-kube-client = { version = "0.77.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.77.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
+kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
+kube-client = { version = "0.85.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { version = "0.85.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.8.1" }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -21,11 +21,11 @@ aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.55.1", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.55.2", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { version = "0.6.7", features = ["headers", "ws"] }
-base64 = { version = "0.13.1", features = ["alloc"] }
+axum = { version = "0.6.20", features = ["headers", "ws"] }
+base64 = { version = "0.21.0", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0", features = ["serde"] }
+bytes = { version = "1.4.0", features = ["serde"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
@@ -39,27 +39,25 @@ dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
-frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
-futures = { version = "0.3.25" }
-futures-channel = { version = "0.3.25", features = ["sink"] }
-futures-core = { version = "0.3.25" }
+futures-channel = { version = "0.3.28", features = ["sink"] }
+futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }
-futures-io = { version = "0.3.25" }
-futures-sink = { version = "0.3.25" }
-futures-task = { version = "0.3.25" }
-futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
+futures-io = { version = "0.3.28" }
+futures-sink = { version = "0.3.28" }
+futures-task = { version = "0.3.28" }
+futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
-hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
+hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
-kube-client = { version = "0.85.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.85.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
-lru = { version = "0.8.1" }
+lru = { version = "0.11.0" }
 memchr = { version = "2.5.0", features = ["use_std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
@@ -70,7 +68,6 @@ num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -89,8 +86,8 @@ ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
-serde = { version = "1.0.152", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
+serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
@@ -103,11 +100,11 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", feat
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
+tungstenite = { version = "0.20.0", features = ["native-tls"] }
 uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }
@@ -121,11 +118,11 @@ aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.55.1", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.55.2", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { version = "0.6.7", features = ["headers", "ws"] }
-base64 = { version = "0.13.1", features = ["alloc"] }
+axum = { version = "0.6.20", features = ["headers", "ws"] }
+base64 = { version = "0.21.0", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
-bytes = { version = "1.3.0", features = ["serde"] }
+bytes = { version = "1.4.0", features = ["serde"] }
 cc = { version = "1.0.78", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4.25", default-features = false, features = ["alloc", "clock", "serde"] }
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
@@ -140,27 +137,25 @@ dec = { version = "0.4.8", default-features = false, features = ["serde"] }
 digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
-frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
-futures = { version = "0.3.25" }
-futures-channel = { version = "0.3.25", features = ["sink"] }
-futures-core = { version = "0.3.25" }
+futures-channel = { version = "0.3.28", features = ["sink"] }
+futures-core = { version = "0.3.28" }
 futures-executor = { version = "0.3.25" }
-futures-io = { version = "0.3.25" }
-futures-sink = { version = "0.3.25" }
-futures-task = { version = "0.3.25" }
-futures-util = { version = "0.3.25", features = ["channel", "io", "sink"] }
+futures-io = { version = "0.3.28" }
+futures-sink = { version = "0.3.28" }
+futures-task = { version = "0.3.28" }
+futures-util = { version = "0.3.28", features = ["channel", "io", "sink"] }
 globset = { version = "0.4.9", features = ["serde1"] }
-hashbrown = { git = "https://github.com/MaterializeInc/hashbrown.git", features = ["raw"] }
+hashbrown = { version = "0.14.0", features = ["raw"] }
 hyper = { version = "0.14.25", features = ["full"] }
 indexmap = { version = "1.9.1", default-features = false, features = ["std"] }
 itertools = { version = "0.10.5" }
 k8s-openapi = { version = "0.19.0", features = ["v1_25"] }
 kube = { version = "0.85.0", features = ["derive", "runtime", "ws"] }
-kube-client = { version = "0.85.0", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
-kube-core = { version = "0.85.0", default-features = false, features = ["jsonpatch", "schema", "ws"] }
+kube-client = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "openssl-tls", "ws"] }
+kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", default-features = false, features = ["jsonpatch", "schema", "ws"] }
 libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
-lru = { version = "0.8.1" }
+lru = { version = "0.11.0" }
 memchr = { version = "2.5.0", features = ["use_std"] }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
@@ -171,7 +166,6 @@ num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -190,8 +184,8 @@ ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
 semver = { version = "1.0.16", features = ["serde"] }
-serde = { version = "1.0.152", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1.0.89", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
+serde = { version = "1.0.164", features = ["alloc", "derive", "rc"] }
+serde_json = { version = "1.0.99", features = ["alloc", "arbitrary_precision", "float_roundtrip", "preserve_order", "raw_value"] }
 sha2 = { version = "0.10.6" }
 similar = { version = "2.2.1", features = ["inline", "unicode"] }
 smallvec = { version = "1.10.0", default-features = false, features = ["const_generics", "serde", "union", "write"] }
@@ -205,11 +199,11 @@ tokio-postgres = { git = "https://github.com/MaterializeInc/rust-postgres", feat
 tokio-stream = { version = "0.1.11", features = ["net", "sync"] }
 tokio-util = { version = "0.7.4", features = ["codec", "compat", "io", "time"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "load-shed", "retry", "timeout", "util"] }
-tower-http = { version = "0.3.5", features = ["auth", "cors", "map-response-body", "trace", "util"] }
+tower-http = { version = "0.4.3", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = { version = "0.1.37", features = ["log"] }
 tracing-core = { version = "0.1.30" }
 tracing-subscriber = { version = "0.3.16", features = ["env-filter", "json"] }
-tungstenite = { version = "0.18.0", features = ["native-tls"] }
+tungstenite = { version = "0.20.0", features = ["native-tls"] }
 uncased = { version = "0.9.7" }
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde", "v4", "v5"] }


### PR DESCRIPTION
### Motivation

To avoid duplicate package version warnings on `serde_yaml` in the cloud repo caused by the introduction of `utoipa` for generating OpenAPI specs, we need to update the `kube` version to 0.85.0. However doing so in the cloud repo (and in https://github.com/MaterializeInc/k8s-controller) requires doing so in the materialize repo first, hence this PR.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The one code change is due to a slight type change in the kube crate: https://github.com/kube-rs/kube/blob/main/CHANGELOG.md#listwatch-changes

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
