### PR TITLE
cloudtests: allow specifying the namespace for testdrive

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/__init__.py
+++ b/misc/python/materialize/cloudtest/k8s/__init__.py
@@ -33,6 +33,8 @@ from pg8000 import Connection, Cursor
 from materialize import ROOT, mzbuild, ui
 from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
 
+DEFAULT_K8S_NAMESPACE = "default"
+
 
 class K8sResource:
     def kubectl(self, *args: str, input: Optional[str] = None) -> str:
@@ -69,7 +71,7 @@ class K8sResource:
         return DEFAULT_K8S_CONTEXT_NAME
 
     def namespace(self) -> str:
-        return "default"
+        return DEFAULT_K8S_NAMESPACE
 
     def kind(self) -> str:
         assert False

--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -13,15 +13,21 @@ from typing import Optional
 
 from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodSpec
 
-from materialize.cloudtest.k8s import K8sPod
+from materialize.cloudtest.k8s import DEFAULT_K8S_NAMESPACE, K8sPod
 from materialize.cloudtest.wait import wait
 
 
 class Testdrive(K8sPod):
-    def __init__(self, release_mode: bool, aws_region: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        release_mode: bool,
+        aws_region: Optional[str] = None,
+        namespace: str = DEFAULT_K8S_NAMESPACE,
+    ) -> None:
         self.aws_region = aws_region
+        self.selected_namespace = namespace
 
-        metadata = V1ObjectMeta(name="testdrive")
+        metadata = V1ObjectMeta(name="testdrive", namespace=namespace)
 
         # Pass through AWS credentials from the host
         env = [
@@ -82,3 +88,6 @@ class Testdrive(K8sPod):
             *args,
             input=input,
         )
+
+    def namespace(self) -> str:
+        return self.selected_namespace


### PR DESCRIPTION
This allows using a different namespace for testdrive as a first step.

### Motivation
Allow usage in cloud repo.