### PR TITLE
parser: print expressions correctly; improve roundtrip testing

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -931,6 +931,8 @@ impl<'a> Parser<'a> {
         Ok(Expr::NullIf { l_expr, r_expr })
     }
 
+    // Parse calls to extract(), which can take the form:
+    // - extract(field from 'interval')
     fn parse_extract_expr(&mut self) -> Result<Expr<Raw>, ParserError> {
         self.expect_token(&Token::LParen)?;
         let field = match self.next_token() {

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -153,30 +153,27 @@ fn datadriven() {
         let input = tc.input.trim();
         match parser::parse_expr(input) {
             Ok(s) => {
-                match parser::parse_expr(&s.to_string()) {
-                    Ok(parsed) => {
-                        // TODO: We always coerce the double colon operator into a Cast expr instead
-                        // of keeping it as an Op (see parse_pg_cast). Expr::Cast always prints
-                        // itself as double colon. We're thus unable to perfectly roundtrip
-                        // `CAST(..)`. We could fix this by keeping "::" as a binary operator and
-                        // teaching func.rs how to handle it, similar to how that file handles "~~"
-                        // (without the parser converting that operator directly into an
-                        // Expr::Like).
-                        if !matches!(parsed, Expr::Cast { .. }) {
-                            if parsed != s {
-                                panic!(
-                                    "reparse comparison failed: {input} != {s}\n{:?}\n!=\n{:?}\n",
+                for printed in [s.to_ast_string(), s.to_ast_string_stable()] {
+                    match parser::parse_expr(&printed) {
+                        Ok(parsed) => {
+                            // TODO: We always coerce the double colon operator into a Cast expr instead
+                            // of keeping it as an Op (see parse_pg_cast). Expr::Cast always prints
+                            // itself as double colon. We're thus unable to perfectly roundtrip
+                            // `CAST(..)`. We could fix this by keeping "::" as a binary operator and
+                            // teaching func.rs how to handle it, similar to how that file handles "~~"
+                            // (without the parser converting that operator directly into an
+                            // Expr::Like).
+                            if !matches!(parsed, Expr::Cast { .. }) {
+                                if parsed != s {
+                                    panic!(
+                                    "reparse comparison failed: {input} != {s}\n{:?}\n!=\n{:?}\n{printed}\n",
                                     s, parsed
                                 );
+                                }
                             }
                         }
+                        Err(err) => panic!("reparse failed: {printed}: {err}\n{s:?}"),
                     }
-                    // TODO: Some functions (EXTRACT) have special syntax: `extract('year' FROM d)`.
-                    // We drop this syntax and convert them into regular functions that don't know
-                    // they are special when printing. It'd be great to change this so we can
-                    // reparse test these!
-                    Err(_) if matches!(s, Expr::Function(_)) => {}
-                    Err(err) => panic!("reparse failed: {s}: {err}\n{s:?}"),
                 }
 
                 if tc.args.get("roundtrip").is_some() {

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -241,7 +241,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(YEAR FROM d)
 ----
-extract('year', d)
+extract('year' FROM d)
 
 parse-scalar
 EXTRACT(MILLENIUM FROM d)
@@ -251,7 +251,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(MILLENNIUM FROM d)
 ----
-extract('millennium', d)
+extract('millennium' FROM d)
 
 parse-scalar
 EXTRACT(CENTURY FROM d)
@@ -261,7 +261,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(CENTURY FROM d)
 ----
-extract('century', d)
+extract('century' FROM d)
 
 parse-scalar
 EXTRACT(ISOYEAR FROM d)
@@ -271,7 +271,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(ISOYEAR FROM d)
 ----
-extract('isoyear', d)
+extract('isoyear' FROM d)
 
 parse-scalar
 EXTRACT(QUARTER FROM d)
@@ -281,7 +281,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(QUARTER FROM d)
 ----
-extract('quarter', d)
+extract('quarter' FROM d)
 
 parse-scalar
 EXTRACT(MONTH FROM d)
@@ -291,7 +291,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(MONTH FROM d)
 ----
-extract('month', d)
+extract('month' FROM d)
 
 parse-scalar
 EXTRACT(DAY FROM d)
@@ -301,7 +301,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(DAY FROM d)
 ----
-extract('day', d)
+extract('day' FROM d)
 
 parse-scalar
 EXTRACT(HOUR FROM d)
@@ -311,7 +311,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(HOUR FROM d)
 ----
-extract('hour', d)
+extract('hour' FROM d)
 
 parse-scalar
 EXTRACT(MINUTE FROM d)
@@ -321,7 +321,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(MINUTE FROM d)
 ----
-extract('minute', d)
+extract('minute' FROM d)
 
 parse-scalar
 EXTRACT(SECOND FROM d)
@@ -331,7 +331,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(SECOND FROM d)
 ----
-extract('second', d)
+extract('second' FROM d)
 
 parse-scalar
 EXTRACT(MILLISECONDS FROM d)
@@ -341,7 +341,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(MILLISECOND FROM d)
 ----
-extract('millisecond', d)
+extract('millisecond' FROM d)
 
 parse-scalar
 EXTRACT(MICROSECONDS FROM d)
@@ -351,7 +351,7 @@ Function(Function { name: Name(UnresolvedItemName([Ident("extract")])), args: Ar
 parse-scalar roundtrip
 EXTRACT(MICROSECONDS FROM d)
 ----
-extract('microseconds', d)
+extract('microseconds' FROM d)
 
 parse-scalar
 EXTRACT(TIMEZONE FROM d)
@@ -895,3 +895,68 @@ position('om', 'Thomas')
 error: Expected IN, found comma
 position('om', 'Thomas')
              ^
+
+parse-scalar roundtrip
+position('om' IN 'Thomas')
+----
+position('om' IN 'Thomas')
+
+parse-scalar roundtrip
+trim('chars' from 'string')
+----
+btrim('string', 'chars')
+
+parse-scalar
+trim('chars' from 'string')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("btrim")])), args: Args { args: [Value(String("string")), Value(String("chars"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+trim(both from 'chars')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("btrim")])), args: Args { args: [Value(String("chars"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+trim(from 'chars')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("btrim")])), args: Args { args: [Value(String("chars"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+trim('chars')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("btrim")])), args: Args { args: [Value(String("chars"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+trim(trailing 'chars')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("rtrim")])), args: Args { args: [Value(String("chars"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+position('str' in 'str')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("position")])), args: Args { args: [Value(String("str")), Value(String("str"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+substring('str', 'int')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("substring")])), args: Args { args: [Value(String("str")), Value(String("int"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+substring('str' FROM 'int')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("substring")])), args: Args { args: [Value(String("str")), Value(String("int"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+substring('str' FROM 'int' FOR 'int')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("substring")])), args: Args { args: [Value(String("str")), Value(String("int")), Value(String("int"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+substring('str' FOR 'int')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("substring")])), args: Args { args: [Value(String("str")), Value(Number("1")), Value(String("int"))], order_by: [] }, filter: None, over: None, distinct: false })
+
+parse-scalar
+substring('str', 'int', 'int')
+----
+Function(Function { name: Name(UnresolvedItemName([Ident("substring")])), args: Args { args: [Value(String("str")), Value(String("int")), Value(String("int"))], order_by: [] }, filter: None, over: None, distinct: false })


### PR DESCRIPTION
Fixes #20572

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a