### PR TITLE
dbt-materialize: set maximum identifier length to 255

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+* **Breaking change.** Set 255 as the maximum identifier length for relation
+    names, after [#20999](https://github.com/MaterializeInc/materialize/pull/20999)
+    introduced a `max_identifier_length` session variable that enforces this
+    limit in Materialize.
+
 * Support cancelling outstanding queries when pressing Ctrl+C.
 
 ## 1.5.1 - 2023-07-24
@@ -75,7 +80,6 @@
 ## 1.2.1 - 2022-11-01
 
 * Add `cluster` to the connection parameters returned on `dbt debug`.
-
 
 * Disallow the `cluster` option for `view` materializations. In the new
   architecture, only materialized views and indexes are associated with a

--- a/misc/dbt-materialize/dbt/adapters/materialize/relation.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/relation.py
@@ -40,10 +40,11 @@ class MaterializeRelationType(StrEnum):
 class MaterializeRelation(PostgresRelation):
     type: Optional[MaterializeRelationType] = None
 
-    # Materialize does not have a 63-character limit for relation
-    # names, unlike PostgreSQL (see dbt-core #2727)
+    # Materialize does not have a 63-character limit for relation names, unlike
+    # PostgreSQL (see dbt-core #2727). Instead, we set 255 as the maximum
+    # identifier length (see #20931).
     def relation_max_name_length(self):
-        return 16384
+        return 255
 
     @classproperty
     def get_relation_type(cls) -> Type[MaterializeRelationType]:

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -149,6 +149,12 @@ test_relation_name_length = """
     SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse'), (NULL, NULL)) _ (a, b)
 """
 
+test_relation_name_length_fail = """
+{{ config(tags='fail',materialized='materializedview') }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse'), (NULL, NULL)) _ (a, b)
+"""
+
 test_hooks = {
     "models": {
         "test": {

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -21,6 +21,7 @@ from fixtures import (
     test_materialized_view,
     test_materialized_view_index,
     test_relation_name_length,
+    test_relation_name_length_fail,
     test_sink,
     test_source,
     test_source_index,
@@ -48,6 +49,10 @@ class TestCustomMaterializations:
             "test_materialized_view.sql": test_materialized_view,
             "test_materialized_view_index.sql": test_materialized_view_index,
             "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
+            "test_relation_name_loooooooooooooooooooooooooooooooooooooooooooooooo\
+             oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\
+             oooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo\
+             oooooooooooooooooooooooooooooonger_than_mz_255_limit.sql": test_relation_name_length_fail,
             "test_source.sql": test_source,
             "test_source_index.sql": test_source_index,
             "test_subsources.sql": test_subsources,
@@ -62,7 +67,7 @@ class TestCustomMaterializations:
         # seed result length
         assert len(results) == 1
         # run models
-        results = run_dbt(["run"])
+        results = run_dbt(["run", "--exclude", "tag:fail"])
         # run result length
         assert len(results) == 10
         # re-run models to ensure there are no lingering errors in recreating
@@ -82,3 +87,9 @@ class TestCustomMaterializations:
         # correct data once sinks land.
         # From benesch: Ideally we'd just ingest the sink back into Materialize
         # with the source and then use `relations_equal` with `test_materialized_view`.
+
+    def test_custom_materializations_fail(self, project):
+        # run models expected to fail
+        results = run_dbt(["run", "--include", "tag:fail"], expect_pass=False)
+        # run result length
+        assert len(results) == 1


### PR DESCRIPTION
Adapts `dbt-materialize` to #20999.