### PR TITLE
feature-benchmark: Do not allow certain scenarios to exceed SCALE = 7

### DIFF
--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -37,6 +37,7 @@ class FastPathFilterNoIndex(FastPath):
     """Measure the time it takes for the fast path to filter our all rows from a materialized view and return"""
 
     SCALE = 7
+    FIXED_SCALE = True  # OOM with 10**8 = 100M records
 
     def init(self) -> List[Action]:
         return [
@@ -67,6 +68,7 @@ class MFPPushdown(Scenario):
     """Test MFP pushdown -- WHERE clause with a suitable condition and no index defined."""
 
     SCALE = 7
+    FIXED_SCALE = True  # OOM with 10**8 = 100M records
 
     def init(self) -> List[Action]:
         return [


### PR DESCRIPTION
Certain scenarios cause an OOM in the Release Qualification CI when run with SCALE = 8

### Motivation

Release Qualification CI is failing. Curiously, those same scenarios have no issues running on the Hetzner machine.

It appears that the limited I/O available in AWS causes the "LeaseReader" panic to happen