### PR TITLE
adapter: fix subscribe cleanup

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -34,7 +34,7 @@ use crate::coord::{
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
     SinkConnectionReady,
 };
-use crate::util::ResultExt;
+use crate::util::{ComputeSinkId, ResultExt};
 use crate::{catalog, AdapterNotice, TimestampContext};
 
 impl Coordinator {
@@ -260,6 +260,11 @@ impl Coordinator {
                 if let Some(active_subscribe) = self.active_subscribes.get_mut(&sink_id) {
                     let remove = active_subscribe.process_response(response);
                     if remove {
+                        let csid = ComputeSinkId {
+                            cluster_id: active_subscribe.cluster_id,
+                            global_id: sink_id,
+                        };
+                        self.drop_compute_sinks([csid]);
                         self.remove_active_subscribe(sink_id).await;
                     }
                 }

--- a/test/testdrive/github-21031.td
+++ b/test/testdrive/github-21031.td
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for https://github.com/MaterializeInc/materialize/issues/21031.
+#
+# This test confirms that subscribes that advance to the empty frontier are
+# fully cleaned up.
+#
+# This test relies on testdrive's automatic retries, since it queries
+# introspection sources that take a while to update.
+
+$ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+
+# Create a collection with an empty frontier to subscribe from.
+> CREATE MATERIALIZED VIEW mv AS SELECT 1 AS a
+
+> BEGIN
+> DECLARE c CURSOR FOR SUBSCRIBE mv
+> FETCH c
+<TIMESTAMP> 1 1
+> COMMIT
+
+# To ensure that the subscribe has reached the introspection sources, we
+# install another dataflow and wait for that to show up. Introspection sources
+# are not serializable, but dataflows still show up in order.
+> CREATE INDEX mv_idx ON mv(a)
+> SELECT count(*)
+  FROM
+    mz_indexes i,
+    mz_internal.mz_compute_exports e
+  WHERE
+    i.name = 'mv_idx' AND
+    e.export_id = i.id
+1
+
+> SELECT count(*) FROM mz_internal.mz_subscriptions
+0
+
+> SELECT count(*) FROM mz_internal.mz_compute_exports e WHERE e.export_id LIKE 't%'
+0


### PR DESCRIPTION
This PR makes adapter call `drop_collections` for subscribes that have advanced to the empty frontier. Previously, such subscribes would only be dropped from the adapter state but never from compute state.

### Motivation

  * This PR fixes a recognized bug.

Fixes #21031

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A