### PR TITLE
Slightly expand SLT fixed features and CI default features

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -112,11 +112,11 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
             # TODO: these should be the same as in mzcompose
             V1EnvVar(
                 name="MZ_SYSTEM_PARAMETER_DEFAULT",
-                value="enable_envelope_upsert_in_subscribe=true",
-            ),
-            V1EnvVar(
-                name="MZ_SYSTEM_PARAMETER_DEFAULT",
-                value="enable_disk_cluster_replicas=true",
+                value=(
+                    "enable_envelope_upsert_in_subscribe=true;"
+                    "enable_disk_cluster_replicas=true;"
+                    "enable_with_mutually_recursive=true"
+                ),
             ),
         ]
 

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -52,6 +52,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_ld_rbac_checks": "true",
     "enable_rbac_checks": "true",
     "enable_monotonic_oneshot_selects": "true",
+    "enable_with_mutually_recursive": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",
     # Following values are set based on Load Test environment to

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1085,16 +1085,19 @@ impl<'a> RunnerInner<'a> {
     /// Set features that should be enabled regardless of whether reset-server was
     /// called. These features may be set conditionally depending on the run configuration.
     async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
-        // If auto_index_selects is on, we should turn on enable_monotonic_oneshot_selects.
-        // TODO(vmarcos): Remove this code when we retire the feature flag.
-        if self.auto_index_selects {
-            self.system_client
-                .execute(
-                    "ALTER SYSTEM SET enable_monotonic_oneshot_selects = on",
-                    &[],
-                )
-                .await?;
-        }
+        // We turn on enable_monotonic_oneshot_selects and enable_with_mutually_recursive,
+        // as these two features have reached enough maturity to do so.
+        // TODO(vmarcos): Remove this code when we retire these feature flags.
+        self.system_client
+            .execute(
+                "ALTER SYSTEM SET enable_monotonic_oneshot_selects = on",
+                &[],
+            )
+            .await?;
+
+        self.system_client
+            .execute("ALTER SYSTEM SET enable_with_mutually_recursive = on", &[])
+            .await?;
 
         // Dangerous functions are useful for tests so we enable it for all tests.
         self.system_client

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -106,9 +106,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
               USER postgres,
               PASSWORD SECRET pgpass
               )
-
-            $ postgres-execute connection=postgres://mz_system:materialize@${{testdrive.materialize-internal-sql-addr}}
-            ALTER SYSTEM SET enable_with_mutually_recursive = true
             """
         )
     )

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1052,12 +1052,6 @@ def workflow_test_github_19610(c: Composition) -> None:
             user="mz_system",
         )
 
-        c.sql(
-            "ALTER SYSTEM SET enable_monotonic_oneshot_selects = true;",
-            port=6877,
-            user="mz_system",
-        )
-
         # set up a test cluster and run a testdrive regression script
         c.sql(
             """
@@ -1162,12 +1156,6 @@ def workflow_test_single_time_monotonicity_enforcers(c: Composition) -> None:
 
         c.sql(
             "ALTER SYSTEM SET enable_repeat_row = true;",
-            port=6877,
-            user="mz_system",
-        )
-
-        c.sql(
-            "ALTER SYSTEM SET enable_monotonic_oneshot_selects = true;",
             port=6877,
             user="mz_system",
         )

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -127,6 +127,8 @@ class FeatureTestScenario:
                 # Include the header.
                 header(f"{cls.__name__} (phase 1)", drop_schema=True),
                 cls.initialize(),
+                # Ensure the feature is off, regardless of CI config.
+                alter_system_set(cls.feature_name(), "off"),
                 # We cannot create item #1 when the feature is turned off (default).
                 statement_error(cls.create_item(ordinal=1), cls.feature_error()),
                 # Turn the feature on.

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -14,11 +14,6 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (a int, b int)
 

--- a/test/sqllogictest/array_subquery.slt
+++ b/test/sqllogictest/array_subquery.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE xs (x int not null)
 

--- a/test/sqllogictest/cockroach/distinct_on.slt
+++ b/test/sqllogictest/cockroach/distinct_on.slt
@@ -24,11 +24,6 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE xyz (
   x INT,

--- a/test/sqllogictest/cockroach/subquery_correlated.slt
+++ b/test/sqllogictest/cockroach/subquery_correlated.slt
@@ -29,11 +29,6 @@ ALTER SYSTEM SET enable_table_foreign_key = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 # ------------------------------------------------------------------------------
 # Create a simple schema that models customers and orders. Each customer has an
 # id (c_id), and has zero or more orders that are related via a foreign key of

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -10,11 +10,6 @@
 # Test requires stable object IDs
 reset-server
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -12,11 +12,6 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -12,11 +12,6 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (
   a int,

--- a/test/sqllogictest/github-16036.slt
+++ b/test/sqllogictest/github-16036.slt
@@ -10,11 +10,6 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/16036
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t1 (v1 TEXT, k1 INTEGER, k2 INTEGER);
 

--- a/test/sqllogictest/github-17808.slt
+++ b/test/sqllogictest/github-17808.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 # Regression test for issues corrected by https://github.com/MaterializeInc/materialize/issues/17808.
 
 # The following query should not frustrate the system, although it did prior to

--- a/test/sqllogictest/github-19290.slt
+++ b/test/sqllogictest/github-19290.slt
@@ -9,11 +9,6 @@
 
 # Regression test for #19290.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE SOURCE tpch
               FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.00001)

--- a/test/sqllogictest/github-9027.slt
+++ b/test/sqllogictest/github-9027.slt
@@ -10,11 +10,6 @@
 # Regression test for https://github.com/MaterializeInc/materialize/issues/9027
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE orders ( o_orderkey integer, o_custkey integer NOT NULL, o_orderstatus text NOT NULL, o_totalprice decimal(15, 2) NOT NULL, o_orderdate DATE NOT NULL, o_orderpriority text NOT NULL, o_clerk text NOT NULL, o_shippriority integer NOT NULL, o_comment text NOT NULL);
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE foo (
     a int,

--- a/test/sqllogictest/outer_join.slt
+++ b/test/sqllogictest/outer_join.slt
@@ -82,7 +82,10 @@ statement ok
 create table left(x int, y int);
 
 statement ok
-create table right1_keyed(x int, y int);
+create table right1(x int, y int);
+
+statement ok
+create view right1_keyed(x, y) as select distinct on(x) * from right1;
 
 statement ok
 create table right2(x int, y int);
@@ -157,23 +160,9 @@ Explained Query:
           map=(null, null)
           Union consolidate_output=true
             Negate
-              Join::Linear
-                linear_stage[0]
-                  lookup={ relation=0, key=[#0] }
-                  stream={ key=[#0], thinning=() }
-                source={ relation=1, key=[#0] }
-                ArrangeBy
-                  raw=true
-                  arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-                  Get::PassArrangements materialize.public.left
-                    raw=true
-                Reduce::Distinct
-                  val_plan
-                    project=()
-                  key_plan=id
-                  Get::Collection l0
-                    project=(#0)
-                    raw=true
+              Get::Collection l0
+                project=(#0, #1)
+                raw=true
             Get::PassArrangements materialize.public.left
               raw=true
         Get::Collection l0
@@ -182,9 +171,11 @@ Explained Query:
     cte l0 =
       Join::Linear
         linear_stage[0]
-          lookup={ relation=1, key=[#0] }
+          closure
+            project=(#0, #2, #1)
+          lookup={ relation=0, key=[#0] }
           stream={ key=[#0], thinning=(#1) }
-        source={ relation=0, key=[#0] }
+        source={ relation=1, key=[#0] }
         ArrangeBy
           raw=true
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
@@ -194,10 +185,11 @@ Explained Query:
         ArrangeBy
           raw=true
           arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
-          Get::Collection materialize.public.right1_keyed
-            raw=true
+          TopK::MonotonicTop1 group_by=[#0] must_consolidate
+            Get::Collection materialize.public.right1
+              raw=true
 
-Source materialize.public.right1_keyed
+Source materialize.public.right1
   filter=((#0) IS NOT NULL)
 Source materialize.public.right2
   filter=((#0) IS NOT NULL)

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 create table foo_raw (a int4, b int8, u text)
 

--- a/test/sqllogictest/session-window-wmr.slt
+++ b/test/sqllogictest/session-window-wmr.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE events (
     -- event ID

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE cities (
     name text NOT NULL,

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -8,11 +8,6 @@
 # by the Apache License, Version 2.0.
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (a int);
 

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE VIEW billion AS SELECT * FROM generate_series(0, 999) AS x, generate_series(0, 999) AS y, generate_series(0, 999) AS z;
 

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -19,11 +19,6 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t1 (a int, b text)
 

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -14,11 +14,6 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t1 (a int, b text)
 

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 #
 # Test various cases of literal lifting
 #

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -12,11 +12,6 @@
 # PR https://github.com/MaterializeInc/materialize/pull/7715
 #
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE SOURCE counter FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
 

--- a/test/sqllogictest/transform/non_null_requirements.slt
+++ b/test/sqllogictest/transform/non_null_requirements.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 #
 # Test various cases of literal lifting
 #

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 ## Test a plausibly correct recursive query.
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -11,11 +11,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE x (a int not null, u int, b bool)
 

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -16,11 +16,6 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE x (a int not null, u int, b bool)
 

--- a/test/sqllogictest/transform/projection_lifting.slt
+++ b/test/sqllogictest/transform/projection_lifting.slt
@@ -11,11 +11,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE edges (src int, dst int)
 

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -8,11 +8,6 @@
 # by the Apache License, Version 2.0.
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE x (f0 int4, f1 string);
 

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t1(f1 INT, f2 INT);
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -12,11 +12,6 @@
 # PR https://github.com/MaterializeInc/materialize/pull/7715
 #
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t1 (f1 INTEGER, f2 INTEGER);
 

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -14,11 +14,6 @@
 #
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -13,11 +13,6 @@
 # PR https://github.com/MaterializeInc/materialize/pull/19680
 #
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE t (a int, b int);
 

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -14,11 +14,6 @@ ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 statement ok
 DROP TABLE IF EXISTS band_members;
 

--- a/test/sqllogictest/transform/union_cancel.slt
+++ b/test/sqllogictest/transform/union_cancel.slt
@@ -8,11 +8,6 @@
 # by the Apache License, Version 2.0.
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_table_keys = true
 ----
 COMPLETE 0

--- a/test/sqllogictest/unsigned_int.slt
+++ b/test/sqllogictest/unsigned_int.slt
@@ -7,11 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 query I
 SELECT 42::uint2
 ----

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -9,11 +9,6 @@
 
 mode cockroach
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-----
-COMPLETE 0
-
 ## Test correct (intended) behavior:
 
 ## Test a plausibly correct recursive query.

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -14,11 +14,6 @@ ALTER SYSTEM SET enable_with_mutually_recursive = true
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_monotonic_oneshot_selects = true
-----
-COMPLETE 0
-
 ## Test correct (intended) behavior:
 
 ## Test a plausibly correct recursive query.

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -14,9 +14,6 @@
 # sources. This also serves to verify that logging is correctly cleaned up under
 # active dataflow cancellation.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-
 > CREATE VIEW divergent AS
   WITH MUTUALLY RECURSIVE
       flip(x int) AS (VALUES(1) EXCEPT ALL SELECT * FROM flip)

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -7,9 +7,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_with_mutually_recursive = true
-
 > SET cluster_replica = r1
 
 # from attributes/mir_unique_keys.slt


### PR DESCRIPTION
This PR slightly expands the set of fixed SLT features and CI default features by taking the following actions:

1. Ensuring that both `enable_monotonic_oneshot_selects` and `enable_with_mutually_recursive` are considered fixed features for SLT runs.
2. Ensuring that not only `enable_monotonic_oneshot_selects` but also `enable_with_mutually_recursive` are turned on by default for `mzcompose` workflows.
3. Addressing a testing difficulty observed in https://github.com/MaterializeInc/materialize/pull/20995#issuecomment-1665991662, which motivated this change.

### Motivation

  * This PR adds a feature that has not yet been specified.

It was observed in PR #20995 that local runs of `sqllogictest` would not, without `--auto-index-selects`, produce the same query plans as in CI. This is because the feature `enable_monotonic_oneshot_selects` was only conditionally enabled as a fixed feature, thus requiring it to be set in the SLT explicitly. This PR now allows the latter setting to not be done, and we still get features that are considered sufficiently mature available by default in both CI runs and in local SLT runs. The two features that are proposed to be in this condition as part of this PR are `enable_monotonic_oneshot_selects` and `enable_with_mutually_recursive`. 

### Tips for reviewer

The commits may be looked at individually. The selection of features was previously discussed with @ggevay, and based on that these features are now considered mature enough. Based on an [internal conversation](https://materializeinc.slack.com/archives/CM7ATT65S/p1688569927165479), I am suggesting a code-owner reviewer from QA instead of Surfaces for this change.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
