### PR TITLE
*: update tonic-build dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,9 +666,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.7"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fb79c228270dcf2426e74864cabc94babb5dbab01a4314e702d2f16540e1591"
+checksum = "f8175979259124331c1d7bf6586ee7e0da434155e4b2d48ec2c8386281d8df39"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -696,16 +696,15 @@ dependencies = [
  "tokio",
  "tokio-tungstenite",
  "tower",
- "tower-http",
  "tower-layer",
  "tower-service",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2f958c80c248b34b9a877a643811be8dbca03ca5ba827f2b63baf3a81e5fc4e"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1222,8 +1221,9 @@ dependencies = [
 
 [[package]]
 name = "console-api"
-version = "0.4.0"
-source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2895653b4d9f1538a83970077cb01dfc77a4810524e51a110944688e916b18e"
 dependencies = [
  "prost",
  "prost-types",
@@ -1233,8 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.8"
-source = "git+https://github.com/MaterializeInc/tokio-console.git#bac69ecb570b7e466b2a254a9f9bf28ac0f3d95b"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4cf42660ac07fcebed809cfe561dd8730bcd35b075215e6479c516bcd0d11cb"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -1564,17 +1565,6 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 1.0.107",
-]
-
-[[package]]
-name = "dashmap"
-version = "5.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8858831f7781322e539ea39e72449c46b059638250c14344fec8d0aa6e539c"
-dependencies = [
- "cfg-if",
- "num_cpus",
- "parking_lot",
 ]
 
 [[package]]
@@ -2752,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.59"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -5750,9 +5740,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4b8347cc26099d3aeee044065ecc3ae11469796b4d65d065a23a584ed92a6f"
+checksum = "9591d937bc0e6d2feb6f71a559540ab300ea49955229c347a517a28d27784c54"
 dependencies = [
  "opentelemetry_api",
  "opentelemetry_sdk",
@@ -5760,16 +5750,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8af72d59a4484654ea8eb183fea5ae4eb6a41d7ac3e3bae5f4d2a282a3a7d3ca"
+checksum = "7e5e5a5c4135864099f3faafbe939eb4d7f9b80ebf68a8448da961b32a7c1275"
 dependencies = [
  "async-trait",
- "futures",
- "futures-util",
+ "futures-core",
  "http",
- "opentelemetry",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "thiserror",
  "tokio",
@@ -5778,27 +5769,35 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "045f8eea8c0fa19f7d48e7bc3128a39c2e5c533d5c61298c548dfefc1064474c"
+checksum = "b1e3f814aa9f8c905d0ee4bde026afd3b2577a97c10e1699912e3e44f0c4cbeb"
 dependencies = [
- "futures",
- "futures-util",
- "opentelemetry",
+ "opentelemetry_api",
+ "opentelemetry_sdk",
  "prost",
  "tonic",
 ]
 
 [[package]]
-name = "opentelemetry_api"
-version = "0.19.0"
+name = "opentelemetry-semantic-conventions"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed41783a5bf567688eb38372f2b7a8530f5a607a4b49d38dd7573236c23ca7e2"
+checksum = "73c9f9340ad135068800e7f1b24e9e09ed9e7143f5bf8518ded3d3ec69789269"
 dependencies = [
- "fnv",
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_api"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a81f725323db1b1206ca3da8bb19874bbd3f57c3bcd59471bfb04525b265b9b"
+dependencies = [
  "futures-channel",
  "futures-util",
  "indexmap",
+ "js-sys",
  "once_cell",
  "pin-project-lite",
  "thiserror",
@@ -5807,21 +5806,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b3a2a91fdbfdd4d212c0dcc2ab540de2c2bcbbd90be17de7a7daf8822d010c1"
+checksum = "fa8e705a0612d48139799fcbaba0d4a90f06277153e43dd2bdc16c6f0edd8026"
 dependencies = [
  "async-trait",
  "crossbeam-channel",
- "dashmap",
- "fnv",
  "futures-channel",
  "futures-executor",
  "futures-util",
  "once_cell",
  "opentelemetry_api",
+ "ordered-float",
  "percent-encoding",
  "rand",
+ "regex",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -8050,14 +8050,13 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.8.3"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
 dependencies = [
- "async-stream",
  "async-trait",
  "axum",
- "base64 0.13.1",
+ "base64 0.21.0",
  "bytes",
  "futures-core",
  "futures-util",
@@ -8069,21 +8068,18 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
- "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
 name = "tonic-build"
-version = "0.8.2"
-source = "git+https://github.com/MaterializeInc/tonic#76489bf665af99d6e0e83f81648fcac283ea57e1"
+version = "0.9.2"
+source = "git+https://github.com/MaterializeInc/tonic#f2892a068a0d7513aac570ae8a58fa48d84b5d45"
 dependencies = [
  "prettyplease 0.2.4",
  "proc-macro2",
@@ -8180,16 +8176,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8202,8 +8188,8 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.19.0"
-source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#3c7e5779db371735c24394b03a6bd31f67214419"
+version = "0.20.0"
+source = "git+https://github.com/MaterializeInc/tracing-opentelemetry.git#405437e84fa3b0f34b91b8655d45a229265a6f14"
 dependencies = [
  "once_cell",
  "opentelemetry",
@@ -8535,9 +8521,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -8545,16 +8531,16 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
  "wasm-bindgen-shared",
 ]
 
@@ -8572,9 +8558,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -8582,22 +8568,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.107",
+ "syn 2.0.18",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.82"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
@@ -8847,7 +8833,6 @@ dependencies = [
  "either",
  "flate2",
  "frunk_core",
- "futures",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -8878,7 +8863,6 @@ dependencies = [
  "openssl",
  "openssl-sys",
  "ordered-float",
- "parking_lot",
  "phf",
  "phf_shared",
  "postgres",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,10 +155,6 @@ tonic-build = { git = "https://github.com/MaterializeInc/tonic" }
 # upstream.
 tracing-opentelemetry = { git = "https://github.com/MaterializeInc/tracing-opentelemetry.git" }
 
-# Waiting on https://github.com/tokio-rs/console/pull/388.
-console-api = { git = "https://github.com/MaterializeInc/tokio-console.git" }
-console-subscriber = { git = "https://github.com/MaterializeInc/tokio-console.git" }
-
 # Waiting on https://github.com/launchdarkly/rust-server-sdk/pull/20 to make
 # it into a release.
 launchdarkly-server-sdk = { git = "https://github.com/MaterializeInc/rust-server-sdk" }

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -50,7 +50,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-tracing = { path = "../tracing" }
 mz-transform = { path = "../transform" }
 mz-cloud-resources = { path = "../cloud-resources" }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
@@ -70,7 +70,7 @@ tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
-tracing-opentelemetry = { version = "0.19.0" }
+tracing-opentelemetry = { version = "0.20.0" }
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.89"
 thiserror = "1.0.37"
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -34,7 +34,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -43,7 +43,7 @@ thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -51,7 +51,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -63,7 +63,7 @@ nix = "0.26.1"
 num_cpus = "1.14.0"
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssl-sys = { version = "0.9.80", features = ["vendored"] }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 pin-project = "1.0.12"
 prometheus = { version = "0.13.3", default-features = false }
 rdkafka-sys = { version = "4.3.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
@@ -87,7 +87,7 @@ tower = { version = "0.4.13", features = ["buffer", "limit", "load-shed"] }
 tower-http = { version = "0.3.5", features = ["cors"] }
 tracing = "0.1.37"
 tracing-core = "0.1.30"
-tracing-opentelemetry = { version = "0.19.0" }
+tracing-opentelemetry = { version = "0.20.0" }
 tracing-subscriber = "0.3.16"
 tungstenite = { version = "0.18.0", features = ["native-tls"] }
 url = "2.3.1"

--- a/src/orchestrator-tracing/Cargo.toml
+++ b/src/orchestrator-tracing/Cargo.toml
@@ -22,7 +22,7 @@ mz-tracing = { path = "../tracing" }
 sentry-tracing = { version = "0.29.1" }
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.16", default-features = false }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"] }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/orchestrator/Cargo.toml
+++ b/src/orchestrator/Cargo.toml
@@ -20,7 +20,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"
-tonic-build = "0.8.0"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -49,15 +49,15 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = tru
 atty = { version = "0.2.14", optional = true }
 http = { version = "0.2.8", optional = true }
 tracing = { version = "0.1.37", optional = true }
-tracing-opentelemetry = { version = "0.19.0", optional = true }
-tonic = { version = "0.8.2", features = ["transport"], optional = true }
+tracing-opentelemetry = { version = "0.20.0", optional = true }
+tonic = { version = "0.9.2", features = ["transport"], optional = true }
 tokio-native-tls = { version = "0.3.0", optional = true }
 native-tls = { version = "0.2.11", features = ["alpn"], optional = true }
 hyper = { version = "0.14.23", features = ["http1", "server"], optional = true }
 hyper-tls = { version = "0.5.0", optional = true }
-opentelemetry = { version = "0.19.0", features = ["rt-tokio", "trace"], optional = true }
-opentelemetry-otlp = { version = "0.12.0", optional = true }
-console-subscriber = { version = "0.1.8", optional = true }
+opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"], optional = true }
+opentelemetry-otlp = { version = "0.13.0", optional = true }
+console-subscriber = { version = "0.1.10", optional = true }
 sentry-tracing = { version = "0.29.1", optional = true }
 yansi = { version = "0.5.1", optional = true }
 

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -56,7 +56,7 @@ timely = { version = "0.12.0", default-features = false, features = ["bincode"] 
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -83,7 +83,7 @@ tempfile = "3.2.0"
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -35,7 +35,7 @@ privileges = ["postgres_array"]
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/rocksdb-types/Cargo.toml
+++ b/src/rocksdb-types/Cargo.toml
@@ -21,7 +21,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -34,7 +34,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -34,7 +34,7 @@ sysinfo = "0.27.2"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = "1.24.2"
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tower = "0.4.13"
 tracing = "0.1.37"
 sentry-tracing = "0.29.1"
@@ -43,7 +43,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -59,7 +59,7 @@ timely = { version = "0.12.0", default-features = false, features = ["bincode"] 
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
-tonic = "0.8.2"
+tonic = "0.9.2"
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"
 url = { version = "2.3.1", features = ["serde"] }
@@ -69,7 +69,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 itertools = "0.10.5"

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -80,7 +80,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [build-dependencies]
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [dev-dependencies]
 async-trait = "0.1.68"

--- a/src/tracing/Cargo.toml
+++ b/src/tracing/Cargo.toml
@@ -21,7 +21,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [build-dependencies]
 prost-build = "0.11.2"
 protobuf-src = "1.1.0"
-tonic-build = "0.8.2"
+tonic-build = "0.9.2"
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -21,7 +21,7 @@ aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.55.1", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.55.2", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { version = "0.6.7", features = ["headers", "ws"] }
+axum = { version = "0.6.18", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
@@ -40,7 +40,6 @@ digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
 frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
-futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.25", features = ["sink"] }
 futures-core = { version = "0.3.25" }
 futures-executor = { version = "0.3.25" }
@@ -70,7 +69,6 @@ num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }
@@ -121,7 +119,7 @@ aws-sdk-sts = { version = "0.26.0", default-features = false, features = ["nativ
 aws-sig-auth = { version = "0.55.1", default-features = false, features = ["sign-eventstream"] }
 aws-sigv4 = { version = "0.55.1", features = ["sign-eventstream"] }
 aws-smithy-http = { version = "0.55.2", default-features = false, features = ["event-stream", "rt-tokio"] }
-axum = { version = "0.6.7", features = ["headers", "ws"] }
+axum = { version = "0.6.18", features = ["headers", "ws"] }
 base64 = { version = "0.13.1", features = ["alloc"] }
 bstr = { version = "0.2.14" }
 byteorder = { version = "1.4.3" }
@@ -141,7 +139,6 @@ digest = { version = "0.10.6", features = ["mac", "std"] }
 either = { version = "1.8.0", features = ["serde"] }
 flate2 = { version = "1.0.24", features = ["zlib"] }
 frunk_core = { version = "0.4.0", default-features = false, features = ["std"] }
-futures = { version = "0.3.25" }
 futures-channel = { version = "0.3.25", features = ["sink"] }
 futures-core = { version = "0.3.25" }
 futures-executor = { version = "0.3.25" }
@@ -171,7 +168,6 @@ num-traits = { version = "0.2.15", features = ["i128"] }
 openssl = { version = "0.10.55", features = ["vendored"] }
 openssl-sys = { version = "0.9.90", default-features = false, features = ["vendored"] }
 ordered-float = { version = "3.4.0", features = ["serde"] }
-parking_lot = { version = "0.12.1", features = ["send_guard"] }
 phf = { version = "0.11.1", features = ["uncased"] }
 phf_shared = { version = "0.11.1", features = ["uncased"] }
 postgres = { git = "https://github.com/MaterializeInc/rust-postgres", default-features = false, features = ["with-chrono-0_4"] }


### PR DESCRIPTION
The master branch of [our tonic fork](https://github.com/MaterializeInc/tonic) was rebased, removing the commit we previously depended on. Upgrade the tonic-build dependency to unbreak the Mz build.

Doing this also requires bumping a bunch of other crates, to avoid ending up with duplicate dependencies.

### Motivation

  * This PR adds updates a dependency.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
