### PR TITLE
compute*: log sent/received commands and responses

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -33,7 +33,6 @@ use timely::communication::Allocate;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::worker::Worker as TimelyWorker;
-use tokio::sync::mpsc;
 use tracing::{error, info, span, Level};
 use uuid::Uuid;
 
@@ -42,6 +41,7 @@ use crate::logging;
 use crate::logging::compute::ComputeEvent;
 use crate::metrics::{CollectionMetrics, ComputeMetrics};
 use crate::render::LinearJoinImpl;
+use crate::server::ResponseSender;
 
 /// Worker-local state that is maintained across dataflows.
 ///
@@ -138,13 +138,13 @@ impl ComputeState {
 }
 
 /// A wrapper around [ComputeState] with a live timely worker and response channel.
-pub struct ActiveComputeState<'a, A: Allocate> {
+pub(crate) struct ActiveComputeState<'a, A: Allocate> {
     /// The underlying Timely worker.
     pub timely_worker: &'a mut TimelyWorker<A>,
     /// The compute state itself.
     pub compute_state: &'a mut ComputeState,
     /// The channel over which frontier information is reported.
-    pub response_tx: &'a mut mpsc::UnboundedSender<ComputeResponse>,
+    pub response_tx: &'a mut ResponseSender,
 }
 
 /// A token that keeps a sink alive.


### PR DESCRIPTION
This PR extends the controller and replica code to log commands and responses observed by both components with `trace` level. The intent is to have this available as a debugging tool when we need to diagnose bugs in the communication between the controller and replicas.

### Usage

The new logs are emitted at `trace` level, to not overwhelm our infrastructure, so you have to fiddle with the log level to see them. This can be done by setting the `log_filter` system variable. Log in as `mz_system`, then run:

* for controller logs: `alter system set log_filter = 'mz_compute_client::controller::replica=trace,info';`
* for replica logs: `alter system set log_filter = 'mz_compute::server=trace,info';`

### Motivation

  * This PR adds a known-desirable feature.

Add logging of transmitted compute commands and responses, to enable debugging communication bugs in production.

### Tips for reviewer

Logging in the controller is straightforward, since there is one place where commands are sent and responses are received from the replica. Logging on the replica is more involved, since commands are received at a place different from where responses are sent, and commands are received at multiple places too. To ensure that we log all commands and responses, I remade the existing `CommandReceiver` and `ResponseSender` type aliases into actual wrapper types and added the logging to their send/recv calls.

I included a number of small cleanups where I noticed opportunities. Hope you don't mind!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A