### PR TITLE
Changing the max inflight bytes to fraction instead of percent

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -81,13 +81,13 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             max_inflight_bytes_default: config.storage_dataflow_max_inflight_bytes(),
             // Interpret the `Numeric` as a float here, we don't need perfect
             // precision for a percentage. Unfortunately `Decimal` makes us handle errors.
-            max_inflight_bytes_cluster_size_percent: config
-                .storage_dataflow_max_inflight_bytes_to_cluster_size_percent()
+            max_inflight_bytes_cluster_size_fraction: config
+                .storage_dataflow_max_inflight_bytes_to_cluster_size_fraction()
                 .and_then(|d| match d.try_into() {
                     Err(e) => {
                         tracing::error!(
                             "Couldn't convert {:?} to f64, so defaulting to `None`: {e:?}",
-                            config.storage_dataflow_max_inflight_bytes_to_cluster_size_percent()
+                            config.storage_dataflow_max_inflight_bytes_to_cluster_size_fraction()
                         );
                         None
                     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -894,16 +894,16 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
     internal: true,
 };
 
-/// The percentage of the cluster replica size to be used as the maximum number of
+/// The fraction of the cluster replica size to be used as the maximum number of
 /// in-flight bytes emitted by persist_sources feeding storage dataflows.
 /// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
 /// For this value to be used storage_dataflow_max_inflight_bytes needs to be set.
-const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT: ServerVar<Option<Numeric>> =
+const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION: ServerVar<Option<Numeric>> =
     ServerVar {
-        name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_percent"),
+        name: UncasedStr::new("storage_dataflow_max_inflight_bytes_to_cluster_size_fraction"),
         value: &None,
         description:
-            "The percentage of the cluster replica size to be used as the maximum number of \
+            "The fraction of the cluster replica size to be used as the maximum number of \
     in-flight bytes emitted by persist_sources feeding storage dataflows. \
     If not configured, the storage_dataflow_max_inflight_bytes value will be used.",
         internal: true,
@@ -1953,7 +1953,7 @@ impl SystemVars {
             .with_var(&CRDB_TCP_USER_TIMEOUT)
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
-            .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
+            .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
@@ -2433,9 +2433,9 @@ impl SystemVars {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
     }
 
-    /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_percent` configuration parameter.
-    pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_percent(&self) -> Option<Numeric> {
-        *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT)
+    /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_fraction` configuration parameter.
+    pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_fraction(&self) -> Option<Numeric> {
+        *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
     }
 
     /// Returns the `storage_dataflow_max_inflight_bytes_disk_only` configuration parameter.
@@ -3921,7 +3921,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == PG_REPLICATION_KEEPALIVES_RETRIES.name()
         || name == PG_REPLICATION_TCP_USER_TIMEOUT.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
-        || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_PERCENT.name()
+        || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
         || is_upsert_rocksdb_config_var(name)
         || is_persist_config_var(name)

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -46,8 +46,8 @@ message ProtoUpsertAutoSpillConfig {
 }
 
 message ProtoStorageMaxInflightBytesConfig {
-    reserved 2, 3;
+    reserved 2, 3, 5;
     optional uint64 max_in_flight_bytes_default = 1;
-    optional double max_in_flight_bytes_cluster_size_percent = 5;
     bool disk_only = 4;
+    optional double max_in_flight_bytes_cluster_size_fraction = 6;
 }

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -50,11 +50,11 @@ pub struct StorageParameters {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
 pub struct StorageMaxInflightBytesConfig {
-    /// The default value for the max in-flight bytes
+    /// The default value for the max in-flight bytes.
     pub max_inflight_bytes_default: Option<usize>,
-    /// Specified percentage which will be used to calculate the max in-flight from the
-    /// memory limit of the cluster in use.
-    pub max_inflight_bytes_cluster_size_percent: Option<f64>,
+    /// Fraction of the memory limit of the cluster in use to be used as the
+    /// max in-flight bytes for backpressure.
+    pub max_inflight_bytes_cluster_size_fraction: Option<f64>,
     /// Whether or not the above configs only apply to disk-using dataflows.
     pub disk_only: bool,
 }
@@ -63,7 +63,7 @@ impl Default for StorageMaxInflightBytesConfig {
     fn default() -> Self {
         Self {
             max_inflight_bytes_default: Default::default(),
-            max_inflight_bytes_cluster_size_percent: Default::default(),
+            max_inflight_bytes_cluster_size_fraction: Default::default(),
             disk_only: true,
         }
     }
@@ -73,14 +73,16 @@ impl RustType<ProtoStorageMaxInflightBytesConfig> for StorageMaxInflightBytesCon
     fn into_proto(&self) -> ProtoStorageMaxInflightBytesConfig {
         ProtoStorageMaxInflightBytesConfig {
             max_in_flight_bytes_default: self.max_inflight_bytes_default.map(u64::cast_from),
-            max_in_flight_bytes_cluster_size_percent: self.max_inflight_bytes_cluster_size_percent,
+            max_in_flight_bytes_cluster_size_fraction: self
+                .max_inflight_bytes_cluster_size_fraction,
             disk_only: self.disk_only,
         }
     }
     fn from_proto(proto: ProtoStorageMaxInflightBytesConfig) -> Result<Self, TryFromProtoError> {
         Ok(Self {
             max_inflight_bytes_default: proto.max_in_flight_bytes_default.map(usize::cast_from),
-            max_inflight_bytes_cluster_size_percent: proto.max_in_flight_bytes_cluster_size_percent,
+            max_inflight_bytes_cluster_size_fraction: proto
+                .max_in_flight_bytes_cluster_size_fraction,
             disk_only: proto.disk_only,
         })
     }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -388,6 +388,12 @@ where
                                         if let Some(storage_dataflow_max_inflight_bytes) =
                                             backpressure_max_inflight_bytes
                                         {
+                                            tracing::info!(
+                                                ?backpressure_max_inflight_bytes,
+                                                "timely-{} using backpressure in upsert for source {}",
+                                                base_source_config.worker_id,
+                                                id
+                                            );
                                             if !storage_state
                                                 .dataflow_parameters
                                                 .storage_dataflow_max_inflight_bytes_config

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -563,7 +563,7 @@ fn get_backpressure_max_inflight_bytes(
 ) -> Option<usize> {
     let StorageMaxInflightBytesConfig {
         max_inflight_bytes_default,
-        max_inflight_bytes_cluster_size_percent,
+        max_inflight_bytes_cluster_size_fraction,
         disk_only: _,
     } = inflight_bytes_config;
 
@@ -571,9 +571,9 @@ fn get_backpressure_max_inflight_bytes(
     if max_inflight_bytes_default.is_some() {
         let current_cluster_max_bytes_limit =
             cluster_memory_limit.as_ref().and_then(|cluster_memory| {
-                max_inflight_bytes_cluster_size_percent.map(|percent| {
+                max_inflight_bytes_cluster_size_fraction.map(|fraction| {
                     // We just need close the correct % of bytes here, so we just use lossy casts.
-                    usize::cast_lossy(f64::cast_lossy(*cluster_memory) * percent / 100.0)
+                    usize::cast_lossy(f64::cast_lossy(*cluster_memory) * fraction)
                 })
             });
         current_cluster_max_bytes_limit.or(*max_inflight_bytes_default)
@@ -764,7 +764,7 @@ mod test {
     fn test_no_default() {
         let config = StorageMaxInflightBytesConfig {
             max_inflight_bytes_default: None,
-            max_inflight_bytes_cluster_size_percent: Some(50.0),
+            max_inflight_bytes_cluster_size_fraction: Some(0.5),
             disk_only: false,
         };
         let memory_limit = Some(1000);
@@ -779,7 +779,7 @@ mod test {
     fn test_no_matching_size() {
         let config = StorageMaxInflightBytesConfig {
             max_inflight_bytes_default: Some(10000),
-            max_inflight_bytes_cluster_size_percent: Some(50.0),
+            max_inflight_bytes_cluster_size_fraction: Some(0.5),
             disk_only: false,
         };
 
@@ -795,7 +795,7 @@ mod test {
     fn test_calculated_cluster_limit() {
         let config = StorageMaxInflightBytesConfig {
             max_inflight_bytes_default: Some(10000),
-            max_inflight_bytes_cluster_size_percent: Some(50.0),
+            max_inflight_bytes_cluster_size_fraction: Some(0.5),
             disk_only: false,
         };
         let memory_limit = Some(2000);

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -156,7 +156,7 @@ def workflow_rehydration(c: Composition) -> None:
         "clusterd1",
     ]
 
-    for (style, mz, clusterd) in [
+    for style, mz, clusterd in [
         (
             "with DISK",
             Materialized(
@@ -168,7 +168,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "enable_disk_cluster_replicas": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
-                    "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",
+                    "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
                     "storage_dataflow_max_inflight_bytes_disk_only": "false",
                 },
                 environment_extra=materialized_environment_extra,
@@ -190,7 +190,7 @@ def workflow_rehydration(c: Composition) -> None:
                 additional_system_parameter_defaults={
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
-                    "storage_dataflow_max_inflight_bytes_to_cluster_size_percent": "1",
+                    "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
                     "storage_dataflow_max_inflight_bytes_disk_only": "false",
                 },
                 environment_extra=materialized_environment_extra,
@@ -200,7 +200,6 @@ def workflow_rehydration(c: Composition) -> None:
             ),
         ),
     ]:
-
         with c.override(
             mz,
             clusterd,
@@ -254,7 +253,6 @@ def run_one_failpoint(c: Composition, failpoint: str, error_message: str) -> Non
     with c.override(
         Testdrive(no_reset=True, consistent_seed=True),
     ):
-
         dependencies = ["zookeeper", "kafka", "clusterd1", "materialized"]
         c.up(*dependencies)
         c.run("testdrive", "failpoint/02-source.td")
@@ -293,7 +291,7 @@ def workflow_incident_49(c: Composition) -> None:
         "schema-registry",
     ]
 
-    for (style, mz) in [
+    for style, mz in [
         (
             "with DISK",
             Materialized(
@@ -313,7 +311,6 @@ def workflow_incident_49(c: Composition) -> None:
             ),
         ),
     ]:
-
         with c.override(
             mz,
             Testdrive(no_reset=True, consistent_seed=True),
@@ -369,7 +366,7 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
         ("drop-source-in-cluster.td", "DROP SOURCE dropped_upsert", False),
     ]
 
-    for (testdrive_file, drop_stmt, cluster_dropped) in scenarios:
+    for testdrive_file, drop_stmt, cluster_dropped in scenarios:
         with c.override(
             Testdrive(no_reset=True),
         ):


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
Changing the type from percent to a fraction. So instead of values like 0.25% it will be directly 0.0025.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
