### PR TITLE
slt: do not reformat in sorted cockroach mode

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -696,7 +696,7 @@ fn format_datum(d: Slt, typ: &Type, mode: Mode, col: usize) -> String {
     }
 }
 
-fn format_row(row: &Row, types: &[Type], mode: Mode, sort: &Sort) -> Vec<String> {
+fn format_row(row: &Row, types: &[Type], mode: Mode) -> Vec<String> {
     let mut formatted: Vec<String> = vec![];
     for i in 0..row.len() {
         let t: Option<Slt> = row.get::<usize, Option<Slt>>(i);
@@ -706,19 +706,8 @@ fn format_row(row: &Row, types: &[Type], mode: Mode, sort: &Sort) -> Vec<String>
             None => "NULL".into(),
         });
     }
-    if mode == Mode::Cockroach && sort.yes() {
-        formatted
-            .iter()
-            .flat_map(|s| {
-                crate::parser::split_cols(s, types.len())
-                    .into_iter()
-                    .map(ToString::to_string)
-                    .collect::<Vec<_>>()
-            })
-            .collect()
-    } else {
-        formatted
-    }
+
+    formatted
 }
 
 impl<'a> Runner<'a> {
@@ -1394,7 +1383,7 @@ impl<'a> RunnerInner<'a> {
                     location,
                 });
             }
-            let row = format_row(row, expected_types, *mode, sort);
+            let row = format_row(row, expected_types, *mode);
             formatted_rows.push(row);
         }
 


### PR DESCRIPTION
### Motivation

This fixes https://github.com/MaterializeInc/materialize/issues/21065.

### Tips for reviewer

I analyzed the code: The logic in question splits a text input at whitespaces, discards empty entries, and collects the resulting entries. It aims to get rid of superfluous whitespaces.
The logic is invoked for the column values of the actual result. As a consequence, column values containing a space are split and treated as two separate values.

I don't see any reason why we want to have this special behaviour in mode `rowsort` but not in other modes. This logic was introduced with c5f09c43befbaaa6517db10f2b273b11c863e337 ("ci/slt: Support immediate "SendRows" declaration") together with other changes in 2019.

All SLT tests are passing without this logic ([test pipeline](https://buildkite.com/materialize/tests/builds/61292), [SQL logic test pipeline](https://buildkite.com/materialize/sql-logic-tests/builds/5640)). Therefore, I suggest to remove this special handling.

### Tested with

```
mode cockroach

statement ok
CREATE TABLE x (a TEXT, b TEXT)

statement ok
INSERT INTO x VALUES ('a a', 'b');

query TT rowsort
SELECT * FROM x;
----
a␠a b
```

Let me know if I should check in this test code somewhere.
