### PR TITLE
Adding a flag to optimize upsert rocksdb for point lookups

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -58,6 +58,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
                 config.upsert_rocksdb_retry_duration(),
                 config.upsert_rocksdb_stats_log_interval_seconds(),
                 config.upsert_rocksdb_stats_persist_interval_seconds(),
+                config.upsert_rocksdb_point_lookup_block_cache_size_mb(),
             ) {
                 Ok(u) => u,
                 Err(e) => {

--- a/src/rocksdb-types/src/config.proto
+++ b/src/rocksdb-types/src/config.proto
@@ -43,4 +43,5 @@ message ProtoRocksDbTuningParameters {
     mz_proto.ProtoDuration retry_max_duration = 9;
     uint32 stats_log_interval_seconds = 10;
     uint32 stats_persist_interval_seconds = 11;
+    optional uint32 point_lookup_block_cache_size_mb = 12;
 }

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -61,6 +61,7 @@ pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) 
         retry_max_duration: _,
         stats_log_interval_seconds,
         stats_persist_interval_seconds,
+        point_lookup_block_cache_size_mb,
         dynamic: _,
     } = config;
 
@@ -101,4 +102,8 @@ pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) 
 
     options.set_stats_dump_period_sec(*stats_log_interval_seconds);
     options.set_stats_persist_period_sec(*stats_persist_interval_seconds);
+
+    if let Some(block_cache_size_mb) = point_lookup_block_cache_size_mb {
+        options.optimize_for_point_lookup((*block_cache_size_mb).into());
+    }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -772,6 +772,15 @@ mod upsert_rocksdb {
                   Only takes effect on source restart (Materialize).",
         internal: true,
     };
+    pub static UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB: ServerVar<Option<u32>> =
+        ServerVar {
+            name: UncasedStr::new("upsert_rocksdb_point_lookup_block_cache_size_mb"),
+            value: &None,
+            description: "Tuning parameter for RocksDB as used in `UPSERT/DEBEZIUM` \
+                  sources. Described in the `mz_rocksdb_types::config` module. \
+                  Only takes effect on source restart (Materialize).",
+            internal: true,
+        };
 }
 
 /// Controls the connect_timeout setting when connecting to PG via replication.
@@ -1944,6 +1953,7 @@ impl SystemVars {
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_RETRY_DURATION)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
@@ -2346,6 +2356,10 @@ impl SystemVars {
 
     pub fn upsert_rocksdb_stats_persist_interval_seconds(&self) -> u32 {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS)
+    }
+
+    pub fn upsert_rocksdb_point_lookup_block_cache_size_mb(&self) -> Option<u32> {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.
@@ -3944,6 +3958,7 @@ fn is_upsert_rocksdb_config_var(name: &str) -> bool {
         || name == upsert_rocksdb::UPSERT_ROCKSDB_BATCH_SIZE.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB.name()
 }
 
 /// Returns whether the named variable is a persist configuration parameter.


### PR DESCRIPTION
Adding a flag to optimize upsert rocksdb for point lookups.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
When testing with GOAT on production, we are seeing a gradual slowdown after the rehydrating almost 80% of data, especially as there are more reads. We are trying to optimize rocksdb more for our workload which is just point lookup by keys.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
