### PR TITLE
testdrive: Fortify tests to run correctly under --replicas 4

### DIFF
--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -7,6 +7,9 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# This test uses introspection queries that need to be targeted to a replica
+> SET cluster_replica = r1
+
 # Start from a TPC-H load generator source with small data.
 > CREATE SOURCE lgtpch FROM LOAD GENERATOR TPCH (SCALE FACTOR 0.0001, TICK INTERVAL 0.1) FOR ALL TABLES WITH (SIZE = '1');
 

--- a/test/testdrive/github-21031.td
+++ b/test/testdrive/github-21031.td
@@ -12,6 +12,10 @@
 # This test confirms that subscribes that advance to the empty frontier are
 # fully cleaned up.
 #
+
+# This test uses introspection queries that need to be targeted to a replica
+> SET cluster_replica = r1
+
 # This test relies on testdrive's automatic retries, since it queries
 # introspection sources that take a while to update.
 


### PR DESCRIPTION
Certain testdrive tests use introspection queries that need to be explicitly targeted to a particular repica.

### Motivation

Nightly testdrive with replicas = 4 was failing.

@vmarcos @teskje FYI