### PR TITLE
Introduce built-in `mz_expected_group_size_advice`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -889,6 +889,24 @@ are contained in operators under each dataflow.
 | `records` | [`numeric`] | The number of records in all arrangements in the dataflow.                   |
 | `batches` | [`numeric`] | The number of batches in all arrangements in the dataflow.                   |
 
+### `mz_expected_group_size_advice`
+
+The `mz_expected_group_size_advice` view provides advice on opportunities to set the `EXPECTED GROUP SIZE`
+[query hint]. This hint is applicable to dataflows maintaining [`MIN`], [`MAX`], or [Top K] query patterns. The
+maintainance of these query patterns is implemented inside an operator scope, called a region, through a
+hierarchical scheme for either reduction or top-k computation.
+
+<!-- RELATION_SPEC mz_internal.mz_expected_group_size_advice -->
+| Field           | Type        | Meaning                                                                                                             |
+|-----------------|-------------|---------------------------------------------------------------------------------------------------------------------|
+| `dataflow_id`   | [`uint8`]   | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                                        |
+| `dataflow_name` | [`text`]    | The internal name of the dataflow hosting the min/max reduction or top-k.                                           |
+| `region_id`     | [`uint8`] | The ID of the root operator scope. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).               |
+| `region_name`   | [`text`]    | The internal name of the root operator scope for the min/max reduction or top-k.                                    |
+| `levels`        | [`bigint`] | The number of levels in the hierarchical scheme implemented by the region.                                           |
+| `to_cut`        | [`bigint`] | The number of levels that can be eliminated (cut) from the region's hierarchy.                                       |
+| `hint`          | [`double precision`] | The hint value for `EXPECTED GROUP SIZE` that will eliminate `to_cut` levels from the regions' hierarchy.  |
+
 ### `mz_message_counts`
 
 The `mz_message_counts` view describes the messages sent and received over the [dataflow] channels in the system.
@@ -1012,6 +1030,10 @@ Field          | Type                         | Meaning
 [`timestamp with time zone`]: /sql/types/timestamp
 [arrangement]: /get-started/arrangements/#arrangements
 [dataflow]: /get-started/arrangements/#dataflows
+[`MIN`]: /sql/functions/#min
+[`MAX`]: /sql/functions/#max
+[Top K]: /transform-data/patterns/top-k
+[query hint]: /sql/select/#query-hints
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_aggregates -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_batches_raw -->

--- a/src/compute-client/src/plan/mod.rs
+++ b/src/compute-client/src/plan/mod.rs
@@ -2295,6 +2295,8 @@ impl<T> CollectionPlan for Plan<T> {
 /// Returns bucket sizes, descending, suitable for hierarchical decomposition of an operator, based
 /// on the expected number of rows that will have the same group key.
 fn bucketing_of_expected_group_size(expected_group_size: Option<u64>) -> Vec<u64> {
+    // NOTE(vmarcos): The fan-in of 16 defined below is used in the tuning advice built-in view
+    // mz_internal.mz_expected_group_size_advice.
     let mut buckets = vec![];
     let mut current = 16;
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -734,6 +734,8 @@ where
             // Build a series of stages for the reduction
             // Arrange the final result into (key, Row)
             let error_logger = self.error_logger();
+            // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
+            // view mz_internal.mz_expected_group_size_advice.
             let arranged =
                 partial.arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
             // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
@@ -802,6 +804,8 @@ where
         R: MaybeValidatingRow<Vec<Row>, (Row, u64)>,
     {
         let error_logger = self.error_logger();
+        // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
+        // view mz_internal.mz_expected_group_size_advice.
         let arranged_input = input
             .arrange_named::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
 

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -386,6 +386,8 @@ where
 {
     // We only want to arrange parts of the input that are not part of the actual output
     // such that `input.concat(&negated_output.negate())` yields the correct TopK
+    // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
+    // built-in view mz_internal.mz_expected_group_size_advice.
     input
         .arrange_named::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
         .reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -576,6 +576,7 @@ mz_dataflow_operators
 mz_dataflow_operators_per_worker
 mz_dataflows
 mz_dataflows_per_worker
+mz_expected_group_size_advice
 mz_frontiers
 mz_global_frontiers
 mz_kafka_sources

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -467,6 +467,17 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 4  batches  numeric
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_expected_group_size_advice' ORDER BY position
+----
+1  dataflow_id  uint8
+2  dataflow_name  text
+3  region_id  uint8
+4  region_name  text
+5  levels  bigint
+6  to_cut  bigint
+7  hint  double␠precision
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_message_counts' ORDER BY position
 ----
 1  channel_id  uint8

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -413,6 +413,10 @@ mz_dataflows_per_worker
 VIEW
 materialize
 mz_internal
+mz_expected_group_size_advice
+VIEW
+materialize
+mz_internal
 mz_frontiers
 SOURCE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -594,6 +594,7 @@ mz_dataflow_operator_reachability_per_worker
 mz_dataflow_operators
 mz_dataflows
 mz_dataflows_per_worker
+mz_expected_group_size_advice
 mz_global_frontiers
 mz_message_counts
 mz_message_counts_per_worker

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -89,81 +89,9 @@
   );
 4095
 
-> WITH operators AS (
-  SELECT
-      dod.dataflow_id,
-      dor.id AS region_id,
-      dod.id,
-      ars.records
-  FROM
-      mz_internal.mz_dataflow_operator_dataflows dod
-      JOIN mz_internal.mz_dataflow_addresses doa
-          ON dod.id = doa.id
-      JOIN mz_internal.mz_dataflow_addresses dra
-          ON dra.address = doa.address[:list_length(doa.address) - 1]
-      JOIN mz_internal.mz_dataflow_operators dor
-          ON dor.id = dra.id
-      JOIN mz_internal.mz_arrangement_sizes ars
-          ON ars.operator_id = dod.id
-  WHERE
-      dod.name = 'Arranged TopK input'
-      OR dod.name = 'Arranged MinsMaxesHierarchical input'
-      OR dod.name = 'Arrange ReduceMinsMaxes'
-  ),
-  levels AS (
-      SELECT o.dataflow_id, o.region_id, COUNT(*) AS levels
-      FROM operators o
-      GROUP BY o.dataflow_id, o.region_id
-  ),
-  pivot AS (
-      SELECT
-          o1.dataflow_id,
-          o1.region_id,
-          o1.id,
-          o1.records
-      FROM operators o1
-      WHERE
-          o1.id = (
-              SELECT MIN(o2.id)
-              FROM operators o2
-              WHERE
-                  o2.dataflow_id = o1.dataflow_id
-                  AND o2.region_id = o1.region_id
-              OPTIONS (EXPECTED GROUP SIZE = 8)
-          )
-  ),
-  candidates AS (
-      SELECT
-          o.dataflow_id,
-          o.region_id,
-          o.id,
-          o.records
-      FROM
-          operators o
-          JOIN pivot p
-              ON o.dataflow_id = p.dataflow_id
-                  AND o.region_id = p.region_id
-                  AND o.id <> p.id
-      WHERE o.records >= p.records * (1 - 0.15)
-  ),
-  cuts AS (
-      SELECT c.dataflow_id, c.region_id, COUNT(*) to_cut
-      FROM candidates c
-      GROUP BY c.dataflow_id, c.region_id
-      HAVING COUNT(*) > 0
-  )
-  SELECT
-      dod.dataflow_name,
-      dod.name AS region_name,
-      l.levels,
-      c.to_cut,
-      pow(16, l.levels - c.to_cut) - 1 AS hint
-  FROM cuts c
-      JOIN levels l
-          ON c.dataflow_id = l.dataflow_id AND c.region_id = l.region_id
-      JOIN mz_internal.mz_dataflow_operator_dataflows dod
-          ON dod.dataflow_id = c.dataflow_id AND dod.id = c.region_id
-  ORDER BY dod.dataflow_name, dod.name;
+> SELECT dataflow_name, region_name, levels, to_cut, hint
+  FROM mz_internal.mz_expected_group_size_advice
+  ORDER BY dataflow_name, region_name;
 "Dataflow: materialize.public.lineitem_by_orderkey" ReduceHierarchical 8 7 15
 "Dataflow: materialize.public.lineitem_by_orderkey" TopK 8 7 15
 "Dataflow: materialize.public.lineitem_by_partsuppkey" TopK 8 6 255
@@ -200,81 +128,9 @@
   FROM lineitem l1
   GROUP BY l1.l_orderkey;
 
-> WITH operators AS (
-  SELECT
-      dod.dataflow_id,
-      dor.id AS region_id,
-      dod.id,
-      ars.records
-  FROM
-      mz_internal.mz_dataflow_operator_dataflows dod
-      JOIN mz_internal.mz_dataflow_addresses doa
-          ON dod.id = doa.id
-      JOIN mz_internal.mz_dataflow_addresses dra
-          ON dra.address = doa.address[:list_length(doa.address) - 1]
-      JOIN mz_internal.mz_dataflow_operators dor
-          ON dor.id = dra.id
-      JOIN mz_internal.mz_arrangement_sizes ars
-          ON ars.operator_id = dod.id
-  WHERE
-      dod.name = 'Arranged TopK input'
-      OR dod.name = 'Arranged MinsMaxesHierarchical input'
-      OR dod.name = 'Arrange ReduceMinsMaxes'
-  ),
-  levels AS (
-      SELECT o.dataflow_id, o.region_id, COUNT(*) AS levels
-      FROM operators o
-      GROUP BY o.dataflow_id, o.region_id
-  ),
-  pivot AS (
-      SELECT
-          o1.dataflow_id,
-          o1.region_id,
-          o1.id,
-          o1.records
-      FROM operators o1
-      WHERE
-          o1.id = (
-              SELECT MIN(o2.id)
-              FROM operators o2
-              WHERE
-                  o2.dataflow_id = o1.dataflow_id
-                  AND o2.region_id = o1.region_id
-              OPTIONS (EXPECTED GROUP SIZE = 8)
-          )
-  ),
-  candidates AS (
-      SELECT
-          o.dataflow_id,
-          o.region_id,
-          o.id,
-          o.records
-      FROM
-          operators o
-          JOIN pivot p
-              ON o.dataflow_id = p.dataflow_id
-                  AND o.region_id = p.region_id
-                  AND o.id <> p.id
-      WHERE o.records >= p.records * (1 - 0.15)
-  ),
-  cuts AS (
-      SELECT c.dataflow_id, c.region_id, COUNT(*) to_cut
-      FROM candidates c
-      GROUP BY c.dataflow_id, c.region_id
-      HAVING COUNT(*) > 0
-  )
-  SELECT
-      dod.dataflow_name,
-      dod.name AS region_name,
-      l.levels,
-      c.to_cut,
-      pow(16, l.levels - c.to_cut) - 1 AS hint
-  FROM cuts c
-      JOIN levels l
-          ON c.dataflow_id = l.dataflow_id AND c.region_id = l.region_id
-      JOIN mz_internal.mz_dataflow_operator_dataflows dod
-          ON dod.dataflow_id = c.dataflow_id AND dod.id = c.region_id
-  ORDER BY dod.dataflow_name, dod.name;
+> SELECT dataflow_name, region_name, levels, to_cut, hint
+  FROM mz_internal.mz_expected_group_size_advice
+  ORDER BY dataflow_name, region_name;
 "Dataflow: materialize.public.lineitem_by_orderkey" ReduceHierarchical 8 7 15
 "Dataflow: materialize.public.lineitem_by_partsuppkey" TopK 8 6 255
 "Dataflow: materialize.public.lineitem_by_partsuppkey" ReduceHierarchical 8 6 255


### PR DESCRIPTION
This PR creates a new built-in view, `mz_internal.mz_expected_group_size_advice`, to provide advice on tuning the `EXPECTED GROUP SIZE` for dataflows running in a given replica that include min/max/top-k maintenance patterns. The view comprises a large query, with annotations, that exploits information from introspection sources in determining if the levels of a hierarchical reduction can be further cut down.

The PR improves usability of the query reviewed in #20971. Advances #20184.

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/20184

### Tips for reviewer

This PR only introduces the new built-in view, and leaves documentation updates to a separate PR ([see Slack discussion](https://materializeinc.slack.com/archives/CPNFV9CVB/p1690789892302589)). If we'd prefer documentation updates to be done here, please let me know. These documentation updates would include documenting the view itself, but also touch on how to tune the `EXPECTED GROUP SIZE` hint and how that tuning process relates to using the view.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
