### PR TITLE
test: Deflake test_storage_usage_collection_interval_timestamps

### DIFF
--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -873,27 +873,51 @@ fn test_storage_usage_doesnt_update_between_restarts() {
     }
 }
 
+// Test that all rows for a single collection use the same timestamp.
 #[mz_ore::test]
 fn test_storage_usage_collection_interval_timestamps() {
-    let config =
-        util::Config::default().with_storage_usage_collection_interval(Duration::from_secs(5));
+    let storage_interval_s = 2;
+    let config = util::Config::default()
+        .with_storage_usage_collection_interval(Duration::from_secs(storage_interval_s));
     let server = util::start_server(config).unwrap();
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Retry because it may take some time for the initial snapshot to be taken.
-    Retry::default().max_duration(Duration::from_secs(10)).retry(|_| {
+    let rows = Retry::default().max_duration(Duration::from_secs(10)).retry(|_| {
         let rows = client
             .query(
-                "SELECT collection_timestamp, SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage GROUP BY collection_timestamp ORDER BY collection_timestamp;",
+                "SELECT EXTRACT(EPOCH FROM collection_timestamp)::integer, SUM(size_bytes)::int8 FROM mz_catalog.mz_storage_usage GROUP BY collection_timestamp ORDER BY collection_timestamp;",
                 &[],
             )
             .map_err(|e| e.to_string()).unwrap();
-        if rows.len() == 1 {
-            Ok(())
+
+        if rows.is_empty() {
+            Err("expected some timestamp, instead found None".to_string())
         } else {
-            Err(format!("expected a single timestamp, instead found {}", rows.len()))
+            Ok(rows)
         }
     }).unwrap();
+
+    // If there are multiple timestamps, make sure they are at least storage interval (2 seconds) apart.
+    let timestamps: Vec<_> = rows
+        .into_iter()
+        .map(|row| row.get::<_, i32>(0))
+        .map(|ts| u64::try_from(ts).unwrap())
+        .collect();
+    let mut prev = None;
+
+    for timestamp in timestamps {
+        match prev {
+            None => {
+                prev = Some(timestamp);
+            }
+            Some(prev_timestamp) => {
+                assert!(timestamp - prev_timestamp >= storage_interval_s,
+                            "found storage collection timestamps, {prev_timestamp} and {timestamp}, that are less than {storage_interval_s} s apart");
+                prev = Some(timestamp);
+            }
+        }
+    }
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
The test_storage_usage_collection_interval_timestamps tests that after
starting up Materialize for the first time, an initial storage usage
collection is executed, and all rows generated use the same timestamp.

The storage usage interval used for the test used to be 5 seconds, so
if the test took longer than 5 seconds then we would have more than one
timestamp and mistakenly fail the test.

This commit updates the test so that if multiple timestamps are found,
we assert that they are taken at least storage usage interval
units apart.

Fixes #21074

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
