### PR TITLE
make grpc keep-alive system vars optional

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -146,8 +146,8 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
 
 fn grpc_client_config(config: &SystemVars) -> GrpcClientParameters {
     GrpcClientParameters {
-        connect_timeout: Some(config.grpc_connect_timeout()),
-        http2_keep_alive_interval: Some(config.grpc_client_http2_keep_alive_interval()),
-        http2_keep_alive_timeout: Some(config.grpc_client_http2_keep_alive_timeout()),
+        connect_timeout: config.grpc_connect_timeout(),
+        http2_keep_alive_interval: config.grpc_client_http2_keep_alive_interval(),
+        http2_keep_alive_timeout: config.grpc_client_http2_keep_alive_timeout(),
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1154,21 +1154,21 @@ pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
 mod grpc_client {
     use super::*;
 
-    pub const CONNECT_TIMEOUT: ServerVar<Duration> = ServerVar {
+    pub const CONNECT_TIMEOUT: ServerVar<Option<Duration>> = ServerVar {
         name: UncasedStr::new("grpc_client_connect_timeout"),
-        value: &Duration::from_secs(5),
+        value: &Some(Duration::from_secs(5)),
         description: "Timeout to apply to initial gRPC client connection establishment.",
         internal: true,
     };
-    pub const HTTP2_KEEP_ALIVE_INTERVAL: ServerVar<Duration> = ServerVar {
+    pub const HTTP2_KEEP_ALIVE_INTERVAL: ServerVar<Option<Duration>> = ServerVar {
         name: UncasedStr::new("grpc_client_http2_keep_alive_interval"),
-        value: &Duration::from_secs(3),
+        value: &Some(Duration::from_secs(3)),
         description: "Idle time to wait before sending HTTP/2 PINGs to maintain established gRPC client connections.",
         internal: true,
     };
-    pub const HTTP2_KEEP_ALIVE_TIMEOUT: ServerVar<Duration> = ServerVar {
+    pub const HTTP2_KEEP_ALIVE_TIMEOUT: ServerVar<Option<Duration>> = ServerVar {
         name: UncasedStr::new("grpc_client_http2_keep_alive_timeout"),
-        value: &Duration::from_secs(5),
+        value: &Some(Duration::from_secs(5)),
         description:
             "Time to wait for HTTP/2 pong response before terminating a gRPC client connection.",
         internal: true,
@@ -2561,15 +2561,15 @@ impl SystemVars {
         *self.expect_value(&*WEBHOOKS_SECRETS_CACHING_TTL_SECS)
     }
 
-    pub fn grpc_client_http2_keep_alive_interval(&self) -> Duration {
+    pub fn grpc_client_http2_keep_alive_interval(&self) -> Option<Duration> {
         *self.expect_value(&grpc_client::HTTP2_KEEP_ALIVE_INTERVAL)
     }
 
-    pub fn grpc_client_http2_keep_alive_timeout(&self) -> Duration {
+    pub fn grpc_client_http2_keep_alive_timeout(&self) -> Option<Duration> {
         *self.expect_value(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
     }
 
-    pub fn grpc_connect_timeout(&self) -> Duration {
+    pub fn grpc_connect_timeout(&self) -> Option<Duration> {
         *self.expect_value(&grpc_client::CONNECT_TIMEOUT)
     }
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Making the keep-alive types `Option<Duration>` will allow us to fully disable http/2 keep-alives on our grpc connections if needed. https://github.com/MaterializeInc/materialize/issues/20299#issuecomment-1671967388 has the motivation, though it's still not clear if it's keep-alive related or not.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
