### PR TITLE
stash: Prevent retry on unrecoverable errors

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -215,7 +215,7 @@ impl StashError {
     /// or a retry is not safe due to an indeterminate state).
     pub fn is_unrecoverable(&self) -> bool {
         match &self.inner {
-            InternalStashError::Fence(_) => true,
+            InternalStashError::Fence(_) | InternalStashError::StashNotWritable(_) => true,
             _ => false,
         }
     }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -359,7 +359,7 @@ impl StashFactory {
                 Ok(()) => break,
                 Err(err) => {
                     warn!("initial stash connection error, retrying: {err}");
-                    if retry.next().await.is_none() {
+                    if err.is_unrecoverable() || retry.next().await.is_none() {
                         return Err(err);
                     }
                 }


### PR DESCRIPTION
Currently, when if the stash fails to establish a connection with CockroachDB, it will retry the connection for a certain amount of time. This wastes time and can lead to confusion if the error is unrecoverable. This commit teaches the stash connection logic to not retry unrecoverable errors.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
