### PR TITLE
clusters: fix merge skew with topology spread constraints

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -939,6 +939,19 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                     } else {
                         "DoNotSchedule".to_string()
                     },
+                    // TODO(guswynn): restore these once they are supported.
+                    // Consider node affinities when calculating topology spread. This is the
+                    // default: <https://docs.rs/k8s-openapi/latest/k8s_openapi/api/core/v1/struct.TopologySpreadConstraint.html#structfield.node_affinity_policy>,
+                    // made explicit.
+                    // node_affinity_policy: Some("Honor".to_string()),
+                    // Do not consider node taints when calculating topology spread. This is the
+                    // default: <https://docs.rs/k8s-openapi/latest/k8s_openapi/api/core/v1/struct.TopologySpreadConstraint.html#structfield.node_taints_policy>,
+                    // made explicit.
+                    // node_taints_policy: Some("Ignore".to_string()),
+                    match_label_keys: None,
+                    // Once the above are restorted, we should't have `..Default::default()` here because the specifics of these fields are
+                    // subtle enough where we want compilation failures when we upgrade
+                    ..Default::default()
                 };
                 Some(vec![constraint])
             } else {


### PR DESCRIPTION
not a trivial merge-skew fix, had to think about it

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
