### PR TITLE
docs: document replica scheduling constraints

### DIFF
--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -48,14 +48,9 @@ _replica_name_ | A name for this replica.
 {{% replica-options %}}
 
 {{< note >}}
-If you do not specify an availability zone, Materialize will automatically
-assign the availability zone with the least existing replicas for the
-associated cluster to increase the cluster's tolerance to availability zone
-failure.
-
-To check the availability zone associated with each replica in a cluster, use
-the [`mz_cluster_replicas`](/sql/system-catalog/mz_catalog/#mz_cluster_replicas)
-system table.
+If you do not specify an availability zone, Materialize will assign the replica
+to an arbitrary availability zone. For details on how replicas are assigned
+between availability zones, see [Availability zone assignment](/sql/create-cluster/#availability-zone-assignment).
 {{< /note >}}
 
 ## Details
@@ -103,8 +98,6 @@ cluster. In these cases, the slower machines will likely be continually burdened
 with a backlog of work. If all of the faster machines become unreachable, the
 system might experience delays in replying to requests while the slower machines
 catch up to the last known time that the faster machines had computed.
-
-
 
 ## Example
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -105,16 +105,21 @@ _replica_name_ | A name for a cluster replica.
 
 {{% replica-options %}}
 
-{{< note >}}
-If you do not specify an availability zone, Materialize will automatically
-assign the availability zone with the least existing replicas for the
-associated cluster to increase the cluster's tolerance to availability zone
-failure.
+## Availability zone assignment
 
-To check the availability zone associated with each replica in a cluster, use
-the [`mz_cluster_replicas`](/sql/system-catalog/mz_catalog/#mz_cluster_replicas)
-system table.
-{{< /note >}}
+When assigning replicas of a [managed cluster](#managed-clusters) to
+availability zones, Materialize makes the following guarantees, within each
+cluster:
+
+{{< warning >}}
+These guarantees do not apply to [unmanaged clusters](#unmanaged-clusters).
+{{< /warning >}}
+
+- Different replicas are _never_ scheduled on the same node.
+- Different replicas are _always_ spread evenly across availability
+  zones. **Known limitation:** replicas with more than 1 process are excluded
+  from this constraint. See [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes)
+  to determine if that is the case for your replicas.
 
 ## Details
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -82,17 +82,17 @@ Field               | Type      | Meaning
 The `mz_clusters` table contains a row for each cluster in the system.
 
 <!-- RELATION_SPEC mz_catalog.mz_clusters -->
-| Field                | Type                 | Meaning                                                                                                            |
-|----------------------|----------------------|--------------------------------------------------------------------------------------------------------------------|
-| `id`                 | [`text`]             | Materialize's unique ID for the cluster.                                                                           |
-| `name`               | [`text`]             | The name of the cluster.                                                                                           |
-| `owner_id`           | [`text`]             | The role ID of the owner of the cluster. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles). |
-| `privileges`         | [`mz_aclitem array`] | The privileges belonging to the cluster.                                                                           |
-| `managed`            | [`boolean`]          | Whether the cluster has automatically managed replicas.                                                            |
-| `size`               | [`text`]             | If the cluster is managed, the desired size of the cluster's replicas. If the cluster is unmanaged, `NULL`.        |
-| `replication_factor` | [`uint4`]            | If the cluster is managed, the desired number of replicas of the cluster. If the cluster is unmanaged, `NULL`.     |
-| `disk`               | [`boolean`]          | If the replicas have a local disk.                                                                                 |
-| `availability_zones` | [`list`]             | The AWS availability zones of the cluster.                                                                         |
+| Field                | Type                 | Meaning                                                                                                                                  |
+|----------------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`                 | [`text`]             | Materialize's unique ID for the cluster.                                                                                                 |
+| `name`               | [`text`]             | The name of the cluster.                                                                                                                 |
+| `owner_id`           | [`text`]             | The role ID of the owner of the cluster. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).                       |
+| `privileges`         | [`mz_aclitem array`] | The privileges belonging to the cluster.                                                                                                 |
+| `managed`            | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/#managed-clusters) with automatically managed replicas.                   |
+| `size`               | [`text`]             | If the cluster is managed, the desired size of the cluster's replicas. `NULL` for unmanaged clusters.                                    |
+| `replication_factor` | [`uint4`]            | If the cluster is managed, the desired number of replicas of the cluster. `NULL` for unmanaged clusters.                                 |
+| `disk`               | [`boolean`]          | **Unstable** If the cluster is managed, `true` if the replicas have the `DISK` option . `NULL` for unmanaged clusters.                   |
+| `availability_zones` | [`text list`]        | **Unstable** If the cluster is managed, the list of availability zones specified in `AVAILABILITY ZONES`. `NULL` for unmanaged clusters. |
 
 ### `mz_columns`
 

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -3,7 +3,6 @@ Field                               | Value      | Description
 `MANAGED`                           | `bool`     | Default: `true`. Indicates whether the cluster is a [managed cluster](/sql/create-cluster/#managed-and-unmanaged-clusters). We infer the value for `MANAGED` to be true unless you specify replicas manually.
 `SIZE`                              | `text`     | The size of the cluster replicas. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
 `REPLICATION FACTOR`                | `text`     | The replication factor of the cluster. Can be 0 to disable computations.
-`AVAILABILITY ZONES`                | `text[]`   | If you want the cluster replicas to reside in specific availability zones. You must specify a list of [AWS availability zone IDs] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
 `INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
 `INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Indicates whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -1,7 +1,7 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
-`AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID] in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
+`AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
 `INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
 `INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*


### PR DESCRIPTION
based on https://www.notion.so/materialize/Top-down-replica-topology-constraints-038ebdf80e304e7daf987a1e8b0798f2 and https://github.com/MaterializeInc/materialize/pull/20815

@benesch and @doy-materialize you might want to take a look here

@alex-hunt-materialize and @jubrad may be interested in the privatelink note

### Motivation

docs 

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
