### PR TITLE
cloudtest: use the prod version of k8s in cloudtest

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -557,7 +557,10 @@ steps:
     parallelism: 3
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
-    inputs: [test/cloudtest, misc/python/materialize/cloudtest]
+    inputs:
+      - test/cloudtest
+      - misc/python/materialize/cloudtest
+      - misc/kind
     plugins:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:

--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -22,6 +22,7 @@ kubeadmConfigPatches:
         "service-node-port-range": "32000-32063"
 nodes:
   - role: control-plane
+    image: kindest/node:v1.25.9
     extraPortMappings:
       - containerPort: 32000
         hostPort: 32000


### PR DESCRIPTION
The default for the `kind` version we use in ci is 1.24, noticed this should be the same as prod here: https://materializeinc.slack.com/archives/CL68GT3AT/p1691614268926589?thread_ts=1691610396.932559&cid=CL68GT3AT

### Motivation

  * This PR fixes a previously unreported bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
