### PR TITLE
sql: Add SHOW ROLES command

### DIFF
--- a/doc/user/content/sql/show-roles.md
+++ b/doc/user/content/sql/show-roles.md
@@ -1,0 +1,50 @@
+---
+title: "SHOW ROLES"
+description: "`SHOW ROLES` lists the roles available in Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`SHOW ROLES` lists the roles available in Materialize.
+
+## Syntax
+
+{{< diagram "show-roles.svg" >}}
+
+## Examples
+
+```sql
+SHOW ROLES;
+```
+```nofmt
+ name
+----------------
+ joe@ko.sh
+ mike@ko.sh
+```
+
+```sql
+SHOW ROLES LIKE 'jo%';
+```
+```nofmt
+ name
+----------------
+ joe@ko.sh
+```
+
+```sql
+SHOW ROLES WHERE name = 'mike@ko.sh';
+```
+```nofmt
+ name
+----------------
+ mike@ko.sh
+```
+
+
+## Related pages
+
+- [`CREATE ROLE`](../create-role)
+- [`DROP ROLE`](../drop-role)

--- a/doc/user/layouts/partials/sql-grammar/show-roles.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-roles.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="409" height="113">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="66" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">ROLES</text>
+   <rect x="221" y="35" width="50" height="32" rx="10"/>
+   <rect x="219"
+         y="33"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="53">LIKE</text>
+   <rect x="291" y="35" width="70" height="32" rx="10"/>
+   <rect x="289"
+         y="33"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="299" y="53">pattern</text>
+   <rect x="221" y="79" width="70" height="32" rx="10"/>
+   <rect x="219"
+         y="77"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="229" y="97">WHERE</text>
+   <rect x="311" y="79" width="48" height="32"/>
+   <rect x="309" y="77" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="319" y="97">expr</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m66 0 h10 m20 0 h10 m0 0 h150 m-180 0 h20 m160 0 h20 m-200 0 q10 0 10 10 m180 0 q0 -10 10 -10 m-190 10 v12 m180 0 v-12 m-180 12 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m50 0 h10 m0 0 h10 m70 0 h10 m-170 -10 v20 m180 0 v-20 m-180 20 v24 m180 0 v-24 m-180 24 q0 10 10 10 m160 0 q10 0 10 -10 m-170 10 h10 m70 0 h10 m0 0 h10 m48 0 h10 m0 0 h2 m23 -76 h-3"/>
+   <polygon points="399 17 407 13 407 21"/>
+   <polygon points="399 17 391 13 391 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -391,6 +391,9 @@ show_indexes ::=
     ('LIKE' 'pattern' | 'WHERE' expr)
 show_materialized_views ::=
     'SHOW' 'MATERIALIZED VIEWS' ('FROM' schema_name)? ('IN CLUSTER' cluster_name)?
+show_roles ::=
+  'SHOW' 'ROLES'
+  ('LIKE' 'pattern' | 'WHERE' expr)?
 show_secrets ::=
     'SHOW' 'SECRETS' ('FROM' schema_name)? ('LIKE' 'pattern' | 'WHERE' expr)?
 show_variable ::=

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -283,6 +283,14 @@ pub fn show_schemas<'a>(
     ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 
+pub fn show_roles<'a>(
+    scx: &'a StatementContext<'a>,
+    filter: Option<ShowStatementFilter<Aug>>,
+) -> Result<ShowSelect<'a>, PlanError> {
+    let query = format!("SELECT name FROM mz_catalog.mz_roles WHERE id NOT LIKE 's%'",);
+    ShowSelect::new(scx, query, filter, None, Some(&["name"]))
+}
+
 pub fn show_objects<'a>(
     scx: &'a StatementContext<'a>,
     ShowObjectsStatement {
@@ -299,7 +307,10 @@ pub fn show_objects<'a>(
         ShowObjectType::Sink => show_sinks(scx, from, filter),
         ShowObjectType::Type => show_types(scx, from, filter),
         ShowObjectType::Object => show_all_objects(scx, from, filter),
-        ShowObjectType::Role => bail_unsupported!("SHOW ROLES"),
+        ShowObjectType::Role => {
+            assert!(from.is_none(), "parser should reject from");
+            show_roles(scx, filter)
+        }
         ShowObjectType::Cluster => {
             assert!(from.is_none(), "parser should reject from");
             show_clusters(scx, filter)

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -287,7 +287,7 @@ pub fn show_roles<'a>(
     scx: &'a StatementContext<'a>,
     filter: Option<ShowStatementFilter<Aug>>,
 ) -> Result<ShowSelect<'a>, PlanError> {
-    let query = format!("SELECT name FROM mz_catalog.mz_roles WHERE id NOT LIKE 's%'",);
+    let query = "SELECT name FROM mz_catalog.mz_roles WHERE id NOT LIKE 's%'".to_string();
     ShowSelect::new(scx, query, filter, None, Some(&["name"]))
 }
 

--- a/test/sqllogictest/role.slt
+++ b/test/sqllogictest/role.slt
@@ -236,3 +236,29 @@ db error: ERROR: system cluster 'mz_system' cannot be modified
 
 statement error role name "external_foo" is reserved
 CREATE ROLE external_foo
+
+# Test SHOW ROLES
+
+query T
+SHOW ROLES
+----
+materialize
+
+statement ok
+CREATE ROLE foo
+
+query T
+SHOW ROLES
+----
+foo
+materialize
+
+query T
+SHOW ROLES WHERE name = 'foo'
+----
+foo
+
+query T
+SHOW ROLES LIKE 'f%'
+----
+foo

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -428,12 +428,16 @@ DROP ROLE group1
 statement ok
 DROP ROLE joe
 
-# SHOW ROLES/USERS is not yet implemented
-statement error SHOW ROLES not yet supported
+# SHOW ROLES/USERS
+query T
 show roles
+----
+materialize
 
-statement error SHOW ROLES not yet supported
+query T
 show users
+----
+materialize
 
 # Test grant/revoke multiple roles
 


### PR DESCRIPTION
This commit adds a SHOW ROLES command that displays all user roles. It behaves similarly to all other SHOW commands.

Works towards resolving #20452

### Motivation
 This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add a `SHOW ROLES` command.
