### PR TITLE
test: Fix flakiness when running queries against a log source

### DIFF
--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -89,6 +89,9 @@
   );
 4095
 
+# Needed when running the next queries that touches a log source
+> SET CLUSTER_REPLICA=r1
+
 > WITH operators AS (
   SELECT
       dod.dataflow_id,

--- a/test/testdrive/github-21031.td
+++ b/test/testdrive/github-21031.td
@@ -30,6 +30,9 @@ $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
 <TIMESTAMP> 1 1
 > COMMIT
 
+# Needed when running the next query that touches a log source
+> SET CLUSTER_REPLICA=r1
+
 # To ensure that the subscribe has reached the introspection sources, we
 # install another dataflow and wait for that to show up. Introspection sources
 # are not serializable, but dataflows still show up in order.


### PR DESCRIPTION
I don't understand why the failure is flaky but seems to happen pretty frequently for 'testdrive 4 replicas' (https://buildkite.com/materialize/nightlies/builds/3149 and https://buildkite.com/materialize/nightlies/builds/3118). Since we're querying a log source we need a set cluster replica so I'm setting it

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
