### PR TITLE
storage: implement very coarse hydration backpressure

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -98,6 +98,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
             disk_only: config.storage_dataflow_max_inflight_bytes_disk_only(),
         },
         grpc_client: grpc_client_config(config),
+        delay_sources_past_rehydration: config.storage_dataflow_delay_sources_past_rehydration(),
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -907,7 +907,7 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
 /// (namely, upsert) till after rehydration is finished.
 const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("storage_dataflow_delay_sources_past_rehydration"),
-    value: &true,
+    value: &false,
     description: "Whether or not to delay sources producing values in some scenarios \
                   (namely, upsert) till after rehydration is finished",
     internal: true,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -903,6 +903,16 @@ const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
     internal: true,
 };
 
+/// Whether or not to delay sources producing values in some scenarios
+/// (namely, upsert) till after rehydration is finished.
+const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("storage_dataflow_delay_sources_past_rehydration"),
+    value: &true,
+    description: "Whether or not to delay sources producing values in some scenarios \
+                  (namely, upsert) till after rehydration is finished",
+    internal: true,
+};
+
 /// The fraction of the cluster replica size to be used as the maximum number of
 /// in-flight bytes emitted by persist_sources feeding storage dataflows.
 /// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
@@ -2046,6 +2056,7 @@ impl SystemVars {
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
+            .with_var(&STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
@@ -2541,6 +2552,11 @@ impl SystemVars {
     /// Returns the `storage_dataflow_max_inflight_bytes_to_cluster_size_fraction` configuration parameter.
     pub fn storage_dataflow_max_inflight_bytes_to_cluster_size_fraction(&self) -> Option<Numeric> {
         *self.expect_value(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
+    }
+
+    /// Returns the `storage_dataflow_max_inflight_bytes` configuration parameter.
+    pub fn storage_dataflow_delay_sources_past_rehydration(&self) -> bool {
+        *self.expect_value(&STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION)
     }
 
     /// Returns the `storage_dataflow_max_inflight_bytes_disk_only` configuration parameter.
@@ -4064,6 +4080,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
+        || name == STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION.name()
         || is_upsert_rocksdb_config_var(name)
         || is_persist_config_var(name)
         || is_tracing_var(name)

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -29,6 +29,7 @@ message ProtoStorageParameters {
     ProtoUpsertAutoSpillConfig upsert_auto_spill_config = 9;
     ProtoStorageMaxInflightBytesConfig storage_dataflow_max_inflight_bytes_config = 10;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 11;
+    bool storage_dataflow_delay_sources_past_rehydration = 12;
 }
 
 

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -46,6 +46,8 @@ pub struct StorageParameters {
     pub storage_dataflow_max_inflight_bytes_config: StorageMaxInflightBytesConfig,
     /// gRPC client parameters.
     pub grpc_client: GrpcClientParameters,
+    /// Configuration for basic hydration backpressure.
+    pub delay_sources_past_rehydration: bool,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -127,6 +129,7 @@ impl StorageParameters {
             upsert_auto_spill_config,
             storage_dataflow_max_inflight_bytes_config,
             grpc_client,
+            delay_sources_past_rehydration,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -141,6 +144,7 @@ impl StorageParameters {
         self.storage_dataflow_max_inflight_bytes_config =
             storage_dataflow_max_inflight_bytes_config;
         self.grpc_client.update(grpc_client);
+        self.delay_sources_past_rehydration = delay_sources_past_rehydration;
     }
 }
 
@@ -163,6 +167,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 self.storage_dataflow_max_inflight_bytes_config.into_proto(),
             ),
             grpc_client: Some(self.grpc_client.into_proto()),
+            storage_dataflow_delay_sources_past_rehydration: self.delay_sources_past_rehydration,
         }
     }
 
@@ -198,6 +203,7 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             grpc_client: proto
                 .grpc_client
                 .into_rust_if_some("ProtoStorageParameters::grpc_client")?,
+            delay_sources_past_rehydration: proto.storage_dataflow_delay_sources_past_rehydration,
         })
     }
 }

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -35,6 +35,8 @@ pub struct DataflowParameters {
     /// used in `UPSERT/DEBEZIUM` sources.
     pub storage_dataflow_max_inflight_bytes_config:
         mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
+    /// Configuration for basic hydration backpressure.
+    pub delay_sources_past_rehydration: bool,
 }
 
 impl DataflowParameters {
@@ -45,12 +47,14 @@ impl DataflowParameters {
         rocksdb_params: mz_rocksdb::RocksDBTuningParameters,
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
         storage_dataflow_max_inflight_bytes_config: mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
+        delay_sources_past_rehydration: bool,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.upsert_rocksdb_tuning_config.apply(rocksdb_params);
         self.auto_spill_config = auto_spill_config;
         self.storage_dataflow_max_inflight_bytes_config =
             storage_dataflow_max_inflight_bytes_config;
+        self.delay_sources_past_rehydration = delay_sources_past_rehydration;
     }
 }
 
@@ -101,6 +105,8 @@ pub enum InternalStorageCommand {
             mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
         /// Upsert autospill configuration.
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
+        /// Configuration for basic hydration backpressure.
+        delay_sources_past_rehydration: bool,
     },
 }
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -134,6 +134,17 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
         remap_collection_id: description.remap_collection_id.clone(),
     };
 
+    // A set of channels (1 per worker) used to signal rehydration being finished
+    // to raw sources. These are channels and not timely streams because they
+    // have to cross a scope boundary.
+    //
+    // Note that these will be entirely subsumed by full `hydration` backpressure,
+    // once that is implemented.
+    let (starter, mut start_signal) = tokio::sync::mpsc::channel::<()>(1);
+    let start_signal = async move {
+        let _ = start_signal.recv().await;
+    };
+
     // Build the _raw_ ok and error sources using `create_raw_source` and the
     // correct `SourceReader` implementations
     let (streams, mut health, capability) = match connection {
@@ -144,6 +155,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 base_source_config.clone(),
                 connection,
                 storage_state.connection_context.clone(),
+                start_signal,
             );
             let streams: Vec<_> = streams
                 .into_iter()
@@ -158,6 +170,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 base_source_config.clone(),
                 connection,
                 storage_state.connection_context.clone(),
+                start_signal,
             );
             let streams: Vec<_> = streams
                 .into_iter()
@@ -172,6 +185,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 base_source_config.clone(),
                 connection,
                 storage_state.connection_context.clone(),
+                start_signal,
             );
             let streams: Vec<_> = streams
                 .into_iter()
@@ -186,6 +200,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 base_source_config.clone(),
                 connection,
                 storage_state.connection_context.clone(),
+                start_signal,
             );
             let streams: Vec<_> = streams
                 .into_iter()
@@ -216,6 +231,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
             error_collections,
             storage_state,
             base_source_config.clone(),
+            starter.clone(),
         );
         needed_tokens.extend(extra_tokens);
         outputs.push((ok, err));
@@ -237,6 +253,7 @@ fn render_source_stream<G>(
     mut error_collections: Vec<Collection<G, DataflowError, Diff>>,
     storage_state: &mut crate::storage_state::StorageState,
     base_source_config: RawSourceCreationConfig,
+    rehydrated_token: impl std::any::Any + 'static,
 ) -> (
     Collection<G, Row, Diff>,
     Collection<G, DataflowError, Diff>,
@@ -483,29 +500,47 @@ where
                                 refine_antichain(&resume_upper),
                                 previous,
                                 previous_token,
-                                base_source_config,
+                                base_source_config.clone(),
                                 &storage_state.instance_context,
                                 &storage_state.dataflow_parameters,
                                 backpressure_metrics,
                             );
 
+                            use mz_timely_util::probe::ProbeNotify;
+                            let handle = mz_timely_util::probe::Handle::default();
+                            let upsert = upsert.inner.probe_notify_with(vec![handle.clone()]);
+                            let probe = mz_timely_util::probe::source(
+                                scope.clone(),
+                                format!("upsert_probe({id})"),
+                                handle,
+                            );
+
+                            // If configured, delay raw sources until we rehydrate the upsert
+                            // source. Otherwise, drop the token, unblocking the sources at the
+                            // end rendering.
+                            if storage_state
+                                .dataflow_parameters
+                                .delay_sources_past_rehydration
+                            {
+                                crate::render::upsert::rehydration_finished(
+                                    scope.clone(),
+                                    &base_source_config,
+                                    rehydrated_token,
+                                    refine_antichain(&resume_upper),
+                                    &probe,
+                                );
+                            } else {
+                                drop(rehydrated_token)
+                            };
+
                             // If backpressure is enabled, we probe the upsert operator's
                             // output, which is the easiest way to extract frontier information.
                             let upsert = match feedback_handle {
                                 Some(feedback_handle) => {
-                                    use mz_timely_util::probe::ProbeNotify;
-                                    let handle = mz_timely_util::probe::Handle::default();
-                                    let upsert =
-                                        upsert.inner.probe_notify_with(vec![handle.clone()]);
-                                    mz_timely_util::probe::source(
-                                        scope.clone(),
-                                        format!("upsert_probe({id})"),
-                                        handle,
-                                    )
-                                    .connect_loop(feedback_handle);
+                                    probe.connect_loop(feedback_handle);
                                     upsert.as_collection()
                                 }
-                                None => upsert,
+                                None => upsert.as_collection(),
                             };
 
                             (upsert.leave(), health_update.leave())

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -80,6 +80,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
         config: RawSourceCreationConfig,
         _connection_context: ConnectionContext,
         _resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+        _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<
             G,

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -111,6 +111,7 @@ impl SourceRender for KafkaSourceConnection {
         connection_context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<Partitioned<PartitionId, MzOffset>>>
             + 'static,
+        start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<
             G,
@@ -133,6 +134,53 @@ impl SourceRender for KafkaSourceConnection {
             let health_cap = capabilities.pop().unwrap();
             let mut data_cap = capabilities.pop().unwrap();
             assert!(capabilities.is_empty());
+
+            // Start offsets is a map from partition to the next offset to read
+            // from.
+            let mut start_offsets: BTreeMap<_, i64> = self
+                .start_offsets.clone()
+                .into_iter()
+                .filter(|(pid, _offset)| config.responsible_for(pid))
+                .map(|(k, v)| (k, v))
+                .collect();
+
+            let mut partition_capabilities = BTreeMap::new();
+            let mut max_pid = None;
+            let resume_upper = Antichain::from_iter(
+                config.source_resume_uppers[&config.id]
+                    .iter()
+                    .map(Partitioned::<_, _>::decode_row),
+            );
+            for ts in resume_upper.elements() {
+                if let Some(pid) = ts.partition() {
+                    max_pid = std::cmp::max(max_pid, Some(*pid));
+                    if config.responsible_for(pid) {
+                        let restored_offset = i64::try_from(ts.timestamp().offset)
+                            .expect("restored kafka offsets must fit into i64");
+                        if let Some(start_offset) = start_offsets.get_mut(pid) {
+                            *start_offset = std::cmp::max(restored_offset, *start_offset);
+                        } else {
+                            start_offsets.insert(*pid, restored_offset);
+                        }
+
+                        let part_ts = Partitioned::with_partition(*pid, ts.timestamp().clone());
+                        partition_capabilities.insert(*pid, data_cap.delayed(&part_ts));
+                    }
+                }
+            }
+            let future_ts = Partitioned::with_range(max_pid, None, MzOffset::from(0));
+            data_cap.downgrade(&future_ts);
+
+            // Note that we wait for this AFTER we downgrade to the source `resume_upper`. This
+            // allows downstream operators (namely, the `reclock_operator`) to downgrade to the
+            // `resume_upper`, which is necessary for this basic form of backpressure to work.
+            start_signal.await;
+            info!(
+                source_id = config.id.to_string(),
+                worker_id = config.worker_id,
+                num_workers = config.worker_count,
+                "kafka worker noticed rehydration is finished, instantiating Kafka source reader at offsets {start_offsets:?}"
+            );
 
             let group_id = self.group_id(config.id);
             let KafkaSourceConnection {
@@ -212,49 +260,6 @@ impl SourceRender for KafkaSourceConnection {
                     unreachable!("pending future never returns");
                 }
             };
-
-            // Start offsets is a map from partition to the next offset to read
-            // from.
-            let mut start_offsets: BTreeMap<_, i64> = self
-                .start_offsets
-                .into_iter()
-                .filter(|(pid, _offset)| config.responsible_for(pid))
-                .map(|(k, v)| (k, v))
-                .collect();
-
-            let mut partition_capabilities = BTreeMap::new();
-            let mut max_pid = None;
-            let resume_upper = Antichain::from_iter(
-                config.source_resume_uppers[&config.id]
-                    .iter()
-                    .map(Partitioned::<_, _>::decode_row),
-            );
-            for ts in resume_upper.elements() {
-                if let Some(pid) = ts.partition() {
-                    max_pid = std::cmp::max(max_pid, Some(*pid));
-                    if config.responsible_for(pid) {
-                        let restored_offset = i64::try_from(ts.timestamp().offset)
-                            .expect("restored kafka offsets must fit into i64");
-                        if let Some(start_offset) = start_offsets.get_mut(pid) {
-                            *start_offset = std::cmp::max(restored_offset, *start_offset);
-                        } else {
-                            start_offsets.insert(*pid, restored_offset);
-                        }
-
-                        let part_ts = Partitioned::with_partition(*pid, ts.timestamp().clone());
-                        partition_capabilities.insert(*pid, data_cap.delayed(&part_ts));
-                    }
-                }
-            }
-            let future_ts = Partitioned::with_range(max_pid, None, MzOffset::from(0));
-            data_cap.downgrade(&future_ts);
-
-            info!(
-                source_id = config.id.to_string(),
-                worker_id = config.worker_id,
-                num_workers = config.worker_count,
-                "instantiating Kafka source reader at offsets {start_offsets:?}"
-            );
 
             let partition_info = Arc::new(Mutex::new(None));
             let metadata_thread_handle = {

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -123,6 +123,7 @@ impl SourceRender for PostgresSourceConnection {
         config: RawSourceCreationConfig,
         context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+        _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<G, (usize, Result<SourceMessage<(), Row>, SourceReaderError>), Diff>,
         Option<Stream<G, Infallible>>,

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -53,6 +53,7 @@ impl SourceRender for TestScriptSourceConnection {
         config: RawSourceCreationConfig,
         _connection_context: ConnectionContext,
         _resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
+        _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<
             G,
@@ -72,6 +73,7 @@ impl SourceRender for TestScriptSourceConnection {
 
         let button = builder.build(move |caps| async move {
             let mut cap = caps.into_element();
+
             let commands: Vec<ScriptCommand> =
                 serde_json::from_str(&self.desc_json).expect("Invalid command description");
 

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -73,6 +73,7 @@ pub trait SourceRender {
         config: RawSourceCreationConfig,
         connection_context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<Self::Time>> + 'static,
+        start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
         Collection<
             G,

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -860,11 +860,13 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 rocksdb,
                 storage_dataflow_max_inflight_bytes_config,
                 auto_spill_config,
+                delay_sources_past_rehydration,
             } => self.storage_state.dataflow_parameters.update(
                 pg,
                 rocksdb,
                 auto_spill_config,
                 storage_dataflow_max_inflight_bytes_config,
+                delay_sources_past_rehydration,
             ),
         }
     }
@@ -1180,6 +1182,7 @@ impl StorageState {
                         storage_dataflow_max_inflight_bytes_config: params
                             .storage_dataflow_max_inflight_bytes_config,
                         auto_spill_config: params.upsert_auto_spill_config,
+                        delay_sources_past_rehydration: params.delay_sources_past_rehydration,
                     })
                 }
             }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -36,6 +36,7 @@ SERVICES = [
         additional_system_parameter_defaults={
             "disk_cluster_replicas_default": "true",
             "enable_unmanaged_cluster_replicas": "true",
+            "storage_dataflow_delay_sources_past_rehydration": "true",
         },
         environment_extra=materialized_environment_extra,
     ),
@@ -170,6 +171,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
                     "storage_dataflow_max_inflight_bytes_disk_only": "false",
+                    "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
                 environment_extra=materialized_environment_extra,
             ),
@@ -192,6 +194,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
                     "storage_dataflow_max_inflight_bytes_disk_only": "false",
+                    "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
                 environment_extra=materialized_environment_extra,
             ),
@@ -296,7 +299,8 @@ def workflow_incident_49(c: Composition) -> None:
             "with DISK",
             Materialized(
                 additional_system_parameter_defaults={
-                    "disk_cluster_replicas_default": "true"
+                    "disk_cluster_replicas_default": "true",
+                    "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
                 environment_extra=materialized_environment_extra,
             ),
@@ -305,7 +309,8 @@ def workflow_incident_49(c: Composition) -> None:
             "without DISK",
             Materialized(
                 additional_system_parameter_defaults={
-                    "disk_cluster_replicas_default": "false"
+                    "disk_cluster_replicas_default": "false",
+                    "storage_dataflow_delay_sources_past_rehydration": "true",
                 },
                 environment_extra=materialized_environment_extra,
             ),
@@ -410,6 +415,7 @@ def workflow_autospill(c: Composition) -> None:
                 "upsert_source_disk_default": "true",
                 "upsert_rocksdb_auto_spill_to_disk": "true",
                 "upsert_rocksdb_auto_spill_threshold_bytes": "200",
+                "storage_dataflow_delay_sources_past_rehydration": "true",
             },
         ),
     ):


### PR DESCRIPTION
This pr implements an _extremely_ constrained version of "hydration backpressure" that delays the creation of kafka consumers until after the `upsert` operator has rehydrated the state.

Couple important notes about the implementation
- This impl will be subsumed by full hydration backpressure someday
- Channels instead of timely streams are used, because we need this information to flow across distinct timestamp scopes
- Only Kafka sources are supported, others ignore the new api on `SourceReader::render
- There is of course, an LD flag that restores the old behavior exactly.

Some of the subtleties around ts management are mentioned in comments inline!

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
