### PR TITLE
persist: fix "force keep" stats trimming bug

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -208,27 +208,14 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: kafka-persistence
-    label: Kafka persistence
+  - id: persistence
+    label: Persistence tests
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: persistence
-          run: kafka-sources
-    agents:
-      queue: linux-x86_64
-
-  - id: table-persistence
-    label: Table persistence
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persistence
-          run: user-tables
     agents:
       queue: linux-x86_64
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -474,10 +474,13 @@ class Composition:
         sql: str,
         service: str = "materialized",
         user: str = "materialize",
+        port: Optional[int] = None,
         password: Optional[str] = None,
     ) -> Any:
         """Execute and return results of a SQL query."""
-        with self.sql_cursor(service=service, user=user, password=password) as cursor:
+        with self.sql_cursor(
+            service=service, user=user, port=port, password=password
+        ) as cursor:
             cursor.execute(sql)
             return cursor.fetchall()
 

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -683,10 +683,15 @@ pub(crate) struct BatchParts<T> {
     batch_metrics: BatchWriteMetrics,
 }
 
+// NB: In practice, the inputs to this end up getting downcased before they make
+// it here.
 fn force_keep_stats_col(name: &str) -> bool {
-    name == "mz_internal_super_secret_source_data_errors"
-        || name == "timestamp"
+    // If we trim the "err" column, then we can't ever use pushdown on this part
+    // (because it could have >0 errors).
+    name == "err"
+        // Various flavors of timestamp column names found in the wild.
         || name == "ts"
+        || name.ends_with("timestamp")
         || name.ends_with("time")
         || name.ends_with("_at")
         || name.starts_with("last_")


### PR DESCRIPTION
This was found by a customer who was trying to use pushdown. When it didn't work, we looked at the stats and found the entire "ok" struct containing the timestamp field had been trimmed, which is not how the force_keep_col stuff is meant to work.

Concretely, trim_to_budget method previously only operates on the top level struct columns. This (sorta) worked before #19309, but now there are always two columns at the top level, "ok" and "err", and the real columns are all nested under "ok". As a result, we'd end up trimming the entire "ok" struct before even getting a chance to hand the timestamp column to force_keep_col.

The fix is to make trim_to_budget recursive, also keeping any ancestors of "force keep" columns.


### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

I manually tested this with bin/environmentd and the following:

```
CREATE TABLE foo (big0 string, big1 string, big2 string, big3 string, big4 string, big5 string, barTimestamp string, big6 string, big7 string);
INSERT INTO foo VALUES (repeat('x', 1024), repeat('x', 1024), repeat('x', 1024), repeat('x', 1024), repeat('x', 1024), repeat('x', 1024), repeat('SENTINEL', 2048), repeat('x', 1024), repeat('x', 1024));
INSPECT SHARD 'u1';
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
