### PR TITLE
adapter: Use timestamps in constant queries

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -342,7 +342,7 @@ impl crate::coord::Coordinator {
             };
         }
 
-        let timestamp = determination.timestamp_context.timestamp_or_default();
+        let timestamp = determination.timestamp_context.timestamp_owned();
 
         // The remaining cases are a peek into a maintained arrangement, or building a dataflow.
         // In both cases we will want to peek, and the main difference is that we might want to

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -325,7 +325,7 @@ fn test_timestamp_selection() {
                     if tc.args.contains_key("full") {
                         format!("{}\n", serde_json::to_string_pretty(&ts).unwrap())
                     } else {
-                        format!("{}\n", ts.timestamp_context.timestamp_or_default())
+                        format!("{}\n", ts.timestamp_context.timestamp_owned())
                     }
                 }
                 _ => panic!("unknown directive {}", tc.directive),

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1347,7 +1347,7 @@ fn test_github_18950() {
 
         let explain: String = row.get(0);
         let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
-        let explain_timestamp = explain.determination.timestamp_context.timestamp().unwrap();
+        let explain_timestamp = explain.determination.timestamp_context.timestamp();
 
         if let Some(timestamp) = query_timestamp {
             assert_eq!(timestamp, *explain_timestamp);
@@ -1413,7 +1413,7 @@ fn test_github_18950() {
 
     let explain: String = row.get(0);
     let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
-    let explain_timestamp = explain.determination.timestamp_context.timestamp().unwrap();
+    let explain_timestamp = explain.determination.timestamp_context.timestamp();
 
     assert_eq!(*explain_timestamp, mz_now_timestamp);
 }

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -94,3 +94,42 @@ SELECT * FROM data AS OF NULL::numeric;
 
 query error can't use null as a mz_timestamp for AS OF
 SUBSCRIBE (SELECT 1) AS OF NULL::timestamptz;
+
+# Test that timestamps are used for constant queries
+
+statement ok
+create view events_over_time as values ('joe', 100), ('mike', 101), ('sam', 200);
+
+statement ok
+create view events as select * from events_over_time where mz_now() >= column2;
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE events AS OF 0
+
+query IITI
+FETCH ALL c
+----
+100  1  joe   100
+101  1  mike  101
+200  1  sam   200
+
+statement ok
+COMMIT
+
+query TI
+SELECT * FROM events AS OF 0
+----
+
+query TI
+SELECT * FROM events AS OF 100
+----
+joe  100
+
+query TI
+SELECT * FROM events AS OF 101
+----
+joe  100
+mike 101


### PR DESCRIPTION
Previously, the timestamp chosen by the Coordinator for constant queries was always the maximum timestamp. The rationale was that the answer to constant queries were known up to the end of time, so we choose the freshest timestamp possible.

There was also some code gymnastics we did to all allow constant queries in any type of transaction. Ignoring the timestamp for these queries made this gymnastics easier.

Timestamps chosen for constant queries affect the answer if the query has with a temporal filter or the query uses AS OF. So previously, we would give the wrong answer for these types of queries.

This commit updates timestamp selection for constant queries so that we pick a valid, potentially non-maximum, timestamp. The logic for timestamp selection is the same as non-constant queries.

Fixes #18948

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - TODO: Figure out how to explain this in release notes that makes sense.
