### PR TITLE
adapter: Use timestamps for temporal subscribes

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2572,10 +2572,8 @@ impl Coordinator {
         let id_bundle = self
             .index_oracle(cluster_id)
             .sufficient_collections(&depends_on);
-        let mut timeline = self.validate_timeline_context(id_bundle.iter())?;
-        if matches!(timeline, TimelineContext::TimestampIndependent)
-            && (from.contains_temporal() || when.advance_to_timestamp().is_some())
-        {
+        let mut timeline = self.validate_timeline_context(depends_on.clone())?;
+        if matches!(timeline, TimelineContext::TimestampIndependent) && from.contains_temporal() {
             // If the from IDs are timestamp independent but the query contains temporal functions,
             // or uses AS OF then the timeline context needs to be upgraded to timestamp dependent.
             timeline = TimelineContext::TimestampDependent;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2574,8 +2574,8 @@ impl Coordinator {
             .sufficient_collections(&depends_on);
         let mut timeline = self.validate_timeline_context(depends_on.clone())?;
         if matches!(timeline, TimelineContext::TimestampIndependent) && from.contains_temporal() {
-            // If the from IDs are timestamp independent but the query contains temporal functions,
-            // or uses AS OF then the timeline context needs to be upgraded to timestamp dependent.
+            // If the from IDs are timestamp independent but the query contains temporal functions
+            // then the timeline context needs to be upgraded to timestamp dependent.
             timeline = TimelineContext::TimestampDependent;
         }
         let as_of = self

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -759,6 +759,13 @@ impl SubscribeFrom {
             SubscribeFrom::Query { expr, .. } => expr.depends_on(),
         }
     }
+
+    pub fn contains_temporal(&self) -> bool {
+        match self {
+            SubscribeFrom::Id(_) => false,
+            SubscribeFrom::Query { expr, .. } => expr.contains_temporal(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -98,7 +98,7 @@ SUBSCRIBE (SELECT 1) AS OF NULL::timestamptz;
 # Test that timestamps are used for constant queries
 
 statement ok
-create view events_over_time as values ('joe', 100), ('mike', 101), ('sam', 200);
+create view events_over_time as values ('joe', 100), ('mike', 101), ('sam', 200), ('end', 18446744073709551615);
 
 statement ok
 create view events as select * from events_over_time where mz_now() >= column2;
@@ -112,9 +112,10 @@ DECLARE c CURSOR FOR SUBSCRIBE events AS OF 0
 query IITI
 FETCH ALL c
 ----
-100  1  joe   100
-101  1  mike  101
-200  1  sam   200
+100                   1  joe   100
+101                   1  mike  101
+200                   1  sam   200
+18446744073709551615  1  end  18446744073709551615
 
 statement ok
 COMMIT
@@ -140,11 +141,24 @@ BEGIN
 statement ok
 DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1) AS OF 42
 
-# TODO(jkosh44) Is this right? What timestamp should be displayed???
 query III
 FETCH ALL c
 ----
 42  1  1
+
+statement ok
+COMMIT
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1)
+
+query III
+FETCH ALL c
+----
+18446744073709551615  1  1
 
 statement ok
 COMMIT

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -95,7 +95,7 @@ SELECT * FROM data AS OF NULL::numeric;
 query error can't use null as a mz_timestamp for AS OF
 SUBSCRIBE (SELECT 1) AS OF NULL::timestamptz;
 
-# Test that timestamps are used for constant queries
+# Test that timestamps are used for constant queries with temporal filters
 
 statement ok
 create view events_over_time as values ('joe', 100), ('mike', 101), ('sam', 200), ('end', 18446744073709551615);

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -141,10 +141,11 @@ BEGIN
 statement ok
 DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1) AS OF 42
 
+# TODO(jkosh44) It's not entirely clear what the answer to this should be.
 query III
 FETCH ALL c
 ----
-42  1  1
+18446744073709551615  1  1
 
 statement ok
 COMMIT

--- a/test/sqllogictest/as_of.slt
+++ b/test/sqllogictest/as_of.slt
@@ -94,3 +94,57 @@ SELECT * FROM data AS OF NULL::numeric;
 
 query error can't use null as a mz_timestamp for AS OF
 SUBSCRIBE (SELECT 1) AS OF NULL::timestamptz;
+
+# Test that timestamps are used for constant queries
+
+statement ok
+create view events_over_time as values ('joe', 100), ('mike', 101), ('sam', 200);
+
+statement ok
+create view events as select * from events_over_time where mz_now() >= column2;
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE events AS OF 0
+
+query IITI
+FETCH ALL c
+----
+100  1  joe   100
+101  1  mike  101
+200  1  sam   200
+
+statement ok
+COMMIT
+
+query TI
+SELECT * FROM events AS OF 0
+----
+
+query TI
+SELECT * FROM events AS OF 100
+----
+joe  100
+
+query TI
+SELECT * FROM events AS OF 101
+----
+joe  100
+mike 101
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c CURSOR FOR SUBSCRIBE (SELECT 1) AS OF 42
+
+# TODO(jkosh44) Is this right? What timestamp should be displayed???
+query III
+FETCH ALL c
+----
+42  1  1
+
+statement ok
+COMMIT


### PR DESCRIPTION
Previously, all subscribes that were timeline independent were
considered timestamps independent. This is not always true, if a
subscribe contains a temporal filter then it is timestamp dependent
even if it is timeline independent. This logic was already being done
for peeks but was left off of subscribes. This commit adds the logic to
promote timeline independent temporal subscribes to timestamps
dependent.

Fixes #18948

### Motivation
  * This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix timestamp selection for `SUBSCRIBE`s with temporal filters.
