### PR TITLE
Adding more upsert stats

### DIFF
--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -15,6 +15,7 @@ mz-ore = { path = "../ore", features = ["async", "metrics", "test"] }
 mz-proto = { path = "../proto" }
 mz-rocksdb-types = { path = "../rocksdb-types" }
 num_cpus = "1.14.0"
+prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -184,6 +184,8 @@ pub struct RocksDBInstanceMetrics {
     pub multi_get_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     /// Size of multi_get non-empty results.
     pub multi_get_result_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    /// Total size of bytes returned in the result
+    pub multi_get_result_bytes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     /// Size of write batches.
     pub multi_put_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
@@ -623,6 +625,9 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                         instance_metrics
                             .multi_get_result_count
                             .inc_by(returned_gets);
+                        instance_metrics
+                            .multi_get_result_bytes
+                            .inc_by(processed_gets_size);
                         batch.clear();
                         response_sender.send(Ok((
                             MultiGetResult {

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -186,6 +186,10 @@ pub struct RocksDBInstanceMetrics {
     pub multi_get_result_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     /// Total size of bytes returned in the result
     pub multi_get_result_bytes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    /// The number of calls to rocksdb multi_get
+    pub multi_get_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    /// The number of calls to rocksdb multi_put
+    pub multi_put_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     /// Size of write batches.
     pub multi_put_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 }
@@ -585,6 +589,7 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                                 instance_metrics
                                     .multi_get_size
                                     .inc_by(batch_size.try_into().unwrap());
+                                instance_metrics.multi_get_count.inc();
 
                                 RetryResult::Ok(gets)
                             }
@@ -708,6 +713,7 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                                 instance_metrics
                                     .multi_put_size
                                     .inc_by(batch_size.try_into().unwrap());
+                                instance_metrics.multi_put_count.inc();
                                 RetryResult::Ok(())
                             }
                             Err(e) => match e.kind() {

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -583,9 +583,8 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                                 instance_metrics
                                     .multi_get_size
                                     .inc_by(batch_size.try_into().unwrap());
-                                let processed_gets: u64 = gets.len().try_into().unwrap();
 
-                                RetryResult::Ok((processed_gets, gets))
+                                RetryResult::Ok(gets)
                             }
                             Err(e) => match e.kind() {
                                 ErrorKind::TryAgain => RetryResult::RetryableErr(Error::RocksDB(e)),
@@ -595,7 +594,8 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                     });
 
                 let _ = match retry_result {
-                    Ok((processed_gets, gets)) => {
+                    Ok(gets) => {
+                        let processed_gets: u64 = gets.len().try_into().unwrap();
                         let mut processed_gets_size = 0;
                         let mut returned_gets: u64 = 0;
                         for previous_value in gets {

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -84,8 +84,10 @@ fn metrics_for_tests() -> Result<Box<RocksDBMetrics>, anyhow::Error> {
     Ok(Box::new(RocksDBMetrics {
         multi_get_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["one".to_string()]),
         multi_get_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["two".to_string()]),
-        multi_put_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["three".to_string()]),
-        multi_put_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
+        multi_get_result_size: fake_hist_vec
+            .get_delete_on_drop_histogram(vec!["three".to_string()]),
+        multi_put_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
+        multi_put_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["five".to_string()]),
     }))
 }
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -73,21 +73,23 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
-use mz_ore::metrics::HistogramVecExt;
+use mz_ore::metrics::{CounterVecExt, HistogramVecExt};
 use mz_rocksdb::{InstanceOptions, RocksDBConfig, RocksDBInstance, RocksDBMetrics};
-use prometheus::{HistogramOpts, HistogramVec};
+use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
 
 fn metrics_for_tests() -> Result<Box<RocksDBMetrics>, anyhow::Error> {
     let fake_hist_vec =
         HistogramVec::new(HistogramOpts::new("fake", "fake_help"), &["fake_label"])?;
+    let face_counter_vec =
+        IntCounterVec::new(Opts::new("fake_counter", "fake_help"), &["fake_label"])?;
 
     Ok(Box::new(RocksDBMetrics {
         multi_get_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["one".to_string()]),
-        multi_get_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["two".to_string()]),
-        multi_get_result_size: fake_hist_vec
-            .get_delete_on_drop_histogram(vec!["three".to_string()]),
+        multi_get_size: face_counter_vec.get_delete_on_drop_counter(vec!["two".to_string()]),
+        multi_get_result_size: face_counter_vec
+            .get_delete_on_drop_counter(vec!["three".to_string()]),
         multi_put_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["four".to_string()]),
-        multi_put_size: fake_hist_vec.get_delete_on_drop_histogram(vec!["five".to_string()]),
+        multi_put_size: face_counter_vec.get_delete_on_drop_counter(vec!["five".to_string()]),
     }))
 }
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -97,6 +97,8 @@ fn instance_metrics_for_tests() -> Result<Box<RocksDBInstanceMetrics>, anyhow::E
         multi_get_size: face_counter_vec.get_delete_on_drop_counter(vec!["two".to_string()]),
         multi_get_result_count: face_counter_vec
             .get_delete_on_drop_counter(vec!["three".to_string()]),
+        multi_get_result_bytes: face_counter_vec
+            .get_delete_on_drop_counter(vec!["four".to_string()]),
         multi_put_size: face_counter_vec.get_delete_on_drop_counter(vec!["five".to_string()]),
     }))
 }

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -99,7 +99,9 @@ fn instance_metrics_for_tests() -> Result<Box<RocksDBInstanceMetrics>, anyhow::E
             .get_delete_on_drop_counter(vec!["three".to_string()]),
         multi_get_result_bytes: face_counter_vec
             .get_delete_on_drop_counter(vec!["four".to_string()]),
-        multi_put_size: face_counter_vec.get_delete_on_drop_counter(vec!["five".to_string()]),
+        multi_get_count: face_counter_vec.get_delete_on_drop_counter(vec!["five".to_string()]),
+        multi_put_count: face_counter_vec.get_delete_on_drop_counter(vec!["six".to_string()]),
+        multi_put_size: face_counter_vec.get_delete_on_drop_counter(vec!["seven".to_string()]),
     }))
 }
 

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -74,16 +74,16 @@
 // END LINT CONFIG
 
 use mz_ore::metrics::{CounterVecExt, HistogramVecExt};
-use mz_rocksdb::{InstanceOptions, RocksDBConfig, RocksDBInstance, RocksDBMetrics};
+use mz_rocksdb::{InstanceOptions, RocksDBConfig, RocksDBInstance, RocksDBSharedMetrics};
 use prometheus::{HistogramOpts, HistogramVec, IntCounterVec, Opts};
 
-fn metrics_for_tests() -> Result<Box<RocksDBMetrics>, anyhow::Error> {
+fn metrics_for_tests() -> Result<Box<RocksDBSharedMetrics>, anyhow::Error> {
     let fake_hist_vec =
         HistogramVec::new(HistogramOpts::new("fake", "fake_help"), &["fake_label"])?;
     let face_counter_vec =
         IntCounterVec::new(Opts::new("fake_counter", "fake_help"), &["fake_label"])?;
 
-    Ok(Box::new(RocksDBMetrics {
+    Ok(Box::new(RocksDBSharedMetrics {
         multi_get_latency: fake_hist_vec.get_delete_on_drop_histogram(vec!["one".to_string()]),
         multi_get_size: face_counter_vec.get_delete_on_drop_counter(vec!["two".to_string()]),
         multi_get_result_size: face_counter_vec

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -177,7 +177,8 @@ where
             source_config.worker_id,
             source_config.id
         );
-        let rocksdb_metrics = Arc::clone(&upsert_metrics.rocksdb);
+        let rocksdb_shared_metrics = Arc::clone(&upsert_metrics.rocksdb_shared);
+        let rocksdb_instance_metrics = Arc::clone(&upsert_metrics.rocksdb_instance_metrics);
         let rocksdb_dir = scratch_directory
             .join(source_config.id.to_string())
             .join(source_config.worker_id.to_string());
@@ -201,7 +202,8 @@ where
                             instance_path: rocksdb_dir,
                             env,
                             tuning_config: tuning,
-                            metrics: rocksdb_metrics,
+                            shared_metrics: rocksdb_shared_metrics,
+                            instance_metrics: rocksdb_instance_metrics,
                         },
                         spill_threshold,
                         rocksdb_in_use_metric,
@@ -223,7 +225,8 @@ where
                             &rocksdb_dir,
                             mz_rocksdb::InstanceOptions::defaults_with_env(env),
                             tuning,
-                            rocksdb_metrics,
+                            rocksdb_shared_metrics,
+                            rocksdb_instance_metrics,
                             // For now, just use the same config as the one used for
                             // merging snapshots.
                             upsert_bincode_opts(),

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -95,6 +95,7 @@ impl UpsertStateBackend for RocksDB {
 
         g_stats.processed_gets += stats.processed_gets;
         g_stats.processed_gets_size += stats.processed_gets_size;
+        g_stats.returned_gets += stats.returned_gets;
         Ok(g_stats)
     }
 }

--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -94,6 +94,7 @@ impl UpsertStateBackend for RocksDB {
             .await?;
 
         g_stats.processed_gets += stats.processed_gets;
+        g_stats.processed_gets_size += stats.processed_gets_size;
         Ok(g_stats)
     }
 }

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -857,6 +857,9 @@ where
         self.worker_metrics
             .multi_get_result_count
             .inc_by(stats.returned_gets);
+        self.worker_metrics
+            .multi_get_result_bytes
+            .inc_by(stats.processed_gets_size);
 
         Ok(())
     }

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -75,7 +75,7 @@ use std::time::Instant;
 
 use bincode::Options;
 use itertools::Itertools;
-use mz_ore::cast::{CastFrom, CastLossy};
+use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::DeleteOnDropGauge;
 use mz_rocksdb::RocksDBConfig;
@@ -733,9 +733,7 @@ where
         self.metrics
             .merge_snapshot_latency
             .observe(now.elapsed().as_secs_f64());
-        self.metrics
-            .merge_snapshot_updates
-            .observe(f64::cast_lossy(stats.updates));
+        self.metrics.merge_snapshot_updates.inc_by(stats.updates);
 
         self.snapshot_stats += stats;
         // Updating the metrics
@@ -797,9 +795,7 @@ where
         self.metrics
             .multi_put_latency
             .observe(now.elapsed().as_secs_f64());
-        self.metrics
-            .multi_put_size
-            .observe(f64::cast_lossy(stats.processed_puts));
+        self.metrics.multi_put_size.inc_by(stats.processed_puts);
 
         self.stats.update_envelope_state_bytes_by(stats.size_diff);
         self.stats.update_envelope_state_count_by(stats.values_diff);
@@ -828,9 +824,7 @@ where
         self.metrics
             .multi_get_latency
             .observe(now.elapsed().as_secs_f64());
-        self.metrics
-            .multi_get_size
-            .observe(f64::cast_lossy(stats.processed_gets));
+        self.metrics.multi_get_size.inc_by(stats.processed_gets);
 
         Ok(())
     }

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -349,8 +349,10 @@ pub struct PutStats {
 /// Statistics for a single call to `multi_get`.
 #[derive(Clone, Default, Debug)]
 pub struct GetStats {
-    /// The number of puts/deletes processed
+    /// The number of gets processed
     pub processed_gets: u64,
+    /// The total size in bytes returned
+    pub processed_gets_size: u64,
 }
 
 /// A trait that defines the fundamental primitives required by a state-backing of
@@ -450,6 +452,7 @@ impl UpsertStateBackend for InMemoryHashMap {
             stats.processed_gets += 1;
             let value = self.state.get(&key).cloned();
             let size = value.as_ref().map(|v| v.memory_size());
+            stats.processed_gets_size += size.unwrap_or(0);
             *result_out = UpsertValueAndSize { value, size };
         }
         Ok(stats)

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -216,13 +216,14 @@ pub(super) struct UpsertMetrics {
     pub(super) merge_snapshot_deletes: IntCounterVec,
     pub(super) multi_get_latency: HistogramVec,
     pub(super) multi_get_size: IntCounterVec,
+    pub(super) multi_get_result_count: IntCounterVec,
     pub(super) multi_put_latency: HistogramVec,
     pub(super) multi_put_size: IntCounterVec,
 
     // These are used by `rocksdb`.
     pub(super) rocksdb_multi_get_latency: HistogramVec,
     pub(super) rocksdb_multi_get_size: IntCounterVec,
-    pub(super) rocksdb_multi_get_result_size: IntCounterVec,
+    pub(super) rocksdb_multi_get_result_count: IntCounterVec,
     pub(super) rocksdb_multi_put_latency: HistogramVec,
     pub(super) rocksdb_multi_put_size: IntCounterVec,
     // These are maps so that multiple timely workers can interact with the same
@@ -315,6 +316,13 @@ impl UpsertMetrics {
                     metrics about sub-batches.",
                 var_labels: ["source_id", "worker_id"],
             )),
+            multi_get_result_count: registry.register(metric!(
+                name: "mz_storage_upsert_multi_get_result_count_total",
+                help: "The number of non-empty records returned in a multi_get batch. \
+                    Specific implementations of upsert state may have more detailed \
+                    metrics about sub-batches.",
+                var_labels: ["source_id", "worker_id"],
+            )),
             multi_put_latency: registry.register(metric!(
                 name: "mz_storage_upsert_multi_put_latency",
                 help: "The latencies, in fractional seconds, \
@@ -346,8 +354,8 @@ impl UpsertMetrics {
                     of getting batches of values from RocksDB for this source.",
                 var_labels: ["source_id", "worker_id"],
             )),
-            rocksdb_multi_get_result_size: registry.register(metric!(
-                name: "mz_storage_rocksdb_multi_get_result_size_total",
+            rocksdb_multi_get_result_count: registry.register(metric!(
+                name: "mz_storage_rocksdb_multi_get_result_count_total",
                 help: "The number of non-empty records returned, \
                     when getting batches of values from RocksDB for this source.",
                 var_labels: ["source_id"],

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -217,6 +217,7 @@ pub(super) struct UpsertMetrics {
     pub(super) multi_get_latency: HistogramVec,
     pub(super) multi_get_size: IntCounterVec,
     pub(super) multi_get_result_count: IntCounterVec,
+    pub(super) multi_get_result_bytes: IntCounterVec,
     pub(super) multi_put_latency: HistogramVec,
     pub(super) multi_put_size: IntCounterVec,
 
@@ -224,6 +225,7 @@ pub(super) struct UpsertMetrics {
     pub(super) rocksdb_multi_get_latency: HistogramVec,
     pub(super) rocksdb_multi_get_size: IntCounterVec,
     pub(super) rocksdb_multi_get_result_count: IntCounterVec,
+    pub(super) rocksdb_multi_get_result_bytes: IntCounterVec,
     pub(super) rocksdb_multi_put_latency: HistogramVec,
     pub(super) rocksdb_multi_put_size: IntCounterVec,
     // These are maps so that multiple timely workers can interact with the same
@@ -323,6 +325,13 @@ impl UpsertMetrics {
                     metrics about sub-batches.",
                 var_labels: ["source_id", "worker_id"],
             )),
+            multi_get_result_bytes: registry.register(metric!(
+                name: "mz_storage_upsert_multi_get_result_bytes_total",
+                help: "The total size of records returned in a multi_get batch. \
+                    Specific implementations of upsert state may have more detailed \
+                    metrics about sub-batches.",
+                var_labels: ["source_id", "worker_id"],
+            )),
             multi_put_latency: registry.register(metric!(
                 name: "mz_storage_upsert_multi_put_latency",
                 help: "The latencies, in fractional seconds, \
@@ -357,6 +366,12 @@ impl UpsertMetrics {
             rocksdb_multi_get_result_count: registry.register(metric!(
                 name: "mz_storage_rocksdb_multi_get_result_count_total",
                 help: "The number of non-empty records returned, \
+                    when getting batches of values from RocksDB for this source.",
+                var_labels: ["source_id"],
+            )),
+            rocksdb_multi_get_result_bytes: registry.register(metric!(
+                name: "mz_storage_rocksdb_multi_get_result_bytes_total",
+                help: "The total size of records returned, \
                     when getting batches of values from RocksDB for this source.",
                 var_labels: ["source_id"],
             )),

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -278,7 +278,7 @@ impl UpsertMetrics {
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
             merge_snapshot_updates: registry.register(metric!(
-                name: "mz_storage_upsert_merge_snapshot_updates_counter",
+                name: "mz_storage_upsert_merge_snapshot_updates_total",
                 help: "The batch size, \
                     of merging snapshot updates into upsert state for this source. \
                     Specific implementations of upsert state may have more detailed \
@@ -286,13 +286,13 @@ impl UpsertMetrics {
                 var_labels: ["source_id"],
             )),
             merge_snapshot_inserts: registry.register(metric!(
-                name: "mz_storage_upsert_merge_snapshot_inserts_counter",
+                name: "mz_storage_upsert_merge_snapshot_inserts_total",
                 help: "The number of inserts in a batch for merging snapshot updates \
                     for this source.",
                 var_labels: ["source_id"],
             )),
             merge_snapshot_deletes: registry.register(metric!(
-                name: "mz_storage_upsert_merge_snapshot_deletes_counter",
+                name: "mz_storage_upsert_merge_snapshot_deletes_total",
                 help: "The number of deletes in a batch for merging snapshot updates \
                     for this source.",
                 var_labels: ["source_id"],
@@ -307,7 +307,7 @@ impl UpsertMetrics {
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
             multi_get_size: registry.register(metric!(
-                name: "mz_storage_upsert_multi_get_size_counter",
+                name: "mz_storage_upsert_multi_get_size_total",
                 help: "The batch size, \
                     of getting values from the upsert state for this source. \
                     Specific implementations of upsert state may have more detailed \
@@ -324,7 +324,7 @@ impl UpsertMetrics {
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
             multi_put_size: registry.register(metric!(
-                name: "mz_storage_upsert_multi_put_size_counter",
+                name: "mz_storage_upsert_multi_put_size_total",
                 help: "The batch size, \
                     of getting values into the upsert state for this source. \
                     Specific implementations of upsert state may have more detailed \
@@ -340,13 +340,13 @@ impl UpsertMetrics {
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
             rocksdb_multi_get_size: registry.register(metric!(
-                name: "mz_storage_rocksdb_multi_get_size_counter",
+                name: "mz_storage_rocksdb_multi_get_size_total",
                 help: "The batch size, \
                     of getting batches of values from RocksDB for this source.",
                 var_labels: ["source_id"],
             )),
             rocksdb_multi_get_result_size: registry.register(metric!(
-                name: "mz_storage_rocksdb_multi_get_result_size_counter",
+                name: "mz_storage_rocksdb_multi_get_result_size_total",
                 help: "The number of non-empty records returned, \
                     when getting batches of values from RocksDB for this source.",
                 var_labels: ["source_id"],
@@ -359,7 +359,7 @@ impl UpsertMetrics {
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
             rocksdb_multi_put_size: registry.register(metric!(
-                name: "mz_storage_rocksdb_multi_put_size_counter",
+                name: "mz_storage_rocksdb_multi_put_size_total",
                 help: "The batch size, \
                     of putting batches of values into RocksDB for this source.",
                 var_labels: ["source_id"],

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -220,6 +220,7 @@ pub(super) struct UpsertMetrics {
     // These are used by `rocksdb`.
     pub(super) rocksdb_multi_get_latency: HistogramVec,
     pub(super) rocksdb_multi_get_size: HistogramVec,
+    pub(super) rocksdb_multi_get_result_size: HistogramVec,
     pub(super) rocksdb_multi_put_latency: HistogramVec,
     pub(super) rocksdb_multi_put_size: HistogramVec,
     // These are maps so that multiple timely workers can interact with the same
@@ -337,6 +338,13 @@ impl UpsertMetrics {
                 var_labels: ["source_id"],
                 buckets: vec![10.0, 100.0, 1000.0, 10000.0, 100000.0],
             )),
+            rocksdb_multi_get_result_size: registry.register(metric!(
+                name: "mz_storage_rocksdb_multi_get_result_size",
+                help: "The number of non-empty records returned, \
+                    when getting batches of values from RocksDB for this source.",
+                var_labels: ["source_id"],
+                buckets: vec![10.0, 100.0, 1000.0, 10000.0, 100000.0],
+            )),
             rocksdb_multi_put_latency: registry.register(metric!(
                 name: "mz_storage_rocksdb_multi_put_latency",
                 help: "The latencies, in fractional seconds, \
@@ -390,6 +398,9 @@ impl UpsertMetrics {
                     .get_delete_on_drop_histogram(vec![source_id.clone()]),
                 multi_get_size: self
                     .rocksdb_multi_get_size
+                    .get_delete_on_drop_histogram(vec![source_id.clone()]),
+                multi_get_result_size: self
+                    .rocksdb_multi_get_result_size
                     .get_delete_on_drop_histogram(vec![source_id.clone()]),
                 multi_put_latency: self
                     .rocksdb_multi_put_latency

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -212,6 +212,8 @@ pub(super) struct UpsertMetrics {
     // These are used by `shared`.
     pub(super) merge_snapshot_latency: HistogramVec,
     pub(super) merge_snapshot_updates: IntCounterVec,
+    pub(super) merge_snapshot_inserts: IntCounterVec,
+    pub(super) merge_snapshot_deletes: IntCounterVec,
     pub(super) multi_get_latency: HistogramVec,
     pub(super) multi_get_size: IntCounterVec,
     pub(super) multi_put_latency: HistogramVec,
@@ -281,6 +283,18 @@ impl UpsertMetrics {
                     of merging snapshot updates into upsert state for this source. \
                     Specific implementations of upsert state may have more detailed \
                     metrics about sub-batches.",
+                var_labels: ["source_id"],
+            )),
+            merge_snapshot_inserts: registry.register(metric!(
+                name: "mz_storage_upsert_merge_snapshot_inserts_counter",
+                help: "The number of inserts in a batch for merging snapshot updates \
+                    for this source.",
+                var_labels: ["source_id"],
+            )),
+            merge_snapshot_deletes: registry.register(metric!(
+                name: "mz_storage_upsert_merge_snapshot_deletes_counter",
+                help: "The number of deletes in a batch for merging snapshot updates \
+                    for this source.",
                 var_labels: ["source_id"],
             )),
             multi_get_latency: registry.register(metric!(
@@ -415,6 +429,8 @@ impl UpsertMetrics {
 pub(crate) struct UpsertSharedMetrics {
     pub(crate) merge_snapshot_latency: DeleteOnDropHistogram<'static, Vec<String>>,
     pub(crate) merge_snapshot_updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) merge_snapshot_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) merge_snapshot_deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_latency: DeleteOnDropHistogram<'static, Vec<String>>,
     pub(crate) multi_get_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_put_latency: DeleteOnDropHistogram<'static, Vec<String>>,
@@ -430,6 +446,12 @@ impl UpsertSharedMetrics {
                 .get_delete_on_drop_histogram(vec![source_id.clone()]),
             merge_snapshot_updates: metrics
                 .merge_snapshot_updates
+                .get_delete_on_drop_counter(vec![source_id.clone()]),
+            merge_snapshot_inserts: metrics
+                .merge_snapshot_inserts
+                .get_delete_on_drop_counter(vec![source_id.clone()]),
+            merge_snapshot_deletes: metrics
+                .merge_snapshot_deletes
                 .get_delete_on_drop_counter(vec![source_id.clone()]),
             multi_get_latency: metrics
                 .multi_get_latency

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -383,7 +383,7 @@ impl UpsertMetrics {
                 var_labels: ["source_id", "worker_id"],
             )),
             rocksdb_multi_put_count: registry.register(metric!(
-                name: "mz_storage_rocksdb_multi_get_count_total",
+                name: "mz_storage_rocksdb_multi_put_count_total",
                 help: "The number of calls to rocksdb multi_put.",
                 var_labels: ["source_id", "worker_id"],
             )),

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -226,6 +226,8 @@ pub(super) struct UpsertMetrics {
     pub(super) rocksdb_multi_get_size: IntCounterVec,
     pub(super) rocksdb_multi_get_result_count: IntCounterVec,
     pub(super) rocksdb_multi_get_result_bytes: IntCounterVec,
+    pub(super) rocksdb_multi_get_count: IntCounterVec,
+    pub(super) rocksdb_multi_put_count: IntCounterVec,
     pub(super) rocksdb_multi_put_latency: HistogramVec,
     pub(super) rocksdb_multi_put_size: IntCounterVec,
     // These are maps so that multiple timely workers can interact with the same
@@ -367,13 +369,23 @@ impl UpsertMetrics {
                 name: "mz_storage_rocksdb_multi_get_result_count_total",
                 help: "The number of non-empty records returned, \
                     when getting batches of values from RocksDB for this source.",
-                var_labels: ["source_id"],
+                var_labels: ["source_id", "worker_id"],
             )),
             rocksdb_multi_get_result_bytes: registry.register(metric!(
                 name: "mz_storage_rocksdb_multi_get_result_bytes_total",
                 help: "The total size of records returned, \
                     when getting batches of values from RocksDB for this source.",
-                var_labels: ["source_id"],
+                var_labels: ["source_id", "worker_id"],
+            )),
+            rocksdb_multi_get_count: registry.register(metric!(
+                name: "mz_storage_rocksdb_multi_get_count_total",
+                help: "The number of calls to rocksdb multi_get.",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            rocksdb_multi_put_count: registry.register(metric!(
+                name: "mz_storage_rocksdb_multi_get_count_total",
+                help: "The number of calls to rocksdb multi_put.",
+                var_labels: ["source_id", "worker_id"],
             )),
             rocksdb_multi_put_latency: registry.register(metric!(
                 name: "mz_storage_rocksdb_multi_put_latency",
@@ -386,7 +398,7 @@ impl UpsertMetrics {
                 name: "mz_storage_rocksdb_multi_put_size_total",
                 help: "The batch size, \
                     of putting batches of values into RocksDB for this source.",
-                var_labels: ["source_id"],
+                var_labels: ["source_id", "worker_id"],
             )),
             rocksdb_shared,
         }

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -306,7 +306,6 @@ impl UpsertMetrics {
                 var_labels: ["source_id"],
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
-            // Choose a relatively low number of representative buckets.
             multi_get_size: registry.register(metric!(
                 name: "mz_storage_upsert_multi_get_size_counter",
                 help: "The batch size, \
@@ -324,7 +323,6 @@ impl UpsertMetrics {
                 var_labels: ["source_id"],
                 buckets: histogram_seconds_buckets(0.000_500, 32.0),
             )),
-            // Choose a relatively low number of representative buckets.
             multi_put_size: registry.register(metric!(
                 name: "mz_storage_upsert_multi_put_size_counter",
                 help: "The batch size, \

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -495,6 +495,7 @@ pub struct UpsertMetrics {
     pub(crate) merge_snapshot_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) merge_snapshot_deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) multi_get_result_bytes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_result_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_put_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 
@@ -545,6 +546,9 @@ impl UpsertMetrics {
             multi_get_result_count: base
                 .multi_get_result_count
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+            multi_get_result_bytes: base
+                .multi_get_result_bytes
+                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
             multi_put_size: base
                 .multi_put_size
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
@@ -557,6 +561,9 @@ impl UpsertMetrics {
                     .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_get_result_count: base
                     .rocksdb_multi_get_result_count
+                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                multi_get_result_bytes: base
+                    .rocksdb_multi_get_result_bytes
                     .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_put_size: base
                     .rocksdb_multi_put_size

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -495,6 +495,7 @@ pub struct UpsertMetrics {
     pub(crate) merge_snapshot_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) merge_snapshot_deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) multi_get_result_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_put_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
 
     pub(crate) shared: Arc<UpsertSharedMetrics>,
@@ -541,6 +542,9 @@ impl UpsertMetrics {
             multi_get_size: base
                 .multi_get_size
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+            multi_get_result_count: base
+                .multi_get_result_count
+                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
             multi_put_size: base
                 .multi_put_size
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
@@ -551,8 +555,8 @@ impl UpsertMetrics {
                 multi_get_size: base
                     .rocksdb_multi_get_size
                     .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
-                multi_get_result_size: base
-                    .rocksdb_multi_get_result_size
+                multi_get_result_count: base
+                    .rocksdb_multi_get_result_count
                     .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_put_size: base
                     .rocksdb_multi_put_size

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -565,6 +565,12 @@ impl UpsertMetrics {
                 multi_get_result_bytes: base
                     .rocksdb_multi_get_result_bytes
                     .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                multi_get_count: base
+                    .rocksdb_multi_get_count
+                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+                multi_put_count: base
+                    .rocksdb_multi_put_count
+                    .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
                 multi_put_size: base
                     .rocksdb_multi_put_size
                     .get_delete_on_drop_counter(vec![source_id_s, worker_id]),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

- Adding counter for multi_get non empty results from rocksdb
- Converted existing histogram to calculate sizes and count to counter type and made them worker specific
- Added counter for + and - diffs in merge updates


### Motivation
To get more metrics to debug GOAT rehydration slowness with backpressure

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
