### PR TITLE
doc/developer: explain that we now require reviews for PRs

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -17,9 +17,9 @@ We use [GitHub pull requests](https://github.com/MaterializeInc/materialize/pull
 small, must be submitted as a pull request, and that pull request must pass a
 battery of automated tests before it merges.
 
-Any substantial PR must additionally be reviewed by one or more engineers who
-are familiar with the areas of the codebase that are touched in the PR. The
-goals of code review are threefold:
+All PRs must be reviewed by one or more employees who are familiar with the
+areas of the codebase that are touched in the PR. The goals of code review are
+threefold:
 
 1. To ensure the health of the codebase improves over time.
 
@@ -381,18 +381,9 @@ strategy works best when you are fairly confident in the change. If you're not
 confident in the change, consider assigning _both_ an experienced an
 inexperienced reviewer.
 
-Coming soon: a breakdown of which tech lead is responsible for each area of the
-codebase. The tech lead needn't review every PR in their area of responsibility,
-but can help direct code review requests to the appropriate engineer.
-
 ### Merging
 
 #### When to merge
-
-For sufficiently trivial changes, you can consider merging without review. This
-should be somewhat rare, however, and only when you have high confidence that a)
-the change is correct, and b) the change is uncontroversial. When in doubt, get
-a review!
 
 When a reviewer approves your PR, they will either press the "approve" button
 in GitHub's code review interface, leaving a big green checkmark on your PR,
@@ -411,6 +402,10 @@ SQL layer LGTM, but please get someone else to review the docs changes." In this
 case you must use your discretion as to when you have received a covering set
 of approvals. (This is a great reason to prefer small PRs when possible, since
 you can gather full approvals from various owners in parallel.)
+
+We've configured GitHub to require at least one formal approval (i.e., clicking
+"Approve" in the review UI, rather than just posting a comment like "LGTM")
+before a PR can be merged.
 
 #### Stalled PRs
 


### PR DESCRIPTION
To ease our SOC2 controls, we now require at least one formal review of each PR. This commit updates the developer documentation accordingly.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* This PR updates internal documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
