### PR TITLE
storage: Refactor CollectionManager to spawn a task per-collection

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -879,7 +879,7 @@ impl Coordinator {
                     let body = desc
                         .get_by_name(&"body".into())
                         .map(|(_idx, ty)| ty.clone())
-                        .ok_or(name)?;
+                        .ok_or(name.clone())?;
                     let header = desc
                         .get_by_name(&"headers".into())
                         .map(|(_idx, ty)| ty.clone());
@@ -898,7 +898,11 @@ impl Coordinator {
             };
 
             // Get a channel so we can queue updates to be written.
-            let row_tx = coord.controller.storage.monotonic_appender(entry.id());
+            let row_tx = coord
+                .controller
+                .storage
+                .monotonic_appender(entry.id())
+                .map_err(|_| name)?;
             Ok(AppendWebhookResponse {
                 tx: row_tx,
                 body_ty,

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -192,7 +192,13 @@ where
                             let min_time_to_complete = Instant::now() + DEFAULT_TICK;
 
                             // Reset the interval which is used to periodically bump the uppers
-                            // because the uppers will get bumped with the following update.
+                            // because the uppers will get bumped with the following update. This
+                            // makes it such that we will write at most once every `interval`.
+                            //
+                            // For example, let's say our `DEFAULT_TICK` interval is 10, so at
+                            // `t + 10`, `t + 20`, ... we'll bump the uppers. If we receive an
+                            // update at `t + 3` we want to shift this window so we bump the uppers
+                            // at `t + 13`, `t + 23`, ... which reseting the interval accomplishes.
                             interval.reset();
 
                             let (rows, responders): (Vec<_>, Vec<_>) = batch

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -155,7 +155,7 @@ where
     }
 }
 
-/// Spawns a [`tokio::task`] that will continuously bump the upper for the specified collection,
+/// Spawns an [`mz_ore::task`] that will continuously bump the upper for the specified collection,
 /// and append data that is sent via the provided [`mpsc::Sender`].
 ///
 /// TODO(parkmycar): One day if we want to customize the tick interval for each collection, that
@@ -206,6 +206,11 @@ where
                             let request = vec![(id, rows, T::from(now()))];
 
                             // We'll try really hard to succeed, but eventually stop.
+                            //
+                            // Note: it's very rare we should ever need to retry, and if we need to
+                            // retry it should only take 1 or 2 attempts. We set `max_tries` to be
+                            // high though because if we hit some edge case we want to try hard to
+                            // commit the data.
                             let retries = Retry::default()
                                 .initial_backoff(Duration::from_secs(1))
                                 .clamp_backoff(Duration::from_secs(3))

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -82,6 +82,8 @@ where
         if let Some((_writer, task)) = guard.get(&id) {
             // The collection is already registered and the task is still running so nothing to do.
             if !task.is_finished() {
+                // TODO(parkmycar): Panic here if we never see this error in production.
+                tracing::error!("Registered a collection twice! {id:?}");
                 return;
             }
         }

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -273,6 +273,11 @@ where
                             // Note: if writing to persist took longer than `DEFAULT_TICK` this
                             // await will resolve immediately.
                             tokio::time::sleep_until(min_time_to_complete).await;
+                        } else {
+                            // Sender has been dropped, which means the collection should have been
+                            // unregistered, break out of the run loop if we weren't already
+                            // aborted.
+                            break 'run;
                         }
                     }
 


### PR DESCRIPTION
This PR updates the `CollectionManager` in `storage-controller` to spawn an individual `tokio::task` per managed collection.

Previously `CollectionManager` spawned a _single_ `tokio::task` that pulled updates off of a channel for all of the registered collections, and would append these in a single batch. To rate limit writes to persist for the webhook source, we added artificial latency to the write in https://github.com/MaterializeInc/materialize/pull/20885, this had two side effects:

1. All writes were rate limited, regardless of the collection they were writing to. If `Collection(A)` received an update at `t`, then `Collection(B)` received an update at `t + 100ms`, the update for `Collection(B)` would have to wait until `t + 1,000ms` until it could proceed.
2. Bumping uppers for all registered collections ran as a separate `Future` that was in a `select!` with the append `Future`. This meant that if we received an update for `Collection(A)` at `t` and no updates for `Collection(B)`, it would be _at least_ until `t + 1000ms` until the upper for `Collection(B)` would be bumped.

This PR refactors the `CollectionManager` so each collection we're appending to has it's own "run loop", which solves the aforementioned issues and IMO is a better implementation than what we have previously because:

1. Removes complexity around batching updates for multiple collections, since each "task" handles updates for a single collection.
2. Removes the complexity around unregistering a collection and waiting for a "notify". Now we can shutdown that collections "run loop" and wait for it to exit.
3. Makes it much simpler to change the interval/tick/append rate for an individual collection, e.g. supporting `TIMESTAMP INTERVAL`.

### Motivation

* This PR fixes a previously unreported bug.
  We recently discovered excess latency in some of our `BuiltinSource`s, [Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1691616298456569). I'm pretty sure this is caused by the rate limiting that was recently added for webhooks.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
