### PR TITLE
Document EXPECTED GROUP SIZE tuning

### DIFF
--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -126,7 +126,7 @@ Hint | Value type | Description
 ------|------------|------------
 `EXPECTED GROUP SIZE` | `int` | How many rows will have the same group key. Materialize can render `min` and `max` expressions, and some [Top K patterns](/guides/top-k), more efficiently with this information.
 
-For an example, see [Using query hints](#using-query-hints).
+For examples, see the [Optimization](/transform-data/optimization/#query-hints) page.
 
 ### Column references
 
@@ -226,20 +226,6 @@ names, but the CTEs make the entire query simpler to understand.
 
 With regard to dataflows, this is similar to [ad hoc querying](#ad-hoc-querying)
 above: Materialize tears down the created dataflow after returning the results.
-
-### Using query hints
-
-```sql
-SELECT a,
-       min(b) AS min
-FROM example
-GROUP BY a
-OPTIONS (EXPECTED GROUP SIZE = 100)
-```
-
-Here the hint indicates that there may be up to a hundred distinct `(a, b)` pairs
-for each `a` value, and Materialize can optimize its dataflow rendering with that
-knowledge.
 
 ## Privileges
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -945,18 +945,18 @@ The `mz_dataflow_shutdown_durations_histogram` view describes a histogram of the
 The `mz_expected_group_size_advice` view provides advice on opportunities to set the `EXPECTED GROUP SIZE`
 [query hint]. This hint is applicable to dataflows maintaining [`MIN`], [`MAX`], or [Top K] query patterns. The
 maintainance of these query patterns is implemented inside an operator scope, called a region, through a
-hierarchical scheme for either reduction or top-k computation.
+hierarchical scheme for either aggregation or Top K computations.
 
 <!-- RELATION_SPEC mz_internal.mz_expected_group_size_advice -->
-| Field           | Type        | Meaning                                                                                                             |
-|-----------------|-------------|---------------------------------------------------------------------------------------------------------------------|
-| `dataflow_id`   | [`uint8`]   | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                                        |
-| `dataflow_name` | [`text`]    | The internal name of the dataflow hosting the min/max reduction or top-k.                                           |
-| `region_id`     | [`uint8`] | The ID of the root operator scope. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).               |
-| `region_name`   | [`text`]    | The internal name of the root operator scope for the min/max reduction or top-k.                                    |
-| `levels`        | [`bigint`] | The number of levels in the hierarchical scheme implemented by the region.                                           |
-| `to_cut`        | [`bigint`] | The number of levels that can be eliminated (cut) from the region's hierarchy.                                       |
-| `hint`          | [`double precision`] | The hint value for `EXPECTED GROUP SIZE` that will eliminate `to_cut` levels from the regions' hierarchy.  |
+| Field           | Type                 | Meaning                                                                                                   |
+|-----------------|----------------------|-----------------------------------------------------------------------------------------------------------|
+| `dataflow_id`   | [`uint8`]            | The ID of the [dataflow]. Corresponds to [`mz_dataflows.id`](#mz_dataflows).                              |
+| `dataflow_name` | [`text`]             | The internal name of the dataflow hosting the min/max aggregation or Top K.                               |
+| `region_id`     | [`uint8`]            | The ID of the root operator scope. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).   |
+| `region_name`   | [`text`]             | The internal name of the root operator scope for the min/max aggregation or Top K.                        |
+| `levels`        | [`bigint`]           | The number of levels in the hierarchical scheme implemented by the region.                                |
+| `to_cut`        | [`bigint`]           | The number of levels that can be eliminated (cut) from the region's hierarchy.                            |
+| `hint`          | [`double precision`] | The hint value for `EXPECTED GROUP SIZE` that will eliminate `to_cut` levels from the regions' hierarchy. |
 
 ### `mz_message_counts`
 


### PR DESCRIPTION
This PR documents the tuning of the query hint `EXPECTED GROUP SIZE` by adding a relevant section to the Optimization guide. The guidelines explain how to tune the value from first principles, but also point to the new introspection view `mz_internal.mz_expected_group_size_advice`.

Fixes #20184.

### Motivation

  * This PR adds a known-desirable feature. https://github.com/MaterializeInc/materialize/issues/20184

### Tips for reviewer

@morsapaes and @sjwiesman I am flipping this now to reviewable after a first pass over Seth's comments.

@ggevay I am adding you as a reviewer to sanity check our explanations from a Compute perspective.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates the Optimization guide with reference to Query Hint tuning and the new introspection view `mz_internal.mz_expected_group_size_advice`.
