### PR TITLE
test/debezium: re-enable mysql test and validate precise bigint handling

### DIFF
--- a/misc/images/debezium/Dockerfile
+++ b/misc/images/debezium/Dockerfile
@@ -1,0 +1,24 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# There is no pre-built Docker image that includes both Confluent's Avro
+# converter (which knows how to write schemas to the Confluent Schema Registry)
+# and Debezium connectors, so we have to build our own.
+
+FROM confluentinc/cp-kafka-connect-base:7.3.5
+
+# Be sure to use a `X.Y.Z.Final` tag here; `X.Y` tags refer to the latest minor
+# version in the release series, and minor versions have been known to introduce
+# breakage.
+ARG DEBEZIUM_VERSION="2.4.0.Final"
+
+RUN : \
+    && curl -fsSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/${DEBEZIUM_VERSION}/debezium-connector-mysql-${DEBEZIUM_VERSION}-plugin.tar.gz | tar -zxC /usr/share/java \
+    && curl -fsSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-postgres/${DEBEZIUM_VERSION}/debezium-connector-postgres-${DEBEZIUM_VERSION}-plugin.tar.gz | tar -zxC /usr/share/java \
+    && curl -fsSL https://repo1.maven.org/maven2/io/debezium/debezium-connector-sqlserver/${DEBEZIUM_VERSION}/debezium-connector-sqlserver-${DEBEZIUM_VERSION}-plugin.tar.gz | tar -zxC /usr/share/java

--- a/misc/images/debezium/mzbuild.yml
+++ b/misc/images/debezium/mzbuild.yml
@@ -7,11 +7,5 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
-
-$ mysql-execute name=mysql
-USE test;
-CREATE TABLE t1 (f1 INTEGER PRIMARY KEY, f2 INTEGER, f3 BIGINT UNSIGNED);
-INSERT INTO t1 VALUES (123, 123, 123);
-INSERT INTO t1 VALUES (234, 234, 234);
-COMMIT;
+name: debezium
+description: Kafka Connect with Debezium and Confluent Avro converters.

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -42,7 +42,8 @@ class DebeziumPostgres(Check):
                     "database.history.kafka.bootstrap.servers": "kafka:9092",
                     "database.history.kafka.topic": "schema-changes.history",
                     "truncate.handling.mode": "include",
-                    "decimal.handling.mode": "precise"
+                    "decimal.handling.mode": "precise",
+                    "topic.prefix": "postgres"
                   }
                 }
 

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -32,15 +32,8 @@ from materialize.ui import UIError
 T = TypeVar("T")
 say = ui.speaker("C> ")
 
-# Be sure to use a `X.Y.Z.Final` tag here; `X.Y` tags refer to the latest
-# minor version in the release series, and minor versions have been known to
-# introduce breakage.
-DEFAULT_DEBEZIUM_VERSION = "1.9.6.Final"
-
-LINT_DEBEZIUM_VERSIONS = ["1.4", "1.5", "1.6"]
 
 DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.5"
-
 
 DEFAULT_MZ_VOLUMES = [
     "mzdata:/mzdata",

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -108,7 +108,8 @@ class CreateDebeziumSource(Action):
                         "database.history.kafka.bootstrap.servers": "kafka:9092",
                         "database.history.kafka.topic": "schema-changes.history",
                         "truncate.handling.mode": "include",
-                        "decimal.handling.mode": "precise"
+                        "decimal.handling.mode": "precise",
+                        "topic.prefix": "postgres"
                       }}
                     }}
 

--- a/test/chbench/mzcompose.py
+++ b/test/chbench/mzcompose.py
@@ -81,6 +81,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 "database.history.kafka.topic": "mysql-history",
                 "database.allowPublicKeyRetrieval": "true",
                 "time.precision.mode": "connect",
+                "topic.prefix": "mysql",
             },
         },
     )

--- a/test/debezium/mysql/30-configure-debezium.td
+++ b/test/debezium/mysql/30-configure-debezium.td
@@ -24,6 +24,7 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
 {
     "name": "mysql-connector",
     "config": {
+        "bigint.unsigned.handling.mode": "precise",
         "connector.class": "io.debezium.connector.mysql.MySqlConnector",
         "database.hostname": "mysql",
         "database.port": "3306",
@@ -35,6 +36,9 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
         "database.history.kafka.bootstrap.servers": "kafka:9092",
         "database.history.kafka.topic": "dbhistory.mysql",
         "include.schema.changes": "true",
-        "provide.transaction.metadata": "true"
+        "schema.history.internal.kafka.bootstrap.servers": "kafka:9092",
+        "schema.history.internal.kafka.topic": "schemahistory.mysql",
+        "provide.transaction.metadata": "true",
+        "topic.prefix": "mysql"
     }
 }

--- a/test/debezium/mysql/40-check-smoke.td
+++ b/test/debezium/mysql/40-check-smoke.td
@@ -7,16 +7,13 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# This test is broken and therefore disabled.
-# See: https://github.com/MaterializeInc/materialize/issues/13629
-
 $ schema-registry-wait subject=mysql.test.t1-value
 
 $ mysql-connect name=mysql url=mysql://root@mysql password=${arg.mysql-root-password}
 
 $ mysql-execute name=mysql
 USE test;
-INSERT INTO t1 VALUES (345, 345);
+INSERT INTO t1 VALUES (345, 345, 345);
 COMMIT;
 
 $ schema-registry-wait subject=mysql.transaction-value
@@ -27,42 +24,35 @@ $ schema-registry-wait subject=mysql.transaction-value
     URL '${testdrive.schema-registry-url}'
   );
 
-> CREATE SOURCE mysql_tx_metadata
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'mysql.transaction')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE NONE;
-
 > CREATE SOURCE t1
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'mysql.test.t1')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE DEBEZIUM (
-      TRANSACTION METADATA (SOURCE mysql_tx_metadata, COLLECTION 'test.t1')
-  );
+  ENVELOPE DEBEZIUM;
 
 > SELECT * FROM t1;
-123 123
-234 234
-345 345
+123 123 123
+234 234 234
+345 345 345
 
 $ mysql-execute name=mysql
-INSERT INTO t1 VALUES (456, 456);
+INSERT INTO t1 VALUES (456, 456, 456);
 COMMIT;
 
 > SELECT * FROM t1;
-123 123
-234 234
-345 345
-456 456
+123 123 123
+234 234 234
+345 345 345
+456 456 456
 
 $ mysql-execute name=mysql
 UPDATE t1 SET f2 = f2 * 100
 COMMIT;
 
 > SELECT * FROM t1;
-123 12300
-234 23400
-345 34500
-456 45600
+123 12300 123
+234 23400 234
+345 34500 345
+456 45600 456
 
 $ mysql-execute name=mysql
 DELETE FROM t1;

--- a/test/debezium/postgres/90-decimal-handling-mode.td
+++ b/test/debezium/postgres/90-decimal-handling-mode.td
@@ -49,7 +49,8 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.bootstrap.servers": "kafka:9092",
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
-  "decimal.handling.mode": "double"
+  "decimal.handling.mode": "double",
+  "topic.prefix": "postgres"
 }
 
 # PUT requests do not take effect immediately, we need to sleep
@@ -90,7 +91,8 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
   "provide.transaction.metadata": "true",
-  "decimal.handling.mode": "string"
+  "decimal.handling.mode": "string",
+  "topic.prefix": "postgres"
 }
 
 > SELECT mz_internal.mz_sleep(10)
@@ -128,7 +130,8 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.bootstrap.servers": "kafka:9092",
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
-  "decimal.handling.mode": "precise"
+  "decimal.handling.mode": "precise",
+  "topic.prefix": "postgres"
 }
 
 > SELECT mz_internal.mz_sleep(10)

--- a/test/debezium/postgres/92-large-transaction.td.gh13629
+++ b/test/debezium/postgres/92-large-transaction.td.gh13629
@@ -27,7 +27,8 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
   "provide.transaction.metadata": "true",
-  "decimal.handling.mode": "precise"
+  "decimal.handling.mode": "precise",
+  "topic.prefix": "postgres"
 }
 
 # PUT requests do not take effect immediately, we need to sleep
@@ -121,7 +122,8 @@ $ http-request method=PUT url=http://debezium:8083/connectors/psql-connector/con
   "database.history.kafka.bootstrap.servers": "kafka:9092",
   "database.history.kafka.topic": "schema-changes.history",
   "truncate.handling.mode": "include",
-  "decimal.handling.mode": "precise"
+  "decimal.handling.mode": "precise",
+  "topic.prefix": "postgres"
 }
 
 > SELECT mz_internal.mz_sleep(10)

--- a/test/debezium/postgres/debezium-postgres.td.initialize
+++ b/test/debezium/postgres/debezium-postgres.td.initialize
@@ -54,7 +54,8 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
     "database.history.kafka.bootstrap.servers": "kafka:9092",
     "database.history.kafka.topic": "schema-changes.history",
     "truncate.handling.mode": "include",
-    "decimal.handling.mode": "precise"
+    "decimal.handling.mode": "precise",
+    "topic.prefix": "postgres"
   }
 }
 

--- a/test/debezium/sql-server/30-configure-debezium.td
+++ b/test/debezium/sql-server/30-configure-debezium.td
@@ -35,15 +35,19 @@ $ http-request method=POST url=http://debezium:8083/connectors content-type=appl
     "config": {
         "connector.class": "io.debezium.connector.sqlserver.SqlServerConnector",
         "database.hostname": "sql-server",
+        "database.encrypt": "false",
         "database.port": "1433",
         "database.user": "sa",
         "database.password": "${arg.sa-password}",
-        "database.dbname": "test",
+        "database.names": "test",
         "database.server.name": "sql-server",
         "database.history.kafka.bootstrap.servers": "kafka:9092",
         "database.history.kafka.topic": "schema-changes.history",
+        "schema.history.internal.kafka.bootstrap.servers": "kafka:9092",
+        "schema.history.internal.kafka.topic": "schemahistory.sql-server",
         "snapshot.isolation.mode": "exclusive",
-        "provide.transaction.metadata": "true"
+        "provide.transaction.metadata": "true",
+        "topic.prefix": "sql-server"
 #,
 #        "signal.data.collection": "test.dbo.debezium_signal"
     }

--- a/test/debezium/sql-server/40-check-delete.td
+++ b/test/debezium/sql-server/40-check-delete.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.dbo.delete_table_pk-value
+$ schema-registry-wait subject=sql-server.test.dbo.delete_table_pk-value
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -16,7 +16,7 @@ $ schema-registry-wait subject=sql-server.dbo.delete_table_pk-value
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 > CREATE SOURCE delete_table_pk
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.delete_table_pk')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.delete_table_pk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 

--- a/test/debezium/sql-server/40-check-smoke.td
+++ b/test/debezium/sql-server/40-check-smoke.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.dbo.t1-value
+$ schema-registry-wait subject=sql-server.test.dbo.t1-value
 
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
@@ -31,7 +31,7 @@ $ schema-registry-wait subject=sql-server.transaction-value
 
 # TODO: make sqlserver debezium tx_metadata work.  It doesn't send the END message
 > CREATE SOURCE t1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.t1')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.t1')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 

--- a/test/debezium/sql-server/40-check-transactions.td
+++ b/test/debezium/sql-server/40-check-transactions.td
@@ -7,23 +7,23 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.dbo.transaction_table1-value
+$ schema-registry-wait subject=sql-server.test.dbo.transaction_table1-value
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 > CREATE SOURCE transaction_table1
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.transaction_table1')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.transaction_table1')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 
-$ schema-registry-wait subject=sql-server.dbo.transaction_table2-value
+$ schema-registry-wait subject=sql-server.test.dbo.transaction_table2-value
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
   );
 
 > CREATE SOURCE transaction_table2
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.transaction_table2')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.transaction_table2')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 

--- a/test/debezium/sql-server/40-check-types.td
+++ b/test/debezium/sql-server/40-check-types.td
@@ -10,7 +10,7 @@
 $ sql-server-connect name=sql-server
 server=tcp:sql-server,1433;IntegratedSecurity=true;TrustServerCertificate=true;User ID=sa;Password=${arg.sa-password}
 
-$ schema-registry-wait subject=sql-server.dbo.types_table-value
+$ schema-registry-wait subject=sql-server.test.dbo.types_table-value
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -19,7 +19,7 @@ $ schema-registry-wait subject=sql-server.dbo.types_table-value
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 > CREATE SOURCE types_table
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.types_table')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.types_table')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 

--- a/test/debezium/sql-server/40-check-update.td
+++ b/test/debezium/sql-server/40-check-update.td
@@ -7,12 +7,12 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-$ schema-registry-wait subject=sql-server.dbo.update_table_pk-value
+$ schema-registry-wait subject=sql-server.test.dbo.update_table_pk-value
 
 > CREATE CONNECTION IF NOT EXISTS kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
 > CREATE SOURCE update_table_pk
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.dbo.update_table_pk')
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'sql-server.test.dbo.update_table_pk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM;
 


### PR DESCRIPTION
Before Debezium v2.4.0, the `bigint.unsigned.handling.mode=precise` was broken with Materialize, as Debezium emitted a decimal type with a scale of 64, which is too wide for Materialize's decimal type. Verify that v2.4.0 produces a properly-sized decimal that fits in Materialize's decimal type.

Upstream issue: https://issues.redhat.com/browse/DBZ-6714

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR tests the fix to a recognized bug in Debezium.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
