### PR TITLE
cloud-canary: Fix SHOW CLUSTERS output

### DIFF
--- a/test/cloud-canary/canary-clusters.td
+++ b/test/cloud-canary/canary-clusters.td
@@ -14,7 +14,7 @@
 > SET cluster=cluster1;
 
 > SHOW CLUSTERS LIKE 'cluster1';
-cluster1
+cluster1 "replica1 (3xsmall), replica2 (3xsmall)"
 
 > SHOW CLUSTER REPLICAS WHERE cluster = 'cluster1';
 cluster1 replica1 3xsmall true


### PR DESCRIPTION
The output now contains information about the replicas of each cluster.


### Motivation

Nightly CI was failing.