### PR TITLE
ci: Run Nightly on changes affecting SHOW

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -707,6 +707,8 @@ steps:
       # Changes to the SQL syntax
       - src/sql-parser/src
       - src/expr-parser/src
+      # Changes to SHOW
+      - src/sql/src/plan/statement/show.rs
       # Changes to feature flags and other settings
       - src/adapter/src/flags.rs
       - src/persist-client/src/cfg*


### PR DESCRIPTION
Changes affecting the output of SHOW should trigger Nightly in order to avoid breaking Nightly tests that use SHOW

### Motivation

Nightly broke after a PR changed the output to `SHOW CLUSTERS` . This could have been prevented had Nightly been auto-triggered on the PR.