### PR TITLE
doc/user: add basic auth example for webhooks

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -78,7 +78,7 @@ see [Request Limits](#request-limits).
 
 {{< /note >}}
 
-## Validating Requests
+## Request Validation
 
 It's common for applications using webhooks to provide a method for validating a request is
 legitimate. Using `CHECK` you can specify an expression to do this validation for your Webhook
@@ -123,3 +123,33 @@ Webhook sources apply the following limits to received requests:
 * Maximum number of concurrent connections is 100, across all webhook sources. Trying to connect
 when the server is at the maximum will return 429 Too Many Requests.
 * Requests that contain a header name specified more than once will be rejected with 401 Unauthorized.
+
+
+## Examples
+
+### Creating a Basic Authentication
+
+[Basic Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Authentication#basic_authentication_scheme) enables a simple and rudimentary way to grant authorization to your Webhook source.
+To store the sensitive credentials and make it reusable accros multiple `CREATE SOURCE` statements use [Secrets](https://materialize.com/docs/sql/create-secret/).
+
+```sql
+  CREATE SECRET BASIC_HOOK_AUTH AS 'Basic <base64_auth>';
+```
+
+### Creating a Source
+
+After a successful secret creation, you can use the same secret to create different Webhooks with the same basic authentication to check if a request is valid.
+
+```sql
+  CREATE SOURCE webhook_with_basic_auth IN CLUSTER my_cluster
+  FROM WEBHOOK
+    BODY FORMAT JSON
+    CHECK (
+      WITH (
+        HEADERS,
+        BODY AS request_body,
+        SECRET BASIC_HOOK_AUTH,
+      )
+      headers->'authorization' = BASIC_HOOK_AUTH
+    );
+```


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds a basic authentication example to the create Webhook source.
I've used it to build a Grafana -> Materialize alerting Webhook.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
