### PR TITLE
Clarify function of FILTER clause

### DIFF
--- a/doc/user/content/sql/functions/filters.md
+++ b/doc/user/content/sql/functions/filters.md
@@ -6,7 +6,9 @@ menu:
     parent: 'sql-functions'
 ---
 
-You can use a `FILTER` clause on an aggregate function to specify which rows are sent to an [aggregate function](../#aggregate-func). Rows for which the `filter_clause` evaluates to false are discarded.
+You can use a `FILTER` clause on an aggregate function to specify which rows are sent to an [aggregate function](../#aggregate-func). Rows for which the `filter_clause` evaluates to true contribute to the aggregation.
+
+Temporal filters cannot be used in aggregate function filters.
 
 ## Syntax
 
@@ -17,6 +19,7 @@ You can use a `FILTER` clause on an aggregate function to specify which rows are
 ```sql
 SELECT
     COUNT(*) AS unfiltered,
-    COUNT(*) FILTER (WHERE i < 5) AS filtered
+    -- The FILTER guards the evaluation which might otherwise error.
+    COUNT(1 / (5 - i)) FILTER (WHERE i < 5) AS filtered
 FROM generate_series(1,10) AS s(i)
 ```

--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -37,6 +37,8 @@ You can only use `mz_now()` to establish a temporal filter under the following c
 - The comparison must be one of `=`, `<`, `<=`, `>`, or `>=`, or operators that desugar to them or a conjunction of them (for example, `BETWEEN...AND...`).
     At the moment, you can't use the `!=` operator with `mz_now()`.
 
+You cannot use temporal filters in the `WHERE` clause of an [aggregate `FILTER` expression](/sql/functions/filters.md).
+
 ## Examples
 
 These examples create real objects.


### PR DESCRIPTION
Our description of the `FILTER` clause seemed to be lightly incorrect, and also did not explain that temporal filters could not be used (as the `WHERE` keyword does not translate into a SQL `WHERE` but rather a `CASE`).

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
