### PR TITLE
stash: Get rid of SerializedRole struct

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -44,7 +44,7 @@ use crate::catalog::storage::stash::DEPLOY_GENERATION;
 use crate::catalog::{
     self, is_reserved_name, Catalog, ClusterConfig, ClusterVariant, DefaultPrivilegeAclItem,
     DefaultPrivilegeObject, RoleMembership, SerializedCatalogItem, SerializedReplicaConfig,
-    SerializedReplicaLocation, SerializedReplicaLogging, SerializedRole, SystemObjectMapping,
+    SerializedReplicaLocation, SerializedReplicaLogging, SystemObjectMapping,
 };
 use crate::coord::timeline;
 
@@ -353,9 +353,9 @@ impl Connection {
             .map(RustType::from_proto)
             .map_ok(|(k, v): (RoleKey, RoleValue)| Role {
                 id: k.id,
-                name: v.role.name,
-                attributes: v.role.attributes,
-                membership: v.role.membership,
+                name: v.name,
+                attributes: v.attributes,
+                membership: v.membership,
             })
             .collect::<Result<_, _>>()?;
 
@@ -870,7 +870,7 @@ async fn transaction<'a>(stash: &'a mut Stash) -> Result<Transaction<'a>, Error>
         items: TableTransaction::new(items, |a: &ItemValue, b| {
             a.schema_id == b.schema_id && a.name == b.name
         })?,
-        roles: TableTransaction::new(roles, |a: &RoleValue, b| a.role.name == b.role.name)?,
+        roles: TableTransaction::new(roles, |a: &RoleValue, b| a.name == b.name)?,
         clusters: TableTransaction::new(clusters, |a: &ClusterValue, b| a.name == b.name)?,
         cluster_replicas: TableTransaction::new(cluster_replicas, |a: &ClusterReplicaValue, b| {
             a.cluster_id == b.cluster_id && a.name == b.name
@@ -1025,11 +1025,22 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub(crate) fn insert_user_role(&mut self, role: SerializedRole) -> Result<RoleId, Error> {
+    pub(crate) fn insert_user_role(
+        &mut self,
+        name: String,
+        attributes: RoleAttributes,
+        membership: RoleMembership,
+    ) -> Result<RoleId, Error> {
         let id = self.get_and_increment_id(USER_ROLE_ID_ALLOC_KEY.to_string())?;
         let id = RoleId::User(id);
-        let name = role.name.clone();
-        match self.roles.insert(RoleKey { id }, RoleValue { role }) {
+        match self.roles.insert(
+            RoleKey { id },
+            RoleValue {
+                name: name.clone(),
+                attributes,
+                membership,
+            },
+        ) {
             Ok(_) => Ok(id),
             Err(_) => Err(Error::new(ErrorKind::RoleAlreadyExists(name))),
         }
@@ -1301,7 +1312,7 @@ impl<'a> Transaction<'a> {
     }
 
     pub(crate) fn remove_role(&mut self, name: &str) -> Result<(), Error> {
-        let roles = self.roles.delete(|_k, v| v.role.name == name);
+        let roles = self.roles.delete(|_k, v| v.name == name);
         assert!(
             roles.iter().all(|(k, _)| k.id.is_user()),
             "cannot delete non-user roles"
@@ -1447,10 +1458,10 @@ impl<'a> Transaction<'a> {
     /// Runtime is linear with respect to the total number of items in the stash.
     /// DO NOT call this function in a loop, implement and use some `Self::update_roles` instead.
     /// You should model it after [`Self::update_items`].
-    pub(crate) fn update_role(&mut self, id: RoleId, role: SerializedRole) -> Result<(), Error> {
+    pub(crate) fn update_role(&mut self, id: RoleId, role: catalog::Role) -> Result<(), Error> {
         let n = self.roles.update(move |k, _v| {
             if k.id == id {
-                Some(RoleValue { role: role.clone() })
+                Some(RoleValue::from(role.clone()))
             } else {
                 None
             }
@@ -1995,7 +2006,19 @@ pub struct RoleKey {
 
 #[derive(Clone, PartialOrd, PartialEq, Eq, Ord, Debug)]
 pub struct RoleValue {
-    role: SerializedRole,
+    name: String,
+    attributes: RoleAttributes,
+    membership: RoleMembership,
+}
+
+impl From<catalog::Role> for RoleValue {
+    fn from(role: catalog::Role) -> Self {
+        RoleValue {
+            name: role.name,
+            attributes: role.attributes,
+            membership: role.membership,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord)]

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -16,7 +16,6 @@ use crate::catalog::storage::{
 };
 use crate::catalog::{
     ClusterConfig, ClusterVariant, ClusterVariantManaged, RoleMembership, SerializedCatalogItem,
-    SerializedRole,
 };
 
 use super::{
@@ -580,23 +579,21 @@ impl RustType<proto::RoleMembership> for RoleMembership {
 impl RustType<proto::RoleValue> for RoleValue {
     fn into_proto(&self) -> proto::RoleValue {
         proto::RoleValue {
-            name: self.role.name.to_string(),
-            attributes: Some(self.role.attributes.into_proto()),
-            membership: Some(self.role.membership.into_proto()),
+            name: self.name.to_string(),
+            attributes: Some(self.attributes.into_proto()),
+            membership: Some(self.membership.into_proto()),
         }
     }
 
     fn from_proto(proto: proto::RoleValue) -> Result<Self, TryFromProtoError> {
         Ok(RoleValue {
-            role: SerializedRole {
-                name: proto.name,
-                attributes: proto
-                    .attributes
-                    .into_rust_if_some("RoleValue::attributes")?,
-                membership: proto
-                    .membership
-                    .into_rust_if_some("RoleValue::membership")?,
-            },
+            name: proto.name,
+            attributes: proto
+                .attributes
+                .into_rust_if_some("RoleValue::attributes")?,
+            membership: proto
+                .membership
+                .into_rust_if_some("RoleValue::membership")?,
         })
     }
 }


### PR DESCRIPTION
### Motivation

* This PR refactors existing code.

Now that we define the serialization of the Stash in protobuf, we don't have a need for this intermediary struct.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
