### PR TITLE
adapter: Update show command in views comment

### DIFF
--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1633,14 +1633,12 @@ fn plan_set_expr(
             // what schema to use. As a result Materialize will fail to boot.
             //
             // Some `SHOW` commands are ok, like `SHOW CLUSTERS`, and there are probably other ways
-            // around this issue. Such as expanding the `SHOW` command in the SQL definition. For
-            // now we just disallow any `SHOW` commands in views.
+            // around this issue. Such as expanding the `SHOW` command in the SQL definition.
+            // However, banning show commands in views gives us more flexibility to change their
+            // output.
             //
-            // Ideally, the `SHOW` commands that use the current schema would expand to use the
-            // `current_schema()` function, instead of hard-coding the current schema id, so that
-            // planning can correctly identify that they are unmaterializable. However, that's a
-            // little tricky because `current_schema()` returns a schema name not id, which is what
-            // we need.
+            // TODO(jkosh44) Add message to error that prints out an equivalent view definition
+            // with all show commands expanded into their equivalent SELECT statements.
             if qcx.lifetime == QueryLifetime::Static {
                 return Err(PlanError::ShowCommandInView);
             }


### PR DESCRIPTION
Update comment in the planner to indicate that we don't intend to allow SHOW commands in views.

Closes #21027

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
