### PR TITLE
storage: shutdown upsert sources correctly

### DIFF
--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -494,7 +494,7 @@ where
                                 } else {
                                     (Collection::new(empty(scope)), None, None, None)
                                 };
-                            let (upsert, health_update) = crate::render::upsert::upsert(
+                            let (upsert, health_update, upsert_token) = crate::render::upsert::upsert(
                                 &upsert_input.enter(scope),
                                 upsert_envelope.clone(),
                                 refine_antichain(&resume_upper),
@@ -505,6 +505,12 @@ where
                                 &storage_state.dataflow_parameters,
                                 backpressure_metrics,
                             );
+
+                            // Even though we register the `persist_sink` token at a top-level,
+                            // which will stop any data from being committed, we also register
+                            // a token for the `upsert` operator which may be in the middle of
+                            // rehydration processing the `persist_source` input above.
+                            needed_tokens.push(upsert_token);
 
                             use mz_timely_util::probe::ProbeNotify;
                             let handle = mz_timely_util::probe::Handle::default();


### PR DESCRIPTION
This resolves an issue in an incident where continuously restarting sources eventually causes ooms. It appears we do not shut down the upsert operator until we finish rehydration, leaking memory.

I originally thought that this fix also revealed a correctness bug, where the `upsert` operator could produce incorrect data, as it sees an empty frontier from the kafka input. It actually _could_ produce wrong data, but that data could not be committed because of the fixes resulting from https://github.com/MaterializeInc/materialize/issues/18837 and https://github.com/MaterializeInc/materialize/pull/19079.

https://github.com/MaterializeInc/materialize/pull/19079 shows us that we need to be quite careful with using `tokens`, but this seems like a fairly innocuous use of them: simply stop and drop the upsert state as soon as we can.

There is still a race here where a new upsert operator could start before the other is shutdown. This is fine for memory-backed upsert, but could cause continuous errors for rocksdb-backed upsert, where 2 instances of the same operator are fighting for the same file lock. That will have to be fixed as a followup.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
