### PR TITLE
ci: Larger instance for "Checks upgrade from previous version, whole-…

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -480,7 +480,7 @@ steps:
     label: "Checks upgrade from previous version, whole-Mz restart"
     timeout_in_minutes: 60
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:


### PR DESCRIPTION
…Mz restart"

Platform-check based jobs that perform whole-Mz restarts, with or without upgrade, OOM when run on the default CI instance size.

### Motivation

Nightly CI was failing.