### PR TITLE
Unbilled replica design doc

### DIFF
--- a/doc/developer/design/20230814_unbilled_replicas.md
+++ b/doc/developer/design/20230814_unbilled_replicas.md
@@ -14,107 +14,97 @@ customer.
 We extend Materialize with a concept of unbilled replicas, which server compute
 traffic but are not charged to a customer's account.
 
-To achieve this, we extend clusters and their replicas with concept of profiles.
-A profile defines properties shared by a group of replicas within a cluster.
+To achieve this, we extend clusters and their replicas with concept of replica sets.
+A replica set defines properties shared by a partition of replicas within a cluster.
+We allow internal users to create replica sets with specific billing information to add free or cost-reduced resouces to user environemnts, without changing the structure of a user's deplyoment.
 
 ## Goals
 
 We introduce unbilled clusters by the following means:
-* Introduce cluster profiles.
-* Add a billing property to cluster profiles.
-* Record cluster profile properties in audit events.
+* Introduce replica sets.
+* Add a billing property to replica sets.
+* Record replica set properties in audit events.
 
 ## Non-Goals
 
 We do not plan to do the following:
-* Allow customers general access to cluster profiles.
+* Allow customers general access to replica sets.
 
 ## Overview
 
-We introduce the concept of cluster profiles, which capture groups
-of replica sharing configuration aspects. Profiles can co-exist, and a default
-profile captures the current configuration. Each replica is a member of a single
-profile.
+We introduce the concept of replica sets, which capture partitions
+of replicas sharing configuration aspects. Replica sets can co-exist, and a default
+replica set captures the current configuration of a cluster. Each replica is a member of a single
+replica set.
 
-At this time, we only support cluster profiles for internal users, but do not
-give customers the permission to directly interact with cluster profiles. This
+At this time, we only support replica sets for internal users, but do not
+give customers the permission to directly interact with replica sets. This
 is to give us time to validate the feature, and decide on reserved names.
 
 ## Detailed description
 
-We extend clusters to support multiple replica configurations, and name each a profile.
-A cluster profile describes the properties of a group of replicas within a cluster.
-A cluster can have several profiles, and each replica is part of a single profile.
+We extend clusters to support multiple replica configurations, and name each a replica set.
+A replica set describes the properties of a partition of replicas within a cluster.
+A cluster can have several replica sets, and each replica is part of a single replica set.
 
-Multiple profiles within a cluster can co-exist simultaneously, but have different parameters.
+Multiple replica set within a cluster can co-exist simultaneously, and can have different parameters.
 We do not change that all replicas in a cluster execute equivalent commands and participate equally in producing responses.
 
 ```sql
--- Creating a managed cluster profile without billing
-CREATE CLUSTER PROFILE cluster.support WITH (SIZE '3xlarge', BILLED AS 'unbilled');
--- Drop the profile, releasing any associated resource.
-DROP CLUSTER PROFILE cluster.support;
+-- Creating a managed replica set without billing
+CREATE REPLICA SET cluster.support WITH (SIZE '3xlarge', BILLED AS 'unbilled');
+-- Drop the replica set, releasing any associated resource.
+DROP REPLICA SET cluster.support;
 
--- Alternatively, create an unmanaged profile without billing.
-CREATE CLUSTER PROFILE cluster.support WITH (MANAGED = FALSE, BILLED AS 'unbilled');
--- Create a replica in the profile.
-CREATE CLUSTER REPLICA cluster.r1 SIZE '3xlarge' IN PROFILE support;
--- Drop the profile, also dropping replica `r1`.
-DROP CLUSTER PROFILE cluster.support CASCADE;
+-- Alternatively, create an unmanaged replica set without billing.
+CREATE REPLICA SET cluster.support WITH (MANAGED = FALSE, BILLED AS 'unbilled');
+-- Create a replica in the replica set.
+CREATE CLUSTER REPLICA cluster.r1 SIZE '3xlarge' IN REPLICA SET support;
+-- Drop the replica set, also dropping replica `r1`.
+DROP REPLICA SET cluster.support CASCADE;
 ```
 
-### Profiles and replicas
+### Replica sets and replicas
 
 At the moment, clusters only contain replicas.
-With the introduction of cluster profiles, we change this property to allow different kinds of objects as part of a cluster.
-Replicas and profiles share a common cluster namespace, so their names need to be unique within a cluster, but can be reused across clusters.
+With the introduction of replica sets, we change this property to allow different kinds of objects as part of a cluster.
+Replicas and replica sets share a common cluster namespace, so their names need to be unique within a cluster, but can be reused across clusters.
 
-At this time, users do not need to work with profiles if they don't choose to.
-Each cluster has an implicit profile (a.k.a, the `NULL` profile?) that they interact with using the managed or unmanaged cluster SQL API.
+At this time, users do not need to work with replica sets if they don't choose to.
+Each cluster has an implicit replica set (a.k.a, the `NULL` replica set?) that they interact with using the managed or unmanaged cluster SQL API.
 
-The following example demonstrates using the implicit profile:
+The following example demonstrates using the implicit replica set:
 ```sql
 CREATE CLUSTER clname SIZE '3xlarge';
 ```
 
-### Resources within profiles
+### Resources within replica sets
 
-Replicas are part of a profile, and their lifetime is tied to that of the profile:
+Replicas are part of a replica sets, and their lifetime is tied to that of the replica set:
 
 ```sql
--- Cluster `cl` has a profile `default` with one replica `r1`
-DROP CLUSTER PROFILE cl.default;
-ERROR: Cluster profile cl.default has objects
+-- Cluster `cl` has an implicit replica set with one replica `r1`
+DROP REPLICA SET cl.default;
+ERROR: Replica set cl.default has objects
 HINT: Drop objects first, or specify CASCADE.
 
-DROP CLUSTER PROFILE cl.default CASCADE;
+DROP REPLICA SET cl.default CASCADE;
 ```
 
-### Managed and unmanaged profiles
+### Managed and unmanaged replica sets
 
-We can mix managed and unmanaged profiles:
+We can mix managed and unmanaged replica sets:
 
 ```sql
--- Create cluster without profiles
-CREATE CLUSTER cl;
--- Create `default` profile, which include replicas `cl.default_r1`, `cl.default_r2`:
-CREATE CLUSTER PROFILE cl.default SIZE '3xsmall', REPLICATION FACTOR 2;
--- Create `p1` profile, which includes replica `cl.r1`:
-CREATE CLUSTER PROFILE cl.p1 REPLICAS (r1 SIZE 'large');
+-- Create the a cluster with an implicit managed replica set, which include replicas `cl.r1`, `cl.r2`:
+CREATE CLUSTER cl SIZE '3xsmall', REPLICATION FACTOR 2;
+-- Create the `p1` replica set, which includes replica `cl.p1_r1`:
+CREATE REPLICA SET cl.p1 REPLICAS (p1_r1 SIZE 'large');
 ```
 
 This requires a change to the names of replicas in managed clusters. Instead of
-only using the names `r1..rN`, we could use the profile name, or `default`, as a
+only using the names `r1..rN`, we could use the replica set name, or `default`, as a
 prefix.
-
-This is equivalent to creating the default profile in-line:
-
-```sql
--- Create default profile as part of the cluster:
-CREATE CLUSTER cl SIZE '3xsmall', REPLICATION FACTOR 2;
--- Create `p1` profile:
-CREATE CLUSTER PROFILE cl.p1 REPLICAS (r1 SIZE 'large');
-```
 
 The syntax to drop replicas stays the same:
 
@@ -123,28 +113,35 @@ The syntax to drop replicas stays the same:
 DROP CLUSTER REPLICA cl.r1;
 ```
 
-### Altering profiles
+### Altering replica sets
 
 * Similar to altering clusters
-* Altering profile name: Rename profile, rename replicas for managed profiles
-* Should we allow moving replicas between profiles?
-
-```sql
-ALTER CLUSTER REPLICA cl.r1 IN PROFILE support;
-ERROR: Cannot move billed replica to unbilled profile.
-```
-
-* Can we use RBAC to limit what users can do with unbilled profiles?
+  ```sql
+  ALTER REPLICA SET cl.p1 SET (REPLICATION FACTOR 0);
+  ```
+* Altering replica set name: Rename the replica set, rename replicas for managed replica sets
+  ```sql
+  ALTER REPLICA SET cl.p1 RENAME TO p2;
+  ```
+* Should we allow moving replicas between replica sets?
+  ```sql
+  ALTER CLUSTER REPLICA cl.r1 IN REPLICA SET support;
+  ERROR: Cannot move billed replica to unbilled replica set.
+  ```
+* Can we use RBAC to limit what users can do with unbilled replica sets?
+  * Owner can modify
+  * Owner can change owner
+  * Cluster owner can drop
 
 ### System catalog
 
-We need to present cluster profiles in the system catalog.
-We extend the `mz_cluster_replicas` table with a `profile_id` column that names the profile ID, or `NULL` if the replica is part of the implicit default profile.
+We need to present replica sets in the system catalog.
+We extend the `mz_cluster_replicas` table with a `replica_set_id` column that names the replica set ID, or `NULL` if the replica is part of the implicit default replica set.
 
-We add a `mz_cluster_profiles` table that has the following columns:
-* `cluster_id`: The ID of the cluster the profile belongs to.
-* `profile_id`: The ID of the profile within the cluster namespace.
-* `managed`: Whether the profile is a managed replica profile.
+We add a `mz_replica_sets` table that has the following columns:
+* `cluster_id`: The ID of the cluster the replica set belongs to.
+* `replica_set_id`: The ID of the replica set within the cluster namespace.
+* `managed`: Whether the replica set is a managed. `true` if managed, `false` if unmanaged.
 * `size`: If `managed`, the size of replicas. `NULL` otherwise.
 * `replication_factor`:  If `managed`, the replica replication factor. `NULL` otherwise.
 * Introspection settings, which need to be defined. They are currently not exposed in the catalog.
@@ -154,9 +151,7 @@ An open question is whether this data should be presented as columns or a JSON b
 ### Stash
 
 The stash currently stores replicas as the only items within replicas.
-We need to change this such that replicas are a variant of items, with profiles being the alternative.
-
-
+We need to change this such that replicas are a variant of items, with replica sets being the alternative.
 
 ### Billing
 
@@ -170,8 +165,8 @@ that we lack an audit trail of events. For this reason alone, we'd like to
 include unbilled replicas in the audit log, but clearly marked as such.
 
 ```sql
--- Create an unbilled profile
-CREATE CLUSTER PROFILE cl.support BILLED = false, SIZE 'xlarge';
+-- Create an unbilled replica set
+CREATE REPLICA SET cl.support BILLED AS 'free', SIZE 'xlarge';
 ```
 
 The `BILLED` setting is reserved for Materialize and cannot be used by users.
@@ -180,7 +175,7 @@ The `BILLED` setting is reserved for Materialize and cannot be used by users.
 
 ### Cluster replica properties
 
-Instead of introducing profiles, we could encode the information directly on
+Instead of introducing replica sets, we could encode the information directly on
 replicas. This has the benefit that we don't have to introduce a novel concept,
 but it doesn't integrate well with managed clusters.
 
@@ -199,9 +194,9 @@ be billed based on different billing profiles.
 
 ## Open questions
 
-* Are we convinced that a cluster profiles feature is worth adding?
-* Cluster profiles would be interesting for the following features:
-  * Customer-specific scheduling of profiles to switch between business hours
+* Are we convinced that replica sets are worth adding?
+* Replica sets would be interesting for the following features:
+  * Customer-specific scheduling of replica sets to switch between business hours
     and off-hours replica configurations.
   * Namespacing for clusters during graceful reconfigurations.
   * Namespacing for clusters during automatic load-based reconfiguration.

--- a/doc/developer/design/20230814_unbilled_replicas.md
+++ b/doc/developer/design/20230814_unbilled_replicas.md
@@ -103,8 +103,7 @@ CREATE REPLICA SET cl.p1 REPLICAS (p1_r1 SIZE 'large');
 ```
 
 This requires a change to the names of replicas in managed clusters. Instead of
-only using the names `r1..rN`, we could use the replica set name, or `default`, as a
-prefix.
+only using the names `r1..rN`, we could use the replica set name as a prefix.
 
 The syntax to drop replicas stays the same:
 
@@ -166,10 +165,10 @@ include unbilled replicas in the audit log, but clearly marked as such.
 
 ```sql
 -- Create an unbilled replica set
-CREATE REPLICA SET cl.support BILLED AS 'free', SIZE 'xlarge';
+CREATE REPLICA SET cl.support BILL AS 'free', SIZE 'xlarge';
 ```
 
-The `BILLED` setting is reserved for Materialize and cannot be used by users.
+The `BILL` setting is reserved for Materialize and cannot be used by users.
 
 ## Alternatives
 

--- a/doc/developer/design/20230814_unbilled_replicas.md
+++ b/doc/developer/design/20230814_unbilled_replicas.md
@@ -1,0 +1,95 @@
+# Unbilled replicas
+
+- [#20317)](https://github.com/MaterializeInc/materialize/issues/20317)
+
+## Context
+
+Support requires the ability to dynamically add resources to a user's environment
+without incurring substantial costs for the user. For example, when support
+notices that after a version upgrade, Materialize needs additional compute
+resources, support should be able to add such resources for a limited amount of
+time without requiring explicit approval and complicated reimbursement for the
+customer.
+
+We extend Materialize with a concept of unbilled replicas, which server compute
+traffic but are not charged to a customer's account.
+
+## Goals
+
+We introduce unbilled clusters by the following means:
+* Introduce cluster profiles.
+* Add a billing property to cluster profiles.
+* Record cluster profile properties in audit events.
+
+## Non-Goals
+
+We do not plan to do the following:
+* Allow customers general access to cluster profiles.
+
+## Overview
+
+We introduce the notion of different cluster profiles, which capture groups
+of replica sharing configuration aspects. Profiles can co-exist, and a default
+profile captures the current configuration.
+
+At this time, we only support cluster profiles for internal users, but do not
+give customers the permission to directly interact with cluster profiles. This
+is to give us time to validate the feature, and decide on reserved names.
+
+## Detailed description
+
+```sql
+-- Creating a managed cluster profile without billing
+CREATE CLUSTER PROFILE cluster.support WITH (SIZE '3xlarge', BILLED = FALSE);
+-- Drop the profile, releasing any associated resource.
+DROP CLUSTER PROFILE cluster.support;
+
+-- Alternatively, create an unmanaged profile without billing.
+CREATE CLUSTER PROFILE cluster.support WITH (MANAGED = FALSE, BILLED = FALSE);
+-- Create a replica in the profile, identifying the profile in the name.
+CREATE CLUSTER REPLICA cluster.support.r1 SIZE '3xlarge';
+-- Drop the profile
+DROP CLUSTER PROFILE cluster.support CASCADE;
+```
+
+### Billing
+
+Materialize records when a user creates and drops cluster replicas. We need to
+log unbilled replicas differently, either indicating in the audit log that
+someone else covers their cost, or not logging events for unbilled replicas in
+the audit log.
+
+Not logging cluster replica events has several disadvantages, most importantly
+that we lack an audit trail of events. For this reason alone, we'd like to
+include unbilled replicas in the audit log, but clearly marked as such.
+
+## Alternatives
+
+### Cluster replica properties
+
+Instead of introducing profiles, we could encode the information directly on
+replicas. This has the benefit that we don't have to introduce a novel concept,
+but it doesn't integrate well with managed clusters.
+
+To avoid the interaction with managed clusters, we could allow unbilled replicas
+only for unmanaged clusters where there are no constraints across replicas.
+
+### Specific billing information
+
+Instead of adding a boolean property indicating whether a replica is billed to a
+customer, we could add a proper string indicating _who_ should be billed for a
+replica. Even if the customer isn't billed, we'd want to track the spending for
+accounting purposes.
+
+In the future, this could allow customers to be more specific as to who should
+be billed based on different billing profiles.
+
+## Open questions
+
+* Are we convinced that a cluster profiles feature is worth adding?
+* Cluster profiles would be interesting for the following features:
+  * Customer-specific scheduling of profiles to switch between business hours
+    and off-hours replica configurations.
+  * Namespacing for clusters during graceful reconfigurations.
+  * Namespacing for clusters during automatic load-based reconfiguration.
+  * Blue/green deployments where sets replicas as a whole could be moved.

--- a/doc/developer/design/20230814_unbilled_replicas.md
+++ b/doc/developer/design/20230814_unbilled_replicas.md
@@ -1,6 +1,6 @@
 # Unbilled replicas
 
-- [#20317)](https://github.com/MaterializeInc/materialize/issues/20317)
+- [#20317](https://github.com/MaterializeInc/materialize/issues/20317)
 
 ## Context
 
@@ -12,8 +12,10 @@ time without requiring explicit approval and complicated reimbursement for the
 customer.
 
 We extend Materialize with a concept of unbilled replicas, which server compute
-traffic but are not charged to a customer's account. To achieve this, we extend
-properties of clusters and their replicas with a profiles abstraction.
+traffic but are not charged to a customer's account.
+
+To achieve this, we extend clusters and their replicas with concept of profiles.
+A profile defines properties shared by a group of replicas within a cluster.
 
 ## Goals
 
@@ -29,9 +31,10 @@ We do not plan to do the following:
 
 ## Overview
 
-We introduce the notion of cluster profiles, which capture groups
+We introduce the concept of cluster profiles, which capture groups
 of replica sharing configuration aspects. Profiles can co-exist, and a default
-profile captures the current configuration.
+profile captures the current configuration. Each replica is a member of a single
+profile.
 
 At this time, we only support cluster profiles for internal users, but do not
 give customers the permission to directly interact with cluster profiles. This
@@ -40,8 +43,11 @@ is to give us time to validate the feature, and decide on reserved names.
 ## Detailed description
 
 We extend clusters to support multiple replica configurations, and name each a profile.
-A cluster profile describes the properties of a set of replicas within a cluster.
+A cluster profile describes the properties of a group of replicas within a cluster.
 A cluster can have several profiles, and each replica is part of a single profile.
+
+Multiple profiles within a cluster can co-exist simultaneously, but have different parameters.
+We do not change that all replicas in a cluster execute equivalent commands and participate equally in producing responses.
 
 ```sql
 -- Creating a managed cluster profile without billing
@@ -59,13 +65,16 @@ DROP CLUSTER PROFILE cluster.support CASCADE;
 
 ### Profiles and replicas
 
-When a user doesn't specify a profile, they interact with the default profile:
+At the moment, clusters only contain replicas.
+With the introduction of cluster profiles, we change this property to allow different kinds of objects as part of a cluster.
+Replicas and profiles share a common cluster namespace, so their names need to be unique within a cluster, but can be reused across clusters.
 
+At this time, users do not need to work with profiles if they don't choose to.
+Each cluster has an implicit profile (a.k.a, the `NULL` profile?) that they interact with using the managed or unmanaged cluster SQL API.
+
+The following example demonstrates using the implicit profile:
 ```sql
 CREATE CLUSTER clname SIZE '3xlarge';
--- Equivalent to:
-CREATE CLUSTER clname;
-CREATE CLUSTER PROFILE clname.default SIZE '3xlarge';
 ```
 
 ### Resources within profiles
@@ -126,6 +135,28 @@ ERROR: Cannot move billed replica to unbilled profile.
 ```
 
 * Can we use RBAC to limit what users can do with unbilled profiles?
+
+### System catalog
+
+We need to present cluster profiles in the system catalog.
+We extend the `mz_cluster_replicas` table with a `profile_id` column that names the profile ID, or `NULL` if the replica is part of the implicit default profile.
+
+We add a `mz_cluster_profiles` table that has the following columns:
+* `cluster_id`: The ID of the cluster the profile belongs to.
+* `profile_id`: The ID of the profile within the cluster namespace.
+* `managed`: Whether the profile is a managed replica profile.
+* `size`: If `managed`, the size of replicas. `NULL` otherwise.
+* `replication_factor`:  If `managed`, the replica replication factor. `NULL` otherwise.
+* Introspection settings, which need to be defined. They are currently not exposed in the catalog.
+
+An open question is whether this data should be presented as columns or a JSON blob.
+
+### Stash
+
+The stash currently stores replicas as the only items within replicas.
+We need to change this such that replicas are a variant of items, with profiles being the alternative.
+
+
 
 ### Billing
 

--- a/doc/developer/design/20230814_unbilled_replicas.md
+++ b/doc/developer/design/20230814_unbilled_replicas.md
@@ -61,10 +61,10 @@ ERROR: BILLED AS and INTERNAL not permitted for non-system users.
 HINT: Contact support for billing-related inquiries.
 ```
 
-We introduce an internal `mz_managed_cluster_replicas` table that lists replicas managed by managed clusters.
+We introduce an internal `mz_internal_cluster_replicas` table that lists replicas with the `INTERNAL` flag.
 Joining this table with all replicas allows users to determine which replicas are part of their configuration and which ones are managed by Materialize.
 ```sql
-SELECT id FROM mz_internal.mz_managed_cluster_replicas;
+SELECT id FROM mz_internal.mz_internal_cluster_replicas;
 id
 u123
 u234


### PR DESCRIPTION
### Motivation

Design doc for #20317.

Rendered: https://github.com/antiguru/materialize/blob/unbilled_replicas_design/doc/developer/design/20230814_unbilled_replicas.md

## Implemented alternative

```
CREATE CLUSTER REPLICA clsname.support_free SIZE 'xsmall', BILLED AS 'free', INTERNAL;
```


## Not implemented alternative:

Introduce replica sets that capture the configuration of a partition of cluster's replicas. I'll let an example speak for itself:

```
-- Customer has a cluster `serving`:
CREATE CLUSTER serving SIZE '3xsmall', REPLICATION FACTOR 2;

-- 3xsmall might be too small to handle the workload after a change on Materialize's side.
-- We add a larger instance until we figure out what's going on:
CREATE REPLICA SET serving.support SIZE 'large', REPLICATION FACTOR 1, BILLED AS 'free';

-- At this point, the cluster `serving` has three replicas, two of size 3xsmall billed
-- as usual, and a single large that's not billed.

-- We figure out large is not large enough:
ALTER REPLICA SET serving.support SET (SIZE '2xlarge');

-- We fixed the problem!
DROP REPLICA SET serving.support;
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
