### PR TITLE
tracing: set OpenTelemetry error handler

### DIFF
--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -339,23 +339,24 @@ where
 
             if now.saturating_sub(last_log) >= OPENTELEMETRY_ERROR_MSG_BACKOFF_SECONDS {
                 if last_log_in_epoch_seconds
-                    .compare_exchange_weak(last_log, now, Ordering::SeqCst, Ordering::SeqCst)
+                    .compare_exchange_weak(last_log, now, Ordering::Relaxed, Ordering::Relaxed)
                     .is_err()
                 {
                     return;
                 }
+                use crate::error::ErrorExt;
                 match err {
                     Error::Trace(err) => {
-                        warn!("{}", err);
+                        warn!("OpenTelemetry error: {}", err.display_with_causes());
                     }
                     Error::Metric(err) => {
-                        warn!("{}", err);
+                        warn!("OpenTelemetry error: {}", err.display_with_causes());
                     }
                     Error::Log(err) => {
-                        warn!("{}", err);
+                        warn!("OpenTelemetry error: {}", err.display_with_causes());
                     }
                     Error::Other(err) => {
-                        warn!("{}", err);
+                        warn!("OpenTelemetry error: {}", err);
                     }
                     _ => {
                         warn!("unknown OpenTelemetry error");

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -40,7 +40,7 @@ use prometheus::IntCounter;
 use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
-use tracing::{error, warn, Event, Level, Subscriber};
+use tracing::{warn, Event, Level, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::fmt::format::{format, Writer};

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -335,7 +335,6 @@ where
                 .duration_since(std::time::SystemTime::UNIX_EPOCH)
                 .expect("Failed to get duration since Unix epoch")
                 .as_secs();
-
             let last_log = last_log_in_epoch_seconds.load(Ordering::SeqCst);
 
             if now.saturating_sub(last_log) >= OPENTELEMETRY_ERROR_MSG_BACKOFF_SECONDS {

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -338,9 +338,9 @@ where
             let last_log = last_log_in_epoch_seconds.load(Ordering::SeqCst);
 
             if now.saturating_sub(last_log) >= OPENTELEMETRY_ERROR_MSG_BACKOFF_SECONDS {
-                if !last_log_in_epoch_seconds
+                if last_log_in_epoch_seconds
                     .compare_exchange_weak(last_log, now, Ordering::SeqCst, Ordering::SeqCst)
-                    .is_ok()
+                    .is_err()
                 {
                     return;
                 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Create our own error handler to:
1. Rate limit the number of error logs. By default the OTel library will emit an enormous number of duplicate logs if any errors occur, one per batch send attempt, until the error is resolved.
2. Log the errors via our tracing layer, so they are formatted consistently with the rest of our logs, rather than the direct `eprintln` used by the OTel library.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
