### PR TITLE
lint: Use `pyright` rather than `mypy`

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -23,11 +23,9 @@ typecheck_cmd="npx pyright@$pyright_version"
 python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)
 
-compose_files=$(git_files "**/mzcompose.py")
-test_files=$(git_files "test/**.py")
-unique_files=$(echo $compose_files $test_files | sort -u)
+compose_files=$(git_files "**/mzcompose.py" | grep -v "test/")
 
-try $typecheck_cmd "${python_folders[@]}" $unique_files
+try $typecheck_cmd "${python_folders[@]}" $compose_files "test/"
 
 try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
 

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -23,21 +23,16 @@ typecheck_cmd="npx pyright@$PYRIGHT_VERSION --level=error"
 python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)
 
-try $typecheck_cmd "${python_folders[@]}"
-if ! try_last_failed; then
-    # mzcompose.py files need to be passed to the typechecker individually to avoid
-    # duplicate module warnings. We don't check these if the previous `pyright`
-    # invocation failed, though, or we'll get a ton of duplicate warnings.
-    for file in $(git_files "**/mzcompose.py"); do
-        try $typecheck_cmd "$file"
-    done
+compose_files=$(git_files "**/mzcompose.py")
+test_files=$(git_files "test/**.py")
+unique_files=$(echo $compose_files $test_files | sort -u)
 
-    for file in $(git_files "test/**.py"); do
-        if [[ $file == *"mzcompose"* ]]; then
-            continue
-        fi
-        try $typecheck_cmd "$file"
-    done
+try $typecheck_cmd "${python_folders[@]}" $unique_files
+
+try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
+
+if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
+  try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 fi
 try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
 

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -17,23 +17,26 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-mypy_folders=(ci misc/python)
+PYRIGHT_VERSION="1.1.323"
+typecheck_cmd="npx pyright@$PYRIGHT_VERSION --level=error"
+
+python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)
 
-try bin/pyactivate -m mypy "${mypy_folders[@]}"
+try $typecheck_cmd "${python_folders[@]}"
 if ! try_last_failed; then
-    # mzcompose.py files need to be passed to mypy individually to avoid
-    # duplicate module warnings. We don't check these if the previous `mypy`
+    # mzcompose.py files need to be passed to the typechecker individually to avoid
+    # duplicate module warnings. We don't check these if the previous `pyright`
     # invocation failed, though, or we'll get a ton of duplicate warnings.
     for file in $(git_files "**/mzcompose.py"); do
-        try bin/pyactivate -m mypy "$file"
+        try $typecheck_cmd "$file"
     done
 
     for file in $(git_files "test/**.py"); do
         if [[ $file == *"mzcompose"* ]]; then
             continue
         fi
-        try bin/pyactivate -m mypy "$file"
+        try $typecheck_cmd "$file"
     done
 fi
 try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -25,6 +25,9 @@ flake8_folders=(ci misc/python test)
 
 compose_files=$(git_files "**/mzcompose.py" | grep -v "test/")
 
+# NOTE: we actually _want_ the word-splitting behavior on `typecheck_cmd` below,
+# so turn off the warning
+# shellcheck disable=SC2086
 try $typecheck_cmd "${python_folders[@]}" $compose_files "test/"
 
 try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -35,10 +35,4 @@ if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
   try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 fi
 
-# try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
-
-# if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
-#   try bin/pyactivate -m pytest -qq --doctest-modules misc/python
-# fi
-
-# try_finish
+try_finish

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -17,8 +17,8 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-PYRIGHT_VERSION="1.1.323"
-typecheck_cmd="npx pyright@$PYRIGHT_VERSION"
+pyright_version=$(sh ci/builder/pyright-version.sh)
+typecheck_cmd="npx pyright@$pyright_version"
 
 python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -18,7 +18,7 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 PYRIGHT_VERSION="1.1.323"
-typecheck_cmd="npx pyright@$PYRIGHT_VERSION --level=error"
+typecheck_cmd="npx pyright@$PYRIGHT_VERSION"
 
 python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)
@@ -34,10 +34,11 @@ try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[
 if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
   try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 fi
-try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
 
-if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
-  try bin/pyactivate -m pytest -qq --doctest-modules misc/python
-fi
+# try bin/pyactivate -m flake8 --select F --extend-exclude venv "${flake8_folders[@]}"
 
-try_finish
+# if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
+#   try bin/pyactivate -m pytest -qq --doctest-modules misc/python
+# fi
+
+# try_finish

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -191,6 +191,12 @@ RUN mkdir rust \
 RUN ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-ld.lld \
     && ln -s /usr/bin/lld /opt/x-tools/$ARCH_GCC-unknown-linux-gnu/bin/$ARCH_GCC-unknown-linux-gnu-lld
 
+# Install the locked version of our typechecker -- it'll be invoked via `npx`,
+# so using the same command here should ensure it's installed and cached in the
+# right place
+COPY pyright-version.sh /workdir/
+RUN npx pyright@$(sh /workdir/pyright-version.sh) --help
+
 # Install Python dependencies. These are so quick to install and change
 # frequently enough that it makes sense to install them last.
 

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -97,7 +97,6 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     lld \
     llvm \
     make \
-    npm \
     openssh-client \
     pkg-config \
     postgresql-client-14 \

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -110,6 +110,11 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     xz-utils \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Node.js LTS, for our Python typechecker. This is up here because we don't
+# expect it to change often.
+RUN curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y nodejs
+
 RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/autouseradd-1.3.0-$ARCH_GO.tar.gz \
     | tar xz -C / --strip-components 1 \
     && curl -fsSL https://github.com/koalaman/shellcheck/releases/download/v0.8.0/shellcheck-v0.8.0.linux.$ARCH_GCC.tar.xz > shellcheck.tar.xz \

--- a/ci/builder/pyright-version.sh
+++ b/ci/builder/pyright-version.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# pyright-version.sh — specifies version of Pyright typechecker we use
+# as a string printed to stdout, for use from other tools
+
+printf "1.1.323"

--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -25,7 +25,6 @@ kubernetes==25.3.0
 kubernetes-stubs==22.6.0.post1
 launchdarkly-api==11.0.0
 matplotlib==3.7.2
-mypy==1.4.1
 networkx==3.0
 networkx-stubs==0.0.1
 numpy==1.25.0

--- a/doc/developer/zippy.md
+++ b/doc/developer/zippy.md
@@ -111,7 +111,7 @@ Actions have a `requires()` and a `provides()` method. The `requires()` method i
 ```python
 class CreateView(Action):
     @classmethod
-    def requires(self) -> List[Set[Type[Capability]]]:
+    def requires(cls) -> List[Set[Type[Capability]]]:
         return [{MzIsRunning, SourceExists}, {MzIsRunning, TableExists}]
 ```
 

--- a/misc/python/materialize/cli/crate_diagram.py
+++ b/misc/python/materialize/cli/crate_diagram.py
@@ -107,7 +107,7 @@ def main(show: bool, diagram_file: Optional[str], roots: List[str]) -> None:
     if roots:
         (local_deps, areas) = filter_to_roots(areas, local_deps, roots)
 
-    diagram_file = MZ_ROOT / diagram_file
+    diagram_file = str(MZ_ROOT / diagram_file)
     with NamedTemporaryFile(mode="w+", prefix="mz-arch-diagram-") as out:
         write_dot_graph(member_meta, local_deps, areas, out)
 
@@ -135,13 +135,13 @@ def main(show: bool, diagram_file: Optional[str], roots: List[str]) -> None:
 def filter_to_roots(
     areas: DepBuilder, local_deps: DepMap, roots: List[str]
 ) -> Tuple[DepMap, DepBuilder]:
-    new_deps: DefaultDict[str, Set[str]] = defaultdict(set)
+    new_deps = defaultdict(set)
 
     try:
         add_deps(local_deps, new_deps, roots)
     except KeyError as e:
         raise click.ClickException(f"Unknown crate {e}")
-    new_deps = {root: list(deps) for root, deps in new_deps.items()}
+    new_dep_map: DepMap = {root: list(deps) for root, deps in new_deps.items()}
 
     filtered_crates = set()
     for root, deps in new_deps.items():
@@ -154,7 +154,7 @@ def filter_to_roots(
             if child in filtered_crates:
                 new_areas[area].append(child)
 
-    return (new_deps, new_areas)
+    return (new_dep_map, new_areas)
 
 
 def add_deps(
@@ -201,7 +201,7 @@ def write_dot_graph(
     out.flush()
 
 
-def add_hover_style(diagram_file: Path) -> None:
+def add_hover_style(diagram_file: Path | str) -> None:
     found_svg = False
     with open(diagram_file, "r") as fh:
         lines = fh.readlines()

--- a/misc/python/materialize/cli/crate_diagram.py
+++ b/misc/python/materialize/cli/crate_diagram.py
@@ -107,11 +107,11 @@ def main(show: bool, diagram_file: Optional[str], roots: List[str]) -> None:
     if roots:
         (local_deps, areas) = filter_to_roots(areas, local_deps, roots)
 
-    diagram_file = str(MZ_ROOT / diagram_file)
+    diagram_file_path = MZ_ROOT / diagram_file
     with NamedTemporaryFile(mode="w+", prefix="mz-arch-diagram-") as out:
         write_dot_graph(member_meta, local_deps, areas, out)
 
-        cmd = ["dot", "-Tsvg", "-o", str(diagram_file), out.name]
+        cmd = ["dot", "-Tsvg", "-o", str(diagram_file_path), out.name]
         try:
             spawn.runv(cmd)
         except subprocess.CalledProcessError:

--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -593,7 +593,7 @@ To see the available workflows, run:
             # Upload test report to Buildkite Test Analytics.
             junit_suite = junit_xml.TestSuite(composition.name)
 
-            for (name, result) in composition.test_results.items():
+            for name, result in composition.test_results.items():
                 test_case = junit_xml.TestCase(name, composition.name, result.duration)
                 if result.error:
                     test_case.add_error_info(message=result.error)
@@ -679,6 +679,7 @@ class ArgumentParser(argparse.ArgumentParser):
     ) -> Tuple[argparse.Namespace, List[str]]:
         namespace, unknown_args = super().parse_known_args(args, namespace)
         setattr(namespace, "unknown_args", unknown_args)
+        assert namespace is not None
         return namespace, []
 
 
@@ -688,9 +689,10 @@ class ArgumentSubparser(argparse.ArgumentParser):
         args: Optional[Sequence[Text]] = None,
         namespace: Optional[argparse.Namespace] = None,
     ) -> Tuple[argparse.Namespace, List[str]]:
-        namespace, unknown_args = super().parse_known_args(args, namespace)
-        setattr(namespace, "unknown_subargs", unknown_args)
-        return namespace, []
+        new_namespace, unknown_args = super().parse_known_args(args, namespace)
+        setattr(new_namespace, "unknown_subargs", unknown_args)
+        assert new_namespace is not None
+        return new_namespace, []
 
 
 if __name__ == "__main__":

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -283,7 +283,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
                 ]
             )
 
-        for (k, v) in self.env.items():
+        for k, v in self.env.items():
             env.append(V1EnvVar(name=k, value=v))
 
         return env
@@ -298,8 +298,8 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         except ValueError:
             return default
 
-        version = Version.parse(version)
-        return bool(operator(tag_version, version))
+        cmp_version = Version.parse(version)
+        return bool(operator(tag_version, cmp_version))
 
     def _meets_minimum_version(self, version: str) -> bool:
         return self._meets_version(version=version, operator=operator.ge, default=True)

--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -25,7 +25,7 @@ def sql_query(
     vars: Optional[Sequence[Any]] = None,
 ) -> List[List[Any]]:
     cur = conn.cursor()
-    cur.execute(query, vars)
+    cur.execute(query.encode("utf8"), vars)
     return [list(row) for row in cur]
 
 
@@ -35,7 +35,7 @@ def sql_execute(
     vars: Optional[Sequence[Any]] = None,
 ) -> None:
     cur = conn.cursor()
-    cur.execute(query, vars)
+    cur.execute(query.encode("utf8"), vars)
 
 
 def sql_execute_ddl(

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -113,7 +113,7 @@ class KafkaExecutor(Executor):
         a = AdminClient(kafka_conf)
         fs = a.create_topics(
             [
-                confluent_kafka.admin.NewTopic(
+                confluent_kafka.admin.NewTopic(  # type: ignore
                     self.topic, num_partitions=1, replication_factor=1
                 )
             ]

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -557,7 +557,7 @@ class Image:
                 f"mzbuild image name {self.name} contains invalid character; only alphanumerics and hyphens allowed"
             )
 
-        self.depends_on = []
+        self.depends_on: list[str] = []
         with open(self.path / "Dockerfile", "rb") as f:
             for line in f:
                 match = self._DOCKERFILE_MZFROM_RE.match(line)
@@ -917,7 +917,7 @@ class Repository:
         self.rd = RepositoryDetails(root, arch, release_mode, coverage, stable)
         self.images: Dict[str, Image] = {}
         self.compositions: Dict[str, Path] = {}
-        for (path, dirs, files) in os.walk(self.root, topdown=True):
+        for path, dirs, files in os.walk(self.root, topdown=True):
             if path == str(root / "misc"):
                 dirs.remove("python")
             # Filter out some particularly massive ignored directories to keep

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -720,7 +720,7 @@ class Composition:
             force: Whether to force the removal (i.e., don't error if the
                 volume does not exist).
         """
-        volumes = (f"{self.name}_{v}" for v in volumes)
+        volumes = tuple(f"{self.name}_{v}" for v in volumes)
         spawn.runv(
             ["docker", "volume", "rm", *(["--force"] if force else []), *volumes]
         )

--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -105,7 +105,7 @@ class Materialized(Service):
         additional_system_parameter_defaults: Optional[Dict[str, str]] = None,
         soft_assertions: bool = True,
     ) -> None:
-        depends_on: Dict[str, ServiceDependency] = {
+        depends_graph: Dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
         }
 
@@ -157,7 +157,7 @@ class Materialized(Service):
         command += [f"--environment-id={environment_id}"]
 
         if external_minio:
-            depends_on["minio"] = {"condition": "service_healthy"}
+            depends_graph["minio"] = {"condition": "service_healthy"}
             persist_blob_url = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
 
         if persist_blob_url:
@@ -190,7 +190,7 @@ class Materialized(Service):
         ]
 
         if external_cockroach:
-            depends_on["cockroach"] = {"condition": "service_healthy"}
+            depends_graph["cockroach"] = {"condition": "service_healthy"}
             command += [
                 "--adapter-stash-url=postgres://root@cockroach:26257?options=--search_path=adapter",
                 "--storage-stash-url=postgres://root@cockroach:26257?options=--search_path=storage",
@@ -227,7 +227,7 @@ class Materialized(Service):
 
         config.update(
             {
-                "depends_on": depends_on,
+                "depends_on": depends_graph,
                 "command": command,
                 "ports": [6875, 6876, 6877, 6878, 26257],
                 "environment": environment,
@@ -870,7 +870,7 @@ class Testdrive(Service):
         if no_reset:
             entrypoint.append("--no-reset")
 
-        for (k, v) in materialize_params.items():
+        for k, v in materialize_params.items():
             entrypoint.append(f"--materialize-param={k}={v}")
 
         entrypoint.append(f"--default-timeout={default_timeout}")

--- a/misc/python/materialize/optbench/__init__.py
+++ b/misc/python/materialize/optbench/__init__.py
@@ -8,12 +8,14 @@
 # by the Apache License, Version 2.0.
 
 from importlib import resources
-from importlib.abc import Traversable
-from typing import List
+from pathlib import Path
+from typing import List, cast
 
 
-def resource_path(name: str) -> Traversable:
-    return resources.files(__package__) / name
+def resource_path(name: str) -> Path:
+    # NOTE: we have to do this cast because pyright is not comfortable with the
+    # Traversable protocol.
+    return cast(Path, resources.files(__package__)) / name
 
 
 def scenarios() -> List[str]:
@@ -39,10 +41,10 @@ class Scenario:
     def __init__(self, value: str) -> None:
         self.value = value
 
-    def schema_path(self) -> Traversable:
+    def schema_path(self) -> Path:
         return resource_path(f"schema/{self}.sql")
 
-    def workload_path(self) -> Traversable:
+    def workload_path(self) -> Path:
         return resource_path(f"workload/{self}.sql")
 
     def __str__(self) -> str:

--- a/misc/python/materialize/optbench/sql.py
+++ b/misc/python/materialize/optbench/sql.py
@@ -11,7 +11,7 @@ import logging
 import re
 import ssl
 from enum import Enum
-from importlib.abc import Traversable
+from pathlib import Path
 from typing import Any, Dict, List, Optional, cast
 
 import numpy as np
@@ -154,6 +154,6 @@ class Database:
 # -----------------
 
 
-def parse_from_file(path: Traversable) -> List[str]:
+def parse_from_file(path: Path) -> List[str]:
     """Parses a *.sql file to a list of queries."""
     return sqlparse.split(path.read_text())

--- a/misc/python/materialize/output_consistency/generators/query_generator.py
+++ b/misc/python/materialize/output_consistency/generators/query_generator.py
@@ -247,7 +247,7 @@ class QueryGenerator:
         expressions: List[Expression],
         row_selection: DataRowSelection,
     ) -> List[Expression]:
-        indices_to_remove = []
+        indices_to_remove: list[int] = []
 
         for index, expression in enumerate(expressions):
             ignore_verdict = self.ignore_filter.shall_ignore_expression(

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -37,7 +37,7 @@ from materialize.output_consistency.validation.validation_message import (
 )
 
 
-@dataclass(frozen=True)
+@dataclass
 class IgnoreVerdict:
     ignore: bool
 
@@ -50,7 +50,7 @@ class YesIgnore(IgnoreVerdict):
         self.reason = reason
 
 
-@dataclass(frozen=True)
+@dataclass
 class NoIgnore(IgnoreVerdict):
     ignore: bool = False
 

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -37,15 +37,17 @@ from materialize.output_consistency.validation.validation_message import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class IgnoreVerdict:
     ignore: bool
 
 
-@dataclass(frozen=True)
 class YesIgnore(IgnoreVerdict):
     reason: str
-    ignore: bool = True
+
+    def __init__(self, reason: str, ignore: bool = True):
+        super().__init__(ignore)
+        self.reason = reason
 
 
 @dataclass(frozen=True)
@@ -107,7 +109,6 @@ class PreExecutionInconsistencyIgnoreFilter:
         expression: ExpressionWithArgs,
         row_selection: DataRowSelection,
     ) -> IgnoreVerdict:
-
         expression_characteristics = (
             expression.recursively_collect_involved_characteristics(row_selection)
         )

--- a/misc/python/materialize/query_fitness/pick.py
+++ b/misc/python/materialize/query_fitness/pick.py
@@ -19,7 +19,7 @@ threshold = 0.5
 
 
 def main() -> None:
-    conn = pg8000.connect(database="pstoev", password="pstoev")
+    conn = pg8000.connect(database="pstoev", password="pstoev", user=None)
     fitness_func = AllPartsEssential(conn=conn)
 
     for query in sys.stdin:
@@ -35,6 +35,7 @@ def dump_slt(conn: pg8000.Connection, query: str) -> None:
     cursor.execute("ROLLBACK")
     cursor.execute(query)
     row = cursor.fetchone()
+    assert row is not None
     cols = len(row)
     colspec = "I" * cols
     print(

--- a/misc/python/materialize/scalability/endpoint.py
+++ b/misc/python/materialize/scalability/endpoint.py
@@ -41,11 +41,11 @@ class Endpoint:
     def sql(self, sql: str) -> None:
         conn = self.sql_connection()
         cursor = conn.cursor()
-        cursor.execute(sql)
+        cursor.execute(sql.encode("utf8"))
 
     def name(self) -> str:
         cursor = self.sql_connection().cursor()
-        cursor.execute("SELECT mz_version()")
+        cursor.execute(b"SELECT mz_version()")
         row = cursor.fetchone()
         assert row is not None
         return str(row[0])

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -13,7 +13,7 @@ from psycopg import Cursor, ProgrammingError
 class Operation:
     def execute(self, cursor: Cursor) -> None:
         try:
-            cursor.execute(self.sql_statement())
+            cursor.execute(self.sql_statement().encode('utf8'))
             cursor.fetchall()
         except ProgrammingError as e:
             assert "the last operation didn't produce a result" in str(e)

--- a/misc/python/materialize/scalability/operation.py
+++ b/misc/python/materialize/scalability/operation.py
@@ -13,7 +13,7 @@ from psycopg import Cursor, ProgrammingError
 class Operation:
     def execute(self, cursor: Cursor) -> None:
         try:
-            cursor.execute(self.sql_statement().encode('utf8'))
+            cursor.execute(self.sql_statement().encode("utf8"))
             cursor.fetchall()
         except ProgrammingError as e:
             assert "the last operation didn't produce a result" in str(e)

--- a/misc/python/materialize/zippy/crdb_actions.py
+++ b/misc/python/materialize/zippy/crdb_actions.py
@@ -29,7 +29,7 @@ class CockroachRestart(Action):
     """Restart the CockroachDB instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {CockroachIsRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -38,7 +38,7 @@ class DebeziumStop(Action):
     """Stop the Debezium instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {DebeziumRunning}
 
     def withholds(self) -> Set[Type[Capability]]:
@@ -52,7 +52,7 @@ class CreateDebeziumSource(Action):
     """Creates a Debezium source in Materialized."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning, KafkaRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -9,7 +9,7 @@
 
 import random
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional, Set, Type, TypeVar, Union, Sequence
+from typing import Dict, List, Optional, Sequence, Set, Type, TypeVar, Union
 
 from materialize.mzcompose import Composition
 
@@ -42,7 +42,8 @@ class Capabilities:
 
     def _extend(self, capabilities: Sequence[Capability]) -> None:
         """Add new capabilities."""
-        self._capabilities = list(*self._capabilities, *capabilities)
+        new_capabilities = list(capabilities)
+        self._capabilities = list(self._capabilities) + new_capabilities
 
     def remove_capability_instance(self, capability: Capability) -> None:
         """Remove a specific capability."""
@@ -66,7 +67,9 @@ class Capabilities:
         """Get all capabilities of the specified type."""
         matches: List[T] = [
             # NOTE: unfortunately pyright can't handle this
-            cap for cap in self._capabilities if type(cap) == capability  # type: ignore
+            cap
+            for cap in self._capabilities
+            if type(cap) == capability  # type: ignore
         ]
         return matches
 
@@ -178,8 +181,11 @@ class Test:
 
         for action in actions:
             self._actions.append(action)
+            print("test:", action)
             self._capabilities._extend(action.provides())
+            print(" - ", self._capabilities, action.provides())
             self._capabilities._remove(action.withholds())
+            print(" - ", self._capabilities, action.withholds())
 
     def run(self, c: Composition) -> None:
         """Run the Zippy test."""

--- a/misc/python/materialize/zippy/kafka_actions.py
+++ b/misc/python/materialize/zippy/kafka_actions.py
@@ -54,7 +54,7 @@ class KafkaStop(Action):
     """Stop the Kafka instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {KafkaRunning}
 
     def withholds(self) -> Set[Type[Capability]]:
@@ -175,7 +175,7 @@ class KafkaInsertParallel(KafkaInsert):
     """Inserts data into a Kafka topic using background threads."""
 
     @classmethod
-    def require_explicit_mention(self) -> bool:
+    def require_explicit_mention(cls) -> bool:
         return True
 
     def parallel(self) -> bool:

--- a/misc/python/materialize/zippy/minio_actions.py
+++ b/misc/python/materialize/zippy/minio_actions.py
@@ -29,7 +29,7 @@ class MinioRestart(Action):
     """Restart the Minio instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MinioIsRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -21,7 +21,7 @@ class MzStart(Action):
     """Starts a Mz instance (all components are running in the same container)."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {CockroachIsRunning, MinioIsRunning}
 
     def run(self, c: Composition) -> None:
@@ -49,7 +49,7 @@ class MzStop(Action):
     """Stops the entire Mz instance (all components are running in the same container)."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:
@@ -63,7 +63,7 @@ class MzRestart(Action):
     """Restarts the entire Mz instance (all components are running in the same container)."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:
@@ -75,7 +75,7 @@ class KillClusterd(Action):
     """Kills the clusterd processes in the environmentd container. The process orchestrator will restart them."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, ViewExists}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/peek_actions.py
+++ b/misc/python/materialize/zippy/peek_actions.py
@@ -19,7 +19,7 @@ class PeekCancellation(Action):
     """Perfoms a peek cancellation."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -24,7 +24,7 @@ class CreatePostgresCdcTable(Action):
     """Creates a Postgres CDC source in Materialized."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning, PostgresRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -31,7 +31,7 @@ class PostgresStop(Action):
     """Stop the Postgres instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {PostgresRunning}
 
     def withholds(self) -> Set[Type[Capability]]:
@@ -53,7 +53,7 @@ class CreatePostgresTable(Action):
     """Creates a table on the Postgres instance. 50% of the tables have a PK."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, PostgresRunning}
 
     def __init__(self, capabilities: Capabilities) -> None:
@@ -106,7 +106,7 @@ class PostgresDML(Action):
     MAX_BATCH_SIZE = 10000
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, PostgresRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -21,7 +21,7 @@ class DropDefaultReplica(Action):
     """Drops the default replica."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def run(self, c: Composition) -> None:
@@ -41,7 +41,7 @@ class CreateReplica(Action):
     """Creates a replica on the default cluster."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def __init__(self, capabilities: Capabilities) -> None:
@@ -106,7 +106,7 @@ class DropReplica(Action):
     replica: Optional[ReplicaExists]
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, ReplicaExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -23,7 +23,7 @@ class CreateSinkParameterized(ActionFactory):
     """Creates a sink over an existing view. Then creates a source over that sink and a view over that source."""
 
     @classmethod
-    def requires(self) -> List[Set[Type[Capability]]]:
+    def requires(cls) -> List[Set[Type[Capability]]]:
         return [{MzIsRunning, StoragedRunning, ViewExists}]
 
     def __init__(self, max_sinks: int = 10) -> None:

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -23,7 +23,7 @@ class CreateSourceParameterized(ActionFactory):
     """Creates a source in Materialized."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning, KafkaRunning, TopicExists}
 
     def __init__(self, max_sources: int = 10) -> None:

--- a/misc/python/materialize/zippy/storaged_actions.py
+++ b/misc/python/materialize/zippy/storaged_actions.py
@@ -21,7 +21,7 @@ class StoragedStart(Action):
     """Starts a storaged clusterd instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {CockroachIsRunning, MinioIsRunning}
 
     def run(self, c: Composition) -> None:
@@ -35,7 +35,7 @@ class StoragedRestart(Action):
     """Restarts the entire storaged clusterd instance."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning}
 
     def run(self, c: Composition) -> None:
@@ -45,7 +45,7 @@ class StoragedRestart(Action):
 
 class StoragedKill(Action):
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning}
 
     def run(self, c: Composition) -> None:

--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -27,7 +27,7 @@ class CreateTableParameterized(ActionFactory):
         self.max_rows_per_action = max_rows_per_action
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning}
 
     def new(self, capabilities: Capabilities) -> List[Action]:
@@ -84,7 +84,7 @@ class ValidateTable(Action):
     """Validates that a single table contains data that is consistent with the expected min/max watermark."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, TableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
@@ -106,7 +106,7 @@ class DML(Action):
     """Performs an INSERT, DELETE or UPDATE against a table."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, TableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -26,7 +26,7 @@ class CreateViewParameterized(ActionFactory):
     """Emits CreateView Actions within the constraints specified in the constructor."""
 
     @classmethod
-    def requires(self) -> List[Set[Type[Capability]]]:
+    def requires(cls) -> List[Set[Type[Capability]]]:
         return [
             {MzIsRunning, SourceExists},
             {MzIsRunning, TableExists},
@@ -126,7 +126,7 @@ class ValidateView(Action):
     """Validates a view."""
 
     @classmethod
-    def requires(self) -> Set[Type[Capability]]:
+    def requires(cls) -> Set[Type[Capability]]:
         return {MzIsRunning, StoragedRunning, ViewExists}
 
     def __init__(self, capabilities: Capabilities) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,15 @@ venvPath = "./misc/python"
 venv = "venv"
 exclude = ["./misc/python/venv"]
 
-reportMissingImports = true
+reportMissingImports = "warning"
 reportMissingModuleSource = "warning"
-reportMissingTypeStubs = true
-typeCheckingMode = "strict"
+reportMissingTypeStubs = "warning"
+reportOptionalMemberAccess = "warning"
+reportUnboundVariable = "warning"
+reportPrivateImportUsage = "warning"
+reportTypedDictNotRequiredAccess = "warning"
+reportOptionalSubscript = "warning"
+typeCheckingMode = "basic"
 ignore = [
   # Rust build artifacts are not subject to our static analysis.
   "target/",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,37 +8,13 @@
 # by the Apache License, Version 2.0.
 
 [tool.black]
-target_version = ["py310"]
+target_version = ["py311"]
 
 [tool.isort]
 extend_skip = ["target"]
 known_first_party = ["materialize"]
 profile = "black"
-py_version = "310"
-
-# [tool.mypy]
-# # Basic mypy configuration.
-# error_summary = false
-# exclude = "/venv/"
-# explicit_package_bases = true
-# namespace_packages = true
-# pretty = true
-# python_version = "3.9"
-
-# # Lint rules.
-# allow_redefinition = true
-# disallow_incomplete_defs = true
-# disallow_subclassing_any = true
-# disallow_untyped_calls = true
-# disallow_untyped_decorators = true
-# disallow_untyped_defs = true
-# no_implicit_optional = true
-# strict_equality = true
-# warn_unused_configs = true
-# warn_redundant_casts = true
-# warn_unused_ignores = true
-# warn_return_any = true
-# warn_unreachable = true
+py_version = "311"
 
 [tool.pyright]
 # Allow pyright to find imports for python files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,37 +8,37 @@
 # by the Apache License, Version 2.0.
 
 [tool.black]
-target_version = ["py38"]
+target_version = ["py310"]
 
 [tool.isort]
 extend_skip = ["target"]
 known_first_party = ["materialize"]
 profile = "black"
-py_version = "38"
+py_version = "310"
 
-[tool.mypy]
-# Basic mypy configuration.
-error_summary = false
-exclude = "/venv/"
-explicit_package_bases = true
-namespace_packages = true
-pretty = true
-python_version = "3.9"
+# [tool.mypy]
+# # Basic mypy configuration.
+# error_summary = false
+# exclude = "/venv/"
+# explicit_package_bases = true
+# namespace_packages = true
+# pretty = true
+# python_version = "3.9"
 
-# Lint rules.
-allow_redefinition = true
-disallow_incomplete_defs = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-disallow_untyped_decorators = true
-disallow_untyped_defs = true
-no_implicit_optional = true
-strict_equality = true
-warn_unused_configs = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
-warn_unreachable = true
+# # Lint rules.
+# allow_redefinition = true
+# disallow_incomplete_defs = true
+# disallow_subclassing_any = true
+# disallow_untyped_calls = true
+# disallow_untyped_decorators = true
+# disallow_untyped_defs = true
+# no_implicit_optional = true
+# strict_equality = true
+# warn_unused_configs = true
+# warn_redundant_casts = true
+# warn_unused_ignores = true
+# warn_return_any = true
+# warn_unreachable = true
 
 [tool.pyright]
 # Allow pyright to find imports for python files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,3 +47,12 @@ extraPaths = ["misc/python"]
 venvPath = "./misc/python"
 venv = "venv"
 exclude = ["./misc/python/venv"]
+
+reportMissingImports = true
+reportMissingModuleSource = "warning"
+reportMissingTypeStubs = true
+typeCheckingMode = "strict"
+ignore = [
+  # Rust build artifacts are not subject to our static analysis.
+  "target/",
+]

--- a/test/cloudtest/conftest.py
+++ b/test/cloudtest/conftest.py
@@ -28,8 +28,9 @@ def pytest_configure(config: "Config") -> None:
 def mz(pytestconfig: pytest.Config) -> MaterializeApplication:
     return MaterializeApplication(
         release_mode=(not pytestconfig.getoption("dev")),
-        aws_region=pytestconfig.getoption("aws_region"),
-        log_filter=pytestconfig.getoption("log_filter"),
+        # NOTE(necaris): pyright doesn't like that the `getoption` default type is `Notset`
+        aws_region=pytestconfig.getoption("aws_region", None),  # type: ignore
+        log_filter=pytestconfig.getoption("log_filter", None),  # type: ignore
     )
 
 

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -124,14 +124,13 @@ def test_upgrade_from_version(
                 )
             )
 
-    priors = priors + prior_patch_versions
-    priors.sort()
-    priors = [f"{prior}" for prior in priors]
+    priors = sorted(priors + prior_patch_versions)
+    prior_strings = [repr(prior) for prior in priors]
 
     if len(priors) == 0:
-        priors = ["*"]
+        prior_strings = ["*"]
 
-    version_glob = "{" + ",".join(["any_version", *priors, from_version]) + "}"
+    version_glob = "{" + ",".join(["any_version", *prior_strings, from_version]) + "}"
     print(">>> Version glob pattern: " + version_glob)
 
     c.down(destroy_volumes=True)

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -124,8 +124,9 @@ def test_upgrade_from_version(
                 )
             )
 
-    priors = sorted(priors + prior_patch_versions)
-    prior_strings = [repr(prior) for prior in priors]
+    # We need this to be a new variable binding otherwise `pyright` complains of
+    # a type mismatch
+    prior_strings = sorted(str(p) for p in priors + prior_patch_versions)
 
     if len(priors) == 0:
         prior_strings = ["*"]

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -70,7 +70,7 @@ def run_with_concurrency(
     init_cursor = init_conn.cursor()
     for init_sql in init_sqls:
         print(init_sql)
-        init_cursor.execute(init_sql)
+        init_cursor.execute(init_sql.encode("utf8"))
 
     connect_sqls = schema.connect_sqls()
 
@@ -83,7 +83,7 @@ def run_with_concurrency(
         conn.autocommit = True
         cursor = conn.cursor()
         for connect_sql in connect_sqls:
-            cursor.execute(connect_sql)
+            cursor.execute(connect_sql.encode("utf8"))
         cursor_pool.append(cursor)
 
     print(f"Benchmarking workload {type(workload)} at concurrency {concurrency} ...")


### PR DESCRIPTION
Swap out invocations of `mypy` for `pyright`, and ensure the typechecking pass succeeds.

### Motivation

  * This PR adds a known-desirable feature.

  As part of unifying the Cloud and Materialize repos, it'd be great to use the same linting infra across both. Between `mypy` as used in the Materialize repo and `pyright` as used in Cloud, `pyright` is faster, has better type inference, and provides a language server implementation.