### PR TITLE
persist: recursively trim JSON stats

### DIFF
--- a/src/persist-types/src/columnar.rs
+++ b/src/persist-types/src/columnar.rs
@@ -41,8 +41,8 @@
 //! overhead.
 //!
 //! The Data trait has associated types for the exclusive "builder" type for the
-//! column and for the shared "reader" type. These implement also implement some
-//! common traits to make relationships between types more structured.
+//! column and for the shared "reader" type. These also implement some common traits
+//! to make relationships between types more structured.
 //!
 //! Finally, the [Schema] trait maps an implementor of [Codec] to the underlying
 //! column structure. It also provides a [PartEncoder] and [PartDecoder] for

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -1897,8 +1897,6 @@ mod tests {
         // everything else.
         trim_to_budget_jsonb(&mut stats, &mut budget_shortfall, &|name| name == "b");
 
-        println!("{stats:?}");
-
         assert_eq!(stats.elements.len(), 1);
         assert_eq!(stats.elements[0].name, "context");
 

--- a/src/persist-types/src/stats.rs
+++ b/src/persist-types/src/stats.rs
@@ -15,7 +15,6 @@ use std::any::Any;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
-use mz_ore::cast::CastFrom;
 use proptest_derive::Arbitrary;
 use prost::Message;
 use serde::ser::{SerializeMap, SerializeStruct};


### PR DESCRIPTION
This PR implements recursive stats trimming for JSON columns. Previously if the stats for a JSON column were over our budget we would drop stats for the entire column, instead of recursively trimming them. This heavily impacted webhook sources since generally webhook sources contain a single column `body` that contains the entire event.

<details>
  <summary>Stats from Buildkite event</summary>
  
  ## `main`
  ```
  "stats": {
      "cols": {
          "err": {
              "lower": "",
              "nulls": 1,
              "upper": ""
          },
          "ok": {
              "len": 1
          }
      },
      "len": 1
  }
  ```

  ## This PR
  ```json
  "stats": {
    "cols": {
        "err": {
            "lower": "",
            "nulls": 1,
            "upper": ""
        },
        "ok": {
            "body": {
                "build": {
                    "len": 1,
                    "stats": {
                        "author": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "blocked": {
                            "len": 1,
                            "stats": {
                                "lower": false,
                                "upper": false
                            }
                        },
                        "blocked_state": {
                            "len": 1,
                            "stats": {
                                "lower": "",
                                "upper": ""
                            }
                        },
                        "branch": {
                            "len": 1,
                            "stats": {
                                "lower": "main",
                                "upper": "main"
                            }
                        },
                        "commit": {
                            "len": 1,
                            "stats": {
                                "lower": "HEAD",
                                "upper": "HEAD"
                            }
                        },
                        "created_at": {
                            "len": 1,
                            "stats": {
                                "lower": "2023-08-07T16:02:56.072Z",
                                "upper": "2023-08-07T16:02:56.072Z"
                            }
                        },
                        "creator": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "finished_at": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "meta_data": {
                            "len": 1,
                            "stats": {}
                        },
                        "number": {
                            "len": 1,
                            "stats": {
                                "lower": "c201050a0314237c",
                                "upper": "c201050a0314237c"
                            }
                        },
                        "pull_request": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "rebuilt_from": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "scheduled_at": {
                            "len": 1,
                            "stats": {
                                "lower": "2023-08-07T16:02:56.017Z",
                                "upper": "2023-08-07T16:02:56.017Z"
                            }
                        },
                        "source": {
                            "len": 1,
                            "stats": {
                                "lower": "schedule",
                                "upper": "schedule"
                            }
                        },
                        "started_at": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "state": {
                            "len": 1,
                            "stats": {
                                "lower": "scheduled",
                                "upper": "scheduled"
                            }
                        },
                        "tag": {
                            "len": 1,
                            "stats": "json_nulls"
                        }
                    }
                },
                "event": {
                    "len": 1,
                    "stats": {
                        "lower": "build.scheduled",
                        "upper": "build.scheduled"
                    }
                },
                "pipeline": {
                    "len": 1,
                    "stats": {
                        "archived_at": {
                            "len": 1,
                            "stats": "json_nulls"
                        },
                        "created_at": {
                            "len": 1,
                            "stats": {
                                "lower": "2020-04-30T13:39:18.060Z",
                                "upper": "2020-04-30T13:39:18.060Z"
                            }
                        },
                        "created_by": {
                            "len": 1,
                            "stats": {
                                "created_at": {
                                    "len": 1,
                                    "stats": {
                                        "lower": "2019-07-29T14:18:16.820Z",
                                        "upper": "2019-07-29T14:18:16.820Z"
                                    }
                                }
                            }
                        }
                    }
                },
                "sender": {
                    "len": 1,
                    "stats": "json_nulls"
                }
            },
            "len": 1
        }
    },
    "len": 1
  }
  ```
</details>

### Motivation

Fixes #21143

### Tips for reviewer

IMO the right thing to do is probably add some trait (or re-use an existing one) so we can be generic over `ProtoStructStats` and `ProtoJsonMapStats`, e.g. some `ProtoRecursiveStats` trait, but I wasn't sure if that was desirable. I saw the `DynStats` trait which I briefly added a `fn recurse(...)` to, but then I realized the trimming is done in terms of proto. If persist folks have want to take a different approach for this implementation, please let me know!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
