### PR TITLE
Adding counters for inserts, updates and deletes for upserts

### DIFF
--- a/src/storage/src/render/upsert/rocksdb.rs
+++ b/src/storage/src/render/upsert/rocksdb.rs
@@ -46,13 +46,16 @@ impl UpsertStateBackend for RocksDB {
                     match (&value, previous_persisted_size) {
                         (Some(_), Some(ps)) => {
                             p_stats.size_diff -= ps;
+                            p_stats.updates += 1;
                         }
                         (None, Some(ps)) => {
                             p_stats.size_diff -= ps;
                             p_stats.values_diff -= 1;
+                            p_stats.deletes += 1;
                         }
                         (Some(_), None) => {
                             p_stats.values_diff += 1;
+                            p_stats.inserts += 1;
                         }
                         (None, None) => {}
                     }

--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -214,6 +214,9 @@ pub(super) struct UpsertMetrics {
     pub(super) merge_snapshot_updates: IntCounterVec,
     pub(super) merge_snapshot_inserts: IntCounterVec,
     pub(super) merge_snapshot_deletes: IntCounterVec,
+    pub(super) upsert_inserts: IntCounterVec,
+    pub(super) upsert_updates: IntCounterVec,
+    pub(super) upsert_deletes: IntCounterVec,
     pub(super) multi_get_latency: HistogramVec,
     pub(super) multi_get_size: IntCounterVec,
     pub(super) multi_get_result_count: IntCounterVec,
@@ -301,6 +304,21 @@ impl UpsertMetrics {
                 name: "mz_storage_upsert_merge_snapshot_deletes_total",
                 help: "The number of deletes in a batch for merging snapshot updates \
                     for this source.",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            upsert_inserts: registry.register(metric!(
+                name: "mz_storage_upsert_inserts_total",
+                help: "The number of inserts done by the upsert operator",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            upsert_updates: registry.register(metric!(
+                name: "mz_storage_upsert_updates_total",
+                help: "The number of updates done by the upsert operator",
+                var_labels: ["source_id", "worker_id"],
+            )),
+            upsert_deletes: registry.register(metric!(
+                name: "mz_storage_upsert_deletes_total",
+                help: "The number of deletes done by the upsert operator.",
                 var_labels: ["source_id", "worker_id"],
             )),
             multi_get_latency: registry.register(metric!(

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -495,6 +495,9 @@ pub struct UpsertMetrics {
     pub(crate) merge_snapshot_updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) merge_snapshot_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) merge_snapshot_deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) upsert_inserts: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) upsert_updates: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
+    pub(crate) upsert_deletes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_size: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_result_bytes: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
     pub(crate) multi_get_result_count: DeleteOnDropCounter<'static, AtomicU64, Vec<String>>,
@@ -540,6 +543,15 @@ impl UpsertMetrics {
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
             merge_snapshot_deletes: base
                 .merge_snapshot_deletes
+                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+            upsert_inserts: base
+                .upsert_inserts
+                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+            upsert_updates: base
+                .upsert_updates
+                .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
+            upsert_deletes: base
+                .upsert_deletes
                 .get_delete_on_drop_counter(vec![source_id_s.clone(), worker_id.clone()]),
             multi_get_size: base
                 .multi_get_size


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
More metrics to track upsert behaviour! 

### Motivation

Metrics have been pretty handy in figuring out spill to disk behaviour for our customers. Adding more so that we know the rate of inserts/deletes/updates in an upsert.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
