### PR TITLE
[persist] Split distinct batches into distinct runs

### DIFF
--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -201,6 +201,9 @@ mod tests {
                             "compare-and-append" => {
                                 machine_dd::compare_and_append(&mut state, args).await
                             }
+                            "compare-and-append-batches" => {
+                                machine_dd::compare_and_append_batches(&mut state, args).await
+                            }
                             "compare-and-downgrade-since" => {
                                 machine_dd::compare_and_downgrade_since(&mut state, args).await
                             }

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1029,7 +1029,7 @@ pub mod datadriven {
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 
     use crate::batch::{
-        validate_truncate_batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
+        validate_truncate_batch, Batch, BatchBuilder, BatchBuilderConfig, BatchBuilderInternal,
     };
     use crate::fetch::{fetch_batch_part, Cursor};
     use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
@@ -1554,34 +1554,48 @@ pub mod datadriven {
             .await
             .map_err(|err| anyhow!("{:?}", err))?;
 
-        let mut updates = Vec::new();
+        let mut result = String::new();
+
         for batch in snapshot {
-            for part in batch.parts {
-                let part = fetch_batch_part(
-                    &datadriven.shard_id,
-                    datadriven.client.blob.as_ref(),
-                    datadriven.client.metrics.as_ref(),
-                    datadriven.machine.applier.shard_metrics.as_ref(),
-                    &datadriven.client.metrics.read.batch_fetcher,
-                    &part.key,
-                    &batch.desc,
-                )
-                .await
-                .expect("invalid batch part");
-                let mut cursor = Cursor::default();
-                while let Some((k, _v, mut t, d)) = cursor.pop(&part) {
-                    t.advance_by(as_of.borrow());
-                    updates.push((String::decode(k).unwrap(), t, i64::decode(d)));
+            writeln!(
+                result,
+                "<batch {:?}-{:?}>",
+                batch.desc.lower().elements(),
+                batch.desc.upper().elements()
+            );
+            for (run, parts) in batch.runs().enumerate() {
+                writeln!(result, "<run {run}>");
+                for (part_id, part) in parts.into_iter().enumerate() {
+                    writeln!(result, "<part {part_id}>");
+                    let part = fetch_batch_part(
+                        &datadriven.shard_id,
+                        datadriven.client.blob.as_ref(),
+                        datadriven.client.metrics.as_ref(),
+                        datadriven.machine.applier.shard_metrics.as_ref(),
+                        &datadriven.client.metrics.read.batch_fetcher,
+                        &part.key,
+                        &batch.desc,
+                    )
+                    .await
+                    .expect("invalid batch part");
+
+                    let mut updates = Vec::new();
+                    let mut cursor = Cursor::default();
+                    while let Some((k, _v, mut t, d)) = cursor.pop(&part) {
+                        t.advance_by(as_of.borrow());
+                        updates.push((String::decode(k).unwrap(), t, i64::decode(d)));
+                    }
+
+                    consolidate_updates(&mut updates);
+
+                    for (k, t, d) in updates {
+                        writeln!(result, "{k} {t} {d}");
+                    }
                 }
             }
         }
-        consolidate_updates(&mut updates);
 
-        let mut s = String::new();
-        for (k, t, d) in updates {
-            write!(s, "{k} {t} {d}\n");
-        }
-        Ok(s)
+        Ok(result)
     }
 
     pub async fn register_listen(
@@ -1705,6 +1719,55 @@ pub mod datadriven {
         let (_, maintenance) = datadriven.machine.expire_leased_reader(&reader_id).await;
         datadriven.routine.push(maintenance);
         Ok(format!("{} ok\n", datadriven.machine.seqno()))
+    }
+
+    pub async fn compare_and_append_batches(
+        datadriven: &mut MachineState,
+        args: DirectiveArgs<'_>,
+    ) -> Result<String, anyhow::Error> {
+        let expected_upper = args.expect_antichain("expected_upper");
+        let new_upper = args.expect_antichain("new_upper");
+
+        let mut batches: Vec<Batch<String, (), u64, i64>> = args
+            .args
+            .get("batches")
+            .expect("missing batches")
+            .into_iter()
+            .map(|batch| {
+                let hollow = datadriven
+                    .batches
+                    .get(batch)
+                    .expect("unknown batch")
+                    .clone();
+                Batch::new(
+                    Arc::clone(&datadriven.client.blob),
+                    datadriven.shard_id,
+                    datadriven.client.cfg.build_version.clone(),
+                    hollow,
+                )
+            })
+            .collect();
+
+        let mut writer = datadriven
+            .client
+            .open_writer(
+                datadriven.shard_id,
+                Arc::new(StringSchema),
+                Arc::new(UnitSchema),
+                Diagnostics::for_tests(),
+            )
+            .await?;
+
+        let mut batch_refs: Vec<_> = batches.iter_mut().collect();
+
+        let () = writer
+            .compare_and_append_batch(batch_refs.as_mut_slice(), expected_upper, new_upper)
+            .await?
+            .expect("upper match");
+
+        writer.expire().await;
+
+        Ok("ok\n".into())
     }
 
     pub async fn expire_writer(

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -453,14 +453,14 @@ where
         let since = Antichain::from_elem(T::minimum());
         let desc = Description::new(lower, upper, since);
 
-        let (mut parts, mut num_updates) = (Vec::new(), 0);
-        let mut runs = vec![];
+        let (mut parts, mut num_updates, mut runs) = (vec![], 0, vec![]);
         for batch in batches.iter() {
             let () = validate_truncate_batch(&batch.batch.desc, &desc)?;
             for run in batch.batch.runs() {
                 // Mark the boundary if this is not the first run in the batch.
-                if parts.len() != 0 {
-                    runs.push(parts.len());
+                let start_index = parts.len();
+                if start_index != 0 {
+                    runs.push(start_index);
                 }
                 parts.extend_from_slice(run);
             }

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -729,6 +729,7 @@ mod tests {
     use std::str::FromStr;
 
     use differential_dataflow::consolidation::consolidate_updates;
+    use mz_ore::collections::CollectionExt;
     use serde_json::json;
 
     use crate::tests::{all_ok, new_test_client};
@@ -801,6 +802,15 @@ mod tests {
         write
             .expect_compare_and_append_batch(&mut [&mut batch0, &mut batch1], 0, 4)
             .await;
+
+        let batch = write
+            .machine
+            .snapshot(&Antichain::from_elem(3))
+            .await
+            .expect("just wrote this")
+            .into_element();
+
+        assert!(batch.runs().count() >= 2);
 
         let expected = vec![
             (("1".to_owned(), "one".to_owned()), 1, 2),

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -458,12 +458,14 @@ where
         for batch in batches.iter() {
             let () = validate_truncate_batch(&batch.batch.desc, &desc)?;
             for run in batch.batch.runs() {
+                // Mark the boundary if this is not the first run in the batch.
+                if parts.len() != 0 {
+                    runs.push(parts.len());
+                }
                 parts.extend_from_slice(run);
-                runs.push(parts.len());
             }
             num_updates += batch.batch.len;
         }
-        runs.pop(); // We mark the end of each run above, but the last one is implicit
 
         let heartbeat_timestamp = (self.cfg.now)();
         let res = self

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -293,3 +293,43 @@ part 1
 part 2
 <run 3>
 part 3
+
+# parts from different batches appended together get different runs
+write-batch output=b0 lower=0 upper=2 target_size=10
+a 0 1
+b 0 1
+----
+parts=2 len=2
+
+write-batch output=b1 lower=0 upper=2 target_size=10 consolidate=false
+c 0 1
+d 0 1
+----
+parts=2 len=2
+
+write-batch output=b2 lower=0 upper=2 target_size=10
+e 1 1
+----
+parts=1 len=1
+
+compare-and-append-batches expected_upper=0 new_upper=2 batches=(b0,b1,b2)
+----
+ok
+
+snapshot as_of=1
+----
+<batch [0]-[2]>
+<run 0>
+<part 0>
+a 1 1
+<part 1>
+b 1 1
+<run 1>
+<part 0>
+c 1 1
+<run 2>
+<part 0>
+d 1 1
+<run 3>
+<part 0>
+e 1 1

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -96,7 +96,15 @@ v12 ok
 # We can still read data
 snapshot as_of=2
 ----
+<batch [0]-[2]>
+<run 0>
+<part 0>
+k1 2 1
 k2 2 1
+<batch [2]-[]>
+<run 0>
+<part 0>
+k1 2 -1
 
 # Flush out any maintenance so we ensure the tombstone process creates the
 # maintenance it needs.


### PR DESCRIPTION
### Motivation

Previously-unreported bug! When compare-and-append-batch is called with more than one part -- common in the case of multi-worker sinks -- we previously would roll all those unrelated parts into a single large run. This preserves the runs from the original batches.

### Tips for reviewer

I'll follow up with a test for this!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
