### PR TITLE
sql: adjust catalog state when updating items

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7247,16 +7247,39 @@ impl Catalog {
         );
 
         let conn_id = old_entry.item().conn_id().unwrap_or(&SYSTEM_CONN_ID);
-        let schema = &mut state.get_schema_mut(
+        let schema = state.get_schema_mut(
             &old_entry.name().qualifiers.database_spec,
             &old_entry.name().qualifiers.schema_spec,
             conn_id,
         );
         schema.items.remove(&old_entry.name().item);
+
+        // We only need to install this item on item in the `used_by` of net-new
+        // dependencies.
+        let net_new_deps: Vec<_> = to_item
+            .uses()
+            .0
+            .difference(&old_entry.uses().0)
+            .cloned()
+            .collect();
+
         let mut new_entry = old_entry.clone();
         new_entry.name = to_name;
         new_entry.item = to_item;
+
         schema.items.insert(new_entry.name().item.clone(), id);
+
+        for u in net_new_deps {
+            match state.entry_by_id.get_mut(&u) {
+                Some(metadata) => metadata.used_by.push(new_entry.id),
+                None => panic!(
+                    "Catalog: missing dependent catalog item {} while updating {}",
+                    &u,
+                    state.resolve_full_name(&new_entry.name, new_entry.conn_id())
+                ),
+            }
+        }
+
         state.entry_by_id.insert(id, new_entry);
         builtin_table_updates.extend(state.pack_item_update(id, 1));
         Ok(())


### PR DESCRIPTION
When updating an item, we did not properly adjust its dependents. We now do this by essentially dropping and adding and the item.

### Motivation

This PR fixes a previously unreported bug.

The following sequence of commands renders a user's source immutable:

```
CREATE SOURCE foo FROM POSTGRES...;
ALTER SOURCE foo ADD SUBSOURCE bar;
DROP SOURCE bar;
```

What should happen in this scenario is that `DROP SOURCE bar` is prohibited because it is a subsource--however, if `bar` was added via `ADD SUBSOURCE` and `envd` had not rebooted, the dependency between `bar` and `foo` was not instantiated in memory, so `DROP SOURCE` was not prohibited.

This would successfully drop the source, which would make the `create_sql` of `foo` corrupted because it referred to a source that no longer existed.

@MaterializeInc/surfaces This is a high priority bug, so I'd like to get it in this week's release. Getting a review ASAP would be very helpful.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that could lead to catalog corruption if dropping a PostgreSQL subsource via `DROP SOURCE` after adding it via `ALTER SOURCE...ADD SUBSOURCE`. The proper command to drop subsources is `ALTER SOURCE...DROP SUBSOURCE` and `DROP SOURCE` should error when trying to drop subsources.
