### PR TITLE
tests: fix "running platform checks fails because of docker compose version string"

### DIFF
--- a/misc/python/materialize/cli/mzcompose.py
+++ b/misc/python/materialize/cli/mzcompose.py
@@ -414,6 +414,8 @@ class DockerComposeCommand(Command):
             .strip()
             .strip("v")
             .split("+")[0]
+            # remove suffix like "-desktop.1"
+            .split("-")[0]
         )
         version = tuple(int(i) for i in output.split("."))
         if version < MIN_COMPOSE_VERSION:


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/21189.

Version string can be "2.20.2-desktop.1"
