### PR TITLE
Fix `CollectIndexRequests` when both a join and a full scan uses an index

### DIFF
--- a/doc/user/content/transform-data/optimization.md
+++ b/doc/user/content/transform-data/optimization.md
@@ -55,10 +55,11 @@ EXPLAIN SELECT * FROM foo WHERE x = 42 AND y = 'hello';
 #### Matching multi-column indexes to multi-column `WHERE` clauses
 
 In general, your index key should exactly match the columns that are constrained in the `WHERE` clause. In more detail:
-- If the `WHERE` clause constrains fewer fields than your index key includes, then **the index will not be used**. For example, an index on `(x, y)` cannot be used to speed up `WHERE x = 7`.
+- **_If the `WHERE` clause constrains fewer fields than your index key includes, then the index will not be used_** for a lookup, but will be fully scanned. For example, an index on `(x, y)` cannot be used to execute `WHERE x = 7` as a point lookup.
 - If the `WHERE` clause constrains more fields than your index key includes, then the index might still provide some speedup, but it won't necessarily be optimal: In this case, the index lookup is performed using only those constraints that are included in the index key, and the rest of the constraints will be used to subsequently filter the result of the index lookup.
 - If `OR` is used and not all arguments constrain the same fields, create an index for the intersection of the constrained fields. For example, if you have `WHERE (x = 51 AND y = 'bbb') OR (x = 76 AND z = 9)`, create an index just on `x`.
 - If `OR` is used and its arguments constrain completely disjoint sets of fields (e.g. `WHERE x = 5 OR y = 'aaa'`), try to rewrite your query using a `UNION` (or `UNION ALL`), where each argument of the `UNION` has one of the original `OR` arguments.
+- If the same input is being used in a join as well as being constrained by equalities to literals, then an index can be used to speed up either the join (see below) or the literal equalities (see above). Which of these will perform better depends on data characteristics.
 
 ### `JOIN`
 

--- a/src/repr/src/explain.proto
+++ b/src/repr/src/explain.proto
@@ -21,5 +21,8 @@ message ProtoIndexUsageType {
         bool delta_join = 4;
         google.protobuf.Empty plan_root = 5;
         google.protobuf.Empty unknown = 6;
+        google.protobuf.Empty dangling_arrange_by = 7;
+        google.protobuf.Empty sink_export = 8;
+        google.protobuf.Empty index_export = 9;
     }
 }

--- a/src/repr/src/explain/text.rs
+++ b/src/repr/src/explain/text.rs
@@ -9,6 +9,7 @@
 
 //! Structs and traits for `EXPLAIN AS TEXT`.
 
+use itertools::Itertools;
 use std::fmt;
 
 use mz_ore::str::{separated, Indent, IndentLike};
@@ -81,7 +82,7 @@ where
                 "{}- {} ({})",
                 ctx.as_mut(),
                 index_name,
-                separated(", ", usage_types)
+                separated(", ", usage_types.iter().sorted().dedup())
             )?;
         }
         *ctx.as_mut() -= 1;

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -456,8 +456,6 @@ pub fn optimize_dataflow_monotonic(dataflow: &mut DataflowDesc) -> Result<(), Tr
 ///
 /// The input plans should be normalized with `NormalizeLets`! Otherwise we might find dangling
 /// `ArrangeBy`s at the top of unused Let bindings.
-///
-/// Should be called on a [DataflowDesc] only once.
 #[tracing::instrument(
     target = "optimizer",
     level = "debug",
@@ -470,23 +468,8 @@ fn prune_and_annotate_dataflow_index_imports(
 ) -> Result<(), TransformError> {
     // This will be a mapping of
     // (ids used by exports and objects to build) ->
-    // (arrangement keys and usage types on that id that have been explicitly requested by the MIR
-    // plans)
+    // (arrangement keys and usage types on that id that have been requested)
     let mut index_reqs_by_id = BTreeMap::new();
-
-    // First, insert `sink_exports` and `index_exports` into `index_reqs_by_id` to account for the
-    // (currently only theoretical) possibility that we are using an index that we are also building
-    // ourselves.
-    for (_id, sink_desc) in dataflow.sink_exports.iter() {
-        index_reqs_by_id
-            .entry(sink_desc.from)
-            .or_insert_with(Vec::new);
-    }
-    for (_id, (index_desc, _)) in dataflow.index_exports.iter() {
-        index_reqs_by_id
-            .entry(index_desc.on_id)
-            .or_insert_with(Vec::new);
-    }
 
     // Go through the MIR plans of `objects_to_build` and collect which arrangements are requested
     // for which we also have an available index.
@@ -495,26 +478,73 @@ fn prune_and_annotate_dataflow_index_imports(
             .collect_index_reqs(build_desc.plan.as_inner_mut())?;
     }
 
-    // Add full index scans, i.e., where an index exists, but either no specific key was requested
-    // or the requested key didn't match an existing index in the above code.
-    for (id, requests_with_matching_indexes) in index_reqs_by_id.iter_mut() {
-        if requests_with_matching_indexes.is_empty() {
-            // Pick an arbitrary index to be fully scanned.
-            // TODO: There are various edge cases where a better choice would be possible:
-            // - Some indexes might be less skewed than others.
-            // - Some indexes might have an error, while others don't.
-            //   https://github.com/MaterializeInc/materialize/issues/15557
-            // - Some indexes might have less extra data in their keys, which won't be used in a
-            //   full scan.
+    // Collect index usages by `sink_exports`.
+    // A sink export sometimes wants to directly use an imported index. I know of one case where
+    // this happens: The dataflow for a SUBSCRIBE on an indexed view won't have any
+    // `objects_to_build`, but will want to directly read from the index and write to a sink.
+    for (_sink_id, sink_desc) in dataflow.sink_exports.iter() {
+        // First, let's see if there exists an index on the id that the sink wants. If not, there is
+        // nothing we can do here.
+        if let Some(arbitrary_index_key) = indexes.indexes_on(sink_desc.from).next() {
+            // If yes, then we'll add a request of _some_ index: If we already collected an index
+            // request on this id, then use that, otherwise use the above arbitrarily picked index.
+            let requested_keys = index_reqs_by_id
+                .entry(sink_desc.from)
+                .or_insert_with(Vec::new);
+            if let Some((already_requested_key, _usage_type)) = requested_keys.get(0) {
+                requested_keys.push((already_requested_key.clone(), IndexUsageType::SinkExport));
+            } else {
+                requested_keys.push((arbitrary_index_key.to_owned(), IndexUsageType::SinkExport));
+            }
+        }
+    }
+
+    // Collect index usages by `index_exports`.
+    for (_id, (index_desc, _)) in dataflow.index_exports.iter() {
+        // First, let's see if there exists an index on the id that the exported index is on. If
+        // not, there is nothing we can do here.
+        if let Some(arbitrary_index_key) = indexes.indexes_on(index_desc.on_id).next() {
+            // If yes, then we'll add an index request of some index: If we already collected an
+            // index request on this id, then use that, otherwise use the above arbitrarily picked
+            // index.
+            let requested_keys = index_reqs_by_id
+                .entry(index_desc.on_id)
+                .or_insert_with(Vec::new);
+            if let Some((already_requested_key, _usage_type)) = requested_keys.get(0) {
+                requested_keys.push((already_requested_key.clone(), IndexUsageType::IndexExport));
+            } else {
+                // This is surprising: Actually, an index creation dataflow always has a plan in
+                // `objects_to_build` that will have a Get of the object that the index is on (see
+                // `DataflowDescription::export_index`). Therefore, we should have already requested
+                // an index usage when seeing that Get in `CollectIndexRequests`.
+                soft_panic_or_log!("We are seeing an index export on an id that's not mentioned in `objects_to_build`");
+                requested_keys.push((arbitrary_index_key.to_owned(), IndexUsageType::IndexExport));
+            }
+        }
+    }
+
+    // By now, `index_reqs_by_id` has all ids that we think might benefit from having an index on.
+    // Moreover, for each of these ids, if any index exists on it, then we should have already
+    // picked one. If not, then we have a bug somewhere. In that case, do a soft panic, and add an
+    // Unknown usage, picking an arbitrary index.
+    for (id, index_reqs) in index_reqs_by_id.iter_mut() {
+        if index_reqs.is_empty() {
+            // Try to pick an arbitrary index to be fully scanned.
             if let Some(key) = indexes.indexes_on(*id).next() {
-                requests_with_matching_indexes.push((key.to_owned(), IndexUsageType::FullScan));
+                soft_panic_or_log!(
+                    "prune_and_annotate_dataflow_index_imports didn't find any index for an id, even though one exists
+id: {}, key: {:?}",
+                    id,
+                    key
+                );
+                index_reqs.push((key.to_owned(), IndexUsageType::Unknown));
             }
         }
     }
 
     // Annotate index imports by their usage types
     for (
-        _index_id,
+        index_id,
         IndexImport {
             desc: index_desc,
             typ: _,
@@ -523,16 +553,24 @@ fn prune_and_annotate_dataflow_index_imports(
         },
     ) in dataflow.index_imports.iter_mut()
     {
-        if let Some(requested_accesses) = index_reqs_by_id.get(&index_desc.on_id) {
-            assert!(usage_types.is_none()); // We should be called on a dataflow only once
-            *usage_types = Some(Vec::new());
-            assert!(!requested_accesses.is_empty()); // See above at the "Add full index scans"
-            for (req_key, req_usage_type) in requested_accesses {
+        // A sanity check that we are not importing an index that we are also exporting.
+        assert!(!dataflow
+            .index_exports
+            .iter()
+            .map(|(exported_index_id, _)| exported_index_id)
+            .any(|exported_index_id| exported_index_id == index_id));
+
+        let mut new_usage_types = Vec::new();
+        // Let's see whether something has requested an index on this object that this imported
+        // index is on.
+        if let Some(index_reqs) = index_reqs_by_id.get(&index_desc.on_id) {
+            for (req_key, req_usage_type) in index_reqs {
                 if *req_key == index_desc.key {
-                    usage_types.as_mut().unwrap().push(req_usage_type.clone());
+                    new_usage_types.push(req_usage_type.clone());
                 }
             }
         }
+        *usage_types = Some(new_usage_types);
     }
 
     // Prune index imports to only those that are used
@@ -540,10 +578,7 @@ fn prune_and_annotate_dataflow_index_imports(
         .index_imports
         .retain(|_, index_import| match &index_import.usage_types {
             None => false,
-            Some(usage_types) => {
-                !usage_types.is_empty()
-                // (can be empty here when an other index on this same object is used)
-            }
+            Some(usage_types) => !usage_types.is_empty(),
         });
 
     mz_repr::explain::trace_plan(dataflow);
@@ -603,179 +638,228 @@ impl<'a> CollectIndexRequests<'a> {
         expr: &MirRelationExpr,
         contexts: &Vec<IndexUsageContext>,
     ) -> Result<(), RecursionLimitError> {
-        // See comment on `IndexUsageContext`.
-        Ok(match expr {
-            MirRelationExpr::Let { id, value, body } => {
-                let shadowed_context = self.context_across_lets.insert(id.clone(), Vec::new());
-                // No shadowing in MIR
-                assert!(shadowed_context.is_none());
-                // We go backwards: Recurse on the body and then the value.
-                self.collect_index_reqs_inner(body, contexts)?;
-                // The above call filled in the entry for `id` in `context_across_lets` (if it
-                // was referenced). Anyhow, at least an empty entry should exist, because we started
-                // above with inserting it.
-                self.collect_index_reqs_inner(
-                    value,
-                    &self.context_across_lets.get(id).unwrap().clone(),
-                )?;
-                // Clean up the id from the saved contexts.
-                self.context_across_lets.remove(id);
-            }
-            MirRelationExpr::LetRec {
-                ids,
-                values,
-                limits: _,
-                body,
-            } => {
-                for id in ids {
-                    let shadowed_context = self.context_across_lets.insert(id.clone(), Vec::new());
-                    assert!(shadowed_context.is_none()); // No shadowing in MIR
-                }
-                // We go backwards: Recurse on the body first.
-                self.collect_index_reqs_inner(body, contexts)?;
-                // Reset the contexts of the ids (of the current LetRec), because an arrangement
-                // from a value can't be used in the body.
-                for id in ids {
-                    *self.context_across_lets.get_mut(id).unwrap() = Vec::new();
-                }
-                // Recurse on the values in reverse order.
-                // Note that we do only one pass, i.e., we won't see context through a Get that
-                // refers to the previous iteration. But this is ok, because we can't reuse
-                // arrangements across iterations anyway.
-                for (id, value) in ids.iter().zip(values.iter()).rev() {
-                    self.collect_index_reqs_inner(
-                        value,
-                        &self.context_across_lets.get(id).unwrap().clone(),
-                    )?;
-                }
-                // Clean up the ids from the saved contexts.
-                for id in ids {
-                    self.context_across_lets.remove(id);
-                }
-            }
-            MirRelationExpr::Get {
-                id: Id::Local(local_id),
-                ..
-            } => {
-                // Add the current context to the vector of contexts of `local_id`.
-                // (The unwrap is safe, because the Let and LetRec cases start with inserting an
-                // empty entry.)
-                self.context_across_lets
-                    .get_mut(local_id)
-                    .unwrap()
-                    .extend(contexts.iter().cloned());
-                // No recursive call here, because Get has no inputs.
-            }
-            MirRelationExpr::Join {
-                inputs,
-                implementation,
-                ..
-            } => {
-                match implementation {
-                    JoinImplementation::Differential(..) => {
-                        for input in inputs {
-                            self.collect_index_reqs_inner(
-                                input,
-                                &IndexUsageContext::from_usage_type(
-                                    IndexUsageType::DifferentialJoin,
-                                ),
-                            )?;
-                        }
-                    }
-                    JoinImplementation::DeltaQuery(..) => {
-                        // For Delta joins, the first input is special, see
-                        // https://github.com/MaterializeInc/materialize/issues/6789
-                        self.collect_index_reqs_inner(
-                            &inputs[0],
-                            &IndexUsageContext::from_usage_type(IndexUsageType::DeltaJoin(true)),
-                        )?;
-                        for input in &inputs[1..] {
-                            self.collect_index_reqs_inner(
-                                input,
-                                &IndexUsageContext::from_usage_type(IndexUsageType::DeltaJoin(
-                                    false,
-                                )),
-                            )?;
-                        }
-                    }
-                    JoinImplementation::IndexedFilter(..) => {
-                        for input in inputs {
-                            self.collect_index_reqs_inner(
-                                input,
-                                &IndexUsageContext::from_usage_type(IndexUsageType::Lookup),
-                            )?;
-                        }
-                    }
-                    JoinImplementation::Unimplemented => {
-                        soft_panic_or_log!(
-                            "CollectIndexRequests encountered an Unimplemented join"
-                        );
-                    }
-                }
-            }
-            MirRelationExpr::ArrangeBy { input, keys } => {
-                let mut new_contexts = contexts.clone();
-                IndexUsageContext::add_keys(&mut new_contexts, keys);
-                self.collect_index_reqs_inner(input, &new_contexts)?;
-            }
-            MirRelationExpr::Get {
-                id: Id::Global(global_id),
-                ..
-            } => {
-                self.index_reqs_by_id
-                    .entry(*global_id)
-                    .or_insert_with(Vec::new);
-                for context in contexts {
-                    match &context.requested_keys {
-                        None => {
-                            // We have some index usage context, but didn't see an `ArrangeBy`.
-                            match context.usage_type {
-                                IndexUsageType::FullScan => {
-                                    // Not possible, because we add these later, only after
-                                    // `CollectIndexRequests` has already run.
-                                    unreachable!()
-                                },
-                                // You can find more info on why the following join cases shouldn't
-                                // happen in comments of the Join lowering to LIR.
-                                IndexUsageType::Lookup => soft_panic_or_log!("CollectIndexRequests encountered an IndexedFilter join without an ArrangeBy"),
-                                IndexUsageType::DifferentialJoin => soft_panic_or_log!("CollectIndexRequests encountered a Differential join without an ArrangeBy"),
-                                IndexUsageType::DeltaJoin(_) => soft_panic_or_log!("CollectIndexRequests encountered a Delta join without an ArrangeBy"),
-                                IndexUsageType::PlanRoot => {
-                                    // This is ok: happens when the entire query is a `Get`.
-                                },
-                                IndexUsageType::Unknown => {
-                                    // Not possible, because we create IndexUsageType::Unknown
-                                    // only when we see an `ArrangeBy`.
-                                    unreachable!()
-                                },
+        self.checked_recur_mut(|this| {
+
+            // If an index exists on `on_id`, this function picks an index to be fully scanned.
+            let pick_index_for_full_scan = |on_id: &GlobalId| {
+                // Pick an arbitrary index
+                // TODO: There are various edge cases where a better than arbitrary choice would be
+                // possible:
+                // - Some indexes might be less skewed than others.
+                // - Some indexes might have an error, while others don't.
+                //   https://github.com/MaterializeInc/materialize/issues/15557
+                // - Some indexes might have less extra data in their keys, which won't be used in a
+                //   full scan.
+                // - We might want to prefer using an index that we are already using elsewhere in this
+                //   same dataflow, to avoid adding dependencies to more indexes than necessary.
+                this.indexes_available.indexes_on(*on_id).next()
+            };
+
+            // See comment on `IndexUsageContext`.
+            Ok(match expr {
+                MirRelationExpr::Join {
+                    inputs,
+                    implementation,
+                    ..
+                } => {
+                    match implementation {
+                        JoinImplementation::Differential(..) => {
+                            for input in inputs {
+                                this.collect_index_reqs_inner(
+                                    input,
+                                    &IndexUsageContext::from_usage_type(
+                                        IndexUsageType::DifferentialJoin,
+                                    ),
+                                )?;
                             }
                         }
-                        Some(requested_keys) => {
-                            for requested_key in requested_keys {
-                                if self
-                                    .indexes_available
-                                    .indexes_on(*global_id)
-                                    .find(|available_key| available_key == &requested_key)
-                                    .is_some()
-                                {
-                                    self.index_reqs_by_id
-                                        .get_mut(global_id)
-                                        .unwrap()
-                                        .push((requested_key.clone(), context.usage_type.clone()));
+                        JoinImplementation::DeltaQuery(..) => {
+                            // For Delta joins, the first input is special, see
+                            // https://github.com/MaterializeInc/materialize/issues/6789
+                            this.collect_index_reqs_inner(
+                                &inputs[0],
+                                &IndexUsageContext::from_usage_type(IndexUsageType::DeltaJoin(true)),
+                            )?;
+                            for input in &inputs[1..] {
+                                this.collect_index_reqs_inner(
+                                    input,
+                                    &IndexUsageContext::from_usage_type(IndexUsageType::DeltaJoin(
+                                        false,
+                                    )),
+                                )?;
+                            }
+                        }
+                        JoinImplementation::IndexedFilter(..) => {
+                            for input in inputs {
+                                this.collect_index_reqs_inner(
+                                    input,
+                                    &IndexUsageContext::from_usage_type(IndexUsageType::Lookup),
+                                )?;
+                            }
+                        }
+                        JoinImplementation::Unimplemented => {
+                            soft_panic_or_log!(
+                            "CollectIndexRequests encountered an Unimplemented join"
+                        );
+                        }
+                    }
+                }
+                MirRelationExpr::ArrangeBy { input, keys } => {
+                    this.collect_index_reqs_inner(input, &IndexUsageContext::add_keys(contexts, keys))?;
+                }
+                MirRelationExpr::Get {
+                    id: Id::Global(global_id),
+                    ..
+                } => {
+                    this.index_reqs_by_id
+                        .entry(*global_id)
+                        .or_insert_with(Vec::new);
+                    // If the context is empty, it means we didn't see an operator that would
+                    // specifically want to use an index for this Get. However, let's still try to find
+                    // an index for a full scan.
+                    let mut try_full_scan = contexts.is_empty();
+                    for context in contexts {
+                        match &context.requested_keys {
+                            None => {
+                                // We have some index usage context, but didn't see an `ArrangeBy`.
+                                match context.usage_type {
+                                    IndexUsageType::FullScan | IndexUsageType::SinkExport | IndexUsageType::IndexExport => {
+                                        // Not possible, because these don't go through
+                                        // IndexUsageContext at all.
+                                        unreachable!()
+                                    },
+                                    // You can find more info on why the following join cases shouldn't
+                                    // happen in comments of the Join lowering to LIR.
+                                    IndexUsageType::Lookup => soft_panic_or_log!("CollectIndexRequests encountered an IndexedFilter join without an ArrangeBy"),
+                                    IndexUsageType::DifferentialJoin => soft_panic_or_log!("CollectIndexRequests encountered a Differential join without an ArrangeBy"),
+                                    IndexUsageType::DeltaJoin(_) => soft_panic_or_log!("CollectIndexRequests encountered a Delta join without an ArrangeBy"),
+                                    IndexUsageType::PlanRoot => {
+                                        // This is ok: happens when the entire query is a `Get`.
+                                    },
+                                    IndexUsageType::DanglingArrangeBy => {
+                                        // Not possible, because we create IndexUsageType::Unknown
+                                        // only when we see an `ArrangeBy`.
+                                        unreachable!()
+                                    },
+                                    IndexUsageType::Unknown => {
+                                        // These are added only after `CollectIndexRequests` has run.
+                                        unreachable!()
+                                    }
+                                }
+                                try_full_scan = true;
+                            }
+                            Some(requested_keys) => {
+                                for requested_key in requested_keys {
+                                    if this
+                                        .indexes_available
+                                        .indexes_on(*global_id)
+                                        .find(|available_key| available_key == &requested_key)
+                                        .is_some()
+                                    {
+                                        this.index_reqs_by_id
+                                            .get_mut(global_id)
+                                            .unwrap()
+                                            .push((requested_key.clone(), context.usage_type.clone()));
+                                    } else {
+                                        // If there is a key requested for which we don't have an index,
+                                        // then we might still be able to do a full scan of a
+                                        // differently keyed index.
+                                        try_full_scan = true;
+                                    }
+                                }
+                                if requested_keys.is_empty() {
+                                    // It's a bit weird if an MIR ArrangeBy is not requesting any key,
+                                    // but let's try a full scan in that case anyhow.
+                                    try_full_scan = true;
                                 }
                             }
                         }
                     }
+                    if try_full_scan {
+                        // TODO: Keep in mind that when having 2 contexts coming from 2 uses of a Let,
+                        // this code can't distinguish between the case when there is 1 ArrangeBy at the
+                        // top of the Let, or when the 2 uses each have an `ArrangeBy`. In both cases,
+                        // we'll add only 1 full scan, which would be wrong in the latter case. However,
+                        // the latter case can't currently happen until we do
+                        // https://github.com/MaterializeInc/materialize/issues/21145
+                        if let Some(key) = pick_index_for_full_scan(global_id) {
+                            this.index_reqs_by_id
+                                .get_mut(global_id)
+                                .unwrap()
+                                .push((key.to_owned(), IndexUsageType::FullScan));
+                        }
+                    }
                 }
-            }
-            _ => {
-                // Nothing interesting at this node, empty the context.
-                let empty_context = Vec::new();
-                // And recurse.
-                for child in expr.children() {
-                    self.collect_index_reqs_inner(child, &empty_context)?;
+                MirRelationExpr::Get {
+                    id: Id::Local(local_id),
+                    ..
+                } => {
+                    // Add the current context to the vector of contexts of `local_id`.
+                    // (The unwrap is safe, because the Let and LetRec cases start with inserting an
+                    // empty entry.)
+                    this.context_across_lets
+                        .get_mut(local_id)
+                        .unwrap()
+                        .extend(contexts.iter().cloned());
+                    // No recursive call here, because Get has no inputs.
                 }
-            }
+                MirRelationExpr::Let { id, value, body } => {
+                    let shadowed_context = this.context_across_lets.insert(id.clone(), Vec::new());
+                    // No shadowing in MIR
+                    assert!(shadowed_context.is_none());
+                    // We go backwards: Recurse on the body and then the value.
+                    this.collect_index_reqs_inner(body, contexts)?;
+                    // The above call filled in the entry for `id` in `context_across_lets` (if it
+                    // was referenced). Anyhow, at least an empty entry should exist, because we started
+                    // above with inserting it.
+                    this.collect_index_reqs_inner(
+                        value,
+                        &this.context_across_lets[id].clone(),
+                    )?;
+                    // Clean up the id from the saved contexts.
+                    this.context_across_lets.remove(id);
+                }
+                MirRelationExpr::LetRec {
+                    ids,
+                    values,
+                    limits: _,
+                    body,
+                } => {
+                    for id in ids {
+                        let shadowed_context = this.context_across_lets.insert(id.clone(), Vec::new());
+                        assert!(shadowed_context.is_none()); // No shadowing in MIR
+                    }
+                    // We go backwards: Recurse on the body first.
+                    this.collect_index_reqs_inner(body, contexts)?;
+                    // Reset the contexts of the ids (of the current LetRec), because an arrangement
+                    // from a value can't be used in the body.
+                    for id in ids {
+                        *this.context_across_lets.get_mut(id).unwrap() = Vec::new();
+                    }
+                    // Recurse on the values in reverse order.
+                    // Note that we do only one pass, i.e., we won't see context through a Get that
+                    // refers to the previous iteration. But this is ok, because we can't reuse
+                    // arrangements across iterations anyway.
+                    for (id, value) in ids.iter().zip(values.iter()).rev() {
+                        this.collect_index_reqs_inner(
+                            value,
+                            &this.context_across_lets[id].clone(),
+                        )?;
+                    }
+                    // Clean up the ids from the saved contexts.
+                    for id in ids {
+                        this.context_across_lets.remove(id);
+                    }
+                }
+                _ => {
+                    // Nothing interesting at this node, recurse with the empty context (regardless of
+                    // what context we got from above).
+                    let empty_context = Vec::new();
+                    for child in expr.children() {
+                        this.collect_index_reqs_inner(child, &empty_context)?;
+                    }
+                }
+            })
         })
     }
 }
@@ -808,17 +892,21 @@ impl IndexUsageContext {
         }]
     }
 
-    // Add the keys of an ArrangeBy into the context.
+    // Add the keys of an ArrangeBy into the contexts.
     // Soft_panics if haven't already seen something that indicates what the index will be used for.
-    pub fn add_keys(contexts: &mut Vec<IndexUsageContext>, keys_to_add: &Vec<Vec<MirScalarExpr>>) {
+    pub fn add_keys(
+        old_contexts: &Vec<IndexUsageContext>,
+        keys_to_add: &Vec<Vec<MirScalarExpr>>,
+    ) -> Vec<IndexUsageContext> {
+        let mut contexts = old_contexts.clone();
         if contexts.is_empty() {
             // No join above us, and we are not at the root. Why does this ArrangeBy even exist?
             soft_panic_or_log!("CollectIndexRequests encountered a dangling ArrangeBy");
             // Anyhow, let's create a context with an Unknown index usage, so that we have a place
             // to note down the requested keys below.
-            *contexts = IndexUsageContext::from_usage_type(IndexUsageType::Unknown);
+            contexts = IndexUsageContext::from_usage_type(IndexUsageType::DanglingArrangeBy);
         }
-        for context in contexts {
+        for context in contexts.iter_mut() {
             if context.requested_keys.is_none() {
                 context.requested_keys = Some(BTreeSet::new());
             }
@@ -828,5 +916,6 @@ impl IndexUsageContext {
                 .unwrap()
                 .extend(keys_to_add.iter().cloned());
         }
+        contexts
     }
 }

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -587,6 +587,8 @@ impl Optimizer {
             // you remove this transform for examples.
             Box::new(crate::threshold_elision::ThresholdElision),
             // We need this to ensure that `CollectIndexRequests` gets a normalized plan.
+            // (For example, `FoldConstants` can break the normalized form by removing all
+            // references to a Let, see https://github.com/MaterializeInc/materialize/issues/21175)
             Box::new(crate::normalize_lets::NormalizeLets::new(false)),
             Box::new(crate::typecheck::Typecheck::new(Rc::clone(ctx)).disallow_new_globals()),
         ];

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -165,6 +165,6 @@ Source materialize.public.v
   filter=((#0) IS NOT NULL)
 
 Used Indexes:
-  - materialize.public.u_d_idx (differential join)
+  - materialize.public.u_d_idx (*** full scan ***, differential join)
 
 EOF

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -253,10 +253,10 @@ Explained Query:
           Get materialize.public.customer // { arity: 8 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join 1st input)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join 1st input (full scan))
 
 EOF
 
@@ -314,10 +314,10 @@ Explained Query:
               Get materialize.public.customer // { arity: 8 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join 1st input)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join 1st input (full scan))
 
 EOF
 
@@ -540,10 +540,10 @@ Explained Query:
             Get materialize.public.customer // { arity: 8 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join 1st input)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join 1st input (full scan))
 
 EOF
 
@@ -648,10 +648,10 @@ Explained Query:
             Get materialize.public.customer // { arity: 8 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join 1st input)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join 1st input (full scan))
 
 EOF
 

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -170,7 +170,7 @@ Explained Query:
         Get materialize.public.t
 
 Used Indexes:
-  - materialize.public.t_x (differential join, differential join)
+  - materialize.public.t_x (differential join)
 
 EOF
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -352,9 +352,10 @@ Source materialize.public.region
   filter=(like["EUROP%"](padchar(#1)))
 
 Used Indexes:
+  - materialize.public.fk_stock_warehouse (*** full scan ***)
   - materialize.public.fk_stock_supplier (differential join)
-  - materialize.public.fk_nation_regionkey (differential join)
-  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.fk_nation_regionkey (*** full scan ***, differential join)
+  - materialize.public.fk_supplier_nationkey (*** full scan ***, differential join)
 
 EOF
 
@@ -1211,7 +1212,7 @@ Source materialize.public.item
   filter=(like["%b"](padchar(#4)))
 
 Used Indexes:
-  - materialize.public.fk_orderline_item (differential join, differential join)
+  - materialize.public.fk_orderline_item (differential join)
 
 EOF
 
@@ -1474,7 +1475,7 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.fk_order_customer (*** full scan ***)
-  - materialize.public.fk_orderline_order (differential join, differential join)
+  - materialize.public.fk_orderline_order (differential join)
   - materialize.public.fk_stock_warehouse (*** full scan ***)
   - materialize.public.fk_nation_regionkey (*** full scan ***)
   - materialize.public.fk_supplier_nationkey (*** full scan ***)

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -922,3 +922,69 @@ Used Indexes:
   - materialize.public.t_a_idx_1 (delta join 1st input, delta join, delta join)
 
 EOF
+
+# An index is used in both a join and a full scan.
+query T multiline
+EXPLAIN
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t AS t1, t AS t2
+ WHERE t1.a = t2.a)
+UNION
+(SELECT *
+ FROM t
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct group_by=[#0, #1]
+      Union
+        Project (#4, #5)
+          Filter (#0) IS NOT NULL
+            Map ((#0 + #0), (#1 + #3))
+              Join on=(#0 = #2) type=differential
+                Get l0
+                Get l0
+        Filter (#1 > 5)
+          Get materialize.public.t
+  With
+    cte l0 =
+      ArrangeBy keys=[[#0]]
+        Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (differential join, differential join)
+
+EOF
+
+# An index exists that can't be used for the join because of having the wrong key.
+query T multiline
+EXPLAIN
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t AS t1, t AS t2
+ WHERE t1.b = t2.b)
+UNION
+(SELECT *
+ FROM t
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct group_by=[#0, #1]
+      Union
+        Project (#4, #5)
+          Map ((#0 + #2), (#1 + #1))
+            Join on=(#1 = #3) type=differential
+              Get l0
+              Get l0
+        Filter (#1 > 5)
+          Get materialize.public.t
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]]
+        Filter (#1) IS NOT NULL
+          Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -282,7 +282,7 @@ Explained Query:
                         Get materialize.public.mv
 
 Used Indexes:
-  - materialize.public.t_a_idx (differential join)
+  - materialize.public.t_a_idx (*** full scan ***, differential join)
 
 EOF
 
@@ -485,7 +485,7 @@ Explained Query:
         Get materialize.public.t
 
 Used Indexes:
-  - materialize.public.t_a_idx (differential join)
+  - materialize.public.t_a_idx (*** full scan ***, differential join)
 
 EOF
 
@@ -631,10 +631,10 @@ Explained Query:
           Get materialize.public.v
 
 Used Indexes:
-  - materialize.public.u_c_idx (delta join)
-  - materialize.public.u_d_idx (delta join)
-  - materialize.public.v_e_idx (delta join)
-  - materialize.public.t_b_idx (delta join 1st input)
+  - materialize.public.u_c_idx (delta join lookup)
+  - materialize.public.u_d_idx (delta join lookup)
+  - materialize.public.v_e_idx (delta join lookup)
+  - materialize.public.t_b_idx (delta join 1st input (full scan))
 
 EOF
 
@@ -661,10 +661,10 @@ Explained Query:
           Get materialize.public.v
 
 Used Indexes:
-  - materialize.public.u_c_idx (delta join)
-  - materialize.public.u_d_idx (delta join)
-  - materialize.public.v_e_idx (delta join)
-  - materialize.public.t_b_idx (delta join 1st input)
+  - materialize.public.u_c_idx (delta join lookup)
+  - materialize.public.u_d_idx (delta join lookup)
+  - materialize.public.v_e_idx (delta join lookup)
+  - materialize.public.t_b_idx (delta join 1st input (full scan))
 
 EOF
 
@@ -854,7 +854,7 @@ Explained Query:
 
 EOF
 
-# Let's test the weird situation that two identical indexes exist.
+## "Used indexes" tests
 
 statement ok
 CREATE TABLE t (
@@ -867,6 +867,67 @@ CREATE TABLE u (
   c int,
   d int
 );
+
+# If two indexes exist on the same table, then "Used indexes" should print the one that we are actually going to use
+
+statement ok
+CREATE INDEX u_c ON u(c);
+
+statement ok
+CREATE INDEX u_d ON u(d);
+
+query T multiline
+EXPLAIN
+SELECT *
+FROM t, u
+WHERE t.b = u.c;
+----
+Explained Query:
+  Project (#0, #1, #1, #3)
+    Filter (#1) IS NOT NULL
+      Join on=(#1 = #2) type=differential
+        ArrangeBy keys=[[#1]]
+          Filter (#1) IS NOT NULL
+            Get materialize.public.t
+        ArrangeBy keys=[[#0]]
+          Get materialize.public.u
+
+Source materialize.public.t
+  filter=((#1) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.u_c (differential join)
+
+EOF
+
+query T multiline
+EXPLAIN
+SELECT *
+FROM t, u
+WHERE t.b = u.d;
+----
+Explained Query:
+  Project (#0..=#2, #1)
+    Filter (#1) IS NOT NULL
+      Join on=(#1 = #3) type=differential
+        ArrangeBy keys=[[#1]]
+          Filter (#1) IS NOT NULL
+            Get materialize.public.t
+        ArrangeBy keys=[[#1]]
+          Get materialize.public.u
+
+Source materialize.public.t
+  filter=((#1) IS NOT NULL)
+
+Used Indexes:
+  - materialize.public.u_d (differential join)
+
+EOF
+
+statement ok
+DROP INDEX u_c;
+
+# Let's test the weird situation that two identical indexes exist.
 
 statement ok
 CREATE INDEX t_a_idx_1 ON t(a);
@@ -890,10 +951,8 @@ Explained Query:
           Filter (#0) IS NOT NULL
             Get materialize.public.u
 
-Source materialize.public.u
-  filter=((#0) IS NOT NULL)
-
 Used Indexes:
+  - materialize.public.u_d (*** full scan ***)
   - materialize.public.t_a_idx_1 (differential join)
 
 EOF
@@ -919,7 +978,7 @@ Explained Query:
         Get materialize.public.t
 
 Used Indexes:
-  - materialize.public.t_a_idx_1 (delta join 1st input, delta join, delta join)
+  - materialize.public.t_a_idx_1 (delta join lookup, delta join 1st input (full scan))
 
 EOF
 
@@ -952,7 +1011,7 @@ Explained Query:
         Get materialize.public.t
 
 Used Indexes:
-  - materialize.public.t_a_idx_1 (differential join, differential join)
+  - materialize.public.t_a_idx_1 (*** full scan ***, differential join)
 
 EOF
 
@@ -986,5 +1045,132 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF
+
+# Similar to the previous test, but exercises the full scan code inside the context loop of the Get case in
+# `collect_index_reqs_inner`, where we don't have an index for the requested key.
+
+statement ok
+CREATE TABLE t_non_null (
+  a int NOT NULL,
+  b int NOT NULL
+);
+
+statement ok
+CREATE INDEX t_non_null_a_idx ON t_non_null(a);
+
+query T multiline
+EXPLAIN
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t_non_null AS t1, t_non_null AS t2
+ WHERE t1.b = t2.b)
+UNION
+(SELECT *
+ FROM t_non_null
+ WHERE b > 5)
+----
+Explained Query:
+  Return
+    Distinct group_by=[#0, #1]
+      Union
+        Project (#4, #5)
+          Map ((#0 + #2), (#1 + #1))
+            Join on=(#1 = #3) type=differential
+              Get l0
+              Get l0
+        Filter (#1 > 5)
+          Get materialize.public.t_non_null
+  With
+    cte l0 =
+      ArrangeBy keys=[[#1]]
+        Get materialize.public.t_non_null
+
+Used Indexes:
+  - materialize.public.t_non_null_a_idx (*** full scan ***)
+
+EOF
+
+# This has 1 more full scan than the previous test, because the join needs 2 different arrangements.
+query T multiline
+EXPLAIN
+(SELECT t1.a + t2.a AS a, t1.b + t2.b AS b
+ FROM t_non_null AS t1, t_non_null AS t2
+ WHERE t1.b = t2.b + 1)
+UNION
+(SELECT *
+ FROM t_non_null
+ WHERE b > 5)
+----
+Explained Query:
+  Distinct group_by=[#0, #1]
+    Union
+      Project (#4, #5)
+        Map ((#0 + #2), (#1 + #3))
+          Join on=(#1 = (#3 + 1)) type=differential
+            ArrangeBy keys=[[#1]]
+              Get materialize.public.t_non_null
+            ArrangeBy keys=[[(#1 + 1)]]
+              Get materialize.public.t_non_null
+      Filter (#1 > 5)
+        Get materialize.public.t_non_null
+
+Used Indexes:
+  - materialize.public.t_non_null_a_idx (*** full scan ***)
+
+EOF
+
+# An index is used in both a lookup and a full scan.
+query T multiline
+EXPLAIN
+SELECT * FROM t
+UNION
+SELECT * FROM t WHERE a = 5;
+----
+Explained Query:
+  Distinct group_by=[#0, #1]
+    Union
+      Get materialize.public.t
+      Project (#0, #1)
+        ReadExistingIndex materialize.public.t lookup_value=(5)
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***, lookup)
+
+EOF
+
+# Several lookups using different indexes
+
+statement ok
+CREATE INDEX t_b_idx ON t(b);
+
+query T multiline
+EXPLAIN
+SELECT * FROM t
+UNION ALL
+SELECT * FROM t WHERE b = 7
+UNION ALL
+SELECT * FROM t WHERE a = 5
+UNION ALL
+SELECT * FROM u WHERE c = 3
+UNION ALL
+SELECT * FROM u WHERE d = 1;
+----
+Explained Query:
+  Union
+    Get materialize.public.t
+    Project (#0, #1)
+      ReadExistingIndex materialize.public.t lookup_value=(7)
+    Project (#0, #1)
+      ReadExistingIndex materialize.public.t lookup_value=(5)
+    Filter (#0 = 3)
+      Get materialize.public.u
+    Project (#0, #1)
+      ReadExistingIndex materialize.public.u lookup_value=(1)
+
+Used Indexes:
+  - materialize.public.u_d (*** full scan ***, lookup)
+  - materialize.public.t_a_idx_1 (*** full scan ***, lookup)
+  - materialize.public.t_b_idx (lookup)
 
 EOF

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -1009,9 +1009,9 @@ Explained Query:
       arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
 
 Used Indexes:
-  - materialize.public.t_a_idx (delta join 1st input)
-  - materialize.public.u_c_idx (delta join)
-  - materialize.public.v_e_idx (delta join)
+  - materialize.public.t_a_idx (delta join 1st input (full scan))
+  - materialize.public.u_c_idx (delta join lookup)
+  - materialize.public.v_e_idx (delta join lookup)
 
 EOF
 

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -248,7 +248,7 @@ Explained Query:
 
 Used Indexes:
   - mz_internal.mz_clusters_ind (differential join)
-  - mz_internal.mz_cluster_replicas_ind (differential join)
+  - mz_internal.mz_cluster_replicas_ind (*** full scan ***, differential join)
   - mz_internal.mz_cluster_replica_sizes_ind (differential join)
   - mz_internal.mz_cluster_replica_metrics_ind (differential join)
 

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -296,14 +296,14 @@ Explained Query:
           Get materialize.public.supplier // { arity: 7 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join, delta join)
-  - materialize.public.fk_nation_regionkey (delta join, delta join)
-  - materialize.public.pk_region_regionkey (delta join, delta join)
-  - materialize.public.pk_part_partkey (delta join 1st input)
-  - materialize.public.pk_supplier_suppkey (delta join, delta join)
-  - materialize.public.fk_supplier_nationkey (delta join, delta join)
-  - materialize.public.fk_partsupp_partkey (delta join, delta join)
-  - materialize.public.fk_partsupp_suppkey (delta join, delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.fk_nation_regionkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.fk_partsupp_partkey (delta join lookup)
+  - materialize.public.fk_partsupp_suppkey (delta join lookup)
 
 EOF
 
@@ -352,10 +352,10 @@ Explained Query:
                 Get materialize.public.lineitem // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join 1st input)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join)
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
 
 EOF
 
@@ -408,7 +408,7 @@ Explained Query:
                     Get materialize.public.lineitem // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_orders_orderkey (delta join 1st input)
+  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
   - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
 
 EOF
@@ -584,15 +584,15 @@ Explained Query:
           Get materialize.public.nation // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join, delta join)
-  - materialize.public.pk_supplier_suppkey (delta join 1st input)
-  - materialize.public.fk_supplier_nationkey (delta join 1st input)
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.fk_customer_nationkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join)
-  - materialize.public.fk_lineitem_suppkey (delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.fk_customer_nationkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
 
 EOF
 
@@ -672,19 +672,19 @@ Explained Query:
                   Get materialize.public.region // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join, delta join)
-  - materialize.public.fk_nation_regionkey (delta join)
-  - materialize.public.pk_region_regionkey (delta join)
-  - materialize.public.pk_part_partkey (delta join 1st input)
-  - materialize.public.pk_supplier_suppkey (delta join)
-  - materialize.public.fk_supplier_nationkey (delta join)
-  - materialize.public.pk_customer_custkey (delta join)
-  - materialize.public.fk_customer_nationkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join)
-  - materialize.public.fk_lineitem_partkey (delta join)
-  - materialize.public.fk_lineitem_suppkey (delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.fk_nation_regionkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.fk_customer_nationkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_partkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
 
 EOF
 
@@ -751,16 +751,16 @@ Explained Query:
               Get materialize.public.nation // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join)
-  - materialize.public.pk_part_partkey (delta join 1st input)
-  - materialize.public.pk_supplier_suppkey (delta join)
-  - materialize.public.fk_supplier_nationkey (delta join)
-  - materialize.public.pk_partsupp_partkey_suppkey (delta join)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join)
-  - materialize.public.fk_lineitem_partkey (delta join)
-  - materialize.public.fk_lineitem_suppkey (delta join)
-  - materialize.public.fk_lineitem_partsuppkey (delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.pk_partsupp_partkey_suppkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_partkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+  - materialize.public.fk_lineitem_partsuppkey (delta join lookup)
 
 EOF
 
@@ -822,12 +822,12 @@ Explained Query:
                 Get materialize.public.nation // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join)
-  - materialize.public.pk_customer_custkey (delta join 1st input)
-  - materialize.public.fk_customer_nationkey (delta join 1st input)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
 
 EOF
 
@@ -894,10 +894,10 @@ Explained Query:
                 Get materialize.public.nation // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join)
-  - materialize.public.pk_supplier_suppkey (delta join)
-  - materialize.public.fk_supplier_nationkey (delta join)
-  - materialize.public.fk_partsupp_suppkey (delta join 1st input)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.fk_partsupp_suppkey (delta join 1st input (full scan))
 
 EOF
 
@@ -1013,7 +1013,7 @@ Explained Query:
                 Get materialize.public.orders // { arity: 9 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (differential join)
+  - materialize.public.pk_customer_custkey (*** full scan ***, differential join)
   - materialize.public.fk_orders_custkey (differential join)
 
 EOF
@@ -1288,7 +1288,7 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.pk_part_partkey (differential join)
-  - materialize.public.fk_lineitem_partkey (differential join, differential join)
+  - materialize.public.fk_lineitem_partkey (differential join)
 
 EOF
 
@@ -1369,10 +1369,10 @@ Explained Query:
           Get materialize.public.lineitem // { arity: 16 }
 
 Used Indexes:
-  - materialize.public.pk_customer_custkey (delta join 1st input)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_orders_custkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (differential join, delta join)
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
 
 EOF
 
@@ -1671,12 +1671,12 @@ Explained Query:
                 Get materialize.public.nation // { arity: 4 }
 
 Used Indexes:
-  - materialize.public.pk_nation_nationkey (delta join)
-  - materialize.public.pk_supplier_suppkey (delta join 1st input)
-  - materialize.public.fk_supplier_nationkey (delta join 1st input)
-  - materialize.public.pk_orders_orderkey (delta join)
-  - materialize.public.fk_lineitem_orderkey (differential join, differential join, delta join)
-  - materialize.public.fk_lineitem_suppkey (delta join)
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
 
 EOF
 

--- a/test/sqllogictest/transform/join_fusion.slt
+++ b/test/sqllogictest/transform/join_fusion.slt
@@ -181,6 +181,7 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.pk_orders_orderkey (*** full scan ***)
+  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
   - materialize.public.fk_lineitem_orderkey (lookup)
 
 EOF

--- a/test/sqllogictest/transform/join_index.slt
+++ b/test/sqllogictest/transform/join_index.slt
@@ -636,17 +636,17 @@ Explained Query:
           Get materialize.public.big // { arity: 14 }
 
 Used Indexes:
-  - materialize.public.big_idx_a (delta join 1st input)
-  - materialize.public.big_idx_b (delta join)
-  - materialize.public.big_idx_c (delta join)
-  - materialize.public.big_idx_d (delta join)
-  - materialize.public.big_idx_e (delta join)
-  - materialize.public.big_idx_f (delta join)
-  - materialize.public.big_idx_g (delta join)
-  - materialize.public.big_idx_h (delta join)
-  - materialize.public.big_idx_i (delta join)
-  - materialize.public.big_idx_j (delta join)
-  - materialize.public.big_idx_k (delta join)
+  - materialize.public.big_idx_a (delta join 1st input (full scan))
+  - materialize.public.big_idx_b (delta join lookup)
+  - materialize.public.big_idx_c (delta join lookup)
+  - materialize.public.big_idx_d (delta join lookup)
+  - materialize.public.big_idx_e (delta join lookup)
+  - materialize.public.big_idx_f (delta join lookup)
+  - materialize.public.big_idx_g (delta join lookup)
+  - materialize.public.big_idx_h (delta join lookup)
+  - materialize.public.big_idx_i (delta join lookup)
+  - materialize.public.big_idx_j (delta join lookup)
+  - materialize.public.big_idx_k (delta join lookup)
 
 EOF
 
@@ -678,8 +678,8 @@ Explained Query:
           Get materialize.public.big // { arity: 14 }
 
 Used Indexes:
-  - materialize.public.big_idx_a (delta join 1st input)
-  - materialize.public.big_idx_c (delta join)
+  - materialize.public.big_idx_a (delta join 1st input (full scan))
+  - materialize.public.big_idx_c (delta join lookup)
   - materialize.public.big_idx_y (lookup)
 
 EOF
@@ -727,6 +727,6 @@ Explained Query:
       ReadExistingIndex materialize.public.big lookup_value=(5) // { arity: 15 }
 
 Used Indexes:
-  - materialize.public.big_idx_a (lookup)
+  - materialize.public.big_idx_a (*** full scan ***, lookup)
 
 EOF

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1238,6 +1238,6 @@ Explained Query:
                   Get l0
 
 Used Indexes:
-  - materialize.public.idx_t5_f1 (lookup)
+  - materialize.public.idx_t5_f1 (*** full scan ***, lookup)
 
 EOF

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -178,7 +178,7 @@ Explained Query:
                     Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (differential join)
+  - materialize.public.i1 (*** full scan ***, differential join)
 
 EOF
 
@@ -242,7 +242,7 @@ Explained Query:
                       Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (differential join)
+  - materialize.public.i1 (*** full scan ***, differential join)
 
 EOF
 
@@ -462,7 +462,7 @@ Explained Query:
       ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -519,7 +519,7 @@ Explained Query:
       ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -571,7 +571,7 @@ Explained Query:
       ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -618,7 +618,7 @@ Explained Query:
       ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -698,7 +698,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (differential join, differential join, differential join)
+  - materialize.public.i1 (*** full scan ***, differential join)
 
 EOF
 
@@ -739,7 +739,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup, lookup)
+  - materialize.public.i1 (lookup)
 
 EOF
 
@@ -816,7 +816,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup, lookup)
+  - materialize.public.i1 (lookup)
 
 EOF
 
@@ -899,7 +899,7 @@ Explained Query:
               ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -1147,7 +1147,7 @@ Explained Query:
               ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -1181,7 +1181,7 @@ Explained Query:
               ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -1214,7 +1214,7 @@ Explained Query:
             ReadExistingIndex materialize.public.t1 lookup_value=(1) // { arity: 3 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup)
+  - materialize.public.i1 (*** full scan ***, lookup)
 
 EOF
 
@@ -1296,7 +1296,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup, lookup)
+  - materialize.public.i1 (lookup)
 
 EOF
 
@@ -1337,7 +1337,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup, lookup)
+  - materialize.public.i1 (lookup)
 
 EOF
 
@@ -1360,7 +1360,7 @@ Explained Query:
         Get materialize.public.t1 // { arity: 2 }
 
 Used Indexes:
-  - materialize.public.i1 (lookup, lookup)
+  - materialize.public.i1 (lookup)
 
 EOF
 

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -431,7 +431,7 @@ Explained Query:
         arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
 
 Used Indexes:
-  - materialize.public.t_idx (differential join, differential join)
+  - materialize.public.t_idx (differential join)
 
 EOF
 


### PR DESCRIPTION
This fixes a silly bug in `prune_and_annotate_dataflow_index_imports` where it was not picking up a full scan if the index was also used in some other way. I moved recognizing full scans into the main traversal inside `collect_index_reqs_inner`. The loop which used to add full scans before this PR now shouldn't have any work to do, so it soft_panics if it still finds something to do.

The above soft panic revealed that ids occurring only in `sink_exports` were also being added by this loop before. Now I made adding them explicit in the `sink_exports` loop, and added a separate index usage type for this. I also clarified the `index_exports` loop. And I moved both of these loop to after the main loop that calls `CollectIndexRequests`.

I also adjusted the `IndexUsageType` printing a bit based on what we discussed with @aalexandrov and @teskje in yesterday's optimizer sync.

I've also addressed @aalexandrov's retrospective comments on the [first PR](https://github.com/MaterializeInc/materialize/pull/21119).

I also added a lot more tests.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

It's best to review commit by commit, and hide whitespace changes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - [x] Nightly: https://buildkite.com/materialize/nightlies/builds/3347
  - [x] Full SLT: https://buildkite.com/materialize/sql-logic-tests/builds/5654
  - [x] I also manually tested SUBSCRIBEs in various situations (many of these were probably already being tested in slts): on a view, mat view, source, table, and indexed versions of all of these.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
