### PR TITLE
storage: split PersistWriteWorker into table and monotonic

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -318,7 +318,7 @@ impl Coordinator {
         let append_fut = self
             .controller
             .storage
-            .append(appends)
+            .append_table(appends)
             .expect("invalid updates");
         if should_block {
             // We may panic here if the storage controller has shut down, because we cannot

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -145,7 +145,19 @@ pub enum DataSource {
     /// This source's data is does not need to be managed by the storage
     /// controller, e.g. it's a materialized view, table, or subsource.
     // TODO? Add a means to track some data sources' GlobalIds.
-    Other,
+    Other(DataSourceOther),
+}
+
+/// Describes how data is written to a collection maintained outside of the
+/// storage controller.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DataSourceOther {
+    /// `environmentd` appends timestamped data, i.e. it is a `TABLE`.
+    TableWrites,
+    /// Compute maintains, i.e. it is a `MATERIALIZED VIEW`.
+    Compute,
+    /// Some other sources writes this data, i.e. a subsource.
+    Source,
 }
 
 /// Describes a request to create a source.
@@ -196,20 +208,18 @@ impl<T> CollectionDescription<T> {
                 //
                 // See <https://github.com/MaterializeInc/materialize/issues/20211>.
             }
-            DataSource::Other => {
+            DataSource::Other(_) => {
                 // We don't know anything about it's dependencies.
             }
         }
 
         result
     }
-}
 
-impl<T> From<RelationDesc> for CollectionDescription<T> {
-    fn from(desc: RelationDesc) -> Self {
+    pub fn from_desc(desc: RelationDesc, source: DataSourceOther) -> Self {
         Self {
             desc,
-            data_source: DataSource::Other,
+            data_source: DataSource::Other(source),
             since: None,
             status_collection_id: None,
         }
@@ -412,7 +422,7 @@ pub trait StorageController: Debug + Send {
     /// The method may return an error, indicating an immediately visible error, and also the
     /// oneshot may return an error if one is encountered during the write.
     // TODO(petrosagg): switch upper to `Antichain<Timestamp>`
-    fn append(
+    fn append_table(
         &mut self,
         commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError>;
@@ -813,9 +823,11 @@ pub struct StorageControllerState<T: Timestamp + Lattice + Codec64 + TimestampMa
     pub(super) collections: BTreeMap<GlobalId, CollectionState<T>>,
     pub(super) exports: BTreeMap<GlobalId, ExportState<T>>,
     pub(super) stash: mz_stash::Stash,
-    /// Write handle for persist shards.
-    pub(super) persist_write_handles: persist_handles::PersistWriteWorker<T>,
-    /// Read handles for persist shards.
+    /// Write handle for table shards.
+    pub(super) persist_table_worker: persist_handles::PersistTableWriteWorker<T>,
+    /// Write handle for monotonic shards.
+    pub(super) persist_monotonic_worker: persist_handles::PersistMonotonicWriteWorker<T>,
+    /// Read handles for all shards.
     ///
     /// These handles are on the other end of a Tokio task, so that work can be done asynchronously
     /// without blocking the storage controller.
@@ -1099,8 +1111,9 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             .await
             .expect("stash operation must succeed");
 
-        let persist_write_handles = persist_handles::PersistWriteWorker::new(tx);
-        let collection_manager_write_handle = persist_write_handles.clone();
+        let persist_table_worker = persist_handles::PersistTableWriteWorker::new(tx.clone());
+        let persist_monotonic_worker = persist_handles::PersistMonotonicWriteWorker::new(tx);
+        let collection_manager_write_handle = persist_monotonic_worker.clone();
 
         let collection_manager =
             collection_mgmt::CollectionManager::new(collection_manager_write_handle, now.clone());
@@ -1109,7 +1122,8 @@ impl<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulatio
             collections: BTreeMap::default(),
             exports: BTreeMap::default(),
             stash,
-            persist_write_handles,
+            persist_table_worker,
+            persist_monotonic_worker,
             persist_read_handles: persist_handles::PersistReadWorker::new(),
             stashed_response: None,
             pending_compaction_commands: vec![],
@@ -1435,7 +1449,22 @@ where
                     metadata.clone(),
                 );
 
-                self.state.persist_write_handles.register(id, write);
+                match description.data_source {
+                    DataSource::Introspection(_) | DataSource::Webhook => {
+                        debug!(desc = ?description, meta = ?metadata, "registering {} with persist monotonic worker", id);
+                        self.state.persist_monotonic_worker.register(id, write);
+                    }
+                    DataSource::Other(DataSourceOther::TableWrites) => {
+                        debug!(desc = ?description, meta = ?metadata, "registering {} with persist table worker", id);
+                        self.state.persist_table_worker.register(id, write);
+                    }
+                    DataSource::Ingestion(_)
+                    | DataSource::Progress
+                    | DataSource::Other(DataSourceOther::Compute)
+                    | DataSource::Other(DataSourceOther::Source) => {
+                        debug!(desc = ?description, meta = ?metadata, "not registering {} with a controller persist worker", id);
+                    }
+                }
                 self.state.persist_read_handles.register(id, since_handle);
 
                 self.state.collections.insert(id, collection_state);
@@ -1486,7 +1515,7 @@ where
                 DataSource::Webhook
                 | DataSource::Introspection(_)
                 | DataSource::Progress
-                | DataSource::Other => {
+                | DataSource::Other(_) => {
                     // No since to patch up and no read holds to install on
                     // dependencies!
                 }
@@ -1587,7 +1616,7 @@ where
                     // Register the collection so our manager knows about it.
                     self.state.collection_manager.register_collection(id);
                 }
-                DataSource::Progress | DataSource::Other => {}
+                DataSource::Progress | DataSource::Other(_) => {}
             }
         }
 
@@ -1910,7 +1939,7 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip_all)]
-    fn append(
+    fn append_table(
         &mut self,
         commands: Vec<(GlobalId, Vec<Update<Self::Timestamp>>, Self::Timestamp)>,
     ) -> Result<tokio::sync::oneshot::Receiver<Result<(), StorageError>>, StorageError> {
@@ -1923,7 +1952,7 @@ where
             }
         }
 
-        Ok(self.state.persist_write_handles.append(commands))
+        Ok(self.state.persist_table_worker.append(commands))
     }
 
     fn monotonic_appender(&self, id: GlobalId) -> Result<MonotonicAppender, StorageError> {
@@ -2232,12 +2261,18 @@ where
                 let shards_to_finalize: Vec<_> = ids
                     .iter()
                     .filter_map(|id| {
-                        // Drop all write handles. This is safe to do because there will be no more
-                        // data passed to the write handle. n.b. we do not need to drop the read
-                        // handle because this code is only ever executed in response to dropping a
-                        // collection, which downgrades the write handle to the empty anitchain,
-                        // which in turn drops the read handle.
-                        self.state.persist_write_handles.drop_handle(*id);
+                        // Drop all write handles. This is safe to do because
+                        // there will be no more data passed to the write
+                        // handle. n.b. we do not need to drop the read handle
+                        // because this code is only ever executed in response
+                        // to dropping a collection, which downgrades the write
+                        // handle to the empty anitchain, which in turn drops
+                        // the read handle.
+                        //
+                        // At most one of these workers will have the handle,
+                        // but it's safe to drop from both.
+                        self.state.persist_table_worker.drop_handle(*id);
+                        self.state.persist_monotonic_worker.drop_handle(*id);
 
                         self.state.collections.remove(id).map(
                             |CollectionState {
@@ -3102,7 +3137,20 @@ where
                 )
                 .await;
 
-            self.state.persist_write_handles.update(id, write);
+            match collection_desc.data_source {
+                DataSource::Introspection(_) | DataSource::Webhook => {
+                    self.state.persist_monotonic_worker.update(id, write);
+                }
+                DataSource::Other(DataSourceOther::TableWrites) => {
+                    self.state.persist_table_worker.update(id, write);
+                }
+                DataSource::Ingestion(_)
+                | DataSource::Progress
+                | DataSource::Other(DataSourceOther::Compute)
+                | DataSource::Other(DataSourceOther::Source) => {
+                    // No-op.
+                }
+            }
             self.state.persist_read_handles.update(id, since_handle);
         }
     }
@@ -3293,7 +3341,7 @@ where
         for id in collections {
             let collection = self.collection(id).expect("known to exist");
             assert!(
-                matches!(collection.description.data_source, DataSource::Other | DataSource::Ingestion(_)),
+                matches!(collection.description.data_source, DataSource::Other(_) | DataSource::Ingestion(_)),
                 "only primary sources w/ subsources and subsources can have dependency read holds installed"
             );
 
@@ -3477,7 +3525,7 @@ impl<T: Timestamp> CollectionState<T> {
             DataSource::Ingestion(ingestion) => Some(ingestion.instance_id),
             DataSource::Webhook
             | DataSource::Introspection(_)
-            | DataSource::Other
+            | DataSource::Other(_)
             | DataSource::Progress => None,
         }
     }

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -45,7 +45,7 @@ where
     T: Timestamp + Lattice + Codec64 + TimestampManipulation,
 {
     collections: Arc<Mutex<BTreeMap<GlobalId, (WriteChannel, WriteTask, ShutdownSender)>>>,
-    write_handle: persist_handles::PersistWriteWorker<T>,
+    write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
     now: NowFn,
 }
 
@@ -63,7 +63,7 @@ where
     T: Timestamp + Lattice + Codec64 + From<EpochMillis> + TimestampManipulation,
 {
     pub(super) fn new(
-        write_handle: persist_handles::PersistWriteWorker<T>,
+        write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
         now: NowFn,
     ) -> CollectionManager<T> {
         CollectionManager {
@@ -173,7 +173,7 @@ where
 /// TODO(parkmycar): Maybe add prometheus metrics for each collection?
 fn write_task<T>(
     id: GlobalId,
-    write_handle: persist_handles::PersistWriteWorker<T>,
+    write_handle: persist_handles::PersistMonotonicWriteWorker<T>,
     now: NowFn,
 ) -> (WriteChannel, WriteTask, ShutdownSender)
 where
@@ -248,7 +248,7 @@ where
                                     // Failed to receive which means the worker shutdown.
                                     Err(_recv_error) => {
                                         // Sender hung up, this seems fine and can happen when shutting down.
-                                        notify_listeners(responders, || Err(StorageError::ShuttingDown("PersistWriteWorker")));
+                                        notify_listeners(responders, || Err(StorageError::ShuttingDown("PersistMonotonicWriteWorker")));
 
                                         // End the task since we can no longer send writes to persist.
                                         break 'run;

--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -595,6 +595,381 @@ where
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct PersistWriteWorker<T: Timestamp + Lattice + Codec64 + TimestampManipulation> {
+    inner: Arc<PersistWriteWorkerInner<T>>,
+}
+
+/// Commands for [PersistWriteWorker].
+#[derive(Debug)]
+enum PersistWriteWorkerCmd<T: Timestamp + Lattice + Codec64> {
+    Register(GlobalId, WriteHandle<SourceData, (), T, Diff>),
+    Update(GlobalId, WriteHandle<SourceData, (), T, Diff>),
+    DropHandle(GlobalId),
+    Append(
+        Vec<(GlobalId, Vec<Update<T>>, T)>,
+        tokio::sync::oneshot::Sender<Result<(), StorageError>>,
+    ),
+    /// Appends `Vec<TimelessUpdate>` to `GlobalId` at, essentially,
+    /// `max(write_frontier, T)`.
+    MonotonicAppend(
+        Vec<(GlobalId, Vec<TimestamplessUpdate>, T)>,
+        tokio::sync::oneshot::Sender<Result<(), StorageError>>,
+    ),
+    Shutdown,
+}
+
+impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistWriteWorker<T> {
+    pub(crate) fn new(
+        mut frontier_responses: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
+    ) -> Self {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<(tracing::Span, _)>();
+
+        mz_ore::task::spawn(|| "PersistWriteHandles", async move {
+            let mut write_handles =
+                BTreeMap::<GlobalId, WriteHandle<SourceData, (), T, Diff>>::new();
+
+            let mut shutdown = false;
+            while !shutdown {
+                tokio::select! {
+                    cmd = rx.recv() => {
+                        if let Some(cmd) = cmd {
+                            // Peel off all available commands.
+                            // We do this in case we can consolidate commands.
+                            // It would be surprising to receive multiple concurrent `Append` commands,
+                            // but we might receive multiple *empty* `Append` commands.
+                            let mut commands = VecDeque::new();
+                            commands.push_back(cmd);
+                            while let Ok(cmd) = rx.try_recv() {
+                                commands.push_back(cmd);
+                            }
+
+                            // Accumulated updates and upper frontier.
+                            let mut all_updates = BTreeMap::default();
+                            let mut all_responses = Vec::default();
+
+                            while let Some((span, command)) = commands.pop_front() {
+                                match command {
+                                    PersistWriteWorkerCmd::Register(id, write_handle) => {
+                                        let previous = write_handles.insert(id, write_handle);
+                                        if previous.is_some() {
+                                            panic!(
+                                                "already registered a WriteHandle for collection {:?}",
+                                                id
+                                            );
+                                        }
+                                    }
+                                    PersistWriteWorkerCmd::Update(id, write_handle) => {
+                                        write_handles.insert(id, write_handle).expect("PersistWriteWorkerCmd::Update only valid for updating extant write handles");
+                                    },
+                                    PersistWriteWorkerCmd::DropHandle(id) => {
+                                        // n.b. this should only remove the
+                                        // handle from the persist worker and
+                                        // not take any additional action such
+                                        // as closing the shard it's connected
+                                        // to because dataflows might still be
+                                        // using it.
+                                        write_handles.remove(&id);
+                                    }
+                                    PersistWriteWorkerCmd::Append(updates, response) => {
+                                        let mut ids = BTreeSet::new();
+                                        for (id, update, upper) in updates {
+                                            ids.insert(id);
+                                            let (old_span, updates, old_upper) =
+                                                all_updates.entry(id).or_insert_with(|| {
+                                                    (
+                                                        span.clone(),
+                                                        Vec::default(),
+                                                        Antichain::from_elem(T::minimum()),
+                                                    )
+                                                });
+
+                                            if old_span.id() != span.id() {
+                                                // Link in any spans for `Append`
+                                                // operations that we lump together by
+                                                // doing this. This is not ideal,
+                                                // because we only have a true tracing
+                                                // history for the "first" span that we
+                                                // process, but it's better than
+                                                // nothing.
+                                                old_span.follows_from(span.id());
+                                            }
+                                            updates.extend(update);
+                                            old_upper.join_assign(&Antichain::from_elem(upper));
+                                        }
+                                        all_responses.push((ids, response));
+                                    }
+                                    PersistWriteWorkerCmd::MonotonicAppend(updates, response) => {
+                                        let mut updates_outer = Vec::with_capacity(updates.len());
+                                        for (id, update, at_least) in updates {
+                                            let current_upper = write_handles[&id].upper().clone();
+                                            if update.is_empty() && current_upper.is_empty() {
+                                                // Ignore timestamp advancement for
+                                                // closed collections. TODO? Make this a
+                                                // correctable error
+                                                continue;
+                                            }
+
+                                            let lower = if current_upper.less_than(&at_least) {
+                                                at_least
+                                            } else {
+                                                current_upper
+                                                    .elements()
+                                                    .iter()
+                                                    .min()
+                                                    .expect("cannot append data to closed collection")
+                                                    .clone()
+                                            };
+
+                                            let upper = lower.step_forward();
+                                            let update = update
+                                                .into_iter()
+                                                .map(|TimestamplessUpdate { row, diff }| Update {
+                                                    row,
+                                                    diff,
+                                                    timestamp: lower.clone(),
+                                                })
+                                                .collect::<Vec<_>>();
+
+                                            updates_outer.push((id, update, upper));
+                                        }
+                                        commands.push_front((
+                                            span,
+                                            PersistWriteWorkerCmd::Append(updates_outer, response),
+                                        ));
+                                    }
+                                    PersistWriteWorkerCmd::Shutdown => {
+                                        shutdown = true;
+                                    }
+                                }
+                            }
+
+                            async fn append_work<T2: Timestamp + Lattice + Codec64>(
+                                frontier_responses: &mut tokio::sync::mpsc::UnboundedSender<
+                                    StorageResponse<T2>,
+                                >,
+                                write_handles: &mut BTreeMap<
+                                    GlobalId,
+                                    WriteHandle<SourceData, (), T2, Diff>,
+                                >,
+                                mut commands: BTreeMap<
+                                    GlobalId,
+                                    (tracing::Span, Vec<Update<T2>>, Antichain<T2>),
+                                >,
+                            ) -> Result<(), Vec<GlobalId>> {
+                                let futs = FuturesUnordered::new();
+
+                                // We cannot iterate through the updates and then set off a persist call
+                                // on the write handle because we cannot mutably borrow the write handle
+                                // multiple times.
+                                //
+                                // Instead, we first group the update by ID above and then iterate
+                                // through all available write handles and see if there are any updates
+                                // for it. If yes, we send them all in one go.
+                                for (id, write) in write_handles.iter_mut() {
+                                    if let Some((span, updates, new_upper)) = commands.remove(id) {
+                                        let persist_upper = write.upper().clone();
+                                        let updates = updates
+                                            .into_iter()
+                                            .map(|u| ((SourceData(Ok(u.row)), ()), u.timestamp, u.diff));
+
+                                        futs.push(async move {
+                                            let persist_upper = persist_upper.clone();
+                                            write
+                                                .compare_and_append(
+                                                    updates.clone(),
+                                                    persist_upper.clone(),
+                                                    new_upper.clone(),
+                                                )
+                                                .instrument(span.clone())
+                                                .await
+                                                .expect("cannot append updates")
+                                                .or(Err(*id))?;
+
+                                            Ok::<_, GlobalId>((*id, new_upper))
+                                        })
+                                    }
+                                }
+
+                                use futures::StreamExt;
+                                // Ensure all futures run to completion, and track status of each of them individually
+                                let (new_uppers, failed_appends): (Vec<_>, Vec<_>) = futs
+                                    .collect::<Vec<_>>()
+                                    .await
+                                    .into_iter()
+                                    .partition_result();
+
+                                // It is not strictly an error for the controller to hang up.
+                                let _ =
+                                    frontier_responses.send(StorageResponse::FrontierUppers(new_uppers));
+
+                                if failed_appends.is_empty() {
+                                    Ok(())
+                                } else {
+                                    Err(failed_appends)
+                                }
+                            }
+
+                            let result =
+                                append_work(&mut frontier_responses, &mut write_handles, all_updates).await;
+
+                            for (ids, response) in all_responses {
+                                let result = match &result {
+                                    Err(bad_ids) => {
+                                        let filtered: Vec<_> = bad_ids.iter().filter(|id| ids.contains(id)).copied().collect();
+                                        if filtered.is_empty() {
+                                            Ok(())
+                                        } else {
+                                            Err(StorageError::InvalidUppers(filtered))
+                                        }
+                                    }
+                                    Ok(()) => Ok(()),
+                                };
+                                // It is not an error for the other end to hang up.
+                                let _ = response.send(result);
+                            }
+
+                            if shutdown {
+                                tracing::trace!("shutting down persist write append task");
+                                break;
+                            }
+                        } else {
+                            shutdown = true;
+                        }
+                    }
+                }
+            }
+
+            tracing::info!("PersistWriteWorker shutting down");
+        });
+
+        Self {
+            inner: Arc::new(PersistWriteWorkerInner::new(tx)),
+        }
+    }
+
+    pub(crate) fn register(
+        &self,
+        id: GlobalId,
+        write_handle: WriteHandle<SourceData, (), T, Diff>,
+    ) {
+        self.send(PersistWriteWorkerCmd::Register(id, write_handle))
+    }
+
+    /// Update the existing write handle associated with `id` to `write_handle`.
+    ///
+    /// Note that this should only be called when updating a write handle; to
+    /// initially associate an `id` to a write handle, use [`Self::register`].
+    ///
+    /// # Panics
+    /// - If `id` is not currently associated with any write handle.
+    #[allow(dead_code)]
+    pub(crate) fn update(&self, id: GlobalId, write_handle: WriteHandle<SourceData, (), T, Diff>) {
+        self.send(PersistWriteWorkerCmd::Update(id, write_handle))
+    }
+
+    pub(crate) fn append(
+        &self,
+        updates: Vec<(GlobalId, Vec<Update<T>>, T)>,
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if updates.is_empty() {
+            tx.send(Ok(()))
+                .expect("rx has not been dropped at this point");
+            rx
+        } else {
+            self.send(PersistWriteWorkerCmd::Append(updates, tx));
+            rx
+        }
+    }
+
+    /// Appends values to collections associated with `GlobalId`, but lets
+    /// the persist worker chose timestamps guaranteed to be monotonic and
+    /// that the time will be at least `T`.
+    ///
+    /// This lets the writer influence how far forward the timestamp will be
+    /// advanced, while still guaranteeing that it will advance.
+    ///
+    /// Note it is still possible for the append operation to fail in the
+    /// face of contention from other writers.
+    ///
+    /// # Panics
+    /// - If appending non-empty `TimelessUpdate` to closed collections
+    ///   (i.e. those with empty uppers), whose uppers cannot be
+    ///   monotonically increased.
+    ///
+    ///   Collections with empty uppers can continue receiving empty
+    ///   updates, i.e. those used soley to advance collections' uppers.
+    pub(crate) fn monotonic_append(
+        &self,
+        updates: Vec<(GlobalId, Vec<TimestamplessUpdate>, T)>,
+    ) -> tokio::sync::oneshot::Receiver<Result<(), StorageError>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        if updates.is_empty() {
+            tx.send(Ok(()))
+                .expect("rx has not been dropped at this point");
+            rx
+        } else {
+            self.send(PersistWriteWorkerCmd::MonotonicAppend(updates, tx));
+            rx
+        }
+    }
+
+    /// Drops the handle associated with `id` from this worker.
+    ///
+    /// Note that this does not perform any other cleanup, such as finalizing
+    /// the handle's shard.
+    pub(crate) fn drop_handle(&self, id: GlobalId) {
+        self.send(PersistWriteWorkerCmd::DropHandle(id))
+    }
+
+    fn send(&self, cmd: PersistWriteWorkerCmd<T>) {
+        self.inner.send(cmd);
+    }
+}
+
+/// Contains the components necessary for sending commands to a `PersistWriteWorker`.
+///
+/// When `Drop`-ed sends a shutdown command, as such this should _never_ implement `Clone` because
+/// if one clone is dropped, the other clones will be unable to send commands. If you need this
+/// to be `Clone`-able, wrap it in an `Arc` or `Rc` first.
+///
+/// #[derive(Clone)] <-- do not do this.
+///
+#[derive(Debug)]
+struct PersistWriteWorkerInner<T: Timestamp + Lattice + Codec64 + TimestampManipulation> {
+    /// Sending side of a channel that we can use to send commands.
+    tx: UnboundedSender<(tracing::Span, PersistWriteWorkerCmd<T>)>,
+}
+
+impl<T> Drop for PersistWriteWorkerInner<T>
+where
+    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
+{
+    fn drop(&mut self) {
+        self.send(PersistWriteWorkerCmd::Shutdown);
+        // TODO: Can't easily block on shutdown occurring.
+    }
+}
+
+impl<T> PersistWriteWorkerInner<T>
+where
+    T: Timestamp + Lattice + Codec64 + TimestampManipulation,
+{
+    fn new(tx: UnboundedSender<(tracing::Span, PersistWriteWorkerCmd<T>)>) -> Self {
+        PersistWriteWorkerInner { tx }
+    }
+
+    fn send(&self, cmd: PersistWriteWorkerCmd<T>) {
+        match self.tx.send((tracing::Span::current(), cmd)) {
+            Ok(()) => (), // All good!
+            Err(e) => {
+                tracing::trace!("could not forward command: {:?}", e);
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;


### PR DESCRIPTION
In particular, because the upcoming Pv2 txn management stuff wants to operate on the set of all tables and this makes it _far_ easier to reason about what's going on.

The intermediate state here is duplicative, but the impl of the table worker will be completely replaced by #20954. Getting this refactor in now so that no one breaks it in the meantime.

As far as I can tell, this really shouldn't have any behavior difference:

- We hold a few less persist WriteHandles than we did before, but they were never used and heartbeats were recently removed from WriteHandles, so this amounts to an insignificant memory reduction.
- We no longer group up the monotonic and table appends into one big batch to concurrently run, instead grouping each into batches separately. From looking at traces, these seemed to end up getting batched separately (because of time) in practice, anyway.

We might also want to do the same sort of split for the read worker, but I'm not sure yet, so leaving that out for now.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Ignore the first commit, I just copy-paste the existing code so that it's easy to see exactly what changed in the second commit.

I thought about cleaning up the indentation of all this while I was in here, but decided against it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
