### PR TITLE
adapter: Retry txn aborted errors when opening the stash

### DIFF
--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -312,26 +312,15 @@ impl Connection {
 
         // Add any new builtin Clusters or Cluster Replicas that may be newly defined.
         if !conn.stash.is_readonly() {
-            let mut txn = match transaction(&mut conn.stash).await {
-                Ok(txn) => txn,
-                Err(e) => {
-                    return Err((conn.stash, e));
-                }
-            };
-
-            match add_new_builtin_clusters_migration(&mut txn) {
-                Ok(()) => {}
-                Err(e) => {
-                    return Err((conn.stash, e));
-                }
-            }
-            match add_new_builtin_cluster_replicas_migration(&mut txn, bootstrap_args) {
-                Ok(()) => {}
-                Err(e) => {
-                    return Err((conn.stash, e));
-                }
-            }
-            match txn.commit().await {
+            let stash_ptr = &mut conn.stash;
+            match (|stash_ptr| async {
+                let mut txn = transaction(stash_ptr).await?;
+                add_new_builtin_clusters_migration(&mut txn)?;
+                add_new_builtin_cluster_replicas_migration(&mut txn, bootstrap_args)?;
+                txn.commit().await
+            })(stash_ptr)
+            .await
+            {
                 Ok(()) => {}
                 Err(e) => {
                     return Err((conn.stash, e));

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -86,6 +86,7 @@ use mz_ore::soft_assert;
 use mz_proto::{RustType, TryFromProtoError};
 use serde::{Deserialize, Serialize};
 use timely::progress::Antichain;
+use tokio_postgres::error::SqlState;
 
 pub mod objects;
 
@@ -224,6 +225,16 @@ impl StashError {
     pub fn can_recover_with_write_mode(&self) -> bool {
         match &self.inner {
             InternalStashError::StashNotWritable(_) => true,
+            _ => false,
+        }
+    }
+
+    /// The underlying transaction failed in a way that must be resolved by retrying
+    pub fn should_retry(&self) -> bool {
+        match &self.inner {
+            InternalStashError::Postgres(e) => {
+                matches!(e.code(), Some(&SqlState::T_R_SERIALIZATION_FAILURE))
+            }
             _ => false,
         }
     }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

During a release envd died while coming up with these logs (full context: https://materializeinc.slack.com/archives/CTESPM7FU/p1692118866332649): 
```
environmentd {"timestamp":"2023-08-14T14:25:52.607764Z","level":"INFO","fields":{"message":"Requested deploy generation 12"},"target":"mz_environmentd","span":{"name":"environmentd::serve"},"spans":[{"name":"environmentd::run"},{"name":"environmentd::serve"}]}                                                                                                                                                                                                            
environmentd {"timestamp":"2023-08-14T14:25:53.130943Z","level":"INFO","fields":{"message":"Found stash generation Some(11)"},"target":"mz_environmentd","span":{"name":"environmentd::serve"},"spans":[{"name":"environmentd::run"},{"name":"environmentd::serve"}]}                                                                                                                                                                                                           
environmentd {"timestamp":"2023-08-14T14:25:53.131009Z","level":"INFO","fields":{"message":"Stash generation Some(11) is less than deploy generation 12. Performing pre-flight checks"},"target":"mz_environmentd","span":{"name":"environmentd::serve"},"spans":[{"name":"environmentd::run"},{"name":"environmentd::serve"}]}                                                                                                                                                 
environmentd {"timestamp":"2023-08-14T14:25:54.258305Z","level":"INFO","fields":{"message":"tokio-postgres stash error, retry attempt 1: stash error: postgres: db error: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: TransactionAbortedError(ABORT_REASON_CLIENT_REJECT): \"sql txn\" meta={id=89b29be8 key=/Table/40015/1/881885966348976132/0 pri=0.00000000 epo=0 ts=1692023153.098540532,0 min=1692023153.098540532,0 seq=60} lock=true stat=PENDING
 rts=1692023153.098540532,0 wto=false gul=1692023153.348540532,0\nHINT: See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#abort_reason_client_reject, code: Some(SqlState(E40001))"},"target":"mz_stash::postgres","span":{"name":"storage::open"},"spans":[{"name":"environmentd::run"},{"name":"environmentd::serve"},{"name":"storage::open"}]}                                                                                           
environmentd environmentd: fatal: Stash upgrade would have failed with this error: stash error: postgres: db error: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: TransactionAbortedError(ABORT_REASON_CLIENT_REJECT): "sql txn" meta={id=89b29be8 key=/Table/40015/1/881885966348976132/0 pri=0.00000000 epo=0 ts=1692023153.098540532,0 min=1692023153.098540532,0 seq=60} lock=true stat=PENDING rts=1692023153.098540532,0 wto=false gul=1692023153.348540532,0                                                                                                                                                                                                                                
environmentd HINT: See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#abort_reason_client_reject
```

This is a cockroach transaction that we should retry: this error isn't a problem but the only solution is for the client to retry. Today we don't retry stash transactions when opened in savepoint mode (https://github.com/MaterializeInc/materialize/blob/26ec7a41cb246d2aad6d1b0b96738ac43a4c5439/src/stash/src/postgres.rs#L680-L696). This PR adds retrying in open instead.

I don't love changing all the `?` to `match`es, but I can't think of a nicer way without try blocks.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
