### PR TITLE
coord: Update idle metric to report when coordinator might be stuck

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -55,7 +55,7 @@ impl Metrics {
             queue_busy_seconds: registry.register(metric!(
                 name: "mz_coord_queue_busy_seconds",
                 help: "The number of seconds the coord queue was processing before it was empty. This is a sampled metric and does not measure the full coord queue wait/idle times.",
-                buckets: histogram_seconds_buckets(0.000_128, 8.0)
+                buckets: histogram_seconds_buckets(0.000_128, 32.0)
             )),
             determine_timestamp: registry.register(metric!(
                 name: "mz_determine_timestamp",


### PR DESCRIPTION
This PR updates the existing "coord idle metric" to report when the coordinator takes longer than 60 seconds to process the last message we sent. If it takes longer than 60 seconds we report the coordinator as being "stuck" by using `tracing::error!`. These errors get reported to Sentry so we should know if customers ever hit this, and AFAIK at least some of our tests in CI will fail if unexpected errors are traced.

Note: I tested this manually by adding a `tokio::time::sleep` to the Coordinator's `async fn handle_message(...)` and checked that we logged the error.

### Motivation

While working on https://github.com/MaterializeInc/materialize/pull/21116 I ran into (and fixed) an edge case that could cause the coordinator to get stuck waiting for the storage-controller's `async fn process(...)` to complete. If we had alerted on a stuck coordinator then the issue would have been more obvious.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
