### PR TITLE
webhook: Bump request limits

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -120,7 +120,7 @@ sources.
 Webhook sources apply the following limits to received requests:
 
 * Maximum size of the request body is `2MB`. Requests larger than this will fail with 413 Payload Too Large.
-* Maximum number of concurrent connections is 100, across all webhook sources. Trying to connect
+* Maximum number of concurrent connections is 250, across all webhook sources. Trying to connect
 when the server is at the maximum will return 429 Too Many Requests.
 * Requests that contain a header name specified more than once will be rejected with 401 Unauthorized.
 

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -30,7 +30,7 @@ use thiserror::Error;
 /// TODO(parkmycar): Make this configurable via LaunchDarkly and/or as a setting on each webhook
 /// source. The blocker for doing this today is an `axum` layer that allows us to __reduce__ the
 /// concurrency limit, the current one only allows you to increase it.
-pub const CONCURRENCY_LIMIT: usize = 100;
+pub const CONCURRENCY_LIMIT: usize = 250;
 
 pub async fn handle_webhook(
     State(client): State<mz_adapter::Client>,

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -31,7 +31,7 @@ use crate::client::TimestamplessUpdate;
 use crate::controller::{persist_handles, StorageError};
 
 // Note(parkmycar): The capacity here was chosen arbitrarily.
-const CHANNEL_CAPACITY: usize = 128;
+const CHANNEL_CAPACITY: usize = 255;
 // Default rate at which we append data and advance the uppers of managed collections.
 const DEFAULT_TICK: Duration = Duration::from_secs(1);
 


### PR DESCRIPTION
This PR bumps the number of concurrent requests webhooks support from 100 to 250. During testing I found we should be able to support way more than 250, so we should still have ample headroom even with this bumped limit.

### Motivation

On a customer call they indicated needing to support spikes of "low hundreds" per-second. In a follow up I'll make this configurable via LaunchDarkly, wanted to get this merged to make sure they were unblocked though.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
