### PR TITLE
frontegg-auth: remove dep on mz_sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4042,7 +4042,6 @@ dependencies = [
  "derivative",
  "jsonwebtoken",
  "mz-ore",
- "mz-sql",
  "reqwest",
  "serde",
  "thiserror",

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -747,7 +747,10 @@ async fn auth(
             };
             let claims = frontegg.validate_access_token(&token, user.as_deref())?;
             User {
-                external_metadata: Some(ExternalUserMetadata::from(&claims)),
+                external_metadata: Some(ExternalUserMetadata {
+                    user_id: claims.user_id,
+                    admin: claims.is_admin,
+                }),
                 name: claims.email,
             }
         }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -12,7 +12,6 @@ base64 = "0.13.1"
 derivative = "2.2.0"
 jsonwebtoken = "8.2.0"
 mz-ore = { path = "../ore", features = ["network"] }
-mz-sql = { path = "../sql" }
 reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use derivative::Derivative;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use mz_ore::now::NowFn;
-use mz_sql::session::user::ExternalUserMetadata;
 use serde::{Deserialize, Serialize};
 use tokio::time;
 use tracing::info;
@@ -267,13 +266,4 @@ pub struct ValidatedClaims {
     pub is_admin: bool,
     // Prevent construction outside of `Authentication::validate_access_token`.
     _private: (),
-}
-
-impl From<&ValidatedClaims> for ExternalUserMetadata {
-    fn from(claims: &ValidatedClaims) -> ExternalUserMetadata {
-        ExternalUserMetadata {
-            user_id: claims.user_id,
-            admin: claims.is_admin,
-        }
-    }
 }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -200,7 +200,10 @@ where
                     conn.conn_id().clone(),
                     User {
                         name: response.claims.email.clone(),
-                        external_metadata: Some(ExternalUserMetadata::from(&response.claims)),
+                        external_metadata: Some(ExternalUserMetadata {
+                            user_id: response.claims.user_id,
+                            admin: response.claims.is_admin,
+                        }),
                     },
                 );
 
@@ -210,7 +213,10 @@ where
                 let is_expired =
                     frontegg.continuously_revalidate_api_token_response(response, move |claims| {
                         // Ignore error if client has hung up.
-                        let _ = external_metadata_tx.send(ExternalUserMetadata::from(claims));
+                        let _ = external_metadata_tx.send(ExternalUserMetadata {
+                            user_id: claims.user_id,
+                            admin: claims.is_admin,
+                        });
                     });
 
                 Ok((session, is_expired))


### PR DESCRIPTION
It was just here for a From impl that doesn't seem terribly necessary. Instead inline the impl where it was previously used.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
