### PR TITLE
adapter: Support SHOW COLUMNS as the introspection user

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -882,7 +882,8 @@ impl ExecuteResponse {
             DropObjects => vec![DroppedObject],
             DropOwned => vec![DroppedOwned],
             PlanKind::EmptyQuery => vec![ExecuteResponseKind::EmptyQuery],
-            Explain | Select | ShowAllVariables | ShowCreate | ShowVariable | InspectShard => {
+            Explain | Select | ShowAllVariables | ShowCreate | ShowColumns | ShowVariable
+            | InspectShard => {
                 vec![CopyTo, SendingRows, SendingRowsImmediate]
             }
             Execute | ReadThenWrite => vec![

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -82,6 +82,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::EmptyQuery
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
+        | Plan::ShowColumns(_)
         | Plan::ShowVariable(_)
         | Plan::InspectShard(_)
         | Plan::SetVariable(_)
@@ -250,7 +251,7 @@ pub fn user_privilege_hack(
         //     <https://github.com/MaterializeInc/materialize/issues/18027> for more
         //     details.
         //
-        Plan::ShowCreate(_) => {
+        Plan::ShowCreate(_) | Plan::ShowColumns(_) => {
             return Ok(());
         }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -62,8 +62,8 @@ impl Coordinator {
     pub(crate) async fn sequence_plan(
         &mut self,
         mut ctx: ExecuteContext,
-        plan: Plan,
-        resolved_ids: ResolvedIds,
+        mut plan: Plan,
+        mut resolved_ids: ResolvedIds,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
         let mut responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
@@ -105,430 +105,442 @@ impl Coordinator {
             return ctx.retire(Err(e));
         }
 
-        match plan {
-            Plan::CreateSource(plan) => {
-                let source_id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
-                let result = self
-                    .sequence_create_source(
-                        ctx.session_mut(),
-                        vec![CreateSourcePlans {
-                            source_id,
-                            plan,
-                            resolved_ids,
-                        }],
-                    )
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateSources(plans) => {
-                assert!(
-                    resolved_ids.0.is_empty(),
-                    "each plan has separate resolved_ids"
-                );
-                let result = self.sequence_create_source(ctx.session_mut(), plans).await;
-                ctx.retire(result);
-            }
-            Plan::CreateConnection(plan) => {
-                self.sequence_create_connection(ctx, plan, resolved_ids)
-                    .await;
-            }
-            Plan::CreateDatabase(plan) => {
-                let result = self.sequence_create_database(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateSchema(plan) => {
-                let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateRole(plan) => {
-                let result = self.sequence_create_role(ctx.session(), plan).await;
-                if result.is_ok() {
-                    self.maybe_send_rbac_notice(ctx.session());
+        loop {
+            match plan {
+                Plan::CreateSource(plan) => {
+                    let source_id =
+                        return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
+                    let result = self
+                        .sequence_create_source(
+                            ctx.session_mut(),
+                            vec![CreateSourcePlans {
+                                source_id,
+                                plan,
+                                resolved_ids,
+                            }],
+                        )
+                        .await;
+                    ctx.retire(result);
                 }
-                ctx.retire(result);
-            }
-            Plan::CreateCluster(plan) => {
-                let result = self.sequence_create_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateClusterReplica(plan) => {
-                let result = self
-                    .sequence_create_cluster_replica(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateTable(plan) => {
-                let result = self
-                    .sequence_create_table(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateSecret(plan) => {
-                let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateSink(plan) => {
-                self.sequence_create_sink(ctx, plan, resolved_ids).await;
-            }
-            Plan::CreateView(plan) => {
-                let result = self
-                    .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateMaterializedView(plan) => {
-                let result = self
-                    .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateIndex(plan) => {
-                let result = self
-                    .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateType(plan) => {
-                let result = self
-                    .sequence_create_type(ctx.session(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::DropObjects(plan) => {
-                let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::DropOwned(plan) => {
-                let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::EmptyQuery => {
-                ctx.retire(Ok(ExecuteResponse::EmptyQuery));
-            }
-            Plan::ShowAllVariables => {
-                let result = self.sequence_show_all_variables(ctx.session());
-                ctx.retire(result);
-            }
-            Plan::ShowVariable(plan) => {
-                let result = self.sequence_show_variable(ctx.session(), plan);
-                ctx.retire(result);
-            }
-            Plan::InspectShard(plan) => {
-                // TODO: Ideally, this await would happen off the main thread.
-                let result = self.sequence_inspect_shard(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::SetVariable(plan) => {
-                let result = self.sequence_set_variable(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::ResetVariable(plan) => {
-                let result = self.sequence_reset_variable(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::SetTransaction(plan) => {
-                let result = self.sequence_set_transaction(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::StartTransaction(plan) => {
-                if matches!(
-                    ctx.session().transaction(),
-                    TransactionStatus::InTransaction(_)
-                ) {
-                    ctx.session()
-                        .add_notice(AdapterNotice::ExistingTransactionInProgress);
+                Plan::CreateSources(plans) => {
+                    assert!(
+                        resolved_ids.0.is_empty(),
+                        "each plan has separate resolved_ids"
+                    );
+                    let result = self.sequence_create_source(ctx.session_mut(), plans).await;
+                    ctx.retire(result);
                 }
-                let result = ctx.session_mut().start_transaction(
-                    self.now_datetime(),
-                    plan.access,
-                    plan.isolation_level,
-                );
-                ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
-            }
-            Plan::CommitTransaction(CommitTransactionPlan {
-                ref transaction_type,
-            })
-            | Plan::AbortTransaction(AbortTransactionPlan {
-                ref transaction_type,
-            }) => {
-                let action = match &plan {
-                    Plan::CommitTransaction(_) => EndTransactionAction::Commit,
-                    Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
-                    _ => unreachable!(),
-                };
-                if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit() {
-                    // In Postgres, if a user sends a COMMIT or ROLLBACK in an
-                    // implicit transaction, a warning is sent warning them.
-                    // (The transaction is still closed and a new implicit
-                    // transaction started, though.)
-                    ctx.session()
-                        .add_notice(AdapterNotice::ExplicitTransactionControlInImplicitTransaction);
+                Plan::CreateConnection(plan) => {
+                    self.sequence_create_connection(ctx, plan, resolved_ids)
+                        .await;
                 }
-                self.sequence_end_transaction(ctx, action);
-            }
-            Plan::Select(plan) => {
-                self.sequence_peek(ctx, plan, target_cluster).await;
-            }
-            Plan::Subscribe(plan) => {
-                let result = self
-                    .sequence_subscribe(&mut ctx, plan, target_cluster)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::SideEffectingFunc(plan) => {
-                ctx.retire(self.sequence_side_effecting_func(plan));
-            }
-            Plan::ShowCreate(plan) => {
-                ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
-            }
-            Plan::CopyFrom(plan) => {
-                let (tx, _, session, ctx_extra) = ctx.into_parts();
-                tx.send(
-                    Ok(ExecuteResponse::CopyFrom {
-                        id: plan.id,
-                        columns: plan.columns,
-                        params: plan.params,
-                        ctx_extra,
-                    }),
-                    session,
-                );
-            }
-            Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
-                self.sequence_copy_rows(ctx, id, columns, rows);
-            }
-            Plan::Explain(plan) => {
-                self.sequence_explain(ctx, plan, target_cluster).await;
-            }
-            Plan::Insert(plan) => {
-                self.sequence_insert(ctx, plan).await;
-            }
-            Plan::ReadThenWrite(plan) => {
-                self.sequence_read_then_write(ctx, plan).await;
-            }
-            Plan::AlterNoop(plan) => {
-                ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
-            }
-            Plan::AlterCluster(plan) => {
-                let result = self.sequence_alter_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterClusterRename(plan) => {
-                let result = self
-                    .sequence_alter_cluster_rename(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterClusterReplicaRename(plan) => {
-                let result = self
-                    .sequence_alter_cluster_replica_rename(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterSetCluster(plan) => {
-                let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterItemRename(plan) => {
-                let result = self.sequence_alter_item_rename(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterIndexSetOptions(plan) => {
-                let result = self.sequence_alter_index_set_options(plan);
-                ctx.retire(result);
-            }
-            Plan::AlterIndexResetOptions(plan) => {
-                let result = self.sequence_alter_index_reset_options(plan);
-                ctx.retire(result);
-            }
-            Plan::AlterRole(plan) => {
-                let result = self.sequence_alter_role(ctx.session(), plan).await;
-                if result.is_ok() {
-                    self.maybe_send_rbac_notice(ctx.session());
+                Plan::CreateDatabase(plan) => {
+                    let result = self.sequence_create_database(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
                 }
-                ctx.retire(result);
-            }
-            Plan::AlterSecret(plan) => {
-                let result = self.sequence_alter_secret(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSink(plan) => {
-                let result = self.sequence_alter_sink(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::PurifiedAlterSource {
-                alter_source,
-                subsources,
-            } => {
-                let result = self
-                    .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterSource(_) => {
-                unreachable!("ALTER SOURCE must be purified")
-            }
-            Plan::AlterSystemSet(plan) => {
-                let result = self.sequence_alter_system_set(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSystemReset(plan) => {
-                let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSystemResetAll(plan) => {
-                let result = self
-                    .sequence_alter_system_reset_all(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::DiscardTemp => {
-                self.drop_temp_items(ctx.session()).await;
-                ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
-            }
-            Plan::DiscardAll => {
-                let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
+                Plan::CreateSchema(plan) => {
+                    let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateRole(plan) => {
+                    let result = self.sequence_create_role(ctx.session(), plan).await;
+                    if result.is_ok() {
+                        self.maybe_send_rbac_notice(ctx.session());
+                    }
+                    ctx.retire(result);
+                }
+                Plan::CreateCluster(plan) => {
+                    let result = self.sequence_create_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateClusterReplica(plan) => {
+                    let result = self
+                        .sequence_create_cluster_replica(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateTable(plan) => {
+                    let result = self
+                        .sequence_create_table(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSecret(plan) => {
+                    let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSink(plan) => {
+                    self.sequence_create_sink(ctx, plan, resolved_ids).await;
+                }
+                Plan::CreateView(plan) => {
+                    let result = self
+                        .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateMaterializedView(plan) => {
+                    let result = self
+                        .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateIndex(plan) => {
+                    let result = self
+                        .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateType(plan) => {
+                    let result = self
+                        .sequence_create_type(ctx.session(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::DropObjects(plan) => {
+                    let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::DropOwned(plan) => {
+                    let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::EmptyQuery => {
+                    ctx.retire(Ok(ExecuteResponse::EmptyQuery));
+                }
+                Plan::ShowAllVariables => {
+                    let result = self.sequence_show_all_variables(ctx.session());
+                    ctx.retire(result);
+                }
+                Plan::ShowVariable(plan) => {
+                    let result = self.sequence_show_variable(ctx.session(), plan);
+                    ctx.retire(result);
+                }
+                Plan::InspectShard(plan) => {
+                    // TODO: Ideally, this await would happen off the main thread.
+                    let result = self.sequence_inspect_shard(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::SetVariable(plan) => {
+                    let result = self.sequence_set_variable(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::ResetVariable(plan) => {
+                    let result = self.sequence_reset_variable(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::SetTransaction(plan) => {
+                    let result = self.sequence_set_transaction(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::StartTransaction(plan) => {
+                    if matches!(
+                        ctx.session().transaction(),
+                        TransactionStatus::InTransaction(_)
+                    ) {
+                        ctx.session()
+                            .add_notice(AdapterNotice::ExistingTransactionInProgress);
+                    }
+                    let result = ctx.session_mut().start_transaction(
+                        self.now_datetime(),
+                        plan.access,
+                        plan.isolation_level,
+                    );
+                    ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
+                }
+                Plan::CommitTransaction(CommitTransactionPlan {
+                    ref transaction_type,
+                })
+                | Plan::AbortTransaction(AbortTransactionPlan {
+                    ref transaction_type,
+                }) => {
+                    let action = match &plan {
+                        Plan::CommitTransaction(_) => EndTransactionAction::Commit,
+                        Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
+                        _ => unreachable!(),
+                    };
+                    if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit()
+                    {
+                        // In Postgres, if a user sends a COMMIT or ROLLBACK in an
+                        // implicit transaction, a warning is sent warning them.
+                        // (The transaction is still closed and a new implicit
+                        // transaction started, though.)
+                        ctx.session().add_notice(
+                            AdapterNotice::ExplicitTransactionControlInImplicitTransaction,
+                        );
+                    }
+                    self.sequence_end_transaction(ctx, action);
+                }
+                Plan::Select(plan) => {
+                    self.sequence_peek(ctx, plan, target_cluster).await;
+                }
+                Plan::Subscribe(plan) => {
+                    let result = self
+                        .sequence_subscribe(&mut ctx, plan, target_cluster)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::SideEffectingFunc(plan) => {
+                    ctx.retire(self.sequence_side_effecting_func(plan));
+                }
+                Plan::ShowCreate(plan) => {
+                    ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
+                }
+                Plan::ShowColumns(show_columns_plan) => {
+                    plan = *show_columns_plan.select_plan;
+                    resolved_ids = show_columns_plan.new_resolved_ids;
+                    continue;
+                }
+                Plan::CopyFrom(plan) => {
+                    let (tx, _, session, ctx_extra) = ctx.into_parts();
+                    tx.send(
+                        Ok(ExecuteResponse::CopyFrom {
+                            id: plan.id,
+                            columns: plan.columns,
+                            params: plan.params,
+                            ctx_extra,
+                        }),
+                        session,
+                    );
+                }
+                Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
+                    self.sequence_copy_rows(ctx, id, columns, rows);
+                }
+                Plan::Explain(plan) => {
+                    self.sequence_explain(ctx, plan, target_cluster).await;
+                }
+                Plan::Insert(plan) => {
+                    self.sequence_insert(ctx, plan).await;
+                }
+                Plan::ReadThenWrite(plan) => {
+                    self.sequence_read_then_write(ctx, plan).await;
+                }
+                Plan::AlterNoop(plan) => {
+                    ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
+                }
+                Plan::AlterCluster(plan) => {
+                    let result = self.sequence_alter_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterClusterRename(plan) => {
+                    let result = self
+                        .sequence_alter_cluster_rename(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterClusterReplicaRename(plan) => {
+                    let result = self
+                        .sequence_alter_cluster_replica_rename(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSetCluster(plan) => {
+                    let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterItemRename(plan) => {
+                    let result = self.sequence_alter_item_rename(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterIndexSetOptions(plan) => {
+                    let result = self.sequence_alter_index_set_options(plan);
+                    ctx.retire(result);
+                }
+                Plan::AlterIndexResetOptions(plan) => {
+                    let result = self.sequence_alter_index_reset_options(plan);
+                    ctx.retire(result);
+                }
+                Plan::AlterRole(plan) => {
+                    let result = self.sequence_alter_role(ctx.session(), plan).await;
+                    if result.is_ok() {
+                        self.maybe_send_rbac_notice(ctx.session());
+                    }
+                    ctx.retire(result);
+                }
+                Plan::AlterSecret(plan) => {
+                    let result = self.sequence_alter_secret(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSink(plan) => {
+                    let result = self.sequence_alter_sink(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::PurifiedAlterSource {
+                    alter_source,
+                    subsources,
+                } => {
+                    let result = self
+                        .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSource(_) => {
+                    unreachable!("ALTER SOURCE must be purified")
+                }
+                Plan::AlterSystemSet(plan) => {
+                    let result = self.sequence_alter_system_set(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSystemReset(plan) => {
+                    let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSystemResetAll(plan) => {
+                    let result = self
+                        .sequence_alter_system_reset_all(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::DiscardTemp => {
                     self.drop_temp_items(ctx.session()).await;
-                    let conn_meta = self
-                        .active_conns
-                        .get_mut(ctx.session().conn_id())
-                        .expect("must exist for active session");
-                    let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
-                    self.drop_compute_sinks(drop_sinks);
-                    ctx.session_mut().reset();
-                    Ok(ExecuteResponse::DiscardedAll)
-                } else {
-                    Err(AdapterError::OperationProhibitsTransaction(
-                        "DISCARD ALL".into(),
-                    ))
-                };
-                ctx.retire(ret);
-            }
-            Plan::Declare(plan) => {
-                let param_types = vec![];
-                self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
-            }
-            Plan::Fetch(FetchPlan {
-                name,
-                count,
-                timeout,
-            }) => {
-                let ctx_extra = std::mem::take(ctx.extra_mut());
-                ctx.retire(Ok(ExecuteResponse::Fetch {
+                    ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
+                }
+                Plan::DiscardAll => {
+                    let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
+                        self.drop_temp_items(ctx.session()).await;
+                        let conn_meta = self
+                            .active_conns
+                            .get_mut(ctx.session().conn_id())
+                            .expect("must exist for active session");
+                        let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
+                        self.drop_compute_sinks(drop_sinks);
+                        ctx.session_mut().reset();
+                        Ok(ExecuteResponse::DiscardedAll)
+                    } else {
+                        Err(AdapterError::OperationProhibitsTransaction(
+                            "DISCARD ALL".into(),
+                        ))
+                    };
+                    ctx.retire(ret);
+                }
+                Plan::Declare(plan) => {
+                    let param_types = vec![];
+                    self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
+                }
+                Plan::Fetch(FetchPlan {
                     name,
                     count,
                     timeout,
-                    ctx_extra,
-                }));
-            }
-            Plan::Close(plan) => {
-                if ctx.session_mut().remove_portal(&plan.name) {
-                    ctx.retire(Ok(ExecuteResponse::ClosedCursor));
-                } else {
-                    ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
+                }) => {
+                    let ctx_extra = std::mem::take(ctx.extra_mut());
+                    ctx.retire(Ok(ExecuteResponse::Fetch {
+                        name,
+                        count,
+                        timeout,
+                        ctx_extra,
+                    }));
                 }
-            }
-            Plan::Prepare(plan) => {
-                if ctx
-                    .session()
-                    .get_prepared_statement_unverified(&plan.name)
-                    .is_some()
-                {
-                    ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
-                } else {
-                    ctx.session_mut().set_prepared_statement(
-                        plan.name,
-                        Some(plan.stmt),
-                        plan.sql,
-                        plan.desc,
-                        self.catalog().transient_revision(),
-                        self.now(),
-                    );
-                    ctx.retire(Ok(ExecuteResponse::Prepare));
-                }
-            }
-            Plan::Execute(plan) => {
-                match self.sequence_execute(ctx.session_mut(), plan) {
-                    Ok(portal_name) => {
-                        let (tx, _, session, extra) = ctx.into_parts();
-                        self.internal_cmd_tx
-                            .send(Message::Command(Command::Execute {
-                                portal_name,
-                                session,
-                                tx: tx.take(),
-                                outer_ctx_extra: Some(extra),
-                                span: tracing::Span::none(),
-                            }))
-                            .expect("sending to self.internal_cmd_tx cannot fail");
-                    }
-                    Err(err) => ctx.retire(Err(err)),
-                };
-            }
-            Plan::Deallocate(plan) => match plan.name {
-                Some(name) => {
-                    if ctx.session_mut().remove_prepared_statement(&name) {
-                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
+                Plan::Close(plan) => {
+                    if ctx.session_mut().remove_portal(&plan.name) {
+                        ctx.retire(Ok(ExecuteResponse::ClosedCursor));
                     } else {
-                        ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
+                        ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
                     }
                 }
-                None => {
-                    ctx.session_mut().remove_all_prepared_statements();
-                    ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
+                Plan::Prepare(plan) => {
+                    if ctx
+                        .session()
+                        .get_prepared_statement_unverified(&plan.name)
+                        .is_some()
+                    {
+                        ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
+                    } else {
+                        ctx.session_mut().set_prepared_statement(
+                            plan.name,
+                            Some(plan.stmt),
+                            plan.sql,
+                            plan.desc,
+                            self.catalog().transient_revision(),
+                            self.now(),
+                        );
+                        ctx.retire(Ok(ExecuteResponse::Prepare));
+                    }
                 }
-            },
-            Plan::Raise(RaisePlan { severity }) => {
-                ctx.session()
-                    .add_notice(AdapterNotice::UserRequested { severity });
-                ctx.retire(Ok(ExecuteResponse::Raised));
-            }
-            Plan::RotateKeys(RotateKeysPlan { id }) => {
-                let result = self.sequence_rotate_keys(ctx.session(), id).await;
-                ctx.retire(result);
-            }
-            Plan::GrantPrivileges(plan) => {
-                let result = self
-                    .sequence_grant_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::RevokePrivileges(plan) => {
-                let result = self
-                    .sequence_revoke_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterDefaultPrivileges(plan) => {
-                let result = self
-                    .sequence_alter_default_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::GrantRole(plan) => {
-                let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::RevokeRole(plan) => {
-                let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterOwner(plan) => {
-                let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::ReassignOwned(plan) => {
-                let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::ValidateConnection(plan) => {
-                let connection_context = self.connection_context.clone();
-                mz_ore::task::spawn(|| "coord::validate_connection", async move {
-                    let res = match plan.connection.validate(plan.id, &connection_context).await {
-                        Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
-                        Err(err) => Err(err.into()),
+                Plan::Execute(plan) => {
+                    match self.sequence_execute(ctx.session_mut(), plan) {
+                        Ok(portal_name) => {
+                            let (tx, _, session, extra) = ctx.into_parts();
+                            self.internal_cmd_tx
+                                .send(Message::Command(Command::Execute {
+                                    portal_name,
+                                    session,
+                                    tx: tx.take(),
+                                    outer_ctx_extra: Some(extra),
+                                    span: tracing::Span::none(),
+                                }))
+                                .expect("sending to self.internal_cmd_tx cannot fail");
+                        }
+                        Err(err) => ctx.retire(Err(err)),
                     };
-                    ctx.retire(res);
-                });
+                }
+                Plan::Deallocate(plan) => match plan.name {
+                    Some(name) => {
+                        if ctx.session_mut().remove_prepared_statement(&name) {
+                            ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
+                        } else {
+                            ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
+                        }
+                    }
+                    None => {
+                        ctx.session_mut().remove_all_prepared_statements();
+                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
+                    }
+                },
+                Plan::Raise(RaisePlan { severity }) => {
+                    ctx.session()
+                        .add_notice(AdapterNotice::UserRequested { severity });
+                    ctx.retire(Ok(ExecuteResponse::Raised));
+                }
+                Plan::RotateKeys(RotateKeysPlan { id }) => {
+                    let result = self.sequence_rotate_keys(ctx.session(), id).await;
+                    ctx.retire(result);
+                }
+                Plan::GrantPrivileges(plan) => {
+                    let result = self
+                        .sequence_grant_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::RevokePrivileges(plan) => {
+                    let result = self
+                        .sequence_revoke_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterDefaultPrivileges(plan) => {
+                    let result = self
+                        .sequence_alter_default_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::GrantRole(plan) => {
+                    let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::RevokeRole(plan) => {
+                    let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterOwner(plan) => {
+                    let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::ReassignOwned(plan) => {
+                    let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::ValidateConnection(plan) => {
+                    let connection_context = self.connection_context.clone();
+                    mz_ore::task::spawn(|| "coord::validate_connection", async move {
+                        let res = match plan.connection.validate(plan.id, &connection_context).await
+                        {
+                            Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
+                            Err(err) => Err(err.into()),
+                        };
+                        ctx.retire(res);
+                    });
+                }
             }
+            break;
         }
     }
 

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -62,8 +62,8 @@ impl Coordinator {
     pub(crate) async fn sequence_plan(
         &mut self,
         mut ctx: ExecuteContext,
-        mut plan: Plan,
-        mut resolved_ids: ResolvedIds,
+        plan: Plan,
+        resolved_ids: ResolvedIds,
     ) {
         event!(Level::TRACE, plan = format!("{:?}", plan));
         let mut responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
@@ -105,442 +105,434 @@ impl Coordinator {
             return ctx.retire(Err(e));
         }
 
-        loop {
-            match plan {
-                Plan::CreateSource(plan) => {
-                    let source_id =
-                        return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
-                    let result = self
-                        .sequence_create_source(
-                            ctx.session_mut(),
-                            vec![CreateSourcePlans {
-                                source_id,
-                                plan,
-                                resolved_ids,
-                            }],
-                        )
-                        .await;
-                    ctx.retire(result);
+        match plan {
+            Plan::CreateSource(plan) => {
+                let source_id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
+                let result = self
+                    .sequence_create_source(
+                        ctx.session_mut(),
+                        vec![CreateSourcePlans {
+                            source_id,
+                            plan,
+                            resolved_ids,
+                        }],
+                    )
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateSources(plans) => {
+                assert!(
+                    resolved_ids.0.is_empty(),
+                    "each plan has separate resolved_ids"
+                );
+                let result = self.sequence_create_source(ctx.session_mut(), plans).await;
+                ctx.retire(result);
+            }
+            Plan::CreateConnection(plan) => {
+                self.sequence_create_connection(ctx, plan, resolved_ids)
+                    .await;
+            }
+            Plan::CreateDatabase(plan) => {
+                let result = self.sequence_create_database(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::CreateSchema(plan) => {
+                let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::CreateRole(plan) => {
+                let result = self.sequence_create_role(ctx.session(), plan).await;
+                if result.is_ok() {
+                    self.maybe_send_rbac_notice(ctx.session());
                 }
-                Plan::CreateSources(plans) => {
-                    assert!(
-                        resolved_ids.0.is_empty(),
-                        "each plan has separate resolved_ids"
-                    );
-                    let result = self.sequence_create_source(ctx.session_mut(), plans).await;
-                    ctx.retire(result);
+                ctx.retire(result);
+            }
+            Plan::CreateCluster(plan) => {
+                let result = self.sequence_create_cluster(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::CreateClusterReplica(plan) => {
+                let result = self
+                    .sequence_create_cluster_replica(ctx.session(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateTable(plan) => {
+                let result = self
+                    .sequence_create_table(ctx.session_mut(), plan, resolved_ids)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateSecret(plan) => {
+                let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::CreateSink(plan) => {
+                self.sequence_create_sink(ctx, plan, resolved_ids).await;
+            }
+            Plan::CreateView(plan) => {
+                let result = self
+                    .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateMaterializedView(plan) => {
+                let result = self
+                    .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateIndex(plan) => {
+                let result = self
+                    .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::CreateType(plan) => {
+                let result = self
+                    .sequence_create_type(ctx.session(), plan, resolved_ids)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::DropObjects(plan) => {
+                let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::DropOwned(plan) => {
+                let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::EmptyQuery => {
+                ctx.retire(Ok(ExecuteResponse::EmptyQuery));
+            }
+            Plan::ShowAllVariables => {
+                let result = self.sequence_show_all_variables(ctx.session());
+                ctx.retire(result);
+            }
+            Plan::ShowVariable(plan) => {
+                let result = self.sequence_show_variable(ctx.session(), plan);
+                ctx.retire(result);
+            }
+            Plan::InspectShard(plan) => {
+                // TODO: Ideally, this await would happen off the main thread.
+                let result = self.sequence_inspect_shard(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::SetVariable(plan) => {
+                let result = self.sequence_set_variable(ctx.session_mut(), plan);
+                ctx.retire(result);
+            }
+            Plan::ResetVariable(plan) => {
+                let result = self.sequence_reset_variable(ctx.session_mut(), plan);
+                ctx.retire(result);
+            }
+            Plan::SetTransaction(plan) => {
+                let result = self.sequence_set_transaction(ctx.session_mut(), plan);
+                ctx.retire(result);
+            }
+            Plan::StartTransaction(plan) => {
+                if matches!(
+                    ctx.session().transaction(),
+                    TransactionStatus::InTransaction(_)
+                ) {
+                    ctx.session()
+                        .add_notice(AdapterNotice::ExistingTransactionInProgress);
                 }
-                Plan::CreateConnection(plan) => {
-                    self.sequence_create_connection(ctx, plan, resolved_ids)
-                        .await;
+                let result = ctx.session_mut().start_transaction(
+                    self.now_datetime(),
+                    plan.access,
+                    plan.isolation_level,
+                );
+                ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
+            }
+            Plan::CommitTransaction(CommitTransactionPlan {
+                ref transaction_type,
+            })
+            | Plan::AbortTransaction(AbortTransactionPlan {
+                ref transaction_type,
+            }) => {
+                let action = match &plan {
+                    Plan::CommitTransaction(_) => EndTransactionAction::Commit,
+                    Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
+                    _ => unreachable!(),
+                };
+                if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit() {
+                    // In Postgres, if a user sends a COMMIT or ROLLBACK in an
+                    // implicit transaction, a warning is sent warning them.
+                    // (The transaction is still closed and a new implicit
+                    // transaction started, though.)
+                    ctx.session()
+                        .add_notice(AdapterNotice::ExplicitTransactionControlInImplicitTransaction);
                 }
-                Plan::CreateDatabase(plan) => {
-                    let result = self.sequence_create_database(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
+                self.sequence_end_transaction(ctx, action);
+            }
+            Plan::Select(plan) => {
+                self.sequence_peek(ctx, plan, target_cluster).await;
+            }
+            Plan::Subscribe(plan) => {
+                let result = self
+                    .sequence_subscribe(&mut ctx, plan, target_cluster)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::SideEffectingFunc(plan) => {
+                ctx.retire(self.sequence_side_effecting_func(plan));
+            }
+            Plan::ShowCreate(plan) => {
+                ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
+            }
+            Plan::ShowColumns(show_columns_plan) => {
+                self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster)
+                    .await;
+            }
+            Plan::CopyFrom(plan) => {
+                let (tx, _, session, ctx_extra) = ctx.into_parts();
+                tx.send(
+                    Ok(ExecuteResponse::CopyFrom {
+                        id: plan.id,
+                        columns: plan.columns,
+                        params: plan.params,
+                        ctx_extra,
+                    }),
+                    session,
+                );
+            }
+            Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
+                self.sequence_copy_rows(ctx, id, columns, rows);
+            }
+            Plan::Explain(plan) => {
+                self.sequence_explain(ctx, plan, target_cluster).await;
+            }
+            Plan::Insert(plan) => {
+                self.sequence_insert(ctx, plan).await;
+            }
+            Plan::ReadThenWrite(plan) => {
+                self.sequence_read_then_write(ctx, plan).await;
+            }
+            Plan::AlterNoop(plan) => {
+                ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
+            }
+            Plan::AlterCluster(plan) => {
+                let result = self.sequence_alter_cluster(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterClusterRename(plan) => {
+                let result = self
+                    .sequence_alter_cluster_rename(ctx.session(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::AlterClusterReplicaRename(plan) => {
+                let result = self
+                    .sequence_alter_cluster_replica_rename(ctx.session(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::AlterSetCluster(plan) => {
+                let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterItemRename(plan) => {
+                let result = self.sequence_alter_item_rename(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterIndexSetOptions(plan) => {
+                let result = self.sequence_alter_index_set_options(plan);
+                ctx.retire(result);
+            }
+            Plan::AlterIndexResetOptions(plan) => {
+                let result = self.sequence_alter_index_reset_options(plan);
+                ctx.retire(result);
+            }
+            Plan::AlterRole(plan) => {
+                let result = self.sequence_alter_role(ctx.session(), plan).await;
+                if result.is_ok() {
+                    self.maybe_send_rbac_notice(ctx.session());
                 }
-                Plan::CreateSchema(plan) => {
-                    let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::CreateRole(plan) => {
-                    let result = self.sequence_create_role(ctx.session(), plan).await;
-                    if result.is_ok() {
-                        self.maybe_send_rbac_notice(ctx.session());
-                    }
-                    ctx.retire(result);
-                }
-                Plan::CreateCluster(plan) => {
-                    let result = self.sequence_create_cluster(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::CreateClusterReplica(plan) => {
-                    let result = self
-                        .sequence_create_cluster_replica(ctx.session(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::CreateTable(plan) => {
-                    let result = self
-                        .sequence_create_table(ctx.session_mut(), plan, resolved_ids)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::CreateSecret(plan) => {
-                    let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::CreateSink(plan) => {
-                    self.sequence_create_sink(ctx, plan, resolved_ids).await;
-                }
-                Plan::CreateView(plan) => {
-                    let result = self
-                        .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::CreateMaterializedView(plan) => {
-                    let result = self
-                        .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::CreateIndex(plan) => {
-                    let result = self
-                        .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::CreateType(plan) => {
-                    let result = self
-                        .sequence_create_type(ctx.session(), plan, resolved_ids)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::DropObjects(plan) => {
-                    let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::DropOwned(plan) => {
-                    let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::EmptyQuery => {
-                    ctx.retire(Ok(ExecuteResponse::EmptyQuery));
-                }
-                Plan::ShowAllVariables => {
-                    let result = self.sequence_show_all_variables(ctx.session());
-                    ctx.retire(result);
-                }
-                Plan::ShowVariable(plan) => {
-                    let result = self.sequence_show_variable(ctx.session(), plan);
-                    ctx.retire(result);
-                }
-                Plan::InspectShard(plan) => {
-                    // TODO: Ideally, this await would happen off the main thread.
-                    let result = self.sequence_inspect_shard(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::SetVariable(plan) => {
-                    let result = self.sequence_set_variable(ctx.session_mut(), plan);
-                    ctx.retire(result);
-                }
-                Plan::ResetVariable(plan) => {
-                    let result = self.sequence_reset_variable(ctx.session_mut(), plan);
-                    ctx.retire(result);
-                }
-                Plan::SetTransaction(plan) => {
-                    let result = self.sequence_set_transaction(ctx.session_mut(), plan);
-                    ctx.retire(result);
-                }
-                Plan::StartTransaction(plan) => {
-                    if matches!(
-                        ctx.session().transaction(),
-                        TransactionStatus::InTransaction(_)
-                    ) {
-                        ctx.session()
-                            .add_notice(AdapterNotice::ExistingTransactionInProgress);
-                    }
-                    let result = ctx.session_mut().start_transaction(
-                        self.now_datetime(),
-                        plan.access,
-                        plan.isolation_level,
-                    );
-                    ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
-                }
-                Plan::CommitTransaction(CommitTransactionPlan {
-                    ref transaction_type,
-                })
-                | Plan::AbortTransaction(AbortTransactionPlan {
-                    ref transaction_type,
-                }) => {
-                    let action = match &plan {
-                        Plan::CommitTransaction(_) => EndTransactionAction::Commit,
-                        Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
-                        _ => unreachable!(),
-                    };
-                    if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit()
-                    {
-                        // In Postgres, if a user sends a COMMIT or ROLLBACK in an
-                        // implicit transaction, a warning is sent warning them.
-                        // (The transaction is still closed and a new implicit
-                        // transaction started, though.)
-                        ctx.session().add_notice(
-                            AdapterNotice::ExplicitTransactionControlInImplicitTransaction,
-                        );
-                    }
-                    self.sequence_end_transaction(ctx, action);
-                }
-                Plan::Select(plan) => {
-                    self.sequence_peek(ctx, plan, target_cluster).await;
-                }
-                Plan::Subscribe(plan) => {
-                    let result = self
-                        .sequence_subscribe(&mut ctx, plan, target_cluster)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::SideEffectingFunc(plan) => {
-                    ctx.retire(self.sequence_side_effecting_func(plan));
-                }
-                Plan::ShowCreate(plan) => {
-                    ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
-                }
-                Plan::ShowColumns(show_columns_plan) => {
-                    plan = *show_columns_plan.select_plan;
-                    resolved_ids = show_columns_plan.new_resolved_ids;
-                    continue;
-                }
-                Plan::CopyFrom(plan) => {
-                    let (tx, _, session, ctx_extra) = ctx.into_parts();
-                    tx.send(
-                        Ok(ExecuteResponse::CopyFrom {
-                            id: plan.id,
-                            columns: plan.columns,
-                            params: plan.params,
-                            ctx_extra,
-                        }),
-                        session,
-                    );
-                }
-                Plan::CopyRows(CopyRowsPlan { id, columns, rows }) => {
-                    self.sequence_copy_rows(ctx, id, columns, rows);
-                }
-                Plan::Explain(plan) => {
-                    self.sequence_explain(ctx, plan, target_cluster).await;
-                }
-                Plan::Insert(plan) => {
-                    self.sequence_insert(ctx, plan).await;
-                }
-                Plan::ReadThenWrite(plan) => {
-                    self.sequence_read_then_write(ctx, plan).await;
-                }
-                Plan::AlterNoop(plan) => {
-                    ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
-                }
-                Plan::AlterCluster(plan) => {
-                    let result = self.sequence_alter_cluster(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterClusterRename(plan) => {
-                    let result = self
-                        .sequence_alter_cluster_rename(ctx.session(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::AlterClusterReplicaRename(plan) => {
-                    let result = self
-                        .sequence_alter_cluster_replica_rename(ctx.session(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::AlterSetCluster(plan) => {
-                    let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterItemRename(plan) => {
-                    let result = self.sequence_alter_item_rename(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterIndexSetOptions(plan) => {
-                    let result = self.sequence_alter_index_set_options(plan);
-                    ctx.retire(result);
-                }
-                Plan::AlterIndexResetOptions(plan) => {
-                    let result = self.sequence_alter_index_reset_options(plan);
-                    ctx.retire(result);
-                }
-                Plan::AlterRole(plan) => {
-                    let result = self.sequence_alter_role(ctx.session(), plan).await;
-                    if result.is_ok() {
-                        self.maybe_send_rbac_notice(ctx.session());
-                    }
-                    ctx.retire(result);
-                }
-                Plan::AlterSecret(plan) => {
-                    let result = self.sequence_alter_secret(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterSink(plan) => {
-                    let result = self.sequence_alter_sink(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::PurifiedAlterSource {
-                    alter_source,
-                    subsources,
-                } => {
-                    let result = self
-                        .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::AlterSource(_) => {
-                    unreachable!("ALTER SOURCE must be purified")
-                }
-                Plan::AlterSystemSet(plan) => {
-                    let result = self.sequence_alter_system_set(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterSystemReset(plan) => {
-                    let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterSystemResetAll(plan) => {
-                    let result = self
-                        .sequence_alter_system_reset_all(ctx.session(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::DiscardTemp => {
+                ctx.retire(result);
+            }
+            Plan::AlterSecret(plan) => {
+                let result = self.sequence_alter_secret(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterSink(plan) => {
+                let result = self.sequence_alter_sink(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::PurifiedAlterSource {
+                alter_source,
+                subsources,
+            } => {
+                let result = self
+                    .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::AlterSource(_) => {
+                unreachable!("ALTER SOURCE must be purified")
+            }
+            Plan::AlterSystemSet(plan) => {
+                let result = self.sequence_alter_system_set(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterSystemReset(plan) => {
+                let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterSystemResetAll(plan) => {
+                let result = self
+                    .sequence_alter_system_reset_all(ctx.session(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::DiscardTemp => {
+                self.drop_temp_items(ctx.session()).await;
+                ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
+            }
+            Plan::DiscardAll => {
+                let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
                     self.drop_temp_items(ctx.session()).await;
-                    ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
-                }
-                Plan::DiscardAll => {
-                    let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
-                        self.drop_temp_items(ctx.session()).await;
-                        let conn_meta = self
-                            .active_conns
-                            .get_mut(ctx.session().conn_id())
-                            .expect("must exist for active session");
-                        let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
-                        self.drop_compute_sinks(drop_sinks);
-                        ctx.session_mut().reset();
-                        Ok(ExecuteResponse::DiscardedAll)
-                    } else {
-                        Err(AdapterError::OperationProhibitsTransaction(
-                            "DISCARD ALL".into(),
-                        ))
-                    };
-                    ctx.retire(ret);
-                }
-                Plan::Declare(plan) => {
-                    let param_types = vec![];
-                    self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
-                }
-                Plan::Fetch(FetchPlan {
+                    let conn_meta = self
+                        .active_conns
+                        .get_mut(ctx.session().conn_id())
+                        .expect("must exist for active session");
+                    let drop_sinks = std::mem::take(&mut conn_meta.drop_sinks);
+                    self.drop_compute_sinks(drop_sinks);
+                    ctx.session_mut().reset();
+                    Ok(ExecuteResponse::DiscardedAll)
+                } else {
+                    Err(AdapterError::OperationProhibitsTransaction(
+                        "DISCARD ALL".into(),
+                    ))
+                };
+                ctx.retire(ret);
+            }
+            Plan::Declare(plan) => {
+                let param_types = vec![];
+                self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
+            }
+            Plan::Fetch(FetchPlan {
+                name,
+                count,
+                timeout,
+            }) => {
+                let ctx_extra = std::mem::take(ctx.extra_mut());
+                ctx.retire(Ok(ExecuteResponse::Fetch {
                     name,
                     count,
                     timeout,
-                }) => {
-                    let ctx_extra = std::mem::take(ctx.extra_mut());
-                    ctx.retire(Ok(ExecuteResponse::Fetch {
-                        name,
-                        count,
-                        timeout,
-                        ctx_extra,
-                    }));
-                }
-                Plan::Close(plan) => {
-                    if ctx.session_mut().remove_portal(&plan.name) {
-                        ctx.retire(Ok(ExecuteResponse::ClosedCursor));
-                    } else {
-                        ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
-                    }
-                }
-                Plan::Prepare(plan) => {
-                    if ctx
-                        .session()
-                        .get_prepared_statement_unverified(&plan.name)
-                        .is_some()
-                    {
-                        ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
-                    } else {
-                        ctx.session_mut().set_prepared_statement(
-                            plan.name,
-                            Some(plan.stmt),
-                            plan.sql,
-                            plan.desc,
-                            self.catalog().transient_revision(),
-                            self.now(),
-                        );
-                        ctx.retire(Ok(ExecuteResponse::Prepare));
-                    }
-                }
-                Plan::Execute(plan) => {
-                    match self.sequence_execute(ctx.session_mut(), plan) {
-                        Ok(portal_name) => {
-                            let (tx, _, session, extra) = ctx.into_parts();
-                            self.internal_cmd_tx
-                                .send(Message::Command(Command::Execute {
-                                    portal_name,
-                                    session,
-                                    tx: tx.take(),
-                                    outer_ctx_extra: Some(extra),
-                                    span: tracing::Span::none(),
-                                }))
-                                .expect("sending to self.internal_cmd_tx cannot fail");
-                        }
-                        Err(err) => ctx.retire(Err(err)),
-                    };
-                }
-                Plan::Deallocate(plan) => match plan.name {
-                    Some(name) => {
-                        if ctx.session_mut().remove_prepared_statement(&name) {
-                            ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
-                        } else {
-                            ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
-                        }
-                    }
-                    None => {
-                        ctx.session_mut().remove_all_prepared_statements();
-                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
-                    }
-                },
-                Plan::Raise(RaisePlan { severity }) => {
-                    ctx.session()
-                        .add_notice(AdapterNotice::UserRequested { severity });
-                    ctx.retire(Ok(ExecuteResponse::Raised));
-                }
-                Plan::RotateKeys(RotateKeysPlan { id }) => {
-                    let result = self.sequence_rotate_keys(ctx.session(), id).await;
-                    ctx.retire(result);
-                }
-                Plan::GrantPrivileges(plan) => {
-                    let result = self
-                        .sequence_grant_privileges(ctx.session_mut(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::RevokePrivileges(plan) => {
-                    let result = self
-                        .sequence_revoke_privileges(ctx.session_mut(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::AlterDefaultPrivileges(plan) => {
-                    let result = self
-                        .sequence_alter_default_privileges(ctx.session_mut(), plan)
-                        .await;
-                    ctx.retire(result);
-                }
-                Plan::GrantRole(plan) => {
-                    let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::RevokeRole(plan) => {
-                    let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::AlterOwner(plan) => {
-                    let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::ReassignOwned(plan) => {
-                    let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
-                    ctx.retire(result);
-                }
-                Plan::ValidateConnection(plan) => {
-                    let connection_context = self.connection_context.clone();
-                    mz_ore::task::spawn(|| "coord::validate_connection", async move {
-                        let res = match plan.connection.validate(plan.id, &connection_context).await
-                        {
-                            Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
-                            Err(err) => Err(err.into()),
-                        };
-                        ctx.retire(res);
-                    });
+                    ctx_extra,
+                }));
+            }
+            Plan::Close(plan) => {
+                if ctx.session_mut().remove_portal(&plan.name) {
+                    ctx.retire(Ok(ExecuteResponse::ClosedCursor));
+                } else {
+                    ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
                 }
             }
-            break;
+            Plan::Prepare(plan) => {
+                if ctx
+                    .session()
+                    .get_prepared_statement_unverified(&plan.name)
+                    .is_some()
+                {
+                    ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
+                } else {
+                    ctx.session_mut().set_prepared_statement(
+                        plan.name,
+                        Some(plan.stmt),
+                        plan.sql,
+                        plan.desc,
+                        self.catalog().transient_revision(),
+                        self.now(),
+                    );
+                    ctx.retire(Ok(ExecuteResponse::Prepare));
+                }
+            }
+            Plan::Execute(plan) => {
+                match self.sequence_execute(ctx.session_mut(), plan) {
+                    Ok(portal_name) => {
+                        let (tx, _, session, extra) = ctx.into_parts();
+                        self.internal_cmd_tx
+                            .send(Message::Command(Command::Execute {
+                                portal_name,
+                                session,
+                                tx: tx.take(),
+                                outer_ctx_extra: Some(extra),
+                                span: tracing::Span::none(),
+                            }))
+                            .expect("sending to self.internal_cmd_tx cannot fail");
+                    }
+                    Err(err) => ctx.retire(Err(err)),
+                };
+            }
+            Plan::Deallocate(plan) => match plan.name {
+                Some(name) => {
+                    if ctx.session_mut().remove_prepared_statement(&name) {
+                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
+                    } else {
+                        ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
+                    }
+                }
+                None => {
+                    ctx.session_mut().remove_all_prepared_statements();
+                    ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
+                }
+            },
+            Plan::Raise(RaisePlan { severity }) => {
+                ctx.session()
+                    .add_notice(AdapterNotice::UserRequested { severity });
+                ctx.retire(Ok(ExecuteResponse::Raised));
+            }
+            Plan::RotateKeys(RotateKeysPlan { id }) => {
+                let result = self.sequence_rotate_keys(ctx.session(), id).await;
+                ctx.retire(result);
+            }
+            Plan::GrantPrivileges(plan) => {
+                let result = self
+                    .sequence_grant_privileges(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::RevokePrivileges(plan) => {
+                let result = self
+                    .sequence_revoke_privileges(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::AlterDefaultPrivileges(plan) => {
+                let result = self
+                    .sequence_alter_default_privileges(ctx.session_mut(), plan)
+                    .await;
+                ctx.retire(result);
+            }
+            Plan::GrantRole(plan) => {
+                let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::RevokeRole(plan) => {
+                let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::AlterOwner(plan) => {
+                let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::ReassignOwned(plan) => {
+                let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
+                ctx.retire(result);
+            }
+            Plan::ValidateConnection(plan) => {
+                let connection_context = self.connection_context.clone();
+                mz_ore::task::spawn(|| "coord::validate_connection", async move {
+                    let res = match plan.connection.validate(plan.id, &connection_context).await {
+                        Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
+                        Err(err) => Err(err.into()),
+                    };
+                    ctx.retire(res);
+                });
+            }
         }
     }
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -810,7 +810,7 @@ fn generate_required_privileges(
 
             for privilege in generate_required_privileges(
                 catalog,
-                &*select_plan,
+                &Plan::Select(select_plan.clone()),
                 target_cluster_id,
                 new_resolved_ids,
                 role_id,

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -324,6 +324,7 @@ pub fn generate_required_role_membership(
         | Plan::EmptyQuery
         | Plan::ShowAllVariables
         | Plan::ShowCreate(_)
+        | Plan::ShowColumns(_)
         | Plan::ShowVariable(_)
         | Plan::InspectShard(_)
         | Plan::SetVariable(_)
@@ -400,6 +401,7 @@ fn generate_required_ownership(plan: &Plan) -> Vec<ObjectId> {
         | Plan::Select(_)
         | Plan::Subscribe(_)
         | Plan::ShowCreate(_)
+        | Plan::ShowColumns(_)
         | Plan::CopyFrom(_)
         | Plan::CopyRows(_)
         | Plan::Explain(_)
@@ -794,7 +796,29 @@ fn generate_required_privileges(
                 role_id,
             )]
         }
+        Plan::ShowColumns(plan::ShowColumnsPlan {
+            id,
+            select_plan,
+            new_resolved_ids,
+        }) => {
+            let item = catalog.get_item(id);
+            let mut privileges = vec![(
+                SystemObjectId::Object(item.name().qualifiers.clone().into()),
+                AclMode::USAGE,
+                role_id,
+            )];
 
+            for privilege in generate_required_privileges(
+                catalog,
+                &*select_plan,
+                target_cluster_id,
+                new_resolved_ids,
+                role_id,
+            ) {
+                privileges.push(privilege);
+            }
+            privileges
+        }
         Plan::Select(plan::SelectPlan {
             source,
             when: _,

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -780,7 +780,7 @@ pub struct ShowCreatePlan {
 #[derive(Debug)]
 pub struct ShowColumnsPlan {
     pub id: GlobalId,
-    pub select_plan: Box<Plan>,
+    pub select_plan: SelectPlan,
     pub new_resolved_ids: ResolvedIds,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -122,6 +122,7 @@ pub enum Plan {
     EmptyQuery,
     ShowAllVariables,
     ShowCreate(ShowCreatePlan),
+    ShowColumns(ShowColumnsPlan),
     ShowVariable(ShowVariablePlan),
     InspectShard(InspectShardPlan),
     SetVariable(SetVariablePlan),
@@ -262,6 +263,7 @@ impl Plan {
                 PlanKind::Select,
                 PlanKind::ShowVariable,
                 PlanKind::ShowCreate,
+                PlanKind::ShowColumns,
                 PlanKind::ShowAllVariables,
                 PlanKind::InspectShard,
             ],
@@ -313,6 +315,7 @@ impl Plan {
             Plan::EmptyQuery => "do nothing",
             Plan::ShowAllVariables => "show all variables",
             Plan::ShowCreate(_) => "show create",
+            Plan::ShowColumns(_) => "show columns",
             Plan::ShowVariable(_) => "show variable",
             Plan::InspectShard(_) => "inspect shard",
             Plan::SetVariable(_) => "set variable",
@@ -772,6 +775,13 @@ impl SubscribeFrom {
 pub struct ShowCreatePlan {
     pub id: GlobalId,
     pub row: Row,
+}
+
+#[derive(Debug)]
+pub struct ShowColumnsPlan {
+    pub id: GlobalId,
+    pub select_plan: Box<Plan>,
+    pub new_resolved_ids: ResolvedIds,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -16,7 +16,7 @@
 use std::fmt::Write;
 
 use mz_ore::collections::CollectionExt;
-use mz_repr::{Datum, RelationDesc, Row, ScalarType};
+use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowObjectType,
@@ -31,13 +31,15 @@ use crate::ast::{
 };
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::names::{
-    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedItemName,
-    ResolvedSchemaName,
+    self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedIds,
+    ResolvedItemName, ResolvedSchemaName,
 };
 use crate::parse;
 use crate::plan::scope::Scope;
 use crate::plan::statement::{dml, StatementContext, StatementDesc};
-use crate::plan::{query, transform_ast, HirRelationExpr, Params, Plan, PlanError, ShowCreatePlan};
+use crate::plan::{
+    query, transform_ast, HirRelationExpr, Params, Plan, PlanError, ShowColumnsPlan, ShowCreatePlan,
+};
 
 pub fn describe_show_create_view(
     _: &StatementContext,
@@ -568,7 +570,7 @@ pub fn show_indexes<'a>(
 pub fn show_columns<'a>(
     scx: &'a StatementContext<'a>,
     ShowColumnsStatement { table_name, filter }: ShowColumnsStatement<Aug>,
-) -> Result<ShowSelect<'a>, PlanError> {
+) -> Result<ShowColumnsSelect<'a>, PlanError> {
     let entry = scx.get_item_by_resolved_name(&table_name)?;
     let full_name = scx.catalog.resolve_full_name(entry.name());
 
@@ -597,13 +599,18 @@ pub fn show_columns<'a>(
          WHERE mz_columns.id = '{}'",
         entry.id(),
     );
-    ShowSelect::new(
+    let (show_select, new_resolved_ids) = ShowSelect::new_with_resolved_ids(
         scx,
         query,
         filter,
         Some("position"),
         Some(&["name", "nullable", "type"]),
-    )
+    )?;
+    Ok(ShowColumnsSelect {
+        id: entry.id(),
+        show_select,
+        new_resolved_ids,
+    })
 }
 
 // The rationale for which fields to include in the tuples are those
@@ -682,6 +689,17 @@ impl<'a> ShowSelect<'a> {
         order: Option<&str>,
         projection: Option<&[&str]>,
     ) -> Result<ShowSelect<'a>, PlanError> {
+        Self::new_with_resolved_ids(scx, query, filter, order, projection)
+            .map(|(show_select, _)| show_select)
+    }
+
+    fn new_with_resolved_ids(
+        scx: &'a StatementContext,
+        query: String,
+        filter: Option<ShowStatementFilter<Aug>>,
+        order: Option<&str>,
+        projection: Option<&[&str]>,
+    ) -> Result<(ShowSelect<'a>, ResolvedIds), PlanError> {
         let filter = match filter {
             Some(ShowStatementFilter::Like(like)) => format!("name LIKE {}", Value::String(like)),
             Some(ShowStatementFilter::Where(expr)) => expr.to_string(),
@@ -701,9 +719,9 @@ impl<'a> ShowSelect<'a> {
             Statement::Select(select) => select,
             _ => panic!("ShowSelect::new called with non-SELECT statement"),
         };
-        let (mut stmt, _) = names::resolve(scx.catalog, stmt)?;
+        let (mut stmt, new_resolved_ids) = names::resolve(scx.catalog, stmt)?;
         transform_ast::transform(scx, &mut stmt)?;
-        Ok(ShowSelect { scx, stmt })
+        Ok((ShowSelect { scx, stmt }, new_resolved_ids))
     }
 
     /// Computes the shape of this `ShowSelect`.
@@ -719,6 +737,31 @@ impl<'a> ShowSelect<'a> {
     /// Converts this `ShowSelect` into a [`(HirRelationExpr, Scope)`].
     pub fn plan_hir(self, qcx: &QueryContext) -> Result<(HirRelationExpr, Scope), PlanError> {
         query::plan_nested_query(&mut qcx.clone(), &self.stmt.query)
+    }
+}
+
+pub struct ShowColumnsSelect<'a> {
+    id: GlobalId,
+    new_resolved_ids: ResolvedIds,
+    show_select: ShowSelect<'a>,
+}
+
+impl<'a> ShowColumnsSelect<'a> {
+    pub fn describe(self) -> Result<StatementDesc, PlanError> {
+        self.show_select.describe()
+    }
+
+    pub fn plan(self) -> Result<Plan, PlanError> {
+        let select_plan = self.show_select.plan()?;
+        Ok(Plan::ShowColumns(ShowColumnsPlan {
+            id: self.id,
+            select_plan: Box::new(select_plan),
+            new_resolved_ids: self.new_resolved_ids,
+        }))
+    }
+
+    pub fn plan_hir(self, qcx: &QueryContext) -> Result<(HirRelationExpr, Scope), PlanError> {
+        self.show_select.plan_hir(qcx)
     }
 }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -759,7 +759,16 @@ impl<'a> ShowColumnsSelect<'a> {
                 select_plan,
                 new_resolved_ids: self.new_resolved_ids,
             })),
-            _ => Err(PlanError::Unstructured(format!("SHOW COLUMNS didn't produce a SelectPlan as expected, produced {:?} instead. Please file a bug.", select_plan)))
+            _ => {
+                tracing::error!(
+                    "SHOW COLUMNS produced a non select plan. plan: {:?}",
+                    select_plan
+                );
+                Err(PlanError::Unstructured(
+                    "SHOW COLUMNS didn't produce an unexpected plan. Please file a bug."
+                        .to_string(),
+                ))
+            }
         }
     }
 

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -753,11 +753,14 @@ impl<'a> ShowColumnsSelect<'a> {
 
     pub fn plan(self) -> Result<Plan, PlanError> {
         let select_plan = self.show_select.plan()?;
-        Ok(Plan::ShowColumns(ShowColumnsPlan {
-            id: self.id,
-            select_plan: Box::new(select_plan),
-            new_resolved_ids: self.new_resolved_ids,
-        }))
+        match select_plan {
+            Plan::Select(select_plan) => Ok(Plan::ShowColumns(ShowColumnsPlan {
+                id: self.id,
+                select_plan,
+                new_resolved_ids: self.new_resolved_ids,
+            })),
+            _ => Err(PlanError::Unstructured(format!("SHOW COLUMNS didn't produce a SelectPlan as expected, produced {:?} instead. Please file a bug.", select_plan)))
+        }
     }
 
     pub fn plan_hir(self, qcx: &QueryContext) -> Result<(HirRelationExpr, Scope), PlanError> {

--- a/test/testdrive/show_columns.td
+++ b/test/testdrive/show_columns.td
@@ -1,0 +1,47 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+> CREATE TABLE t(a int)
+
+> SHOW COLUMNS FROM t
+a true integer
+
+$ postgres-execute connection=mz_support
+SHOW COLUMNS FROM t
+
+# enable RBAC
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_ld_rbac_checks=true;
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_rbac_checks=true;
+
+$ postgres-execute connection=mz_system
+CREATE TABLE priv(a int)
+
+$ postgres-execute connection=mz_system
+REVOKE SELECT ON TABLE priv FROM materialize
+
+! SELECT * from priv;
+contains:permission denied for TABLE "materialize.public.priv"
+
+> SHOW COLUMNS FROM priv
+a true integer
+
+# Make sure we can't exfiltrate data by supplying a where expression
+# that references the underlying table
+! SHOW COLUMNS FROM priv WHERE char_length(name) = any (select * from priv)
+contains:permission denied for TABLE "materialize.public.priv"
+
+$ postgres-execute connection=mz_support
+SHOW COLUMNS FROM priv
+

--- a/test/testdrive/show_columns.td
+++ b/test/testdrive/show_columns.td
@@ -44,4 +44,3 @@ contains:permission denied for TABLE "materialize.public.priv"
 
 $ postgres-execute connection=mz_support
 SHOW COLUMNS FROM priv
-


### PR DESCRIPTION
SHOW COLUMNS is special. The other SHOW commands are either showing information about a single object and don't allow arbitrary extensions to the underlying query (like SHOW TABLE) or are general queries that don't need to refer to any particular object (like SHOW INDEXES). In order to allow SHOW COLUMNS to refer to user objects and accept arbitrary where conditions we have to special case it.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer
The diff in sequencer.rs is large because I added a level of indentation. Try ignoring whitespace to make it more manageable, the only semantic change was adding a case for ShowColumnsPlan and a loop so that ShowColumnsPlan could delegate to its underlying plan

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
