### PR TITLE
compute: add worker_id to the replica history metrics

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -98,7 +98,7 @@ impl ComputeState {
         tracing_handle: Arc<TracingHandle>,
     ) -> Self {
         let traces = TraceManager::new(metrics.for_traces(worker_id));
-        let command_history = ComputeCommandHistory::new(metrics.for_history());
+        let command_history = ComputeCommandHistory::new(metrics.for_history(worker_id));
 
         Self {
             collections: Default::default(),

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -18,7 +18,7 @@ use prometheus::core::{AtomicF64, GenericCounter};
 pub struct ComputeMetrics {
     // command history
     history_command_count: raw::UIntGaugeVec,
-    history_dataflow_count: UIntGauge,
+    history_dataflow_count: raw::UIntGaugeVec,
 
     // reconciliation
     reconciliation_reused_dataflows_count_total: raw::IntCounterVec,
@@ -38,11 +38,12 @@ impl ComputeMetrics {
             history_command_count: registry.register(metric!(
                 name: "mz_compute_replica_history_command_count",
                 help: "The number of commands in the replica's command history.",
-                var_labels: ["command_type"],
+                var_labels: ["worker_id", "command_type"],
             )),
             history_dataflow_count: registry.register(metric!(
                 name: "mz_compute_replica_history_dataflow_count",
                 help: "The number of dataflows in the replica's command history.",
+                var_labels: ["worker_id"],
             )),
             reconciliation_reused_dataflows_count_total: registry.register(metric!(
                 name: "mz_compute_reconciliation_reused_dataflows_count_total",
@@ -72,13 +73,13 @@ impl ComputeMetrics {
         }
     }
 
-    pub fn for_history(&self) -> HistoryMetrics<UIntGauge> {
+    pub fn for_history(&self, worker_id: usize) -> HistoryMetrics<UIntGauge> {
+        let worker = worker_id.to_string();
         let command_counts = CommandMetrics::build(|typ| {
             self.history_command_count
-                .get_metric_with_label_values(&[typ])
-                .unwrap()
+                .with_label_values(&[&worker, typ])
         });
-        let dataflow_count = self.history_dataflow_count.clone();
+        let dataflow_count = self.history_dataflow_count.with_label_values(&[&worker]);
 
         HistoryMetrics {
             command_counts,

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -14,6 +14,14 @@ use mz_repr::GlobalId;
 use prometheus::core::{AtomicF64, GenericCounter};
 
 /// Metrics exposed by compute replicas.
+//
+// Most of the metrics here use the `raw` implementations, rather than the `DeleteOnDrop` wrappers
+// because their labels are fixed throughout the lifetime of the replica process. For example, any
+// metric labeled only by `worker_id` can be `raw` since the number of workers cannot change.
+//
+// Metrics that are labelled by a dimension that can change throughout the lifetime of the process
+// (such as `collection_id`) MUST NOT use the `raw` metric types and must use the `DeleteOnDrop`
+// types instead, to avoid memory leaks.
 #[derive(Clone, Debug)]
 pub struct ComputeMetrics {
     // command history

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -314,7 +314,7 @@ def workflow_test_github_15531(c: Composition) -> None:
             STORAGE ADDRESSES ['clusterd1:2103'],
             COMPUTECTL ADDRESSES ['clusterd1:2101'],
             COMPUTE ADDRESSES ['clusterd1:2102'],
-            WORKERS 2
+            WORKERS 1
         ));
         SET cluster = cluster1;
         -- table for fast-path peeks


### PR DESCRIPTION
This PR adds a `worker_id` label to the two replica history metrics `mz_compute_replica_history_command_count` and
`mz_compute_replica_history_dataflow_count`.

Each worker keeps its own command history, and so not having a `worker_id` label is a bug because it can cause inconsistencies when multiple workers try to update the same timeseries.

Introducing these metrics without a `worker_id` label was an oversight. The compute metrics design doc does include that label for these metrics.

### Motivation

  * This PR fixes a previously unreported bug.

The per-worker replica history metrics are missing a `worker_id` label, which causes confusion when multiple worker are updating the same timeseries.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
