### PR TITLE
Index usage docs

### DIFF
--- a/doc/user/content/sql/functions/now_and_mz_now.md
+++ b/doc/user/content/sql/functions/now_and_mz_now.md
@@ -24,7 +24,7 @@ The typical uses of `now()` and `mz_now()` are:
 
 * **Query timestamp introspection**
 
-  An ad-hoc `SELECT` query with `now()` and `mz_now()` can be useful if you need to understand how up to date the data returned by a query is.
+  An ad hoc `SELECT` query with `now()` and `mz_now()` can be useful if you need to understand how up to date the data returned by a query is.
   The data returned by the query reflects the results as of the logical time returned by a call to `mz_now()` in that query.
 
 
@@ -105,7 +105,7 @@ INSERT INTO events VALUES (
 );
 ```
 
-Execute this ad-hoc query that adds the current system timestamp and current logical timestamp to the events in the `events` table.
+Execute this ad hoc query that adds the current system timestamp and current logical timestamp to the events in the `events` table.
 
 ```sql
 SELECT now(), mz_now(), * FROM events


### PR DESCRIPTION
This is the docs update corresponding to https://github.com/MaterializeInc/materialize/pull/21119 and https://github.com/MaterializeInc/materialize/pull/21196, i.e., the "Used indexes" part of EXPLAIN showing _how_ each index is going to be used. The main part of this PR is the new text at the end of `optimization.md`.

(Note that the first commit is from https://github.com/MaterializeInc/materialize/pull/21196. No need to review it separately.)

I also added an example for the situation that we ran into with @teskje in the "Joins with Filters" section.

Additionally, I made a number of changes in `select.md`:
- The ad hoc queries section had some problems:
  - The two paragraphs seemed redundant, so I shortened the second one.
  - Actually, the section above the ad hoc queries section also showed ad hoc queries. I reorganized them as follows: renamed the old ad hoc section, moved both section down one level, and grouped them into a new ad hoc queries section.
- Adjusted the examples a bit.

### Motivation

Add docs for https://github.com/MaterializeInc/materialize/pull/21119 and https://github.com/MaterializeInc/materialize/pull/21196, plus fix some doc issues.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
