### PR TITLE
Bump openssl cryptography

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -8,7 +8,7 @@ black==22.12.0
 boto3-stubs[ec2,iam,kinesis,s3,sqs,ssm,sts]==1.26.89
 boto3==1.26.64
 click==8.1.3
-cryptography==39.0.1
+cryptography==41.0.0
 colored==1.4.4
 docker==6.0.1
 ec2instanceconnectcli==1.0.2


### PR DESCRIPTION
Addresses vuln in versions below 41.0.0

<!--
Bumps version of cryptography package to 41.0.0
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

 https://deps.dev/advisory/osv/GHSA-5cpq-8wj7-hf2v


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

One line change in ci/builder/requirements.txt
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
