### PR TITLE
Shrink scratch buffers in upsert and rocksdb

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -61,6 +61,7 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
                 config.upsert_rocksdb_stats_log_interval_seconds(),
                 config.upsert_rocksdb_stats_persist_interval_seconds(),
                 config.upsert_rocksdb_point_lookup_block_cache_size_mb(),
+                config.upsert_rocksdb_shrink_allocated_buffers_by_ratio(),
             ) {
                 Ok(u) => u,
                 Err(e) => {

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -101,6 +101,8 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         },
         grpc_client: grpc_client_config(config),
         delay_sources_past_rehydration: config.storage_dataflow_delay_sources_past_rehydration(),
+        shrink_upsert_unused_buffers_by_ratio: config
+            .storage_shrink_upsert_unused_buffers_by_ratio(),
     }
 }
 

--- a/src/rocksdb-types/src/config.proto
+++ b/src/rocksdb-types/src/config.proto
@@ -44,4 +44,5 @@ message ProtoRocksDbTuningParameters {
     uint32 stats_log_interval_seconds = 10;
     uint32 stats_persist_interval_seconds = 11;
     optional uint32 point_lookup_block_cache_size_mb = 12;
+    uint64 shrink_buffers_by_ratio = 13;
 }

--- a/src/rocksdb/src/config.rs
+++ b/src/rocksdb/src/config.rs
@@ -62,6 +62,7 @@ pub fn apply_to_options(config: &RocksDBConfig, options: &mut rocksdb::Options) 
         stats_log_interval_seconds,
         stats_persist_interval_seconds,
         point_lookup_block_cache_size_mb,
+        shrink_buffers_by_ratio: _,
         dynamic: _,
     } = config;
 

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -663,6 +663,12 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                 for _ in buf_size..batch_size {
                     encoded_batch_buffers.push(Some(Vec::new()));
                 }
+                // shrinking the buffers in case the scratch buffer's is more than
+                // double the batch size
+                if buf_size / 2 > batch_size {
+                    encoded_batch_buffers.shrink_to(buf_size / 2);
+                    encoded_batch.shrink_to(buf_size / 2);
+                }
                 assert!(encoded_batch_buffers.len() >= batch_size);
 
                 // TODO(guswynn): sort by key before writing.

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -663,11 +663,15 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
                 for _ in buf_size..batch_size {
                     encoded_batch_buffers.push(Some(Vec::new()));
                 }
-                // shrinking the buffers in case the scratch buffer's is more than
+                // shrinking the buffers in case the scratch buffer's capacity is more than
                 // double the batch size
-                if buf_size / 2 > batch_size {
-                    encoded_batch_buffers.shrink_to(buf_size / 2);
-                    encoded_batch.shrink_to(buf_size / 2);
+                let half_capacity = encoded_batch_buffers.capacity() / 2;
+                if half_capacity > batch_size {
+                    encoded_batch_buffers.truncate(half_capacity);
+                    encoded_batch_buffers.shrink_to(half_capacity);
+
+                    encoded_batch.truncate(half_capacity);
+                    encoded_batch.shrink_to(half_capacity);
                 }
                 assert!(encoded_batch_buffers.len() >= batch_size);
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -924,6 +924,16 @@ const STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION: ServerVar<bool> = ServerV
     internal: true,
 };
 
+/// Configuration ratio to shrink unusef buffers in upsert by.
+/// For eg: is 2 is set, then the buffers will be reduced by 2 i.e. halved.
+/// Default is 0, which means shrinking is disabled.
+const STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("storage_shrink_upsert_unused_buffers_by_ratio"),
+    value: &0,
+    description: "Configuration ratio to shrink unusef buffers in upsert by",
+    internal: true,
+};
+
 /// The fraction of the cluster replica size to be used as the maximum number of
 /// in-flight bytes emitted by persist_sources feeding storage dataflows.
 /// If not configured, the storage_dataflow_max_inflight_bytes value will be used.
@@ -2130,6 +2140,7 @@ impl SystemVars {
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
             .with_var(&STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION)
+            .with_var(&STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
@@ -2643,6 +2654,11 @@ impl SystemVars {
     /// Returns the `storage_dataflow_max_inflight_bytes` configuration parameter.
     pub fn storage_dataflow_delay_sources_past_rehydration(&self) -> bool {
         *self.expect_value(&STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION)
+    }
+
+    /// Returns the `storage_shrink_upsert_unused_buffers_by_ratio` configuration parameter.
+    pub fn storage_shrink_upsert_unused_buffers_by_ratio(&self) -> usize {
+        *self.expect_value(&STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO)
     }
 
     /// Returns the `storage_dataflow_max_inflight_bytes_disk_only` configuration parameter.
@@ -4232,6 +4248,7 @@ pub fn is_storage_config_var(name: &str) -> bool {
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION.name()
         || name == STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY.name()
         || name == STORAGE_DATAFLOW_DELAY_SOURCES_PAST_REHYDRATION.name()
+        || name == STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO.name()
         || is_upsert_rocksdb_config_var(name)
         || is_persist_config_var(name)
         || is_tracing_var(name)

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -782,6 +782,16 @@ mod upsert_rocksdb {
                   Only takes effect on source restart (Materialize).",
             internal: true,
         };
+
+    /// The number of times by which allocated buffers will be shrinked in upsert rocksdb.
+    /// If value is 0, then no shrinking will occur.
+    pub static UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO: ServerVar<usize> = ServerVar {
+        name: UncasedStr::new("upsert_rocksdb_shrink_allocated_buffers_by_ratio"),
+        value: &mz_rocksdb_types::defaults::DEFAULT_SHRINK_BUFFERS_BY_RATIO,
+        description:
+            "The number of times by which allocated buffers will be shrinked in upsert rocksdb.",
+        internal: true,
+    };
 }
 
 /// Controls the connect_timeout setting when connecting to PG via replication.
@@ -2107,6 +2117,7 @@ impl SystemVars {
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS)
             .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB)
+            .with_var(&upsert_rocksdb::UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO)
             .with_var(&PERSIST_BLOB_TARGET_SIZE)
             .with_var(&PERSIST_BLOB_CACHE_MEM_LIMIT_BYTES)
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
@@ -2533,6 +2544,10 @@ impl SystemVars {
 
     pub fn upsert_rocksdb_point_lookup_block_cache_size_mb(&self) -> Option<u32> {
         *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB)
+    }
+
+    pub fn upsert_rocksdb_shrink_allocated_buffers_by_ratio(&self) -> usize {
+        *self.expect_value(&upsert_rocksdb::UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO)
     }
 
     /// Returns the `persist_blob_target_size` configuration parameter.
@@ -4239,6 +4254,7 @@ fn is_upsert_rocksdb_config_var(name: &str) -> bool {
         || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_LOG_INTERVAL_SECONDS.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_STATS_PERSIST_INTERVAL_SECONDS.name()
         || name == upsert_rocksdb::UPSERT_ROCKSDB_POINT_LOOKUP_BLOCK_CACHE_SIZE_MB.name()
+        || name == upsert_rocksdb::UPSERT_ROCKSDB_SHRINK_ALLOCATED_BUFFERS_BY_RATIO.name()
 }
 
 /// Returns whether the named variable is a persist configuration parameter.

--- a/src/storage-client/src/types/parameters.proto
+++ b/src/storage-client/src/types/parameters.proto
@@ -30,6 +30,7 @@ message ProtoStorageParameters {
     ProtoStorageMaxInflightBytesConfig storage_dataflow_max_inflight_bytes_config = 10;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 11;
     bool storage_dataflow_delay_sources_past_rehydration = 12;
+    uint64 shrink_upsert_unused_buffers_by_ratio = 13;
 }
 
 

--- a/src/storage-client/src/types/parameters.rs
+++ b/src/storage-client/src/types/parameters.rs
@@ -48,6 +48,8 @@ pub struct StorageParameters {
     pub grpc_client: GrpcClientParameters,
     /// Configuration for basic hydration backpressure.
     pub delay_sources_past_rehydration: bool,
+    /// Configuration ratio to shrink upsert buffers by.
+    pub shrink_upsert_unused_buffers_by_ratio: usize,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -130,6 +132,7 @@ impl StorageParameters {
             storage_dataflow_max_inflight_bytes_config,
             grpc_client,
             delay_sources_past_rehydration,
+            shrink_upsert_unused_buffers_by_ratio,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -145,6 +148,7 @@ impl StorageParameters {
             storage_dataflow_max_inflight_bytes_config;
         self.grpc_client.update(grpc_client);
         self.delay_sources_past_rehydration = delay_sources_past_rehydration;
+        self.shrink_upsert_unused_buffers_by_ratio = shrink_upsert_unused_buffers_by_ratio;
     }
 }
 
@@ -168,6 +172,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             ),
             grpc_client: Some(self.grpc_client.into_proto()),
             storage_dataflow_delay_sources_past_rehydration: self.delay_sources_past_rehydration,
+            shrink_upsert_unused_buffers_by_ratio: u64::cast_from(
+                self.shrink_upsert_unused_buffers_by_ratio,
+            ),
         }
     }
 
@@ -204,6 +211,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
                 .grpc_client
                 .into_rust_if_some("ProtoStorageParameters::grpc_client")?,
             delay_sources_past_rehydration: proto.storage_dataflow_delay_sources_past_rehydration,
+            shrink_upsert_unused_buffers_by_ratio: usize::cast_from(
+                proto.shrink_upsert_unused_buffers_by_ratio,
+            ),
         })
     }
 }

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -37,6 +37,9 @@ pub struct DataflowParameters {
         mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
     /// Configuration for basic hydration backpressure.
     pub delay_sources_past_rehydration: bool,
+    /// Configuration ratio to shrink upsert buffers.
+    /// Defaults to 0, which means no shrinking will happen.
+    pub shrink_upsert_unused_buffers_by_ratio: usize,
 }
 
 impl DataflowParameters {
@@ -48,6 +51,7 @@ impl DataflowParameters {
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
         storage_dataflow_max_inflight_bytes_config: mz_storage_client::types::parameters::StorageMaxInflightBytesConfig,
         delay_sources_past_rehydration: bool,
+        shrink_upsert_unused_buffers_by_ratio: usize,
     ) {
         self.pg_replication_timeouts = pg_replication_timeouts;
         self.upsert_rocksdb_tuning_config.apply(rocksdb_params);
@@ -55,6 +59,7 @@ impl DataflowParameters {
         self.storage_dataflow_max_inflight_bytes_config =
             storage_dataflow_max_inflight_bytes_config;
         self.delay_sources_past_rehydration = delay_sources_past_rehydration;
+        self.shrink_upsert_unused_buffers_by_ratio = shrink_upsert_unused_buffers_by_ratio;
     }
 }
 
@@ -107,6 +112,8 @@ pub enum InternalStorageCommand {
         auto_spill_config: mz_storage_client::types::parameters::UpsertAutoSpillConfig,
         /// Configuration for basic hydration backpressure.
         delay_sources_past_rehydration: bool,
+        /// Configuration ratio to shrink upsert buffers by
+        shrink_upsert_unused_buffers_by_ratio: usize,
     },
 }
 

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -218,6 +218,11 @@ where
     // If we are configured to delay raw sources till we rehydrate, we do so. Otherwise, skip
     // this, to prevent unnecessary work.
     let wait_for_input_resumption = dataflow_paramters.delay_sources_past_rehydration;
+    let upsert_config = UpsertConfig {
+        wait_for_input_resumption,
+        shrink_upsert_unused_buffers_by_ratio: dataflow_paramters
+            .shrink_upsert_unused_buffers_by_ratio,
+    };
 
     if let Some(scratch_directory) = instance_context.scratch_directory.as_ref() {
         let tuning = dataflow_paramters.upsert_rocksdb_tuning_config.clone();
@@ -266,7 +271,7 @@ where
                         rocksdb_in_use_metric,
                     )
                 },
-                wait_for_input_resumption,
+                upsert_config,
             )
         } else {
             upsert_inner(
@@ -293,7 +298,7 @@ where
                         .unwrap(),
                     )
                 },
-                wait_for_input_resumption,
+                upsert_config,
             )
         }
     } else {
@@ -311,7 +316,7 @@ where
             upsert_metrics,
             source_config,
             || async { InMemoryHashMap::default() },
-            wait_for_input_resumption,
+            upsert_config,
         )
     }
 }
@@ -323,6 +328,7 @@ fn stage_input<T, O>(
     data: &mut Vec<((UpsertKey, Option<UpsertValue>, O), T, Diff)>,
     input_upper: &Antichain<T>,
     resume_upper: &Antichain<T>,
+    storage_shrink_upsert_unused_buffers_by_ratio: usize,
 ) where
     T: PartialOrder,
     O: Ord,
@@ -336,9 +342,21 @@ fn stage_input<T, O>(
         (time, key, Reverse(order), value)
     }));
 
-    if stash.capacity() / 2 > stash.len() {
-        stash.shrink_to(stash.capacity() / 2);
+    if storage_shrink_upsert_unused_buffers_by_ratio > 0 {
+        let reduced_capacity = stash.capacity() / storage_shrink_upsert_unused_buffers_by_ratio;
+        if reduced_capacity > stash.len() {
+            stash.shrink_to(reduced_capacity);
+        }
     }
+}
+
+// Created a struct to hold the configs for upserts.
+// So that new configs don't require a new method parameter.
+struct UpsertConfig {
+    // Whether or not to wait for the `input` to reach the `resumption_frontier`
+    // before we finalize `rehydration`.
+    wait_for_input_resumption: bool,
+    shrink_upsert_unused_buffers_by_ratio: usize,
 }
 
 fn upsert_inner<G: Scope, O: timely::ExchangeData + Ord, F, Fut, US>(
@@ -350,9 +368,7 @@ fn upsert_inner<G: Scope, O: timely::ExchangeData + Ord, F, Fut, US>(
     upsert_metrics: UpsertMetrics,
     source_config: crate::source::RawSourceCreationConfig,
     state: F,
-    // Whether or not to wait for the `input` to reach the `resumption_frontier`
-    // before we finalize `rehydration`.
-    wait_for_input_resumption: bool,
+    upsert_config: UpsertConfig,
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
@@ -402,6 +418,7 @@ where
             upsert_shared_metrics,
             upsert_metrics,
             source_config.source_statistics,
+            upsert_config.shrink_upsert_unused_buffers_by_ratio
         );
         let mut events = vec![];
         let mut snapshot_upper = Antichain::from_elem(Timestamp::minimum());
@@ -410,7 +427,7 @@ where
         let mut input_upper = Antichain::from_elem(Timestamp::minimum());
 
         while !PartialOrder::less_equal(&resume_upper, &snapshot_upper)
-            || (wait_for_input_resumption && !PartialOrder::less_equal(&resume_upper, &input_upper))
+            || (upsert_config.wait_for_input_resumption && !PartialOrder::less_equal(&resume_upper, &input_upper))
         {
             let previous_event = tokio::select! {
                 // Note that these are both cancel-safe. The reason we drain the `input` is to
@@ -422,7 +439,7 @@ where
                 input_event = input.next_mut() => {
                     match input_event {
                         Some(AsyncEvent::Data(_cap, data)) => {
-                            stage_input(&mut stash, data, &input_upper, &resume_upper);
+                            stage_input(&mut stash, data, &input_upper, &resume_upper, upsert_config.shrink_upsert_unused_buffers_by_ratio);
                         }
                         Some(AsyncEvent::Progress(upper)) => {
                             input_upper = upper;
@@ -540,7 +557,7 @@ where
         } {
             match event {
                 AsyncEvent::Data(_cap, data) => {
-                    stage_input(&mut stash, data, &input_upper, &resume_upper);
+                    stage_input(&mut stash, data, &input_upper, &resume_upper, upsert_config.shrink_upsert_unused_buffers_by_ratio);
                 }
                 AsyncEvent::Progress(upper) => {
                     // Ignore progress updates before the `resume_upper`, which is our initial

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -711,6 +711,7 @@ where
             let reduced_capacity =
                 self.merge_scratch.capacity() / self.shrink_upsert_unused_buffers_by_ratio;
             if reduced_capacity > batch_size {
+                // These vectors have already been cleared above and should be empty here
                 self.merge_scratch.shrink_to(reduced_capacity);
                 self.merge_upsert_scratch.shrink_to(reduced_capacity);
                 self.multi_get_scratch.shrink_to(reduced_capacity);

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -861,12 +861,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
                 storage_dataflow_max_inflight_bytes_config,
                 auto_spill_config,
                 delay_sources_past_rehydration,
+                shrink_upsert_unused_buffers_by_ratio,
             } => self.storage_state.dataflow_parameters.update(
                 pg,
                 rocksdb,
                 auto_spill_config,
                 storage_dataflow_max_inflight_bytes_config,
                 delay_sources_past_rehydration,
+                shrink_upsert_unused_buffers_by_ratio,
             ),
         }
     }
@@ -1183,6 +1185,8 @@ impl StorageState {
                             .storage_dataflow_max_inflight_bytes_config,
                         auto_spill_config: params.upsert_auto_spill_config,
                         delay_sources_past_rehydration: params.delay_sources_past_rehydration,
+                        shrink_upsert_unused_buffers_by_ratio: params
+                            .shrink_upsert_unused_buffers_by_ratio,
                     })
                 }
             }

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -172,6 +172,9 @@ def workflow_rehydration(c: Composition) -> None:
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
                     "storage_dataflow_max_inflight_bytes_disk_only": "false",
                     "storage_dataflow_delay_sources_past_rehydration": "true",
+                    # Enabling shrinking buffers
+                    "upsert_rocksdb_shrink_allocated_buffers_by_ratio": "4",
+                    "storage_shrink_upsert_unused_buffers_by_ratio": "4",
                 },
                 environment_extra=materialized_environment_extra,
             ),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Shrinking scratch buffers in upsert and rocksdb if the batch size becomes significantly (less then half) small.

### Motivation
When we see a drastic drop in the batch size being processed, we are still not releasing the allocated memory of previously bigger batches. 

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Let me know if I should have used something else instead of various `shrink` methods. Also, did you have more places in mind?

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
