### PR TITLE
docs/user: document DISK options

### DIFF
--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -72,6 +72,43 @@ Valid `size` options are:
 - `5xlarge`
 - `6xlarge`
 
+The [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes) table lists the CPU, memory, and disk allocation for each replica size.
+
+{{< warning >}}
+The values in the `mz_internal.mz_cluster_replica_sizes` may change at any time.
+You should not rely on them for any kind of capacity planning.
+{{< /warning >}}
+
+### Disk-attached replicas
+
+{{< private-preview />}}
+
+{{< warning >}}
+**Pricing for this feature is likely to change.**
+
+Disk-attached replicas currently consume credits at the same rate as
+non-disk-attached replicas. In the future, disk-attached replicas will likely
+consume credits at a faster rate.
+{{< /warning >}}
+
+The `DISK` option attaches a disk to the replica.
+
+Attaching a disk allows you to trade off performance for cost. A replica of a
+given size has access to several times more disk than memory, allowing the
+processing of larger data sets at that replica size. Operations on a disk,
+however, are much slower than operations in memory, and so a workload that
+spills to disk will perform more slowly than a workload that does not. Note that
+exact storage medium for the attached disk is not specified, and its performance
+characteristics are subject to change.
+
+Consider attaching a disk to replicas that contain sources that use the
+[upsert envelope](/sql/create-source/#upsert-envelope) or the
+[Debezium envelope](/sql/create-source/#debezium-envelope). When you place
+these sources on a replica with an attached disk, they will automatically spill
+state to disk. These sources will therefore use less memory but may ingest
+data more slowly. See [Sizing a source](/sql/create-source/#sizing-a-source) for details.
+
+
 ### Deployment options
 
 Materialize is an active-replication-based system, which means you expect each

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -105,6 +105,8 @@ _replica_name_ | A name for a cluster replica.
 
 {{% replica-options %}}
 
+See [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica) for details.
+
 ## Availability zone assignment
 
 When assigning replicas of a [managed cluster](#managed-clusters) to

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -217,7 +217,7 @@ Debezium may produce duplicate records if the connector is interrupted. Material
 
 ### Sizing a source
 
-Some sources are low traffic and require relatively few resources to handle data ingestion, while others are high traffic and require hefty resource allocations. You choose the amount of CPU and memory available to a source using the `SIZE` option, and adjust the provisioned size after source creation using the [`ALTER SOURCE`](/sql/alter-source) command.
+Some sources are low traffic and require relatively few resources to handle data ingestion, while others are high traffic and require hefty resource allocations. You choose the amount of CPU, memory, and disk available to a source using the `SIZE` option, and adjust the provisioned size after source creation using the [`ALTER SOURCE`](/sql/alter-source) command.
 
 It's a good idea to size up a source when:
 
@@ -227,9 +227,13 @@ It's a good idea to size up a source when:
 
   * You are using the [upsert envelope](#upsert-envelope) or [Debezium
     envelope](#debezium-envelope), and your source contains **many unique
-    keys**. These envelopes must keep in-memory state proportional to the number
-    of unique keys in the upstream external system. Larger sizes can store more
-    unique keys.
+    keys**. These envelopes maintain state proportional to the number of unique
+    keys in the upstream external system. Larger sizes can store more unique
+    keys.
+
+    In this case, it's also possible to enable _spill to disk_ to accommodate
+    larger state sizes without sizing up. See [`Disk-attached replicas`]
+    (/sql/create-cluster-replica#disk-attached-replicas) for more details.
 
 Sources that specify the `SIZE` option are linked to a single-purpose cluster
 dedicated to maintaining that source.

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -31,13 +31,13 @@ for all processes of all extant cluster replicas.
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_metrics -->
-| Field               | Type         | Meaning                                                                           |
-| ------------------- | ------------ | --------                                                                          |
-| `replica_id`        | [`text`]     | The ID of a cluster replica.                                                      |
-| `process_id`        | [`uint8`]    | An identifier of a compute process within a replica.                              |
-| `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.                              |
-| `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.                                                  |
-| `disk_bytes`        | [`uint8`]    | The number of bytes used in the attached disk, if there is one. `NULL` otherwise. |
+| Field               | Type         | Meaning                                                                                                                                                      |
+| ------------------- | ------------ | --------                                                                                                                                                     |
+| `replica_id`        | [`text`]     | The ID of a cluster replica.                                                                                                                                 |
+| `process_id`        | [`uint8`]    | An identifier of a compute process within a replica.                                                                                                         |
+| `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.                                                                                                         |
+| `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.                                                                                                                             |
+| `disk_bytes`        | [`uint8`]    | Approximate disk usage in bytes, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
 
 ### `mz_cluster_replica_sizes`
 
@@ -45,20 +45,20 @@ The `mz_cluster_replica_sizes` table contains a mapping of logical sizes
 (e.g. "xlarge") to physical sizes (number of processes, and CPU and memory allocations per process).
 
 {{< warning >}}
-The values in this table may change at any time, and users should not rely on
-them for any kind of capacity planning.
+The values in this table may change at any time. You should not rely on them for
+any kind of capacity planning.
 {{< /warning >}}
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_sizes -->
-| Field                  | Type        | Meaning                                                          |
-|------------------------|-------------|------------------------------------------------------------------|
-| `size`                 | [`text`]    | The human-readable replica size.                                 |
-| `processes`            | [`uint8`]   | The number of processes in the replica.                          |
-| `workers`              | [`uint8`]   | The number of Timely Dataflow workers per process.               |
-| `cpu_nano_cores`       | [`uint8`]   | The CPU allocation per process, in billionths of a vCPU core.    |
-| `memory_bytes`         | [`uint8`]   | The RAM allocation per process, in billionths of a vCPU core.    |
-| `disk_bytes`           | [`uint8`]   | The size of the attached disk, if there is one. `NULL` otherwise |
-| `credits_per_hour`     | [`numeric`] | The number of compute credits consumed per hour.                 |
+| Field                  | Type        | Meaning                                                                                                                                                      |
+|------------------------|-------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `size`                 | [`text`]    | The human-readable replica size.                                                                                                                             |
+| `processes`            | [`uint8`]   | The number of processes in the replica.                                                                                                                      |
+| `workers`              | [`uint8`]   | The number of Timely Dataflow workers per process.                                                                                                           |
+| `cpu_nano_cores`       | [`uint8`]   | The CPU allocation per process, in billionths of a vCPU core.                                                                                                |
+| `memory_bytes`         | [`uint8`]   | The RAM allocation per process, in billionths of a vCPU core.                                                                                                |
+| `disk_bytes`           | [`uint8`]   | The disk allocation per process, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
+| `credits_per_hour`     | [`numeric`] | The number of compute credits consumed per hour.                                                                                                             |
 
 ### `mz_cluster_links`
 
@@ -102,13 +102,13 @@ for all processes of all extant cluster replicas, as a percentage of the total r
 At this time, we do not make any guarantees about the exactness or freshness of these numbers.
 
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_utilization -->
-| Field            | Type                 | Meaning                                                                              |
-|------------------|----------------------|--------------------------------------------------------------------------------------|
-| `replica_id`     | [`text`]             | The ID of a cluster replica.                                                         |
-| `process_id`     | [`uint8`]            | An identifier of a compute process within a replica.                                 |
-| `cpu_percent`    | [`double precision`] | Approximate CPU usage, in percent of the total allocation.                           |
-| `memory_percent` | [`double precision`] | Approximate RAM usage, in percent of the total allocation.                           |
-| `disk_percent`   | [`double precision`] | Approximate disk usage in % of the attached disk, if there is one. `NULL` otherwise. |
+| Field            | Type                 | Meaning                                                                                                                                                                                |
+|------------------|----------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `replica_id`     | [`text`]             | The ID of a cluster replica.                                                                                                                                                           |
+| `process_id`     | [`uint8`]            | An identifier of a compute process within a replica.                                                                                                                                   |
+| `cpu_percent`    | [`double precision`] | Approximate CPU usage in percent of the total allocation.                                                                                                                              |
+| `memory_percent` | [`double precision`] | Approximate RAM usage in percent of the total allocation.                                                                                                                              |
+| `disk_percent`   | [`double precision`] | Approximate disk usage in percent of the total allocation, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
 
 ### `mz_cluster_replica_heartbeats`
 

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -6,3 +6,4 @@ Field                               | Value      | Description
 `INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
 `INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Indicates whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*
+`DISK`                              | `bool`     | **Private preview** Default: `false`. Whether to attach a disk to the cluster replicas. See [Disk-attached replicas](/sql/create-cluster-replica/#disk-attached-replicas) for details.

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -5,3 +5,4 @@ Field                               | Value      | Description
 `INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
 `INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*
+`DISK`                              | `bool`     | **Private preview** Default: `false`. Whether to attach a disk to the replica. See [Disk-attached replicas](/sql/create-cluster-replica/#disk-attached-replicas) for details.


### PR DESCRIPTION
Documenting the new feature (and marking it as private-preview)

### Motivation
docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
