### PR TITLE
persist-txn: pull a batch of work out of the integration branch

### DIFF
--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -46,7 +46,7 @@ pub struct Transactor {
     txns_id: ShardId,
     oracle: LocalOracle,
     client: PersistClient,
-    txns: TxnsHandle,
+    txns: TxnsHandle<Vec<u8>, (), u64, i64>,
     data_reads: BTreeMap<ShardId, (u64, ReadHandle<Vec<u8>, (), u64, i64>)>,
 }
 
@@ -54,7 +54,14 @@ impl Transactor {
     pub async fn new(client: PersistClient, txns_id: ShardId) -> Result<Self, MaelstromError> {
         let mut oracle = LocalOracle::new();
         let init_ts = oracle.write_ts();
-        let txns = TxnsHandle::open(init_ts, client.clone(), txns_id).await;
+        let txns = TxnsHandle::open(
+            init_ts,
+            client.clone(),
+            txns_id,
+            Arc::new(VecU8Schema),
+            Arc::new(UnitSchema),
+        )
+        .await;
         Ok(Transactor {
             txns_id,
             oracle,
@@ -98,7 +105,7 @@ impl Transactor {
             let mut txn = self.txns.begin();
             for (data_id, writes) in writes {
                 for (data, diff) in writes {
-                    txn.write(&data_id, data, diff).await;
+                    txn.write(&data_id, data, (), diff).await;
                 }
             }
             let mut write_ts = self.oracle.write_ts();
@@ -234,7 +241,7 @@ impl Transactor {
         data_ids: impl Iterator<Item = &ShardId>,
     ) -> BTreeMap<ShardId, Vec<(Vec<u8>, u64, i64)>> {
         // Ensure these reads don't block.
-        let () = self.txns.apply_le(read_ts).await;
+        let () = self.txns.apply_le(&read_ts).await;
 
         let mut reads = BTreeMap::new();
         for data_id in data_ids {

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -216,7 +216,17 @@ impl Transactor {
 
         let mut init_ts = self.oracle.write_ts();
         loop {
-            let res = self.txns.register(*data_id, init_ts).await;
+            let data_write = self
+                .client
+                .open_writer(
+                    *data_id,
+                    Arc::new(VecU8Schema),
+                    Arc::new(UnitSchema),
+                    Diagnostics::from_purpose("txn data"),
+                )
+                .await
+                .expect("data schema shouldn't change");
+            let res = self.txns.register(init_ts, data_write).await;
             match res {
                 Ok(()) => {
                     self.data_reads.insert(*data_id, (init_ts, data_read));

--- a/src/persist-txn/src/error.rs
+++ b/src/persist-txn/src/error.rs
@@ -13,9 +13,9 @@ use mz_persist_client::ShardId;
 
 /// The data shard was not registered.
 #[derive(Debug)]
-pub struct NotRegistered {
+pub struct NotRegistered<T> {
     /// The data shard that was not registered.
     pub data_id: ShardId,
     /// The exclusive txns shard time at which it was not registered.
-    pub ts: u64,
+    pub ts: T,
 }

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -214,6 +214,8 @@ mod tests {
     use mz_persist_client::PersistClient;
     use mz_persist_types::codec_impls::{UnitSchema, VecU8Schema};
 
+    use crate::tests::writer;
+
     use super::*;
 
     // Regression test for a bug caught during code review, where it was
@@ -232,7 +234,7 @@ mod tests {
         )
         .await;
         let d0 = ShardId::new();
-        txns.register(d0, 2).await.unwrap();
+        txns.register(2, writer(&client, d0).await).await.unwrap();
 
         let mut txn = txns.begin();
         txn.write(&d0, "foo".into(), (), 1).await;

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -12,20 +12,30 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use mz_persist_client::ShardId;
-use timely::progress::Antichain;
+use mz_persist_types::{Codec, Codec64};
+use timely::order::TotalOrder;
+use timely::progress::{Antichain, Timestamp};
 use tracing::debug;
 
 use crate::txns::{self, TxnsHandle};
+use crate::StepForward;
 
 /// An in-progress transaction.
 #[derive(Debug)]
-pub struct Txn {
-    writes: BTreeMap<ShardId, Vec<(Vec<u8>, i64)>>,
+pub struct Txn<K, V, D> {
+    writes: BTreeMap<ShardId, Vec<(K, V, D)>>,
 }
 
-impl Txn {
+impl<K, V, D> Txn<K, V, D>
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    D: Semigroup + Codec64 + Send + Sync,
+{
     pub(crate) fn new() -> Self {
         Txn {
             writes: BTreeMap::default(),
@@ -39,8 +49,11 @@ impl Txn {
     /// TODO(txn): Allow this to spill to s3 (for bounded memory) once persist
     /// can make the ts rewrite op efficient.
     #[allow(clippy::unused_async)]
-    pub async fn write(&mut self, data_id: &ShardId, data: Vec<u8>, diff: i64) {
-        self.writes.entry(*data_id).or_default().push((data, diff))
+    pub async fn write(&mut self, data_id: &ShardId, key: K, val: V, diff: D) {
+        self.writes
+            .entry(*data_id)
+            .or_default()
+            .push((key, val, diff))
     }
 
     /// Commit this transaction at `commit_ts`.
@@ -56,17 +69,20 @@ impl Txn {
     /// correctness nor liveness require this followup be done.
     ///
     /// Panics if any involved data shards were not registered before commit ts.
-    pub async fn commit_at(
+    pub async fn commit_at<T>(
         &self,
-        handle: &mut TxnsHandle,
-        commit_ts: u64,
-    ) -> Result<TxnApply, u64> {
+        handle: &mut TxnsHandle<K, V, T, D>,
+        commit_ts: T,
+    ) -> Result<TxnApply<T>, T>
+    where
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    {
         // TODO(txn): Use ownership to disallow a double commit.
         let mut txns_upper = txns::recent_upper(&mut handle.txns_write).await;
 
         // Validate that the involved data shards are all registered. txns_upper
         // only advances in the loop below, so we only have to check this once.
-        let () = handle.txns_cache.update_ge(txns_upper).await;
+        let () = handle.txns_cache.update_ge(&txns_upper).await;
         for (data_id, _) in self.writes.iter() {
             let registered_before_commit_ts = handle
                 .txns_cache
@@ -74,7 +90,7 @@ impl Txn {
                 .map_or(false, |x| x < commit_ts);
             assert!(
                 registered_before_commit_ts,
-                "{} should be registered before commit at {}",
+                "{} should be registered before commit at {:?}",
                 data_id, commit_ts
             );
         }
@@ -85,14 +101,17 @@ impl Txn {
             // that, then it's no longer possible to write and the caller needs
             // to decide what to do.
             if commit_ts < txns_upper {
-                debug!("commit_at {} mismatch current={}", commit_ts, txns_upper);
+                debug!(
+                    "commit_at {:?} mismatch current={:?}",
+                    commit_ts, txns_upper
+                );
                 return Err(txns_upper);
             }
             debug!(
-                "commit_at {}: [{}, {}) begin",
+                "commit_at {:?}: [{:?}, {:?}) begin",
                 commit_ts,
                 txns_upper,
-                commit_ts + 1
+                commit_ts.step_forward(),
             );
 
             let mut txn_batches = Vec::new();
@@ -100,12 +119,12 @@ impl Txn {
             for (data_id, updates) in self.writes.iter() {
                 let data_write = handle.datas.get_write(data_id).await;
                 // TODO(txn): Tighter lower bound?
-                let mut batch = data_write.builder(Antichain::from_elem(0));
-                for (k, d) in updates.iter() {
-                    batch.add(k, &(), &commit_ts, d).await.expect("valid usage");
+                let mut batch = data_write.builder(Antichain::from_elem(T::minimum()));
+                for (k, v, d) in updates.iter() {
+                    batch.add(k, v, &commit_ts, d).await.expect("valid usage");
                 }
                 let batch = batch
-                    .finish(Antichain::from_elem(commit_ts + 1))
+                    .finish(Antichain::from_elem(commit_ts.step_forward()))
                     .await
                     .expect("valid usage");
                 let batch = batch.into_transmittable_batch();
@@ -124,23 +143,23 @@ impl Txn {
 
             let txns_updates = txns_updates
                 .iter()
-                .map(|(k, v)| ((k, v), commit_ts, 1))
+                .map(|(k, v)| ((k, v), &commit_ts, 1))
                 .collect::<Vec<_>>();
             let res = crate::small_caa(
                 || "txns commit",
                 &mut handle.txns_write,
                 &txns_updates,
-                txns_upper,
-                commit_ts + 1,
+                txns_upper.clone(),
+                commit_ts.step_forward(),
             )
             .await;
             match res {
                 Ok(()) => {
                     debug!(
-                        "commit_at {}: [{}, {}) success",
+                        "commit_at {:?}: [{:?}, {:?}) success",
                         commit_ts,
                         txns_upper,
-                        commit_ts + 1
+                        commit_ts.step_forward(),
                     );
                     // The batch we wrote at commit_ts did commit. Mark it as
                     // such to avoid a WARN in the logs.
@@ -170,21 +189,30 @@ impl Txn {
 /// A token representing the asynchronous "apply" work expected to be promptly
 /// performed by a txn committer.
 #[derive(Debug)]
-pub struct TxnApply {
-    pub(crate) commit_ts: u64,
+pub struct TxnApply<T> {
+    pub(crate) commit_ts: T,
 }
 
-impl TxnApply {
+impl<T> TxnApply<T> {
     /// Applies the txn, unblocking reads at timestamp it was committed at.
-    pub async fn apply(self, handle: &mut TxnsHandle) {
-        debug!("txn apply {}", self.commit_ts);
-        handle.apply_le(self.commit_ts).await
+    pub async fn apply<K, V, D>(self, handle: &mut TxnsHandle<K, V, T, D>)
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+        D: Semigroup + Codec64 + Send + Sync,
+    {
+        debug!("txn apply {:?}", self.commit_ts);
+        handle.apply_le(&self.commit_ts).await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use mz_persist_client::PersistClient;
+    use mz_persist_types::codec_impls::{UnitSchema, VecU8Schema};
 
     use super::*;
 
@@ -195,12 +223,19 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn commit_unregistered_table() {
         let client = PersistClient::new_for_tests().await;
-        let mut txns = TxnsHandle::open(0, client.clone(), ShardId::new()).await;
+        let mut txns = TxnsHandle::<Vec<u8>, (), u64, i64>::open(
+            0,
+            client.clone(),
+            ShardId::new(),
+            Arc::new(VecU8Schema),
+            Arc::new(UnitSchema),
+        )
+        .await;
         let d0 = ShardId::new();
         txns.register(d0, 2).await.unwrap();
 
         let mut txn = txns.begin();
-        txn.write(&d0, "foo".into(), 1).await;
+        txn.write(&d0, "foo".into(), (), 1).await;
         // This panics because the commit ts is before the register ts.
         let _ = txn.commit_at(&mut txns, 1).await;
     }

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -16,8 +16,8 @@ use std::sync::Arc;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use mz_persist_client::write::WriteHandle;
-use mz_persist_client::{Diagnostics, PersistClient, ShardId};
-use mz_persist_types::codec_impls::{StringSchema, TodoSchema};
+use mz_persist_client::{Diagnostics, PersistClient, ShardId, ShardIdSchema};
+use mz_persist_types::codec_impls::StringSchema;
 use mz_persist_types::{Codec, Codec64};
 use timely::order::TotalOrder;
 use timely::progress::Timestamp;
@@ -132,7 +132,7 @@ where
         let (mut txns_write, txns_read) = client
             .open(
                 txns_id,
-                Arc::new(TodoSchema::<ShardId>::default()),
+                Arc::new(ShardIdSchema),
                 Arc::new(StringSchema),
                 Diagnostics {
                     shard_name: "txns".to_owned(),


### PR DESCRIPTION
This is a few mechanical changes that I've pulled out of my WIP branch to integrate persist-txn with the rest of mz and get it passing CI. See individual commits for details.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Only look at the last 3 commits, the first few are 20954.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
