### PR TITLE
adapter,compute: make ReplicaId an enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,6 +3673,7 @@ dependencies = [
  "itertools",
  "mz-ore",
  "mz-proto",
+ "mz-stash",
  "once_cell",
  "prometheus",
  "proptest",

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -153,7 +153,7 @@ is instantiated once per `pytest` invocation
 ```
 from materialize.cloudtest.util.wait import wait
 
-wait(condition="condition=Ready", resource="pod/compute-cluster-1-replica-1-0")
+wait(condition="condition=Ready", resource="pod/compute-cluster-u1-replica-u1-0")
 ```
 
 `wait` uses `kubectl wait` behind the scenes. Here is what the `kubectl wait`

--- a/doc/developer/guide-tokio-console.md
+++ b/doc/developer/guide-tokio-console.md
@@ -25,9 +25,9 @@ different processes, e.g.:
 
 ```text
 environmentd: [...]  INFO mz_ore::tracing: starting tokio console on http://127.0.0.1:6669
-compute-cluster-u1-replica-1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]3ee9
-compute-cluster-s1-replica-2: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]f5b6
-compute-cluster-s2-replica-3: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]7af2
+compute-cluster-u1-replica-u1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]3ee9
+compute-cluster-s1-replica-s1: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]f5b6
+compute-cluster-s2-replica-s2: [...]  INFO mz_ore::tracing: starting tokio console on /var/folders/30/[...]7af2
 ```
 
 Then, in a different tmux pane/terminal, run the `tokio-console` command with the listen address of

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -130,7 +130,7 @@ each replica, including the times at which it was created and dropped
 <!-- RELATION_SPEC mz_internal.mz_cluster_replica_history -->
 | Field                 | Type                         | Meaning                                                                                                                                   |
 |-----------------------|------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------|
-| `internal_replica_id` | [`text`]                     | An internal identifier of a cluster replica. Guaranteed to be unique, but not guaranteed to correspond to any user-facing replica ID.     |
+| `replica_id`          | [`text`]                     | The ID of a cluster replica.                                                                                                              |
 | `size`                | [`text`]                     | The size of the cluster replica. Corresponds to [`mz_cluster_replica_sizes.size`](#mz_cluster_replica_sizes).                             |
 | `cluster_name`        | [`text`]                     | The name of the cluster associated with the replica.                                                                                      |
 | `replica_name`        | [`text`]                     | The name of the replica.                                                                                                                  |

--- a/misc/python/materialize/checks/replica.py
+++ b/misc/python/materialize/checks/replica.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.util import MzVersion
 
 
 class CreateReplica(Check):
@@ -46,7 +47,36 @@ class CreateReplica(Check):
                 123
                 > SELECT * FROM create_replica_view;
                 123
-           """
+
+                # Confirm that all replica_ids have been migrated to the uXXX/sXXX format
+                > SELECT COUNT(*)
+                  FROM mz_cluster_replicas
+                  WHERE id NOT LIKE 's%'
+                  AND id NOT LIKE 'u%';
+                0
+
+                # Confirm that there are CREATE events for all replicas with new-format IDs
+                # resultset should not contain any NULLs
+                > SELECT DISTINCT event_type
+                  FROM mz_cluster_replicas
+                  LEFT JOIN mz_audit_events ON (
+                    mz_cluster_replicas.id = mz_audit_events.details->>'replica_id'
+                    AND mz_audit_events.event_type = 'create'
+                  )
+                  WHERE mz_cluster_replicas.id LIKE 'u%';
+                create
+                """
+                + """
+                # Confirm that there are DROP events for replicas with old-format IDs
+                > SELECT COUNT(*) >= 2 FROM mz_audit_events
+                  WHERE object_type = 'cluster-replica'
+                  AND event_type = 'drop'
+                  AND details->>'replica_id' NOT LIKE 's%'
+                  AND details->>'replica_id' NOT LIKE 'u%';
+                true
+                """
+                if self.base_version < MzVersion.parse("0.66.0-dev")
+                else ""
             )
         )
 

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -122,7 +122,7 @@ class MaterializeApplication(Application):
         self.wait_create_completed()
 
     def wait_create_completed(self) -> None:
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
     def acquire_images(self) -> None:
         repo = mzbuild.Repository(
@@ -149,9 +149,9 @@ class MaterializeApplication(Application):
         # NOTE[btv] - This will need to change if the order of
         # creating clusters/replicas changes, but it seemed fine to
         # assume this order, since we already assume it in `create`.
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-2-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-3-0")
+        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-s1-0")
+        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-s2-0")
 
     def wait_for_sql(self) -> None:
         """Wait until environmentd pod is ready and can accept SQL connections"""

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -122,7 +122,11 @@ class MaterializeApplication(Application):
         self.wait_create_completed()
 
     def wait_create_completed(self) -> None:
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+        wait(
+            condition="condition=Ready",
+            resource="pod",
+            label="cluster.environmentd.materialize.cloud/cluster-id=u1",
+        )
 
     def acquire_images(self) -> None:
         repo = mzbuild.Repository(
@@ -149,9 +153,12 @@ class MaterializeApplication(Application):
         # NOTE[btv] - This will need to change if the order of
         # creating clusters/replicas changes, but it seemed fine to
         # assume this order, since we already assume it in `create`.
-        wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s1-replica-s1-0")
-        wait(condition="condition=Ready", resource="pod/cluster-s2-replica-s2-0")
+        for cluster_id in ("u1", "s1", "s2"):
+            wait(
+                condition="condition=Ready",
+                resource="pod",
+                label=f"cluster.environmentd.materialize.cloud/cluster-id={cluster_id}",
+            )
 
     def wait_for_sql(self) -> None:
         """Wait until environmentd pod is ready and can accept SQL connections"""

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4825,8 +4825,8 @@ impl Catalog {
         self.storage().await.allocate_user_cluster_id().await
     }
 
-    pub async fn allocate_replica_id(&self) -> Result<ReplicaId, Error> {
-        self.storage().await.allocate_replica_id().await
+    pub async fn allocate_user_replica_id(&self) -> Result<ReplicaId, Error> {
+        self.storage().await.allocate_user_replica_id().await
     }
 
     pub fn allocate_oid(&mut self) -> Result<u32, Error> {
@@ -4840,14 +4840,14 @@ impl Catalog {
         self.storage().await.get_all_persisted_timestamps().await
     }
 
-    /// Get the next user ID without allocating it.
-    pub async fn get_next_user_global_id(&self) -> Result<GlobalId, Error> {
-        self.storage().await.get_next_user_global_id().await
+    /// Get the next system replica id without allocating it.
+    pub async fn get_next_system_replica_id(&self) -> Result<u64, Error> {
+        self.storage().await.get_next_system_replica_id().await
     }
 
-    /// Get the next replica id without allocating it.
-    pub async fn get_next_replica_id(&self) -> Result<ReplicaId, Error> {
-        self.storage().await.get_next_replica_id().await
+    /// Get the next user replica id without allocating it.
+    pub async fn get_next_user_replica_id(&self) -> Result<u64, Error> {
+        self.storage().await.get_next_user_replica_id().await
     }
 
     /// Persist new global timestamp for a timeline to disk.
@@ -8882,7 +8882,7 @@ mod tests {
     use std::iter;
 
     use itertools::Itertools;
-    use mz_controller::clusters::ClusterId;
+    use mz_controller::clusters::{ClusterId, ReplicaId};
     use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
     use mz_ore::collections::CollectionExt;
     use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
@@ -10003,7 +10003,10 @@ mod tests {
 
         assert_eq!(
             mz_sql::catalog::ObjectType::ClusterReplica,
-            catalog.get_object_type(&ObjectId::ClusterReplica((ClusterId::User(1), 1)))
+            catalog.get_object_type(&ObjectId::ClusterReplica((
+                ClusterId::User(1),
+                ReplicaId::User(1),
+            )))
         );
         assert_eq!(
             mz_sql::catalog::ObjectType::Role,
@@ -10025,7 +10028,7 @@ mod tests {
             None,
             catalog.get_privileges(&SystemObjectId::Object(ObjectId::ClusterReplica((
                 ClusterId::User(1),
-                1
+                ReplicaId::User(1),
             ))))
         );
         assert_eq!(

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -4417,7 +4417,7 @@ pub const MZ_CLUSTER_REPLICA_HISTORY: BuiltinView = BuiltinView {
                 WHERE object_type = 'cluster-replica' AND event_type = 'drop'
             )
         SELECT
-            creates.replica_id AS internal_replica_id,
+            creates.replica_id,
             creates.size,
             creates.cluster_name,
             creates.replica_name,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -12,7 +12,6 @@ use std::net::Ipv4Addr;
 use bytesize::ByteSize;
 use chrono::{DateTime, Utc};
 use mz_audit_log::{EventDetails, EventType, ObjectType, VersionedEvent, VersionedStorageUsage};
-use mz_compute_client::controller::NewReplicaId;
 use mz_controller::clusters::{
     ClusterId, ClusterStatus, ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ProcessId,
     ReplicaAllocation, ReplicaId, ReplicaLocation,
@@ -255,9 +254,6 @@ impl CatalogState {
             _ => (None, None, None),
         };
 
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let id = NewReplicaId::User(id);
-
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
@@ -305,9 +301,6 @@ impl CatalogState {
             ClusterStatus::NotReady(None) => None,
             ClusterStatus::NotReady(Some(NotReadyReason::OomKilled)) => Some("oom-killed"),
         };
-
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let replica_id = NewReplicaId::User(replica_id);
 
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_STATUSES),
@@ -1134,9 +1127,6 @@ impl CatalogState {
         last_heartbeat: DateTime<Utc>,
         diff: Diff,
     ) -> BuiltinTableUpdate {
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let id = NewReplicaId::User(id);
-
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
             row: Row::pack_slice(&[
@@ -1178,9 +1168,6 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let id = self.resolve_builtin_table(&MZ_CLUSTER_REPLICA_METRICS);
-
-        // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-        let replica_id = NewReplicaId::User(replica_id);
 
         let rows = updates.iter().enumerate().map(
             |(

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -71,7 +71,8 @@ const SCHEMA_ID_ALLOC_KEY: &str = "schema";
 const USER_ROLE_ID_ALLOC_KEY: &str = "user_role";
 const USER_CLUSTER_ID_ALLOC_KEY: &str = "user_compute";
 const SYSTEM_CLUSTER_ID_ALLOC_KEY: &str = "system_compute";
-const REPLICA_ID_ALLOC_KEY: &str = "replica";
+const USER_REPLICA_ID_ALLOC_KEY: &str = "replica";
+const SYSTEM_REPLICA_ID_ALLOC_KEY: &str = "system_replica";
 pub(crate) const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
 pub(crate) const STORAGE_USAGE_ID_ALLOC_KEY: &str = "storage_usage";
 
@@ -140,7 +141,8 @@ fn add_new_builtin_cluster_replicas_migration(
         if matches!(replica_names, None)
             || matches!(replica_names, Some(names) if !names.contains(builtin_replica.name))
         {
-            let replica_id = txn.get_and_increment_id(REPLICA_ID_ALLOC_KEY.to_string())?;
+            let replica_id = txn.get_and_increment_id(SYSTEM_REPLICA_ID_ALLOC_KEY.to_string())?;
+            let replica_id = ReplicaId::System(replica_id);
             let config = builtin_cluster_replica_config(bootstrap_args);
             txn.insert_cluster_replica(
                 *cluster_id,
@@ -758,19 +760,20 @@ impl Connection {
         Ok(ClusterId::User(id))
     }
 
-    pub async fn allocate_replica_id(&mut self) -> Result<ReplicaId, Error> {
-        let id = self.allocate_id(REPLICA_ID_ALLOC_KEY, 1).await?;
-        Ok(id.into_element())
+    pub async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, Error> {
+        let id = self.allocate_id(USER_REPLICA_ID_ALLOC_KEY, 1).await?;
+        let id = id.into_element();
+        Ok(ReplicaId::User(id))
     }
 
-    /// Get the next user id without allocating it.
-    pub async fn get_next_user_global_id(&mut self) -> Result<GlobalId, Error> {
-        self.get_next_id("user").await.map(GlobalId::User)
+    /// Get the next system replica id without allocating it.
+    pub async fn get_next_system_replica_id(&mut self) -> Result<u64, Error> {
+        self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await
     }
 
-    /// Get the next replica id without allocating it.
-    pub async fn get_next_replica_id(&mut self) -> Result<ReplicaId, Error> {
-        self.get_next_id(REPLICA_ID_ALLOC_KEY).await
+    /// Get the next user replica id without allocating it.
+    pub async fn get_next_user_replica_id(&mut self) -> Result<u64, Error> {
+        self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
 
     async fn get_next_id(&mut self, id_type: &str) -> Result<u64, Error> {

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -213,16 +213,13 @@ impl RustType<proto::ClusterIntrospectionSourceIndexValue>
 impl RustType<proto::ClusterReplicaKey> for ClusterReplicaKey {
     fn into_proto(&self) -> proto::ClusterReplicaKey {
         proto::ClusterReplicaKey {
-            id: Some(proto::ReplicaId { value: self.id }),
+            id: Some(self.id.into_proto()),
         }
     }
 
     fn from_proto(proto: proto::ClusterReplicaKey) -> Result<Self, TryFromProtoError> {
         Ok(ClusterReplicaKey {
-            id: proto
-                .id
-                .map(|id| id.value)
-                .ok_or_else(|| TryFromProtoError::missing_field("ClusterReplicaKey::id"))?,
+            id: proto.id.into_rust_if_some("ClusterReplicaKey::id")?,
         })
     }
 }

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 
 use itertools::max;
+use mz_compute_client::controller::ReplicaId;
 use mz_controller::clusters::ClusterId;
 use mz_ore::now::EpochMillis;
 use mz_proto::ProtoType;
@@ -28,9 +29,9 @@ use crate::catalog::object_type_to_audit_object_type;
 use crate::catalog::storage::{
     BootstrapArgs, DefaultPrivilegesKey, DefaultPrivilegesValue, RoleMembership,
     SystemPrivilegesKey, SystemPrivilegesValue, AUDIT_LOG_ID_ALLOC_KEY, DATABASE_ID_ALLOC_KEY,
-    MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, REPLICA_ID_ALLOC_KEY, SCHEMA_ID_ALLOC_KEY,
-    STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY, USER_CLUSTER_ID_ALLOC_KEY,
-    USER_ROLE_ID_ALLOC_KEY,
+    MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY,
+    SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, USER_CLUSTER_ID_ALLOC_KEY,
+    USER_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
 };
 use crate::rbac;
 
@@ -93,8 +94,8 @@ const SYSTEM_ID_ALLOC_KEY: &str = "system";
 const DEFAULT_USER_CLUSTER_ID: ClusterId = ClusterId::User(1);
 const DEFAULT_USER_CLUSTER_NAME: &str = "default";
 
-const DEFAULT_REPLICA_ID: u64 = 1;
-const DEFAULT_REPLICA_NAME: &str = "r1";
+const DEFAULT_USER_REPLICA_ID: ReplicaId = ReplicaId::User(1);
+const DEFAULT_SYSTEM_REPLICA_ID: ReplicaId = ReplicaId::System(1);
 
 const MATERIALIZE_DATABASE_ID_VAL: u64 = 1;
 const MATERIALIZE_DATABASE_ID: DatabaseId = DatabaseId::User(MATERIALIZE_DATABASE_ID_VAL);
@@ -600,12 +601,14 @@ pub async fn initialize(
             [(
                 proto::ClusterReplicaKey {
                     id: Some(proto::ReplicaId {
-                        value: DEFAULT_REPLICA_ID,
+                        value: Some(proto::replica_id::Value::User(
+                            DEFAULT_USER_REPLICA_ID.inner_id(),
+                        )),
                     }),
                 },
                 proto::ClusterReplicaValue {
                     cluster_id: Some(DEFAULT_USER_CLUSTER_ID.into_proto()),
-                    name: DEFAULT_REPLICA_NAME.to_string(),
+                    name: DEFAULT_USER_REPLICA_ID.to_string(),
                     config: Some(default_replica_config(options)),
                     owner_id: Some(MZ_SYSTEM_ROLE_ID.into_proto()),
                 },
@@ -619,8 +622,8 @@ pub async fn initialize(
             proto::audit_log_event_v1::CreateClusterReplicaV1 {
                 cluster_id: DEFAULT_USER_CLUSTER_ID.to_string(),
                 cluser_name: DEFAULT_USER_CLUSTER_NAME.to_string(),
-                replica_name: DEFAULT_REPLICA_NAME.to_string(),
-                replica_id: Some(DEFAULT_REPLICA_ID.to_string().into()),
+                replica_name: DEFAULT_USER_REPLICA_ID.to_string(),
+                replica_id: Some(DEFAULT_USER_REPLICA_ID.to_string().into()),
                 logical_size: options.default_cluster_replica_size.to_string(),
                 disk: false,
             },
@@ -771,10 +774,18 @@ pub async fn initialize(
                 ),
                 (
                     proto::IdAllocKey {
-                        name: REPLICA_ID_ALLOC_KEY.to_string(),
+                        name: USER_REPLICA_ID_ALLOC_KEY.to_string(),
                     },
                     proto::IdAllocValue {
-                        next_id: DEFAULT_REPLICA_ID + 1,
+                        next_id: DEFAULT_USER_REPLICA_ID.inner_id() + 1,
+                    },
+                ),
+                (
+                    proto::IdAllocKey {
+                        name: SYSTEM_REPLICA_ID_ALLOC_KEY.to_string(),
+                    },
+                    proto::IdAllocValue {
+                        next_id: DEFAULT_SYSTEM_REPLICA_ID.inner_id() + 1,
                     },
                 ),
                 (

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -2022,7 +2022,10 @@ pub async fn serve(
                     .await?;
                 coord
                     .controller
-                    .remove_orphaned_replicas(coord.catalog().get_next_replica_id().await?)
+                    .remove_orphaned_replicas(
+                        coord.catalog().get_next_user_replica_id().await?,
+                        coord.catalog().get_next_system_replica_id().await?,
+                    )
                     .await
                     .map_err(AdapterError::Orchestrator)?;
                 Ok(())

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -133,7 +133,7 @@ impl Coordinator {
         )?;
 
         for replica_name in (0..replication_factor).map(managed_cluster_replica_name) {
-            let id = self.catalog_mut().allocate_replica_id().await?;
+            let id = self.catalog_mut().allocate_user_replica_id().await?;
             self.create_managed_cluster_replica_op(
                 cluster_id,
                 id,
@@ -322,7 +322,7 @@ impl Coordinator {
 
             ops.push(catalog::Op::CreateClusterReplica {
                 cluster_id: id,
-                id: self.catalog_mut().allocate_replica_id().await?,
+                id: self.catalog_mut().allocate_user_replica_id().await?,
                 name: replica_name.clone(),
                 config,
                 owner_id: *session.current_role_id(),
@@ -447,7 +447,7 @@ impl Coordinator {
             },
         };
 
-        let id = self.catalog_mut().allocate_replica_id().await?;
+        let id = self.catalog_mut().allocate_user_replica_id().await?;
         // Replicas have the same owner as their cluster.
         let owner_id = self.catalog().get_cluster(cluster_id).owner_id();
         let op = catalog::Op::CreateClusterReplica {
@@ -731,7 +731,7 @@ impl Coordinator {
                 }
             }
             for name in (0..*new_replication_factor).map(managed_cluster_replica_name) {
-                let id = self.catalog_mut().allocate_replica_id().await?;
+                let id = self.catalog_mut().allocate_user_replica_id().await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,
@@ -763,7 +763,7 @@ impl Coordinator {
             for name in
                 (*replication_factor..*new_replication_factor).map(managed_cluster_replica_name)
             {
-                let id = self.catalog_mut().allocate_replica_id().await?;
+                let id = self.catalog_mut().allocate_user_replica_id().await?;
                 self.create_managed_cluster_replica_op(
                     cluster_id,
                     id,

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -105,7 +105,7 @@ impl Coordinator {
         };
         ops.push(catalog::Op::CreateClusterReplica {
             cluster_id,
-            id: self.catalog().allocate_replica_id().await?,
+            id: self.catalog().allocate_user_replica_id().await?,
             name: LINKED_CLUSTER_REPLICA_NAME.into(),
             config: ReplicaConfig {
                 location,

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -15,6 +15,7 @@ http = "0.2.8"
 itertools = "0.10.5"
 mz-ore = { path = "../ore", features = ["tracing_"] }
 mz-proto = { path = "../proto" }
+mz-stash = { path = "../stash" }
 once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}

--- a/src/cluster-client/src/lib.rs
+++ b/src/cluster-client/src/lib.rs
@@ -78,11 +78,69 @@
 #![warn(missing_docs)]
 
 use std::fmt;
+use std::str::FromStr;
+
+use anyhow::bail;
+use serde::{Deserialize, Serialize};
 
 pub mod client;
 
 /// Identifier of a replica.
-pub type ReplicaId = u64;
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+pub enum ReplicaId {
+    /// A user replica.
+    User(u64),
+    /// A system replica.
+    System(u64),
+}
+
+impl ReplicaId {
+    /// Return the inner numeric ID value.
+    pub fn inner_id(&self) -> u64 {
+        match self {
+            ReplicaId::User(id) => *id,
+            ReplicaId::System(id) => *id,
+        }
+    }
+
+    /// Whether this value identifies a user replica.
+    pub fn is_user(&self) -> bool {
+        matches!(self, Self::User(_))
+    }
+
+    /// Whether this value identifies a system replica.
+    pub fn is_system(&self) -> bool {
+        matches!(self, Self::System(_))
+    }
+}
+
+impl fmt::Display for ReplicaId {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::User(id) => write!(f, "u{}", id),
+            Self::System(id) => write!(f, "s{}", id),
+        }
+    }
+}
+
+impl FromStr for ReplicaId {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let first = s.chars().next();
+        let rest = s.get(1..);
+        if let (Some(prefix), Some(num)) = (first, rest) {
+            let id = num.parse()?;
+            match prefix {
+                'u' => return Ok(Self::User(id)),
+                's' => return Ok(Self::System(id)),
+                _ => (),
+            }
+        }
+
+        bail!("invalid replica ID: {}", s);
+    }
+}
 
 /// Identifier of a replica.
 // TODO(#18377): Replace `ReplicaId` with this type.

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -29,7 +29,7 @@
 //! from compacting beyond the allowed compaction of each of its outputs, ensuring that we can
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroI64;
 use std::time::Duration;
 
@@ -74,10 +74,6 @@ pub type ComputeInstanceId = StorageInstanceId;
 
 /// Identifier of a replica.
 pub type ReplicaId = mz_cluster_client::ReplicaId;
-
-/// Identifier of a replica.
-// TODO(#18377): Replace `ReplicaId` with this type.
-pub type NewReplicaId = mz_cluster_client::NewReplicaId;
 
 /// Responses from the compute controller.
 #[derive(Debug)]

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -29,7 +29,7 @@
 //! from compacting beyond the allowed compaction of each of its outputs, ensuring that we can
 //! recover each dataflow to its current state in case of failure or other reconfiguration.
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::num::NonZeroI64;
 use std::time::Duration;
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -418,7 +418,8 @@ where
     /// Remove orphaned replicas.
     pub async fn remove_orphaned_replicas(
         &mut self,
-        next_replica_id: ReplicaId,
+        next_user_replica_id: u64,
+        next_system_replica_id: u64,
     ) -> Result<(), anyhow::Error> {
         let desired: BTreeSet<_> = self.metrics_tasks.keys().copied().collect();
 
@@ -431,15 +432,20 @@ where
             .collect::<Result<_, _>>()?;
 
         for (cluster_id, replica_id) in actual {
-            if replica_id >= next_replica_id {
+            let smaller_next = match replica_id {
+                ReplicaId::User(id) if id >= next_user_replica_id => {
+                    Some(ReplicaId::User(next_user_replica_id))
+                }
+                ReplicaId::System(id) if id >= next_system_replica_id => {
+                    Some(ReplicaId::System(next_system_replica_id))
+                }
+                _ => None,
+            };
+            if let Some(next) = smaller_next {
                 // Found a replica in kubernetes with a higher replica ID than
                 // what we are aware of. This must have been created by an
                 // environmentd with higher epoch number.
-                halt!(
-                    "found replica id ({}) in orchestrator >= next id ({})",
-                    replica_id,
-                    next_replica_id
-                );
+                halt!("found replica ID ({replica_id}) in orchestrator >= next ID ({next})");
             }
 
             if !desired.contains(&replica_id) {
@@ -652,7 +658,7 @@ fn parse_replica_service_name(
     service_name: &str,
 ) -> Result<(ComputeInstanceId, ReplicaId), anyhow::Error> {
     static SERVICE_NAME_RE: Lazy<Regex> =
-        Lazy::new(|| Regex::new(r"(?-u)^([us]\d+)-replica-(\d+)$").unwrap());
+        Lazy::new(|| Regex::new(r"(?-u)^([us]\d+)-replica-([us]\d+)$").unwrap());
 
     let caps = SERVICE_NAME_RE
         .captures(service_name)

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1688,7 +1688,7 @@ impl<'a> Fold<Raw, Aug> for NameResolver<'a> {
                             // The ID is arbitrary here; we just need some dummy
                             // value to return.
                             cluster_id: ClusterId::System(0),
-                            replica_id: 0,
+                            replica_id: ReplicaId::System(0),
                         })
                     }
                 }

--- a/src/stash/build.rs
+++ b/src/stash/build.rs
@@ -205,6 +205,7 @@ fn main() -> anyhow::Result<()> {
         .enum_attribute("DatabaseId.value", ATTR)
         .enum_attribute("SchemaId.value", ATTR)
         .enum_attribute("RoleId.value", ATTR)
+        .enum_attribute("ReplicaId.value", ATTR)
         .enum_attribute("ReplicaConfig.location", ATTR)
         .enum_attribute("AuditLogEventV1.details", ATTR)
         .enum_attribute("AuditLogKey.event", ATTR)

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "caeba871ee4c70243741bb5efa474b9e"
+    "md5": "f7d98ebfafc35c8704434e6b338a9ac1"
   },
   {
     "name": "objects_v25.proto",
@@ -38,5 +38,9 @@
   {
     "name": "objects_v33.proto",
     "md5": "b5f70889965589369efc18ec36e8cbd8"
+  },
+  {
+    "name": "objects_v34.proto",
+    "md5": "e99c9e18fd5c1d998f8cb89360cf8f53"
   }
 ]

--- a/src/stash/protos/objects.proto
+++ b/src/stash/protos/objects.proto
@@ -264,7 +264,10 @@ message SchemaId {
 }
 
 message ReplicaId {
-    uint64 value = 1;
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
 }
 
 message ReplicaLogging {

--- a/src/stash/protos/objects_v34.proto
+++ b/src/stash/protos/objects_v34.proto
@@ -1,0 +1,598 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+        bool disk = 6;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        optional string availability_zone = 2;
+        bool disk = 4;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+}
+
+message SystemPrivilegesValue {
+    AclMode acl_mode = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+        OBJECT_TYPE_SYSTEM = 16;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluser_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+        bool disk = 6;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message AlterSetClusterV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_cluster = 3;
+        StringWrapper new_cluster = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message UpdatePrivilegeV1 {
+        string object_id = 1;
+        string grantee_id = 2;
+        string grantor_id = 3;
+        string privileges = 4;
+    }
+
+    message AlterDefaultPrivilegeV1 {
+        string role_id = 1;
+        StringWrapper database_id = 2;
+        StringWrapper schema_id = 3;
+        string grantee_id= 4;
+        string privileges = 5;
+    }
+
+    message UpdateOwnerV1 {
+        string object_id = 1;
+        string old_owner_id = 2;
+        string new_owner_id = 3;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    message UpdateItemV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 27
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        AlterSetClusterV1 alter_set_cluster_v1 = 25;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        UpdatePrivilegeV1 update_privilege_v1 = 22;
+        AlterDefaultPrivilegeV1 alter_default_privilege_v1 = 23;
+        UpdateOwnerV1 update_owner_v1 = 24;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+        UpdateItemV1 update_item_v1 = 26;
+    }
+}

--- a/src/stash/protos/objects_v34.proto
+++ b/src/stash/protos/objects_v34.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v34;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -107,7 +107,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 33;
+pub const STASH_VERSION: u64 = 34;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -182,7 +182,7 @@ impl From<String> for proto::StringWrapper {
 /// You should not implement this yourself, instead use the `wire_compatible!` macro.
 pub unsafe trait WireCompatible<T: prost::Message>: prost::Message + Default {
     /// Converts the type `T` into `Self` by serializing `T` and deserializing as `Self`.
-    fn convert(old: T) -> Self {
+    fn convert(old: &T) -> Self {
         let bytes = old.encode_to_vec();
         // Note: use Bytes to enable possible re-use of the underlying buffer.
         let bytes = Bytes::from(bytes);

--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -190,6 +190,8 @@ pub unsafe trait WireCompatible<T: prost::Message>: prost::Message + Default {
     }
 }
 
+unsafe impl WireCompatible<()> for () {}
+
 /// Defines one protobuf type as wire compatible with another.
 ///
 /// ```text

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -916,6 +916,7 @@ impl Stash {
                             30 => upgrade::v30_to_v31::upgrade(),
                             31 => upgrade::v31_to_v32::upgrade(&mut tx).await?,
                             32 => upgrade::v32_to_v33::upgrade(&mut tx).await?,
+                            33 => upgrade::v33_to_v34::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -54,6 +54,7 @@ pub(crate) mod v29_to_v30;
 pub(crate) mod v30_to_v31;
 pub(crate) mod v31_to_v32;
 pub(crate) mod v32_to_v33;
+pub(crate) mod v33_to_v34;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -1,0 +1,171 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use crate::objects::wire_compatible;
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod objects_v32 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v32.rs"));
+}
+
+pub mod objects_v33 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v33.rs"));
+}
+
+wire_compatible!(objects_v32::RoleKey with objects_v33::RoleKey);
+wire_compatible!(objects_v32::RoleValue with objects_v33::RoleValue);
+
+const MZ_INTROSPECTION_ROLE_ID: objects_v33::RoleId = objects_v33::RoleId {
+    value: Some(objects_v33::role_id::Value::System(2)),
+};
+
+/// Rename mz_introspection to mz_support
+pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    const ROLES_COLLECTION: TypedCollection<objects_v32::RoleKey, objects_v32::RoleValue> =
+        TypedCollection::new("role");
+
+    let old_role_key = objects_v33::RoleKey {
+        id: Some(MZ_INTROSPECTION_ROLE_ID),
+    };
+
+    ROLES_COLLECTION
+        .migrate_compat::<objects_v33::RoleKey, objects_v33::RoleValue>(tx, |entries| {
+            let mut updates = Vec::new();
+            for (key, value) in entries {
+                let new_value = if key == &old_role_key {
+                    objects_v33::RoleValue {
+                        name: "mz_support".to_string(),
+                        ..value.clone()
+                    }
+                } else {
+                    value.clone()
+                };
+                updates.push(MigrationAction::Update(
+                    key.clone(),
+                    (key.clone(), new_value),
+                ));
+            }
+            updates
+        })
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use itertools::Itertools;
+
+    use super::upgrade;
+
+    use crate::upgrade::v32_to_v33::{objects_v32, objects_v33, MZ_INTROSPECTION_ROLE_ID};
+    use crate::{DebugStashFactory, TypedCollection};
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test() {
+        let factory: DebugStashFactory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        let roles_v32: TypedCollection<objects_v32::RoleKey, objects_v32::RoleValue> =
+            TypedCollection::new("role");
+
+        let system_role_id_v32 = objects_v32::RoleId {
+            value: Some(objects_v32::role_id::Value::System(1)),
+        };
+        let introspection_role_id_v32 = objects_v32::RoleId {
+            value: Some(objects_v32::role_id::Value::System(2)),
+        };
+
+        roles_v32
+            .insert_without_overwrite(
+                &mut stash,
+                vec![
+                    (
+                        objects_v32::RoleKey {
+                            id: Some(system_role_id_v32),
+                        },
+                        objects_v32::RoleValue {
+                            name: "mz_system".to_string(),
+                            attributes: Some(objects_v32::RoleAttributes { inherit: true }),
+                            membership: Some(objects_v32::RoleMembership {
+                                map: Default::default(),
+                            }),
+                        },
+                    ),
+                    (
+                        objects_v32::RoleKey {
+                            id: Some(introspection_role_id_v32),
+                        },
+                        objects_v32::RoleValue {
+                            name: "mz_introspection".to_string(),
+                            attributes: Some(objects_v32::RoleAttributes { inherit: true }),
+                            membership: Some(objects_v32::RoleMembership {
+                                map: Default::default(),
+                            }),
+                        },
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Run our migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .expect("migration failed");
+
+        let roles_v33: TypedCollection<objects_v33::RoleKey, objects_v33::RoleValue> =
+            TypedCollection::new("role");
+        let roles = roles_v33.iter(&mut stash).await.unwrap();
+
+        let system_role_id_v33 = objects_v33::RoleId {
+            value: Some(objects_v33::role_id::Value::System(1)),
+        };
+        let mut roles = roles
+            .into_iter()
+            .map(|((key, value), _timestamp, _diff)| (key, value))
+            .collect_vec();
+        roles.sort();
+        assert_eq!(
+            roles,
+            vec![
+                (
+                    objects_v33::RoleKey {
+                        id: Some(system_role_id_v33),
+                    },
+                    objects_v33::RoleValue {
+                        name: "mz_system".to_string(),
+                        attributes: Some(objects_v33::RoleAttributes { inherit: true }),
+                        membership: Some(objects_v33::RoleMembership {
+                            map: Default::default(),
+                        }),
+                    },
+                ),
+                (
+                    objects_v33::RoleKey {
+                        id: Some(MZ_INTROSPECTION_ROLE_ID),
+                    },
+                    objects_v33::RoleValue {
+                        name: "mz_support".to_string(),
+                        attributes: Some(objects_v33::RoleAttributes { inherit: true }),
+                        membership: Some(objects_v33::RoleMembership {
+                            map: Default::default(),
+                        }),
+                    },
+                )
+            ]
+        );
+    }
+}

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -10,6 +10,7 @@
 use crate::objects::{wire_compatible, WireCompatible};
 use crate::upgrade::MigrationAction;
 use crate::{StashError, Transaction, TypedCollection};
+use std::collections::BTreeMap;
 
 pub mod objects_v33 {
     include!(concat!(env!("OUT_DIR"), "/objects_v33.rs"));
@@ -22,9 +23,12 @@ pub mod objects_v34 {
 wire_compatible!(objects_v33::ClusterReplicaValue with objects_v34::ClusterReplicaValue);
 wire_compatible!(objects_v33::IdAllocKey with objects_v34::IdAllocKey);
 wire_compatible!(objects_v33::IdAllocValue with objects_v34::IdAllocValue);
+wire_compatible!(objects_v33::AuditLogKey with objects_v34::AuditLogKey);
 
 /// Rename mz_introspection to mz_support
 pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
+    let now = mz_ore::now::SYSTEM_TIME();
+
     pub const CLUSTER_REPLICA_COLLECTION: TypedCollection<
         objects_v33::ClusterReplicaKey,
         objects_v33::ClusterReplicaValue,
@@ -34,6 +38,9 @@ pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
         objects_v33::IdAllocKey,
         objects_v33::IdAllocValue,
     > = TypedCollection::new("id_alloc");
+
+    pub const AUDIT_LOG_COLLECTION: TypedCollection<objects_v33::AuditLogKey, ()> =
+        TypedCollection::new("audit_log");
 
     CLUSTER_REPLICA_COLLECTION
         .migrate_to::<_, objects_v34::ClusterReplicaValue>(tx, |entries| {
@@ -57,7 +64,9 @@ pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
                             value: Some(objects_v33::cluster_id::Value::System(cluster_id)),
                         }),
                     ) => objects_v34::replica_id::Value::System(*cluster_id),
-                    _ => panic!("Incorrect cluster replica data in stash {key:?} -> {value:?}"),
+                    _ => {
+                        panic!("Incorrect cluster replica data in stash {key:?} -> {value:?}")
+                    }
                 };
                 let new_key = objects_v34::ReplicaId {
                     value: Some(new_key),
@@ -89,7 +98,157 @@ pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {
             }
             updates
         })
-        .await
+        .await?;
+
+    // We need to allocate additional audit events, which need IDs. Gather the current next_id.
+    const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
+    let audit_log_id_alloc_key = objects_v33::IdAllocKey {
+        name: AUDIT_LOG_ID_ALLOC_KEY.to_string(),
+    };
+    let mut next_audit_log_id = if let Some(value) = tx
+        .peek_key_one(
+            ID_ALLOCATOR_COLLECTION.from_tx(tx).await?,
+            &objects_v33::IdAllocKey {
+                name: AUDIT_LOG_ID_ALLOC_KEY.to_string(),
+            },
+        )
+        .await?
+    {
+        value.next_id
+    } else {
+        return Err("Absent value for auditlog ID allocator".into());
+    };
+
+    let mut live_replicas = BTreeMap::new();
+    for ((key, ()), _time, _diff) in tx.iter(AUDIT_LOG_COLLECTION.from_tx(tx).await?).await? {
+        let (event_type, details) =
+            if let Some(objects_v33::audit_log_key::Event::V1(objects_v33::AuditLogEventV1 {
+                details: Some(details),
+                event_type,
+                ..
+            })) = key.event
+            {
+                (event_type, details)
+            } else {
+                continue;
+            };
+
+        match &details {
+            objects_v33::audit_log_event_v1::Details::CreateClusterReplicaV1(event) => {
+                assert_eq!(
+                    event_type,
+                    objects_v33::audit_log_event_v1::EventType::Create as i32,
+                );
+                let key = (event.cluster_id.clone(), event.replica_id.clone());
+                let prev = live_replicas.insert(key, event.clone());
+                assert_eq!(prev, None, "replica created twice");
+            }
+            objects_v33::audit_log_event_v1::Details::DropClusterReplicaV1(event) => {
+                assert_eq!(
+                    event_type,
+                    objects_v33::audit_log_event_v1::EventType::Drop as i32,
+                );
+                let key = (event.cluster_id.clone(), event.replica_id.clone());
+                let prev = live_replicas.remove(&key);
+                assert!(prev.is_some(), "non-existing replica dropped");
+            }
+            _ => continue,
+        };
+    }
+
+    let mut updates = Vec::with_capacity(live_replicas.len() * 2);
+    for (_, details) in live_replicas {
+        let old_id = details.replica_id.expect("live replicas have IDs");
+        let Ok(numeric_id) = old_id.inner.parse::<u64>() else {
+            continue;  // replica_id is already in the new format
+        };
+
+        // We should only see user clusters in the audit log, but there is no harm in
+        // handling system clusters too, just to be sure.
+        assert_eq!(
+            details.cluster_id.chars().nth(0),
+            Some('u'),
+            "Can only migrate user clusters in audit log"
+        );
+        let new_id = format!("u{numeric_id}");
+
+        let drop_event = objects_v34::AuditLogEventV1 {
+            id: next_audit_log_id,
+            event_type: objects_v34::audit_log_event_v1::EventType::Drop as i32,
+            object_type: objects_v34::audit_log_event_v1::ObjectType::ClusterReplica as i32,
+            details: Some(
+                objects_v34::audit_log_event_v1::Details::DropClusterReplicaV1(
+                    objects_v34::audit_log_event_v1::DropClusterReplicaV1 {
+                        cluster_id: details.cluster_id.clone(),
+                        cluster_name: details.cluser_name.clone(),
+                        replica_id: Some(objects_v34::StringWrapper {
+                            inner: old_id.inner,
+                        }),
+                        replica_name: details.replica_name.clone(),
+                    },
+                ),
+            ),
+            user: None,
+            occurred_at: Some(objects_v34::EpochMillis { millis: now }),
+        };
+        let create_event = objects_v34::AuditLogEventV1 {
+            id: next_audit_log_id + 1,
+            event_type: objects_v34::audit_log_event_v1::EventType::Create as i32,
+            object_type: objects_v34::audit_log_event_v1::ObjectType::ClusterReplica as i32,
+            details: Some(
+                objects_v34::audit_log_event_v1::Details::CreateClusterReplicaV1(
+                    objects_v34::audit_log_event_v1::CreateClusterReplicaV1 {
+                        cluster_id: details.cluster_id,
+                        cluser_name: details.cluser_name,
+                        replica_id: Some(objects_v34::StringWrapper { inner: new_id }),
+                        replica_name: details.replica_name,
+                        logical_size: details.logical_size,
+                        disk: details.disk,
+                    },
+                ),
+            ),
+            user: None,
+            occurred_at: Some(objects_v34::EpochMillis { millis: now }),
+        };
+
+        updates.push(MigrationAction::Insert(
+            objects_v34::AuditLogKey {
+                event: Some(objects_v34::audit_log_key::Event::V1(drop_event)),
+            },
+            (),
+        ));
+        updates.push(MigrationAction::Insert(
+            objects_v34::AuditLogKey {
+                event: Some(objects_v34::audit_log_key::Event::V1(create_event)),
+            },
+            (),
+        ));
+        next_audit_log_id += 2;
+    }
+
+    AUDIT_LOG_COLLECTION
+        .migrate_compat::<objects_v34::AuditLogKey, ()>(tx, |_entries| updates)
+        .await?;
+
+    let key = objects_v34::IdAllocKey {
+        name: AUDIT_LOG_ID_ALLOC_KEY.to_string(),
+    };
+
+    ID_ALLOCATOR_COLLECTION
+        .migrate_compat(tx, |_| {
+            vec![MigrationAction::Update(
+                key.clone(),
+                (
+                    key,
+                    objects_v34::IdAllocValue {
+                        next_id: next_audit_log_id,
+                    },
+                ),
+            )]
+        })
+        .await?;
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -33,7 +33,7 @@ use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
 use mz_build_info::BuildInfo;
 use mz_cluster_client::client::ClusterReplicaLocation;
-use mz_cluster_client::{NewReplicaId, ReplicaId};
+use mz_cluster_client::ReplicaId;
 use mz_ore::collections::HashSet;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
@@ -2517,10 +2517,7 @@ where
             };
             let object_id = object_id.to_string();
             let object_datum = Datum::String(&object_id);
-            let replica_id = replica_id.map(|id| {
-                // TODO(#18377): Make replica IDs `NewReplicaId`s throughout the code.
-                NewReplicaId::User(id).to_string()
-            });
+            let replica_id = replica_id.as_ref().map(ToString::to_string);
             let replica_datum = replica_id.as_deref().map_or(Datum::Null, Datum::String);
 
             let row = Row::pack_slice(&[object_datum, replica_datum, time_datum]);

--- a/test/cloudtest/test_crash.py
+++ b/test/cloudtest/test_crash.py
@@ -113,8 +113,8 @@ def test_crash_environmentd(mz: MaterializeApplication) -> None:
 
     def get_replica() -> Tuple[V1Pod, V1StatefulSet]:
         """Find the stateful set for the replica of the default cluster"""
-        compute_pod_name = "cluster-u1-replica-1-0"
-        ss_name = "cluster-u1-replica-1"
+        compute_pod_name = "cluster-u1-replica-u1-0"
+        ss_name = "cluster-u1-replica-u1"
         compute_pod = mz.environmentd.api().read_namespaced_pod(
             compute_pod_name, mz.environmentd.namespace()
         )

--- a/test/cloudtest/test_smoke.py
+++ b/test/cloudtest/test_smoke.py
@@ -14,7 +14,7 @@ from materialize.cloudtest.util.wait import wait
 
 
 def test_wait(mz: MaterializeApplication) -> None:
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
 
 def test_sql(mz: MaterializeApplication) -> None:

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -56,7 +56,11 @@ def test_upgrade(
         log_filter=log_filter,
         release_mode=(not dev),
     )
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
+    wait(
+        condition="condition=Ready",
+        resource="pod",
+        label="cluster.environmentd.materialize.cloud/cluster-id=u1",
+    )
 
     executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -56,7 +56,7 @@ def test_upgrade(
         log_filter=log_filter,
         release_mode=(not dev),
     )
-    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-1-0")
+    wait(condition="condition=Ready", resource="pod/cluster-u1-replica-u1-0")
 
     executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
     scenario = CloudtestUpgrade(checks=Check.__subclasses__(), executor=executor)

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
@@ -13,8 +13,16 @@
 # Test that the "disk" option on the linked cluster defaults to false
 > SELECT cluster, replica FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_upgrade_kafka_sink'
 materialize_public_upgrade_kafka_sink  linked
+
+# NOTE: Due to `migrate_replica_ids_in_audit_log`, we currently see additional
+# `drop` and `create` events for each replica that existed before the
+# migration. Those events don't have a user attached, so we can recognize them
+# and filter them out.
 > SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id'
   FROM mz_audit_events
-  WHERE details->>'name' = 'materialize_public_upgrade_kafka_sink' OR details->>'cluster_name' = 'materialize_public_upgrade_kafka_sink'
+  WHERE (
+    details->>'name' = 'materialize_public_upgrade_kafka_sink'
+    OR details->>'cluster_name' = 'materialize_public_upgrade_kafka_sink'
+  ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_upgrade_kafka_sink\"}"
 create  cluster-replica  "{\"cluster_name\":\"materialize_public_upgrade_kafka_sink\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
@@ -42,8 +42,16 @@ SELECT user FROM linked_cluster_audit_event_user ORDER BY priority DESC LIMIT 1
 # Test that the "disk" option on the linked cluster defaults to false
 > SELECT cluster, replica FROM (SHOW CLUSTER REPLICAS) WHERE cluster = 'materialize_public_kafka_source'
 materialize_public_kafka_source  linked
+
+# NOTE: Due to `migrate_replica_ids_in_audit_log`, we currently see additional
+# `drop` and `create` events for each replica that existed before the
+# migration. Those events don't have a user attached, so we can recognize them
+# and filter them out.
 > SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id', user
   FROM mz_audit_events
-  WHERE details->>'name' = 'materialize_public_kafka_source' OR details->>'cluster_name' = 'materialize_public_kafka_source'
+  WHERE (
+    details->>'name' = 'materialize_public_kafka_source'
+    OR details->>'cluster_name' = 'materialize_public_kafka_source'
+  ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_kafka_source\"}"  ${expected-user}
 create  cluster-replica  "{\"cluster_name\":\"materialize_public_kafka_source\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"  ${expected-user}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -91,7 +91,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 ----
 1  create  role  {"id":"u1","name":"materialize"}  NULL
 2  grant  cluster  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
-3 grant  database {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
+3  grant  database  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
 4  grant  schema  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
 5  grant  type  {"database_id":null,"grantee_id":"p","privileges":"U","role_id":"p","schema_id":null}  NULL
 6  create  database  {"id":"u1","name":"materialize"}  NULL
@@ -102,7 +102,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 11  create  cluster  {"id":"u1","name":"default"}  NULL
 12  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
 13  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
-14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"1","replica_name":"r1"}  NULL
+14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"u1","replica_name":"u1"}  NULL
 15  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 16  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 17  create  database  {"id":"u2","name":"test"}  materialize
@@ -116,7 +116,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  role  {"id":"u2","name":"foo"}  materialize
 26  drop  role  {"id":"u2","name":"foo"}  materialize
 27  create  cluster  {"id":"u2","name":"foo"}  materialize
-28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"4","replica_name":"r"}  materialize
+28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
 29  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
 30  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
 31  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
@@ -129,14 +129,14 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 38  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
 39  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
 40  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"5","replica_name":"linked"}  materialize
+41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
 42  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
-43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"5","replica_name":"linked"}  materialize
-44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"6","replica_name":"linked"}  materialize
+43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u3","replica_name":"linked"}  materialize
+44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
 45  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 46  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
 47  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
-48  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"6","replica_name":"linked"}  materialize
+48  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u4","replica_name":"linked"}  materialize
 49  drop  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
 50  create  source  {"database":"materialize","id":"u9","item":"accounts","schema":"public","size":null,"type":"subsource"}  materialize
 51  create  source  {"database":"materialize","id":"u10","item":"auctions","schema":"public","size":null,"type":"subsource"}  materialize
@@ -145,11 +145,11 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 54  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
 55  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
 56  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"7","replica_name":"linked"}  materialize
+57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
 58  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
-59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"4"}  materialize
+59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"u2"}  materialize
 60  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize
-61  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"4","replica_name":"s"}  materialize
+61  drop  cluster-replica  {"cluster_id":"u2","cluster_name":"bar","replica_id":"u2","replica_name":"s"}  materialize
 62  drop  cluster  {"id":"u2","name":"bar"}  materialize
 
 simple conn=mz_system,user=mz_system
@@ -181,11 +181,11 @@ false
 query TTTTBBBT
 SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
-1  default  r1  1  true  false  NULL  1
-4  foo  r  1  true  true  true  1
-5  materialize_public_s  linked  1  true  true  true  1
-6  materialize_public_s  linked  2  true  true  true  1
-7  materialize_public_multiplex  linked  1  true  false  NULL  1
+u1  default  u1  1  true  false  NULL  1
+u2  foo  r  1  true  true  true  1
+u3  materialize_public_s  linked  1  true  true  true  1
+u4  materialize_public_s  linked  2  true  true  true  1
+u5  materialize_public_multiplex  linked  1  true  false  NULL  1
 
 simple conn=mz_system,user=mz_system
 CREATE ROLE r1;

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -179,7 +179,7 @@ SELECT occurred_at::text = '1970-01-01 00:00:00.666+00' FROM mz_audit_events ORD
 false
 
 query TTTTBBBT
-SELECT internal_replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
+SELECT replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
 u1  default  u1  1  true  false  NULL  1
 u2  foo  r  1  true  true  true  1

--- a/test/sqllogictest/web-console.slt
+++ b/test/sqllogictest/web-console.slt
@@ -110,9 +110,9 @@ FROM mz_clusters c
 LEFT OUTER JOIN mz_cluster_replicas r ON c.id = r.cluster_id
 ORDER BY r.id
 ----
+s1 mz_system s1 r1 1
+s2 mz_introspection s2 r1 1
 u1 default u1 r1 1
-s1 mz_system u2 r1 1
-s2 mz_introspection u3 r1 1
 
 
 # ---- useClusterUtilization.ts


### PR DESCRIPTION
This commit converts the `ReplicaId` type from a plain `u64` into an
enum that has `User` and `System` variants. This brings replica IDs in
line with cluster IDs and makes it possible to differenciate between
user and system replicas based on their IDs.

There are no breaking changes to the system tables, since we already
changed the type of `mz_cluster_replicas.id` in a0714eb. The only
user-visible change is that replicas in system clusters now have `s*`
IDs instead of `u*` IDs.

The names of replica processes in the orchestrator have changed. We will
need to adjust for this in our testing and cloud infrastructure in.
Also, the durable catalog state requires a migration. Both of these
tasks are deferred to follow-up commits.

# Conflicts:
#	src/adapter/src/catalog.rs
#	src/adapter/src/catalog/builtin_table_updates.rs
#	src/adapter/src/catalog/storage.rs
#	src/adapter/src/coord/sequencer/inner.rs
#	src/cluster-client/src/lib.rs
#	src/compute-client/src/controller.rs
#	test/sqllogictest/audit_log.slt<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
