### PR TITLE
cloudtests: extract CloudtestApplicationBase

### DIFF
--- a/misc/python/materialize/cloudtest/app/application.py
+++ b/misc/python/materialize/cloudtest/app/application.py
@@ -25,7 +25,7 @@ class Application:
     def __init__(self) -> None:
         pass
 
-    def create(self) -> None:
+    def create_resources(self) -> None:
         self.acquire_images()
         for resource in self.resources:
             resource.create()

--- a/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
+++ b/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
@@ -1,0 +1,64 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import subprocess
+from typing import List, Optional
+
+from materialize import MZ_ROOT, mzbuild
+from materialize.cloudtest.app.application import Application
+from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
+
+
+class CloudtestApplicationBase(Application):
+    def __init__(
+        self,
+        release_mode: bool = True,
+        aws_region: Optional[str] = None,
+        log_filter: Optional[str] = None,
+    ) -> None:
+        super().__init__()
+        self.release_mode = release_mode
+        self.aws_region = aws_region
+        self.mz_root = MZ_ROOT
+
+        self.resources = self.get_resources(log_filter)
+        self.images = self.get_images()
+
+        self.create_resources()
+        self.wait_resource_creation_completed()
+
+    def get_resources(self, log_filter: Optional[str]) -> List[K8sResource]:
+        raise NotImplementedError
+
+    def get_images(self) -> List[str]:
+        raise NotImplementedError
+
+    def wait_resource_creation_completed(self) -> None:
+        raise NotImplementedError
+
+    def acquire_images(self) -> None:
+        repo = mzbuild.Repository(
+            self.mz_root, release_mode=self.release_mode, coverage=self.coverage_mode()
+        )
+        for image in self.images:
+            self._acquire_image(repo, image)
+
+    def _acquire_image(self, repo: mzbuild.Repository, image: str) -> None:
+        deps = repo.resolve_dependencies([repo.images[image]])
+        deps.acquire()
+        for dep in deps:
+            subprocess.check_call(
+                [
+                    "kind",
+                    "load",
+                    "docker-image",
+                    f"--name={self.cluster_name()}",
+                    dep.spec(),
+                ]
+            )

--- a/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
+++ b/misc/python/materialize/cloudtest/app/cloudtest_application_base.py
@@ -30,6 +30,7 @@ class CloudtestApplicationBase(Application):
         self.resources = self.get_resources(log_filter)
         self.images = self.get_images()
 
+    def create_resources_and_wait(self) -> None:
         self.create_resources()
         self.wait_resource_creation_completed()
 

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -48,13 +48,14 @@ class MaterializeApplication(CloudtestApplicationBase):
         self.environmentd = EnvironmentdService()
         self.materialized_alias = MaterializedAliasService()
         self.testdrive = Testdrive(release_mode=release_mode, aws_region=aws_region)
+        super().__init__(release_mode, aws_region, log_filter)
 
         # Register the VpcEndpoint CRD.
         self.register_vpc_endpoint()
 
         self.start_metrics_server()
 
-        super().__init__(release_mode, aws_region, log_filter)
+        self.create_resources_and_wait()
 
     def get_resources(self, log_filter: Optional[str]) -> List[K8sResource]:
         return [


### PR DESCRIPTION
This PR introduces a new base class `CloudtestApplicationBase` as base for `MaterializeApplication` and `CloudtestApplication`. `CloudtestApplicationBase` inherits the more generic class `Application`.

### Motivation
* We want to keep the base class `Application` generic and not add any kind-related stuff.
* `CloudtestApplication` currently inherits `MaterializeApplication` to re-use some of the logic but this is not logical and requires some hacks. This will be cleaned up with this PR.
* Since it will not be possible to 100% align cloudtests of both repos, both `MaterializeApplication` and `CloudtestApplication` will continue to exist.