### PR TITLE
Vectors only own allocation if capacity larger 0

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -219,11 +219,15 @@ pub trait ArrangementSize {
 /// Helper to compute the size of a vector in memory.
 ///
 /// The function only considers the immediate allocation of the vector, but is oblivious of any
-/// pointers to owned allocations.
+/// pointers to owned allocations. It only invokes the callback for allocations that exist, i.e.,
+/// calling [`vec_size`] on a vector with no capacity will not invoke `callback`.
 #[inline]
 fn vec_size<T>(data: &Vec<T>, mut callback: impl FnMut(usize, usize)) {
     let size_of_t = std::mem::size_of::<T>();
-    callback(data.len() * size_of_t, data.capacity() * size_of_t);
+    // A vector only owns an allocation if the capacity is > 0.
+    if data.capacity() > 0 {
+        callback(data.len() * size_of_t, data.capacity() * size_of_t);
+    }
 }
 
 /// Helper for [`ArrangementSize`] to install a common operator holding on to a trace.


### PR DESCRIPTION
Prior to this change, we were counting empty vectors as allocations for arrangement size logging. This is misleading as vectors without a capacity do not have a heap allocation, and as such should not report any allocation. This change fixes this by only calling the callback if the vector owns an allocation. This behavior is correct as the callback should be called for each owned allocation.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
