### PR TITLE
cloudtest: Migrate from psycopg2 to psycopg3

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -1,7 +1,7 @@
 # Packages required for Python developer tools.
 #
 # Please be thoughtful about adding dependencies. Packages with native
-# dependencies (e.g., psycopg2) tend to be troublesome unless they ship binary
+# dependencies tend to be troublesome unless they ship binary
 # wheels for a wide variety of platforms, including M1 Macs.
 
 black==22.12.0
@@ -38,7 +38,6 @@ prettytable==3.5.0
 psutil==5.9.4
 psycopg==3.1.10
 psycopg-binary==3.1.10
-psycopg2==2.9.6
 pydantic==1.10.4
 pyelftools==0.29
 pyjwt==2.8.0
@@ -57,7 +56,6 @@ types-Markdown==3.4.2.1
 types-pkg-resources==0.1.3
 types-prettytable==3.4.2.3
 types-psutil==5.9.5.10
-types-psycopg2==2.9.6
 types-PyMYSQL==1.0.19.1
 types-PyYAML==6.0.12.2
 types-requests==2.28.11.7

--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -9,8 +9,8 @@
 
 from typing import Any, List, Optional, Sequence
 
-import psycopg2
-from psycopg2.extensions import connection
+import psycopg
+from psycopg.connection import Connection
 
 from materialize.cloudtest.config.environment_config import EnvironmentConfig
 from materialize.cloudtest.util.common import eprint
@@ -19,29 +19,29 @@ from materialize.cloudtest.util.web_request import post
 
 
 def sql_query(
-    conn: connection,
+    conn: Connection,
     query: str,
     vars: Optional[Sequence[Any]] = None,
 ) -> List[List[Any]]:
     cur = conn.cursor()
-    cur.execute(query, vars)  # type: ignore
+    cur.execute(query, vars)
     return [list(row) for row in cur]
 
 
 def sql_execute(
-    conn: connection,
+    conn: Connection,
     query: str,
     vars: Optional[Sequence[Any]] = None,
 ) -> None:
     cur = conn.cursor()
-    cur.execute(query, vars)  # type: ignore[no-untyped-call]
+    cur.execute(query, vars)
 
 
-def pgwire_sql_conn(config: EnvironmentConfig) -> connection:
+def pgwire_sql_conn(config: EnvironmentConfig) -> Connection:
     environment = wait_for_environmentd(config)
     pgwire_url: str = environment["regionInfo"]["sqlAddress"]
     (pgwire_host, pgwire_port) = pgwire_url.split(":")
-    conn = psycopg2.connect(
+    conn = psycopg.connect(
         dbname="materialize",
         user=config.e2e_test_user_email,
         password=config.auth.app_password,

--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -9,7 +9,7 @@
 
 import unittest
 
-import psycopg2
+import psycopg2  # type: ignore
 import psycopg3  # type: ignore
 import sqlalchemy  # type: ignore
 from psycopg3.oids import builtins  # type: ignore


### PR DESCRIPTION
Remove all mentions of psycopg2 except in the test/lang/python tests

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

I am not sure how multiple generations of psycopg will play together, so lets not risk it.