### PR TITLE
adapter: various refactors to stop transiting sessions

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5106,11 +5106,16 @@ impl Catalog {
             .map(Op::DropObject)
             .collect()
     }
+
+    /// Drops schema for connection if it exists. Returns an error if it exists and has items.
+    /// Returns Ok if conn_id's temp schema does not exist.
     pub fn drop_temporary_schema(&mut self, conn_id: &ConnectionId) -> Result<(), Error> {
-        if !self.state.temporary_schemas[conn_id].items.is_empty() {
+        let Some(schema) = self.state.temporary_schemas.remove(conn_id) else {
+            return Ok(());
+        };
+        if !schema.items.is_empty() {
             return Err(Error::new(ErrorKind::SchemaNotEmpty(MZ_TEMP_SCHEMA.into())));
         }
-        self.state.temporary_schemas.remove(conn_id);
         Ok(())
     }
 

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -61,7 +61,7 @@ use crate::catalog::{
     Database, DefaultPrivilegeObject, Error, ErrorKind, Func, Index, MaterializedView, Sink,
     StorageSinkConnectionState, Type, View, SYSTEM_CONN_ID,
 };
-use crate::session::Session;
+use crate::coord::ConnMeta;
 use crate::subscribe::ActiveSubscribe;
 
 /// An update to a built-in table.
@@ -1264,13 +1264,13 @@ impl CatalogState {
         }
     }
 
-    pub fn pack_session_update(&self, session: &Session, diff: Diff) -> BuiltinTableUpdate {
-        let connect_dt = mz_ore::now::to_datetime(session.connect_time());
+    pub fn pack_session_update(&self, conn: &ConnMeta, diff: Diff) -> BuiltinTableUpdate {
+        let connect_dt = mz_ore::now::to_datetime(conn.connected_at());
         BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_SESSIONS),
             row: Row::pack_slice(&[
-                Datum::UInt32(session.conn_id().unhandled()),
-                Datum::String(&session.session_role_id().to_string()),
+                Datum::UInt32(conn.conn_id().unhandled()),
+                Datum::String(&conn.session_role_id().to_string()),
                 Datum::TimestampTz(connect_dt.try_into().expect("must fit")),
             ]),
             diff,

--- a/src/adapter/src/catalog/inner.rs
+++ b/src/adapter/src/catalog/inner.rs
@@ -25,7 +25,7 @@ use crate::catalog::{
     catalog_type_to_audit_object_type, BuiltinTableUpdate, Catalog, CatalogEntry, CatalogItem,
     CatalogState, DataSourceDesc, Error, ErrorKind, Index, MaterializedView, Sink, Source,
 };
-use crate::session::Session;
+use crate::coord::SessionMeta;
 use crate::AdapterError;
 
 impl Catalog {
@@ -37,7 +37,7 @@ impl Catalog {
         oracle_write_ts: Timestamp,
         drop_ids: &BTreeSet<GlobalId>,
         audit_events: &mut Vec<VersionedEvent>,
-        session: Option<&Session>,
+        session: Option<&impl SessionMeta>,
         id: GlobalId,
         cluster_id: ClusterId,
     ) -> Result<(), AdapterError> {

--- a/src/adapter/src/catalog/inner.rs
+++ b/src/adapter/src/catalog/inner.rs
@@ -25,7 +25,7 @@ use crate::catalog::{
     catalog_type_to_audit_object_type, BuiltinTableUpdate, Catalog, CatalogEntry, CatalogItem,
     CatalogState, DataSourceDesc, Error, ErrorKind, Index, MaterializedView, Sink, Source,
 };
-use crate::coord::SessionMeta;
+use crate::coord::ConnMeta;
 use crate::AdapterError;
 
 impl Catalog {
@@ -37,7 +37,7 @@ impl Catalog {
         oracle_write_ts: Timestamp,
         drop_ids: &BTreeSet<GlobalId>,
         audit_events: &mut Vec<VersionedEvent>,
-        session: Option<&impl SessionMeta>,
+        session: Option<&ConnMeta>,
         id: GlobalId,
         cluster_id: ClusterId,
     ) -> Result<(), AdapterError> {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -618,9 +618,10 @@ impl SessionClient {
 
     /// Terminates the client session.
     pub async fn terminate(&mut self) {
+        let conn_id = self.session().conn_id().clone();
         let res = self
-            .send(|tx, session| Command::Terminate {
-                session,
+            .send_without_session(|tx| Command::Terminate {
+                conn_id,
                 tx: Some(tx),
             })
             .await;
@@ -768,7 +769,10 @@ impl Drop for SessionClient {
             // We may not have a connection to the Coordinator if the session was
             // prematurely terminated, for example due to a timeout.
             if let Some(inner) = &self.inner {
-                inner.send(Command::Terminate { session, tx: None })
+                inner.send(Command::Terminate {
+                    conn_id: session.conn_id().clone(),
+                    tx: None,
+                })
             }
         }
     }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -133,8 +133,8 @@ pub enum Command {
     },
 
     Terminate {
-        session: Session,
-        tx: Option<oneshot::Sender<Response<()>>>,
+        conn_id: ConnectionId,
+        tx: Option<oneshot::Sender<Result<(), AdapterError>>>,
     },
 
     /// Performs any cleanup and logging actions necessary for
@@ -158,12 +158,12 @@ impl Command {
             | Command::DumpCatalog { session, .. }
             | Command::CopyRows { session, .. }
             | Command::GetSystemVars { session, .. }
-            | Command::SetSystemVars { session, .. }
-            | Command::Terminate { session, .. } => Some(session),
+            | Command::SetSystemVars { session, .. } => Some(session),
             Command::CancelRequest { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
             | Command::AppendWebhook { .. }
+            | Command::Terminate { .. }
             | Command::RetireExecute { .. } => None,
         }
     }
@@ -176,12 +176,12 @@ impl Command {
             | Command::DumpCatalog { session, .. }
             | Command::CopyRows { session, .. }
             | Command::GetSystemVars { session, .. }
-            | Command::SetSystemVars { session, .. }
-            | Command::Terminate { session, .. } => Some(session),
+            | Command::SetSystemVars { session, .. } => Some(session),
             Command::CancelRequest { .. }
             | Command::CatalogSnapshot { .. }
             | Command::PrivilegedCancelRequest { .. }
             | Command::AppendWebhook { .. }
+            | Command::Terminate { .. }
             | Command::RetireExecute { .. } => None,
         }
     }

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -27,7 +27,7 @@ impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_id = client.new_conn_id()?;
         let session = client.new_session(conn_id, SYSTEM_USER.clone());
-        let (session_client, _) = client.startup(session, vec![]).await?;
+        let session_client = client.startup(session, vec![]).await?;
         Ok(Self { session_client })
     }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -107,6 +107,7 @@ use mz_sql::ast::{CreateSubsourceStatement, Raw, Statement};
 use mz_sql::catalog::EnvironmentId;
 use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{CopyFormat, CreateConnectionPlan, Params, QueryWhen};
+use mz_sql::session::user::User;
 use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::controller::{
     CollectionDescription, CreateExportToken, DataSource, DataSourceOther, StorageError,
@@ -535,6 +536,34 @@ pub struct ConnMeta {
 
     /// The authenticated role of the session, set once at session connection.
     pub(crate) authenticated_role: RoleId,
+}
+
+/// Metadata about a session. This type is used to limit and enumerate coordinator access to session
+/// innards. It will be used in the future when Sessions are no longer transmitted between the
+/// Coordinator and Adapter.
+pub trait SessionMeta {
+    fn conn_id(&self) -> &ConnectionId;
+    fn user(&self) -> &User;
+    fn application_name(&self) -> &str;
+    fn current_role_id(&self) -> &RoleId;
+}
+
+impl SessionMeta for Session {
+    fn conn_id(&self) -> &ConnectionId {
+        self.conn_id()
+    }
+
+    fn user(&self) -> &User {
+        self.user()
+    }
+
+    fn application_name(&self) -> &str {
+        self.application_name()
+    }
+
+    fn current_role_id(&self) -> &RoleId {
+        self.current_role_id()
+    }
 }
 
 #[derive(Debug)]

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -901,7 +901,7 @@ impl Coordinator {
 
         self.clear_transaction(session);
 
-        self.drop_temp_items(session).await;
+        self.drop_temp_items(session.conn_id()).await;
         self.catalog_mut()
             .drop_temporary_schema(session.conn_id())
             .unwrap_or_terminate("unable to drop temporary schema");

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -682,12 +682,12 @@ impl Coordinator {
 
     /// Removes all temporary items created by the specified connection, though
     /// not the temporary schema itself.
-    pub(crate) async fn drop_temp_items(&mut self, session: &Session) {
-        let ops = self.catalog_mut().drop_temp_item_ops(session.conn_id());
+    pub(crate) async fn drop_temp_items(&mut self, conn_id: &ConnectionId) {
+        let ops = self.catalog_mut().drop_temp_item_ops(conn_id);
         if ops.is_empty() {
             return;
         }
-        self.catalog_transact(Some(session), ops)
+        self.catalog_transact_conn(Some(conn_id), ops)
             .await
             .expect("unable to drop temporary items for conn_id");
     }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -94,7 +94,7 @@ impl Coordinator {
     /// [`CatalogState`]: crate::catalog::CatalogState
     /// [`DataflowDesc`]: mz_compute_client::types::dataflows::DataflowDesc
     #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn catalog_transact_with<F, R>(
+    pub(crate) async fn catalog_transact_with<'a, F, R>(
         &mut self,
         conn_id: Option<&ConnectionId>,
         mut ops: Vec<catalog::Op>,
@@ -350,7 +350,7 @@ impl Coordinator {
             ..
         } = self;
         let catalog = Arc::make_mut(catalog);
-        let conn = conn_id.map(|id| active_conns.get(id).expect("must exist"));
+        let conn = conn_id.map(|id| active_conns.get(id).expect("connection must exist"));
         let TransactionResult {
             builtin_table_updates,
             audit_events,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -11,6 +11,7 @@
 //! and altering objects.
 
 use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
 use std::time::Duration;
 
 use fail::fail_point;
@@ -48,7 +49,7 @@ use crate::catalog::{
 use crate::client::ConnectionId;
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::{TimelineContext, TimelineState};
-use crate::coord::{Coordinator, ReplicaMetadata, SessionMeta};
+use crate::coord::{Coordinator, ReplicaMetadata};
 use crate::session::Session;
 use crate::telemetry::SegmentClientExt;
 use crate::util::{ComputeSinkId, ResultExt};
@@ -65,10 +66,21 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn catalog_transact(
         &mut self,
-        session: Option<&impl SessionMeta>,
+        session: Option<&Session>,
         ops: Vec<catalog::Op>,
     ) -> Result<(), AdapterError> {
-        self.catalog_transact_with(session, ops, |_| Ok(())).await
+        self.catalog_transact_with(session.map(|session| session.conn_id()), ops, |_| Ok(()))
+            .await
+    }
+
+    /// Same as [`Self::catalog_transact_with`] without a closure passed in.
+    #[tracing::instrument(level = "debug", skip_all)]
+    pub(crate) async fn catalog_transact_conn(
+        &mut self,
+        conn_id: Option<&ConnectionId>,
+        ops: Vec<catalog::Op>,
+    ) -> Result<(), AdapterError> {
+        self.catalog_transact_with(conn_id, ops, |_| Ok(())).await
     }
 
     /// Perform a catalog transaction. The closure is passed a [`CatalogTxn`]
@@ -84,7 +96,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn catalog_transact_with<F, R>(
         &mut self,
-        session: Option<&impl SessionMeta>,
+        conn_id: Option<&ConnectionId>,
         mut ops: Vec<catalog::Op>,
         f: F,
     ) -> Result<R, AdapterError>
@@ -319,12 +331,7 @@ impl Coordinator {
                 .map(catalog::Op::DropTimeline),
         );
 
-        self.validate_resource_limits(
-            &ops,
-            session
-                .map(|session| session.conn_id())
-                .unwrap_or(&SYSTEM_CONN_ID),
-        )?;
+        self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID))?;
 
         // This will produce timestamps that are guaranteed to increase on each
         // call, and also never be behind the system clock. If the system clock
@@ -336,13 +343,20 @@ impl Coordinator {
         // regress or pause for 10s.
         let oracle_write_ts = self.get_local_write_ts().await.timestamp;
 
-        let (catalog, controller) = self.catalog_and_controller_mut();
+        let Coordinator {
+            catalog,
+            controller,
+            active_conns,
+            ..
+        } = self;
+        let catalog = Arc::make_mut(catalog);
+        let conn = conn_id.map(|id| active_conns.get(id).expect("must exist"));
         let TransactionResult {
             builtin_table_updates,
             audit_events,
             result,
         } = catalog
-            .transact(oracle_write_ts, session, ops, |catalog| {
+            .transact(oracle_write_ts, conn, ops, |catalog| {
                 f(CatalogTxn {
                     dataflow_client: controller,
                     catalog,
@@ -474,9 +488,10 @@ impl Coordinator {
         }
         .await;
 
+        let conn = conn_id.and_then(|id| self.active_conns.get(id));
         if let (Some(segment_client), Some(user_metadata)) = (
             &self.segment_client,
-            session.and_then(|s| s.user().external_metadata.as_ref()),
+            conn.and_then(|s| s.user().external_metadata.as_ref()),
         ) {
             for VersionedEvent::V1(event) in audit_events {
                 let event_type = format!(
@@ -484,11 +499,9 @@ impl Coordinator {
                     event.object_type.as_title_case(),
                     event.event_type.as_title_case()
                 );
-                // Note: when there is no Session, that means something internal to
+                // Note: when there is no ConnMeta, that means something internal to
                 // environmentd initiated the transaction, hence the default name.
-                let application_name = session
-                    .map(|s| s.application_name())
-                    .unwrap_or("environmentd");
+                let application_name = conn.map(|s| s.application_name()).unwrap_or("environmentd");
                 segment_client.environment_track(
                     &self.catalog().config().environment_id,
                     application_name,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -48,7 +48,7 @@ use crate::catalog::{
 use crate::client::ConnectionId;
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::{TimelineContext, TimelineState};
-use crate::coord::{Coordinator, ReplicaMetadata};
+use crate::coord::{Coordinator, ReplicaMetadata, SessionMeta};
 use crate::session::Session;
 use crate::telemetry::SegmentClientExt;
 use crate::util::{ComputeSinkId, ResultExt};
@@ -65,7 +65,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn catalog_transact(
         &mut self,
-        session: Option<&Session>,
+        session: Option<&impl SessionMeta>,
         ops: Vec<catalog::Op>,
     ) -> Result<(), AdapterError> {
         self.catalog_transact_with(session, ops, |_| Ok(())).await
@@ -84,7 +84,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn catalog_transact_with<F, R>(
         &mut self,
-        session: Option<&Session>,
+        session: Option<&impl SessionMeta>,
         mut ops: Vec<catalog::Op>,
         f: F,
     ) -> Result<R, AdapterError>

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -34,6 +34,7 @@ use crate::coord::{
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
     SinkConnectionReady,
 };
+use crate::session::Session;
 use crate::util::{ComputeSinkId, ResultExt};
 use crate::{catalog, AdapterNotice, TimestampContext};
 
@@ -176,7 +177,7 @@ impl Coordinator {
             });
         }
 
-        if let Err(err) = self.catalog_transact(None, ops).await {
+        if let Err(err) = self.catalog_transact(None::<&Session>, ops).await {
             tracing::warn!("Failed to update storage metrics: {:?}", err);
         }
         self.schedule_storage_usage_collection();
@@ -620,7 +621,7 @@ impl Coordinator {
             let old_status = replica.status();
 
             self.catalog_transact(
-                None,
+                None::<&Session>,
                 vec![catalog::Op::UpdateClusterReplicaStatus {
                     event: event.clone(),
                 }],

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -337,7 +337,11 @@ impl Coordinator {
     }
 
     pub(super) async fn create_cluster(&mut self, cluster_id: ClusterId) {
-        let (catalog, controller) = self.catalog_and_controller_mut();
+        let Coordinator {
+            catalog,
+            controller,
+            ..
+        } = self;
         let cluster = catalog.get_cluster(cluster_id);
         let cluster_id = cluster.id;
         let introspection_source_ids: Vec<_> =

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -97,7 +97,7 @@ use crate::coord::{
     peek, Coordinator, CreateConnectionValidationReady, ExecuteContext, Message, PeekStage,
     PeekStageFinish, PeekStageOptimize, PeekStageTimestamp, PeekStageValidate, PendingRead,
     PendingReadTxn, PendingTxn, PendingTxnResponse, PlanValidity, RealTimeRecencyContext,
-    SinkConnectionReady, TargetCluster, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+    SessionMeta, SinkConnectionReady, TargetCluster, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
 };
 use crate::error::AdapterError;
 use crate::explain::optimizer_trace::OptimizerTrace;
@@ -492,10 +492,10 @@ impl Coordinator {
         }
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip(self, session))]
     pub(super) async fn sequence_create_role(
         &mut self,
-        session: &Session,
+        session: &impl SessionMeta,
         plan::CreateRolePlan { name, attributes }: plan::CreateRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let oid = self.catalog_mut().allocate_oid()?;
@@ -4910,7 +4910,7 @@ impl Coordinator {
 
     pub(super) async fn sequence_reassign_owned(
         &mut self,
-        session: &mut Session,
+        session: &Session,
         plan::ReassignOwnedPlan {
             old_roles,
             new_role,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -496,7 +496,7 @@ impl Coordinator {
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn sequence_create_role(
         &mut self,
-        conn_id: &ConnectionId,
+        conn_id: Option<&ConnectionId>,
         plan::CreateRolePlan { name, attributes }: plan::CreateRolePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let oid = self.catalog_mut().allocate_oid()?;
@@ -505,7 +505,7 @@ impl Coordinator {
             oid,
             attributes,
         };
-        self.catalog_transact_conn(Some(conn_id), vec![op])
+        self.catalog_transact_conn(conn_id, vec![op])
             .await
             .map(|_| ExecuteResponse::CreatedRole)
     }

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -22,7 +22,7 @@ use rand::SeedableRng;
 use rand::{distributions::Bernoulli, prelude::Distribution, thread_rng};
 use uuid::Uuid;
 
-use crate::coord::Coordinator;
+use crate::coord::{ConnMeta, Coordinator};
 use crate::session::Session;
 
 /// Metadata required for logging a prepared statement.
@@ -263,17 +263,14 @@ impl Coordinator {
     }
 
     /// Record a new connection event
-    pub fn begin_session_for_statement_logging(&mut self, session: &Session) {
+    pub fn begin_session_for_statement_logging(&mut self, session: &ConnMeta) {
         let id = session.uuid();
-        let connected_at = session.connect_time();
-        let application_name = session.application_name().to_owned();
         let session_role = session.session_role_id();
-        let authenticated_user = self.catalog.get_role(session_role).name.clone();
         let event = SessionHistoryEvent {
             id,
-            connected_at,
-            application_name,
-            authenticated_user,
+            connected_at: session.connected_at(),
+            application_name: session.application_name().to_owned(),
+            authenticated_user: self.catalog.get_role(session_role).name.clone(),
         };
         self.statement_logging.unlogged_sessions.insert(id, event);
     }

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -124,7 +124,7 @@ pub mod telemetry;
 pub use crate::client::{Client, Handle, SessionClient};
 pub use crate::command::{
     AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator, Canceled, ExecuteResponse,
-    ExecuteResponseKind, RowsFuture, StartupMessage, StartupResponse,
+    ExecuteResponseKind, RowsFuture, StartupResponse,
 };
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -135,9 +135,6 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
             }
         }
         Command::Startup { .. }
-        | Command::Declare { .. }
-        | Command::Prepare { .. }
-        | Command::VerifyPreparedStatement { .. }
         | Command::Execute { .. }
         | Command::Commit { .. }
         | Command::CancelRequest { .. }
@@ -147,6 +144,7 @@ pub fn check_command(catalog: &Catalog, cmd: &Command) -> Result<(), Unauthorize
         | Command::SetSystemVars { .. }
         | Command::AppendWebhook { .. }
         | Command::Terminate { .. }
+        | Command::CatalogSnapshot { .. }
         | Command::RetireExecute { .. } => Ok(()),
     }
 }

--- a/src/adapter/src/severity.rs
+++ b/src/adapter/src/severity.rs
@@ -151,6 +151,7 @@ impl Severity {
                 PlanNotice::ObjectDoesNotExist { .. } => Severity::Notice,
                 PlanNotice::UpsertSinkKeyNotEnforced { .. } => Severity::Warning,
             },
+            AdapterNotice::UnknownSessionDatabase(_) => Severity::Notice,
         }
     }
 }

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -85,7 +85,7 @@ impl<T: Transmittable + std::fmt::Debug> ClientTransmitter<T> {
         {
             self.internal_cmd_tx
                 .send(Message::Command(Command::Terminate {
-                    session: res.session,
+                    conn_id: res.session.conn_id().clone(),
                     tx: None,
                 }))
                 .expect("coordinator unexpectedly gone");

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -143,7 +143,7 @@ async fn datadriven() {
                             catalog
                                 .transact(
                                     mz_repr::Timestamp::MIN,
-                                    None,
+                                    None::<&Session>,
                                     vec![Op::CreateItem {
                                         id,
                                         oid,

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -143,7 +143,7 @@ async fn datadriven() {
                             catalog
                                 .transact(
                                     mz_repr::Timestamp::MIN,
-                                    None::<&Session>,
+                                    None,
                                     vec![Op::CreateItem {
                                         id,
                                         oid,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -473,7 +473,7 @@ impl AuthedClient {
                 set_setting_keys.push(key);
             }
         }
-        let (adapter_client, _) = adapter_client.startup(session, set_setting_keys).await?;
+        let adapter_client = adapter_client.startup(session, set_setting_keys).await?;
         Ok(AuthedClient {
             client: adapter_client,
             drop_connection,

--- a/src/pgwire/src/message.rs
+++ b/src/pgwire/src/message.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 
 use itertools::Itertools;
 use mz_adapter::session::TransactionCode;
-use mz_adapter::{AdapterError, AdapterNotice, Severity, StartupMessage};
+use mz_adapter::{AdapterError, AdapterNotice, Severity};
 use mz_repr::{ColumnName, RelationDesc};
 use postgres::error::SqlState;
 
@@ -316,17 +316,6 @@ impl ErrorResponse {
             message: notice.to_string(),
             detail: notice.detail(),
             hint: notice.hint(),
-            position: None,
-        }
-    }
-
-    pub fn from_startup_message(message: StartupMessage) -> ErrorResponse {
-        ErrorResponse {
-            severity: Severity::Notice,
-            code: SqlState::SUCCESSFUL_COMPLETION,
-            message: message.to_string(),
-            detail: message.detail(),
-            hint: message.hint(),
             position: None,
         }
     }

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -91,7 +91,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 ----
 1  create  role  {"id":"u1","name":"materialize"}  NULL
 2  grant  cluster  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
-3 grant  database {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
+3  grant  database  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
 4  grant  schema  {"database_id":null,"grantee_id":"s2","privileges":"U","role_id":"p","schema_id":null}  NULL
 5  grant  type  {"database_id":null,"grantee_id":"p","privileges":"U","role_id":"p","schema_id":null}  NULL
 6  create  database  {"id":"u1","name":"materialize"}  NULL
@@ -244,3 +244,15 @@ query ITTTT
 SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
 ----
 71  alter  table  {"new_owner_id":"u3","object_id":"Iu17","old_owner_id":"u1"}  mz_system
+
+# Test events for auto-created users, which have the username only in the event details, but not the user column.
+simple conn=c,user=new_user
+SELECT 1
+----
+1
+COMPLETE 1
+
+query ITTTT
+SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY id DESC LIMIT 1
+----
+72  create  role  {"id":"u4","name":"new_user"}  NULL


### PR DESCRIPTION
This is work related to [a milestone 1.1](https://www.notion.so/materialize/Use-case-Isolation-Milestone-1-72db9064b01b43fdafd0a807a28c7342) (note: that document may list outdated priorities, but that's nevertheless what this work is for). The specific goal here was to begin the ability to have an RPC layer between coord and adapter.

This PR contains commits that remove direct dependencies on sessions in the coordinator. It also changes various adapter commands so they no longer send sessions. This is needed because an RPC layer cannot transfer Sessions as they contain various non-network safe data, and would be preventively large and slow to transfer for all messages.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

    * Recommend to review each commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
