### PR TITLE
mz: add retry to the disable command

### DIFF
--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -85,16 +85,26 @@ pub async fn disable(cx: RegionContext) -> Result<(), Error> {
     let loading_spinner = cx
         .output_formatter()
         .loading_spinner("Retrieving information...");
-    let cloud_provider = cx.get_cloud_provider().await?;
 
-    loading_spinner.set_message("Disabling region...");
-    cx.cloud_client()
-        .delete_region(cloud_provider.clone())
-        .await?;
+    // The `delete_region` method retries disabling a region,
+    // has an inner timeout, and manages a `504` response.
+    // For any other type of error response, we handle it here
+    // with a retry loop.
+    Retry::default()
+        .max_duration(Duration::from_secs(360))
+        .clamp_backoff(Duration::from_secs(1))
+        .retry_async(|_| async {
+            let cloud_provider = cx.get_cloud_provider().await?;
 
-    loading_spinner.finish_with_message("Region disabled.");
+            loading_spinner.set_message("Disabling region...");
+            cx.cloud_client()
+                .delete_region(cloud_provider.clone())
+                .await?;
 
-    Ok(())
+            loading_spinner.finish_with_message("Region disabled.");
+            Ok(())
+        })
+        .await
 }
 
 /// Lists all the available regions and their status.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This pull request (PR) adds the `Retry` feature to the `disable region` command, similar to the `enable region` command. 
The underlying `delete_region` method in the `cloud-client` already contains a loop for handling region disablement. However, it may fail in the case of an unknown error, such as the [502 error occurring here.](https://materializeinc.slack.com/archives/CL68GT3AT/p1692341105058849)
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
