### PR TITLE
Remove unused clusterd shutdown code

### DIFF
--- a/src/compute/src/arrangement/manager.rs
+++ b/src/compute/src/arrangement/manager.rs
@@ -95,11 +95,6 @@ impl TraceManager {
     pub fn del_trace(&mut self, id: &GlobalId) -> bool {
         self.traces.remove(id).is_some()
     }
-
-    /// Removes all managed traces.
-    pub fn del_all_traces(&mut self) {
-        self.traces.clear();
-    }
 }
 
 /// Bundles together traces for the successful computations (`oks`), the

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -408,23 +408,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         self.compute_state.compute_logger = Some(logger);
     }
 
-    /// Disables timely dataflow logging.
-    ///
-    /// This does not unpublish views and is only useful to terminate logging streams to ensure that
-    /// clusterd can terminate cleanly.
-    pub fn shutdown_logging(&mut self) {
-        self.timely_worker.log_register().remove("timely");
-        self.timely_worker
-            .log_register()
-            .remove("timely/reachability");
-        self.timely_worker
-            .log_register()
-            .remove("differential/arrange");
-        self.timely_worker
-            .log_register()
-            .remove("materialize/compute");
-    }
-
     /// Send progress information to the coordinator.
     pub fn report_compute_frontiers(&mut self) {
         let mut new_uppers = Vec::new();

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -399,14 +399,6 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         }
     }
 
-    #[allow(dead_code)]
-    fn shut_down(&mut self, response_tx: &mut ResponseSender) {
-        if let Some(mut compute_state) = self.activate_compute(response_tx) {
-            compute_state.compute_state.traces.del_all_traces();
-            compute_state.shutdown_logging();
-        }
-    }
-
     fn handle_command(&mut self, response_tx: &mut ResponseSender, cmd: ComputeCommand) {
         match &cmd {
             ComputeCommand::CreateInstance(_) => {


### PR DESCRIPTION
Clusterd shutdown happens through terminating the process, there is no alternative (clean) shutdown path. This is to ensure that we don't rely on shutdowns to maintain state.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
