### PR TITLE
persist: fix build failure

### DIFF
--- a/src/persist-client/src/internal/encoding.rs
+++ b/src/persist-client/src/internal/encoding.rs
@@ -49,7 +49,6 @@ use crate::internal::state_diff::{
 use crate::internal::trace::Trace;
 use crate::read::LeasedReaderId;
 use crate::stats::PartStats;
-use crate::write::WriterEnrichedHollowBatch;
 use crate::{PersistConfig, ShardId, WriterId};
 
 #[derive(Debug)]
@@ -1153,43 +1152,6 @@ impl<T: Timestamp + Codec64> RustType<ProtoU64Antichain> for Antichain<T> {
             .map(|x| T::decode(x.to_le_bytes()))
             .collect::<Vec<_>>();
         Ok(Antichain::from(elements))
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct SerdeWriterEnrichedHollowBatch {
-    pub(crate) shard_id: ShardId,
-    pub(crate) version: Version,
-    pub(crate) batch: Vec<u8>,
-}
-
-impl<T: Timestamp + Codec64> From<WriterEnrichedHollowBatch<T>> for SerdeWriterEnrichedHollowBatch {
-    fn from(x: WriterEnrichedHollowBatch<T>) -> Self {
-        SerdeWriterEnrichedHollowBatch {
-            shard_id: x.shard_id,
-            version: x.version,
-            batch: x.batch.into_proto().encode_to_vec(),
-        }
-    }
-}
-
-impl<T: Timestamp + Codec64> From<SerdeWriterEnrichedHollowBatch> for WriterEnrichedHollowBatch<T> {
-    fn from(x: SerdeWriterEnrichedHollowBatch) -> Self {
-        let SerdeWriterEnrichedHollowBatch {
-            shard_id,
-            version,
-            batch,
-        } = x;
-        let proto_batch = ProtoHollowBatch::decode(batch.as_slice())
-            .expect("internal error: could not decode WriterEnrichedHollowBatch");
-        let batch = proto_batch
-            .into_rust()
-            .expect("internal error: could not decode WriterEnrichedHollowBatch");
-        WriterEnrichedHollowBatch {
-            shard_id,
-            version,
-            batch,
-        }
     }
 }
 

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -35,7 +35,7 @@ use crate::batch::{
 };
 use crate::error::{InvalidUsage, UpperMismatch};
 use crate::internal::compact::Compactor;
-use crate::internal::encoding::{Schemas, SerdeWriterEnrichedHollowBatch};
+use crate::internal::encoding::Schemas;
 use crate::internal::machine::Machine;
 use crate::internal::metrics::Metrics;
 use crate::internal::state::{HandleDebugState, HollowBatch, Upper};
@@ -84,25 +84,6 @@ impl WriterId {
     pub(crate) fn new() -> Self {
         WriterId(*Uuid::new_v4().as_bytes())
     }
-}
-
-/// A token representing one written batch.
-///
-/// This may be exchanged (including over the network). It is tradeable via
-/// [`WriteHandle::batch_from_transmittable_batch`].
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(bound(
-    serialize = "T: Timestamp + Codec64",
-    deserialize = "T: Timestamp + Codec64"
-))]
-#[serde(
-    into = "SerdeWriterEnrichedHollowBatch",
-    from = "SerdeWriterEnrichedHollowBatch"
-)]
-pub struct WriterEnrichedHollowBatch<T> {
-    pub(crate) shard_id: ShardId,
-    pub(crate) version: semver::Version,
-    pub(crate) batch: HollowBatch<T>,
 }
 
 /// A "capability" granting the ability to apply updates to some shard at times

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -390,7 +390,7 @@ async fn apply_caa(
     commit_ts: u64,
 ) -> bool {
     let batch = serde_json::from_str(batch_raw).expect("valid batch");
-    let mut batch = data_write.batch_from_hollow_batch(batch);
+    let mut batch = data_write.batch_from_transmittable_batch(batch);
     let mut upper = *data_write
         .upper()
         .as_option()

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -108,10 +108,10 @@ impl Txn {
                     .finish(Antichain::from_elem(commit_ts + 1))
                     .await
                     .expect("valid usage");
-                let batch = batch.into_writer_hollow_batch();
+                let batch = batch.into_transmittable_batch();
                 // TODO(txn): Proto not serde_json.
                 let batch_raw = serde_json::to_string(&batch).expect("valid json");
-                let batch = data_write.batch_from_hollow_batch(batch);
+                let batch = data_write.batch_from_transmittable_batch(batch);
                 txn_batches.push(batch);
                 debug!(
                     "wrote {:.9} batch {} len={}",


### PR DESCRIPTION
Two of my recent PRs had a "ships passing" conflict and broke building on main. Fix by updating persist-txn uses of ProtoBatch to the new name.

While I'm in here, also delete WriterEnrichedHollowBatch, which I meant to do in one of the PRs but missed.


### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
