### PR TITLE
storage/pg: permit tables' output_indexes to change

### DIFF
--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -137,7 +137,26 @@ impl<S: Debug + Eq + PartialEq> IngestionDescription<S> {
                     l_key.cmp(r_key)
                 })
                 .all(|r| match r {
-                    Both((_, l_val), (_, r_val)) => l_val == r_val,
+                    Both(
+                        (
+                            _,
+                            SourceExport {
+                                output_index: _,
+                                storage_metadata: l_metadata,
+                            },
+                        ),
+                        (
+                            _,
+                            SourceExport {
+                                output_index: _,
+                                storage_metadata: r_metadata,
+                            },
+                        ),
+                    ) => {
+                        // the output index may change, but the table's metadata
+                        // may not
+                        l_metadata == r_metadata
+                    }
                     _ => true,
                 }),
             instance_id == &other.instance_id,

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -383,16 +383,27 @@ contains: invalid TEXT COLUMNS option value: unexpected multiple references to p
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"postgres\".\"public\".\"table_f\".\"f2\""
 
+# Drop a table that's in the publication, which shuffles the tables' output
+# indexes, then add a table to the publication and ensure it can be added.
 $ postgres-execute connection=postgres://postgres:postgres@postgres
+DROP TABLE table_c, table_d;
+
 CREATE TABLE table_i (pk INTEGER PRIMARY KEY, f2 an_enum);
 INSERT INTO table_i VALUES (1, 'var0');
 ALTER TABLE table_i REPLICA IDENTITY FULL;
 INSERT INTO table_i VALUES (2, 'var1');
 
+INSERT INTO table_f VALUES (3, 'var1');
+
 > ALTER SOURCE mz_source ADD SUBSOURCE table_i WITH (TEXT COLUMNS [table_i.f2]);
 
 > SELECT regexp_match(create_sql, 'TEXT COLUMNS = \((.*?)\)')[1] FROM (SHOW CREATE SOURCE mz_source);
 "\"postgres\".\"public\".\"table_f\".\"f2\", \"postgres\".\"public\".\"table_i\".\"f2\""
+
+> SELECT * FROM table_f
+1 var0
+2 var1
+3 var1
 
 > ALTER SOURCE mz_source DROP SUBSOURCE table_f, table_i;
 


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.

If the order of tables returned from `mz_postgres_util::publication_info` changed, we would prevent the source from being altered; we errored because the tables' output indexes (`SourceExport`) had changed. However, reording output indexes is fine and this should not have errored. We only need to ensure that the table's metadata hasn't changed.

The easiest way to manufacture this shift in the `output_index` values is to drop a table from the publication, so that is what the newly added test does.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug that prevented `ALTER SOURCE...` from completing on PostgreSQL sources if we observed existing tables listed in a publication in an order different than the first time we saw them.
