### PR TITLE
Align `EXPLAIN MATERIALIZED VIEW` output with the runtime state

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -25,6 +25,7 @@ from materialize.checks.delete import *  # noqa: F401 F403
 from materialize.checks.drop_index import *  # noqa: F401 F403
 from materialize.checks.drop_table import *  # noqa: F401 F403
 from materialize.checks.error import *  # noqa: F401 F403
+from materialize.checks.explain_catalog_item import *  # noqa: F401 F403
 from materialize.checks.float_types import *  # noqa: F401 F403
 from materialize.checks.having import *  # noqa: F401 F403
 from materialize.checks.identifiers import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/explain_catalog_item.py
+++ b/misc/python/materialize/checks/explain_catalog_item.py
@@ -1,0 +1,87 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from textwrap import dedent
+from typing import List
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+
+class ExplainCatalogItem(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE TABLE explain_item_t1(x int, y int);
+
+                > CREATE TABLE explain_item_t2(x int, y int);
+
+                > CREATE INDEX explain_item_t1_y ON explain_item_t1(y);
+                """
+            )
+        )
+
+    def manipulate(self) -> List[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE OR REPLACE MATERIALIZED VIEW explain_mv1 AS
+                  SELECT * FROM explain_item_t1 WHERE y = 7;
+
+                > CREATE OR REPLACE MATERIALIZED VIEW explain_mv2 AS
+                  SELECT * FROM explain_item_t2 WHERE y = 7;
+                """,
+                """
+                > CREATE INDEX explain_item_t2_y ON explain_item_t2(y);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            # 1. Check the MV plans.
+            # 2. Re-create explain_mv2 and check its plan again - it should be
+            #    almost identical to the plan for explain_mv1 after picking up
+            #    explain_item_t2_y as a used index.
+            dedent(
+                """
+                ? EXPLAIN MATERIALIZED VIEW explain_mv1;
+                materialize.public.explain_mv1:
+                  Project (#0, #1)
+                    ReadExistingIndex materialize.public.explain_item_t1 lookup_value=(7)
+
+                Used Indexes:
+                  - materialize.public.explain_item_t1_y (lookup)
+
+
+                ? EXPLAIN MATERIALIZED VIEW explain_mv2;
+                materialize.public.explain_mv2:
+                  Filter (#1 = 7)
+                    Get materialize.public.explain_item_t2
+
+                Source materialize.public.explain_item_t2
+                  filter=((#1 = 7))
+
+
+                > CREATE OR REPLACE MATERIALIZED VIEW explain_mv2_new AS
+                  SELECT * FROM explain_item_t2 WHERE y = 7;
+
+
+                ? EXPLAIN MATERIALIZED VIEW explain_mv2_new;
+                materialize.public.explain_mv2_new:
+                  Project (#0, #1)
+                    ReadExistingIndex materialize.public.explain_item_t2 lookup_value=(7)
+
+                Used Indexes:
+                  - materialize.public.explain_item_t2_y (lookup)
+                """
+            )
+        )

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5402,7 +5402,7 @@ impl Catalog {
             &mut audit_events,
             &mut tx,
             &mut state,
-            drop_ids,
+            &drop_ids,
         )?;
 
         let result = f(&state)?;
@@ -5440,7 +5440,7 @@ impl Catalog {
         state: &mut CatalogState,
         // Provide all of the IDs that are being dropped in this transaction so we can provide
         // stronger invariants about when we change items' dependencies.
-        drop_ids: BTreeSet<GlobalId>,
+        drop_ids: &BTreeSet<GlobalId>,
     ) -> Result<(), AdapterError> {
         // NOTE(benesch): to support altering legacy sized sources and sinks
         // (those with linked clusters), we need to generate retractions for
@@ -5508,7 +5508,7 @@ impl Catalog {
                     tx,
                     builtin_table_updates,
                     oracle_write_ts,
-                    &drop_ids,
+                    drop_ids,
                     audit_events,
                     session,
                     id,
@@ -5609,7 +5609,7 @@ impl Catalog {
                         id,
                         to_name,
                         sink.item,
-                        &drop_ids,
+                        drop_ids,
                     )?;
                 }
                 Op::AlterSource { id, cluster_config } => {
@@ -5709,7 +5709,7 @@ impl Catalog {
                         id,
                         to_name,
                         source.item,
-                        &drop_ids,
+                        drop_ids,
                     )?;
                 }
                 Op::CreateDatabase {
@@ -6927,7 +6927,7 @@ impl Catalog {
                             id,
                             to_name,
                             to_item,
-                            &drop_ids,
+                            drop_ids,
                         )?;
                     }
                 }
@@ -7114,7 +7114,7 @@ impl Catalog {
                         id,
                         name.clone(),
                         to_item.clone(),
-                        &drop_ids,
+                        drop_ids,
                     )?;
                     let entry = state.get_entry(&id);
                     tx.update_item(id, entry)?;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1428,11 +1428,34 @@ impl Coordinator {
 
                     // Re-create the sink on the compute instance.
                     let internal_view_id = self.allocate_transient_id()?;
-                    let mut df = self
-                        .dataflow_builder(mview.cluster_id)
-                        .build_materialized_view_dataflow(entry.id(), internal_view_id)?;
+                    let debug_name = self
+                        .catalog()
+                        .resolve_full_name(entry.name(), entry.conn_id())
+                        .to_string();
+
+                    let mut builder = self.dataflow_builder(mview.cluster_id);
+                    let mut df = builder.build_materialized_view(
+                        entry.id(),
+                        internal_view_id,
+                        debug_name,
+                        &mview.optimized_expr,
+                        &mview.desc,
+                    )?;
+
+                    // Note: ideally, the optimized_plan should be computed and
+                    // set when the CatalogItem is re-constructed (in
+                    // parse_item).
+                    //
+                    // However, it's not clear how exactly to change
+                    // `load_catalog_items` to accomodate for the
+                    // `build_materialized_view` call above.
+                    self.catalog_mut()
+                        .set_optimized_plan(entry.id(), df.clone());
+
+                    // The 'as_of' field of the dataflow changes after restart
                     let as_of = self.bootstrap_materialized_view_as_of(&df, mview.cluster_id);
                     df.set_as_of(as_of);
+
                     self.must_ship_dataflow(df, mview.cluster_id).await;
                 }
                 CatalogItem::Sink(sink) => {

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -36,7 +36,7 @@ use mz_ore::cast::ReinterpretCast;
 use mz_ore::stack::{maybe_grow, CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, GlobalId, Row, Timestamp};
+use mz_repr::{Datum, GlobalId, RelationDesc, Row, Timestamp};
 use mz_sql::catalog::{CatalogRole, SessionCatalog};
 use timely::progress::Antichain;
 use timely::PartialOrder;
@@ -482,12 +482,51 @@ impl<'a> DataflowBuilder<'a> {
         Ok(())
     }
 
+    /// Builds a dataflow description for a materialized view.
+    ///
+    /// For this, we first build a dataflow for the view expression, then we add
+    /// a sink that writes that dataflow's output to storage. `internal_view_id`
+    /// is the ID we assign to the view dataflow internally, so we can connect
+    /// the sink to it.
+    pub fn build_materialized_view(
+        &mut self,
+        exported_sink_id: GlobalId,
+        internal_view_id: GlobalId,
+        debug_name: String,
+        optimized_expr: &OptimizedMirRelationExpr,
+        desc: &RelationDesc,
+    ) -> Result<DataflowDesc, AdapterError> {
+        let mut dataflow = DataflowDesc::new(debug_name);
+
+        self.import_view_into_dataflow(&internal_view_id, optimized_expr, &mut dataflow)?;
+
+        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
+            prep_relation_expr(self.catalog, plan, ExprPrepStyle::Index)?;
+        }
+
+        let sink_description = ComputeSinkDesc {
+            from: internal_view_id,
+            from_desc: desc.clone(),
+            connection: ComputeSinkConnection::Persist(PersistSinkConnection {
+                value_desc: desc.clone(),
+                storage_metadata: (),
+            }),
+            with_snapshot: true,
+            up_to: Antichain::default(),
+        };
+
+        self.build_sink_dataflow_into(&mut dataflow, exported_sink_id, sink_description)?;
+
+        Ok(dataflow)
+    }
+
     /// Builds a dataflow description for the materialized view specified by `id`.
     ///
     /// For this, we first build a dataflow for the view expression, then we
     /// add a sink that writes that dataflow's output to storage.
     /// `internal_view_id` is the ID we assign to the view dataflow internally,
     /// so we can connect the sink to it.
+    #[deprecated(note = "please use `build_materialized_view` instead")]
     pub fn build_materialized_view_dataflow(
         &mut self,
         id: GlobalId,

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -249,7 +249,13 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
 /// The type of object to be explained
 #[derive(Clone, Debug)]
 pub enum Explainee {
-    /// An object that will be served using a dataflow
+    /// An existing materialized view.
+    MaterializedView(GlobalId),
+    /// An existing index.
+    Index(GlobalId),
+    /// An object that will be served using a dataflow.
+    ///
+    /// This variant is deprecated and will be removed in #18089.
     Dataflow(GlobalId),
     /// The object to be explained is a one-off query and may or may not served
     /// using a dataflow.

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -527,6 +527,10 @@ impl fmt::Display for Attributes {
 }
 
 /// A set of indexes that are used in the explained plan.
+///
+/// Each vector element consists of the following components:
+/// 1. The id of the index.
+/// 2. A vector of [IndexUsageType] denoting how the index is used in the plan.
 #[derive(Debug)]
 pub struct UsedIndexes(Vec<(GlobalId, Vec<IndexUsageType>)>);
 

--- a/src/repr/src/explain/text.rs
+++ b/src/repr/src/explain/text.rs
@@ -73,17 +73,12 @@ where
         writeln!(f, "{}Used Indexes:", ctx.as_mut())?;
         *ctx.as_mut() += 1;
         for (id, usage_types) in &self.0 {
-            let index_name = ctx
-                .as_ref()
-                .humanize_id(*id)
-                .unwrap_or_else(|| id.to_string());
-            writeln!(
-                f,
-                "{}- {} ({})",
-                ctx.as_mut(),
-                index_name,
-                separated(", ", usage_types.iter().sorted().dedup())
-            )?;
+            let usage_types = separated(", ", usage_types.iter().sorted().dedup());
+            if let Some(name) = ctx.as_ref().humanize_id(*id) {
+                writeln!(f, "{}- {} ({})", ctx.as_mut(), name, usage_types)?;
+            } else {
+                writeln!(f, "{}- [DELETED INDEX] ({})", ctx.as_mut(), usage_types)?;
+            }
         }
         *ctx.as_mut() -= 1;
         Ok(())

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -316,7 +316,7 @@ pub fn plan_explain(
             };
             let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
             (
-                mz_repr::explain::Explainee::Dataflow(mview.id()),
+                mz_repr::explain::Explainee::MaterializedView(mview.id()),
                 names::resolve(qcx.scx.catalog, query)?.0,
             )
         }

--- a/test/sqllogictest/explain/materialized_view.slt
+++ b/test/sqllogictest/explain/materialized_view.slt
@@ -1,0 +1,109 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+statement ok
+CREATE TABLE accounts(id int, balance int);
+
+
+statement ok
+CREATE OR REPLACE MATERIALIZED VIEW mv AS
+  SELECT * FROM accounts WHERE balance = 100;
+
+
+mode cockroach
+
+
+# baseline explain (no index used)
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Filter (#1 = 100)
+    Get materialize.public.accounts
+
+Source materialize.public.accounts
+  filter=((#1 = 100))
+
+EOF
+
+
+statement ok
+CREATE INDEX accounts_balance_idx ON accounts(balance);
+
+
+# ensure that the index is still not used
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Filter (#1 = 100)
+    Get materialize.public.accounts
+
+Source materialize.public.accounts
+  filter=((#1 = 100))
+
+EOF
+
+
+# re-create the view so it can pick up the index
+statement ok
+CREATE OR REPLACE MATERIALIZED VIEW mv AS
+  SELECT * FROM accounts WHERE balance = 100;
+
+
+# ensure that the index is now used by the view
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#0, #1)
+    ReadExistingIndex materialize.public.accounts lookup_value=(100)
+
+Used Indexes:
+  - materialize.public.accounts_balance_idx (lookup)
+
+EOF
+
+
+# rename the index
+statement ok
+ALTER INDEX accounts_balance_idx RENAME TO accounts_balance_index;
+
+
+# ensure that the index is now used by the view
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#0, #1)
+    ReadExistingIndex materialize.public.accounts lookup_value=(100)
+
+Used Indexes:
+  - materialize.public.accounts_balance_index (lookup)
+
+EOF
+
+
+# drop the index
+statement ok
+DROP INDEX accounts_balance_index;
+
+
+# ensure that the index is now used by the view
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Project (#0, #1)
+    ReadExistingIndex materialize.public.accounts lookup_value=(100)
+
+Used Indexes:
+  - [DELETED INDEX] (lookup)
+
+EOF


### PR DESCRIPTION
Fix the output of

```sql
EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW $name
```

so it aligns with the dataflow that is actually running at the moment.

### Motivation

  * This PR adds a known-desirable feature.

This is the first PR of a series of PRs working towards #20652.
 
### Tips for reviewer

* The changes are best reviewed one commit at a time. 
* Check the commit messages for more context.
* The commits that (a) remove `DataflowBuilder::build_materialized_view_dataflow` and add (b) `DataflowBuilder::build_materialized_view` are non-essential for resolving [#20652](#20652) with the design from the merged design doc [#20941](#20941), but I left them in because they move the code in the right direction and were already done for my (failed) attempt to realize the original design based on `CatalogItem` extensions.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
