### PR TITLE
adapter: Enable subscribe envelope upsert by default and remove feature flag

### DIFF
--- a/doc/user/content/sql/subscribe.md
+++ b/doc/user/content/sql/subscribe.md
@@ -303,8 +303,6 @@ See #18829 for the design doc."
 
 ### Modifying the output format
 
-{{< private-preview />}}
-
 #### `ENVELOPE UPSERT`
 
 To modify the output of `SUBSCRIBE` to support upserts, use `ENVELOPE UPSERT`.
@@ -392,6 +390,8 @@ structure:
 column. Each progress row will have a `NULL` key and a `NULL` value.
 
 #### `ENVELOPE DEBEZIUM`
+
+{{< private-preview />}}
 
 To modify the output of `SUBSCRIBE` to support upserts using a
 [Debezium-style diff envelope](https://materialize.com/docs/sql/create-sink/#debezium-envelope)
@@ -486,6 +486,8 @@ structure:
 before and after value.
 
 #### `WITHIN TIMESTAMP ORDER BY`
+
+{{< private-preview />}}
 
 To modify the ordering of the output of `SUBSCRIBE`, use `WITHIN TIMESTAMP ORDER
 BY`. This clause allows you to specify an `ORDER BY` expression which is used

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -537,7 +537,6 @@ pub fn plan_subscribe(
     let output = match output {
         SubscribeOutput::Diffs => plan::SubscribeOutput::Diffs,
         SubscribeOutput::EnvelopeUpsert { key_columns } => {
-            scx.require_feature_flag(&vars::ENABLE_ENVELOPE_UPSERT_IN_SUBSCRIBE)?;
             let order_by = key_columns
                 .iter()
                 .map(|ident| OrderByExpr {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1395,10 +1395,6 @@ feature_flags!(
         "`ENVELOPE DEBEZIUM (KEY (..))`"
     ),
     (enable_envelope_materialize, "ENVELOPE MATERIALIZE"),
-    (
-        enable_envelope_upsert_in_subscribe,
-        "`ENVELOPE UPSERT` can be used in `SUBSCRIBE`"
-    ),
     (enable_index_options, "INDEX OPTIONS"),
     (
         enable_kafka_config_denylist_options,

--- a/test/sqllogictest/subscribe_outputs.slt
+++ b/test/sqllogictest/subscribe_outputs.slt
@@ -15,11 +15,6 @@ ALTER SYSTEM SET enable_envelope_debezium_in_subscribe = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_envelope_upsert_in_subscribe = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_within_timestamp_order_by_in_subscribe = true
 ----
 COMPLETE 0

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -9,7 +9,6 @@
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_within_timestamp_order_by_in_subscribe = true;
-ALTER SYSTEM SET enable_envelope_upsert_in_subscribe = true;
 ALTER SYSTEM SET enable_envelope_debezium_in_subscribe = true;
 
 $ set-regex match=\d{13,20} replacement=<TIMESTAMP>


### PR DESCRIPTION

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

We've had a few client use it successfully and happily.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
