### PR TITLE
Cloudtest: allow optionally using client TLS certs in requests

### DIFF
--- a/misc/python/materialize/cloudtest/util/controller.py
+++ b/misc/python/materialize/cloudtest/util/controller.py
@@ -45,6 +45,7 @@ class ControllerDefinition:
     default_port: str
     has_configurable_address: bool = True
     endpoint: Optional[Endpoint] = None
+    client_cert: Optional[tuple[str, str]] = None
 
     def default_address(self) -> str:
         return f"http://127.0.0.1:{self.default_port}"

--- a/misc/python/materialize/cloudtest/util/web_request.py
+++ b/misc/python/materialize/cloudtest/util/web_request.py
@@ -9,7 +9,7 @@
 
 import sys
 from contextlib import contextmanager
-from typing import Any, Generator
+from typing import Any, Generator, Optional
 
 import requests
 
@@ -37,6 +37,7 @@ def get(
     path: str,
     timeout: int = 15,
     use_token: bool = True,
+    client_cert: Optional[tuple[str, str]] = None,
 ) -> requests.Response:
     eprint(f"GET {base_url}{path}")
 
@@ -49,6 +50,7 @@ def get(
                 f"{base_url}{path}",
                 headers=headers,
                 timeout=timeout,
+                cert=client_cert,
             )
             response.raise_for_status()
             return response
@@ -72,6 +74,7 @@ def post(
     json: Any,
     timeout: int = 15,
     use_token: bool = True,
+    client_cert: Optional[tuple[str, str]] = None,
 ) -> requests.Response:
     eprint(f"POST {base_url}{path}")
 
@@ -85,6 +88,7 @@ def post(
                 headers=headers,
                 json=json,
                 timeout=timeout,
+                cert=client_cert,
             )
             response.raise_for_status()
             return response
@@ -108,6 +112,7 @@ def patch(
     json: Any,
     timeout: int = 15,
     use_token: bool = True,
+    client_cert: Optional[tuple[str, str]] = None,
 ) -> requests.Response:
     eprint(f"PATCH {base_url}{path}")
 
@@ -121,6 +126,7 @@ def patch(
                 headers=headers,
                 json=json,
                 timeout=timeout,
+                cert=client_cert,
             )
             response.raise_for_status()
             return response
@@ -144,6 +150,7 @@ def delete(
     params: Any = None,
     timeout: int = 15,
     use_token: bool = True,
+    client_cert: Optional[tuple[str, str]] = None,
 ) -> requests.Response:
     eprint(f"DELETE {base_url}{path}")
 
@@ -156,6 +163,7 @@ def delete(
                 f"{base_url}{path}",
                 headers=headers,
                 timeout=timeout,
+                cert=client_cert,
                 **(
                     {
                         "params": params,


### PR DESCRIPTION
### Motivation

I'm working on enabling the Cloud repo's end-to-end tests against our Internal API service which is secured behind [teleport](https://goteleport.com/). To allow the tests to communicate with the Internal API via the teleport tunnel, we generate a temporary client TLS certificate that needs to be provided with each request https://requests.readthedocs.io/en/latest/user/advanced/#client-side-certificates

This PR adds an optional kwarg added to each http method helper to provide the cert for a request. It also adds a field to the `ControllerDefinition` dataclass to cache the cert on a specific controller during test-setup so they can be referenced from any test with access to the `EnvironmentConfig`.

I have a Cloud PR incoming that depends on this change.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
