### PR TITLE
mz: turn the region option as global

### DIFF
--- a/src/mz/src/bin/mz/command/region.rs
+++ b/src/mz/src/bin/mz/command/region.rs
@@ -18,12 +18,10 @@
 use mz::context::Context;
 use mz::error::Error;
 
-use crate::mixin::{ProfileArg, RegionArg};
+use crate::mixin::ProfileArg;
 
 #[derive(Debug, clap::Args)]
 pub struct RegionCommand {
-    #[clap(flatten)]
-    region: RegionArg,
     #[clap(flatten)]
     profile: ProfileArg,
     #[clap(subcommand)]
@@ -50,7 +48,7 @@ pub enum RegionSubcommand {
 pub async fn run(cx: Context, cmd: RegionCommand) -> Result<(), Error> {
     let cx = cx
         .activate_profile(cmd.profile.profile)?
-        .activate_region(cmd.region.region)?;
+        .activate_region()?;
     match cmd.subcommand {
         RegionSubcommand::Enable { version } => mz::command::region::enable(cx, version).await,
         RegionSubcommand::Disable => mz::command::region::disable(cx).await,

--- a/src/mz/src/bin/mz/command/secret.rs
+++ b/src/mz/src/bin/mz/command/secret.rs
@@ -19,12 +19,10 @@ use mz::command::secret::CreateArgs;
 use mz::context::Context;
 use mz::error::Error;
 
-use crate::mixin::{ProfileArg, RegionArg};
+use crate::mixin::ProfileArg;
 
 #[derive(Debug, clap::Args)]
 pub struct SecretCommand {
-    #[clap(flatten)]
-    region: RegionArg,
     #[clap(flatten)]
     profile: ProfileArg,
     #[clap(subcommand)]
@@ -51,7 +49,7 @@ pub enum SecretSubcommand {
 pub async fn run(cx: Context, cmd: SecretCommand) -> Result<(), Error> {
     let mut cx = cx
         .activate_profile(cmd.profile.profile)?
-        .activate_region(cmd.region.region)?;
+        .activate_region()?;
     match cmd.subcommand {
         SecretSubcommand::Create {
             database,

--- a/src/mz/src/bin/mz/command/sql.rs
+++ b/src/mz/src/bin/mz/command/sql.rs
@@ -19,13 +19,11 @@ use mz::command::sql::RunArgs;
 use mz::context::Context;
 use mz::error::Error;
 
-use crate::mixin::{ProfileArg, RegionArg};
+use crate::mixin::ProfileArg;
 
 #[derive(Debug, clap::Args)]
 #[clap(trailing_var_arg = true)]
 pub struct SqlCommand {
-    #[clap(flatten)]
-    region: RegionArg,
     #[clap(flatten)]
     profile: ProfileArg,
     /// Additional arguments to pass to `psql`.
@@ -35,7 +33,7 @@ pub struct SqlCommand {
 pub async fn run(cx: Context, cmd: SqlCommand) -> Result<(), Error> {
     let mut cx = cx
         .activate_profile(cmd.profile.profile)?
-        .activate_region(cmd.region.region)?;
+        .activate_region()?;
     mz::command::sql::run(
         &mut cx,
         RunArgs {

--- a/src/mz/src/bin/mz/main.rs
+++ b/src/mz/src/bin/mz/main.rs
@@ -111,15 +111,15 @@ mod mixin;
 // TODO(guswynn): remove this when we are using Clap v4.
 #[allow(clippy::almost_swapped)]
 mod clap_clippy_hack {
+
     use super::*;
 
     /// Command-line interface for Materialize.
     #[derive(Debug, clap::Parser)]
     #[clap(
-      long_about = None,
+        long_about = None,
         version = mz::VERSION.as_str(),
     )]
-
     pub struct Args {
         /// Set the configuration file.
         #[clap(long, global = true, value_name = "PATH", env = "CONFIG")]
@@ -130,6 +130,8 @@ mod clap_clippy_hack {
         pub(crate) no_color: bool,
         #[clap(subcommand)]
         pub(crate) command: Command,
+        #[clap(long, env = "REGION", global = true)]
+        pub(crate) region: Option<String>,
     }
 
     /// Specifies an output format.
@@ -186,8 +188,8 @@ async fn main() -> Result<(), Error> {
     let cx = Context::load(ContextLoadArgs {
         config_file_path: args.config,
         output_format: args.format.into(),
-        // TODO: no_color: env::no_color() || args.no_color
         no_color: args.no_color,
+        region: args.region,
     })
     .await?;
 

--- a/src/mz/src/bin/mz/mixin.rs
+++ b/src/mz/src/bin/mz/mixin.rs
@@ -33,10 +33,3 @@ pub struct EndpointArgs {
     #[clap(long, hidden = true, env = "ADMIN_ENDPOINT")]
     pub admin_endpoint: Option<Url>,
 }
-
-#[derive(Debug, clap::Args)]
-pub struct RegionArg {
-    /// Use the specified region.
-    #[clap(long, env = "REGION")]
-    pub region: Option<String>,
-}

--- a/src/mz/src/context.rs
+++ b/src/mz/src/context.rs
@@ -47,6 +47,8 @@ pub struct ContextLoadArgs {
     pub output_format: OutputFormat,
     /// Whether to suppress color output.
     pub no_color: bool,
+    /// Global optional region.
+    pub region: Option<String>,
 }
 
 /// Context for a basic command.
@@ -54,6 +56,7 @@ pub struct ContextLoadArgs {
 pub struct Context {
     config_file: ConfigFile,
     output_formatter: OutputFormatter,
+    region: Option<String>,
 }
 
 impl Context {
@@ -63,6 +66,7 @@ impl Context {
             config_file_path,
             output_format,
             no_color,
+            region,
         }: ContextLoadArgs,
     ) -> Result<Context, Error> {
         let config_file_path = match config_file_path {
@@ -73,6 +77,7 @@ impl Context {
         Ok(Context {
             config_file,
             output_formatter: OutputFormatter::new(output_format, no_color),
+            region,
         })
     }
 
@@ -152,13 +157,16 @@ pub struct ProfileContext {
 
 impl ProfileContext {
     /// Loads the profile and returns a region context.
-    pub fn activate_region(self, name: Option<String>) -> Result<RegionContext, Error> {
+    pub fn activate_region(self) -> Result<RegionContext, Error> {
         let profile = self
             .context
             .config_file
             .load_profile(&self.profile_name)
             .unwrap();
-        let region_name = name
+        let region_name = self
+            .context
+            .region
+            .clone()
             .or(profile.region().map(|r| r.to_string()))
             .ok_or_else(|| panic!("no region configured"))
             .unwrap();

--- a/src/mz/tests/e2e.rs
+++ b/src/mz/tests/e2e.rs
@@ -518,6 +518,16 @@ mod tests {
 
         assert!(output.trim().starts_with("Healthy: \tyes"));
 
+        let binding = cmd()
+            .arg("region")
+            .arg("show")
+            .arg("--region aws/us-east-1")
+            // .env("PATH", "/opt/homebrew/bin/")
+            .assert()
+            .success();
+        let output = output_to_string(binding);
+
+        assert!(output.trim().starts_with("Healthy: \tyes"));
         // Test - `mz sql`
         //
         // Assert `mz sql -- -q -c "SELECT 1"

--- a/src/mz/tests/e2e.rs
+++ b/src/mz/tests/e2e.rs
@@ -508,12 +508,7 @@ mod tests {
         //     .assert()
         //     .success();
 
-        let binding = cmd()
-            .arg("region")
-            .arg("show")
-            // .env("PATH", "/opt/homebrew/bin/")
-            .assert()
-            .success();
+        let binding = cmd().arg("region").arg("show").assert().success();
         let output = output_to_string(binding);
 
         assert!(output.trim().starts_with("Healthy: \tyes"));
@@ -521,8 +516,8 @@ mod tests {
         let binding = cmd()
             .arg("region")
             .arg("show")
-            .arg("--region aws/us-east-1")
-            // .env("PATH", "/opt/homebrew/bin/")
+            .arg("--region")
+            .arg("aws/us-east-1")
             .assert()
             .success();
         let output = output_to_string(binding);


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR [globalizes](https://docs.rs/clap/latest/clap/struct.Arg.html#method.global) the `--region` option for the CLI. I believe we should apply a similar modification to the `--profile <name>` option.

[Context.](https://materializeinc.slack.com/archives/CM7ATT65S/p1692369590144129?thread_ts=1692369107.815169&cid=CM7ATT65S)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
