### PR TITLE
sql-lexer: build.rs: only write on change

### DIFF
--- a/src/sql-lexer/build.rs
+++ b/src/sql-lexer/build.rs
@@ -142,7 +142,16 @@ fn main() -> Result<()> {
             phf.build()
         ));
 
-        fs::write(out_dir.join("keywords.rs"), buf.into_string())?;
+        let contents = buf.into_string();
+        let path = out_dir.join("keywords.rs");
+        let needs_write = if let Ok(on_disk) = fs::read(&path) {
+            on_disk != contents.as_bytes()
+        } else {
+            true
+        };
+        if needs_write {
+            fs::write(path, contents)?;
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
This seems to prevent rebuild in some circumstances.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
