### PR TITLE
test/lang/python: upgrade to mainline pyscopg3

### DIFF
--- a/test/lang/python/requirements.txt
+++ b/test/lang/python/requirements.txt
@@ -1,3 +1,3 @@
+psycopg==3.1.10
 psycopg2==2.8.6
-git+https://github.com/psycopg/psycopg3.git@4f053f14901454a7c7895b527ddeb9d8ab57d7fe#subdirectory=psycopg3
 SQLAlchemy==1.3.20


### PR DESCRIPTION
@philip-stoev @nrainer-materialize I saw https://github.com/MaterializeInc/materialize/pull/21248#issuecomment-1683707611 go past and figured I'd take care of it. Please feel free to merge this PR directly if it LGTY.

----

This test was using an old development version of pyscopg3 for historical reasons. This commit upgrades to the latest version of psycopg3.

### Motivation

  * This PR upgrades dependencies.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
