### PR TITLE
feature-benchmark: Fortify the ScaledJoin scenario

### DIFF
--- a/test/feature-benchmark/scenarios_skew.py
+++ b/test/feature-benchmark/scenarios_skew.py
@@ -31,15 +31,15 @@ class SkewedJoin(Scenario):
                 > CREATE MATERIALIZED VIEW v1 AS SELECT COUNT(*) > 0 FROM skewed_table JOIN uniform_table USING (f1)
                   /* A */
 
-                > INSERT INTO uniform_table (f1) SELECT generate_series FROM generate_series(0, {count-1});
+                > INSERT INTO uniform_table (f1) SELECT generate_series FROM generate_series(0, {count-1}::integer);
 
                 # Make sure 0 is overrepresented
-                > INSERT INTO skewed_table (f1) SELECT 0 FROM generate_series(1, {count});
+                > INSERT INTO skewed_table (f1) SELECT 0 FROM generate_series(1, {count}::integer);
                 """
             )
             + "\n".join(
                 [
-                    f"> INSERT INTO skewed_table (f1) SELECT MOD(generate_series, POW(10, {i})) FROM generate_series(1, {count} / {scale});"
+                    f"> INSERT INTO skewed_table (f1) SELECT MOD(generate_series, POW(10, {i})) FROM generate_series(1, ({count} / {scale})::integer);"
                     for i in range(floor(scale))
                 ]
             )


### PR DESCRIPTION
Use casts to force the second argument to generate_series() be an integer.

If --scale=+1 is used, then the scenario attempts to run

```
generate_series(0, 9999999.0);
```

which is not valid in Materialize. The second argument of generate_series() must be strictly an integer.


### Motivation

Release Qualification was failing