### PR TITLE
test: fix mypy errors

### DIFF
--- a/test/lang/python/smoketest.py
+++ b/test/lang/python/smoketest.py
@@ -9,8 +9,8 @@
 
 import unittest
 
-import psycopg  # type: ignore
-import psycopg2  # type: ignore
+import psycopg
+import psycopg2
 import sqlalchemy  # type: ignore
 
 MATERIALIZED_URL = "postgresql://materialize@materialized:6875/materialize"
@@ -151,7 +151,9 @@ class SmokeTest(unittest.TestCase):
                     )
 
                     # Validate the first row, but ignore the timestamp column.
-                    (ts, diff, a, b) = copy.read_row()
+                    row = copy.read_row()
+                    assert row is not None
+                    (ts, diff, a, b) = row
                     self.assertEqual(diff, 1)
                     self.assertEqual(a, 1)
                     self.assertEqual(b, "a")
@@ -166,7 +168,9 @@ class SmokeTest(unittest.TestCase):
                             )
 
                     # Validate the new row, again ignoring the timestamp column.
-                    (ts, diff, a, b) = copy.read_row()
+                    row = copy.read_row()
+                    assert row is not None
+                    (ts, diff, a, b) = row
                     self.assertEqual(diff, 1)
                     self.assertEqual(a, 2)
                     self.assertEqual(b, "b")


### PR DESCRIPTION
This PR fixes mypy errors that have started popping up in main.

I'm not sure what caused them to pop up. Perhaps mypy got updated to a version that started including type annotations for the psycopg packages?

### Motivation

  * This PR fixes a previously unreported bug.

The linting CI job fails with these errors:

```
test/lang/python/smoketest.py:12: error: Unused "type: ignore" comment  [unused-ignore]
    import psycopg  # type: ignore
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/lang/python/smoketest.py:13: error: Unused "type: ignore" comment  [unused-ignore]
    import psycopg2  # type: ignore
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
test/lang/python/smoketest.py:154: error: "None" object is not iterable  [misc]
                        (ts, diff, a, b) = copy.read_row()
                                           ^~~~~~~~~~~~~~~
test/lang/python/smoketest.py:169: error: "None" object is not iterable  [misc]
                        (ts, diff, a, b) = copy.read_row()
                                           ^~~~~~~~~~~~~~~
```

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A