### PR TITLE
scalability testing: Allow multiple targets to be benchmarked and cha…

### DIFF
--- a/ci/builder/requirements.txt
+++ b/ci/builder/requirements.txt
@@ -15,6 +15,7 @@ ec2instanceconnectcli==1.0.2
 flake8==6.0.0
 python-frontmatter==1.0.0
 humanize==4.4.0
+ipympl==0.9.3
 ipywidgets==8.1.0
 isort==5.11.4
 junit-xml==1.9

--- a/misc/python/materialize/scalability/endpoint.py
+++ b/misc/python/materialize/scalability/endpoint.py
@@ -42,3 +42,10 @@ class Endpoint:
         conn = self.sql_connection()
         cursor = conn.cursor()
         cursor.execute(sql)
+
+    def name(self) -> str:
+        cursor = self.sql_connection().cursor()
+        cursor.execute("SELECT mz_version()")
+        row = cursor.fetchone()
+        assert row is not None
+        return str(row[0])

--- a/misc/python/materialize/scalability/endpoints.py
+++ b/misc/python/materialize/scalability/endpoints.py
@@ -57,6 +57,7 @@ class PostgresContainer(Endpoint):
     def __init__(self, composition: Composition) -> None:
         self.composition = composition
         self._port: Optional[int] = None
+        super().__init__()
 
     def host(self) -> str:
         return "localhost"
@@ -77,12 +78,16 @@ class PostgresContainer(Endpoint):
             self.composition.up("postgres")
             self._port = self.composition.default_port("postgres")
 
+    def name(self) -> str:
+        return "postgres"
+
 
 class MaterializeContainer(Endpoint):
     def __init__(self, composition: Composition, image: Optional[str] = None) -> None:
         self.composition = composition
         self.image = image
         self._port: Optional[int] = None
+        super().__init__()
 
     def host(self) -> str:
         return "localhost"

--- a/misc/python/materialize/scalability/workload.py
+++ b/misc/python/materialize/scalability/workload.py
@@ -13,3 +13,9 @@ from materialize.scalability.operation import Operation
 class Workload:
     def operations(self) -> list[Operation]:
         raise NotImplementedError
+
+
+class WorkloadSelfTest(Workload):
+    """Used to self-test the framework, so need to be excluded from regular benchmark runs."""
+
+    pass

--- a/misc/python/materialize/scalability/workloads_test.py
+++ b/misc/python/materialize/scalability/workloads_test.py
@@ -15,29 +15,29 @@ from materialize.scalability.operations_test import (
     SleepInEnvironmentd,
     SleepInPython,
 )
-from materialize.scalability.workload import Workload
+from materialize.scalability.workload import WorkloadSelfTest
 
 
-class EmptyOperatorWorkload(Workload):
+class EmptyOperatorWorkload(WorkloadSelfTest):
     def operations(self) -> list["Operation"]:
         return [EmptyOperation()]
 
 
-class EmptySqlStatementWorkload(Workload):
+class EmptySqlStatementWorkload(WorkloadSelfTest):
     def operations(self) -> list["Operation"]:
         return [EmptySqlStatement()]
 
 
-class Sleep10MsInEnvironmentdWorkload(Workload):
+class Sleep10MsInEnvironmentdWorkload(WorkloadSelfTest):
     def operations(self) -> list["Operation"]:
         return [SleepInEnvironmentd(duration_in_sec=0.01)]
 
 
-class Sleep10MsInClusterdWorkload(Workload):
+class Sleep10MsInClusterdWorkload(WorkloadSelfTest):
     def operations(self) -> list["Operation"]:
         return [SleepInClusterd(duration_in_sec=0.01)]
 
 
-class Sleep10MsInPythonWorkload(Workload):
+class Sleep10MsInPythonWorkload(WorkloadSelfTest):
     def operations(self) -> list["Operation"]:
         return [SleepInPython(duration_in_sec=0.01)]

--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -68,6 +68,17 @@ In both of those cases, Materialize, CRDB and Python will run within the same ma
 ./mzcompose run default --target=remote \--materialize-url="postgres://user:password@host:6875/materialize?sslmode=require" --cluster-name= ...
 ```
 
+## Running against multiple targets:
+
+If you issue separate `./mzcompose run default --target=...` commands, their results will be accumulated in the `results` directory
+and all targets will be displayed together on a single chart.
+
+```
+./mzcompose run default --target=devel-cdb1f682e28d54e85afdcac3c32d43039df093a8
+...
+./mzcompose run default --target=devel-c891e3b4b174bd536b7a15ec212c5202ddc85b95
+```
+
 # Accuracy
 
 The following considerations can potentially impact the accuracy/realism of the reported results:

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -1,0 +1,43 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import os
+import subprocess
+
+import pandas as pd
+from matplotlib import pyplot as plt  # type: ignore
+
+
+def plotit(csv_file_name: str) -> None:
+    targets = next(os.walk("results"))[1]
+    legend = []
+    plt.rcParams["figure.figsize"] = (16, 10)
+    fig, (summary_subplot, details_subplot) = plt.subplots(2, 1)
+    for i, target in enumerate(targets):
+        target_sha = target.split(" ")[1].strip("()")
+        target_comment = subprocess.check_output(
+            ["git", "log", "-1", "--pretty=format:%s", target_sha], text=True
+        )
+        legend.append(f"{target} - {target_comment}")
+
+        df = pd.read_csv(f"results/{target}/{csv_file_name}.csv")
+        summary_subplot.scatter(df["concurrency"], df["tps"], label="tps")
+
+        df_details = pd.read_csv(f"results/{target}/{csv_file_name}_details.csv")
+        details_subplot.scatter(
+            df_details["concurrency"] + i, df_details["wallclock"], alpha=0.25
+        )
+
+    summary_subplot.set_ylabel("Transactions Per Second")
+    summary_subplot.set_xlabel("Concurrent SQL Connections")
+    summary_subplot.legend(legend)
+
+    details_subplot.set_ylabel("Latency in Seconds")
+    details_subplot.set_xlabel("Concurrent SQL Connections")
+    details_subplot.legend(legend)

--- a/test/scalability/scalability.ipynb
+++ b/test/scalability/scalability.ipynb
@@ -2,30 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "eabe7c72-a929-4ceb-abe3-e9bb054f4b88",
-   "metadata": {
-    "jupyter": {
-     "source_hidden": true
-    }
-   },
-   "outputs": [
-    {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "34b7824d333647b19efd9cd5fc31ab79",
-       "version_major": 2,
-       "version_minor": 0
-      },
-      "text/plain": [
-       "interactive(children=(Dropdown(description='CSV File:', options=('SelectOneWorkload',), value='SelectOneWorklo…"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Copyright Materialize, Inc. and contributors. All rights reserved.\n",
     "#\n",
@@ -36,29 +16,17 @@
     "# the Business Source License, use of this software will be governed\n",
     "# by the Apache License, Version 2.0.\n",
     "\n",
+    "%matplotlib ipympl\n",
+    "\n",
     "import pandas as pd\n",
-    "from IPython.display import Javascript, display, clear_output\n",
     "from ipywidgets import widgets, interactive\n",
-    "import ipywidgets as widgets\n",
+    "from lib import plotit\n",
     "\n",
     "workloads = pd.read_csv(\"results/workloads.csv\")\n",
     "\n",
-    "\n",
-    "def plotit(csv_file_name):\n",
-    "    df = pd.read_csv(f\"results/{csv_file_name}.csv\")\n",
-    "    df.plot.scatter(x=\"concurrency\", y=\"tps\")\n",
-    "\n",
-    "    df_details = pd.read_csv(f\"results/{csv_file_name}_details.csv\")\n",
-    "    df_details.plot.scatter(x=\"concurrency\", y=\"wallclock\", size=0.5)\n",
-    "\n",
-    "    df_tps = df_details.groupby(\"concurrency\").sum(\"wallclock\").reset_index()\n",
-    "    df_tps[\"tps\"] = 2048 / (df_tps[\"wallclock\"] / df_tps[\"concurrency\"])\n",
-    "    df_tps.plot(\"concurrency\", \"tps\")\n",
-    "\n",
-    "\n",
     "csv_file_name = widgets.Dropdown(\n",
     "    options=list(workloads[\"workload\"]),\n",
-    "    description=\"CSV File:\",\n",
+    "    description=\"Workload:\",\n",
     ")\n",
     "interactive(plotit, csv_file_name=csv_file_name)"
    ]


### PR DESCRIPTION
…rted together

### Motivation

I wanted to be able to evaluate individual PRs and features.

The end result looks like this:

![download](https://github.com/MaterializeInc/materialize/assets/1279722/11554805-6631-4b87-9a66-5c2dafd989c6)


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
