### PR TITLE
Change `visit_bfs` to `visit_pre`

### DIFF
--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1119,14 +1119,14 @@ impl MapFilterProject {
         let mut reference_count = vec![0; input_arity + self.expressions.len()];
         // Increment reference counts for each use
         for expr in self.expressions.iter() {
-            expr.visit_bfs(&mut |e| {
+            expr.visit_pre(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     reference_count[*i] += 1;
                 }
             });
         }
         for (_, pred) in self.predicates.iter() {
-            pred.visit_bfs(&mut |e| {
+            pred.visit_pre(&mut |e| {
                 if let MirScalarExpr::Column(i) = e {
                     reference_count[*i] += 1;
                 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2045,15 +2045,15 @@ impl MirScalarExpr {
             .chain(variadic.into_iter().flatten())
     }
 
-    /// Visits all subexpressions in breadth-first search order.
-    pub fn visit_bfs<F>(&self, f: &mut F)
+    /// Visits all subexpressions in DFS preorder.
+    pub fn visit_pre<F>(&self, f: &mut F)
     where
         F: FnMut(&Self),
     {
         let mut worklist = vec![self];
         while let Some(e) = worklist.pop() {
             f(e);
-            worklist.extend(e.children());
+            worklist.extend(e.children().rev());
         }
     }
 }


### PR DESCRIPTION
Minor refactoring, as discussed with @aalexandrov here:
https://github.com/MaterializeInc/materialize/pull/21177#discussion_r1294324837

### Motivation

   * This PR refactors existing code: Makes the code consistent with the other `visit_pre` methods.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
