### PR TITLE
storage: extract antichain time iff `T: TotalOrder`

### DIFF
--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -2813,12 +2813,7 @@ where
             *reconciled_updates.entry(row).or_default() += diff;
         }
 
-        match self.state.collections[&id]
-            .write_frontier
-            .elements()
-            .iter()
-            .min()
-        {
+        match self.state.collections[&id].write_frontier.as_option() {
             Some(f) if f > &T::minimum() => {
                 let as_of = f.step_back().unwrap();
 
@@ -2901,12 +2896,7 @@ where
 
         let id = self.state.introspection_ids[&collection];
 
-        let rows = match self.state.collections[&id]
-            .write_frontier
-            .elements()
-            .iter()
-            .min()
-        {
+        let rows = match self.state.collections[&id].write_frontier.as_option() {
             Some(f) if f > &T::minimum() => {
                 let as_of = f.step_back().unwrap();
 

--- a/src/storage-client/src/controller/persist_handles.rs
+++ b/src/storage-client/src/controller/persist_handles.rs
@@ -642,12 +642,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistMonotonicW
                                             let lower = if current_upper.less_than(&at_least) {
                                                 at_least
                                             } else {
-                                                current_upper
-                                                    .elements()
-                                                    .iter()
-                                                    .min()
-                                                    .expect("cannot append data to closed collection")
-                                                    .clone()
+                                                current_upper.into_option().expect("cannot append data to closed collection")
                                             };
 
                                             let upper = lower.step_forward();


### PR DESCRIPTION
### Motivation

The places touched by this PR are attempting to extract a single
timestamp from an Antichain which only makes sense when the timestamp is
totally ordered. However the code as written would compile fine even if
the `TotalOrder` bound were to be lifted, leading to a logic bug.

Using `Antichain::as_option` which is only defined for `T: TotalOrder`
ensures that we get a compile error if we ever attempt to remove the
trait bound.

Thanks to @umanwizard for noticing this pattern

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
