### PR TITLE
CODEOWNERS: add DevEx to `/src/sql-parser`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -82,7 +82,10 @@
 # layer, despite being located in the `sql` crate.
 /src/sql/src/plan/lowering.rs       @MaterializeInc/compute
 /src/sql-lexer                      @MaterializeInc/adapter
-/src/sql-parser                     @MaterializeInc/adapter
+# DevEx is added as an owner of /src/sql-parser to increase awareness of
+# cross-team dependencies via notifications. The code is solely owned by the
+# Adapter team.
+/src/sql-parser                     @MaterializeInc/adapter @MaterializeInc/devex
 /src/sqllogictest                   @MaterializeInc/adapter
 /src/ssh-util                       @MaterializeInc/storage
 /src/stash                          @MaterializeInc/adapter


### PR DESCRIPTION
Most changes that impact external tooling owned by @MaterializeInc/devex (_e.g._ dbt, Terraform) are changes to the SQL syntax. Adding our team as a code owner of `/src/sql-parser` to increase awareness of ongoing work. This isn't meant to set any precedence WRT code reviews, and might be reverted if it turns out to be more overwhelming than useful.

Aligned with @chaas to make sure the Surfaces team is aware of this change.