### PR TITLE
sqlsmith: Silence errors around the use of the avg_internal_v1() func…

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -68,6 +68,8 @@ known_errors = [
     "function list_cat(",  # insufficient type system, parameter types have to match
     "does not support implicitly casting from",
     "aggregate functions that refer exclusively to outer columns not yet supported",  # https://github.com/MaterializeInc/materialize/issues/3720
+    "aggregate functions are not allowed in",  # https://github.com/MaterializeInc/materialize/issues/21295
+    "nested aggregate functions are not allowed",  # https://github.com/MaterializeInc/materialize/issues/21295
     "range lower bound must be less than or equal to range upper bound",
     "violates not-null constraint",
     "division by zero",


### PR DESCRIPTION
…tion

The avg_internal_v1() function was recently introduced to preserve legacy behavior of aggregations. It now shows up in the list of functions and SQLSmith considers it to be non-aggregate, using it in places within the query where it is  not allowed.

Until the issue is fixed on the SQLSmith side, we will silence the error on the mzcompose.py side.

Relates to #21295


### Motivation

Nightly is showing a bunch of spurious SQLSmith errors. I am applying this workaround now and then @def- can fix it properly later.