### PR TITLE
rust: Use rerun-if-changed option in build.rs

### DIFF
--- a/src/sql-lexer/build.rs
+++ b/src/sql-lexer/build.rs
@@ -89,6 +89,8 @@ use uncased::UncasedStr;
 const KEYWORDS_LIST: &str = "src/keywords.txt";
 
 fn main() -> Result<()> {
+    println!("cargo:rerun-if-changed={KEYWORDS_LIST}");
+
     let out_dir = PathBuf::from(env::var_os("OUT_DIR").context("Cannot read OUT_DIR env var")?);
 
     // Generate keywords list and lookup table.

--- a/src/stash/build.rs
+++ b/src/stash/build.rs
@@ -95,6 +95,8 @@ const PROTO_DIRECTORY: &str = "protos";
 const PROTO_HASHES: &str = "protos/hashes.json";
 
 fn main() -> anyhow::Result<()> {
+    println!("cargo:rerun-if-changed={PROTO_DIRECTORY}");
+
     env::set_var("PROTOC", protobuf_src::protoc());
 
     // Read in the persisted hashes from disk.


### PR DESCRIPTION
This PR changes the build scripts in the `mz_stash` and `mz_sql_lexer` crates to specify a "[rerun-if-changed](https://doc.rust-lang.org/cargo/reference/build-scripts.html#rerun-if-changed)" path. Now we should only re-run the build scripts if something in their respective source files change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
