### PR TITLE
webhooks/docs: Move and rename Debugging `CHECK` Statement section

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -115,16 +115,7 @@ sources.
 
 {{< /note >}}
 
-## Request Limits
-
-Webhook sources apply the following limits to received requests:
-
-* Maximum size of the request body is `2MB`. Requests larger than this will fail with 413 Payload Too Large.
-* Maximum number of concurrent connections is 250, across all webhook sources. Trying to connect
-when the server is at the maximum will return 429 Too Many Requests.
-* Requests that contain a header name specified more than once will be rejected with 401 Unauthorized.
-
-## Debugging `CHECK` Statements
+### Debugging Validation
 
 It can be difficult to get your `CHECK` statement correct, especially if your application does not
 have a way to send test events. If you're having trouble with your `CHECK` statement, we recommend
@@ -154,6 +145,15 @@ It's not possible to use `SECRET`s in a `SELECT` statement, so you'll need to pr
 as raw text for debugging.
 
 {{< /note >}}
+
+## Request Limits
+
+Webhook sources apply the following limits to received requests:
+
+* Maximum size of the request body is `2MB`. Requests larger than this will fail with 413 Payload Too Large.
+* Maximum number of concurrent connections is 250, across all webhook sources. Trying to connect
+when the server is at the maximum will return 429 Too Many Requests.
+* Requests that contain a header name specified more than once will be rejected with 401 Unauthorized.
 
 ## Duplicated and Partial Events
 


### PR DESCRIPTION
### Motivation

@jonathan-k-shapiro gave some feedback in Slack that he almost missed the "debugging check statements" section and it would be nice if it was closer to the docs that defined what a `CHECK` statement was. As such, I moved the debugging section under "Request Validation" and renamed it to "Debugging Validation".

### Tips for Reviewers

The git diff isn't great, it looks like I moved the "Request Limits" section, but really I moved "Debugging Validation" from just below it to just above it.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Small organization change to the docs.
