### PR TITLE
[cloudtest] Rename EgressIpConfig -> PgTestDBConfig

### DIFF
--- a/misc/python/materialize/cloudtest/config/environment_config.py
+++ b/misc/python/materialize/cloudtest/config/environment_config.py
@@ -65,7 +65,7 @@ class EnvironmentConfig:
 
 
 @dataclass
-class EgressIpConfig:
+class PgTestDBConfig:
     testdb_dbname: str
     testdb_user: str
     testdb_password: str
@@ -98,7 +98,7 @@ def load_environment_config(pytestconfig: pytest.Config) -> EnvironmentConfig:
     return config
 
 
-def load_egress_ip_config(pytestconfig: pytest.Config) -> EgressIpConfig:
+def load_pg_test_db_config(pytestconfig: pytest.Config) -> PgTestDBConfig:
     args = pytestconfig.option
 
     testdb_dbname = args.testdb_dbname
@@ -112,7 +112,7 @@ def load_egress_ip_config(pytestconfig: pytest.Config) -> EgressIpConfig:
     testdb_port = args.testdb_port
     assert testdb_port is not None
 
-    return EgressIpConfig(
+    return PgTestDBConfig(
         testdb_dbname=testdb_dbname,
         testdb_user=testdb_user,
         testdb_password=testdb_password,


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.
I'm currently implementing a test in the Cloud repo that will validate soft-delete behavior. To do so I'll be re-using the postgres test-db set up for the Egress IP test to generate some source data in the test. This PR simply renames the test-db config to be more generic.

I'll make a corresponding cloud PR to update the name which we can merge when updating the MZ submodule with this commit included. (after we resolve https://github.com/MaterializeInc/cloud/pull/7249)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
