### PR TITLE
Introduce new IndexUsageType for fast path with LIMIT

### DIFF
--- a/src/repr/src/explain.proto
+++ b/src/repr/src/explain.proto
@@ -24,5 +24,6 @@ message ProtoIndexUsageType {
         google.protobuf.Empty dangling_arrange_by = 7;
         google.protobuf.Empty sink_export = 8;
         google.protobuf.Empty index_export = 9;
+        google.protobuf.Empty fast_path_limit = 10;
     }
 }

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -736,6 +736,11 @@ impl<'a> CollectIndexRequests<'a> {
                                     IndexUsageType::PlanRoot => {
                                         // This is ok: happens when the entire query is a `Get`.
                                     },
+                                    IndexUsageType::FastPathLimit => {
+                                        // These are created much later, not even inside
+                                        // `prune_and_annotate_dataflow_index_imports`.
+                                        unreachable!()
+                                    }
                                     IndexUsageType::DanglingArrangeBy => {
                                         // Not possible, because we create IndexUsageType::Unknown
                                         // only when we see an `ArrangeBy`.

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1174,3 +1174,62 @@ Used Indexes:
   - materialize.public.t_b_idx (lookup)
 
 EOF
+
+# Fast path with a LIMIT and no ORDER BY. This is not a full scan.
+query T multiline
+EXPLAIN
+SELECT a+b as x
+FROM t
+WHERE a < 7
+LIMIT 3;
+----
+Explained Query (fast path):
+  Finish limit=3 output=[#0]
+    Project (#2)
+      Filter (#0 < 7)
+        Map ((#0 + #1))
+          ReadExistingIndex materialize.public.t_a_idx_1
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (fast path limit)
+
+EOF
+
+# Same query without a LIMIT, so full scan
+query T multiline
+EXPLAIN
+SELECT a+b as x
+FROM t
+WHERE a < 7;
+----
+Explained Query (fast path):
+  Project (#2)
+    Filter (#0 < 7)
+      Map ((#0 + #1))
+        ReadExistingIndex materialize.public.t_a_idx_1
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF
+
+# Same query with a LIMIT + ORDER BY, so full scan
+query T multiline
+EXPLAIN
+SELECT a+b as x
+FROM t
+WHERE a < 7
+ORDER BY x
+LIMIT 3;
+----
+Explained Query (fast path):
+  Finish order_by=[#0 asc nulls_last] limit=3 output=[#0]
+    Project (#2)
+      Filter (#0 < 7)
+        Map ((#0 + #1))
+          ReadExistingIndex materialize.public.t_a_idx_1
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***)
+
+EOF

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1241,3 +1241,91 @@ Used Indexes:
   - materialize.public.idx_t5_f1 (*** full scan ***, lookup)
 
 EOF
+
+# Check literal constraints with LIMIT
+
+query T multiline
+EXPLAIN
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+LIMIT 1;
+----
+Explained Query (fast path):
+  Finish limit=1 output=[#0, #1]
+    Project (#0, #1)
+      ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2); (3); (4)]
+
+Used Indexes:
+  - materialize.public.idx_t1_a (lookup)
+
+EOF
+
+# Note: This has LIMIT but no ORDER BY, so this is ok to change when row representation changes.
+query IT
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+LIMIT 1;
+----
+1  a
+
+query T multiline
+EXPLAIN
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+ORDER BY -a, b
+LIMIT 3;
+----
+Explained Query (fast path):
+  Finish order_by=[#2 asc nulls_last, #1 asc nulls_last] limit=3 output=[#0, #1]
+    Project (#0, #1, #3)
+      Map (-(#0))
+        ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2); (3); (4)]
+
+Used Indexes:
+  - materialize.public.idx_t1_a (lookup)
+
+EOF
+
+query IT nosort
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+ORDER BY -a, b
+LIMIT 3;
+----
+3  l3
+2  l2
+1  a
+
+query T multiline
+EXPLAIN
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+ORDER BY -a, b
+LIMIT 3 OFFSET 1;
+----
+Explained Query (fast path):
+  Finish order_by=[#2 asc nulls_last, #1 asc nulls_last] limit=3 offset=1 output=[#0, #1]
+    Project (#0, #1, #3)
+      Map (-(#0))
+        ReadExistingIndex materialize.public.idx_t1_a lookup_values=[(1); (2); (3); (4)]
+
+Used Indexes:
+  - materialize.public.idx_t1_a (lookup)
+
+EOF
+
+query IT nosort
+SELECT a,b
+FROM t1
+WHERE a IN (4,3,2,1)
+ORDER BY -a, b
+LIMIT 3 OFFSET 1;
+----
+2  l2
+1  a
+1  l1


### PR DESCRIPTION
Fix the EXPLAIN index usage issue that @parkerhendo found last week: A fast path peek with a LIMIT but no ORDER BY shouldn't be printed as a full scan. (See the logic in `PendingPeek::collect_finished_data`.)

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/21302

### Tips for reviewer

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
