### PR TITLE
webhooks: Fix panic that occurs when renaming a webhook source

### DIFF
--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_ore::str::StrExt;
 use mz_repr::GlobalId;
+use mz_sql_parser::ast::CreateWebhookSourceStatement;
 
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
@@ -52,6 +53,10 @@ pub fn create_stmt_rename(create_stmt: &mut Statement<Raw>, to_item_name: String
             name.0[item_name_len] = Ident::new(to_item_name);
         }
         Statement::CreateConnection(CreateConnectionStatement { name, .. }) => {
+            let item_name_len = name.0.len() - 1;
+            name.0[item_name_len] = Ident::new(to_item_name);
+        }
+        Statement::CreateWebhookSource(CreateWebhookSourceStatement { name, .. }) => {
             let item_name_len = name.0.len() - 1;
             name.0[item_name_len] = Ident::new(to_item_name);
         }
@@ -105,7 +110,8 @@ pub fn create_stmt_rename_refs(
         Statement::CreateSource(_)
         | Statement::CreateTable(_)
         | Statement::CreateSecret(_)
-        | Statement::CreateConnection(_) => {}
+        | Statement::CreateConnection(_)
+        | Statement::CreateWebhookSource(_) => {}
         _ => unreachable!("Internal error: only catalog items need to update item refs"),
     }
 

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -213,6 +213,15 @@ CREATE SOURCE webhook_buildkite2 IN CLUSTER webhook_cluster FROM WEBHOOK
   )
 
 statement ok
+ALTER SOURCE webhook_buildkite2 RENAME TO webhook_buildkite2_renamed;
+
+statement ok
+SELECT * FROM webhook_buildkite2_renamed;
+
+statement error unknown catalog item 'webhook_buildkite2'
+SELECT * FROM webhook_buildkite2;
+
+statement ok
 CREATE SECRET other_secret AS 'another_one';
 
 statement ok

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -36,6 +36,37 @@ a
 b
 c
 
+> CREATE VIEW webhook_text_ascii_code AS SELECT ascii(body) FROM webhook_text WHERE ascii(body) % 2 = 0;
+
+> SELECT * FROM webhook_text_ascii_code;
+98
+
+> ALTER SOURCE webhook_text RENAME TO webhook_text_renamed;
+
+! SELECT * FROM webhook_text;
+contains: unknown catalog item 'webhook_text'
+
+$ webhook-append database=materialize schema=public name=webhook_text status=404
+d
+
+> SELECT * FROM webhook_text_renamed;
+a
+b
+c
+
+$ webhook-append database=materialize schema=public name=webhook_text_renamed
+d
+
+> SELECT * FROM webhook_text_renamed;
+a
+b
+c
+d
+
+> SELECT * FROM webhook_text_ascii_code;
+98
+100
+
 > CREATE SOURCE webhook_json_with_headers IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT JSON
   INCLUDE HEADERS;
@@ -100,11 +131,6 @@ x
 > CREATE TABLE not_a_webhook ( a int8 );
 $ webhook-append database=materialize schema=public name=not_a_webhook status=404
 d
-
-> SELECT * FROM webhook_text;
-a
-b
-c
 
 > CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES;


### PR DESCRIPTION
This PR fixes a panic @bobbyiliev found when experimenting with webhooks. Running `ALTER SOURCE <name> RENAME TO <new_name>;` would panic for webhook sources. This PR fixes the panic and updates `webhook.td` to exercise the scenario.

### Motivation

* This PR fixes a recognized bug
  Fixes: https://github.com/MaterializeInc/materialize/issues/21311

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a panic that would occur when trying to rename a webhook source.
