### PR TITLE
sqlsmith: Silence 'regex parse error'

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -149,6 +149,7 @@ known_errors = [
     "requested length too large",
     "number of columns must be a positive integer literal",
     "regex_extract requires a string literal as its first argument",
+    "regex parse error",
     "out of valid range",
     '" does not exist',  # role does not exist
     "csv_extract number of columns too large",


### PR DESCRIPTION
Passing arbitrary, non-valid-regex output to regexp_extract can naturally result in a parse error.


### Motivation

Nightly CI was showing a false positive.