### PR TITLE
ci: Make sure the cloud-canary test is never run concurrently

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -654,6 +654,8 @@ steps:
     label: "Canary Deploy in Staging Cloud"
     artifact_paths: junit_*.xml
     timeout_in_minutes: 1200
+    concurrency: 1
+    concurrency_group: 'cloud-canary'
     agents:
       queue: linux-x86_64
     plugins:


### PR DESCRIPTION
The cloud canary test operates on a specific Materialize cloud environment, so is unsafe to run concurrently.

### Motivation

Now that we are auto-triggering Nightly on risky commits, the chance for a conflict is considerable.