### PR TITLE
ci: Reduce the timeout of the checks-parallel-* CI steps

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -401,7 +401,7 @@ steps:
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -412,7 +412,7 @@ steps:
 
   - id: checks-parallel-restart-clusterd-compute
     label: "Checks parallel + restart compute clusterd"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -423,7 +423,7 @@ steps:
 
   - id: checks-parallel-restart-entire-mz
     label: "Checks parallel + restart of the entire Mz"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -434,7 +434,7 @@ steps:
 
   - id: checks-parallel-restart-environmentd-clusterd-storage
     label: "Checks parallel + restart of environmentd & storage clusterd"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -445,7 +445,7 @@ steps:
 
   - id: checks-parallel-kill-clusterd-storage
     label: "Checks parallel + kill storage clusterd"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -456,7 +456,7 @@ steps:
 
   - id: checks-parallel-restart-redpanda
     label: "Checks parallel + restart Redpanda & Debezium"
-    timeout_in_minutes: 300
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml


### PR DESCRIPTION
Those steps take less than 5 min to run, so a 300 second timeout was unreasonable and caused a machine to be hogged for 5 hours if there was an issue with the test.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

The jobs in question were suffering from a product bug that caused a 5-hour hang.