### PR TITLE
stash: add trivial `WireCompatible` impl

### DIFF
--- a/src/stash/src/objects.rs
+++ b/src/stash/src/objects.rs
@@ -190,7 +190,12 @@ pub unsafe trait WireCompatible<T: prost::Message>: prost::Message + Default {
     }
 }
 
-unsafe impl WireCompatible<()> for () {}
+// SAFETY: A message type is trivially wire compatible with itself.
+unsafe impl<T: prost::Message + Default> WireCompatible<T> for T {
+    fn convert(old: Self) -> Self {
+        old
+    }
+}
 
 /// Defines one protobuf type as wire compatible with another.
 ///


### PR DESCRIPTION
This PR adds a blanket `WireCompatible` impl for converting a message type to itself.

### Motivation

   * This PR refactors existing code.

This came up in [a discussion](https://github.com/MaterializeInc/materialize/pull/18636#discussion_r1300370663) on a different PR that needed a `WireCompatible` impl from `()` to `()`. I figured rather than adding a bunch of trivial impls when we need them we should just add a blanked impl once.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
