### PR TITLE
scalability framework: Use exponental number of concurrent connections

### DIFF
--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -41,13 +41,13 @@ This is going to display a URL that you can open in your browser
 
 The framework can be directed to execute its queries against various targets:
 
-# Against your current HEAD in a container
+### Against your current HEAD in a container
 
 ```
 ./mzcompose run default --target HEAD ...
 ```
 
-# Against a specific DockerHub tag:
+### Against a specific DockerHub tag:
 
 ```
 ./mzcompose run default --target v1.2.4 ...
@@ -55,14 +55,14 @@ The framework can be directed to execute its queries against various targets:
 
 In both of those cases, Materialize, CRDB and Python will run within the same machine, possibly interfering with each other
 
-# Against a local containerized Postgres instance
+### Against a local containerized Postgres instance
 
 
 ```
 ./mzcompose run default --target postgres ...
 ```
 
-# Against a remote Materialize instance
+### Against a remote Materialize instance
 
 ```
 ./mzcompose run default --target=remote \--materialize-url="postgres://user:password@host:6875/materialize?sslmode=require" --cluster-name= ...
@@ -77,6 +77,15 @@ and all targets will be displayed together on a single chart.
 ./mzcompose run default --target=devel-cdb1f682e28d54e85afdcac3c32d43039df093a8
 ...
 ./mzcompose run default --target=devel-c891e3b4b174bd536b7a15ec212c5202ddc85b95
+```
+
+## Specifying the number of datapoints
+
+The framework uses an exponential function to determine what concurrencies to test. By default, exponent base of 2 is used, with a default
+minimum value of 1 and maximum of 256. To get more data points, you can modify the exponent base to be less than 2:
+
+```
+./mzcompose run default --exponent-base=1.5 --min-concurrency=N --max-concurrency=M
 ```
 
 # Accuracy

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -141,9 +141,17 @@ def run_workload(
 ) -> None:
     df_totals = pd.DataFrame()
     df_details = pd.DataFrame()
-    for concurrency in range(
-        args.min_concurrency, args.max_concurrency + 1, args.concurrency_step
-    ):
+
+    concurrencies: list[int] = [round(args.exponent_base**c) for c in range(0, 1024)]
+    concurrencies = sorted(set(concurrencies))
+    concurrencies = [
+        c
+        for c in concurrencies
+        if c >= args.min_concurrency and c <= args.max_concurrency
+    ]
+    print(f"Concurrencies to benchmark: {concurrencies}")
+
+    for concurrency in concurrencies:
         df_total, df_detail = run_with_concurrency(
             c, endpoint, schema, workload, concurrency, args.count
         )
@@ -166,6 +174,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     parser.add_argument(
+        "--exponent-base",
+        type=float,
+        help="Exponent base to use when deciding what concurrencies to test",
+        default=2,
+    )
+
+    parser.add_argument(
         "--min-concurrency", type=int, help="Minimum concurrency to test", default=1
     )
 
@@ -174,10 +189,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         type=int,
         help="Maximum concurrency to test",
         default=256,
-    )
-
-    parser.add_argument(
-        "--concurrency-step", type=int, help="Maximum concurrency to test", default=10
     )
 
     parser.add_argument(


### PR DESCRIPTION
Previously, the famework was testing concurrences 1 to 265 in incements of ten, so it had to measure ~26 datapoints. Switch to an exponential number of concurrent connections in order to reduce the total number of concurrencies that need to be benchmarked by default. 

### Motivation

The execution times of the scalability benchmark need to be reasonable if people are to be using it.

So we will benchmark the following concurrencies by default 1,2,4,8,16 ... 256 