### PR TITLE
LIMIT by a `MonotonicTopK` instead of `RowSetFinishing`

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -181,9 +181,10 @@ fn permute_oneshot_mfp_around_index(
 /// If the optimized plan is a `Constant` or a `Get` of a maintained arrangement,
 /// we can avoid building a dataflow (and either just return the results, or peek
 /// out of the arrangement, respectively).
-pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
-    dataflow_plan: &mut DataflowDescription<mz_expr::OptimizedMirRelationExpr, (), T>,
+pub fn create_fast_path_plan<T: Timestamp>(
+    dataflow_plan: &mut DataflowDescription<OptimizedMirRelationExpr, (), T>,
     view_id: GlobalId,
+    finishing: Option<&RowSetFinishing>,
 ) -> Result<Option<FastPathPlan>, AdapterError> {
     // At this point, `dataflow_plan` contains our best optimized dataflow.
     // We will check the plan to see if there is a fast path to escape full dataflow construction.
@@ -192,7 +193,7 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
     // to build (no dependent views). There is likely an index to build as well, but we may not be sure.
     if dataflow_plan.objects_to_build.len() >= 1 && dataflow_plan.objects_to_build[0].id == view_id
     {
-        let mir = &dataflow_plan.objects_to_build[0].plan.as_inner_mut();
+        let mut mir = &*dataflow_plan.objects_to_build[0].plan.as_inner_mut();
         if let Some((rows, ..)) = mir.as_const() {
             // In the case of a constant, we can return the result now.
             return Ok(Some(FastPathPlan::Constant(
@@ -202,12 +203,46 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
                 mir.typ(),
             )));
         } else {
+            if let MirRelationExpr::Project { input, outputs } = mir {
+                if outputs.iter().copied().eq(0..input.arity()) {
+                    // Trivial projection, jump through it.
+                    mir = input;
+                }
+            }
+            // If there is a TopK that would be completely covered by the finishing, then jump
+            // through the TopK.
+            if let MirRelationExpr::TopK {
+                input,
+                group_key,
+                order_key,
+                limit,
+                offset,
+                monotonic: _,
+                expected_group_size: _,
+            } = mir
+            {
+                if let Some(finishing) = finishing {
+                    if group_key.is_empty() && *order_key == finishing.order_by && *offset == 0 {
+                        // The following is roughly `limit >= finishing.limit`, but with Options.
+                        let finishing_limits_at_least_as_topk = match (limit, finishing.limit) {
+                            (None, _) => true,
+                            (Some(..), None) => false,
+                            (Some(topk_limit), Some(finishing_limit)) => {
+                                *topk_limit >= finishing_limit
+                            }
+                        };
+                        if finishing_limits_at_least_as_topk {
+                            mir = input;
+                        }
+                    }
+                }
+            }
             // In the case of a linear operator around an indexed view, we
             // can skip creating a dataflow and instead pull all the rows in
             // index and apply the linear operator against them.
             let (mfp, mir) = mz_expr::MapFilterProject::extract_from_expression(mir);
             match mir {
-                mz_expr::MirRelationExpr::Get { id, .. } => {
+                MirRelationExpr::Get { id, .. } => {
                     // Just grab any arrangement
                     // Nothing to be done if an arrangement does not exist
                     for (index_id, IndexImport { desc, .. }) in dataflow_plan.index_imports.iter() {
@@ -220,7 +255,7 @@ pub fn create_fast_path_plan<T: timely::progress::Timestamp>(
                         }
                     }
                 }
-                mz_expr::MirRelationExpr::Join { implementation, .. } => {
+                MirRelationExpr::Join { implementation, .. } => {
                     if let mz_expr::JoinImplementation::IndexedFilter(id, key, vals) =
                         implementation
                     {
@@ -286,9 +321,10 @@ impl crate::coord::Coordinator {
         key: Vec<MirScalarExpr>,
         permutation: BTreeMap<usize, usize>,
         thinned_arity: usize,
+        finishing: &RowSetFinishing,
     ) -> Result<PeekPlan, AdapterError> {
         // try to produce a `FastPathPlan`
-        let fast_path_plan = create_fast_path_plan(&mut dataflow, view_id)?;
+        let fast_path_plan = create_fast_path_plan(&mut dataflow, view_id, Some(finishing))?;
         // derive a PeekPlan from the optional FastPathPlan
         let peek_plan = fast_path_plan.map_or_else(
             // finalize the dataflow and produce a PeekPlan::SlowPath as a default

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2316,6 +2316,7 @@ impl Coordinator {
             real_time_recency_ts,
             key,
             typ,
+            &finishing,
         )?;
 
         let determination = peek_plan.determination.clone();
@@ -2480,6 +2481,7 @@ impl Coordinator {
         real_time_recency_ts: Option<Timestamp>,
         key: Vec<MirScalarExpr>,
         typ: RelationType,
+        finishing: &RowSetFinishing,
     ) -> Result<PlannedPeek, AdapterError> {
         let conn_id = session.conn_id().clone();
         let determination = self.sequence_peek_timestamp(
@@ -2516,6 +2518,7 @@ impl Coordinator {
             key,
             permutation,
             thinning.len(),
+            finishing,
         )?;
 
         Ok(PlannedPeek {
@@ -3084,7 +3087,7 @@ impl Coordinator {
                     |r| prep_relation_expr(state, r, style),
                     |s| prep_scalar_expr(state, s, style),
                 )?;
-                peek::create_fast_path_plan(&mut dataflow, GlobalId::Explain)?
+                peek::create_fast_path_plan(&mut dataflow, GlobalId::Explain, finishing.as_ref())?
             }
             _ => None,
         };

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2860,6 +2860,15 @@ impl RustType<ProtoRowSetFinishing> for RowSetFinishing {
 }
 
 impl RowSetFinishing {
+    /// Returns a trivial finishing, i.e., that does nothing to the result set.
+    pub fn trivial(arity: usize) -> RowSetFinishing {
+        RowSetFinishing {
+            order_by: Vec::new(),
+            limit: None,
+            offset: 0,
+            project: (0..arity).collect(),
+        }
+    }
     /// True if the finishing does nothing to any result set.
     pub fn is_trivial(&self, arity: usize) -> bool {
         self.limit.is_none()

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -124,6 +124,10 @@ pub fn plan_root_query(
 
     if lifetime.is_maintained() {
         expr.finish_maintained(&mut finishing);
+    } else if lifetime.is_one_shot() {
+        expr.pre_finish_one_shot_select(&finishing);
+    } else {
+        unreachable!()
     }
 
     let typ = qcx.relation_type(&expr);

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -831,6 +831,8 @@ pub fn plan_up_to(
 ) -> Result<MirScalarExpr, PlanError> {
     let scope = Scope::empty();
     let desc = RelationDesc::empty();
+    // Even though this is part of a SUBSCRIBE, we need a QueryLifetime::OneShot (instead of
+    // QueryLifetime::Subscribe), because the UP TO is evaluated only once.
     let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     transform_ast::transform(scx, &mut up_to)?;
     let ecx = &ExprContext {
@@ -859,6 +861,8 @@ pub fn plan_as_of(
             AsOf::At(ref mut expr) | AsOf::AtLeast(ref mut expr) => {
                 let scope = Scope::empty();
                 let desc = RelationDesc::empty();
+                // Even for a SUBSCRIBE, we need QueryLifetime::OneShot, because the AS OF is
+                // evaluated only once.
                 let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
                 transform_ast::transform(scx, expr)?;
                 let ecx = &ExprContext {
@@ -915,7 +919,7 @@ pub fn plan_webhook_validate_using(
     scx: &StatementContext,
     validate_using: CreateWebhookSourceCheck<Aug>,
 ) -> Result<WebhookValidation, PlanError> {
-    let qcx = QueryContext::root(scx, QueryLifetime::Static);
+    let qcx = QueryContext::root(scx, QueryLifetime::Source);
 
     let CreateWebhookSourceCheck {
         options,
@@ -1139,7 +1143,7 @@ pub fn plan_index_exprs<'a>(
     exprs: Vec<Expr<Aug>>,
 ) -> Result<Vec<mz_expr::MirScalarExpr>, PlanError> {
     let scope = Scope::from_source(None, on_desc.iter_names());
-    let qcx = QueryContext::root(scx, QueryLifetime::Static);
+    let qcx = QueryContext::root(scx, QueryLifetime::Index);
 
     let ecx = &ExprContext {
         qcx: &qcx,
@@ -1643,7 +1647,7 @@ fn plan_set_expr(
             //
             // TODO(jkosh44) Add message to error that prints out an equivalent view definition
             // with all show commands expanded into their equivalent SELECT statements.
-            if qcx.lifetime == QueryLifetime::Static {
+            if !qcx.lifetime.allow_show() {
                 return Err(PlanError::ShowCommandInView);
             }
 
@@ -5586,15 +5590,50 @@ impl Visit<'_, Aug> for WindowFuncCollector {
     }
 }
 
-/// Specifies how long a query will live. This impacts whether the query is
+/// Specifies how long a query will live.
+///
+/// Currently, it affects whether SHOW commands are allowed.
+///
+/// (This used to also impact whether the query is
 /// allowed to reason about the time at which it is running, e.g., by calling
-/// the `now()` function.
+/// the `now()` function. Nowadays, this is decided by a different mechanism.)
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum QueryLifetime {
-    /// The query's result will be computed at one point in time.
+    /// The query's (or the expression's) result will be computed at one point in time.
     OneShot,
-    /// The query's result will be maintained indefinitely.
-    Static,
+    /// The query (or expression) is used in a dataflow that maintains an index.
+    Index,
+    /// The query (or expression) is used in a dataflow that maintains a materialized view.
+    MaterializedView,
+    /// The query (or expression) is used in a dataflow that maintains a SUBSCRIBE.
+    Subscribe,
+    /// The query (or expression) is part of a (non-materialized) view.
+    View,
+    /// The expression is part of a source definition.
+    Source,
+}
+
+impl QueryLifetime {
+    pub fn is_one_shot(&self) -> bool {
+        let res = matches!(self, QueryLifetime::OneShot);
+        assert_eq!(!res, self.is_maintained());
+        res
+    }
+
+    pub fn is_maintained(&self) -> bool {
+        matches!(
+            self,
+            QueryLifetime::Index
+                | QueryLifetime::MaterializedView
+                | QueryLifetime::Subscribe
+                | QueryLifetime::View
+                | QueryLifetime::Source
+        )
+    }
+
+    pub fn allow_show(&self) -> bool {
+        self.is_one_shot() || matches!(self, QueryLifetime::Subscribe)
+    }
 }
 
 /// Description of a CTE sufficient for query planning.

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -122,6 +122,10 @@ pub fn plan_root_query(
     // `finishing.project`).
     try_push_projection_order_by(&mut expr, &mut finishing.project, &mut finishing.order_by);
 
+    if lifetime.is_maintained() {
+        expr.finish_maintained(&mut finishing);
+    }
+
     let typ = qcx.relation_type(&expr);
     let typ = RelationType::new(
         finishing

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1833,13 +1833,16 @@ pub fn plan_view(
     let query::PlannedQuery {
         mut expr,
         mut desc,
-        finishing,
+        // We get back a trivial finishing, because `plan_root_query` applies the given finishing.
+        // Note: Earlier, we were thinking to maybe persist the finishing information with the view
+        // here to help with materialize#724. However, in the meantime, there might be a better
+        // approach to solve materialize#724:
+        // https://github.com/MaterializeInc/materialize/issues/724#issuecomment-1688293709
+        finishing: _,
         scope: _,
     } = query::plan_root_query(scx, query.clone(), QueryLifetime::View)?;
 
     expr.bind_parameters(params)?;
-    //TODO: materialize#724 - persist finishing information with the view?
-    expr.finish(finishing);
     let relation_expr = expr.optimize_and_lower(&scx.into())?;
 
     let name = if temporary {
@@ -1974,12 +1977,11 @@ pub fn plan_create_materialized_view(
     let query::PlannedQuery {
         mut expr,
         mut desc,
-        finishing,
+        finishing: _, // We get back a trivial finishing, see comment in `plan_view`.
         scope: _,
     } = query::plan_root_query(scx, stmt.query, QueryLifetime::MaterializedView)?;
 
     expr.bind_parameters(params)?;
-    expr.finish(finishing);
     let expr = expr.optimize_and_lower(&scx.into())?;
 
     plan_utils::maybe_rename_columns(

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -754,7 +754,7 @@ pub fn plan_create_source(
                 // of the types are text
                 let mut cast_scx = scx.clone();
                 cast_scx.param_types = Default::default();
-                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Static);
+                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Source);
                 let mut column_types = vec![];
                 for column in table.columns.iter() {
                     column_types.push(ColumnType {
@@ -1835,7 +1835,7 @@ pub fn plan_view(
         mut desc,
         finishing,
         scope: _,
-    } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, query.clone(), QueryLifetime::View)?;
 
     expr.bind_parameters(params)?;
     //TODO: materialize#724 - persist finishing information with the view?
@@ -1976,7 +1976,7 @@ pub fn plan_create_materialized_view(
         mut desc,
         finishing,
         scope: _,
-    } = query::plan_root_query(scx, stmt.query, QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, stmt.query, QueryLifetime::MaterializedView)?;
 
     expr.bind_parameters(params)?;
     expr.finish(finishing);

--- a/test/sqllogictest/explain/decorrelated_plan_as_json.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_json.slt
@@ -1116,75 +1116,67 @@ VIEW ov
       }
     },
     "body": {
-      "Project": {
+      "TopK": {
         "input": {
-          "TopK": {
-            "input": {
-              "Join": {
-                "inputs": [
-                  {
-                    "Get": {
-                      "id": {
-                        "Local": 0
-                      },
-                      "typ": {
-                        "column_types": [],
-                        "keys": [
-                          []
-                        ]
-                      }
-                    }
-                  },
-                  {
-                    "Get": {
-                      "id": {
-                        "Global": {
-                          "User": 1
-                        }
-                      },
-                      "typ": {
-                        "column_types": [
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          },
-                          {
-                            "scalar_type": "Int32",
-                            "nullable": true
-                          }
-                        ],
-                        "keys": []
-                      }
-                    }
-                  }
-                ],
-                "equivalences": [],
-                "implementation": "Unimplemented"
-              }
-            },
-            "group_key": [],
-            "order_key": [
+          "Join": {
+            "inputs": [
               {
-                "column": 1,
-                "desc": false,
-                "nulls_last": true
+                "Get": {
+                  "id": {
+                    "Local": 0
+                  },
+                  "typ": {
+                    "column_types": [],
+                    "keys": [
+                      []
+                    ]
+                  }
+                }
               },
               {
-                "column": 0,
-                "desc": true,
-                "nulls_last": false
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
+                  },
+                  "typ": {
+                    "column_types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ],
+                    "keys": []
+                  }
+                }
               }
             ],
-            "limit": 5,
-            "offset": 0,
-            "monotonic": false,
-            "expected_group_size": null
+            "equivalences": [],
+            "implementation": "Unimplemented"
           }
         },
-        "outputs": [
-          0,
-          1
-        ]
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 1,
+            "desc": false,
+            "nulls_last": true
+          },
+          {
+            "column": 0,
+            "desc": true,
+            "nulls_last": false
+          }
+        ],
+        "limit": 5,
+        "offset": 0,
+        "monotonic": false,
+        "expected_group_size": null
       }
     }
   }
@@ -1218,46 +1210,67 @@ SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
       }
     },
     "body": {
-      "Join": {
-        "inputs": [
-          {
-            "Get": {
-              "id": {
-                "Local": 0
-              },
-              "typ": {
-                "column_types": [],
-                "keys": [
-                  []
-                ]
-              }
-            }
-          },
-          {
-            "Get": {
-              "id": {
-                "Global": {
-                  "User": 1
+      "TopK": {
+        "input": {
+          "Join": {
+            "inputs": [
+              {
+                "Get": {
+                  "id": {
+                    "Local": 0
+                  },
+                  "typ": {
+                    "column_types": [],
+                    "keys": [
+                      []
+                    ]
+                  }
                 }
               },
-              "typ": {
-                "column_types": [
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+              {
+                "Get": {
+                  "id": {
+                    "Global": {
+                      "User": 1
+                    }
                   },
-                  {
-                    "scalar_type": "Int32",
-                    "nullable": true
+                  "typ": {
+                    "column_types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      },
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ],
+                    "keys": []
                   }
-                ],
-                "keys": []
+                }
               }
-            }
+            ],
+            "equivalences": [],
+            "implementation": "Unimplemented"
+          }
+        },
+        "group_key": [],
+        "order_key": [
+          {
+            "column": 1,
+            "desc": false,
+            "nulls_last": true
+          },
+          {
+            "column": 0,
+            "desc": true,
+            "nulls_last": false
           }
         ],
-        "equivalences": [],
-        "implementation": "Unimplemented"
+        "limit": 5,
+        "offset": 0,
+        "monotonic": false,
+        "expected_group_size": null
       }
     }
   }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -142,12 +142,11 @@ query T multiline
 EXPLAIN DECORRELATED PLAN AS TEXT FOR
 VIEW ov
 ----
-Project (#0, #1)
-  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
-    CrossJoin
-      Constant
-        - ()
-      Get materialize.public.t
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+  CrossJoin
+    Constant
+      - ()
+    Get materialize.public.t
 
 EOF
 
@@ -157,10 +156,11 @@ EXPLAIN DECORRELATED PLAN AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
-  CrossJoin
-    Constant
-      - ()
-    Get materialize.public.t
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+    CrossJoin
+      Constant
+        - ()
+      Get materialize.public.t
 
 EOF
 

--- a/test/sqllogictest/explain/raw_plan_as_json.slt
+++ b/test/sqllogictest/explain/raw_plan_as_json.slt
@@ -313,53 +313,45 @@ EXPLAIN RAW PLAN AS JSON FOR
 VIEW ov
 ----
 {
-  "Project": {
+  "TopK": {
     "input": {
-      "TopK": {
-        "input": {
-          "Get": {
-            "id": {
-              "Global": {
-                "User": 1
-              }
-            },
-            "typ": {
-              "column_types": [
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                },
-                {
-                  "scalar_type": "Int32",
-                  "nullable": true
-                }
-              ],
-              "keys": []
-            }
+      "Get": {
+        "id": {
+          "Global": {
+            "User": 1
           }
         },
-        "group_key": [],
-        "order_key": [
-          {
-            "column": 1,
-            "desc": false,
-            "nulls_last": true
-          },
-          {
-            "column": 0,
-            "desc": true,
-            "nulls_last": false
-          }
-        ],
-        "limit": 5,
-        "offset": 0,
-        "expected_group_size": null
+        "typ": {
+          "column_types": [
+            {
+              "scalar_type": "Int32",
+              "nullable": true
+            },
+            {
+              "scalar_type": "Int32",
+              "nullable": true
+            }
+          ],
+          "keys": []
+        }
       }
     },
-    "outputs": [
-      0,
-      1
-    ]
+    "group_key": [],
+    "order_key": [
+      {
+        "column": 1,
+        "desc": false,
+        "nulls_last": true
+      },
+      {
+        "column": 0,
+        "desc": true,
+        "nulls_last": false
+      }
+    ],
+    "limit": 5,
+    "offset": 0,
+    "expected_group_size": null
   }
 }
 EOF
@@ -370,25 +362,45 @@ EXPLAIN RAW PLAN AS JSON FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 {
-  "Get": {
-    "id": {
-      "Global": {
-        "User": 1
+  "TopK": {
+    "input": {
+      "Get": {
+        "id": {
+          "Global": {
+            "User": 1
+          }
+        },
+        "typ": {
+          "column_types": [
+            {
+              "scalar_type": "Int32",
+              "nullable": true
+            },
+            {
+              "scalar_type": "Int32",
+              "nullable": true
+            }
+          ],
+          "keys": []
+        }
       }
     },
-    "typ": {
-      "column_types": [
-        {
-          "scalar_type": "Int32",
-          "nullable": true
-        },
-        {
-          "scalar_type": "Int32",
-          "nullable": true
-        }
-      ],
-      "keys": []
-    }
+    "group_key": [],
+    "order_key": [
+      {
+        "column": 1,
+        "desc": false,
+        "nulls_last": true
+      },
+      {
+        "column": 0,
+        "desc": true,
+        "nulls_last": false
+      }
+    ],
+    "limit": 5,
+    "offset": 0,
+    "expected_group_size": null
   }
 }
 EOF

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -103,9 +103,8 @@ query T multiline
 EXPLAIN RAW PLAN AS TEXT FOR
 VIEW ov
 ----
-Project (#0, #1)
-  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
-    Get materialize.public.t
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+  Get materialize.public.t
 
 EOF
 
@@ -115,7 +114,8 @@ EXPLAIN RAW PLAN AS TEXT FOR
 SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 ----
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
-  Get materialize.public.t
+  TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+    Get materialize.public.t
 
 EOF
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -468,17 +468,18 @@ SELECT t.name AS "tag.name"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l2 // { arity: 3 }
-                Project (#1) // { arity: 1 }
-                  Get l0 // { arity: 2 }
-            Get l2 // { arity: 3 }
+      TopK order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 4 }
+        Project (#0, #3..=#5) // { arity: 4 }
+          Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
+            Union // { arity: 3 }
+              Map (null, null) // { arity: 3 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l2 // { arity: 3 }
+                  Project (#1) // { arity: 1 }
+                    Get l0 // { arity: 2 }
+              Get l2 // { arity: 3 }
     With
       cte l2 =
         Project (#1, #3, #4) // { arity: 3 }
@@ -561,38 +562,39 @@ LIMIT 20
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=20 output=[#0..=#4]
-    Reduce group_by=[#0, #2, #1, #3] aggregates=[count(*)] // { arity: 5 }
-      Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33 = "China") AND (#10) IS NOT NULL AND (#16) IS NOT NULL AND (#25) IS NOT NULL AND (#31) IS NOT NULL // { arity: 37 }
-          Join on=(#1 = #36 AND #10 = #14 AND #16 = #18 AND #25 = #28 AND #31 = #32) type=differential // { arity: 37 }
-            implementation
-              %5[#0]UKA » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
-            ArrangeBy keys=[[#1]] // { arity: 13 }
-              Get materialize.public.message // { arity: 13 }
-            ArrangeBy keys=[[#1]] // { arity: 4 }
-              Get materialize.public.forum // { arity: 4 }
-            ArrangeBy keys=[[#1]] // { arity: 11 }
-              Get materialize.public.person // { arity: 11 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
-              Get materialize.public.city // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
-              Get materialize.public.country // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
-                Project (#7) // { arity: 1 }
-                  Filter (#0) IS NOT NULL // { arity: 9 }
-                    Join on=(#0 = #6 AND #5 = #8) type=differential // { arity: 9 }
-                      implementation
-                        %0:tagclass[#0]KAe » %1:tag[#1]Ke » %2:message_hastag_tag[#1]Ke
-                      ArrangeBy keys=[[#0]] // { arity: 5 }
-                        ReadExistingIndex materialize.public.tagclass lookup_value=("Philosopher") // { arity: 5 }
-                      ArrangeBy keys=[[#1]] // { arity: 2 }
-                        Project (#0, #3) // { arity: 2 }
-                          Filter (#0) IS NOT NULL // { arity: 4 }
-                            Get materialize.public.tag // { arity: 4 }
-                      ArrangeBy keys=[[#1]] // { arity: 2 }
-                        Project (#1, #2) // { arity: 2 }
-                          Get materialize.public.message_hastag_tag // { arity: 3 }
+    TopK order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=20 // { arity: 5 }
+      Reduce group_by=[#0, #2, #1, #3] aggregates=[count(*)] // { arity: 5 }
+        Project (#10, #13, #15, #16) // { arity: 4 }
+          Filter (#33 = "China") AND (#10) IS NOT NULL AND (#16) IS NOT NULL AND (#25) IS NOT NULL AND (#31) IS NOT NULL // { arity: 37 }
+            Join on=(#1 = #36 AND #10 = #14 AND #16 = #18 AND #25 = #28 AND #31 = #32) type=differential // { arity: 37 }
+              implementation
+                %5[#0]UKA » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
+              ArrangeBy keys=[[#1]] // { arity: 13 }
+                Get materialize.public.message // { arity: 13 }
+              ArrangeBy keys=[[#1]] // { arity: 4 }
+                Get materialize.public.forum // { arity: 4 }
+              ArrangeBy keys=[[#1]] // { arity: 11 }
+                Get materialize.public.person // { arity: 11 }
+              ArrangeBy keys=[[#0]] // { arity: 4 }
+                Get materialize.public.city // { arity: 4 }
+              ArrangeBy keys=[[#0]] // { arity: 4 }
+                Get materialize.public.country // { arity: 4 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Distinct group_by=[#0] // { arity: 1 }
+                  Project (#7) // { arity: 1 }
+                    Filter (#0) IS NOT NULL // { arity: 9 }
+                      Join on=(#0 = #6 AND #5 = #8) type=differential // { arity: 9 }
+                        implementation
+                          %0:tagclass[#0]KAe » %1:tag[#1]Ke » %2:message_hastag_tag[#1]Ke
+                        ArrangeBy keys=[[#0]] // { arity: 5 }
+                          ReadExistingIndex materialize.public.tagclass lookup_value=("Philosopher") // { arity: 5 }
+                        ArrangeBy keys=[[#1]] // { arity: 2 }
+                          Project (#0, #3) // { arity: 2 }
+                            Filter (#0) IS NOT NULL // { arity: 4 }
+                              Get materialize.public.tag // { arity: 4 }
+                        ArrangeBy keys=[[#1]] // { arity: 2 }
+                          Project (#1, #2) // { arity: 2 }
+                            Get materialize.public.message_hastag_tag // { arity: 3 }
 
 Used Indexes:
   - materialize.public.tag_id (*** full scan ***)
@@ -677,22 +679,23 @@ LIMIT 100
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Reduce group_by=[#1..=#3, #0] aggregates=[count(#4)] // { arity: 5 }
-        Union // { arity: 5 }
-          Map (null) // { arity: 5 }
-            Union // { arity: 4 }
-              Negate // { arity: 4 }
-                Project (#0..=#3) // { arity: 4 }
-                  Join on=(#1 = #4) type=differential // { arity: 5 }
-                    implementation
-                      %1[#0]UKA » %0:l2[#1]K
-                    Get l2 // { arity: 4 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
-                        Project (#1) // { arity: 1 }
-                          Get l3 // { arity: 5 }
-              Get l1 // { arity: 4 }
-          Get l3 // { arity: 5 }
+      TopK order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 5 }
+        Reduce group_by=[#1..=#3, #0] aggregates=[count(#4)] // { arity: 5 }
+          Union // { arity: 5 }
+            Map (null) // { arity: 5 }
+              Union // { arity: 4 }
+                Negate // { arity: 4 }
+                  Project (#0..=#3) // { arity: 4 }
+                    Join on=(#1 = #4) type=differential // { arity: 5 }
+                      implementation
+                        %1[#0]UKA » %0:l2[#1]K
+                      Get l2 // { arity: 4 }
+                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                        Distinct group_by=[#0] // { arity: 1 }
+                          Project (#1) // { arity: 1 }
+                            Get l3 // { arity: 5 }
+                Get l1 // { arity: 4 }
+            Get l3 // { arity: 5 }
     With
       cte l3 =
         Project (#0..=#3, #5) // { arity: 5 }
@@ -788,17 +791,18 @@ SELECT CreatorPersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
-        Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
-          Union // { arity: 3 }
-            Map (null) // { arity: 3 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Get l3 // { arity: 3 }
-                Project (#1, #2) // { arity: 2 }
-                  Get l2 // { arity: 3 }
-            Get l3 // { arity: 3 }
+      TopK order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 5 }
+        Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
+          Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
+            Union // { arity: 3 }
+              Map (null) // { arity: 3 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Get l3 // { arity: 3 }
+                  Project (#1, #2) // { arity: 2 }
+                    Get l2 // { arity: 3 }
+              Get l3 // { arity: 3 }
     With
       cte l3 =
         Project (#1, #2, #4) // { arity: 3 }
@@ -899,16 +903,17 @@ LIMIT 100
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0))] // { arity: 2 }
-        Union // { arity: 2 }
-          Map (null) // { arity: 2 }
-            Union // { arity: 1 }
-              Negate // { arity: 1 }
+      TopK order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 2 }
+        Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0))] // { arity: 2 }
+          Union // { arity: 2 }
+            Map (null) // { arity: 2 }
+              Union // { arity: 1 }
+                Negate // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Get l4 // { arity: 2 }
                 Project (#0) // { arity: 1 }
-                  Get l4 // { arity: 2 }
-              Project (#0) // { arity: 1 }
-                Get l3 // { arity: 2 }
-          Get l4 // { arity: 2 }
+                  Get l3 // { arity: 2 }
+            Get l4 // { arity: 2 }
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
@@ -1012,26 +1017,27 @@ SELECT RelatedTag.name AS "relatedTag.name"
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-        Project (#1) // { arity: 1 }
-          Join on=(#0 = #2) type=differential // { arity: 3 }
-            implementation
-              %0:l2[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Get l2 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Join on=(#0 = #1) type=differential // { arity: 2 }
-                      implementation
-                        %0:l3[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Get l3 // { arity: 1 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
-                          Get l1 // { arity: 1 }
-                Get l3 // { arity: 1 }
+      TopK order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 2 }
+        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+          Project (#1) // { arity: 1 }
+            Join on=(#0 = #2) type=differential // { arity: 3 }
+              implementation
+                %0:l2[#0]K » %1[#0]K
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Get l2 // { arity: 2 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Join on=(#0 = #1) type=differential // { arity: 2 }
+                        implementation
+                          %0:l3[#0]UKA » %1[#0]UKA
+                        ArrangeBy keys=[[#0]] // { arity: 1 }
+                          Get l3 // { arity: 1 }
+                        ArrangeBy keys=[[#0]] // { arity: 1 }
+                          Distinct group_by=[#0] // { arity: 1 }
+                            Get l1 // { arity: 1 }
+                  Get l3 // { arity: 1 }
     With
       cte l3 =
         Distinct group_by=[#0] // { arity: 1 }
@@ -1128,26 +1134,27 @@ SELECT p.PersonId AS "person.id"
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1, #3]
     Return // { arity: 5 }
-      Map (coalesce(#2, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
-        Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
-          Union // { arity: 3 }
-            Map (null) // { arity: 3 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
+      TopK order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 5 }
+        Map (coalesce(#2, 0), (bigint_to_numeric(#1) + #3)) // { arity: 5 }
+          Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+            Union // { arity: 3 }
+              Map (null) // { arity: 3 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Join on=(#2 = #3) type=differential // { arity: 4 }
+                        implementation
+                          %1[#0]UKA » %0:l10[#2]K
+                        ArrangeBy keys=[[#2]] // { arity: 3 }
+                          Get l10 // { arity: 3 }
+                        ArrangeBy keys=[[#0]] // { arity: 1 }
+                          Distinct group_by=[#0] // { arity: 1 }
+                            Project (#2) // { arity: 1 }
+                              Get l11 // { arity: 4 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(#2 = #3) type=differential // { arity: 4 }
-                      implementation
-                        %1[#0]UKA » %0:l10[#2]K
-                      ArrangeBy keys=[[#2]] // { arity: 3 }
-                        Get l10 // { arity: 3 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
-                          Project (#2) // { arity: 1 }
-                            Get l11 // { arity: 4 }
-                Project (#0, #1) // { arity: 2 }
-                  Get l10 // { arity: 3 }
-            Project (#0, #1, #3) // { arity: 3 }
-              Get l11 // { arity: 4 }
+                    Get l10 // { arity: 3 }
+              Project (#0, #1, #3) // { arity: 3 }
+                Get l11 // { arity: 4 }
     With
       cte l11 =
         Project (#0..=#2, #4) // { arity: 4 }
@@ -1293,23 +1300,24 @@ SELECT Person.id AS "person.id"
 ----
 Explained Query:
   Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[#0..=#2] aggregates=[count(*), sum(#3)] // { arity: 5 }
-      Project (#1..=#3, #25) // { arity: 4 }
-        Filter (#23) IS NULL AND (#11 <= 2012-11-24 00:00:00 UTC) AND (#11 >= 2012-08-29 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 26 }
-          Join on=(#1 = #20 AND #12 = #24) type=delta // { arity: 26 }
-            implementation
-              %0:person » %1:message[#9]KAniif » %2[#0]UKA
-              %1:message » %2[#0]UKA » %0:person[#1]KA
-              %2 » %1:message[#1]KAniif » %0:person[#1]KA
-            ArrangeBy keys=[[#1]] // { arity: 11 }
-              Get materialize.public.person // { arity: 11 }
-            ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
-              Get materialize.public.message // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
-                Project (#2) // { arity: 1 }
-                  Filter (#0 <= 2012-11-24 00:00:00 UTC) AND (#0 >= 2012-08-29 00:00:00 UTC) AND (#2) IS NOT NULL // { arity: 13 }
-                    Get materialize.public.message // { arity: 13 }
+    TopK order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 5 }
+      Reduce group_by=[#0..=#2] aggregates=[count(*), sum(#3)] // { arity: 5 }
+        Project (#1..=#3, #25) // { arity: 4 }
+          Filter (#23) IS NULL AND (#11 <= 2012-11-24 00:00:00 UTC) AND (#11 >= 2012-08-29 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 26 }
+            Join on=(#1 = #20 AND #12 = #24) type=delta // { arity: 26 }
+              implementation
+                %0:person » %1:message[#9]KAniif » %2[#0]UKA
+                %1:message » %2[#0]UKA » %0:person[#1]KA
+                %2 » %1:message[#1]KAniif » %0:person[#1]KA
+              ArrangeBy keys=[[#1]] // { arity: 11 }
+                Get materialize.public.person // { arity: 11 }
+              ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+                Get materialize.public.message // { arity: 13 }
+              ArrangeBy keys=[[#0]] // { arity: 2 }
+                Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+                  Project (#2) // { arity: 1 }
+                    Filter (#0 <= 2012-11-24 00:00:00 UTC) AND (#0 >= 2012-08-29 00:00:00 UTC) AND (#2) IS NOT NULL // { arity: 13 }
+                      Get materialize.public.message // { arity: 13 }
 
 Used Indexes:
   - materialize.public.person_id (delta join 1st input (full scan))
@@ -1402,67 +1410,68 @@ SELECT m.friendId AS "person.id"
 Explained Query:
   Finish order_by=[#2 desc nulls_first, #1 asc nulls_last, #0 asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #8) // { arity: 2 }
-          Filter (#6) IS NOT NULL // { arity: 11 }
-            Join on=(eq(#0, #1, #2) AND eq(#3, #4, #5) AND #6 = #7) type=differential // { arity: 11 }
-              implementation
-                %0[#0]UKA » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:l3[#0]K » %5:tag[#0]KA
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Threshold // { arity: 1 }
-                    Union // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
-                        Project (#4) // { arity: 1 }
-                          Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 5 }
-                            implementation
-                              %0:l2[#0]UKA » %1:l1[#0]K » %2:l1[#0]K
-                            ArrangeBy keys=[[#0]] // { arity: 1 }
-                              Get l2 // { arity: 1 }
-                            Get l1 // { arity: 2 }
-                            Get l1 // { arity: 2 }
-                      Negate // { arity: 1 }
-                        Get l2 // { arity: 1 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Filter (#5 = "Italy") AND (#3) IS NOT NULL // { arity: 8 }
-                      Join on=(#1 = #2 AND #3 = #4) type=differential // { arity: 8 }
-                        implementation
-                          %2:country[#0]KAef » %1:city[#1]Kef » %0:person[#1]Kef
-                        ArrangeBy keys=[[#1]] // { arity: 2 }
-                          Project (#1, #8) // { arity: 2 }
-                            Filter (#1) IS NOT NULL // { arity: 11 }
-                              Get materialize.public.person // { arity: 11 }
-                        ArrangeBy keys=[[#1]] // { arity: 2 }
-                          Project (#0, #3) // { arity: 2 }
-                            Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 4 }
-                              Get materialize.public.city // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 4 }
-                          Get materialize.public.country // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Distinct group_by=[#1, #0] // { arity: 2 }
-                  Project (#1, #9) // { arity: 2 }
-                    Get materialize.public.message // { arity: 13 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Filter (#3) IS NOT NULL // { arity: 9 }
-                      Join on=(#1 = #2 AND #3 = #4) type=differential // { arity: 9 }
-                        implementation
-                          %2:tagclass[#0]KAe » %1:tag[#1]Ke » %0:l3[#1]Ke
-                        ArrangeBy keys=[[#1]] // { arity: 2 }
-                          Get l3 // { arity: 2 }
-                        ArrangeBy keys=[[#1]] // { arity: 2 }
-                          Project (#0, #3) // { arity: 2 }
-                            Filter (#0) IS NOT NULL // { arity: 4 }
-                              Get materialize.public.tag // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 5 }
-                          ReadExistingIndex materialize.public.tagclass lookup_value=("Thing") // { arity: 5 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Get l3 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
-                Get materialize.public.tag // { arity: 4 }
+      TopK order_by=[#2 desc nulls_first, #1 asc nulls_last, #0 asc nulls_last] limit=100 // { arity: 3 }
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+          Project (#0, #8) // { arity: 2 }
+            Filter (#6) IS NOT NULL // { arity: 11 }
+              Join on=(eq(#0, #1, #2) AND eq(#3, #4, #5) AND #6 = #7) type=differential // { arity: 11 }
+                implementation
+                  %0[#0]UKA » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:l3[#0]K » %5:tag[#0]KA
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Threshold // { arity: 1 }
+                      Union // { arity: 1 }
+                        Distinct group_by=[#0] // { arity: 1 }
+                          Project (#4) // { arity: 1 }
+                            Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 5 }
+                              implementation
+                                %0:l2[#0]UKA » %1:l1[#0]K » %2:l1[#0]K
+                              ArrangeBy keys=[[#0]] // { arity: 1 }
+                                Get l2 // { arity: 1 }
+                              Get l1 // { arity: 2 }
+                              Get l1 // { arity: 2 }
+                        Negate // { arity: 1 }
+                          Get l2 // { arity: 1 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#5 = "Italy") AND (#3) IS NOT NULL // { arity: 8 }
+                        Join on=(#1 = #2 AND #3 = #4) type=differential // { arity: 8 }
+                          implementation
+                            %2:country[#0]KAef » %1:city[#1]Kef » %0:person[#1]Kef
+                          ArrangeBy keys=[[#1]] // { arity: 2 }
+                            Project (#1, #8) // { arity: 2 }
+                              Filter (#1) IS NOT NULL // { arity: 11 }
+                                Get materialize.public.person // { arity: 11 }
+                          ArrangeBy keys=[[#1]] // { arity: 2 }
+                            Project (#0, #3) // { arity: 2 }
+                              Filter (#0) IS NOT NULL AND (#3) IS NOT NULL // { arity: 4 }
+                                Get materialize.public.city // { arity: 4 }
+                          ArrangeBy keys=[[#0]] // { arity: 4 }
+                            Get materialize.public.country // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Distinct group_by=[#1, #0] // { arity: 2 }
+                    Project (#1, #9) // { arity: 2 }
+                      Get materialize.public.message // { arity: 13 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[#0] // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Filter (#3) IS NOT NULL // { arity: 9 }
+                        Join on=(#1 = #2 AND #3 = #4) type=differential // { arity: 9 }
+                          implementation
+                            %2:tagclass[#0]KAe » %1:tag[#1]Ke » %0:l3[#1]Ke
+                          ArrangeBy keys=[[#1]] // { arity: 2 }
+                            Get l3 // { arity: 2 }
+                          ArrangeBy keys=[[#1]] // { arity: 2 }
+                            Project (#0, #3) // { arity: 2 }
+                              Filter (#0) IS NOT NULL // { arity: 4 }
+                                Get materialize.public.tag // { arity: 4 }
+                          ArrangeBy keys=[[#0]] // { arity: 5 }
+                            ReadExistingIndex materialize.public.tagclass lookup_value=("Thing") // { arity: 5 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Get l3 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 4 }
+                  Get materialize.public.tag // { arity: 4 }
     With
       cte l3 =
         Project (#1, #2) // { arity: 2 }
@@ -1795,16 +1804,17 @@ SELECT Z.zombieid AS "zombie.id"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #3..=#5) // { arity: 4 }
-        Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
-          Union // { arity: 3 }
-            Map (null, null) // { arity: 3 }
-              Union // { arity: 1 }
-                Negate // { arity: 1 }
-                  Project (#0) // { arity: 1 }
-                    Get l8 // { arity: 3 }
-                Get l2 // { arity: 1 }
-            Get l8 // { arity: 3 }
+      TopK order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 4 }
+        Project (#0, #3..=#5) // { arity: 4 }
+          Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
+            Union // { arity: 3 }
+              Map (null, null) // { arity: 3 }
+                Union // { arity: 1 }
+                  Negate // { arity: 1 }
+                    Project (#0) // { arity: 1 }
+                      Get l8 // { arity: 3 }
+                  Get l2 // { arity: 1 }
+              Get l8 // { arity: 3 }
     With
       cte l8 =
         Project (#0, #2, #3) // { arity: 3 }
@@ -1991,18 +2001,19 @@ SELECT score_ranks.Person1Id AS "person1.id"
 Explained Query:
   Finish order_by=[#3 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
-      Project (#0, #1, #3, #4) // { arity: 4 }
-        TopK group_by=[#2] order_by=[#4 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=1 // { arity: 5 }
-          Union // { arity: 5 }
-            Map (null) // { arity: 5 }
-              Union // { arity: 4 }
-                Negate // { arity: 4 }
+      TopK order_by=[#3 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=100 // { arity: 4 }
+        Project (#0, #1, #3, #4) // { arity: 4 }
+          TopK group_by=[#2] order_by=[#4 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=1 // { arity: 5 }
+            Union // { arity: 5 }
+              Map (null) // { arity: 5 }
+                Union // { arity: 4 }
+                  Negate // { arity: 4 }
+                    Project (#2, #3, #0, #1) // { arity: 4 }
+                      Get l9 // { arity: 5 }
                   Project (#2, #3, #0, #1) // { arity: 4 }
-                    Get l9 // { arity: 5 }
-                Project (#2, #3, #0, #1) // { arity: 4 }
-                  Get l1 // { arity: 4 }
-            Project (#2, #3, #0, #1, #4) // { arity: 5 }
-              Get l9 // { arity: 5 }
+                    Get l1 // { arity: 4 }
+              Project (#2, #3, #0, #1, #4) // { arity: 5 }
+                Get l9 // { arity: 5 }
     With
       cte l9 =
         Project (#0..=#3, #6) // { arity: 5 }
@@ -2202,9 +2213,11 @@ SELECT coalesce(w, -1) FROM results ORDER BY w ASC LIMIT 20
 Explained Query:
   Finish order_by=[#1 asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
-      Project (#1, #2, #2) // { arity: 3 }
-        Filter (#1 = 15393162796819) AND (#2 = #2) // { arity: 3 }
-          Get l3 // { arity: 3 }
+      Project (#0, #1, #1) // { arity: 3 }
+        TopK order_by=[#1 asc nulls_last] limit=20 // { arity: 2 }
+          Project (#1, #2) // { arity: 2 }
+            Filter (#1 = 15393162796819) AND (#2 = #2) // { arity: 3 }
+              Get l3 // { arity: 3 }
     With Mutually Recursive
       cte l3 =
         Project (#2, #0, #1) // { arity: 3 }
@@ -2805,34 +2818,36 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#6 desc nulls_first, #0 asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
-      Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
-        Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
-          Map ((#1 + #4)) // { arity: 7 }
-            Join on=(#0 = #3) type=differential // { arity: 6 }
-              implementation
-                %0[#0]UKAif » %1[#0]UKAiif
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Get l5 // { arity: 3 }
-                    Map (null) // { arity: 3 }
-                      Union // { arity: 2 }
-                        Negate // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
-                              Get l5 // { arity: 3 }
-                        Get l3 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
-                  Union // { arity: 3 }
-                    Get l7 // { arity: 3 }
-                    Map (null) // { arity: 3 }
-                      Union // { arity: 2 }
-                        Negate // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
-                            Project (#0, #1) // { arity: 2 }
-                              Get l7 // { arity: 3 }
-                        Get l6 // { arity: 2 }
+      Project (#0..=#2, #0, #3..=#5) // { arity: 7 }
+        TopK order_by=[#5 desc nulls_first, #0 asc nulls_last] limit=20 // { arity: 6 }
+          Project (#0..=#2, #4..=#6) // { arity: 6 }
+            Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
+              Map ((#1 + #4)) // { arity: 7 }
+                Join on=(#0 = #3) type=differential // { arity: 6 }
+                  implementation
+                    %0[#0]UKAif » %1[#0]UKAiif
+                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                    Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l5 // { arity: 3 }
+                        Map (null) // { arity: 3 }
+                          Union // { arity: 2 }
+                            Negate // { arity: 2 }
+                              Distinct group_by=[#0, #1] // { arity: 2 }
+                                Project (#0, #1) // { arity: 2 }
+                                  Get l5 // { arity: 3 }
+                            Get l3 // { arity: 2 }
+                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                    Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
+                      Union // { arity: 3 }
+                        Get l7 // { arity: 3 }
+                        Map (null) // { arity: 3 }
+                          Union // { arity: 2 }
+                            Negate // { arity: 2 }
+                              Distinct group_by=[#0, #1] // { arity: 2 }
+                                Project (#0, #1) // { arity: 2 }
+                                  Get l7 // { arity: 3 }
+                            Get l6 // { arity: 2 }
     With
       cte l7 =
         Project (#0, #1, #3) // { arity: 3 }
@@ -2972,26 +2987,27 @@ LIMIT 10
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(distinct #1)] // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #3 AND #2 = #4) type=differential // { arity: 5 }
-            implementation
-              %0:l2[#0, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
-              Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                      implementation
-                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Distinct group_by=[#1, #0] // { arity: 2 }
-                          Get l1 // { arity: 2 }
-                Get l3 // { arity: 2 }
+      TopK order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=10 // { arity: 2 }
+        Reduce group_by=[#0] aggregates=[count(distinct #1)] // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = #3 AND #2 = #4) type=differential // { arity: 5 }
+              implementation
+                %0:l2[#0, #2]KK » %1[#0, #1]KK
+              ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+                Get l2 // { arity: 3 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                        implementation
+                          %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Get l3 // { arity: 2 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Distinct group_by=[#1, #0] // { arity: 2 }
+                            Get l1 // { arity: 2 }
+                  Get l3 // { arity: 2 }
     With
       cte l3 =
         Distinct group_by=[#0, #1] // { arity: 2 }
@@ -3085,26 +3101,27 @@ LIMIT 20
 Explained Query:
   Finish order_by=[#2 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
-        Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-            implementation
-              %0:l2[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Get l2 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Union // { arity: 2 }
-                Negate // { arity: 2 }
-                  Project (#0, #1) // { arity: 2 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
-                      implementation
-                        %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Distinct group_by=[#1, #0] // { arity: 2 }
-                          Get l0 // { arity: 2 }
-                Get l3 // { arity: 2 }
+      TopK order_by=[#2 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=20 // { arity: 3 }
+        Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+              implementation
+                %0:l2[#0, #1]KK » %1[#0, #1]KK
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Get l2 // { arity: 2 }
+              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                Union // { arity: 2 }
+                  Negate // { arity: 2 }
+                    Project (#0, #1) // { arity: 2 }
+                      Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                        implementation
+                          %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Get l3 // { arity: 2 }
+                        ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                          Distinct group_by=[#1, #0] // { arity: 2 }
+                            Get l0 // { arity: 2 }
+                  Get l3 // { arity: 2 }
     With
       cte l3 =
         Distinct group_by=[#0, #1] // { arity: 2 }
@@ -3746,23 +3763,24 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+        TopK order_by=[#0 asc nulls_last] limit=20 // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Filter (#1 = #3) // { arity: 4 }
+              Join on=(#1 = #2) type=differential // { arity: 4 }
+                implementation
+                  %1[#0]UKAf » %0:l1[#1]Kf
+                ArrangeBy keys=[[#1]] // { arity: 2 }
+                  Get l1 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+                    CrossJoin type=differential // { arity: 2 }
+                      implementation
+                        %0[×] » %1:l2[×]
+                      ArrangeBy keys=[[]] // { arity: 1 }
+                        Distinct group_by=[#0] // { arity: 1 }
+                          Get l2 // { arity: 1 }
+                      ArrangeBy keys=[[]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
       With
         cte l2 =
           Project (#1) // { arity: 1 }
@@ -3852,23 +3870,24 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Filter (#1 = #3) // { arity: 4 }
-            Join on=(#1 = #2) type=differential // { arity: 4 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 2 }
-                Get l1 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+        TopK order_by=[#0 asc nulls_last] limit=20 // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Filter (#1 = #3) // { arity: 4 }
+              Join on=(#1 = #2) type=differential // { arity: 4 }
+                implementation
+                  %1[#0]UKAf » %0:l1[#1]Kf
+                ArrangeBy keys=[[#1]] // { arity: 2 }
+                  Get l1 // { arity: 2 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+                    CrossJoin type=differential // { arity: 2 }
+                      implementation
+                        %0[×] » %1:l2[×]
+                      ArrangeBy keys=[[]] // { arity: 1 }
+                        Distinct group_by=[#0] // { arity: 1 }
+                          Get l2 // { arity: 1 }
+                      ArrangeBy keys=[[]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
       With
         cte l2 =
           Project (#1) // { arity: 1 }
@@ -3959,23 +3978,24 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
-        Project (#0..=#2) // { arity: 3 }
-          Filter (#1 = #4) // { arity: 5 }
-            Join on=(#1 = #3) type=differential // { arity: 5 }
-              implementation
-                %1[#0]UKAf » %0:l1[#1]Kf
-              ArrangeBy keys=[[#1]] // { arity: 3 }
-                Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-                  CrossJoin type=differential // { arity: 2 }
-                    implementation
-                      %0[×] » %1:l2[×]
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+        TopK order_by=[#0 asc nulls_last] limit=20 // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (#1 = #4) // { arity: 5 }
+              Join on=(#1 = #3) type=differential // { arity: 5 }
+                implementation
+                  %1[#0]UKAf » %0:l1[#1]Kf
+                ArrangeBy keys=[[#1]] // { arity: 3 }
+                  Get l1 // { arity: 3 }
+                ArrangeBy keys=[[#0]] // { arity: 2 }
+                  Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+                    CrossJoin type=differential // { arity: 2 }
+                      implementation
+                        %0[×] » %1:l2[×]
+                      ArrangeBy keys=[[]] // { arity: 1 }
+                        Distinct group_by=[#0] // { arity: 1 }
+                          Get l2 // { arity: 1 }
+                      ArrangeBy keys=[[]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                    ArrangeBy keys=[[]] // { arity: 1 }
-                      Get l2 // { arity: 1 }
       With
         cte l2 =
           Project (#1) // { arity: 1 }
@@ -4108,18 +4128,19 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
-        Project (#0, #1) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 3 }
-            implementation
-              %1[#0]UK » %0:l13[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
-                Get l13 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Filter (#0) IS NOT NULL // { arity: 1 }
-                Reduce aggregates=[min(#0)] // { arity: 1 }
-                  Project (#1) // { arity: 1 }
-                    Get l13 // { arity: 2 }
+        TopK order_by=[#0 asc nulls_last] limit=20 // { arity: 2 }
+          Project (#0, #1) // { arity: 2 }
+            Join on=(#1 = #2) type=differential // { arity: 3 }
+              implementation
+                %1[#0]UK » %0:l13[#1]K
+              ArrangeBy keys=[[#1]] // { arity: 2 }
+                Filter (#1) IS NOT NULL // { arity: 2 }
+                  Get l13 // { arity: 2 }
+              ArrangeBy keys=[[#0]] // { arity: 1 }
+                Filter (#0) IS NOT NULL // { arity: 1 }
+                  Reduce aggregates=[min(#0)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l13 // { arity: 2 }
       With
         cte l13 =
           Project (#1, #2) // { arity: 2 }

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -530,6 +530,38 @@ CREATE MATERIALIZED VIEW mat_tables AS SELECT name FROM (SHOW TABLES);
 statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_views AS SELECT name FROM (SHOW VIEWS);
 
+# LIMIT in materialized view
+
+statement ok
+CREATE MATERIALIZED VIEW mv_limited AS
+SELECT a
+FROM t
+ORDER BY a DESC, a+b
+LIMIT 3;
+
+query I
+SELECT * FROM mv_limited;
+----
+3
+5
+7
+
+statement ok
+DELETE FROM t WHERE a = 5;
+
+query I
+SELECT * FROM mv_limited;
+----
+3
+7
+
+query I
+SELECT * FROM mv_limited
+ORDER BY a
+LIMIT 1;
+----
+3
+
 # Cleanup
 
 statement ok

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -862,3 +862,35 @@ SELECT row_number() OVER (ORDER BY x NULLS LAST), x FROM t;
 2 b
 3 c
 4 NULL
+
+# TopK is inserted by `pre_finish_one_shot_select`
+query T multiline
+EXPLAIN
+SELECT * FROM t
+LIMIT 2;
+----
+Explained Query:
+  Finish limit=2 output=[#0]
+    TopK limit=2
+      Get materialize.public.t
+
+EOF
+
+# But if we have an index, then we do fast path despite the TopK.
+
+statement ok
+CREATE INDEX t_idx ON t(x);
+
+query T multiline
+EXPLAIN
+SELECT * FROM t
+LIMIT 2;
+----
+Explained Query (fast path):
+  Finish limit=2 output=[#0]
+    ReadExistingIndex materialize.public.t_idx
+
+Used Indexes:
+  - materialize.public.t_idx (fast path limit)
+
+EOF

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -310,12 +310,13 @@ LIMIT 10;
 ----
 Explained Query:
   Finish order_by=[#0 desc nulls_first] limit=10 output=[#0..=#2]
-    Project (#1, #0, #2)
-      Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000)), count(*)]
-        Project (#0, #3)
-          Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
-            Map (timestamp_tz_to_mz_timestamp(#0))
-              ReadExistingIndex mz_internal.mz_source_status_history lookup_value=("u6")
+    TopK order_by=[#0 desc nulls_first] limit=10
+      Project (#1, #0, #2)
+        Reduce group_by=[#1] aggregates=[max((extract_epoch_tstz(#0) * 1000)), count(*)]
+          Project (#0, #3)
+            Filter (#6 <= 100) AND (#6 >= 0) AND (#3) IS NOT NULL
+              Map (timestamp_tz_to_mz_timestamp(#0))
+                ReadExistingIndex mz_internal.mz_source_status_history lookup_value=("u6")
 
 Used Indexes:
   - mz_internal.mz_source_status_history_ind (lookup)

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -393,3 +393,24 @@ DELETE FROM t2 WHERE key = 1
 
 ! SUBSCRIBE (SELECT * FROM t2) WITH (PROGRESS, SNAPSHOT) ENVELOPE DEBEZIUM (KEY (invalid_key))
 contains: column "invalid_key" does not exist
+
+# SUBSCRIBE with a query that has a `RowSetFinishing`, which needs to be turned into a TopK
+
+> CREATE TABLE t3 (a int, b int);
+
+> INSERT INTO t3 VALUES (1,2), (3,4), (5,6), (7,8);
+
+> CREATE VIEW limited AS
+  SELECT * FROM t3
+  ORDER BY a DESC, b
+  LIMIT 3;
+
+> BEGIN;
+
+> DECLARE c CURSOR FOR SUBSCRIBE limited;
+
+> FETCH 2 c;
+<TIMESTAMP> 1 5 6
+<TIMESTAMP> 1 3 4
+
+> COMMIT;


### PR DESCRIPTION
This was to address https://github.com/MaterializeInc/materialize/issues/21105, i.e., to make `MonotonicTopK` take over some of the responsibilities of `RowSetFinishing`. However, after having a prototype, [unfortunately it turned out that doing the LIMIT with a TopK is 8-27% slower](https://docs.google.com/spreadsheets/d/1Lx2BgCyBvhUUUBdEpaT1yA0yraFbf6Wry044NxMiv-Q/edit#gid=2080010183). So the benefit that LIMIT would use much less memory for monotonic inputs is probably not worth the downside of being slower on all LIMIT queries, so I'm abandoning this PR. However, I still did various other minor improvements while working on this, so I'll open a new PR (https://github.com/MaterializeInc/materialize/pull/21374) with just those instead.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
