### PR TITLE
sqllogictest: Truncate Numerics like we do Float8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4950,6 +4950,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "dec",
  "fallible-iterator",
  "futures",
  "itertools",

--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -275,6 +275,50 @@ same file. Most of the time, we use `mode cockroach`. The times when we use
     314.3820897445435
     ```
 
+3. In `mode standard` when interpreting a Numeric as an Int we round down to the nearest whole
+   number.
+
+    ```
+    mode standard
+
+    query I
+    SELECT '1.9'::numeric
+    ----
+    1
+
+    query I
+    SELECT '1.5'::numeric
+    ----
+    1
+
+    query I
+    SELECT '1.1'::numeric
+    ----
+    1
+    ```
+
+   `mode cockroach` on the otherhand uses a strategy of rounding half up. That is we round to the
+   nearest integer and halfway values are rounded up.
+
+    ```
+    mode cockroach
+
+    query I
+    SELECT '1.9'::numeric
+    ----
+    2
+
+    query I
+    SELECT '1.5'::numeric
+    ----
+    2
+
+    query I
+    SELECT '1.1'::numeric
+    ----
+    1
+    ```
+
 ### multiline
 
 As you can see [above](#differences-between-modes), generally sqllogictest

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.66"
 bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
+dec = "0.4.8"
 fallible-iterator = "0.2.0"
 futures = "0.3.25"
 itertools = "0.10.5"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -631,6 +631,10 @@ fn format_datum(d: Slt, typ: &Type, mode: Mode, col: usize) -> String {
         (Type::Integer, Value::Numeric(d)) => {
             let mut d = d.0 .0.clone();
             let mut cx = numeric::cx_datum();
+            // Truncate the decimal to match sqlite.
+            if mode == Mode::Standard {
+                cx.set_rounding(dec::Rounding::Down);
+            }
             cx.round(&mut d);
             numeric::munge_numeric(&mut d).unwrap();
             d.to_standard_notation_string()

--- a/test/sqllogictest/numeric.slt
+++ b/test/sqllogictest/numeric.slt
@@ -2214,3 +2214,42 @@ query R
 SELECT sum(f1) FROM A;
 ----
 -Infinity
+
+# sqllogictest rounding/truncation behavior.
+#
+# Note: this behavior is called out in the developer docs, so if it ever changes be sure to update
+# those docs.
+
+query I
+SELECT '1.9'::numeric
+----
+2
+
+query I
+SELECT '1.5'::numeric
+----
+2
+
+query I
+SELECT '1.1'::numeric
+----
+1
+
+mode standard
+
+# For SQLite compatibility, we truncate Numerics when interpreting as an Int.
+
+query I
+SELECT '1.9'::numeric
+----
+1
+
+query I
+SELECT '1.5'::numeric
+----
+1
+
+query I
+SELECT '1.1'::numeric
+----
+1


### PR DESCRIPTION
This PR changes how our sqllogictest framework interprets Numerics when an (I)nt is requested. After https://github.com/MaterializeInc/materialize/pull/21219 was merged some queries that previously returned Floats now started returning Numerics. In sqllogictest we [truncate Floats but round Numerics](https://github.com/MaterializeInc/materialize/blob/main/src/sqllogictest/src/runner.rs#L624-L637) which was causing some SQLite tests to no longer pass in Materialize.

This PR changes the sqllogictest framework to round down/truncate Numerics when running in `mode standard`, and updates the docs to callout this difference between `mode cockroach` and `mode standard`.

FWIW I tested some of the originally failing queries in pre-21219 Materialize, post-21219 Materialize, and Postgres. In all 3 cases I got back the same answers.

### Motivation

* This PR fixes a previously unreported bug.

Our SQL Logic Tests pipeline was totally broken, [Slack](https://materializeinc.slack.com/archives/C02FWJ94HME/p1692701231699089)


### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
