### PR TITLE
scratch: Update config for CI machines

### DIFF
--- a/misc/scratch/ci.json
+++ b/misc/scratch/ci.json
@@ -1,8 +1,8 @@
 {
-    "name": "c5.2xlarge as used by the CI",
+    "name": "c6a.2xlarge as used by the CI",
     "launch_script": "true",
-    "instance_type": "c5.2xlarge",
+    "instance_type": "c6a.2xlarge",
     "ami": "ami-09d56f8956ab235b3",
-    "size_gb": 50,
+    "size_gb": 128,
     "tags": {}
 }


### PR DESCRIPTION
### Motivation

Sometimes it can be useful to spin up a scratch instance that is exactly the same kind used in CI. Currently the scratch config for CI machines is out of date, this PR updates it to be the same as what we use today.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
