### PR TITLE
adapter: thread tracing context through channel/task boundaries

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7390,6 +7390,8 @@ impl Catalog {
 
         *privileges = PrivilegeMap::from_mz_acl_items(flat_privileges);
     }
+
+    #[tracing::instrument(level = "debug", skip_all)]
     pub async fn confirm_leadership(&self) -> Result<(), AdapterError> {
         Ok(self.storage().await.confirm_leadership().await?)
     }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -35,7 +35,7 @@ use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use prometheus::Histogram;
 use serde_json::json;
 use tokio::sync::{mpsc, oneshot, watch};
-use tracing::error;
+use tracing::{error, instrument};
 use uuid::Uuid;
 
 use crate::command::{
@@ -262,6 +262,7 @@ impl Client {
         response
     }
 
+    #[instrument(level = "debug", skip_all)]
     fn send(&self, cmd: Command) {
         self.inner_cmd_tx
             .send(cmd)
@@ -468,6 +469,7 @@ impl SessionClient {
     }
 
     /// Ends a transaction.
+    #[instrument(level = "debug", skip_all)]
     pub async fn end_transaction(
         &mut self,
         action: EndTransactionAction,
@@ -576,6 +578,7 @@ impl SessionClient {
         self.inner.as_mut().expect("inner invariant violated")
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn send<T, F>(&mut self, f: F) -> Result<T, AdapterError>
     where
         F: FnOnce(oneshot::Sender<Response<T>>, Session) -> Command,
@@ -583,6 +586,7 @@ impl SessionClient {
         self.send_with_cancel(f, futures::future::pending()).await
     }
 
+    #[instrument(level = "debug", skip_all)]
     async fn send_with_cancel<T, F>(
         &mut self,
         f: F,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -605,6 +605,7 @@ impl PendingRead {
     ///
     /// If it is necessary to finalize an execute, return the state necessary to do so
     /// (execution context and result)
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn finish(self) -> Option<(ExecuteContext, Result<ExecuteResponse, AdapterError>)> {
         match self {
             PendingRead::Read {
@@ -762,6 +763,7 @@ impl ExecuteContext {
     }
 
     /// Retire the execution, by sending a message to the coordinator.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn retire(self, result: Result<ExecuteResponse, AdapterError>) {
         let Self {
             tx,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -85,6 +85,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn handle_command(&mut self, mut cmd: Command) {
         if let Some(session) = cmd.session_mut() {
             session.apply_external_metadata_updates();

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -38,6 +38,7 @@ use crate::util::{ComputeSinkId, ResultExt};
 use crate::{catalog, AdapterNotice, TimestampContext};
 
 impl Coordinator {
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn handle_message(&mut self, msg: Message) {
         match msg {
             Message::Command(cmd) => self.message_command(cmd).await,

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -523,7 +523,7 @@ impl crate::coord::Coordinator {
 
         Ok(crate::ExecuteResponse::SendingRows {
             future: Box::pin(rows_rx),
-            span: tracing::Span::current(),
+            otel_ctx: OpenTelemetryContext::obtain(),
         })
     }
 
@@ -634,7 +634,7 @@ impl crate::coord::Coordinator {
     pub(crate) fn send_immediate_rows(rows: Vec<Row>) -> ExecuteResponse {
         ExecuteResponse::SendingRowsImmediate {
             rows,
-            span: tracing::Span::none(),
+            otel_ctx: OpenTelemetryContext::obtain(),
         }
     }
 }

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -630,6 +630,7 @@ impl crate::coord::Coordinator {
     /// Constructs an [`ExecuteResponse`] that that will send some rows to the
     /// client immediately, as opposed to asking the dataflow layer to send along
     /// the rows after some computation.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) fn send_immediate_rows(rows: Vec<Row>) -> ExecuteResponse {
         ExecuteResponse::SendingRowsImmediate {
             rows,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1765,6 +1765,7 @@ impl Coordinator {
         }
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(super) fn sequence_end_transaction(
         &mut self,
         mut ctx: ExecuteContext,
@@ -1842,6 +1843,7 @@ impl Coordinator {
         ctx.retire(response);
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn sequence_end_transaction_inner(
         &mut self,
         session: &mut Session,
@@ -1921,6 +1923,7 @@ impl Coordinator {
     }
 
     /// Processes as many peek stages as possible.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn sequence_peek_stage(
         &mut self,
         mut ctx: ExecuteContext,
@@ -1963,6 +1966,7 @@ impl Coordinator {
     }
 
     // Do some simple validation. We must defer most of it until after any off-thread work.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn peek_stage_validate(
         &mut self,
         session: &mut Session,
@@ -2042,6 +2046,7 @@ impl Coordinator {
         })
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn peek_stage_optimize(&mut self, ctx: ExecuteContext, mut stage: PeekStageOptimize) {
         // Generate data structures that can be moved to another task where we will perform possibly
         // expensive optimizations.
@@ -2101,6 +2106,7 @@ impl Coordinator {
         );
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn optimize_peek(
         catalog: &CatalogState,
         compute: ComputeInstanceSnapshot,
@@ -2340,6 +2346,7 @@ impl Coordinator {
 
     /// Determines the query timestamp and acquires read holds on dependent sources
     /// if necessary.
+    #[tracing::instrument(level = "debug", skip_all)]
     fn sequence_peek_timestamp(
         &mut self,
         session: &mut Session,
@@ -2452,6 +2459,7 @@ impl Coordinator {
         Ok(determination)
     }
 
+    #[tracing::instrument(level = "debug", skip_all)]
     fn plan_peek(
         &mut self,
         mut dataflow: DataflowDescription<OptimizedMirRelationExpr>,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -64,6 +64,7 @@ impl<T: Transmittable + std::fmt::Debug> ClientTransmitter<T> {
     /// # Panics
     /// - If in `soft_assert`, `result.is_ok()`, `self.allowed.is_some()`, and
     ///   the result value is not in the set of allowed values.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn send(mut self, result: Result<T, AdapterError>, session: Session) {
         // Guarantee that the value sent is of an allowed type.
         soft_assert!(

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -1046,7 +1046,7 @@ async fn execute_stmt<S: ResultSender>(
         }
         ExecuteResponse::SendingRows {
             future: rows,
-            span: _,
+            otel_ctx: _,
         } => {
             let rows = match sender.await_rows(client.canceled(), rows).await? {
                 PeekResponseUnary::Rows(rows) => {
@@ -1071,7 +1071,7 @@ async fn execute_stmt<S: ResultSender>(
             let tag = format!("SELECT {}", sql_rows.len());
             SqlResult::rows(client, tag, sql_rows, desc).into()
         }
-        ExecuteResponse::SendingRowsImmediate { rows, span: _} => {
+        ExecuteResponse::SendingRowsImmediate { rows, otel_ctx: _} => {
             let mut sql_rows: Vec<Vec<serde_json::Value>> = vec![];
             let mut datum_vec = mz_repr::DatumVec::new();
             let desc = desc.relation_desc.expect("RelationDesc must exist");

--- a/src/ore/src/tracing.rs
+++ b/src/ore/src/tracing.rs
@@ -40,7 +40,7 @@ use prometheus::IntCounter;
 use sentry::integrations::debug_images::DebugImagesIntegration;
 use tonic::metadata::MetadataMap;
 use tonic::transport::Endpoint;
-use tracing::{warn, Event, Level, Subscriber};
+use tracing::{warn, Event, Level, Span, Subscriber};
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::filter::Directive;
 use tracing_subscriber::fmt::format::{format, Writer};
@@ -599,6 +599,17 @@ impl OpenTelemetryContext {
     pub fn attach_as_parent(&self) {
         let parent_cx = global::get_text_map_propagator(|prop| prop.extract(self));
         tracing::Span::current().set_parent(parent_cx);
+    }
+
+    /// Attaches this `Context` to the given [`tracing`] Span, as its parent.
+    /// as its parent.
+    ///
+    /// If there is not enough information in this `OpenTelemetryContext`
+    /// to create a context, then the current thread's `Context` is used
+    /// defaulting to the default `Context`.
+    pub fn attach_as_parent_to(&self, span: &mut Span) {
+        let parent_cx = global::get_text_map_propagator(|prop| prop.extract(self));
+        span.set_parent(parent_cx);
     }
 
     /// Obtains a `Context` from the current [`tracing`] span.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1794,6 +1794,7 @@ impl SessionVars {
     /// [`SessionVars::set`] since the last call to `end_transaction`.
     ///
     /// Returns any session parameters that changed because the transaction ended.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub fn end_transaction(
         &mut self,
         action: EndTransactionAction,


### PR DESCRIPTION
**A DRAFT meant to explain what I mean.**

First commit adds more instrumentation to interesting method. Second commit makes sure we can piece together spans across channel/task boundaries.

### Motivation

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
