### PR TITLE
[http] Set options before calling `startup`

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -452,12 +452,28 @@ impl AuthedClient {
         adapter_client: &Client,
         user: AuthedUser,
         active_connection_count: SharedConnectionCounter,
+        options: BTreeMap<String, String>,
     ) -> Result<Self, AdapterError> {
         let AuthedUser(user) = user;
         let drop_connection = DropConnection::new_connection(&user, active_connection_count)?;
         let conn_id = adapter_client.new_conn_id()?;
-        let session = adapter_client.new_session(conn_id, user);
-        let (adapter_client, _) = adapter_client.startup(session, vec![]).await?;
+        let mut session = adapter_client.new_session(conn_id, user);
+        let mut set_setting_keys = Vec::new();
+        for (key, val) in options {
+            const LOCAL: bool = false;
+            if let Err(err) = session
+                .vars_mut()
+                .set(None, &key, VarInput::Flat(&val), LOCAL)
+            {
+                session.add_notice(AdapterNotice::BadStartupSetting {
+                    name: key.to_string(),
+                    reason: err.to_string(),
+                })
+            } else {
+                set_setting_keys.push(key);
+            }
+        }
+        let (adapter_client, _) = adapter_client.startup(session, set_setting_keys).await?;
         Ok(AuthedClient {
             client: adapter_client,
             drop_connection,
@@ -498,43 +514,31 @@ where
             )
         })?;
         let active_connection_count = req.extensions.get::<SharedConnectionCounter>().unwrap();
-        let mut client = AuthedClient::new(
+
+        let options = if params.options.is_empty() {
+            // It's possible 'options' simply wasn't provided, we don't want that to
+            // count as a failure to deserialize
+            BTreeMap::<String, String>::default()
+        } else {
+            match serde_json::from_str(&params.options) {
+                Ok(options) => options,
+                Err(_e) => {
+                    // If we fail to deserialize options, fail the request.
+                    let code = StatusCode::BAD_REQUEST;
+                    let msg = format!("Failed to deserialize {} map", "options".quoted());
+                    return Err((code, msg));
+                }
+            }
+        };
+
+        let client = AuthedClient::new(
             &adapter_client,
             user.clone(),
             Arc::clone(active_connection_count),
+            options,
         )
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
-
-        // Apply options that were provided in query params.
-        let session = client.client.session();
-        let maybe_options = if params.options.is_empty() {
-            // It's possible 'options' simply wasn't provided, we don't want that to
-            // count as a failure to deserialize
-            Ok(BTreeMap::<String, String>::default())
-        } else {
-            serde_json::from_str(&params.options)
-        };
-
-        if let Ok(options) = maybe_options {
-            for (key, val) in options {
-                const LOCAL: bool = false;
-                if let Err(err) = session
-                    .vars_mut()
-                    .set(None, &key, VarInput::Flat(&val), LOCAL)
-                {
-                    session.add_notice(AdapterNotice::BadStartupSetting {
-                        name: key.to_string(),
-                        reason: err.to_string(),
-                    })
-                }
-            }
-        } else {
-            // If we fail to deserialize options, fail the request.
-            let code = StatusCode::BAD_REQUEST;
-            let msg = format!("Failed to deserialize {} map", "options".quoted());
-            return Err((code, msg));
-        }
 
         Ok(client)
     }
@@ -678,23 +682,13 @@ async fn init_ws(
     };
     let user = auth(frontegg, creds).await?;
 
-    let mut client =
-        AuthedClient::new(adapter_client, user, Arc::clone(active_connection_count)).await?;
-
-    // Assign any options we got from our WebSocket startup.
-    let session = client.client.session();
-    for (key, val) in options {
-        const LOCAL: bool = false;
-        if let Err(err) = session
-            .vars_mut()
-            .set(None, &key, VarInput::Flat(&val), LOCAL)
-        {
-            session.add_notice(AdapterNotice::BadStartupSetting {
-                name: key,
-                reason: err.to_string(),
-            })
-        }
-    }
+    let client = AuthedClient::new(
+        adapter_client,
+        user,
+        Arc::clone(active_connection_count),
+        options,
+    )
+    .await?;
 
     Ok(client)
 }


### PR DESCRIPTION
`mz_session_history` logs the application name that was set on startup. So for HTTP endpoints, the application name is not showing up currently, because it is set just _after_ startup. This fix addresses that.
### Motivation

  * This PR fixes a previously unreported bug.

    Reported [on Slack](https://materializeinc.slack.com/archives/C056M3001Q9/p1692723335108049?thread_ts=1692659442.987799&cid=C056M3001Q9)


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None