### PR TITLE
coord: Report slow Coordinator messages to Prometheus

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -32,6 +32,7 @@ pub struct Metrics {
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub introspection_logins: IntCounter,
     pub statement_logging_actual_bytes: IntCounterVec,
+    pub slow_message_handling: HistogramVec,
 }
 
 impl Metrics {
@@ -110,7 +111,14 @@ impl Metrics {
             statement_logging_actual_bytes: registry.register(metric!(
                 name: "mz_statement_logging_actual_bytes",
                 help: "The total amount of SQL text that was logged by statement logging.",
-            ))
+            )),
+            slow_message_handling: registry.register(metric!(
+                name: "mz_slow_message_handling",
+                help: "Latency for coordinator messages that are 'slow' to process. 'Slow' is \
+                    defined by the LaunchDarkly variable 'coord_slow_message_reporting_threshold'",
+                var_labels: ["message_kind"],
+                buckets: histogram_seconds_buckets(0.128, 32.0),
+            )),
         }
     }
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -822,6 +822,17 @@ static OPENTELEMETRY_FILTER: Lazy<ServerVar<CloneableEnvFilter>> = Lazy::new(|| 
     internal: true,
 });
 
+// Note(parkmycar): This value was chosen arbitrarily.
+const DEFAULT_COORD_SLOW_MESSAGE_REPORTING_THRESHOLD: Duration = Duration::from_millis(100);
+const COORD_SLOW_MESSAGE_REPORTING_THRESHOLD: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("coord_slow_message_reporting_threshold"),
+    value: &DEFAULT_COORD_SLOW_MESSAGE_REPORTING_THRESHOLD,
+    description:
+        "Sets the threshold at which we will report the handling of a coordinator message \
+    for being slow.",
+    internal: true,
+};
+
 /// Sets the maximum number of TCP keepalive probes that will be sent before dropping a connection
 /// when connecting to PG via replication.
 const PG_REPLICATION_KEEPALIVES_RETRIES: ServerVar<u32> = ServerVar {
@@ -2150,6 +2161,7 @@ impl SystemVars {
             .with_var(&LOGGING_FILTER)
             .with_var(&OPENTELEMETRY_FILTER)
             .with_var(&WEBHOOKS_SECRETS_CACHING_TTL_SECS)
+            .with_var(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
             .with_var(&grpc_client::CONNECT_TIMEOUT)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_INTERVAL)
             .with_var(&grpc_client::HTTP2_KEEP_ALIVE_TIMEOUT)
@@ -2737,6 +2749,10 @@ impl SystemVars {
 
     pub fn webhooks_secrets_caching_ttl_secs(&self) -> usize {
         *self.expect_value(&*WEBHOOKS_SECRETS_CACHING_TTL_SECS)
+    }
+
+    pub fn coord_slow_message_reporting_threshold_ms(&self) -> Duration {
+        *self.expect_value(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
     }
 
     pub fn grpc_client_http2_keep_alive_interval(&self) -> Duration {


### PR DESCRIPTION
This PR adds prometheus metrcics to the Coordinator's `handle_message(...)` function. Specifically if any message takes longer than 100ms (Configurable via LaunchDarkly) to complete, then we'll report the kind of message and the duration to a histogram. We only report messages that take longer than a threshold to reduce the overall number of events we send.

### Motivation

  * This PR adds a feature that has not yet been specified.

The goal of this new metric is to validate that nothing is holding the Coordinator up for too long of a time, since message handling is serialized, and to help us determine what needs to be optimized, if anything.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
