### PR TITLE
persist: configurable stats knobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,6 +4421,7 @@ dependencies = [
  "mz-proto",
  "mz-timely-util",
  "num_cpus",
+ "once_cell",
  "prometheus",
  "proptest",
  "proptest-derive",
@@ -5590,9 +5591,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f0b0d4bf799edbc74508c1e8bf170ff5f41238e5f8225603ca7caaae2b7860"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -141,6 +141,7 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         stats_audit_percent: Some(config.persist_stats_audit_percent()),
         stats_collection_enabled: Some(config.persist_stats_collection_enabled()),
         stats_filter_enabled: Some(config.persist_stats_filter_enabled()),
+        stats_budget_bytes: Some(config.persist_stats_budget_bytes()),
         pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
         pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
         rollup_threshold: Some(config.persist_rollup_threshold()),

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -142,6 +142,7 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         stats_collection_enabled: Some(config.persist_stats_collection_enabled()),
         stats_filter_enabled: Some(config.persist_stats_filter_enabled()),
         stats_budget_bytes: Some(config.persist_stats_budget_bytes()),
+        stats_untrimmable_columns: Some(config.persist_stats_untrimmable_columns()),
         pubsub_client_enabled: Some(config.persist_pubsub_client_enabled()),
         pubsub_push_diff_enabled: Some(config.persist_pubsub_push_diff_enabled()),
         rollup_threshold: Some(config.persist_rollup_threshold()),

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -41,6 +41,7 @@ mz-persist = { path = "../persist" }
 mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-timely-util = { path = "../timely-util" }
+once_cell = "1.16.0"
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}

--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -216,10 +216,7 @@ impl BatchBuilderConfig {
                 .dynamic
                 .batch_builder_max_outstanding_parts(),
             stats_collection_enabled: value.dynamic.stats_collection_enabled(),
-            // TODO: Make a dynamic config for this? This initial constant is
-            // the rough upper bound on what we see for the total serialized
-            // batch size in prod, so it will at worst double it.
-            stats_budget: 1024,
+            stats_budget: value.dynamic.stats_budget_bytes(),
         }
     }
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -31,10 +31,17 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_connection_pool_ttl = 15;
     mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
     optional uint64 stats_budget_bytes = 17;
+    optional ProtoUntrimmableColumns stats_untrimmable_columns = 18;
 }
 
 message ProtoRetryParameters {
     mz_proto.ProtoDuration initial_backoff = 1;
     uint32 multiplier = 2;
     mz_proto.ProtoDuration clamp = 3;
+}
+
+message ProtoUntrimmableColumns {
+    repeated string equals = 1;
+    repeated string prefixes = 2;
+    repeated string suffixes = 3;
 }

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -30,6 +30,7 @@ message ProtoPersistParameters {
     optional uint64 blob_cache_mem_limit_bytes = 14;
     mz_proto.ProtoDuration consensus_connection_pool_ttl = 15;
     mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
+    optional uint64 stats_budget_bytes = 17;
 }
 
 message ProtoRetryParameters {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -984,6 +984,14 @@ const PERSIST_STATS_FILTER_ENABLED: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::stats_budget_bytes`].
+const PERSIST_STATS_BUDGET_BYTES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("persist_stats_budget_bytes"),
+    value: &PersistConfig::DEFAULT_STATS_BUDGET_BYTES,
+    description: "The budget (in bytes) of how many stats to maintain per batch part.",
+    internal: true,
+};
+
 /// Controls [`mz_persist_client::cfg::DynamicConfig::pubsub_client_enabled`].
 const PERSIST_PUBSUB_CLIENT_ENABLED: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("persist_pubsub_client_enabled"),
@@ -2127,6 +2135,7 @@ impl SystemVars {
             .with_var(&PERSIST_STATS_AUDIT_PERCENT)
             .with_var(&PERSIST_STATS_COLLECTION_ENABLED)
             .with_var(&PERSIST_STATS_FILTER_ENABLED)
+            .with_var(&PERSIST_STATS_BUDGET_BYTES)
             .with_var(&PERSIST_PUBSUB_CLIENT_ENABLED)
             .with_var(&PERSIST_PUBSUB_PUSH_DIFF_ENABLED)
             .with_var(&PERSIST_ROLLUP_THRESHOLD)
@@ -2658,6 +2667,11 @@ impl SystemVars {
     /// Returns the `persist_stats_filter_enabled` configuration parameter.
     pub fn persist_stats_filter_enabled(&self) -> bool {
         *self.expect_value(&PERSIST_STATS_FILTER_ENABLED)
+    }
+
+    /// Returns the `persist_stats_budget_bytes` configuration parameter.
+    pub fn persist_stats_budget_bytes(&self) -> usize {
+        *self.expect_value(&PERSIST_STATS_BUDGET_BYTES)
     }
 
     /// Returns the `persist_pubsub_client_enabled` configuration parameter.
@@ -4258,6 +4272,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_AUDIT_PERCENT.name()
         || name == PERSIST_STATS_COLLECTION_ENABLED.name()
         || name == PERSIST_STATS_FILTER_ENABLED.name()
+        || name == PERSIST_STATS_BUDGET_BYTES.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -65,6 +65,7 @@
 
 use std::any::Any;
 use std::borrow::Borrow;
+use std::clone::Clone;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 use std::ops::RangeBounds;
@@ -78,6 +79,7 @@ use mz_build_info::BuildInfo;
 use mz_ore::cast;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
+use mz_persist_client::batch::UntrimmableColumns;
 use mz_persist_client::cfg::PersistConfig;
 use mz_repr::adt::numeric::Numeric;
 use mz_sql_parser::ast::TransactionIsolationLevel;
@@ -991,6 +993,17 @@ const PERSIST_STATS_BUDGET_BYTES: ServerVar<usize> = ServerVar {
     description: "The budget (in bytes) of how many stats to maintain per batch part.",
     internal: true,
 };
+
+static PERSIST_DEFAULT_STATS_UNTRIMMABLE_COLUMNS: Lazy<UntrimmableColumns> =
+    Lazy::new(|| PersistConfig::DEFAULT_STATS_UNTRIMMABLE_COLUMNS.clone());
+/// Controls [`mz_persist_client::cfg::DynamicConfig::stats_untrimmable_columns`].
+static PERSIST_STATS_UNTRIMMABLE_COLUMNS: Lazy<ServerVar<UntrimmableColumns>> =
+    Lazy::new(|| ServerVar {
+        name: UncasedStr::new("persist_stats_untrimmable_columns"),
+        value: &PERSIST_DEFAULT_STATS_UNTRIMMABLE_COLUMNS,
+        description: "Which columns to always retain during persist stats trimming.",
+        internal: true,
+    });
 
 /// Controls [`mz_persist_client::cfg::DynamicConfig::pubsub_client_enabled`].
 const PERSIST_PUBSUB_CLIENT_ENABLED: ServerVar<bool> = ServerVar {
@@ -2139,6 +2152,7 @@ impl SystemVars {
             .with_var(&PERSIST_PUBSUB_CLIENT_ENABLED)
             .with_var(&PERSIST_PUBSUB_PUSH_DIFF_ENABLED)
             .with_var(&PERSIST_ROLLUP_THRESHOLD)
+            .with_var(&PERSIST_STATS_UNTRIMMABLE_COLUMNS)
             .with_var(&METRICS_RETENTION)
             .with_var(&UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP)
             .with_var(&ENABLE_LD_RBAC_CHECKS)
@@ -2672,6 +2686,12 @@ impl SystemVars {
     /// Returns the `persist_stats_budget_bytes` configuration parameter.
     pub fn persist_stats_budget_bytes(&self) -> usize {
         *self.expect_value(&PERSIST_STATS_BUDGET_BYTES)
+    }
+
+    /// Returns the `persist_stats_untrimmable_columns` configuration parameter.
+    pub fn persist_stats_untrimmable_columns(&self) -> UntrimmableColumns {
+        self.expect_value(&PERSIST_STATS_UNTRIMMABLE_COLUMNS)
+            .clone()
     }
 
     /// Returns the `persist_pubsub_client_enabled` configuration parameter.
@@ -4184,6 +4204,30 @@ impl From<TransactionIsolationLevel> for IsolationLevel {
     }
 }
 
+impl Value for UntrimmableColumns {
+    fn type_name() -> String {
+        "UntrimmableStatsColumns".to_string()
+    }
+
+    fn parse<'a>(
+        param: &'a (dyn Var + Send + Sync),
+        input: VarInput,
+    ) -> Result<Self::Owned, VarError> {
+        let s = extract_single_value(param, input)?;
+        let cols: UntrimmableColumns =
+            serde_json::from_str(s).map_err(|e| VarError::InvalidParameterValue {
+                parameter: param.into(),
+                values: vec![s.to_string()],
+                reason: format!("{}", e),
+            })?;
+        Ok(cols)
+    }
+
+    fn format(&self) -> String {
+        format!("{}", self)
+    }
+}
+
 impl Value for CloneableEnvFilter {
     fn type_name() -> String {
         "EnvFilter".to_string()
@@ -4273,6 +4317,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_STATS_COLLECTION_ENABLED.name()
         || name == PERSIST_STATS_FILTER_ENABLED.name()
         || name == PERSIST_STATS_BUDGET_BYTES.name()
+        || name == PERSIST_STATS_UNTRIMMABLE_COLUMNS.name()
         || name == PERSIST_PUBSUB_CLIENT_ENABLED.name()
         || name == PERSIST_PUBSUB_PUSH_DIFF_ENABLED.name()
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Gives us two new dynamic knobs for controlling stats collection:

1. `persist_stats_budget_bytes` which controls the # of bytes we dedicate to stats per batch part
2. `persist_stats_untrimmable_columns` which controls the opted-in column names that we will always retain stats for if we see them

Both of these have been on the wishlist, but the desire for them to be dynamic was particularly acute while debugging an issue @chuck-alt-delete sent my way this week

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
