### PR TITLE
Add client-side binding SQL helpers for DDL statements

### DIFF
--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -69,7 +69,7 @@ def sql_query_pgwire(
 ) -> List[List[Any]]:
     with pgwire_sql_conn(config) as conn:
         eprint(f"QUERY: {query}")
-    return sql_query(conn, query, vars)
+        return sql_query(conn, query, vars)
 
 
 def sql_execute_pgwire(

--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -37,6 +37,15 @@ def sql_execute(
     cur.execute(query, vars)
 
 
+def sql_execute_ddl(
+    conn: Connection[Any],
+    query: str,
+    vars: Optional[Sequence[Any]] = None,
+) -> None:
+    cur = psycopg.ClientCursor(conn)
+    cur.execute(query, vars)
+
+
 def pgwire_sql_conn(config: EnvironmentConfig) -> Connection[Any]:
     environment = wait_for_environmentd(config)
     pgwire_url: str = environment["regionInfo"]["sqlAddress"]


### PR DESCRIPTION
Adds SQL helpers that use client-side binding for use with DDL statements. Psycopg 3 uses server-side binding by default, which can't be used for DDL.
Fixes nesting in `sql_query_pgwire`, which was dropping the connection before making the sql query.

### Motivation


  * This PR fixes a previously unreported bug.
The upgrade from psycopg2 broke downstream tests in the cloud repo.
https://github.com/MaterializeInc/cloud/actions/runs/5942092236/job/16115041339
https://www.psycopg.org/psycopg3/docs/basic/from_pg2.html

### Tips for reviewer

Related temporary fixes for the cloud repo https://github.com/MaterializeInc/cloud/pull/7278 and https://github.com/MaterializeInc/cloud/pull/7279, until we can get this merged.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  I'll make the PR after this is merged. We need to bump the submodule and import these new functions.
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  no user-facing behavior changes.
