### PR TITLE
doc: remove sleep from rust example

### DIFF
--- a/doc/user/content/integrations/rust.md
+++ b/doc/user/content/integrations/rust.md
@@ -148,8 +148,6 @@ pub(crate) fn create_materialized_view() -> Result<u64, Error> {
 Materialize is designed to stream changes to views. To subscribe to a stream of updates in Rust, you can use the `SUBSCRIBE` feature. Here's how to subscribe to a stream:
 
 ```rust
-use std::{thread::sleep, time::Duration};
-
 use crate::connection::create_client;
 
 pub(crate) fn subscribe() {
@@ -162,7 +160,6 @@ pub(crate) fn subscribe() {
         for row in results {
             println!("{:}", row.get::<usize, String>(2));
         }
-        sleep(Duration::from_millis(200));
     }
 }
 ```


### PR DESCRIPTION
This is needless, and it will be copy-pasted so we should remove it.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a