### PR TITLE
sql[-parser]: support `TABLE` expressions

### DIFF
--- a/doc/user/content/sql/table.md
+++ b/doc/user/content/sql/table.md
@@ -1,0 +1,55 @@
+---
+title: "TABLE"
+description: "`TABLE` retrieves all rows from a single table."
+menu:
+  main:
+    parent: commands
+---
+
+The `TABLE` expression retrieves all rows from a single table.
+
+## Syntax
+
+{{< diagram "table-expr.svg" >}}
+
+Field | Use
+------|-----
+_table\_name_ | The name of the tablefrom which to retrieve rows.
+
+## Details
+
+`TABLE` expressions can be used anywhere that [`SELECT`] expressions are valid.
+
+The expression `TABLE t` is exactly equivalent to the following [`SELECT`]
+expression:
+
+```sql
+SELECT * FROM t;
+```
+
+## Examples
+
+Using a `TABLE` expression as a standalone statement:
+
+```sql
+TABLE t;
+```
+```nofmt
+ a
+---
+ 1
+ 2
+```
+
+Using a `TABLE` expression in place of a [`SELECT`] expression:
+
+```sql
+TABLE t ORDER BY a DESC LIMIT 1;
+```
+```nofmt
+ a
+---
+ 2
+```
+
+[`SELECT`]: ../select

--- a/doc/user/content/sql/values.md
+++ b/doc/user/content/sql/values.md
@@ -1,0 +1,58 @@
+---
+title: "VALUES"
+description: "`VALUES` constructs a relation from value expressions."
+menu:
+  main:
+    parent: commands
+---
+
+The `VALUES` expression constructs a relation from value expressions.
+
+## Syntax
+
+{{< diagram "values-expr.svg" >}}
+
+Field  | Use
+-------|-----
+_expr_ | The value of a single column of a single row.
+
+## Details
+
+`VALUES` expressions can be used anywhere that [`SELECT`] expressions are valid.
+They are most commonly used in [`INSERT`] statements, but they can also stand
+alone.
+
+## Examples
+
+Using a `VALUES` expression as a standalone statement:
+
+```sql
+VALUES (1, 2, 3), (4, 5, 6);
+```
+```nofmt
+ column1 | column2 | column3
+---------+---------+---------
+       1 |       2 |       3
+       4 |       5 |       6
+```
+
+Using a `VALUES` expression in place of a `SELECT` expression:
+
+```sql
+VALUES (1), (2), (3) ORDER BY column1 DESC LIMIT 2;
+```
+```nofmt
+ column1
+---------
+       3
+       2
+```
+
+Using a `VALUES` expression in an [`INSERT`] statement:
+
+```sql
+INSERT INTO t VALUES (1, 2), (3, 4);
+```
+
+[`INSERT`]: ../insert
+[`SELECT`]: ../select

--- a/doc/user/layouts/partials/sql-grammar/table-expr.svg
+++ b/doc/user/layouts/partials/sql-grammar/table-expr.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="241" height="37">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="66" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">TABLE</text>
+   <rect x="117" y="3" width="96" height="32"/>
+   <rect x="115" y="1" width="96" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="125" y="21">table_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m96 0 h10 m3 0 h-3"/>
+   <polygon points="231 17 239 13 239 21"/>
+   <polygon points="231 17 223 13 223 21"/>
+</svg>

--- a/doc/user/layouts/partials/sql-grammar/values-expr.svg
+++ b/doc/user/layouts/partials/sql-grammar/values-expr.svg
@@ -1,0 +1,51 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="375" height="125">
+   <polygon points="9 105 1 101 1 109"/>
+   <polygon points="17 105 9 101 9 109"/>
+   <rect x="31" y="91" width="76" height="32" rx="10"/>
+   <rect x="29"
+         y="89"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="109">VALUES</text>
+   <rect x="147" y="91" width="26" height="32" rx="10"/>
+   <rect x="145"
+         y="89"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="109">(</text>
+   <rect x="213" y="91" width="48" height="32"/>
+   <rect x="211" y="89" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="221" y="109">expr</text>
+   <rect x="213" y="47" width="24" height="32" rx="10"/>
+   <rect x="211"
+         y="45"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="221" y="65">,</text>
+   <rect x="301" y="91" width="26" height="32" rx="10"/>
+   <rect x="299"
+         y="89"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="309" y="109">)</text>
+   <rect x="147" y="3" width="24" height="32" rx="10"/>
+   <rect x="145"
+         y="1"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="155" y="21">,</text>
+   <path class="line"
+         d="m17 105 h2 m0 0 h10 m76 0 h10 m20 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m-88 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m68 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-68 0 h10 m24 0 h10 m0 0 h24 m20 44 h10 m26 0 h10 m-220 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -68 q0 -10 10 -10 m200 88 l20 0 m-20 0 q10 0 10 -10 l0 -68 q0 -10 -10 -10 m-200 0 h10 m24 0 h10 m0 0 h156 m23 88 h-3"/>
+   <polygon points="365 105 373 101 373 109"/>
+   <polygon points="365 105 357 101 357 109"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -432,6 +432,7 @@ table_ref ::=
     | 'LATERAL'? table_func_call
     | '(' join_expr ')'
   ) ('AS'? table_alias ('(' col_alias (',' col_alias)* ')'))?
+table_expr ::= 'TABLE' table_name
 time_unit ::=
   'MILLENNIUM' | 'CENTURY' | 'DECADE' | 'YEAR' | 'MONTH' | 'DAY' | 'HOUR' | 'MINUTE' | 'SECOND' | 'MILLISECONDS' | 'MICROSECONDS'
 type_bool ::=
@@ -478,6 +479,7 @@ update_stmt ::=
   'UPDATE' table_name ('AS'? alias)?
   'SET' ( column_name '=' expr ) ( ( ',' column_name '=' expr ) )*
   'WHERE' condition
+values_expr ::= 'VALUES' '(' expr (',' expr)* ')' (',' '(' expr (',' expr)* ')')*
 with_ctes ::=
   'WITH'
     cte_binding ( ',' cte_binding )*

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -131,7 +131,7 @@ pub enum SetExpr<T: AstInfo> {
     },
     Values(Values<T>),
     Show(ShowStatement<T>),
-    // TODO: ANSI SQL supports `TABLE` here.
+    Table(T::ItemName),
 }
 
 impl<T: AstInfo> AstDisplay for SetExpr<T> {
@@ -145,6 +145,10 @@ impl<T: AstInfo> AstDisplay for SetExpr<T> {
             }
             SetExpr::Values(v) => f.write_node(v),
             SetExpr::Show(v) => f.write_node(v),
+            SetExpr::Table(t) => {
+                f.write_str("TABLE ");
+                f.write_node(t)
+            }
             SetExpr::SetOperation {
                 left,
                 right,

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -360,7 +360,10 @@ impl<'a> Parser<'a> {
     fn parse_statement_inner(&mut self) -> Result<Statement<Raw>, ParserStatementError> {
         match self.next_token() {
             Some(t) => match t {
-                Token::Keyword(SELECT) | Token::Keyword(WITH) | Token::Keyword(VALUES) => {
+                Token::Keyword(SELECT)
+                | Token::Keyword(WITH)
+                | Token::Keyword(VALUES)
+                | Token::Keyword(TABLE) => {
                     self.prev_token();
                     Ok(Statement::Select(SelectStatement {
                         query: self.parse_query().map_parser_err(StatementKind::Select)?,
@@ -5703,6 +5706,8 @@ impl<'a> Parser<'a> {
             SetExpr::Values(self.parse_values()?)
         } else if self.parse_keyword(SHOW) {
             SetExpr::Show(self.parse_show()?)
+        } else if self.parse_keyword(TABLE) {
+            SetExpr::Table(self.parse_raw_name()?)
         } else {
             return self.expected(
                 self.peek_pos(),

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -118,6 +118,28 @@ VALUES (1)
 VALUES (1)
 
 parse-statement roundtrip
+TABLE t
+----
+TABLE t
+
+parse-statement roundtrip
+TABLE a.b.c
+----
+TABLE a.b.c
+
+parse-statement roundtrip
+TABLE t UNION TABLE t ORDER BY 1
+----
+TABLE t UNION TABLE t ORDER BY 1
+
+parse-statement
+TABLE 1 + 1
+----
+error: Expected identifier, found number "1"
+TABLE 1 + 1
+      ^
+
+parse-statement roundtrip
 SELECT (1)
 ----
 SELECT (1)

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1621,6 +1621,10 @@ fn plan_set_expr(
             Ok((relation_expr, scope))
         }
         SetExpr::Values(Values(values)) => plan_values(qcx, values),
+        SetExpr::Table(name) => {
+            let (expr, scope) = qcx.resolve_table_name(name.clone())?;
+            Ok((expr, scope))
+        }
         SetExpr::Query(query) => {
             let (expr, scope) = plan_nested_query(qcx, query)?;
             Ok((expr, scope))

--- a/test/sqllogictest/table.slt
+++ b/test/sqllogictest/table.slt
@@ -1,0 +1,44 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests for the esoteric TABLE statement.
+
+mode cockroach
+
+statement ok
+CREATE TABLE t (a int)
+
+statement ok
+INSERT INTO t VALUES (1), (2), (3)
+
+query I
+TABLE t
+----
+1
+2
+3
+
+query I
+TABLE materialize.public.t
+----
+1
+2
+3
+
+query I
+TABLE t UNION ALL TABLE t ORDER BY a LIMIT 5
+----
+1
+1
+2
+2
+3
+
+query error unknown catalog item 'noexist'
+TABLE noexist


### PR DESCRIPTION
The `TABLE` expression is an esoteric SQL feature that retrieves all rows from the named SQL table, as in:

    TABLE db.schm.tab

It is not widely used, but is nonetheless important to support for PostgreSQL parity.

This commit adds support and documentation for this expression. It also adds documentation for `VALUES` expressions, which I happened to notice were missing while working on the `TABLE` expression documentation.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

* While esoteric, I'm tired of having to caveat that Materialize doesn't support this statement.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add support for `TABLE` expressions, which retrieve all rows from the named SQL table.
