### PR TITLE
webhooks: Docs for `INCLUDE HEADERS ( <list> )` and `INCLUDE HEADER <name>`

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-source-webhook.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-webhook.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="805" height="391">
+<svg xmlns="http://www.w3.org/2000/svg" width="805" height="729">
    <polygon points="11 17 3 13 3 21"/>
    <polygon points="19 17 11 13 11 21"/>
    <rect x="33" y="3" width="140" height="32" rx="10"/>
@@ -55,65 +55,151 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="511" y="119">BODY FORMAT</text>
-   <rect x="214" y="167" width="170" height="32"/>
-   <rect x="212" y="165" width="170" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="222" y="185">webhook_body_format</text>
-   <rect x="424" y="199" width="152" height="32" rx="10"/>
-   <rect x="422"
-         y="197"
-         width="152"
+   <rect x="372" y="167" width="56" height="32" rx="10"/>
+   <rect x="370"
+         y="165"
+         width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="432" y="217">INCLUDE HEADERS</text>
-   <rect x="45" y="309" width="70" height="32" rx="10"/>
-   <rect x="43"
-         y="307"
-         width="70"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="53" y="327">CHECK</text>
-   <rect x="155" y="309" width="58" height="32" rx="10"/>
-   <rect x="153"
-         y="307"
+   <text class="terminal" x="380" y="185">TEXT</text>
+   <rect x="372" y="211" width="58" height="32" rx="10"/>
+   <rect x="370"
+         y="209"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="163" y="327">WITH</text>
-   <rect x="233" y="309" width="26" height="32" rx="10"/>
-   <rect x="231"
-         y="307"
+   <text class="terminal" x="380" y="229">JSON</text>
+   <rect x="372" y="255" width="66" height="32" rx="10"/>
+   <rect x="370"
+         y="253"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="380" y="273">BYTES</text>
+   <rect x="114" y="353" width="144" height="32" rx="10"/>
+   <rect x="112"
+         y="351"
+         width="144"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="122" y="371">INCLUDE HEADER</text>
+   <rect x="278" y="353" width="108" height="32"/>
+   <rect x="276" y="351" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="286" y="371">header_name</text>
+   <rect x="406" y="353" width="40" height="32" rx="10"/>
+   <rect x="404"
+         y="351"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="414" y="371">AS</text>
+   <rect x="466" y="353" width="104" height="32"/>
+   <rect x="464" y="351" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="474" y="371">column_alias</text>
+   <rect x="610" y="385" width="66" height="32" rx="10"/>
+   <rect x="608"
+         y="383"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="618" y="403">BYTES</text>
+   <rect x="114" y="473" width="152" height="32" rx="10"/>
+   <rect x="112"
+         y="471"
+         width="152"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="122" y="491">INCLUDE HEADERS</text>
+   <rect x="306" y="473" width="26" height="32" rx="10"/>
+   <rect x="304"
+         y="471"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="241" y="327">(</text>
-   <rect x="319" y="309" width="174" height="32"/>
-   <rect x="317" y="307" width="174" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="327" y="327">webhook_check_option</text>
-   <rect x="319" y="265" width="24" height="32" rx="10"/>
-   <rect x="317"
-         y="263"
+   <text class="terminal" x="314" y="491">(</text>
+   <rect x="392" y="505" width="50" height="32" rx="10"/>
+   <rect x="390"
+         y="503"
+         width="50"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="400" y="523">NOT</text>
+   <rect x="482" y="473" width="108" height="32"/>
+   <rect x="480" y="471" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="490" y="491">header_name</text>
+   <rect x="372" y="429" width="24" height="32" rx="10"/>
+   <rect x="370"
+         y="427"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="327" y="283">,</text>
-   <rect x="553" y="309" width="26" height="32" rx="10"/>
-   <rect x="551"
-         y="307"
+   <text class="terminal" x="380" y="447">,</text>
+   <rect x="630" y="473" width="26" height="32" rx="10"/>
+   <rect x="628"
+         y="471"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="561" y="327">)</text>
-   <rect x="619" y="309" width="138" height="32"/>
-   <rect x="617" y="307" width="138" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="627" y="327">check_expression</text>
+   <text class="terminal" x="638" y="491">)</text>
+   <rect x="45" y="647" width="70" height="32" rx="10"/>
+   <rect x="43"
+         y="645"
+         width="70"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="53" y="665">CHECK</text>
+   <rect x="155" y="647" width="58" height="32" rx="10"/>
+   <rect x="153"
+         y="645"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="163" y="665">WITH</text>
+   <rect x="233" y="647" width="26" height="32" rx="10"/>
+   <rect x="231"
+         y="645"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="241" y="665">(</text>
+   <rect x="319" y="647" width="174" height="32"/>
+   <rect x="317" y="645" width="174" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="327" y="665">webhook_check_option</text>
+   <rect x="319" y="603" width="24" height="32" rx="10"/>
+   <rect x="317"
+         y="601"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="327" y="621">,</text>
+   <rect x="553" y="647" width="26" height="32" rx="10"/>
+   <rect x="551"
+         y="645"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="561" y="665">)</text>
+   <rect x="619" y="647" width="138" height="32"/>
+   <rect x="617" y="645" width="138" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="627" y="665">check_expression</text>
    <path class="line"
-         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-442 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m170 0 h10 m20 0 h10 m0 0 h162 m-192 0 h20 m172 0 h20 m-212 0 q10 0 10 10 m192 0 q0 -10 10 -10 m-202 10 v12 m192 0 v-12 m-192 12 q0 10 10 10 m172 0 q10 0 10 -10 m-182 10 h10 m152 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-615 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m70 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m174 0 h10 m-214 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m194 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-194 0 h10 m24 0 h10 m0 0 h150 m-234 44 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m20 -34 h10 m26 0 h10 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v30 m464 0 v-30 m-464 30 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m0 0 h434 m20 -50 h10 m138 0 h10 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v46 m752 0 v-46 m-752 46 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m0 0 h722 m23 -66 h-3"/>
-   <polygon points="795 323 803 319 803 327"/>
-   <polygon points="795 323 787 319 787 327"/>
+         d="m19 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m0 0 h10 m104 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-442 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m108 0 h10 m0 0 h10 m60 0 h10 m0 0 h10 m94 0 h10 m0 0 h10 m126 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-321 66 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m56 0 h10 m0 0 h10 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m58 0 h10 m0 0 h8 m-96 -10 v20 m106 0 v-20 m-106 20 v24 m106 0 v-24 m-106 24 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m22 -88 l2 0 m2 0 l2 0 m2 0 l2 0 m-448 154 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m0 0 h592 m-622 0 h20 m602 0 h20 m-642 0 q10 0 10 10 m622 0 q0 -10 10 -10 m-632 10 v12 m622 0 v-12 m-622 12 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m144 0 h10 m0 0 h10 m108 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m104 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-592 -42 v20 m622 0 v-20 m-622 20 v100 m622 0 v-100 m-622 100 q0 10 10 10 m602 0 q10 0 10 -10 m-612 10 h10 m152 0 h10 m20 0 h10 m26 0 h10 m40 0 h10 m0 0 h60 m-90 0 h20 m70 0 h20 m-110 0 q10 0 10 10 m90 0 q0 -10 10 -10 m-100 10 v12 m90 0 v-12 m-90 12 q0 10 10 10 m70 0 q10 0 10 -10 m-80 10 h10 m50 0 h10 m20 -32 h10 m108 0 h10 m-258 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m238 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-238 0 h10 m24 0 h10 m0 0 h194 m20 44 h10 m26 0 h10 m-390 0 h20 m370 0 h20 m-410 0 q10 0 10 10 m390 0 q0 -10 10 -10 m-400 10 v46 m390 0 v-46 m-390 46 q0 10 10 10 m370 0 q10 0 10 -10 m-380 10 h10 m0 0 h360 m20 -66 h20 m-642 -152 l20 0 m-1 0 q-9 0 -9 -10 l0 4 q0 -10 10 -10 m642 16 l20 0 m-20 0 q10 0 10 -10 l0 4 q0 -10 -10 -10 m-642 0 h10 m0 0 h632 m-682 16 h20 m682 0 h20 m-722 0 q10 0 10 10 m702 0 q0 -10 10 -10 m-712 10 v214 m702 0 v-214 m-702 214 q0 10 10 10 m682 0 q10 0 10 -10 m-692 10 h10 m0 0 h672 m22 -234 l2 0 m2 0 l2 0 m2 0 l2 0 m-775 326 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m70 0 h10 m20 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m40 0 h10 m174 0 h10 m-214 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m194 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-194 0 h10 m24 0 h10 m0 0 h150 m-234 44 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m20 -34 h10 m26 0 h10 m-464 0 h20 m444 0 h20 m-484 0 q10 0 10 10 m464 0 q0 -10 10 -10 m-474 10 v30 m464 0 v-30 m-464 30 q0 10 10 10 m444 0 q10 0 10 -10 m-454 10 h10 m0 0 h434 m20 -50 h10 m138 0 h10 m-752 0 h20 m732 0 h20 m-772 0 q10 0 10 10 m752 0 q0 -10 10 -10 m-762 10 v46 m752 0 v-46 m-752 46 q0 10 10 10 m732 0 q10 0 10 -10 m-742 10 h10 m0 0 h722 m23 -66 h-3"/>
+   <polygon points="795 661 803 657 803 665"/>
+   <polygon points="795 661 787 657 787 665"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -166,8 +166,11 @@ create_source_webhook ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   'IN CLUSTER' cluster_name
   'FROM' 'WEBHOOK'
-  'BODY FORMAT' (webhook_body_format)
-  ('INCLUDE HEADERS')?
+  'BODY FORMAT' ('TEXT' | 'JSON' | 'BYTES')
+  (
+    ('INCLUDE HEADER'  header_name 'AS' column_alias ('BYTES')? )? |
+    ('INCLUDE HEADERS' ( '(' ('NOT')? header_name ( ',' ('NOT')? header_name )* ')' )?)?
+  )*
   ('CHECK'
     ('WITH' '(' ( (webhook_check_option) ( ( ',' webhook_check_option ) )* )? ')' )?
     check_expression


### PR DESCRIPTION
This PR adds documentation for the newly added `INCLUDE HEADER` syntax, and the updated `INCLUDE HEADERS` syntax, introduced in https://github.com/MaterializeInc/materialize/pull/21357. It also adds an example for connecting with Amazon EventBridge.

Fixes https://github.com/MaterializeInc/materialize/issues/21332

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates our documentation for a newly added feature.
