### PR TITLE
adapter,sql: fill in pg_type.typreceive

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1087,5 +1087,6 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_statement_execution_history -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_storage_shards -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_storage_usage_by_shard -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_type_pg_metadata -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_view_foreign_keys -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_view_keys -->

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4279,6 +4279,7 @@ impl Catalog {
             details: CatalogTypeDetails {
                 array_id: builtin.details.array_id,
                 typ,
+                typreceive_oid: builtin.details.typreceive_oid,
             },
         }
     }
@@ -7652,6 +7653,7 @@ impl Catalog {
                 details: CatalogTypeDetails {
                     array_id: None,
                     typ: typ.inner,
+                    typreceive_oid: None,
                 },
                 resolved_ids,
             }),

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -280,6 +280,7 @@ pub const TYPE_BOOL: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Bool,
         array_id: None,
+        typreceive_oid: Some(2436),
     },
 };
 
@@ -290,6 +291,7 @@ pub const TYPE_BYTEA: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Bytes,
         array_id: None,
+        typreceive_oid: Some(2412),
     },
 };
 
@@ -300,6 +302,7 @@ pub const TYPE_INT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int64,
         array_id: None,
+        typreceive_oid: Some(2408),
     },
 };
 
@@ -310,6 +313,7 @@ pub const TYPE_INT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int32,
         array_id: None,
+        typreceive_oid: Some(2406),
     },
 };
 
@@ -320,6 +324,7 @@ pub const TYPE_TEXT: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::String,
         array_id: None,
+        typreceive_oid: Some(2414),
     },
 };
 
@@ -330,6 +335,7 @@ pub const TYPE_OID: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Oid,
         array_id: None,
+        typreceive_oid: Some(2418),
     },
 };
 
@@ -340,6 +346,7 @@ pub const TYPE_FLOAT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Float32,
         array_id: None,
+        typreceive_oid: Some(2424),
     },
 };
 
@@ -350,6 +357,7 @@ pub const TYPE_FLOAT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Float64,
         array_id: None,
+        typreceive_oid: Some(2426),
     },
 };
 
@@ -362,6 +370,7 @@ pub const TYPE_BOOL_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BOOL.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -374,6 +383,7 @@ pub const TYPE_BYTEA_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BYTEA.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -386,6 +396,7 @@ pub const TYPE_INT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -398,6 +409,7 @@ pub const TYPE_TEXT_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TEXT.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -410,6 +422,7 @@ pub const TYPE_INT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -422,6 +435,7 @@ pub const TYPE_FLOAT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_FLOAT4.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -434,6 +448,7 @@ pub const TYPE_FLOAT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_FLOAT8.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -446,6 +461,7 @@ pub const TYPE_OID_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_OID.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -456,6 +472,7 @@ pub const TYPE_DATE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Date,
         array_id: None,
+        typreceive_oid: Some(2468),
     },
 };
 
@@ -466,6 +483,7 @@ pub const TYPE_TIME: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Time,
         array_id: None,
+        typreceive_oid: Some(2470),
     },
 };
 
@@ -476,6 +494,7 @@ pub const TYPE_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Timestamp,
         array_id: None,
+        typreceive_oid: Some(2474),
     },
 };
 
@@ -488,6 +507,7 @@ pub const TYPE_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMP.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -500,6 +520,7 @@ pub const TYPE_DATE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -512,6 +533,7 @@ pub const TYPE_TIME_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIME.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -522,6 +544,7 @@ pub const TYPE_TIMESTAMPTZ: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::TimestampTz,
         array_id: None,
+        typreceive_oid: Some(2476),
     },
 };
 
@@ -534,6 +557,7 @@ pub const TYPE_TIMESTAMPTZ_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMPTZ.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -544,6 +568,7 @@ pub const TYPE_INTERVAL: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Interval,
         array_id: None,
+        typreceive_oid: Some(2478),
     },
 };
 
@@ -556,6 +581,7 @@ pub const TYPE_INTERVAL_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INTERVAL.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -566,6 +592,7 @@ pub const TYPE_NAME: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::PgLegacyName,
         array_id: None,
+        typreceive_oid: Some(2422),
     },
 };
 
@@ -578,6 +605,7 @@ pub const TYPE_NAME_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NAME.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -588,6 +616,7 @@ pub const TYPE_NUMERIC: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Numeric,
         array_id: None,
+        typreceive_oid: Some(2460),
     },
 };
 
@@ -600,6 +629,7 @@ pub const TYPE_NUMERIC_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUMERIC.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -610,6 +640,7 @@ pub const TYPE_RECORD: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: Some(2402),
     },
 };
 
@@ -622,6 +653,7 @@ pub const TYPE_RECORD_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_RECORD.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -632,6 +664,7 @@ pub const TYPE_UUID: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Uuid,
         array_id: None,
+        typreceive_oid: Some(2961),
     },
 };
 
@@ -644,6 +677,7 @@ pub const TYPE_UUID_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UUID.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -654,6 +688,7 @@ pub const TYPE_JSONB: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Jsonb,
         array_id: None,
+        typreceive_oid: Some(3805),
     },
 };
 
@@ -666,6 +701,7 @@ pub const TYPE_JSONB_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_JSONB.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -676,6 +712,7 @@ pub const TYPE_ANY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -686,6 +723,7 @@ pub const TYPE_ANYARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: Some(2502),
     },
 };
 
@@ -696,6 +734,7 @@ pub const TYPE_ANYELEMENT: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -706,6 +745,7 @@ pub const TYPE_ANYNONARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -716,6 +756,7 @@ pub const TYPE_ANYRANGE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -726,6 +767,7 @@ pub const TYPE_CHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::PgLegacyChar,
         array_id: None,
+        typreceive_oid: Some(2434),
     },
 };
 
@@ -736,6 +778,7 @@ pub const TYPE_VARCHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::VarChar,
         array_id: None,
+        typreceive_oid: Some(2432),
     },
 };
 
@@ -746,6 +789,7 @@ pub const TYPE_INT2: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int16,
         array_id: None,
+        typreceive_oid: Some(2404),
     },
 };
 
@@ -758,6 +802,7 @@ pub const TYPE_INT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT2.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -768,6 +813,7 @@ pub const TYPE_BPCHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Char,
         array_id: None,
+        typreceive_oid: Some(2430),
     },
 };
 
@@ -780,6 +826,7 @@ pub const TYPE_CHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_CHAR.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -792,6 +839,7 @@ pub const TYPE_VARCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_VARCHAR.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -804,6 +852,7 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BPCHAR.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -814,6 +863,7 @@ pub const TYPE_REGPROC: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegProc,
         array_id: None,
+        typreceive_oid: Some(2444),
     },
 };
 
@@ -826,6 +876,7 @@ pub const TYPE_REGPROC_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGPROC.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -836,6 +887,7 @@ pub const TYPE_REGTYPE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegType,
         array_id: None,
+        typreceive_oid: Some(2454),
     },
 };
 
@@ -848,6 +900,7 @@ pub const TYPE_REGTYPE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGTYPE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -858,6 +911,7 @@ pub const TYPE_REGCLASS: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegClass,
         array_id: None,
+        typreceive_oid: Some(2452),
     },
 };
 
@@ -870,6 +924,7 @@ pub const TYPE_REGCLASS_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGCLASS.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -880,6 +935,7 @@ pub const TYPE_INT2_VECTOR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int2Vector,
         array_id: None,
+        typreceive_oid: Some(2410),
     },
 };
 
@@ -892,6 +948,7 @@ pub const TYPE_INT2_VECTOR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT2_VECTOR.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -902,6 +959,7 @@ pub const TYPE_ANYCOMPATIBLE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -912,6 +970,7 @@ pub const TYPE_ANYCOMPATIBLEARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: Some(5090),
     },
 };
 
@@ -922,6 +981,7 @@ pub const TYPE_ANYCOMPATIBLENONARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -932,6 +992,7 @@ pub const TYPE_ANYCOMPATIBLERANGE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -942,6 +1003,7 @@ pub const TYPE_LIST: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -952,6 +1014,7 @@ pub const TYPE_MAP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -962,6 +1025,7 @@ pub const TYPE_ANYCOMPATIBLELIST: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -972,6 +1036,7 @@ pub const TYPE_ANYCOMPATIBLEMAP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -982,6 +1047,7 @@ pub const TYPE_UINT2: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt16,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -994,6 +1060,7 @@ pub const TYPE_UINT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT2.name,
         },
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1004,6 +1071,7 @@ pub const TYPE_UINT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt32,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1016,6 +1084,7 @@ pub const TYPE_UINT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT4.name,
         },
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1026,6 +1095,7 @@ pub const TYPE_UINT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt64,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1038,6 +1108,7 @@ pub const TYPE_UINT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT8.name,
         },
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1048,6 +1119,7 @@ pub const TYPE_MZ_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::MzTimestamp,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1060,6 +1132,7 @@ pub const TYPE_MZ_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_MZ_TIMESTAMP.name,
         },
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1072,6 +1145,7 @@ pub const TYPE_INT4_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1084,6 +1158,7 @@ pub const TYPE_INT4_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1096,6 +1171,7 @@ pub const TYPE_INT8_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1108,6 +1184,7 @@ pub const TYPE_INT8_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1120,6 +1197,7 @@ pub const TYPE_DATE_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1132,6 +1210,7 @@ pub const TYPE_DATE_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1144,6 +1223,7 @@ pub const TYPE_NUM_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUMERIC.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1156,6 +1236,7 @@ pub const TYPE_NUM_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUM_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1168,6 +1249,7 @@ pub const TYPE_TS_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMP.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1180,6 +1262,7 @@ pub const TYPE_TS_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TS_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1192,6 +1275,7 @@ pub const TYPE_TSTZ_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMPTZ.name,
         },
         array_id: None,
+        typreceive_oid: Some(3836),
     },
 };
 
@@ -1204,6 +1288,7 @@ pub const TYPE_TSTZ_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TSTZ_RANGE.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
     },
 };
 
@@ -1214,6 +1299,7 @@ pub const TYPE_MZ_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::MzAclItem,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1226,6 +1312,7 @@ pub const TYPE_MZ_ACL_ITEM_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_MZ_ACL_ITEM.name,
         },
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1236,6 +1323,7 @@ pub const TYPE_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::AclItem,
         array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1248,6 +1336,18 @@ pub const TYPE_ACL_ITEM_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_ACL_ITEM.name,
         },
         array_id: None,
+        typreceive_oid: Some(2400),
+    },
+};
+
+pub const TYPE_INTERNAL: BuiltinType<NameReference> = BuiltinType {
+    name: "internal",
+    schema: PG_CATALOG_SCHEMA,
+    oid: 2281,
+    details: CatalogTypeDetails {
+        typ: CatalogType::Pseudo,
+        array_id: None,
+        typreceive_oid: None,
     },
 };
 
@@ -1661,6 +1761,16 @@ pub static MZ_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
             "privileges",
             ScalarType::Array(Box::new(ScalarType::MzAclItem)).nullable(false),
         ),
+    is_retained_metrics_object: false,
+});
+/// PostgreSQL-specific metadata about types that doesn't make sense to expose
+/// in the `mz_types` table as part of our public, stable API.
+pub static MZ_TYPE_PG_METADATA: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_type_pg_metadata",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("typreceive", ScalarType::Oid.nullable(false)),
     is_retained_metrics_object: false,
 });
 pub static MZ_ARRAY_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -2753,7 +2863,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
     )
         AS typarray,
     (CASE mztype WHEN 'a' THEN 'array_in' ELSE NULL END)::pg_catalog.regproc AS typinput,
-    NULL::pg_catalog.oid AS typreceive,
+    COALESCE(mz_internal.mz_type_pg_metadata.typreceive, 0) AS typreceive,
     false::pg_catalog.bool AS typnotnull,
     0::pg_catalog.oid AS typbasetype,
     -1::pg_catalog.int4 AS typtypmod,
@@ -2762,6 +2872,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
     NULL::pg_catalog.text AS typdefault
 FROM
     mz_catalog.mz_types
+    LEFT JOIN mz_internal.mz_type_pg_metadata ON mz_catalog.mz_types.id = mz_internal.mz_type_pg_metadata.id
     JOIN mz_catalog.mz_schemas ON mz_schemas.id = mz_types.schema_id
     JOIN (
             -- 'a' is not a supported typtype, but we use it to denote an array. It is
@@ -4828,6 +4939,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Type(&TYPE_MZ_ACL_ITEM_ARRAY),
         Builtin::Type(&TYPE_ACL_ITEM),
         Builtin::Type(&TYPE_ACL_ITEM_ARRAY),
+        Builtin::Type(&TYPE_INTERNAL),
     ];
     for (schema, funcs) in &[
         (PG_CATALOG_SCHEMA, &*mz_sql::func::PG_CATALOG_BUILTINS),
@@ -4890,6 +5002,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_VIEWS),
         Builtin::Table(&MZ_MATERIALIZED_VIEWS),
         Builtin::Table(&MZ_TYPES),
+        Builtin::Table(&MZ_TYPE_PG_METADATA),
         Builtin::Table(&MZ_ARRAY_TYPES),
         Builtin::Table(&MZ_BASE_TYPES),
         Builtin::Table(&MZ_LIST_TYPES),
@@ -5184,6 +5297,7 @@ mod tests {
                 ty: String,
                 elem: u32,
                 array: u32,
+                receive: Option<u32>,
             }
 
             struct PgOper {
@@ -5220,7 +5334,7 @@ mod tests {
 
             let pg_type: BTreeMap<_, _> = client
                 .query(
-                    "SELECT oid, typname, typtype::text, typelem, typarray FROM pg_type",
+                    "SELECT oid, typname, typtype::text, typelem, typarray, nullif(typreceive::oid, 0) as typreceive FROM pg_type",
                     &[],
                 )
                 .await
@@ -5233,6 +5347,7 @@ mod tests {
                         ty: row.get("typtype"),
                         elem: row.get("typelem"),
                         array: row.get("typarray"),
+                        receive: row.get("typreceive"),
                     };
                     (oid, pg_type)
                 })
@@ -5266,6 +5381,10 @@ mod tests {
                     .expect("unable to resolve type")
                     .oid()
             };
+
+            let func_oids: BTreeSet<_> = BUILTINS::funcs()
+                .flat_map(|f| f.inner.func_impls().into_iter().map(|f| f.oid))
+                .collect();
 
             let mut all_oids = BTreeSet::new();
 
@@ -5316,6 +5435,21 @@ mod tests {
                             "oid {} has name {} in postgres; expected {}",
                             ty.oid, pg_ty.name, ty.name,
                         );
+
+                        assert_eq!(
+                            ty.details.typreceive_oid, pg_ty.receive,
+                            "type {} has typreceive OID {:?} in mz but {:?} in pg",
+                            ty.name, ty.details.typreceive_oid, pg_ty.receive,
+                        );
+
+                        if let Some(typreceive_oid) = ty.details.typreceive_oid {
+                            assert!(
+                                func_oids.contains(&typreceive_oid),
+                                "type {} has typreceive OID {} that does not exist in pg_proc",
+                                ty.name,
+                                typreceive_oid,
+                            );
+                        }
 
                         // Ensure the type matches.
                         match &ty.details.typ {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1157,6 +1157,7 @@ impl Coordinator {
             details: CatalogTypeDetails {
                 array_id: None,
                 typ: plan.typ.inner,
+                typreceive_oid: None,
             },
             resolved_ids,
         };

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -726,6 +726,8 @@ pub struct CatalogTypeDetails<T: TypeReference> {
     pub array_id: Option<GlobalId>,
     /// The description of this type.
     pub typ: CatalogType<T>,
+    /// The OID of the `typreceive` function in PostgreSQL, if available.
+    pub typreceive_oid: Option<u32>,
 }
 
 /// Represents a reference to type in the catalog

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -125,6 +125,7 @@ impl TypeCategory {
             | ParamType::ListAny
             | ParamType::ListAnyCompatible
             | ParamType::ListElementAnyCompatible
+            | ParamType::Internal
             | ParamType::NonVecAny
             | ParamType::MapAny
             | ParamType::MapAnyCompatible
@@ -717,6 +718,9 @@ pub enum ParamType {
     /// this type into generating non-existent range types (e.g. ranges of
     /// floats) that will panic.
     RangeAnyCompatible,
+    /// A psuedotype indicating that the function is only meant to be called
+    /// internally by the database system.
+    Internal,
 }
 
 impl ParamType {
@@ -732,6 +736,7 @@ impl ParamType {
             MapAny | MapAnyCompatible => matches!(t, Map { .. }),
             RangeAny | RangeAnyCompatible => matches!(t, Range { .. }),
             NonVecAny => !t.is_vec(),
+            Internal => false,
             Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t, to),
             RecordAny => matches!(t, Record { .. }),
         }
@@ -785,7 +790,7 @@ impl ParamType {
             | RecordAny
             | RangeAny
             | RangeAnyCompatible => true,
-            Any | Plain(_)  => false,
+            Any | Internal | Plain(_)  => false,
         }
     }
 
@@ -803,6 +808,7 @@ impl ParamType {
             ParamType::AnyElement => "anyelement",
             ParamType::ArrayAny => "anyarray",
             ParamType::ArrayAnyCompatible => "anycompatiblearray",
+            ParamType::Internal => "internal",
             ParamType::ListAny => "list",
             ParamType::ListAnyCompatible => "anycompatiblelist",
             // ListElementAnyCompatible is not identical to AnyCompatible, but reusing its ID appears harmless
@@ -1552,6 +1558,7 @@ fn coerce_args_to_types(
                 _ => cexpr.type_as_any(ecx)?,
             },
             Plain(ty) => do_convert(cexpr, ty)?,
+            Internal => return Err(PlanError::InternalFunctionCall),
             p => {
                 let target = polymorphic_solution
                     .target_for_param_type(p)
@@ -2714,6 +2721,99 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "version" => Scalar {
             params!() => UnmaterializableFunc::Version => String, 89;
         },
+
+        // Internal conversion stubs.
+        "boolrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("boolrecv")) => Bool, 2436;
+        },
+        "textrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("textrecv")) => String, 2414;
+        },
+        "anyarray_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("anyarray_recv")) => ArrayAny, 2502;
+        },
+        "bytearecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("bytearecv")) => Bytes, 2412;
+        },
+        "bpcharrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("bpcharrecv")) => Char, 2430;
+        },
+        "charrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("charrecv")) => PgLegacyChar, 2434;
+        },
+        "date_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("date_recv")) => Date, 2468;
+        },
+        "float4recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("float4recv")) => Float32, 2424;
+        },
+        "float8recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("float8recv")) => Float64, 2426;
+        },
+        "int4recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("int4recv")) => Int32, 2406;
+        },
+        "int8recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("int8recv")) => Int64, 2408;
+        },
+        "interval_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("interval_recv")) => Interval, 2478;
+        },
+        "jsonb_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("jsonb_recv")) => Jsonb, 3805;
+        },
+        "namerecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("namerecv")) => PgLegacyName, 2422;
+        },
+        "numeric_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("numeric_recv")) => Numeric, 2460;
+        },
+        "oidrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("oidrecv")) => Oid, 2418;
+        },
+        "record_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("recordrerecord_recvcv")) => RecordAny, 2402;
+        },
+        "regclassrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("regclassrecv")) => RegClass, 2452;
+        },
+        "regprocrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("regprocrecv")) => RegProc, 2444;
+        },
+        "regtyperecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("regtyperecv")) => RegType, 2454;
+        },
+        "int2recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("int2recv")) => Int16, 2404;
+        },
+        "time_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("time_recv")) => Time, 2470;
+        },
+        "timestamp_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("timestamp_recv")) => Timestamp, 2474;
+        },
+        "timestamptz_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("timestamptz_recv")) => TimestampTz, 2476;
+        },
+        "uuid_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("uuid_recv")) => Uuid, 2961;
+        },
+        "varcharrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("varcharrecv")) => VarChar, 2432;
+        },
+        "int2vectorrecv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("int2vectorrecv")) => Int2Vector, 2410;
+        },
+        "anycompatiblearray_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("anycompatiblearray_recv")) => ArrayAnyCompatible, 5090;
+        },
+        "array_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("array_recv")) => ArrayAny, 2400;
+        },
+        "range_recv" => Scalar {
+            params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("range_recv")) => RangeAny, 3836;
+        },
+
 
         // Aggregates.
         "array_agg" => Aggregate {

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -209,6 +209,7 @@ pub enum PlanError {
     WebhookValidationDoesNotUseColumns,
     WebhookValidationNonDeterministic,
     PgSourceUserSpecifiedDetails,
+    InternalFunctionCall,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -263,6 +264,7 @@ impl PlanError {
                     itertools::join(items, ", ")
                 ))
             }
+            Self::InternalFunctionCall => Some("This function is for the internal use of the database system and cannot be called directly.".into()),
             _ => None,
         }
     }
@@ -564,6 +566,7 @@ impl fmt::Display for PlanError {
             Self::PgSourceUserSpecifiedDetails => f.write_str(
                 "must not specify DETAILS option in CREATE SOURCE"
             ),
+            Self::InternalFunctionCall => f.write_str("cannot call function with arguments of type internal"),
         }
     }
 }

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -674,5 +674,6 @@ mz_statement_execution_history
 mz_storage_shards
 mz_storage_usage_by_shard
 mz_subscriptions
+mz_type_pg_metadata
 mz_view_foreign_keys
 mz_view_keys

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1651,3 +1651,9 @@ simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_dangerous_functions = true
 ----
 COMPLETE 0
+
+query error function textrecv\(\) does not exist
+SELECT textrecv()
+
+query error cannot call function with arguments of type internal
+SELECT textrecv('abc')

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -677,6 +677,10 @@ mz_subscriptions
 BASE TABLE
 materialize
 mz_internal
+mz_type_pg_metadata
+BASE TABLE
+materialize
+mz_internal
 mz_view_foreign_keys
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -564,6 +564,7 @@ mz_sessions
 mz_statement_execution_history
 mz_storage_usage_by_shard
 mz_subscriptions
+mz_type_pg_metadata
 mz_view_foreign_keys
 mz_view_keys
 mz_object_dependencies
@@ -653,7 +654,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-50
+51
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/types.td
+++ b/test/testdrive/types.td
@@ -81,6 +81,7 @@ int4
 int4range
 int8
 int8range
+internal
 uint2
 uint4
 uint8


### PR DESCRIPTION
@mjibson @morsapaes I'm afraid I need to hand off the work here to actually stub out all the `pg_proc` entries and link them into the `typreceive` field for each `BuiltinType`. But I set things up for `bool` and `text`, so the rest of the work from here should just be elbow grease.

----

The `pg_type.typreceive` column specifies the name of the internal PostgreSQL function that can decode binary-encoded values of the type. We were previously always filling this column in as NULL, but doing so trips up Power BI (see #11158). This commit fills in the `typreceive` column as PostgreSQL does for all builtin types.

Fix #11158.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a (`pg_type` changes aren't documented)
