### PR TITLE
parallel-workload: Increase the max_tables Materialize setting

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -65,7 +65,8 @@ def run(
     system_conn.autocommit = True
     with system_conn.cursor() as cur:
         cur.execute("ALTER SYSTEM SET max_schemas_per_database = 105")
-        cur.execute("ALTER SYSTEM SET max_tables = 105")
+        # The presence of ALTER TABLE RENAME can cause the total number of tables to exceed MAX_TABLES
+        cur.execute("ALTER SYSTEM SET max_tables = 200")
         cur.execute("ALTER SYSTEM SET max_materialized_views = 105")
         cur.execute("ALTER SYSTEM SET max_sources = 105")
         cur.execute("ALTER SYSTEM SET max_roles = 105")


### PR DESCRIPTION
Due to the presence of ALTER TABLE RENAME in the workload, it is possible for the total number of tables in the database to exceed the previous setting of 105

Fixes #21347


### Motivation

Nightly was failing with a `max_tables` exceeded error.

ALTER TABLE RENAME in the workload allows a new table to be created under the previous name of the renamed table. Now there are 2 tables in the workload but the framework's internal counters still consider 1 table to be present.