### PR TITLE
crdb-restarts: Do not kill CRDB with SIGKILL

### DIFF
--- a/test/crdb-restarts/mzcompose.py
+++ b/test/crdb-restarts/mzcompose.py
@@ -85,10 +85,17 @@ class CrdbDisruption:
 
 
 DISRUPTIONS = [
-    CrdbDisruption(
-        name="sigkill",
-        disruption=lambda c, id: c.kill(f"cockroach{id}"),
-    ),
+    # Unfortunately this disruption is too aggressive and causes CRDB to enter in a state
+    # where it is no longer able to service queries, with either no error or errors about
+    # 'lost quorum' or 'encountered poisoned latch'
+    #
+    # Most likely the test kills and restarts the nodes too fast for CRDB to handle, even though
+    # the nodes are taken out in succession one by one and never in parallel.
+    #
+    # CrdbDisruption(
+    #    name="sigkill",
+    #    disruption=lambda c, id: c.kill(f"cockroach{id}"),
+    # ),
     CrdbDisruption(
         name="sigterm",
         disruption=lambda c, id: c.kill(f"cockroach{id}", signal="SIGTERM"),


### PR DESCRIPTION
Apparently CRDB can not handle the SIGKILL kills this test uses and the CRDB cluster enters an unavailable state that it fails to recover from.

### Motivation

Nightly CI was failing.