### PR TITLE
Scalability framework: Allow multiple targets to be benchmarked together

### DIFF
--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -39,7 +39,7 @@ This is going to display a URL that you can open in your browser
 
 ## Selecting a target
 
-The framework can be directed to execute its queries against various targets:
+The framework can be directed to execute its queries against various targets. Multiple targets can be specified within a single command line.
 
 ### Against your current HEAD in a container
 
@@ -66,17 +66,6 @@ In both of those cases, Materialize, CRDB and Python will run within the same ma
 
 ```
 ./mzcompose run default --target=remote \--materialize-url="postgres://user:password@host:6875/materialize?sslmode=require" --cluster-name= ...
-```
-
-## Running against multiple targets:
-
-If you issue separate `./mzcompose run default --target=...` commands, their results will be accumulated in the `results` directory
-and all targets will be displayed together on a single chart.
-
-```
-./mzcompose run default --target=devel-cdb1f682e28d54e85afdcac3c32d43039df093a8
-...
-./mzcompose run default --target=devel-c891e3b4b174bd536b7a15ec212c5202ddc85b95
 ```
 
 ## Specifying the number of datapoints

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -21,9 +21,17 @@ def plotit(csv_file_name: str) -> None:
     fig, (summary_subplot, details_subplot) = plt.subplots(2, 1)
     for i, target in enumerate(targets):
         target_sha = target.split(" ")[1].strip("()")
-        target_comment = subprocess.check_output(
-            ["git", "log", "-1", "--pretty=format:%s", target_sha], text=True
-        )
+
+        target_comment = None
+        try:
+            target_comment = subprocess.check_output(
+                ["git", "log", "-1", "--pretty=format:%s", target_sha], text=True
+            )
+        except subprocess.CalledProcessError:
+            # Sometimes mz_version() will report a Git SHA that is not available
+            # in the current repository
+            pass
+
         legend.append(f"{target} - {target_comment}")
 
         df = pd.read_csv(f"results/{target}/{csv_file_name}.csv")

--- a/test/scalability/scalability.ipynb
+++ b/test/scalability/scalability.ipynb
@@ -16,8 +16,6 @@
     "# the Business Source License, use of this software will be governed\n",
     "# by the Apache License, Version 2.0.\n",
     "\n",
-    "%matplotlib ipympl\n",
-    "\n",
     "import pandas as pd\n",
     "from ipywidgets import widgets, interactive\n",
     "from lib import plotit\n",


### PR DESCRIPTION
```
commit 3497c06a0581cf7df87f63e6fb51cf4f2314d96d (HEAD -> scalability-multiple-together, origin/scalability-multiple-together)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Thu Aug 24 10:14:02 2023 +0200

    scalability-framework: Remove matplotlib ipympl
    
    The ipympl engine does not update when a different workload
    is chosen from the drop-down. Revert to the default Jupyter rendering
    engine.

commit 85bf6d405b363cc5d50896d8b821bd219c22cefb
Author: Philip Stoev <pstoev@materialize.com>
Date:   Thu Aug 24 10:13:33 2023 +0200

    scalability-framework: Allow multiple targets to be benchmarked together
```

### Motivation

Previously, one had to run mzcompose twice in order to get multiple targets onto the same set of charts.