### PR TITLE
cluster: treat 0 idle merge effort as 'disabled'

### DIFF
--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -168,12 +168,15 @@ where
         )
         .await?;
 
+        let idle_merge_effort = isize::cast_from(config.idle_arrangement_merge_effort);
+        // We want a value of `0` to disable idle merging. DD will only disable idle merging if we
+        // configure the effort to `None`, not when we set it to `Some(0)`.
+        let idle_merge_effort = (idle_merge_effort > 0).then_some(idle_merge_effort);
+
         let mut worker_config = WorkerConfig::default();
         differential_dataflow::configure(
             &mut worker_config,
-            &differential_dataflow::Config {
-                idle_merge_effort: Some(isize::cast_from(config.idle_arrangement_merge_effort)),
-            },
+            &differential_dataflow::Config { idle_merge_effort },
         );
 
         let worker_guards = execute_from(builders, other, worker_config, move |timely_worker| {


### PR DESCRIPTION
This PR makes it so setting the `IDLE ARRANGEMENT MERGE EFFORT = 0` option fully disables idle merging. The intent of this is firstly to make it at all possible to disable idle merging, but also I think this is the behavior that users would intuitively expect.


### Motivation

  * This PR fixes a previously unreported bug.

It is not possible to fully disable idle arrangement merge effort for replicas.

### Tips for reviewer

This PR tackles the same issue as #19477, but in a different way. Merging this is not equivalent to deciding that we don't want to merge #19477! We can still do that if we decide it has the better solution.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
