### PR TITLE
explain: support `PHYSICAL VIEW FOR MATERIALIZED VIEW`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1456,7 +1456,8 @@ impl Coordinator {
                     let as_of = self.bootstrap_materialized_view_as_of(&df, mview.cluster_id);
                     df.set_as_of(as_of);
 
-                    self.must_ship_dataflow(df, mview.cluster_id).await;
+                    let df = self.must_ship_dataflow(df, mview.cluster_id).await;
+                    self.catalog_mut().set_physical_plan(entry.id(), df);
                 }
                 CatalogItem::Sink(sink) => {
                     // Re-create the sink.

--- a/test/sqllogictest/explain/materialized_view.slt
+++ b/test/sqllogictest/explain/materialized_view.slt
@@ -39,7 +39,7 @@ CREATE INDEX accounts_balance_idx ON accounts(balance);
 
 # ensure that the index is still not used
 query T multiline
-EXPLAIN MATERIALIZED VIEW mv;
+EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW mv;
 ----
 materialize.public.mv:
   Filter (#1 = 100)
@@ -50,6 +50,17 @@ Source materialize.public.accounts
 
 EOF
 
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Get::Collection materialize.public.accounts
+    raw=true
+
+Source materialize.public.accounts
+  filter=((#1 = 100))
+
+EOF
 
 # re-create the view so it can pick up the index
 statement ok
@@ -70,19 +81,68 @@ Used Indexes:
 
 EOF
 
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Join::Linear
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=0, key=[#1] }
+      stream={ key=[#0], thinning=() }
+    source={ relation=1, key=[#0] }
+    Get::PassArrangements materialize.public.accounts
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      Constant
+        - (100)
+
+Used Indexes:
+  - materialize.public.accounts_balance_idx (lookup)
+
+EOF
 
 # rename the index
 statement ok
 ALTER INDEX accounts_balance_idx RENAME TO accounts_balance_index;
 
 
-# ensure that the index is now used by the view
+# ensure that the index is still used by the view
 query T multiline
-EXPLAIN MATERIALIZED VIEW mv;
+EXPLAIN OPTIMiZED PLAN FOR MATERIALIZED VIEW mv;
 ----
 materialize.public.mv:
   Project (#0, #1)
     ReadExistingIndex materialize.public.accounts lookup_value=(100)
+
+Used Indexes:
+  - materialize.public.accounts_balance_index (lookup)
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Join::Linear
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=0, key=[#1] }
+      stream={ key=[#0], thinning=() }
+    source={ relation=1, key=[#0] }
+    Get::PassArrangements materialize.public.accounts
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      Constant
+        - (100)
 
 Used Indexes:
   - materialize.public.accounts_balance_index (lookup)
@@ -102,6 +162,31 @@ EXPLAIN MATERIALIZED VIEW mv;
 materialize.public.mv:
   Project (#0, #1)
     ReadExistingIndex materialize.public.accounts lookup_value=(100)
+
+Used Indexes:
+  - [DELETED INDEX] (lookup)
+
+EOF
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Join::Linear
+    linear_stage[0]
+      closure
+        project=(#1, #0)
+      lookup={ relation=0, key=[#1] }
+      stream={ key=[#0], thinning=() }
+    source={ relation=1, key=[#0] }
+    Get::PassArrangements materialize.public.accounts
+      raw=false
+      arrangements[0]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    ArrangeBy
+      raw=true
+      arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      Constant
+        - (100)
 
 Used Indexes:
   - [DELETED INDEX] (lookup)


### PR DESCRIPTION
Add support for `PHYSICAL VIEW FOR MATERIALIZED VIEW` queries.

### Motivation

  * This PR adds a known-desirable feature.

This is the second task of #20652.

### Tips for reviewer

* The bulk of the diff will disappear once we merge #21261.
* If you want to review now, please only check the last three commits (which are the delta between this and #21261).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
