### PR TITLE
frontegg: Use reqwest_retry to retry on 502 errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8984,6 +8984,7 @@ dependencies = [
  "log",
  "lru",
  "memchr",
+ "mime_guess",
  "native-tls",
  "nix",
  "nom",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4039,6 +4039,7 @@ name = "mz-frontegg-auth"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "axum",
  "base64 0.13.1",
  "derivative",
  "jsonwebtoken",
@@ -4048,6 +4049,7 @@ dependencies = [
  "reqwest-middleware",
  "reqwest-retry",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tracing",
@@ -6719,7 +6721,7 @@ dependencies = [
 [[package]]
 name = "reqwest-middleware"
 version = "0.2.3"
-source = "git+https://github.com/ParkMyCar/reqwest-middleware.git?branch=disable-wasm-deps#16a34524d26c70cb6eb588bdff60b395fec9a77e"
+source = "git+https://github.com/MaterializeInc/reqwest-middleware.git#1c44c7ddbf4954cc2d4de73a760b9a8d84827349"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6732,8 +6734,8 @@ dependencies = [
 
 [[package]]
 name = "reqwest-retry"
-version = "0.2.3"
-source = "git+https://github.com/ParkMyCar/reqwest-middleware.git?branch=disable-wasm-deps#16a34524d26c70cb6eb588bdff60b395fec9a77e"
+version = "0.2.2"
+source = "git+https://github.com/MaterializeInc/reqwest-middleware.git#1c44c7ddbf4954cc2d4de73a760b9a8d84827349"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4045,6 +4045,8 @@ dependencies = [
  "mz-ore",
  "mz-sql",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-retry",
  "serde",
  "thiserror",
  "tokio",
@@ -6696,6 +6698,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "once_cell",
  "percent-encoding",
@@ -6714,10 +6717,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.2.3"
+source = "git+https://github.com/ParkMyCar/reqwest-middleware.git?branch=disable-wasm-deps#16a34524d26c70cb6eb588bdff60b395fec9a77e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "task-local-extensions",
+ "thiserror",
+]
+
+[[package]]
+name = "reqwest-retry"
+version = "0.2.3"
+source = "git+https://github.com/ParkMyCar/reqwest-middleware.git?branch=disable-wasm-deps#16a34524d26c70cb6eb588bdff60b395fec9a77e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "chrono",
+ "futures",
+ "http",
+ "hyper",
+ "reqwest",
+ "reqwest-middleware",
+ "retry-policies",
+ "task-local-extensions",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
+
+[[package]]
+name = "retry-policies"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e09bbcb5003282bcb688f0bae741b278e9c7e8f378f561522c9806c58e075d9b"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rand",
+]
 
 [[package]]
 name = "ring"
@@ -7672,6 +7719,15 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
+]
+
+[[package]]
+name = "task-local-extensions"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
+dependencies = [
+ "pin-utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -175,6 +175,10 @@ kube-core = { git = "https://github.com/MaterializeInc/kube-rs.git", rev = "838a
 # Waiting on `lru` dep to update to `0.11.0`
 mysql_async = { git = "https://github.com/MaterializeInc/mysql_async.git" }
 
+# Removes dependencies required for WASM support that create duplicated deps.
+reqwest-middleware = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
+reqwest-retry = { git = "https://github.com/MaterializeInc/reqwest-middleware.git" }
+
 [patch."https://github.com/frankmcsherry/columnation"]
 # Projects that do not reliably release to crates.io.
 columnation = { git = "https://github.com/MaterializeInc/columnation.git" }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -14,6 +14,8 @@ jsonwebtoken = "8.2.0"
 mz-ore = { path = "../ore", features = ["network"] }
 mz-sql = { path = "../sql" }
 reqwest = { version = "0.11.13", features = ["json"] }
+reqwest-middleware = { version = "0.2.3", git = "https://github.com/ParkMyCar/reqwest-middleware.git", branch = "disable-wasm-deps" }
+reqwest-retry = { version = "0.2.3", git = "https://github.com/ParkMyCar/reqwest-middleware.git", branch = "disable-wasm-deps" }
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["macros"] }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -14,14 +14,19 @@ jsonwebtoken = "8.2.0"
 mz-ore = { path = "../ore", features = ["network"] }
 mz-sql = { path = "../sql" }
 reqwest = { version = "0.11.13", features = ["json"] }
-reqwest-middleware = { version = "0.2.3", git = "https://github.com/ParkMyCar/reqwest-middleware.git", branch = "disable-wasm-deps" }
-reqwest-retry = { version = "0.2.3", git = "https://github.com/ParkMyCar/reqwest-middleware.git", branch = "disable-wasm-deps" }
+reqwest-middleware = "0.2.2"
+reqwest-retry = "0.2.2"
 serde = { version = "1.0.152", features = ["derive"] }
 thiserror = "1.0.37"
 tokio = { version = "1.24.2", features = ["macros"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+
+[dev-dependencies]
+axum = "0.6.20"
+serde_json = "1.0.89"
+tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/frontegg-auth/src/client.rs
+++ b/src/frontegg-auth/src/client.rs
@@ -7,21 +7,16 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::future::Future;
 use std::time::Duration;
 
-use mz_ore::retry::Retry;
-use tracing::warn;
-
-use crate::Error;
+use reqwest_retry::policies::ExponentialBackoff;
+use reqwest_retry::RetryTransientMiddleware;
 
 pub mod tokens;
 
 #[derive(Clone, Debug)]
 pub struct Client {
-    pub client: reqwest::Client,
-    pub retry_backoff: Duration,
-    pub max_retry: Duration,
+    pub client: reqwest_middleware::ClientWithMiddleware,
 }
 
 impl Default for Client {
@@ -36,35 +31,19 @@ impl Default for Client {
 impl Client {
     /// The environmentd Client. Do not change these without a review from the surfaces team.
     pub fn environmentd_default() -> Self {
-        Self {
-            client: reqwest::Client::builder()
-                .timeout(Duration::from_secs(5))
-                .build()
-                .expect("must build Client"),
-            retry_backoff: Duration::from_secs(1),
-            max_retry: Duration::from_secs(30),
-        }
-    }
+        let retry_policy = ExponentialBackoff::builder()
+            .retry_bounds(Duration::from_millis(200), Duration::from_secs(2))
+            .backoff_exponent(2)
+            .build_with_total_retry_duration(Duration::from_secs(30));
 
-    async fn request<T, F, U>(&self, f: F) -> Result<T, Error>
-    where
-        F: Copy + Fn(reqwest::Client) -> U,
-        U: Future<Output = Result<T, Error>>,
-    {
-        Retry::default()
-            .clamp_backoff(self.retry_backoff.clone())
-            .max_duration(self.max_retry.clone())
-            .retry_async_canceling(|state| async move {
-                // Return a Result<Result<T, Error>, Error> so we can
-                // differentiate a retryable or not error.
-                match f(self.client.clone()).await {
-                    Err(Error::ReqwestError(err)) if err.is_timeout() => {
-                        warn!("frontegg timeout, attempt {}: {}", state.i, err);
-                        Err(Error::from(err))
-                    }
-                    v => Ok(v),
-                }
-            })
-            .await?
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("must build Client");
+        let client = reqwest_middleware::ClientBuilder::new(client)
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build();
+
+        Self { client }
     }
 }

--- a/src/frontegg-auth/src/client/tokens.rs
+++ b/src/frontegg-auth/src/client/tokens.rs
@@ -19,18 +19,16 @@ impl Client {
         secret: Uuid,
         admin_api_token_url: &str,
     ) -> Result<ApiTokenResponse, Error> {
-        self.request(|client| async move {
-            let res: ApiTokenResponse = client
-                .post(admin_api_token_url)
-                .json(&ApiTokenArgs { client_id, secret })
-                .send()
-                .await?
-                .error_for_status()?
-                .json::<ApiTokenResponse>()
-                .await?;
-            Ok(res)
-        })
-        .await
+        let res = self
+            .client
+            .post(admin_api_token_url)
+            .json(&ApiTokenArgs { client_id, secret })
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<ApiTokenResponse>()
+            .await?;
+        Ok(res)
     }
 
     /// Exchanges a client id and secret for a jwt token.
@@ -39,18 +37,16 @@ impl Client {
         refresh_url: &str,
         refresh_token: &str,
     ) -> Result<ApiTokenResponse, Error> {
-        self.request(|client| async move {
-            let res: ApiTokenResponse = client
-                .post(refresh_url)
-                .json(&RefreshToken { refresh_token })
-                .send()
-                .await?
-                .error_for_status()?
-                .json::<ApiTokenResponse>()
-                .await?;
-            Ok(res)
-        })
-        .await
+        let res = self
+            .client
+            .post(refresh_url)
+            .json(&RefreshToken { refresh_token })
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<ApiTokenResponse>()
+            .await?;
+        Ok(res)
     }
 }
 

--- a/src/frontegg-auth/src/error.rs
+++ b/src/frontegg-auth/src/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
     InvalidTokenFormat(#[from] jsonwebtoken::errors::Error),
     #[error("authentication token exchange failed: {0}")]
     ReqwestError(#[from] reqwest::Error),
+    #[error("middleware programming error: {0}")]
+    MiddlewareError(anyhow::Error),
     #[error("authentication token expired")]
     TokenExpired,
     #[error("unauthorized organization")]
@@ -27,4 +29,13 @@ pub enum Error {
     WrongEmail,
     #[error("request timeout")]
     Timeout(#[from] tokio::time::error::Elapsed),
+}
+
+impl From<reqwest_middleware::Error> for Error {
+    fn from(value: reqwest_middleware::Error) -> Self {
+        match value {
+            reqwest_middleware::Error::Middleware(e) => Error::MiddlewareError(e),
+            reqwest_middleware::Error::Reqwest(e) => Error::ReqwestError(e),
+        }
+    }
 }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -59,6 +59,7 @@ libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.11.0" }
 memchr = { version = "2.5.0", features = ["use_std"] }
+mime_guess = { version = "2.0.3" }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -83,7 +84,7 @@ rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }
@@ -161,6 +162,7 @@ libc = { version = "0.2.142", features = ["extra_traits", "use_std"] }
 log = { version = "0.4.17", default-features = false, features = ["std"] }
 lru = { version = "0.11.0" }
 memchr = { version = "2.5.0", features = ["use_std"] }
+mime_guess = { version = "2.0.3" }
 native-tls = { version = "0.2.11", default-features = false, features = ["alpn"] }
 nix = { version = "0.26.1" }
 nom = { version = "7.1.2" }
@@ -185,7 +187,7 @@ rand_chacha = { version = "0.3.0" }
 rdkafka-sys = { git = "https://github.com/MaterializeInc/rust-rdkafka.git", features = ["cmake-build", "libz-static", "ssl-vendored", "zstd"] }
 regex = { version = "1.7.0" }
 regex-syntax = { version = "0.6.28" }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.11.13", features = ["blocking", "json", "multipart", "native-tls-vendored"] }
 ring = { version = "0.16.20", features = ["std"] }
 schemars = { version = "0.8.11", features = ["uuid1"] }
 scopeguard = { version = "1.1.0" }


### PR DESCRIPTION
This PR uses `reqwest_retry` in the `mz_frontegg_auth::Client` so we retry on more types of errors than we do now.

Note: In this PR we rely on a fork of `reqwest_retry` because otherwise we end up adding `parking_lot v0.11.2` to our `Cargo.lock`, which is a duplicated dependency. Ideally in the fork we can just upgrade `parking_lot`, but that doesn't work because [`wasm-timer`](https://github.com/tomaka/wasm-timer) also depends on `parking_lot v0.11` and that crate appears to be unmaintained. So if we wanted to retain WASM support for `reqwest_retry` we'd need to fork both `reqwest_retry` and `wasm-timer`. But since we don't need WASM support, in the fork I just comment out the WASM related deps with a note as to why.


### Motivation

* This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/21356

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Retry more often on authentication errors.
