### PR TITLE
Finishing improvements

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2318,6 +2318,7 @@ impl Coordinator {
             real_time_recency_ts,
             key,
             typ,
+            &finishing,
         )?;
 
         let determination = peek_plan.determination.clone();
@@ -2482,6 +2483,7 @@ impl Coordinator {
         real_time_recency_ts: Option<Timestamp>,
         key: Vec<MirScalarExpr>,
         typ: RelationType,
+        finishing: &RowSetFinishing,
     ) -> Result<PlannedPeek, AdapterError> {
         let conn_id = session.conn_id().clone();
         let determination = self.sequence_peek_timestamp(
@@ -2518,6 +2520,7 @@ impl Coordinator {
             key,
             permutation,
             thinning.len(),
+            finishing,
         )?;
 
         Ok(PlannedPeek {
@@ -3096,7 +3099,7 @@ impl Coordinator {
                 |r| prep_relation_expr(state, r, style),
                 |s| prep_scalar_expr(state, s, style),
             )?;
-            peek::create_fast_path_plan(&mut dataflow, GlobalId::Explain)?
+            peek::create_fast_path_plan(&mut dataflow, GlobalId::Explain, finishing.as_ref())?
         };
 
         if let Some(fast_path_plan) = &fast_path_plan {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -2860,6 +2860,15 @@ impl RustType<ProtoRowSetFinishing> for RowSetFinishing {
 }
 
 impl RowSetFinishing {
+    /// Returns a trivial finishing, i.e., that does nothing to the result set.
+    pub fn trivial(arity: usize) -> RowSetFinishing {
+        RowSetFinishing {
+            order_by: Vec::new(),
+            limit: None,
+            offset: 0,
+            project: (0..arity).collect(),
+        }
+    }
     /// True if the finishing does nothing to any result set.
     pub fn is_trivial(&self, arity: usize) -> bool {
         self.limit.is_none()

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1679,23 +1679,21 @@ impl HirRelationExpr {
         if !finishing.is_trivial(self.arity()) {
             let old_finishing =
                 mem::replace(finishing, RowSetFinishing::trivial(finishing.project.len()));
-            *self = HirRelationExpr::Project {
-                input: Box::new(HirRelationExpr::TopK {
-                    input: Box::new(std::mem::replace(
-                        self,
-                        HirRelationExpr::Constant {
-                            rows: vec![],
-                            typ: RelationType::new(Vec::new()),
-                        },
-                    )),
-                    group_key: vec![],
-                    order_key: old_finishing.order_by,
-                    limit: old_finishing.limit,
-                    offset: old_finishing.offset,
-                    expected_group_size: None,
-                }),
-                outputs: old_finishing.project,
-            };
+            *self = HirRelationExpr::TopK {
+                input: Box::new(std::mem::replace(
+                    self,
+                    HirRelationExpr::Constant {
+                        rows: vec![],
+                        typ: RelationType::new(Vec::new()),
+                    },
+                )),
+                group_key: vec![],
+                order_key: old_finishing.order_by,
+                limit: old_finishing.limit,
+                offset: old_finishing.offset,
+                expected_group_size: None,
+            }
+            .project(old_finishing.project)
         }
     }
 

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5614,7 +5614,7 @@ pub enum QueryLifetime {
 impl QueryLifetime {
     /// (This used to impact whether the query is allowed to reason about the time at which it is
     /// running, e.g., by calling the `now()` function. Nowadays, this is decided by a different
-    /// mechanism.)
+    /// mechanism, see `ExprPrepStyle`.)
     pub fn is_one_shot(&self) -> bool {
         let result = match self {
             QueryLifetime::OneShot => true,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -831,6 +831,8 @@ pub fn plan_up_to(
 ) -> Result<MirScalarExpr, PlanError> {
     let scope = Scope::empty();
     let desc = RelationDesc::empty();
+    // Even though this is part of a SUBSCRIBE, we need a QueryLifetime::OneShot (instead of
+    // QueryLifetime::Subscribe), because the UP TO is evaluated only once.
     let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
     transform_ast::transform(scx, &mut up_to)?;
     let ecx = &ExprContext {
@@ -859,6 +861,8 @@ pub fn plan_as_of(
             AsOf::At(ref mut expr) | AsOf::AtLeast(ref mut expr) => {
                 let scope = Scope::empty();
                 let desc = RelationDesc::empty();
+                // Even for a SUBSCRIBE, we need QueryLifetime::OneShot, because the AS OF is
+                // evaluated only once.
                 let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
                 transform_ast::transform(scx, expr)?;
                 let ecx = &ExprContext {
@@ -915,7 +919,7 @@ pub fn plan_webhook_validate_using(
     scx: &StatementContext,
     validate_using: CreateWebhookSourceCheck<Aug>,
 ) -> Result<WebhookValidation, PlanError> {
-    let qcx = QueryContext::root(scx, QueryLifetime::Static);
+    let qcx = QueryContext::root(scx, QueryLifetime::Source);
 
     let CreateWebhookSourceCheck {
         options,
@@ -1139,7 +1143,7 @@ pub fn plan_index_exprs<'a>(
     exprs: Vec<Expr<Aug>>,
 ) -> Result<Vec<mz_expr::MirScalarExpr>, PlanError> {
     let scope = Scope::from_source(None, on_desc.iter_names());
-    let qcx = QueryContext::root(scx, QueryLifetime::Static);
+    let qcx = QueryContext::root(scx, QueryLifetime::Index);
 
     let ecx = &ExprContext {
         qcx: &qcx,
@@ -1643,7 +1647,7 @@ fn plan_set_expr(
             //
             // TODO(jkosh44) Add message to error that prints out an equivalent view definition
             // with all show commands expanded into their equivalent SELECT statements.
-            if qcx.lifetime == QueryLifetime::Static {
+            if !qcx.lifetime.allow_show() {
                 return Err(PlanError::ShowCommandInView);
             }
 
@@ -5586,15 +5590,50 @@ impl Visit<'_, Aug> for WindowFuncCollector {
     }
 }
 
-/// Specifies how long a query will live. This impacts whether the query is
+/// Specifies how long a query will live.
+///
+/// Currently, it affects whether SHOW commands are allowed.
+///
+/// (This used to also impact whether the query is
 /// allowed to reason about the time at which it is running, e.g., by calling
-/// the `now()` function.
+/// the `now()` function. Nowadays, this is decided by a different mechanism.)
 #[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum QueryLifetime {
-    /// The query's result will be computed at one point in time.
+    /// The query's (or the expression's) result will be computed at one point in time.
     OneShot,
-    /// The query's result will be maintained indefinitely.
-    Static,
+    /// The query (or expression) is used in a dataflow that maintains an index.
+    Index,
+    /// The query (or expression) is used in a dataflow that maintains a materialized view.
+    MaterializedView,
+    /// The query (or expression) is used in a dataflow that maintains a SUBSCRIBE.
+    Subscribe,
+    /// The query (or expression) is part of a (non-materialized) view.
+    View,
+    /// The expression is part of a source definition.
+    Source,
+}
+
+impl QueryLifetime {
+    pub fn is_one_shot(&self) -> bool {
+        let res = matches!(self, QueryLifetime::OneShot);
+        assert_eq!(!res, self.is_maintained());
+        res
+    }
+
+    pub fn is_maintained(&self) -> bool {
+        matches!(
+            self,
+            QueryLifetime::Index
+                | QueryLifetime::MaterializedView
+                | QueryLifetime::Subscribe
+                | QueryLifetime::View
+                | QueryLifetime::Source
+        )
+    }
+
+    pub fn allow_show(&self) -> bool {
+        self.is_one_shot() || matches!(self, QueryLifetime::Subscribe)
+    }
 }
 
 /// Description of a CTE sufficient for query planning.

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -754,7 +754,7 @@ pub fn plan_create_source(
                 // of the types are text
                 let mut cast_scx = scx.clone();
                 cast_scx.param_types = Default::default();
-                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Static);
+                let cast_qcx = QueryContext::root(&cast_scx, QueryLifetime::Source);
                 let mut column_types = vec![];
                 for column in table.columns.iter() {
                     column_types.push(ColumnType {
@@ -1837,7 +1837,7 @@ pub fn plan_view(
         mut desc,
         finishing,
         scope: _,
-    } = query::plan_root_query(scx, query.clone(), QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, query.clone(), QueryLifetime::View)?;
 
     expr.bind_parameters(params)?;
     //TODO: materialize#724 - persist finishing information with the view?
@@ -1978,7 +1978,7 @@ pub fn plan_create_materialized_view(
         mut desc,
         finishing,
         scope: _,
-    } = query::plan_root_query(scx, stmt.query, QueryLifetime::Static)?;
+    } = query::plan_root_query(scx, stmt.query, QueryLifetime::MaterializedView)?;
 
     expr.bind_parameters(params)?;
     expr.finish(finishing);

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -409,7 +409,7 @@ pub fn describe_subscribe(
         }
         SubscribeRelation::Query(query) => {
             let query::PlannedQuery { desc, .. } =
-                query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
+                query::plan_root_query(scx, query, QueryLifetime::Subscribe)?;
             desc
         }
     };
@@ -506,7 +506,7 @@ pub fn plan_subscribe(
             // user-supplied query is planned as a subquery whose `ORDER
             // BY`/`LIMIT`/`OFFSET` clauses turn into a TopK operator.
             let query = Query::query(query);
-            let query = plan_query(scx, query, &Params::empty(), QueryLifetime::OneShot)?;
+            let query = plan_query(scx, query, &Params::empty(), QueryLifetime::Subscribe)?;
             assert!(query.finishing.is_trivial(query.desc.arity()));
             let desc = query.desc.clone();
             (
@@ -523,7 +523,7 @@ pub fn plan_subscribe(
     let when = query::plan_as_of(scx, as_of)?;
     let up_to = up_to.map(|up_to| plan_up_to(scx, up_to)).transpose()?;
 
-    let qcx = QueryContext::root(scx, QueryLifetime::OneShot);
+    let qcx = QueryContext::root(scx, QueryLifetime::Subscribe);
     let ecx = ExprContext {
         qcx: &qcx,
         name: "",

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -501,12 +501,10 @@ pub fn plan_subscribe(
             (SubscribeFrom::Id(entry.id()), desc.into_owned(), scope)
         }
         SubscribeRelation::Query(query) => {
-            // There's no way to apply finishing operations to a `SUBSCRIBE`
-            // directly. So we wrap the query in another query so that the
-            // user-supplied query is planned as a subquery whose `ORDER
-            // BY`/`LIMIT`/`OFFSET` clauses turn into a TopK operator.
-            let query = Query::query(query);
             let query = plan_query(scx, query, &Params::empty(), QueryLifetime::Subscribe)?;
+            // There's no way to apply finishing operations to a `SUBSCRIBE` directly, so the
+            // finishing should have already been turned into a `TopK` by
+            // `plan_query` / `plan_root_query`, upon seeing the `QueryLifetime::Subscribe`.
             assert!(query.finishing.is_trivial(query.desc.arity()));
             let desc = query.desc.clone();
             (

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -527,6 +527,38 @@ CREATE MATERIALIZED VIEW mat_tables AS SELECT name FROM (SHOW TABLES);
 statement error SHOW commands are not allowed in views
 CREATE MATERIALIZED VIEW mat_views AS SELECT name FROM (SHOW VIEWS);
 
+# LIMIT in materialized view
+
+statement ok
+CREATE MATERIALIZED VIEW mv_limited AS
+SELECT a
+FROM t
+ORDER BY a DESC, a+b
+LIMIT 3;
+
+query I
+SELECT * FROM mv_limited;
+----
+3
+5
+7
+
+statement ok
+DELETE FROM t WHERE a = 5;
+
+query I
+SELECT * FROM mv_limited;
+----
+3
+7
+
+query I
+SELECT * FROM mv_limited
+ORDER BY a
+LIMIT 1;
+----
+3
+
 # Cleanup
 
 statement ok

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -862,3 +862,163 @@ SELECT row_number() OVER (ORDER BY x NULLS LAST), x FROM t;
 2 b
 3 c
 4 NULL
+
+## TopK removal when it's completely covered by the finishing.
+## See https://github.com/MaterializeInc/materialize/issues/8194
+
+statement ok
+DROP TABLE t;
+
+statement ok
+CREATE TABLE t(x int, y int);
+
+# We could remove the TopK, but we don't do this on the slow path currently.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10) LIMIT 8;
+----
+Explained Query:
+  Finish limit=8 output=[#0, #1]
+    TopK limit=10
+      Get materialize.public.t
+
+EOF
+
+statement ok
+CREATE INDEX t_idx on t(x);
+
+# Same as above, but for fast path recognition we already do the TopK removal.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10) LIMIT 8;
+----
+Explained Query (fast path):
+  Finish limit=8 output=[#0, #1]
+    ReadExistingIndex materialize.public.t_idx
+
+Used Indexes:
+  - materialize.public.t_idx (fast path limit)
+
+EOF
+
+# Same as above, but the finishing would need to be modified (merge the TopK into the finishing), because the TopK's
+# LIMIT is smaller. We don't do this currently, but it wouldn't be too difficult.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 8) LIMIT 10;
+----
+Explained Query:
+  Finish limit=10 output=[#0, #1]
+    TopK limit=8
+      Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# A negative example for the TopK removal: The TopK has a grouping key, so it shouldn't be removed.
+
+query T multiline
+EXPLAIN SELECT * FROM (
+  SELECT * FROM
+    (SELECT DISTINCT x FROM t) grp,
+    LATERAL (
+        SELECT y FROM t
+        WHERE x = grp.x
+        ORDER BY y LIMIT 4
+    )
+) LIMIT 8;
+----
+Explained Query:
+  Finish limit=8 output=[#0, #1]
+    TopK group_by=[#0] order_by=[#1 asc nulls_last] limit=4
+      Filter (#0) IS NOT NULL
+        Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# A negative example for the TopK removal: The TopK has a different ordering key, so it shouldn't be removed.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t ORDER BY x LIMIT 10) ORDER BY y LIMIT 8;
+----
+Explained Query:
+  Finish order_by=[#1 asc nulls_last] limit=8 output=[#0, #1]
+    TopK order_by=[#0 asc nulls_last] limit=10
+      Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# The TopK has an ordering key, but the finishing doesn't. We could merge the TopK into the finishing, but we don't
+# currently do this.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t ORDER BY x LIMIT 10) LIMIT 8;
+----
+Explained Query:
+  Finish limit=8 output=[#0, #1]
+    TopK order_by=[#0 asc nulls_last] limit=10
+      Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# Trivial finishing. We could merge the TopK into the finishing, but we don't currently do this.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t ORDER BY x LIMIT 10);
+----
+Explained Query:
+  TopK order_by=[#0 asc nulls_last] limit=10
+    Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# A negative example for the TopK removal: The TopK's ordering key is a prefix of the RowSetFinishing's, so it shouldn't
+# be removed.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t ORDER BY x LIMIT 10) ORDER BY x, y LIMIT 8;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] limit=8 output=[#0, #1]
+    TopK order_by=[#0 asc nulls_last] limit=10
+      Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF
+
+# 3 nested LIMITs, so TopK fusion is needed to be able to go to fast path.
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM (SELECT * FROM t LIMIT 8) LIMIT 10) LIMIT 6;
+----
+Explained Query (fast path):
+  Finish limit=6 output=[#0, #1]
+    ReadExistingIndex materialize.public.t_idx
+
+Used Indexes:
+  - materialize.public.t_idx (fast path limit)
+
+EOF
+
+# The TopK has an offset, so we shouldn't remove it. (We could merge it into the finishing, but we don't do that
+# currently.)
+query T multiline
+EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10 OFFSET 3) LIMIT 8;
+----
+Explained Query:
+  Finish limit=8 output=[#0, #1]
+    TopK limit=10 offset=3
+      Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_idx (*** full scan ***)
+
+EOF

--- a/test/sqllogictest/subscribe_outputs.slt
+++ b/test/sqllogictest/subscribe_outputs.slt
@@ -195,3 +195,15 @@ mz_timestamp mz_progressed mz_diff a b
 
 statement ok
 COMMIT
+
+# SHOW commands are not allowed in maintained (i.e., non-one-shot) dataflows, but SUBSCRIBE _does_ allow it, even though
+# it's a maintained dataflow.
+
+statement ok
+BEGIN
+
+statement ok
+DECLARE c2 CURSOR FOR SUBSCRIBE TO (SHOW CLUSTER REPLICAS);
+
+statement ok
+COMMIT

--- a/test/testdrive/subscribe-output.td
+++ b/test/testdrive/subscribe-output.td
@@ -393,3 +393,24 @@ DELETE FROM t2 WHERE key = 1
 
 ! SUBSCRIBE (SELECT * FROM t2) WITH (PROGRESS, SNAPSHOT) ENVELOPE DEBEZIUM (KEY (invalid_key))
 contains: column "invalid_key" does not exist
+
+# SUBSCRIBE with a query that has a `RowSetFinishing`, which needs to be turned into a TopK
+
+> CREATE TABLE t3 (a int, b int);
+
+> INSERT INTO t3 VALUES (1,2), (3,4), (5,6), (7,8);
+
+> CREATE VIEW limited AS
+  SELECT * FROM t3
+  ORDER BY a DESC, b
+  LIMIT 3;
+
+> BEGIN;
+
+> DECLARE c CURSOR FOR SUBSCRIBE limited;
+
+> FETCH 2 c;
+<TIMESTAMP> 1 5 6
+<TIMESTAMP> 1 3 4
+
+> COMMIT;


### PR DESCRIPTION
This PR does the following:
- Refactor `QueryLifetime` and how the finishing is applied for maintained dataflows, as discussed with @mjibson [here](https://materializeinc.slack.com/archives/C02FWJ94HME/p1692012086229999). See also below in the Motivation section. (first 2 commits)
- Fix a minor EXPLAIN bug, where a finishing would be correctly applied as a TopK to a view, but not to a materialized view. (in the 2. commit)
- (3. commit) Address the most important case of https://github.com/MaterializeInc/materialize/issues/8194, i.e. when a redundant TopK was preventing fast path before. (Not closing that issue yet, see comments in the slt on what is missing.)

Note that the 3. commit changes the projection in `finish_maintained` to use the `.project` smart constructor, which won't create an actual Project node when the projection is trivial. This causes some of the changes in slt EXPLAINs.

@aalexandrov: We discussed to maybe put the finishing in the `DataflowDescription`. In the end I didn't do this, as this would have been a slightly larger refactoring. I think we'll eventually do it at some point, when we completely want to solve https://github.com/MaterializeInc/materialize/issues/8194, because having it in the `DataflowDescription` would make it easier to _modify_ the finishing in the optimizer pipeline (which would be needed to _merge_ the TopK into the finishing in some cases instead of simply removing the TopK).

### Motivation

  * This PR partially fixes a recognized bug (or adds an optimization, depending on whether we consider the old behavior a "bug"): https://github.com/MaterializeInc/materialize/issues/8194

  * This PR fixes a previously unreported bug: EXPLAIN MAT VIEW was not showing the finishing being turned into a TopK.

   * This PR refactors existing code:
     * The finishing was being applied to static dataflows at 3 points in the code. I moved this into `plan_root`, so now it happens only at one place.
     * SUBSCRIBE was abusing the `QueryLifetime` mechanism: SUBSCRIBE was being categorized as `QueryLifetime::OneShot`, which is not really true. It was this way to allow `SHOW` commands, which lately was the only usage of `QueryLifetime`. However, this was a dangerous situation, because someone might add a usage of `QueryLifetime` at any point, which had the possibility to break SUBSCRIBE.

### Tips for reviewer

Review commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - Added various tests.
  - Ran Nightly: https://buildkite.com/materialize/nightlies/builds/3491#018a283e-7500-4579-8f60-58945a806d76
  - Ran full slt: https://buildkite.com/materialize/sql-logic-tests/builds/5666
  - Ran `test/sqllogictest/order_by.slt` also with not using the smart constructor in `finish_maintained` but always inserting a `Project`.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
