### PR TITLE
storage: de-genericize SourceDesc

### DIFF
--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -62,9 +62,9 @@ include!(concat!(
 
 /// A description of a source ingestion
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct IngestionDescription<S = (), C = GenericSourceConnection> {
+pub struct IngestionDescription<S = ()> {
     /// The source description
-    pub desc: SourceDesc<C>,
+    pub desc: SourceDesc,
     /// Source collections made available to this ingestion.
     pub source_imports: BTreeMap<GlobalId, S>,
     /// Additional storage controller metadata needed to ingest this source
@@ -1653,15 +1653,15 @@ impl RustType<ProtoCompression> for Compression {
 
 /// An external source of updates for a relational collection.
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
-pub struct SourceDesc<C = GenericSourceConnection> {
-    pub connection: C,
+pub struct SourceDesc {
+    pub connection: GenericSourceConnection,
     pub encoding: encoding::SourceDataEncoding,
     pub envelope: SourceEnvelope,
     pub metadata_columns: Vec<IncludedColumnSource>,
     pub timestamp_interval: Duration,
 }
 
-impl Arbitrary for SourceDesc<GenericSourceConnection> {
+impl Arbitrary for SourceDesc {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
 
@@ -1686,7 +1686,7 @@ impl Arbitrary for SourceDesc<GenericSourceConnection> {
     }
 }
 
-impl RustType<ProtoSourceDesc> for SourceDesc<GenericSourceConnection> {
+impl RustType<ProtoSourceDesc> for SourceDesc {
     fn into_proto(&self) -> ProtoSourceDesc {
         ProtoSourceDesc {
             connection: Some(self.connection.into_proto()),
@@ -1716,7 +1716,7 @@ impl RustType<ProtoSourceDesc> for SourceDesc<GenericSourceConnection> {
     }
 }
 
-impl SourceDesc<GenericSourceConnection> {
+impl SourceDesc {
     /// Returns `true` if this connection yields data that is
     /// append-only/monotonic. Append-monly means the source
     /// never produces retractions.
@@ -1782,7 +1782,7 @@ impl SourceDesc<GenericSourceConnection> {
         for compatible in compatibility_checks {
             if !compatible {
                 tracing::warn!(
-                    "SourceDesc<GenericSourceConnection> incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                    "SourceDesc incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
                     self,
                     other
                 );


### PR DESCRIPTION
`SourceDesc` was generic over different types of connections, but the only connection that was ever used was `GenericSourceConnection`. De-mystify the code by de-genericizing `SourceDesc`.

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
