### PR TITLE
test: Fix legacy upgrade tests by bumping avg_internal_v1 to v0.67

### DIFF
--- a/test/legacy-upgrade/check-from-v0.67.0-object-with-avg.td
+++ b/test/legacy-upgrade/check-from-v0.67.0-object-with-avg.td
@@ -14,8 +14,8 @@
 "materialize.public.mat_view_with_avg_internal" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_internal\" (\"a\") IN CLUSTER \"default\" AS SELECT \"mz_catalog\".\"avg_internal_v1\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
 
 
-> SHOW CREATE VIEW view_with_avg_post_v0_66;
-"materialize.public.view_with_avg_post_v0_66" "CREATE VIEW \"materialize\".\"public\".\"view_with_avg_post_v0_66\" (\"a\") AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
+> SHOW CREATE VIEW view_with_avg_post_v0_67;
+"materialize.public.view_with_avg_post_v0_67" "CREATE VIEW \"materialize\".\"public\".\"view_with_avg_post_v0_67\" (\"a\") AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
 
-> SHOW CREATE MATERIALIZED VIEW mat_view_with_avg_post_v0_66;
-"materialize.public.mat_view_with_avg_post_v0_66" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_post_v0_66\" (\"a\") IN CLUSTER \"default\" AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""
+> SHOW CREATE MATERIALIZED VIEW mat_view_with_avg_post_v0_67;
+"materialize.public.mat_view_with_avg_post_v0_67" "CREATE MATERIALIZED VIEW \"materialize\".\"public\".\"mat_view_with_avg_post_v0_67\" (\"a\") IN CLUSTER \"default\" AS SELECT \"pg_catalog\".\"avg\"(\"position\") FROM \"mz_catalog\".\"mz_columns\""

--- a/test/legacy-upgrade/create-in-v0.27.0-object-with-avg.td
+++ b/test/legacy-upgrade/create-in-v0.27.0-object-with-avg.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ skip-if
-SELECT mz_version_num() >= 6600;
+SELECT mz_version_num() >= 6700;
 
 > CREATE VIEW view_with_avg_internal (a) AS SELECT AVG(position) FROM mz_catalog.mz_columns;
 

--- a/test/legacy-upgrade/create-in-v0.67.0-object-with-avg.td
+++ b/test/legacy-upgrade/create-in-v0.67.0-object-with-avg.td
@@ -7,20 +7,20 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# In v0.66 we changed the way types get promoted in the calculation of AVG(...). As such, we had to
+# In v0.67 we changed the way types get promoted in the calculation of AVG(...). As such, we had to
 # migrate all existing objects that used the AVG(...) function to a new name, in this case
 # AVG_INTERNAL_V1(...), so we could update the implementation of AVG(...).
 
-# Since we're creating in v0.66, these views should not get migrated.
+# Since we're creating in v0.67, these views should not get migrated.
 
-> CREATE VIEW view_with_avg_post_v0_66 (a) AS SELECT avg(position) FROM mz_catalog.mz_columns;
-> CREATE MATERIALIZED VIEW mat_view_with_avg_post_v0_66 (a) AS SELECT avg(position) FROM mz_catalog.mz_columns;
+> CREATE VIEW view_with_avg_post_v0_67 (a) AS SELECT avg(position) FROM mz_catalog.mz_columns;
+> CREATE MATERIALIZED VIEW mat_view_with_avg_post_v0_67 (a) AS SELECT avg(position) FROM mz_catalog.mz_columns;
 
 # HACK: We create views of the same names in `create-in-v0.27.0-object-with-avg`, when running with
-# versions <0.66 those views function calls of AVG(...) should get migrated to use AVG_INTERNAL_V1.
-# We skip running that file in versions >=0.66 because then those views would not get migrated, and
-# our check in `check-from-v0.66.0-object-with-avg` would not pass. Instead we manually create the
-# views with AVG_INTERNAL_V1(...) in versions >=0.66 so our aforementioned check continues to work.
+# versions <0.67 those views function calls of AVG(...) should get migrated to use AVG_INTERNAL_V1.
+# We skip running that file in versions >=0.67 because then those views would not get migrated, and
+# our check in `check-from-v0.67.0-object-with-avg` would not pass. Instead we manually create the
+# views with AVG_INTERNAL_V1(...) in versions >=0.67 so our aforementioned check continues to work.
 
 > CREATE VIEW view_with_avg_internal (a) AS SELECT avg_internal_v1(position) FROM mz_catalog.mz_columns;
 > CREATE MATERIALIZED VIEW mat_view_with_avg_internal (a) AS SELECT avg_internal_v1(position) FROM mz_catalog.mz_columns;


### PR DESCRIPTION
This PR updates some legacy upgrade tests to assert the migration of the AVG function in v0.67, bumped from v0.66 since the original PR https://github.com/MaterializeInc/materialize/pull/21219 did not make the v0.66 cut

### Motivation

Fix the legacy upgrade test suite

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
