### PR TITLE
expr: add doc string, fix montonicity of TabletizedScalar

### DIFF
--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -2048,6 +2048,7 @@ pub enum TableFunc {
         width: usize,
     },
     GenerateSubscriptsArray,
+    /// Execute some arbitrary scalar function as a table function.
     TabletizedScalar {
         name: String,
         relation: RelationType,
@@ -2397,7 +2398,7 @@ impl TableFunc {
             TableFunc::UnnestArray { .. } => true,
             TableFunc::UnnestList { .. } => true,
             TableFunc::Wrap { .. } => true,
-            TableFunc::TabletizedScalar { .. } => false,
+            TableFunc::TabletizedScalar { .. } => true,
         }
     }
 }


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Implementation deficiencies noted by @frankmcsherry 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow scalar functions used in table function positions to be planned with their inputs' monotonicity preserved.
