### PR TITLE
Make statement logging persistent

### DIFF
--- a/misc/python/materialize/checks/statement_logging.py
+++ b/misc/python/materialize/checks/statement_logging.py
@@ -16,7 +16,7 @@ from materialize.util import MzVersion
 class StatementLogging(Check):
     def _can_run(self) -> bool:
         return self.base_version >= MzVersion(0, 69, 0)
-    
+
     def initialize(self) -> Testdrive:
         return Testdrive(
             dedent(

--- a/misc/python/materialize/checks/statement_logging.py
+++ b/misc/python/materialize/checks/statement_logging.py
@@ -1,0 +1,56 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.util import MzVersion
+
+
+class StatementLogging(Check):
+    def _can_run(self) -> bool:
+        return self.base_version >= MzVersion(0, 69, 0)
+    
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > ALTER SYSTEM SET statement_logging_max_sample_rate TO 1.0
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > SET statement_logging_sample_rate TO 1.0
+                > SELECT 'hello'; -- Btv was here
+                'hello'
+                > SELECT mz_internal.mz_sleep(20);
+                """,
+                """
+                > SET statement_logging_sample_rate TO 1.0
+                > SELECT 'goodbye'; -- Btv was here
+                > SELECT mz_internal.mz_sleep(20);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%-- Btv was here' ORDER BY mseh.began_at;
+                "SELECT 'hello'; -- Btv was here" success
+                "SELECT 'goodbye'; -- Btv was here" success
+                """
+            )
+        )

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -41,7 +41,10 @@ use mz_sql::session::user::{
     MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SUPPORT_USER_NAME, SYSTEM_USER_NAME,
 };
 use mz_storage_client::controller::IntrospectionType;
-use mz_storage_client::healthcheck::{MZ_SINK_STATUS_HISTORY_DESC, MZ_SOURCE_STATUS_HISTORY_DESC};
+use mz_storage_client::healthcheck::{
+    MZ_PREPARED_STATEMENT_HISTORY_DESC, MZ_SESSION_HISTORY_DESC, MZ_SINK_STATUS_HISTORY_DESC,
+    MZ_SOURCE_STATUS_HISTORY_DESC, MZ_STATEMENT_EXECUTION_HISTORY_DESC,
+};
 use once_cell::sync::Lazy;
 use serde::Serialize;
 
@@ -2043,6 +2046,30 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     is_retained_metrics_object: false,
 });
 
+pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_statement_execution_history",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::StatementExecutionHistory),
+    desc: MZ_STATEMENT_EXECUTION_HISTORY_DESC.clone(),
+    is_retained_metrics_object: false,
+});
+
+pub static MZ_PREPARED_STATEMENT_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_prepared_statement_history",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::PreparedStatementHistory),
+    desc: MZ_PREPARED_STATEMENT_HISTORY_DESC.clone(),
+    is_retained_metrics_object: false,
+});
+
+pub static MZ_SESSION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_session_history",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::SessionHistory),
+    desc: MZ_SESSION_HISTORY_DESC.clone(),
+    is_retained_metrics_object: false,
+});
+
 pub const MZ_SOURCE_STATUSES: BuiltinView = BuiltinView {
     name: "mz_source_statuses",
     schema: MZ_INTERNAL_SCHEMA,
@@ -2248,49 +2275,6 @@ pub static MZ_COMMENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("object_type", ScalarType::String.nullable(false))
         .with_column("sub_id", ScalarType::UInt64.nullable(true))
         .with_column("comment", ScalarType::String.nullable(false)),
-    is_retained_metrics_object: false,
-});
-
-pub static MZ_PREPARED_STATEMENT_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_prepared_statement_history",
-    schema: MZ_INTERNAL_SCHEMA,
-    desc: RelationDesc::empty()
-        .with_column("id", ScalarType::Uuid.nullable(false))
-        .with_column("session_id", ScalarType::Uuid.nullable(false))
-        .with_column("name", ScalarType::String.nullable(false))
-        .with_column("sql", ScalarType::String.nullable(false))
-        .with_column("prepared_at", ScalarType::TimestampTz.nullable(false)),
-    is_retained_metrics_object: false,
-});
-
-pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_statement_execution_history",
-    schema: MZ_INTERNAL_SCHEMA,
-    desc: RelationDesc::empty()
-        .with_column("id", ScalarType::Uuid.nullable(false))
-        .with_column("prepared_statement_id", ScalarType::Uuid.nullable(false))
-        .with_column("sample_rate", ScalarType::Float64.nullable(false))
-        .with_column(
-            "params",
-            ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
-        )
-        .with_column("began_at", ScalarType::TimestampTz.nullable(false))
-        .with_column("finished_at", ScalarType::TimestampTz.nullable(true))
-        .with_column("finished_status", ScalarType::String.nullable(true))
-        .with_column("error_message", ScalarType::String.nullable(true))
-        .with_column("rows_returned", ScalarType::Int64.nullable(true))
-        .with_column("execution_strategy", ScalarType::String.nullable(true)),
-    is_retained_metrics_object: false,
-});
-
-pub static MZ_SESSION_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_session_history",
-    schema: MZ_INTERNAL_SCHEMA,
-    desc: RelationDesc::empty()
-        .with_column("id", ScalarType::Uuid.nullable(false))
-        .with_column("connected_at", ScalarType::TimestampTz.nullable(false))
-        .with_column("application_name", ScalarType::String.nullable(false))
-        .with_column("authenticated_user", ScalarType::String.nullable(false)),
     is_retained_metrics_object: false,
 });
 
@@ -5177,11 +5161,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_AWS_PRIVATELINK_CONNECTIONS),
         Builtin::Table(&MZ_SUBSCRIPTIONS),
         Builtin::Table(&MZ_SESSIONS),
-        Builtin::Table(&MZ_SESSION_HISTORY),
         Builtin::Table(&MZ_DEFAULT_PRIVILEGES),
         Builtin::Table(&MZ_SYSTEM_PRIVILEGES),
-        Builtin::Table(&MZ_PREPARED_STATEMENT_HISTORY),
-        Builtin::Table(&MZ_STATEMENT_EXECUTION_HISTORY),
         Builtin::Table(&MZ_COMMENTS),
         Builtin::Table(&MZ_WEBHOOKS_SOURCES),
         Builtin::View(&MZ_RELATIONS),
@@ -5305,6 +5286,9 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),
         Builtin::View(&MZ_SINK_STATUSES),
         Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
+        Builtin::Source(&MZ_STATEMENT_EXECUTION_HISTORY),
+        Builtin::Source(&MZ_PREPARED_STATEMENT_HISTORY),
+        Builtin::Source(&MZ_SESSION_HISTORY),
         Builtin::View(&MZ_SOURCE_STATUSES),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::Source(&MZ_SOURCE_STATISTICS),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -21,12 +21,11 @@ use mz_expr::MirScalarExpr;
 use mz_orchestrator::{CpuLimit, DiskLimit, MemoryLimit, NotReadyReason, ServiceProcessMetrics};
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
-use mz_ore::now::to_datetime;
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker};
+use mz_repr::{Datum, Diff, GlobalId, Row};
 use mz_sql::ast::{CreateIndexStatement, Statement};
 use mz_sql::catalog::{CatalogCluster, CatalogDatabase, CatalogSchema, CatalogType, TypeCategory};
 use mz_sql::func::FuncImplCatalogDetails;
@@ -51,19 +50,12 @@ use crate::catalog::builtin::{
     MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD, MZ_SUBSCRIPTIONS, MZ_SYSTEM_PRIVILEGES,
     MZ_TABLES, MZ_TYPES, MZ_TYPE_PG_METADATA, MZ_VIEWS, MZ_WEBHOOKS_SOURCES,
 };
-use crate::catalog::builtin::{
-    MZ_PREPARED_STATEMENT_HISTORY, MZ_SESSION_HISTORY, MZ_STATEMENT_EXECUTION_HISTORY,
-};
 use crate::catalog::{
     AwsPrincipalContext, CatalogItem, CatalogState, ClusterVariant, Connection, DataSourceDesc,
     Database, DefaultPrivilegeObject, Error, ErrorKind, Func, Index, MaterializedView, Sink,
     StorageSinkConnectionState, Type, View, SYSTEM_CONN_ID,
 };
 use crate::coord::ConnMeta;
-use crate::statement_logging::{
-    SessionHistoryEvent, StatementBeganExecutionRecord, StatementEndedExecutionReason,
-    StatementEndedExecutionRecord, StatementPreparedRecord,
-};
 use crate::subscribe::ActiveSubscribe;
 
 /// An update to a built-in table.
@@ -1293,29 +1285,6 @@ impl CatalogState {
         }
     }
 
-    pub fn pack_session_history_update(&self, event: &SessionHistoryEvent) -> BuiltinTableUpdate {
-        let SessionHistoryEvent {
-            id,
-            connected_at,
-            application_name,
-            authenticated_user,
-        } = event;
-        BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_SESSION_HISTORY),
-            row: Row::pack_slice(&[
-                Datum::Uuid(*id),
-                Datum::TimestampTz(
-                    mz_ore::now::to_datetime(*connected_at)
-                        .try_into()
-                        .expect("must fit"),
-                ),
-                Datum::String(&*application_name),
-                Datum::String(&*authenticated_user),
-            ]),
-            diff: 1,
-        }
-    }
-
     pub fn pack_default_privileges_update(
         &self,
         default_privilege_object: &DefaultPrivilegeObject,
@@ -1377,145 +1346,6 @@ impl CatalogState {
             )
             .expect("privileges is 1 dimensional, and its length is used for the array length");
         row
-    }
-
-    pub fn pack_statement_prepared_update(
-        &self,
-        record: &StatementPreparedRecord,
-    ) -> BuiltinTableUpdate {
-        let StatementPreparedRecord {
-            id,
-            session_id,
-            name,
-            sql,
-            prepared_at,
-        } = record;
-        let row = Row::pack_slice(&[
-            Datum::Uuid(*id),
-            Datum::Uuid(*session_id),
-            Datum::String(name.as_str()),
-            Datum::String(sql.as_str()),
-            Datum::TimestampTz(to_datetime(*prepared_at).try_into().expect("must fit")),
-        ]);
-        BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_PREPARED_STATEMENT_HISTORY),
-            row,
-            diff: 1,
-        }
-    }
-
-    fn pack_statement_execution_inner(
-        &self,
-        record: &StatementBeganExecutionRecord,
-        packer: &mut RowPacker,
-    ) {
-        let StatementBeganExecutionRecord {
-            id,
-            prepared_statement_id,
-            sample_rate,
-            params,
-            began_at,
-        } = record;
-
-        packer.extend([
-            Datum::Uuid(*id),
-            Datum::Uuid(*prepared_statement_id),
-            Datum::Float64((*sample_rate).into()),
-        ]);
-        packer
-            .push_array(
-                &[ArrayDimension {
-                    lower_bound: 1,
-                    length: params.len(),
-                }],
-                params
-                    .iter()
-                    .map(|p| Datum::from(p.as_ref().map(String::as_str))),
-            )
-            .expect("correct array dimensions");
-        packer.push(Datum::TimestampTz(
-            to_datetime(*began_at).try_into().expect("Sane system time"),
-        ));
-    }
-
-    pub fn pack_statement_began_execution_update(
-        &self,
-        record: &StatementBeganExecutionRecord,
-        diff: Diff,
-    ) -> BuiltinTableUpdate {
-        let mut row = Row::default();
-        let mut packer = row.packer();
-        self.pack_statement_execution_inner(record, &mut packer);
-        packer.extend([
-            // finished_at
-            Datum::Null,
-            // finished_status
-            Datum::Null,
-            // error_message
-            Datum::Null,
-            // rows_returned
-            Datum::Null,
-            // execution_status
-            Datum::Null,
-        ]);
-        BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_STATEMENT_EXECUTION_HISTORY),
-            row,
-            diff,
-        }
-    }
-
-    pub fn pack_full_statement_execution_update(
-        &self,
-        began_record: &StatementBeganExecutionRecord,
-        ended_record: &StatementEndedExecutionRecord,
-    ) -> BuiltinTableUpdate {
-        let mut row = Row::default();
-        let mut packer = row.packer();
-        self.pack_statement_execution_inner(began_record, &mut packer);
-        let (status, error_message, rows_returned, execution_strategy) = match &ended_record.reason
-        {
-            StatementEndedExecutionReason::Success {
-                rows_returned,
-                execution_strategy,
-            } => (
-                "success",
-                None,
-                rows_returned.map(|rr| i64::try_from(rr).expect("must fit")),
-                execution_strategy.map(|es| es.name()),
-            ),
-            StatementEndedExecutionReason::Canceled => ("canceled", None, None, None),
-            StatementEndedExecutionReason::Errored { error } => {
-                ("error", Some(error.as_str()), None, None)
-            }
-            StatementEndedExecutionReason::Aborted => ("aborted", None, None, None),
-        };
-        packer.extend([
-            Datum::TimestampTz(
-                to_datetime(ended_record.ended_at)
-                    .try_into()
-                    .expect("Sane system time"),
-            ),
-            status.into(),
-            error_message.into(),
-            rows_returned.into(),
-            execution_strategy.into(),
-        ]);
-        BuiltinTableUpdate {
-            id: self.resolve_builtin_table(&MZ_STATEMENT_EXECUTION_HISTORY),
-            row,
-            diff: 1,
-        }
-    }
-
-    pub fn pack_statement_ended_execution_updates(
-        &self,
-        began_record: &StatementBeganExecutionRecord,
-        ended_record: &StatementEndedExecutionRecord,
-    ) -> Vec<BuiltinTableUpdate> {
-        let retraction = self.pack_statement_began_execution_update(began_record, -1);
-        let new = self.pack_full_statement_execution_update(began_record, ended_record);
-        vec![retraction, new]
     }
 
     pub fn pack_compute_dependency_update(

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -463,7 +463,8 @@ impl SessionClient {
             Coordinator::describe(&catalog, self.session(), Some(stmt.clone()), param_types)?;
         let params = vec![];
         let result_formats = vec![mz_pgrepr::Format::Text; desc.arity()];
-        let logging = self.session().mint_logging(sql);
+        let now = self.now();
+        let logging = self.session().mint_logging(sql, now);
         self.session().set_portal(
             name,
             desc,

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -235,6 +235,7 @@ pub enum Message<T = mz_repr::Timestamp> {
         ctx: ExecuteContext,
         stage: PeekStage,
     },
+    DrainStatementLog,
 }
 
 impl Message {
@@ -261,6 +262,7 @@ impl Message {
             RetireExecute { .. } => "retire_execute",
             ExecuteSingleStatementTransaction { .. } => "execute_single_statement_transaction",
             PeekStageReady { .. } => "peek_stage_ready",
+            DrainStatementLog => "drain_statement_log",
         }
     }
 }
@@ -1862,6 +1864,7 @@ impl Coordinator {
         });
 
         self.schedule_storage_usage_collection();
+        self.spawn_statement_logging_task();
         flags::tracing_config(self.catalog.system_config()).apply(&self.tracing_handle);
 
         // Report if the handling of a single message takes longer than this threshold.

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -104,6 +104,9 @@ impl Coordinator {
             Message::PeekStageReady { ctx, stage } => {
                 self.sequence_peek_stage(ctx, stage).await;
             }
+            Message::DrainStatementLog => {
+                self.drain_statement_log().await;
+            }
         }
     }
 

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -118,6 +118,8 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         delay_sources_past_rehydration: config.storage_dataflow_delay_sources_past_rehydration(),
         shrink_upsert_unused_buffers_by_ratio: config
             .storage_shrink_upsert_unused_buffers_by_ratio(),
+        truncate_statement_log: config.truncate_statement_log(),
+        statement_logging_retention_time_seconds: config.statement_logging_retention().as_secs(),
     }
 }
 

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -118,16 +118,17 @@ impl<T: TimestampManipulation> Session<T> {
     // binding a statement directly to a portal without creating an
     // intermediate prepared statement. Thus, for those cases, a
     // mechanism for generating the logging metadata directly is needed.
-    pub(crate) fn mint_logging(&self, sql: String) -> Arc<QCell<PreparedStatementLoggingInfo>> {
+    pub(crate) fn mint_logging(
+        &self,
+        sql: String,
+        now: EpochMillis,
+    ) -> Arc<QCell<PreparedStatementLoggingInfo>> {
         Arc::new(QCell::new(
             &self.qcell_owner,
             PreparedStatementLoggingInfo::StillToLog {
                 sql,
                 session_id: self.uuid,
-                prepared_at: Utc::now()
-                    .timestamp_millis()
-                    .try_into()
-                    .expect("sane system time"),
+                prepared_at: now,
                 name: "".to_string(),
                 accounted: false,
             },

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -106,6 +106,7 @@ use mz_ore::{
 };
 use mz_pgrepr::UInt8;
 use mz_sql::session::user::{HTTP_DEFAULT_USER, SYSTEM_USER};
+use postgres::SimpleQueryMessage;
 use postgres_array::Array;
 use rand::RngCore;
 use reqwest::blocking::Client;
@@ -199,12 +200,13 @@ fn test_persistence() {
     );
 }
 
-fn setup_statement_logging(
+fn setup_statement_logging_core(
     max_sample_rate: f64,
     sample_rate: f64,
+    extra_config: util::Config,
 ) -> (util::Server, postgres::Client) {
     let server = util::start_server(
-        util::Config::default()
+        extra_config
             .with_system_parameter_default(
                 "statement_logging_max_sample_rate".to_string(),
                 max_sample_rate.to_string(),
@@ -223,6 +225,13 @@ fn setup_statement_logging(
         )
         .unwrap();
     (server, client)
+}
+
+fn setup_statement_logging(
+    max_sample_rate: f64,
+    sample_rate: f64,
+) -> (util::Server, postgres::Client) {
+    setup_statement_logging_core(max_sample_rate, sample_rate, util::Config::default())
 }
 
 #[mz_ore::test]
@@ -615,6 +624,62 @@ fn test_statement_logging_unsampled_metrics() {
         .get_value();
     let metric_value = usize::cast_from(u64::try_cast_from(metric_value).unwrap());
     assert_eq!(expected_total, metric_value);
+}
+
+#[mz_ore::test]
+// NOTE: Unfortunately, this test requires sleeping
+// for over a minute. I tried to get it to work by manipulating
+// a `NowFn`, but storage and persist seem to get confused by that.
+fn test_statement_logging_persistence() {
+    let data_dir = tempfile::tempdir().unwrap();
+
+    let cfg = util::Config::default()
+        .data_directory(data_dir.path())
+        .with_system_parameter_default(
+            "statement_logging_retention".to_string(),
+            "30s".to_string(),
+        );
+    let (server, mut client) = setup_statement_logging_core(1.0, 1.0, cfg.clone());
+
+    // Issue one statement, then wait long enough for it to surely not be retained on reboot,
+    // then issue another statement. After reboot, check that only the second statement remains.
+    client.simple_query("SELECT 1").unwrap();
+    std::thread::sleep(Duration::from_secs(60));
+    client.simple_query("SELECT 2").unwrap();
+    std::thread::sleep(Duration::from_secs(10));
+
+    std::mem::drop(client);
+    std::mem::drop(server);
+
+    let (_server, mut client) = setup_statement_logging_core(0.0, 0.0, cfg);
+    // Check that we only retained the second query.
+    let result = client
+        .simple_query(
+            "SELECT sql
+FROM
+    mz_internal.mz_statement_execution_history AS mseh,
+    mz_internal.mz_prepared_statement_history AS mpsh,
+    mz_internal.mz_session_history AS msh
+WHERE
+    mseh.prepared_statement_id = mpsh.id
+        AND
+    mpsh.session_id = msh.id",
+        )
+        .unwrap();
+    // one for row, one for "CommandComplete"
+    assert_eq!(result.len(), 2, "the log should have exactly one statement");
+    let SimpleQueryMessage::Row(row) = result.into_iter().next().unwrap() else {
+        panic!("`SELECT` must return a result set");
+    };
+    let sql = row.get(0).expect("`sql` must be present");
+    assert_eq!(sql, "SELECT 2");
+    // Since we only retained the second query, we should also have garbage-collected
+    // the prepared statement and session history entries for the first statement. Verify that here.
+    for tbl in [
+        "mz_internal.mz_statement_execution_history",
+        "mz_internal.mz_prepared_statement_history",
+        "mz_internal.mz_session_history",
+    ] {}
 }
 
 // Test that sources and sinks require an explicit `SIZE` parameter outside of

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -681,7 +681,7 @@ WHERE
         "mz_internal.mz_session_history",
     ] {
         let result: i64 = client
-            .query_one(format!("SELECT count(*) FROM {tbl}"))
+            .query_one(&format!("SELECT count(*) FROM {tbl}"), &[])
             .unwrap()
             .get(0)
             .unwrap();

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -679,7 +679,14 @@ WHERE
         "mz_internal.mz_statement_execution_history",
         "mz_internal.mz_prepared_statement_history",
         "mz_internal.mz_session_history",
-    ] {}
+    ] {
+        let result: i64 = client
+            .query_one(format!("SELECT count(*) FROM {tbl}"))
+            .unwrap()
+            .get(0)
+            .unwrap();
+        assert_eq!(result, 1);
+    }
 }
 
 // Test that sources and sinks require an explicit `SIZE` parameter outside of

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -683,8 +683,8 @@ WHERE
         let result: i64 = client
             .query_one(&format!("SELECT count(*) FROM {tbl}"), &[])
             .unwrap()
-            .get(0)
-            .unwrap();
+            .get(0);
+
         assert_eq!(result, 1);
     }
 }

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -416,7 +416,7 @@ impl Listeners {
                         },
                         persist_clients,
                         storage_stash_url,
-                        now: SYSTEM_TIME.clone(),
+                        now: config.now.clone(),
                         postgres_factory,
                         metrics_registry: metrics_registry.clone(),
                         persist_pubsub_url: format!(

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1256,6 +1256,21 @@ pub static STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE: Lazy<ServerVar<Numeric>> =
         internal: false,
     });
 
+pub const TRUNCATE_STATEMENT_LOG: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("truncate_statement_log"),
+    value: &true,
+    description: "Whether to garbage-collect old statement log entries on startup (Materialize).",
+    internal: true,
+};
+
+pub const STATEMENT_LOGGING_RETENTION: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("statement_logging_retention"),
+    // 30 days
+    value: &Duration::from_secs(30 * 24 * 60 * 60),
+    description: "The time to retain logged statements (Materialize).",
+    internal: true,
+};
+
 pub const AUTO_ROUTE_INTROSPECTION_QUERIES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("auto_route_introspection_queries"),
     value: &true,
@@ -2333,7 +2348,9 @@ impl SystemVars {
             .with_value_constrained_var(
                 &STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE,
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
-            );
+            )
+            .with_var(&TRUNCATE_STATEMENT_LOG)
+            .with_var(&STATEMENT_LOGGING_RETENTION);
 
         for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
@@ -3043,6 +3060,16 @@ impl SystemVars {
     /// Returns the `statement_logging_default_sample_rate` configuration parameter.
     pub fn statement_logging_default_sample_rate(&self) -> Numeric {
         *self.expect_value(&STATEMENT_LOGGING_DEFAULT_SAMPLE_RATE)
+    }
+
+    /// Returns the `truncate_statement_log` configuration parameter.
+    pub fn truncate_statement_log(&self) -> bool {
+        *self.expect_value(&TRUNCATE_STATEMENT_LOG)
+    }
+
+    /// Returns the `statement_logging_retention` configuration parameter.
+    pub fn statement_logging_retention(&self) -> Duration {
+        *self.expect_value(&STATEMENT_LOGGING_RETENTION)
     }
 }
 

--- a/src/storage-client/src/controller/collection_mgmt.rs
+++ b/src/storage-client/src/controller/collection_mgmt.rs
@@ -127,7 +127,7 @@ where
         existed
     }
 
-    /// Appends `updates` to the collection correlated with `id`, does not work for the append to
+    /// Appends `updates` to the collection correlated with `id`, does not wait for the append to
     /// complete.
     ///
     /// # Panics
@@ -224,7 +224,7 @@ where
                                 .into_iter()
                                 .flatten()
                                 .map(|(row, diff)| TimestamplessUpdate { row, diff })
-                                .collect();
+                            .collect();
                             let request = vec![(id, rows, T::from(now()))];
 
                             // We'll try really hard to succeed, but eventually stop.

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -60,6 +60,40 @@ pub static MZ_SINK_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
         .with_column("details", ScalarType::Jsonb.nullable(true))
 });
 
+pub static MZ_PREPARED_STATEMENT_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column("id", ScalarType::Uuid.nullable(false))
+        .with_column("session_id", ScalarType::Uuid.nullable(false))
+        .with_column("name", ScalarType::String.nullable(false))
+        .with_column("sql", ScalarType::String.nullable(false))
+        .with_column("prepared_at", ScalarType::TimestampTz.nullable(false))
+});
+
+pub static MZ_SESSION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column("id", ScalarType::Uuid.nullable(false))
+        .with_column("connected_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("application_name", ScalarType::String.nullable(false))
+        .with_column("authenticated_user", ScalarType::String.nullable(false))
+});
+
+pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column("id", ScalarType::Uuid.nullable(false))
+        .with_column("prepared_statement_id", ScalarType::Uuid.nullable(false))
+        .with_column("sample_rate", ScalarType::Float64.nullable(false))
+        .with_column(
+            "params",
+            ScalarType::Array(Box::new(ScalarType::String)).nullable(false),
+        )
+        .with_column("began_at", ScalarType::TimestampTz.nullable(false))
+        .with_column("finished_at", ScalarType::TimestampTz.nullable(true))
+        .with_column("finished_status", ScalarType::String.nullable(true))
+        .with_column("error_message", ScalarType::String.nullable(true))
+        .with_column("rows_returned", ScalarType::Int64.nullable(true))
+        .with_column("execution_strategy", ScalarType::String.nullable(true))
+});
+
 pub static MZ_SOURCE_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
     RelationDesc::empty()
         .with_column("occurred_at", ScalarType::TimestampTz.nullable(false))

--- a/src/storage-client/src/metrics.rs
+++ b/src/storage-client/src/metrics.rs
@@ -25,6 +25,7 @@ use crate::client::{ProtoStorageCommand, ProtoStorageResponse};
 pub struct StorageControllerMetrics {
     messages_sent_bytes: prometheus::HistogramVec,
     messages_received_bytes: prometheus::HistogramVec,
+    startup_prepared_statements_kept: prometheus::IntGauge,
 }
 
 impl StorageControllerMetrics {
@@ -43,6 +44,11 @@ impl StorageControllerMetrics {
                 var_labels: ["instance"],
                 buckets: HISTOGRAM_BYTE_BUCKETS.to_vec()
             )),
+
+            startup_prepared_statements_kept: metrics_registry.register(metric!(
+                name: "mz_storage_startup_prepared_statements_kept",
+                help: "number of prepared statements kept on startup",
+            )),
         }
     }
 
@@ -58,6 +64,11 @@ impl StorageControllerMetrics {
                     .get_delete_on_drop_histogram(labels),
             }),
         }
+    }
+
+    pub fn set_startup_prepared_statements_kept(&mut self, n: u64) {
+        let n: i64 = n.try_into().expect("realistic number");
+        self.startup_prepared_statements_kept.set(n);
     }
 }
 

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -31,6 +31,8 @@ message ProtoStorageParameters {
     mz_service.params.ProtoGrpcClientParameters grpc_client = 11;
     bool storage_dataflow_delay_sources_past_rehydration = 12;
     uint64 shrink_upsert_unused_buffers_by_ratio = 13;
+    bool truncate_statement_log = 14;
+    uint64 statement_logging_retention_time_seconds = 15;
 }
 
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -47,6 +47,11 @@ pub struct StorageParameters {
     pub delay_sources_past_rehydration: bool,
     /// Configuration ratio to shrink upsert buffers by.
     pub shrink_upsert_unused_buffers_by_ratio: usize,
+    /// Whether to garbage-collect old statement log entries on startup.
+    pub truncate_statement_log: bool,
+    /// How long entries in the statement log should be retained, in seconds.
+    /// Ignored if `truncate_statement_log` is false.
+    pub statement_logging_retention_time_seconds: u64,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
@@ -130,6 +135,8 @@ impl StorageParameters {
             grpc_client,
             delay_sources_past_rehydration,
             shrink_upsert_unused_buffers_by_ratio,
+            statement_logging_retention_time_seconds,
+            truncate_statement_log,
         }: StorageParameters,
     ) {
         self.persist.update(persist);
@@ -146,6 +153,8 @@ impl StorageParameters {
         self.grpc_client.update(grpc_client);
         self.delay_sources_past_rehydration = delay_sources_past_rehydration;
         self.shrink_upsert_unused_buffers_by_ratio = shrink_upsert_unused_buffers_by_ratio;
+        self.statement_logging_retention_time_seconds = statement_logging_retention_time_seconds;
+        self.truncate_statement_log = truncate_statement_log;
     }
 }
 
@@ -172,6 +181,8 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             shrink_upsert_unused_buffers_by_ratio: u64::cast_from(
                 self.shrink_upsert_unused_buffers_by_ratio,
             ),
+            truncate_statement_log: self.truncate_statement_log,
+            statement_logging_retention_time_seconds: self.statement_logging_retention_time_seconds,
         }
     }
 
@@ -211,6 +222,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             shrink_upsert_unused_buffers_by_ratio: usize::cast_from(
                 proto.shrink_upsert_unused_buffers_by_ratio,
             ),
+            truncate_statement_log: proto.truncate_statement_log,
+            statement_logging_retention_time_seconds: proto
+                .statement_logging_retention_time_seconds,
         })
     }
 }

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -526,7 +526,7 @@ BASE TABLE
 materialize
 mz_internal
 mz_prepared_statement_history
-BASE TABLE
+SOURCE
 materialize
 mz_internal
 mz_records_per_dataflow
@@ -570,7 +570,7 @@ SOURCE
 materialize
 mz_internal
 mz_session_history
-BASE TABLE
+SOURCE
 materialize
 mz_internal
 mz_sessions
@@ -686,7 +686,7 @@ VIEW
 materialize
 mz_internal
 mz_statement_execution_history
-BASE TABLE
+SOURCE
 materialize
 mz_internal
 mz_storage_shards

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -538,12 +538,15 @@ mz_message_counts_sent_raw                   log   <null>   <null>
 mz_message_batch_counts_received_raw         log   <null>   <null>
 mz_message_batch_counts_sent_raw             log   <null>   <null>
 mz_peek_durations_histogram_raw              log   <null>   <null>
+mz_prepared_statement_history                source <null>  <null>
 mz_scheduling_elapsed_raw                    log   <null>   <null>
 mz_scheduling_parks_histogram_raw            log   <null>   <null>
+mz_session_history                           source <null>  <null>
 mz_sink_statistics                           source <null>  <null>
 mz_sink_status_history                       source <null>  <null>
 mz_source_statistics                         source <null>  <null>
 mz_source_status_history                     source <null>  <null>
+mz_statement_execution_history               source <null>  <null>
 mz_storage_shards                            source <null>  <null>
 
 > SHOW TABLES FROM mz_internal
@@ -559,10 +562,7 @@ mz_comments
 mz_compute_dependencies
 mz_kafka_sources
 mz_postgres_sources
-mz_prepared_statement_history
-mz_session_history
 mz_sessions
-mz_statement_execution_history
 mz_storage_usage_by_shard
 mz_subscriptions
 mz_type_pg_metadata

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -658,7 +658,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-53
+50
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
This stores the statement log in storage-managed collections, rather than in system tables, so they won't be refreshed and cleared on startup. In order to avoid unnecessarily high load on Cockroach, we buffer the updates and flush them every 5 seconds.

On startup, we re-ingest the log in order to truncate the parts of it that are older than a configurable value, by default 30 days. Currently, this has the potential to use significant memory; we may need to switch to a more incremental approach. We will need to watch this closely when turning on statement logging in prod.

### Motivation

  * This PR adds a known-desirable feature.

    persisted statement logging

### Tips for Reviewer

By far the most complicated part of this is `partially_truncate_statement_logging`. Most of the rest should be straightforward.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Save values in in the statement log for 30 days.
