### PR TITLE
Updating spill to disk defaults

### DIFF
--- a/src/rocksdb-types/src/config.rs
+++ b/src/rocksdb-types/src/config.rs
@@ -526,7 +526,8 @@ pub mod defaults {
 
     /// A reasonable default batch size for gets and puts in RocksDB. Based
     /// on advice here: <https://github.com/facebook/rocksdb/wiki/RocksDB-FAQ>.
-    pub const DEFAULT_BATCH_SIZE: usize = 1024;
+    /// Based on our testing we are using 20 times that.
+    pub const DEFAULT_BATCH_SIZE: usize = 20 * 1024;
 
     /// The default max duration for retrying the retry-able errors in rocksdb.
     pub const DEFAULT_RETRY_DURATION: Duration = Duration::from_secs(1);

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -741,7 +741,6 @@ mod upsert_rocksdb {
     };
 
     /// Controls whether automatic spill to disk should be turned on when using `DISK`.
-    /// Defaults to true, i.e. autospill will always be on when using `DISK`.
     pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
         value: &false,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -744,7 +744,7 @@ mod upsert_rocksdb {
     /// Defaults to true, i.e. autospill will always be on when using `DISK`.
     pub const UPSERT_ROCKSDB_AUTO_SPILL_TO_DISK: ServerVar<bool> = ServerVar {
         name: UncasedStr::new("upsert_rocksdb_auto_spill_to_disk"),
-        value: &true,
+        value: &false,
         description:
             "Controls whether automatic spill to disk should be turned on when using `DISK`",
         internal: true,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -915,7 +915,7 @@ const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
 /// `storage_dataflow_max_inflight_bytes_disk_only` flag
 const STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
     name: UncasedStr::new("storage_dataflow_max_inflight_bytes"),
-    value: &Some(268435456),
+    value: &Some(256 * 1024 * 1024),
     description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
                   storage dataflows. Defaults to backpressure enabled (Materialize).",
     internal: true,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Updating defaults. Will update launchdarkly as well.

### Motivation
Updating spill to disk defaults such that we'll only need to set `enable_disk_cluster_replicas` flag to turn on spill to disk for a customer when testing.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
