### PR TITLE
platform-checks: Run each Check in its own dedicated schema

### DIFF
--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -20,6 +20,9 @@ class Check:
         self.base_version = base_version
         self.rng = rng
 
+    def schema(self) -> str:
+        return self.__class__.__name__
+
     def _can_run(self) -> bool:
         return True
 
@@ -36,6 +39,7 @@ class Check:
         if self._can_run():
             self.current_version = e.current_mz_version
             self._initialize = self.initialize()
+            self._initialize.schema = self.schema()
             self._initialize.execute(e)
 
     def join_initialize(self, e: Executor) -> None:
@@ -49,6 +53,7 @@ class Check:
             assert (
                 len(self._manipulate) == 2
             ), f"manipulate() should return a list with exactly 2 elements, but actually returns {len(self._manipulate)} elements"
+            self._manipulate[phase].schema = self.schema()
             self._manipulate[phase].execute(e)
 
     def join_manipulate(self, e: Executor, phase: int) -> None:
@@ -59,6 +64,7 @@ class Check:
         if self._can_run():
             self.current_version = e.current_mz_version
             self._validate = self.validate()
+            self._validate.schema = self.schema()
             self._validate.execute(e)
 
     def join_validate(self, e: Executor) -> None:

--- a/misc/python/materialize/checks/create_table.py
+++ b/misc/python/materialize/checks/create_table.py
@@ -62,7 +62,7 @@ class CreateTable(Check):
                 2
 
                 > SHOW CREATE TABLE create_table1;
-                materialize.public.create_table1 "CREATE TABLE \\"materialize\\".\\"public\\".\\"create_table1\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
+                materialize.createtable.create_table1 "CREATE TABLE \\"materialize\\".\\"createtable\\".\\"create_table1\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
 
                 ! INSERT INTO create_table1 (f2) VALUES (NULL);
                 contains: null value in column
@@ -74,7 +74,7 @@ class CreateTable(Check):
                 > DELETE FROM create_table1 WHERE f1 = 999;
 
                 > SHOW CREATE TABLE create_table2;
-                materialize.public.create_table2 "CREATE TABLE \\"materialize\\".\\"public\\".\\"create_table2\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
+                materialize.createtable.create_table2 "CREATE TABLE \\"materialize\\".\\"createtable\\".\\"create_table2\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
 
                 ! INSERT INTO create_table2 (f2) VALUES (NULL);
                 contains: null value in column
@@ -86,7 +86,7 @@ class CreateTable(Check):
                 > DELETE FROM create_table2 WHERE f1 = 999;
 
                 > SHOW CREATE TABLE create_table3;
-                materialize.public.create_table3 "CREATE TABLE \\"materialize\\".\\"public\\".\\"create_table3\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
+                materialize.createtable.create_table3 "CREATE TABLE \\"materialize\\".\\"createtable\\".\\"create_table3\\" (\\"f1\\" \\"pg_catalog\\".\\"int4\\", \\"f2\\" \\"pg_catalog\\".\\"int4\\" NOT NULL DEFAULT 1234)"
 
                 ! INSERT INTO create_table3 (f2) VALUES (NULL);
                 contains: null value in column

--- a/misc/python/materialize/checks/databases.py
+++ b/misc/python/materialize/checks/databases.py
@@ -14,6 +14,9 @@ from materialize.checks.checks import Check
 
 
 class CheckDatabaseCreate(Check):
+    def schema(self) -> str:
+        return "public"
+
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))
@@ -78,6 +81,9 @@ class CheckDatabaseCreate(Check):
 
 
 class CheckDatabaseDrop(Check):
+    def schema(self) -> str:
+        return "public"
+
     def manipulate(self) -> List[Testdrive]:
         return [
             Testdrive(dedent(s))

--- a/misc/python/materialize/checks/drop_table.py
+++ b/misc/python/materialize/checks/drop_table.py
@@ -39,6 +39,7 @@ class DropTable(Check):
                 # owned by default_role, thus we have to change the owner
                 # before dropping it:
                 $[version>=4700] postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+                SET SCHEMA=droptable
                 ALTER TABLE drop_table2 OWNER TO materialize;
 
                 > DROP TABLE drop_table2;

--- a/misc/python/materialize/checks/identifiers.py
+++ b/misc/python/materialize/checks/identifiers.py
@@ -193,6 +193,10 @@ class Identifiers(Check):
         self.ident = rng.choice(self.IDENTS) if rng else self.IDENTS[0]
         super().__init__(base_version, rng)
 
+    def schema(self) -> str:
+        # This Check does not use a dedicated schema
+        return "public"
+
     def initialize(self) -> Testdrive:
         cmds = f"""
             > SET cluster=identifiers;

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -82,7 +82,7 @@ class JsonSource(Check):
                 "\\"str\\"" "\\"hello\\""
 
                 > SHOW CREATE SOURCE format_jsonB;
-                materialize.public.format_jsonb "CREATE SOURCE \\"materialize\\".\\"public\\".\\"format_jsonb\\" FROM KAFKA CONNECTION \\"materialize\\".\\"public\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-${testdrive.seed}') KEY FORMAT JSON VALUE FORMAT JSON ENVELOPE UPSERT EXPOSE PROGRESS AS \\"materialize\\".\\"public\\".\\"format_jsonb_progress\\""
+                materialize.jsonsource.format_jsonb "CREATE SOURCE \\"materialize\\".\\"jsonsource\\".\\"format_jsonb\\" FROM KAFKA CONNECTION \\"materialize\\".\\"jsonsource\\".\\"kafka_conn\\" (TOPIC = 'testdrive-format-json-${testdrive.seed}') KEY FORMAT JSON VALUE FORMAT JSON ENVELOPE UPSERT EXPOSE PROGRESS AS \\"materialize\\".\\"jsonsource\\".\\"format_jsonb_progress\\""
            """
             )
         )

--- a/misc/python/materialize/checks/null_value.py
+++ b/misc/python/materialize/checks/null_value.py
@@ -54,7 +54,7 @@ class NullValue(Check):
             dedent(
                 """
                 > SHOW CREATE VIEW null_value_view1;
-                materialize.public.null_value_view1 "CREATE VIEW \\"materialize\\".\\"public\\".\\"null_value_view1\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
+                materialize.nullvalue.null_value_view1 "CREATE VIEW \\"materialize\\".\\"nullvalue\\".\\"null_value_view1\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"nullvalue\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
 
                 > SELECT * FROM null_value_view1;
                 <null> <null> <null>
@@ -71,7 +71,7 @@ class NullValue(Check):
                 <null> <null> <null>
 
                 > SHOW CREATE MATERIALIZED VIEW null_value_view2;
-                materialize.public.null_value_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"null_value_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"public\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
+                materialize.nullvalue.null_value_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"nullvalue\\".\\"null_value_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"f2\\", NULL FROM \\"materialize\\".\\"nullvalue\\".\\"null_value_table\\" WHERE \\"f1\\" IS NULL OR \\"f1\\" IS NOT NULL OR \\"f1\\" = NULL"
 
                 > SELECT * FROM null_value_view2;
                 <null> <null> <null>

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -15,6 +15,10 @@ from materialize.util import MzVersion
 
 
 class Owners(Check):
+    def schema(self) -> str:
+        # This Check does not use its own schema
+        return "public"
+
     def _create_objects(self, role: str, i: int, expensive: bool = False) -> str:
         s = dedent(
             f"""

--- a/misc/python/materialize/checks/pg_cdc.py
+++ b/misc/python/materialize/checks/pg_cdc.py
@@ -96,6 +96,7 @@ class PgCdcBase:
                 ),
                 f"""
                 $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                SET SCHEMA = PgCdc
                 GRANT USAGE ON CONNECTION pg2 TO materialize
 
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
@@ -156,6 +157,7 @@ class PgCdcBase:
             dedent(
                 f"""
                 $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                SET SCHEMA = PgCdc
                 GRANT SELECT ON postgres_source_tableA TO materialize
                 GRANT SELECT ON postgres_source_tableB TO materialize
                 GRANT SELECT ON postgres_source_tableC TO materialize
@@ -201,10 +203,10 @@ class PgCdcBase:
                     ? EXPLAIN SELECT DISTINCT f1, f2 FROM postgres_source_tableA;
                     Explained Query (fast path):
                       Project (#0, #1)
-                        ReadExistingIndex materialize.public.postgres_source_tablea_primary_idx
+                        ReadExistingIndex materialize.pgcdc.postgres_source_tablea_primary_idx
 
                     Used Indexes:
-                      - materialize.public.postgres_source_tablea_primary_idx (*** full scan ***)
+                      - materialize.pgcdc.postgres_source_tablea_primary_idx (*** full scan ***)
                     """
                 )
                 if self.base_version >= MzVersion.parse("0.50.0-dev")

--- a/misc/python/materialize/checks/schemas.py
+++ b/misc/python/materialize/checks/schemas.py
@@ -34,8 +34,7 @@ class CheckSchemas(Check):
         return Testdrive(
             dedent(
                 """
-                > SHOW SCHEMAS;
-                public
+                > SELECT name FROM mz_schemas WHERE name = 'to_be_created';
                 to_be_created
 
                 > SET DATABASE=to_be_dropped;

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -66,6 +66,7 @@ class SinkUpsert(Check):
             for s in [
                 """
                 $[version>=5200] postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                SET SCHEMA=sinkupsert
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize
@@ -108,6 +109,7 @@ class SinkUpsert(Check):
             dedent(
                 """
                 $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                SET schema=sinkupsert
                 GRANT SELECT ON sink_source_view TO materialize
                 GRANT USAGE ON CONNECTION kafka_conn TO materialize
                 GRANT USAGE ON CONNECTION csr_conn TO materialize

--- a/misc/python/materialize/checks/text_bytea_types.py
+++ b/misc/python/materialize/checks/text_bytea_types.py
@@ -52,7 +52,7 @@ class TextByteaTypes(Check):
             dedent(
                 """
                 > SHOW CREATE MATERIALIZED VIEW string_bytea_types_view1;
-                materialize.public.string_bytea_types_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
+                materialize.textbyteatypes.string_bytea_types_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"textbyteatypes\\".\\"string_bytea_types_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"textbyteatypes\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
 
                 > SELECT text_col, text, LENGTH(bytea_col), LENGTH(bytea) FROM string_bytea_types_view1;
                 aaaa това 2 2
@@ -63,7 +63,7 @@ class TextByteaTypes(Check):
                 "това е" това 10 2
 
                 > SHOW CREATE VIEW string_bytea_types_view2;
-                materialize.public.string_bytea_types_view2 "CREATE VIEW \\"materialize\\".\\"public\\".\\"string_bytea_types_view2\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"public\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
+                materialize.textbyteatypes.string_bytea_types_view2 "CREATE VIEW \\"materialize\\".\\"textbyteatypes\\".\\"string_bytea_types_view2\\" AS SELECT \\"text_col\\", \\"bytea_col\\", 'това'::\\"pg_catalog\\".\\"text\\", '\\\\xAAAA'::\\"pg_catalog\\".\\"bytea\\" FROM \\"materialize\\".\\"textbyteatypes\\".\\"text_bytea_types_table\\" WHERE \\"text_col\\" >= ''::\\"pg_catalog\\".\\"text\\" AND \\"bytea_col\\" >= ''::\\"pg_catalog\\".\\"bytea\\""
 
                 > SELECT text_col, text, LENGTH(bytea_col), LENGTH(bytea) FROM string_bytea_types_view2;
                 aaaa това 2 2

--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -60,14 +60,14 @@ class BasicTopK(Check):
             dedent(
                 """
                 > SHOW CREATE MATERIALIZED VIEW basic_topk_view1;
-                materialize.public.basic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                materialize.basictopk.basic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"basictopk\\".\\"basic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"basictopk\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view1;
                 2 32
                 3 48
 
                 > SHOW CREATE MATERIALIZED VIEW basic_topk_view2;
-                materialize.public.basic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"basic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                materialize.basictopk.basic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"basictopk\\".\\"basic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"basictopk\\".\\"basic_topk_table\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM basic_topk_view2;
                 1 16
@@ -126,14 +126,14 @@ class MonotonicTopK(Check):
             dedent(
                 """
                 > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view1;
-                materialize.public.monotonic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
+                materialize.monotonictopk.monotonic_topk_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"monotonictopk\\".\\"monotonic_topk_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"monotonictopk\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view1;
                 E 5
                 D 4
 
                 > SHOW CREATE MATERIALIZED VIEW monotonic_topk_view2;
-                materialize.public.monotonic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
+                materialize.monotonictopk.monotonic_topk_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"monotonictopk\\".\\"monotonic_topk_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"monotonictopk\\".\\"monotonic_topk_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 2"
 
                 > SELECT * FROM monotonic_topk_view2;
                 A 1
@@ -192,13 +192,13 @@ class MonotonicTop1(Check):
             dedent(
                 """
                 > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view1;
-                materialize.public.monotonic_top1_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
+                materialize.monotonictop1.monotonic_top1_view1 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"monotonictop1\\".\\"monotonic_top1_view1\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"monotonictop1\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" DESC NULLS LAST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view1;
                 D 5
 
                 > SHOW CREATE MATERIALIZED VIEW monotonic_top1_view2;
-                materialize.public.monotonic_top1_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"public\\".\\"monotonic_top1_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"public\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
+                materialize.monotonictop1.monotonic_top1_view2 "CREATE MATERIALIZED VIEW \\"materialize\\".\\"monotonictop1\\".\\"monotonic_top1_view2\\" IN CLUSTER \\"default\\" AS SELECT \\"f1\\", \\"pg_catalog\\".\\"count\\"(\\"f1\\") FROM \\"materialize\\".\\"monotonictop1\\".\\"monotonic_top1_source\\" GROUP BY \\"f1\\" ORDER BY \\"f1\\" ASC NULLS FIRST LIMIT 1"
 
                 > SELECT * FROM monotonic_top1_view2;
                 A 1

--- a/misc/python/materialize/checks/webhook.py
+++ b/misc/python/materialize/checks/webhook.py
@@ -39,15 +39,15 @@ class Webhook(Check):
 
                 > CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES;
 
-                $ webhook-append database=materialize schema=public name=webhook_text
+                $ webhook-append database=materialize schema=webhook name=webhook_text
                 fooä
 
-                $ webhook-append database=materialize schema=public name=webhook_json content-type=application/json app=platform-checks1
+                $ webhook-append database=materialize schema=webhook name=webhook_json content-type=application/json app=platform-checks1
                 {
                   "hello": "wörld"
                 }
 
-                $ webhook-append database=materialize schema=public name=webhook_bytes
+                $ webhook-append database=materialize schema=webhook name=webhook_bytes
                 \u0001
                 """
             )
@@ -58,26 +58,26 @@ class Webhook(Check):
             Testdrive(schemas() + dedent(s))
             for s in [
                 """
-                $ webhook-append database=materialize schema=public name=webhook_text
+                $ webhook-append database=materialize schema=webhook name=webhook_text
                 bar❤️
 
-                $ webhook-append database=materialize schema=public name=webhook_json content-type=application/json app=
+                $ webhook-append database=materialize schema=webhook name=webhook_json content-type=application/json app=
                 {
                   "still": 123,
                   "foo": []
                 }
 
-                $ webhook-append database=materialize schema=public name=webhook_bytes
+                $ webhook-append database=materialize schema=webhook name=webhook_bytes
                 \u0000\u0000\u0000\u0000
                 """,
                 """
-                $ webhook-append database=materialize schema=public name=webhook_text
+                $ webhook-append database=materialize schema=webhook name=webhook_text
                 baz１２３
 
-                $ webhook-append database=materialize schema=public name=webhook_json content-type=application/json app=null
+                $ webhook-append database=materialize schema=webhook name=webhook_json content-type=application/json app=null
                 [{"good": "bye"}, 42, null]
 
-                $ webhook-append database=materialize schema=public name=webhook_bytes
+                $ webhook-append database=materialize schema=webhook name=webhook_bytes
                 \u0001\u0002\u0003\u0004
                 """,
             ]


### PR DESCRIPTION
Run each Check in its own schema to avoid conflicts between several Checks attempting to use the same object names.

A few checks perform their own schema operations, so continue to run them with the default schema name of 'public'

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
