### PR TITLE
platform-checks: Disable the Owners check when run in parallel mode 

### DIFF
--- a/misc/python/materialize/checks/array_type.py
+++ b/misc/python/materialize/checks/array_type.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class ArrayType(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def initialize(self) -> Testdrive:

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -20,7 +20,7 @@ class Check:
         self.base_version = base_version
         self.rng = rng
 
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return True
 
     def initialize(self) -> Testdrive:
@@ -33,17 +33,17 @@ class Check:
         assert False
 
     def start_initialize(self, e: Executor) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self.current_version = e.current_mz_version
             self._initialize = self.initialize()
             self._initialize.execute(e)
 
     def join_initialize(self, e: Executor) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self._initialize.join(e)
 
     def start_manipulate(self, e: Executor, phase: int) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self.current_version = e.current_mz_version
             self._manipulate = self.manipulate()
             assert (
@@ -52,17 +52,17 @@ class Check:
             self._manipulate[phase].execute(e)
 
     def join_manipulate(self, e: Executor, phase: int) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self._manipulate[phase].join(e)
 
     def start_validate(self, e: Executor) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self.current_version = e.current_mz_version
             self._validate = self.validate()
             self._validate.execute(e)
 
     def join_validate(self, e: Executor) -> None:
-        if self._can_run():
+        if self._can_run(e):
             self._validate.join(e)
 
 

--- a/misc/python/materialize/checks/default_privileges.py
+++ b/misc/python/materialize/checks/default_privileges.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class DefaultPrivileges(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def initialize(self) -> Testdrive:

--- a/misc/python/materialize/checks/identifiers.py
+++ b/misc/python/materialize/checks/identifiers.py
@@ -15,6 +15,7 @@ from pg8000.converters import literal  # type: ignore
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
@@ -42,7 +43,7 @@ def cluster() -> str:
 
 
 class Identifiers(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         # CREATE ROLE not compatible with older releases
         return self.base_version >= MzVersion.parse("0.47.0-dev")
 

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -11,13 +11,14 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class JsonSource(Check):
     """Test CREATE SOURCE ... FORMAT JSON"""
 
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.60.0-dev")
 
     def initialize(self) -> Testdrive:

--- a/misc/python/materialize/checks/managed_cluster.py
+++ b/misc/python/materialize/checks/managed_cluster.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class CreateManagedCluster(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def manipulate(self) -> List[Testdrive]:
@@ -67,7 +68,7 @@ class CreateManagedCluster(Check):
 
 
 class DropManagedCluster(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def manipulate(self) -> List[Testdrive]:

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -45,8 +45,7 @@ class Owners(Check):
                 f"""
                 CREATE SOURCE owner_source{i} FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
                 CREATE SINK owner_sink{i} FROM owner_mv{i} INTO KAFKA CONNECTION owner_kafka_conn{i} (TOPIC 'sink-sink-owner{i}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION owner_csr_conn{i} ENVELOPE DEBEZIUM
-                -- Disable cluster-related operations due to https://github.com/MaterializeInc/materialize/issues/21317
-                -- CREATE CLUSTER owner_cluster{i} REPLICAS (owner_cluster_r{i} (SIZE '4'))
+                CREATE CLUSTER owner_cluster{i} REPLICAS (owner_cluster_r{i} (SIZE '4'))
                 """
             )
 
@@ -73,7 +72,7 @@ class Owners(Check):
                 f"""
                 ALTER SOURCE owner_source{i} OWNER TO other_owner
                 ALTER SINK owner_sink{i} OWNER TO other_owner
-                -- ALTER CLUSTER owner_cluster{i} OWNER TO other_owner -- https://github.com/MaterializeInc/materialize/issues/21317
+                ALTER CLUSTER owner_cluster{i} OWNER TO other_owner
                 """
             )
 
@@ -88,7 +87,7 @@ class Owners(Check):
             cmds += [
                 f"DROP SOURCE owner_source{i}",
                 f"DROP SINK owner_sink{i}",
-                # f"DROP CLUSTER owner_cluster{i}",
+                f"DROP CLUSTER owner_cluster{i}",
             ]
         cmds += [
             f"DROP SECRET owner_secret{i}",
@@ -350,13 +349,13 @@ class Owners(Check):
                 owner_sink1 owner_role_01
                 owner_sink2 other_owner
 
-                # > SELECT mz_clusters.name, mz_roles.name FROM mz_clusters JOIN mz_roles ON mz_clusters.owner_id = mz_roles.id WHERE mz_clusters.name LIKE 'owner_cluster%'
-                # owner_cluster1 owner_role_01
-                # owner_cluster2 other_owner
+                > SELECT mz_clusters.name, mz_roles.name FROM mz_clusters JOIN mz_roles ON mz_clusters.owner_id = mz_roles.id WHERE mz_clusters.name LIKE 'owner_cluster%'
+                owner_cluster1 owner_role_01
+                owner_cluster2 other_owner
 
-                # > SELECT mz_cluster_replicas.name, mz_roles.name FROM mz_cluster_replicas JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id WHERE mz_cluster_replicas.name LIKE 'owner_cluster_r%'
-                # owner_cluster_r1 owner_role_01
-                # owner_cluster_r2 other_owner
+                > SELECT mz_cluster_replicas.name, mz_roles.name FROM mz_cluster_replicas JOIN mz_roles ON mz_cluster_replicas.owner_id = mz_roles.id WHERE mz_cluster_replicas.name LIKE 'owner_cluster_r%'
+                owner_cluster_r1 owner_role_01
+                owner_cluster_r2 other_owner
 
                 > SELECT mz_connections.name, mz_roles.name FROM mz_connections JOIN mz_roles ON mz_connections.owner_id = mz_roles.id WHERE mz_connections.name LIKE 'owner_%'
                 owner_csr_conn1  owner_role_01
@@ -513,11 +512,11 @@ class Owners(Check):
                 ! SELECT name, unnest(privileges)::text FROM mz_sinks WHERE name LIKE 'owner_sink%'
                 contains: column "privileges" does not exist
 
-                # > SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name LIKE 'owner_cluster%'
-                # owner_cluster1 mz_support=U/owner_role_01
-                # owner_cluster1 owner_role_01=UC/owner_role_01
-                # owner_cluster2 mz_support=U/other_owner
-                # owner_cluster2 other_owner=UC/other_owner
+                > SELECT name, unnest(privileges)::text FROM mz_clusters WHERE name LIKE 'owner_cluster%'
+                owner_cluster1 mz_support=U/owner_role_01
+                owner_cluster1 owner_role_01=UC/owner_role_01
+                owner_cluster2 mz_support=U/other_owner
+                owner_cluster2 other_owner=UC/other_owner
 
                 > SELECT name, unnest(privileges)::text FROM mz_connections WHERE name LIKE 'owner_%'
                 owner_csr_conn1  owner_role_01=U/owner_role_01

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor, MzcomposeExecutorParallel
 from materialize.util import MzVersion
 
 
@@ -115,9 +116,12 @@ class Owners(Check):
             [f"! {cmd} CASCADE\ncontains: must be owner of\n" for cmd in cmds]
         )
 
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         # Object owner changes weren't persisted in some cases earlier than 0.63.0.
-        return self.base_version >= MzVersion.parse("0.63.0-dev")
+        # ALTER SET OWNER hangs in parallel mode - #21317
+        return self.base_version >= MzVersion.parse("0.63.0-dev") and not isinstance(
+            e, MzcomposeExecutorParallel
+        )
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/privileges.py
+++ b/misc/python/materialize/checks/privileges.py
@@ -11,6 +11,7 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
@@ -121,7 +122,7 @@ class Privileges(Check):
             + "\n"
         )
 
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         # Privilege changes weren't persisted in some cases earlier than 0.63.0.
         return self.base_version >= MzVersion.parse("0.63.0-dev")
 

--- a/misc/python/materialize/checks/rename_cluster.py
+++ b/misc/python/materialize/checks/rename_cluster.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class RenameCluster(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def manipulate(self) -> List[Testdrive]:

--- a/misc/python/materialize/checks/rename_replica.py
+++ b/misc/python/materialize/checks/rename_replica.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class RenameReplica(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.58.0-dev")
 
     def manipulate(self) -> List[Testdrive]:

--- a/misc/python/materialize/checks/roles.py
+++ b/misc/python/materialize/checks/roles.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class CreateRole(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.45.0-dev")
 
     def _if_can_grant_revoke(self, text: str) -> str:

--- a/misc/python/materialize/checks/uuid.py
+++ b/misc/python/materialize/checks/uuid.py
@@ -11,11 +11,12 @@ from typing import List
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class UUID(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion(0, 46, 0)
 
     def initialize(self) -> Testdrive:

--- a/misc/python/materialize/checks/webhook.py
+++ b/misc/python/materialize/checks/webhook.py
@@ -12,6 +12,7 @@ from typing import List
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
@@ -20,7 +21,7 @@ def schemas() -> str:
 
 
 class Webhook(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.62.0-dev")
 
     def initialize(self) -> Testdrive:


### PR DESCRIPTION
A hang occurs if the Owners check runs in parallel mode. A previous PR attempted to selectively disable parts of the check, however the hang persisted. So we disable the entire Check if the framework is run in parallel mode.

### Motivation

Nightly CI was failing.