### PR TITLE
formatting: add bin/fmt

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# fmt — formats Rust and Python code.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+. misc/shlib/shlib.bash
+
+try cargo fmt
+
+if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
+  bin/pyfmt
+fi
+
+try_finish


### PR DESCRIPTION
### Motivation

This introduces `bin/fmt`, which formats Rust and Python code.
It allows running this command without thinking whether you are in mz or cloud repo.