### PR TITLE
scalability framework: Specify the desired object count

### DIFF
--- a/misc/python/materialize/scalability/schema.py
+++ b/misc/python/materialize/scalability/schema.py
@@ -31,12 +31,14 @@ class Schema:
         create_index: bool = True,
         transaction_isolation: Optional[TransactionIsolation] = None,
         cluster_name: Optional[str] = None,
+        object_count: int = 1,
     ) -> None:
         self.schema = schema
         self.source = source
         self.create_index = create_index
         self.transaction_isolation = transaction_isolation
         self.cluster_name = cluster_name
+        self.object_count = object_count
 
     def init_sqls(self) -> list[str]:
         init_sqls = self.connect_sqls() + [
@@ -45,15 +47,16 @@ class Schema:
             "DROP TABLE IF EXISTS t1;",
         ]
         if self.source == Source.TABLE:
-            init_sqls.extend(
-                [
-                    "CREATE TABLE t1 (f1 INTEGER DEFAULT 1);",
-                    "INSERT INTO t1 DEFAULT VALUES;",
-                ]
-            )
+            for t in range(1, self.object_count + 1):
+                init_sqls.extend(
+                    [
+                        f"CREATE TABLE t{t} (f1 INTEGER DEFAULT 1);",
+                        f"INSERT INTO t{t} DEFAULT VALUES;",
+                    ]
+                )
 
-        if self.create_index:
-            init_sqls.append("CREATE INDEX i1 ON t1 (f1);")
+                if self.create_index:
+                    init_sqls.append(f"CREATE INDEX i{t} ON t{t} (f1);")
 
         return init_sqls
 

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -178,6 +178,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--target",
         help="Target for the benchmark: 'HEAD', 'local', 'remote', 'Postgres', or a DockerHub tag",
         action="append",
+        default=[],
     )
 
     parser.add_argument(
@@ -211,6 +212,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         type=int,
         default=512,
         help="Number of individual operations to benchmark at concurrency 1 (and COUNT * SQRT(concurrency) for higher concurrencies)",
+    )
+
+    parser.add_argument(
+        "--object-count",
+        metavar="COUNT",
+        type=int,
+        default=1,
+        help="Number of database objects",
     )
 
     parser.add_argument(
@@ -276,6 +285,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         create_index=args.create_index,
         transaction_isolation=args.transaction_isolation,
         cluster_name=args.cluster_name,
+        object_count=args.object_count,
     )
 
     workload_names = [workload.__name__ for workload in workloads]


### PR DESCRIPTION
Since the performance of the product depends on the number of tables, it should be possible to specify it when benchmarking.

### Motivation

As per the original design of the scalability framework and the needs of https://www.notion.so/materialize/Use-case-Isolation-Milestones-f1a37b024ea74b7c9d870778c4349fe3?pvs=4 , we need to be benchmarking with a different number of database objects present in the database.

This PR is a stop-gap measure as it does not allow a chart to be built from benchmark runs against different object counts. However, my intention is to somehow unify the different "dimensions" which one could benchmark and make them all chartable. 