### PR TITLE
Add set operations to `mz_ore::collections::HashSet`

### DIFF
--- a/src/ore/src/collections/hash.rs
+++ b/src/ore/src/collections/hash.rs
@@ -45,7 +45,8 @@
 #![allow(clippy::disallowed_types)]
 
 use std::borrow::Borrow;
-use std::collections::hash_map::Entry;
+use std::collections::hash_map::{Entry, RandomState};
+use std::collections::hash_set::{Difference, Intersection, SymmetricDifference, Union};
 use std::collections::{HashMap as StdMap, HashSet as StdSet, TryReserveError};
 use std::hash::Hash;
 use std::ops::{BitAnd, BitOr, BitXor, Index, Sub};
@@ -419,6 +420,33 @@ where
         Q: Hash + Eq,
     {
         self.0.take(value)
+    }
+
+    /// See [`std::collections::HashSet::difference`].
+    #[inline]
+    pub fn difference<'a>(&'a self, other: &'a HashSet<T>) -> Difference<'a, T, RandomState> {
+        self.0.difference(&other.0)
+    }
+
+    /// See [`std::collections::HashSet::symmetric_difference`].
+    #[inline]
+    pub fn symmetric_difference<'a>(
+        &'a self,
+        other: &'a HashSet<T>,
+    ) -> SymmetricDifference<'a, T, RandomState> {
+        self.0.symmetric_difference(&other.0)
+    }
+
+    /// See [`std::collections::HashSet::intersection`].
+    #[inline]
+    pub fn intersection<'a>(&'a self, other: &'a HashSet<T>) -> Intersection<'a, T, RandomState> {
+        self.0.intersection(&other.0)
+    }
+
+    /// See [`std::collections::HashSet::union`].
+    #[inline]
+    pub fn union<'a>(&'a self, other: &'a HashSet<T>) -> Union<'a, T, RandomState> {
+        self.0.union(&other.0)
     }
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

We ban use of the stdlib's `HashSet` since it exhibits arbitrary iteration order. Instead, we package our own `HashSet` with allowlisted methods. Set operations, however, were not supported. Since these do not expose iteration order, expose them.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

This is being used in another repo that uses `mz_ore`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
