### PR TITLE
[cloudtest] Minor adjustments to test fixture retry behavior

### DIFF
--- a/misc/python/materialize/cloudtest/util/controller.py
+++ b/misc/python/materialize/cloudtest/util/controller.py
@@ -68,7 +68,7 @@ def wait_for_connectable(
     retry(
         f,
         max_attempts=max_attempts,
-        exception_types=[ConnectionRefusedError, socket.gaierror],
+        exception_types=[ConnectionRefusedError, socket.gaierror, socket.timeout],
         message=f"Error connecting to {address}. Tried {max_attempts} times.",
     )
 

--- a/misc/python/materialize/cloudtest/util/environment.py
+++ b/misc/python/materialize/cloudtest/util/environment.py
@@ -90,7 +90,7 @@ def delete_environment_assignment(config: EnvironmentConfig) -> None:
             timeout=305,
         )
 
-    retry(delete_environment, 10, [requests.exceptions.HTTPError])
+    retry(delete_environment, 20, [requests.exceptions.HTTPError])
 
     env_kubectl = Kubectl(config.environment_context)
     sys_kubectl = Kubectl(config.system_context)


### PR DESCRIPTION
### Motivation

#### This PR refactors existing code.
- While working on a test for cloud region soft-deletion I hit a few spurious failures when running the test-suite. This adjusts a couple of the retry handlers to add more test-suite robustness.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
