### PR TITLE
adapter: stub information_schema for PowerBI

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3664,6 +3664,7 @@ SELECT
     o.name AS table_name,
     c.name AS column_name,
     c.position::int8 AS ordinal_position,
+    CASE WHEN c.nullable THEN 'YES' ELSE 'NO' END AS is_nullable,
     c.type AS data_type,
     NULL::pg_catalog.int4 AS character_maximum_length,
     NULL::pg_catalog.int4 AS numeric_precision,
@@ -3693,6 +3694,38 @@ FROM information_schema.table_privileges
 WHERE
     grantor IN (SELECT role_name FROM information_schema.enabled_roles)
     OR grantee IN (SELECT role_name FROM information_schema.enabled_roles)",
+};
+
+pub const INFORMATION_SCHEMA_KEY_COLUMN_USAGE: BuiltinView = BuiltinView {
+    name: "key_column_usage",
+    schema: INFORMATION_SCHEMA,
+    sql: "CREATE VIEW information_schema.key_column_usage AS SELECT
+    NULL::text AS constraint_catalog,
+    NULL::text AS constraint_schema,
+    NULL::text AS constraint_name,
+    NULL::text AS table_catalog,
+    NULL::text AS table_schema,
+    NULL::text AS table_name,
+    NULL::text AS column_name,
+    NULL::integer AS ordinal_position,
+    NULL::integer AS position_in_unique_constraint
+WHERE false",
+};
+
+pub const INFORMATION_SCHEMA_REFERENTIAL_CONSTRAINTS: BuiltinView = BuiltinView {
+    name: "referential_constraints",
+    schema: INFORMATION_SCHEMA,
+    sql: "CREATE VIEW information_schema.referential_constraints AS SELECT
+    NULL::text AS constraint_catalog,
+    NULL::text AS constraint_schema,
+    NULL::text AS constraint_name,
+    NULL::text AS unique_constraint_catalog,
+    NULL::text AS unique_constraint_schema,
+    NULL::text AS unique_constraint_name,
+    NULL::text AS match_option,
+    NULL::text AS update_rule,
+    NULL::text AS delete_rule
+WHERE false",
 };
 
 pub const INFORMATION_SCHEMA_ROUTINES: BuiltinView = BuiltinView {
@@ -3738,6 +3771,24 @@ FROM mz_catalog.mz_relations r
 JOIN mz_catalog.mz_schemas s ON s.id = r.schema_id
 LEFT JOIN mz_catalog.mz_databases d ON d.id = s.database_id
 WHERE s.database_id IS NULL OR d.name = current_database()",
+};
+
+pub const INFORMATION_SCHEMA_TABLE_CONSTRAINTS: BuiltinView = BuiltinView {
+    name: "table_constraints",
+    schema: INFORMATION_SCHEMA,
+    sql: "CREATE VIEW information_schema.table_constraints AS SELECT
+    NULL::text AS constraint_catalog,
+    NULL::text AS constraint_schema,
+    NULL::text AS constraint_name,
+    NULL::text AS table_catalog,
+    NULL::text AS table_schema,
+    NULL::text AS table_name,
+    NULL::text AS constraint_type,
+    NULL::text AS is_deferrable,
+    NULL::text AS initially_deferred,
+    NULL::text AS enforced,
+    NULL::text AS nulls_distinct
+WHERE false",
 };
 
 pub const INFORMATION_SCHEMA_TABLE_PRIVILEGES: BuiltinView = BuiltinView {
@@ -5010,9 +5061,12 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&INFORMATION_SCHEMA_APPLICABLE_ROLES),
         Builtin::View(&INFORMATION_SCHEMA_COLUMNS),
         Builtin::View(&INFORMATION_SCHEMA_ENABLED_ROLES),
+        Builtin::View(&INFORMATION_SCHEMA_KEY_COLUMN_USAGE),
+        Builtin::View(&INFORMATION_SCHEMA_REFERENTIAL_CONSTRAINTS),
         Builtin::View(&INFORMATION_SCHEMA_ROUTINES),
         Builtin::View(&INFORMATION_SCHEMA_SCHEMATA),
         Builtin::View(&INFORMATION_SCHEMA_TABLES),
+        Builtin::View(&INFORMATION_SCHEMA_TABLE_CONSTRAINTS),
         Builtin::View(&INFORMATION_SCHEMA_TABLE_PRIVILEGES),
         Builtin::View(&INFORMATION_SCHEMA_ROLE_TABLE_GRANTS),
         Builtin::View(&INFORMATION_SCHEMA_TRIGGERS),

--- a/test/sqllogictest/information_schema_columns.slt
+++ b/test/sqllogictest/information_schema_columns.slt
@@ -18,9 +18,9 @@ CREATE VIEW other.public.v AS SELECT 1 AS num, 'a' AS char
 statement ok
 CREATE VIEW v AS SELECT 1 AS num, 'a' AS char
 
-query TTTTTTTTT colnames,rowsort
+query TTTTTTTTTT colnames,rowsort
 SELECT * FROM information_schema.columns WHERE table_name = 'v'
 ----
-table_catalog  table_schema  table_name  column_name  ordinal_position  data_type  character_maximum_length  numeric_precision  numeric_scale
-materialize    public        v           num          1                 integer    NULL                      NULL               NULL
-materialize    public        v           char         2                 text       NULL                      NULL               NULL
+table_catalog  table_schema  table_name  column_name  ordinal_position  is_nullable data_type  character_maximum_length  numeric_precision  numeric_scale
+materialize    public        v           num          1                 NO          integer    NULL                      NULL               NULL
+materialize    public        v           char         2                 NO          text       NULL                      NULL               NULL

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -53,6 +53,14 @@ enabled_roles
 VIEW
 materialize
 information_schema
+key_column_usage
+VIEW
+materialize
+information_schema
+referential_constraints
+VIEW
+materialize
+information_schema
 role_table_grants
 VIEW
 materialize
@@ -62,6 +70,10 @@ VIEW
 materialize
 information_schema
 schemata
+VIEW
+materialize
+information_schema
+table_constraints
 VIEW
 materialize
 information_schema


### PR DESCRIPTION
This commit adds a few more stubs to `information_schema` in order to satisfy PowerBI (MaterializeInc/developer-experience#231):

  * `information_schema.columns.is_nullable`
  * `information_schema.key_column_usage`
  * `information_schema.referential_constraints`
  * `information_schema.table_constraints`

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * Basic support for Power BI Desktop.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
