### PR TITLE
lint: get rid of Python lint warnings (2/2)

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -18,7 +18,7 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 pyright_version=$(sh ci/builder/pyright-version.sh)
-typecheck_cmd="npx pyright@$pyright_version"
+typecheck_cmd="npx pyright@$pyright_version --warnings"
 
 python_folders=(ci misc/python)
 flake8_folders=(ci misc/python test)

--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -121,6 +121,7 @@ def mark_covered_lines(
         # DA:111,15524
         # DA:112,0
         # DA:113,15901
+        # TODO: Is this correct at all? Check with def-
         elif method == "DA" and file in coverage:
             line_str, hit_str = content.split(",", 1)
             line_nr = int(line_str)

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -133,6 +133,7 @@ class KafkaExecutor(Executor):
             registry, json.dumps(key_schema), lambda d, ctx: d
         )
 
+        # TODO: Is this correct at all? Should this be self.topic? Check with def-
         registry.register_schema(
             f"{topic}-value", Schema(json.dumps(schema), schema_type="AVRO")
         )

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -509,7 +509,8 @@ class ReconnectAction(Action):
         self.random_role = random_role
 
     def run(self, exe: Executor) -> None:
-        autocommit = exe.cur._c.autocommit
+        conn = exe.conn
+        autocommit = conn.autocommit
         host = self.db.host
         port = self.db.port
         with self.db.lock:
@@ -520,7 +521,6 @@ class ReconnectAction(Action):
             else:
                 user = "materialize"
 
-        conn = exe.cur._c
         try:
             exe.cur.close()
         except:

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -34,13 +34,15 @@ class QueryError(Exception):
 
 class Executor:
     rng: random.Random
+    conn: pg8000.Connection
     cur: pg8000.Cursor
     pg_pid: int
     # Used by INSERT action to prevent writing into different tables in the same transaction
     insert_table: Optional[int]
 
-    def __init__(self, rng: random.Random, cur: pg8000.Cursor):
+    def __init__(self, rng: random.Random, conn: pg8000.Connection, cur: pg8000.Cursor):
         self.rng = rng
+        self.conn = conn
         self.cur = cur
         self.pg_pid = -1
         self.insert_table = None
@@ -51,14 +53,14 @@ class Executor:
     def commit(self) -> None:
         self.insert_table = None
         try:
-            self.cur._c.commit()
+            self.conn.commit()
         except Exception as e:
             raise QueryError(str(e), "commit")
 
     def rollback(self) -> None:
         self.insert_table = None
         try:
-            self.cur._c.rollback()
+            self.conn.rollback()
         except Exception as e:
             raise QueryError(str(e), "rollback")
 

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -83,7 +83,7 @@ def run(
     conn = pg8000.connect(host=host, port=port, user="materialize")
     conn.autocommit = True
     with conn.cursor() as cur:
-        database.create(Executor(rng, cur))
+        database.create(Executor(rng, conn, cur))
     conn.close()
 
     conn = pg8000.connect(
@@ -91,7 +91,7 @@ def run(
     )
     conn.autocommit = True
     with conn.cursor() as cur:
-        database.create_relations(Executor(rng, cur))
+        database.create_relations(Executor(rng, conn, cur))
     conn.close()
 
     workers = []
@@ -213,7 +213,7 @@ def run(
     conn.autocommit = True
     with conn.cursor() as cur:
         print(f"Dropping database {database}")
-        database.drop(Executor(rng, cur))
+        database.drop(Executor(rng, conn, cur))
     conn.close()
 
     ignored_errors: DefaultDict[str, Counter[type[Action]]] = defaultdict(Counter)

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -53,7 +53,7 @@ class Worker:
         self.conn = pg8000.connect(host=host, port=port, user=user, database=database)
         self.conn.autocommit = self.autocommit
         cur = self.conn.cursor()
-        self.exe = Executor(self.rng, cur)
+        self.exe = Executor(self.rng, self.conn, cur)
         self.exe.set_isolation("SERIALIZABLE")
         cur.execute("SELECT pg_backend_pid()")
         self.exe.pg_pid = cur.fetchall()[0][0]


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/21389

### TODOs
* check open TODOs with @def- 
* fix parallel-workload adjustment ("Parallel Workload" will fail otherwise)
* look at: `feature_benchmark/scenario.py:50:25 - warning: Static methods should not take a "self" or "cls" parameter` => see https://github.com/MaterializeInc/materialize/pull/21389#discussion_r1305676583