### PR TITLE
scalability framework: small fixes

### DIFF
--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -272,7 +272,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         endpoint: Optional[Endpoint] = None
         if target == "local":
             endpoint = MaterializeLocal()
-        if target == "remote":
+        elif target == "remote":
             endpoint = MaterializeRemote(materialize_url=args.materialize_url[i])
         elif target == "postgres":
             endpoint = PostgresContainer(composition=c)

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -130,7 +130,6 @@ def run_with_concurrency(
     for measurement in measurements:
         df_detail = pd.concat([df_detail, pd.DataFrame([measurement])])
 
-    assert len(df_detail) == count
     print("Best and worst individual measurements:")
     print(df_detail.sort_values(by=["wallclock"]))
 


### PR DESCRIPTION
### Tips for reviewer

Individual commits have meaningful descriptions. Especially the last commit is controversial, I'd say! You might not like my solution.

Also, with this solution the cursor pool is not a pool anymore, but ... :man_shrugging: 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
