### PR TITLE
[cloudtest] Use correct union types for sql execute statements

### DIFF
--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -7,11 +7,11 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-from typing import Any, Optional, Sequence
+from typing import Any, Optional
 
 import psycopg
+from psycopg.abc import Params, Query
 from psycopg.connection import Connection
-from typing_extensions import LiteralString
 
 from materialize.cloudtest.config.environment_config import EnvironmentConfig
 from materialize.cloudtest.util.common import eprint
@@ -21,27 +21,27 @@ from materialize.cloudtest.util.web_request import post
 
 def sql_query(
     conn: Connection[Any],
-    query: str,
-    vars: Optional[Sequence[Any]] = None,
+    query: Query,
+    vars: Optional[Params] = None,
 ) -> list[list[Any]]:
     cur = conn.cursor()
-    cur.execute(query.encode("utf8"), vars)
+    cur.execute(query, vars)
     return [list(row) for row in cur]
 
 
 def sql_execute(
     conn: Connection[Any],
-    query: str,
-    vars: Optional[Sequence[Any]] = None,
+    query: Query,
+    vars: Optional[Params] = None,
 ) -> None:
     cur = conn.cursor()
-    cur.execute(query.encode("utf8"), vars)
+    cur.execute(query, vars)
 
 
 def sql_execute_ddl(
     conn: Connection[Any],
-    query: LiteralString,
-    vars: Optional[Sequence[Any]] = None,
+    query: Query,
+    vars: Optional[Params] = None,
 ) -> None:
     cur = psycopg.ClientCursor(conn)
     cur.execute(query, vars)
@@ -65,8 +65,8 @@ def pgwire_sql_conn(config: EnvironmentConfig) -> Connection[Any]:
 
 def sql_query_pgwire(
     config: EnvironmentConfig,
-    query: str,
-    vars: Optional[Sequence[Any]] = None,
+    query: Query,
+    vars: Optional[Params] = None,
 ) -> list[list[Any]]:
     with pgwire_sql_conn(config) as conn:
         eprint(f"QUERY: {query}")
@@ -75,8 +75,8 @@ def sql_query_pgwire(
 
 def sql_execute_pgwire(
     config: EnvironmentConfig,
-    query: str,
-    vars: Optional[Sequence[Any]] = None,
+    query: Query,
+    vars: Optional[Params] = None,
 ) -> None:
     with pgwire_sql_conn(config) as conn:
         eprint(f"QUERY: {query}")


### PR DESCRIPTION
### Motivation

This swaps the `LiteralString` type annotation to the `Query` type union defined by `psycopg` so I can use the psycopg `sql.SQL` type in a DDL statement where I can't use a `LiteralString`. See https://www.psycopg.org/psycopg3/docs/advanced/typing.html#checking-literal-strings-in-queries for details

I also switched the `Sequence[Any]` annotations to use the `psycopg` `Params` union-type to future-proof that.

`sql_query` and `sql_execute` still annotate their `query` parameter as `str`, which is actually incorrect with the move to `psycopg` 3.. I can update those too but I was wondering if there was a reason to leave them as-is. LMK your thoughts.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
