### PR TITLE
storage: better kafka error reporting

### DIFF
--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -87,6 +87,7 @@ use crossbeam::thread;
 use mz_avro::schema::{SchemaNode, SchemaPiece, SchemaPieceOrNamed};
 use mz_avro::types::{DecimalValue, Value};
 use mz_avro::Schema;
+use mz_kafka_util::client::MzClientContext;
 use mz_ore::cast::CastFrom;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::retry::Retry;
@@ -769,7 +770,7 @@ async fn main() -> anyhow::Result<()> {
             let producer: ThreadedProducer<mz_kafka_util::client::MzClientContext> =
                 mz_kafka_util::client::create_new_client_config_simple()
                     .set("bootstrap.servers", args.bootstrap_server.to_string())
-                    .create_with_context(mz_kafka_util::client::MzClientContext)
+                    .create_with_context(MzClientContext::default())
                     .unwrap();
             let mut key_buf = vec![];
             let mut value_buf = vec![];

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -11,6 +11,8 @@
 
 use std::collections::BTreeMap;
 use std::error::Error;
+use std::str::FromStr;
+use std::sync::mpsc::{self, Receiver, Sender};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -36,7 +38,119 @@ pub const DEFAULT_FETCH_METADATA_TIMEOUT: Duration = Duration::from_secs(30);
 /// context or a custom context that delegates the `log` and `error` methods to
 /// this implementation.
 #[derive(Clone)]
-pub struct MzClientContext;
+pub struct MzClientContext {
+    /// The last observed error log, if any.
+    error_tx: Sender<MzKafkaError>,
+}
+
+impl Default for MzClientContext {
+    fn default() -> Self {
+        Self::with_errors().0
+    }
+}
+
+impl MzClientContext {
+    /// Constructs a new client context and returns an mpsc `Receiver` that can be used to learn
+    /// about librdkafka errors.
+    pub fn with_errors() -> (Self, Receiver<MzKafkaError>) {
+        let (error_tx, error_rx) = mpsc::channel();
+        (Self { error_tx }, error_rx)
+    }
+
+    fn record_error(&self, msg: &str) {
+        let err = match MzKafkaError::from_str(msg) {
+            Ok(err) => err,
+            Err(()) => {
+                error!(message = msg, "failed to parse kafka error");
+                MzKafkaError::Internal(msg.to_owned())
+            }
+        };
+        // If no one cares about errors we drop them on the floor
+        let _ = self.error_tx.send(err);
+    }
+}
+
+/// A structured error type for errors reported by librdkafka through its logs.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum MzKafkaError {
+    /// Invalid username or password
+    #[error("Invalid username or password")]
+    InvalidCredentials,
+    /// Missing CA certificate
+    #[error("Invalid CA certificate")]
+    InvalidCACertificate,
+    /// Broker does not support SSL connections
+    #[error("Broker does not support SSL connections")]
+    SSLUnsupported,
+    /// Broker did not provide a certificate
+    #[error("Broker did not provide a certificate")]
+    BrokerCertificateMissing,
+    /// Failed to verify broker certificate
+    #[error("Failed to verify broker certificate")]
+    InvalidBrokerCertificate,
+    /// Connection reset
+    #[error("Connection reset: {0}")]
+    ConnectionReset(String),
+    /// Connection timeout
+    #[error("Connection timeout")]
+    ConnectionTimeout,
+    /// Failed to resolve hostname
+    #[error("Failed to resolve hostname")]
+    HostnameResolutionFailed,
+    /// Unsupported SASL mechanism
+    #[error("Unsupported SASL mechanism")]
+    UnsupportedSASLMechanism,
+    /// Unsupported broker version
+    #[error("Unsupported broker version")]
+    UnsupportedBrokerVersion,
+    /// SASL authentication required
+    #[error("SASL authentication required")]
+    SASLAuthenticationRequired,
+    /// SSL authentication required
+    #[error("SSL authentication required")]
+    SSLAuthenticationRequired,
+    /// An internal kafka error
+    #[error("Internal kafka error: {0}")]
+    Internal(String),
+}
+
+impl FromStr for MzKafkaError {
+    type Err = ();
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.contains("Authentication failed: Invalid username or password") {
+            Ok(Self::InvalidCredentials)
+        } else if s.contains("broker certificate could not be verified") {
+            Ok(Self::InvalidCACertificate)
+        } else if s.contains("client SSL authentication might be required") {
+            Ok(Self::SSLAuthenticationRequired)
+        } else if s.contains("connecting to a PLAINTEXT broker listener") {
+            Ok(Self::SSLUnsupported)
+        } else if s.contains("Broker did not provide a certificate") {
+            Ok(Self::BrokerCertificateMissing)
+        } else if s.contains("Failed to verify broker certificate: ") {
+            Ok(Self::InvalidBrokerCertificate)
+        } else if let Some((_prefix, inner)) = s.split_once("Send failed: ") {
+            Ok(Self::ConnectionReset(inner.to_owned()))
+        } else if let Some((_prefix, inner)) = s.split_once("Receive failed: ") {
+            Ok(Self::ConnectionReset(inner.to_owned()))
+        } else if s.contains("request(s) timed out: disconnect") {
+            Ok(Self::ConnectionTimeout)
+        } else if s.contains("Failed to resolve") {
+            Ok(Self::HostnameResolutionFailed)
+        } else if s.contains("mechanism handshake failed:") {
+            Ok(Self::UnsupportedSASLMechanism)
+        } else if s.contains("verify that security.protocol is correctly configured, broker might require SASL authentication") {
+            Ok(Self::SASLAuthenticationRequired)
+        } else if s.contains("incorrect security.protocol configuration (connecting to a SSL listener?)") {
+            Ok(Self::SSLAuthenticationRequired)
+        } else if s.contains("probably due to broker version < 0.10") {
+            Ok(Self::UnsupportedBrokerVersion)
+        } else {
+            Err(())
+        }
+    }
+}
 
 impl ClientContext for MzClientContext {
     fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
@@ -45,6 +159,7 @@ impl ClientContext for MzClientContext {
         // but using `tracing`
         match level {
             Emerg | Alert | Critical | Error => {
+                self.record_error(log_message);
                 error!(target: "librdkafka", "{} {}", fac, log_message);
             }
             Warning => warn!(target: "librdkafka", "{} {}", fac, log_message),
@@ -55,6 +170,7 @@ impl ClientContext for MzClientContext {
     }
 
     fn error(&self, error: KafkaError, reason: &str) {
+        self.record_error(reason);
         // Refer to the comment in the `log` callback.
         error!(target: "librdkafka", "{}: {}", error, reason);
     }

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -257,7 +257,11 @@ async fn purify_create_source(
                 .ok_or_else(|| sql_err!("KAFKA CONNECTION without TOPIC"))?;
 
             let consumer = connection
-                .create_with_context(&connection_context, MzClientContext, &BTreeMap::new())
+                .create_with_context(
+                    &connection_context,
+                    MzClientContext::default(),
+                    &BTreeMap::new(),
+                )
                 .await
                 .map_err(|e| {
                     anyhow!(

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -234,7 +234,11 @@ async fn build_kafka(
     // Create Kafka topic.
     let client: AdminClient<_> = builder
         .connection
-        .create_with_context(&connection_context, MzClientContext, &BTreeMap::new())
+        .create_with_context(
+            &connection_context,
+            MzClientContext::default(),
+            &BTreeMap::new(),
+        )
         .await
         .context("creating admin client failed")?;
     ensure_kafka_topic(

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -224,16 +224,17 @@ impl KafkaSinkSendRetryManager {
 pub struct SinkProducerContext {
     metrics: Arc<SinkMetrics>,
     retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
+    inner: MzClientContext,
 }
 
 impl ClientContext for SinkProducerContext {
     // The shape of the rdkafka *Context traits require us to forward to the `MzClientContext`
     // implementation.
     fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
-        MzClientContext.log(level, fac, log_message)
+        self.inner.log(level, fac, log_message)
     }
     fn error(&self, error: KafkaError, reason: &str) {
-        MzClientContext.error(error, reason)
+        self.inner.error(error, reason)
     }
 }
 impl ProducerContext for SinkProducerContext {
@@ -425,6 +426,7 @@ impl KafkaSinkState {
         let producer_context = SinkProducerContext {
             metrics: Arc::clone(&metrics),
             retry_manager: Arc::clone(&retry_manager),
+            inner: MzClientContext::default(),
         };
 
         let healthchecker = healthchecker.map(Mutex::new);
@@ -492,7 +494,7 @@ impl KafkaSinkState {
                 .connection
                 .create_with_context(
                     connection_context,
-                    MzClientContext,
+                    MzClientContext::default(),
                     &btreemap! {
                         "group.id" => format!("materialize-bootstrap-sink-{sink_id}"),
                         "isolation.level" => "read_committed".into(),

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -191,6 +191,7 @@ impl SourceRender for KafkaSourceConnection {
                     GlueConsumerContext {
                         notificator: Arc::clone(&notificator),
                         stats_tx,
+                        inner: MzClientContext::default(),
                     },
                     &btreemap! {
                         // Default to disabling Kafka auto commit. This can be
@@ -922,6 +923,7 @@ impl PartitionConsumer {
 struct GlueConsumerContext {
     notificator: Arc<Notify>,
     stats_tx: crossbeam_channel::Sender<Jsonb>,
+    inner: MzClientContext,
 }
 
 impl ClientContext for GlueConsumerContext {
@@ -940,10 +942,10 @@ impl ClientContext for GlueConsumerContext {
     // The shape of the rdkafka *Context traits require us to forward to the `MzClientContext`
     // implementation.
     fn log(&self, level: rdkafka::config::RDKafkaLogLevel, fac: &str, log_message: &str) {
-        MzClientContext.log(level, fac, log_message)
+        self.inner.log(level, fac, log_message)
     }
     fn error(&self, error: rdkafka::error::KafkaError, reason: &str) {
-        MzClientContext.error(error, reason)
+        self.inner.error(error, reason)
     }
 }
 

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -790,14 +790,14 @@ pub async fn create_state(
         }
 
         let admin: AdminClient<_> = kafka_config
-            .create_with_context(MzClientContext)
+            .create_with_context(MzClientContext::default())
             .with_context(|| format!("opening Kafka connection: {}", config.kafka_addr))?;
 
         let admin_opts = AdminOptions::new().operation_timeout(Some(config.default_timeout));
 
         kafka_config.set("message.max.bytes", "15728640");
         let producer: FutureProducer<_> = kafka_config
-            .create_with_context(MzClientContext)
+            .create_with_context(MzClientContext::default())
             .with_context(|| format!("opening Kafka producer connection: {}", config.kafka_addr))?;
 
         let topics = BTreeMap::new();

--- a/test/kafka-sasl-plain/smoketest.td
+++ b/test/kafka-sasl-plain/smoketest.td
@@ -25,6 +25,16 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 > CREATE SECRET sasl_password AS 'sekurity'
 
 # Ensure that connectors work with SSL basic_auth
+! CREATE CONNECTION kafka_sasl TO KAFKA (
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = 'PLAIN',
+    SASL USERNAME = 'nobody',
+    SASL PASSWORD = SECRET sasl_password,
+    SSL CERTIFICATE AUTHORITY = '${arg.ca}'
+  );
+contains:Invalid username or password
+
+# Ensure that connectors work with SSL basic_auth
 > CREATE CONNECTION kafka_sasl TO KAFKA (
     BROKER 'kafka:9092',
     SASL MECHANISMS = 'PLAIN',
@@ -66,13 +76,10 @@ $ kafka-verify-data format=avro sink=materialize.public.data_snk sort-messages=t
 {"before": null, "after": {"row": {"a": 1}}}
 {"before": null, "after": {"row": {"a": 2}}}
 
-# Ensure that connectors do not require the certificate authority
-# This ensures that the error is not that the CA was required, but simply that
-# not providing it prohibits connecting.
 ! CREATE CONNECTION kafka_sasl_no_ca TO KAFKA (
     BROKER 'kafka:9092',
     SASL MECHANISMS = 'PLAIN',
     SASL USERNAME = 'materialize',
     SASL PASSWORD = SECRET sasl_password
   );
-contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
+contains:Invalid CA certificate

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -96,9 +96,12 @@ SERVICES = [
             "--ccsr-username=materialize "
             '--var=materialized-kafka-key="$$(</share/secrets/materialized-kafka.key)" '
             '--var=materialized-kafka-crt="$$(</share/secrets/materialized-kafka.crt)" '
+            '--var=materialized-kafka1-key="$$(</share/secrets/materialized-kafka1.key)" '
+            '--var=materialized-kafka1-crt="$$(</share/secrets/materialized-kafka1.crt)" '
             '--var=materialized-schema-registry-key="$$(</share/secrets/materialized-schema-registry.key)" '
             '--var=materialized-schema-registry-crt="$$(</share/secrets/materialized-schema-registry.crt)" '
             '--var=ca-crt="$$(</share/secrets/ca.crt)" '
+            '--var=ca-alt-crt="$$(</share/secrets/ca-selective.crt)" '
             '"$$@"',
         ],
         volumes_extra=["secrets:/share/secrets"],

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -23,8 +23,27 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
 {"a": 1}
 
 > CREATE SECRET ssl_key_kafka AS '${arg.materialized-kafka-key}'
+> CREATE SECRET ssl_key_kafka1 AS '${arg.materialized-kafka1-key}'
 > CREATE SECRET ssl_key_csr AS '${arg.materialized-schema-registry-key}'
 > CREATE SECRET password_csr AS 'sekurity'
+
+# Attempt to connect with the wrong certificate
+! CREATE CONNECTION kafka_ssl TO KAFKA (
+    BROKER 'kafka:9092',
+    SSL KEY = SECRET ssl_key_kafka1,
+    SSL CERTIFICATE = '${arg.materialized-kafka1-crt}',
+    SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}'
+  );
+contains:Connection reset: error:1408F119:SSL routines:ssl3_get_record:decryption failed or bad record mac
+
+# Attempt to connect with the wrong CA
+! CREATE CONNECTION kafka_ssl TO KAFKA (
+    BROKER 'kafka:9092',
+    SSL KEY = SECRET ssl_key_kafka,
+    SSL CERTIFICATE = '${arg.materialized-kafka-crt}',
+    SSL CERTIFICATE AUTHORITY = '${arg.ca-alt-crt}'
+  );
+contains:Invalid CA certificate
 
 # Ensure connections track their dependencies
 > CREATE CONNECTION kafka_ssl TO KAFKA (
@@ -137,4 +156,4 @@ a
     SSL KEY = SECRET ssl_key_kafka,
     SSL CERTIFICATE = '${arg.materialized-kafka-crt}'
   );
-contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
+contains:Invalid CA certificate

--- a/test/test-util/src/kafka/kafka_client.rs
+++ b/test/test-util/src/kafka/kafka_client.rs
@@ -36,7 +36,7 @@ impl KafkaClient {
             config.set(*key, *val);
         }
 
-        let producer = config.create_with_context(MzClientContext)?;
+        let producer = config.create_with_context(MzClientContext::default())?;
 
         Ok(KafkaClient {
             producer,

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -22,7 +22,7 @@ contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport 
 
 ! CREATE CONNECTION fawlty_kafka_conn
   TO KAFKA (BROKER 'non-existent-broker:9092');
-contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
+contains:Failed to resolve hostname
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR tries to understand what went wrong with a Kafka connection by observing the `librdkafka` error log. Unfortunately there isn't a less ugly way to get information of what happened since librdkafka has very limited error codes.
    
Fixes #12465

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
