### PR TITLE
persist: fix incorrect "dangling blob keys" WARN

### DIFF
--- a/src/persist-client/src/batch.rs
+++ b/src/persist-client/src/batch.rs
@@ -177,12 +177,14 @@ where
     /// dropped, the data that it represents will have leaked. The caller is
     /// responsible for turning this back into a [`Batch`] using
     /// [`WriteHandle::batch_from_transmittable_batch`](crate::write::WriteHandle::batch_from_transmittable_batch).
-    pub fn into_transmittable_batch(self) -> ProtoBatch {
-        ProtoBatch {
+    pub fn into_transmittable_batch(mut self) -> ProtoBatch {
+        let ret = ProtoBatch {
             shard_id: self.shard_id.into_proto(),
             version: self.version.to_string(),
             batch: Some(self.batch.into_proto()),
-        }
+        };
+        self.mark_consumed();
+        ret
     }
 }
 


### PR DESCRIPTION
In #21237, I changed how the `into_transmittable_batch` serialization worked and lost the mark_consumed call. This results in persist incorrectly concluding that the batch had been dropped without being processed in some way, and thus incorrectly warning about it.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
