### PR TITLE
dependencies: handle dependency reported as unused

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3368,7 +3368,6 @@ dependencies = [
  "once_cell",
  "open",
  "openssl-probe",
- "postgres-protocol",
  "reqwest",
  "rpassword",
  "security-framework",

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -36,7 +36,6 @@ thiserror = "1.0.37"
 uuid = "1.2.2"
 url = "2.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-postgres-protocol = "0.6.4"
 
 [dev-dependencies]
 assert_cmd = "2.0.5"


### PR DESCRIPTION
Trying to fix https://buildkite.com/materialize/nightlies/builds/3590#018a403d-444e-4a2d-a6ff-45a5ae370067.

[Removing the dependency failed,](https://buildkite.com/materialize/tests/builds/62594#018a408a-14df-4a08-9c0d-262db38ee732) so I assume this is a false positive.