### PR TITLE
expr: guard against reducing to_jsonb(bool): jsonb to _: boolean

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -253,7 +253,8 @@ impl MirRelationExpr {
                             )
                         })?;
                     } else {
-                        writeln!(f, "{}Constant <empty>", ctx.indent)?;
+                        write!(f, "{}Constant <empty>", ctx.indent)?;
+                        self.fmt_attributes(f, ctx)?;
                     }
                 }
                 Err(err) => {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -13,6 +13,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
+use mz_ore::soft_assert;
 use mz_repr::{ColumnType, Datum, ScalarType};
 
 use crate::visit::Visit;
@@ -204,6 +205,13 @@ where
 /// Additionally, it also removes IS NOT NULL predicates if there is another
 /// null rejecting predicate for the same sub-expression.
 pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types: &[ColumnType]) {
+    soft_assert!(
+        predicates
+            .iter()
+            .all(|p| p.typ(column_types).scalar_type == ScalarType::Bool),
+        "cannot canonicalize predicates that are not of type bool"
+    );
+
     // 1) Reduce each individual predicate.
     predicates.iter_mut().for_each(|p| p.reduce(column_types));
 
@@ -350,10 +358,12 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types
         completed.push(predicate_to_apply);
     }
 
-    if completed
-        .iter()
-        .any(|p| p.is_literal_false() || p.is_literal_null())
-    {
+    if completed.iter().any(|p| {
+        (p.is_literal_false() || p.is_literal_null()) &&
+        // This extra check is only needed if we determine that the soft_assert!
+        // at the top of this function would ever fail for a good reason.
+        p.typ(column_types).scalar_type == ScalarType::Bool
+    }) {
         // all rows get filtered away if any predicate is null or false.
         *predicates = vec![MirScalarExpr::literal_ok(Datum::False, ScalarType::Bool)]
     } else {

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1199,7 +1199,11 @@ impl MirScalarExpr {
                             }
                         } else if then == els {
                             *e = then.take();
-                        } else if then.is_literal_ok() && els.is_literal_ok() {
+                        } else if then.is_literal_ok()
+                            && els.is_literal_ok()
+                            && then.typ(column_types).scalar_type == ScalarType::Bool
+                            && els.typ(column_types).scalar_type == ScalarType::Bool
+                        {
                             match (then.as_literal(), els.as_literal()) {
                                 // Note: NULLs from the condition should not be propagated to the result
                                 // of the expression.

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -486,11 +486,17 @@ pub fn annotate_plan<'a>(
                 subtree_refs.iter(),
                 attributes.remove_results::<RelationType>().into_iter(),
             ) {
-                let humanized_columns = types
-                    .into_iter()
-                    .map(|c| context.humanizer.humanize_column_type(&c))
-                    .collect::<Vec<_>>();
-                let attr = bracketed("(", ")", separated(", ", humanized_columns)).to_string();
+                let attr = match types {
+                    Some(types) => {
+                        let humanized_columns = types
+                            .into_iter()
+                            .map(|c| context.humanizer.humanize_column_type(&c))
+                            .collect::<Vec<_>>();
+
+                        bracketed("(", ")", separated(", ", humanized_columns)).to_string()
+                    }
+                    None => "(<error>)".to_string(),
+                };
                 let attrs = annotations.entry(expr).or_default();
                 attrs.types = Some(attr);
             }

--- a/src/transform/tests/testdata/canonicalize_mfp
+++ b/src/transform/tests/testdata/canonicalize_mfp
@@ -23,7 +23,7 @@ build apply=CanonicalizeMfp
 (project
     (filter
         (map (get x) [(call_binary add_int64 #1 #2)])
-        [(call_binary add_int64 null #3)])
+        [(call_binary eq (call_binary add_int64 null #3) (5 Int32))])
      [#1])
 ----
 Project (#1)

--- a/src/transform/tests/testdata/let-get
+++ b/src/transform/tests/testdata/let-get
@@ -13,10 +13,10 @@ build apply=PredicatePushdown
       [[1 2 3]
        [4 5 6]]
       [int64 int64 int64])
-   (filter (get x) [#0]))
+   (filter (get x) [(call_binary eq #0 (5 Int32))]))
 ----
 Filter
-  Filter #0
+  Filter (#0 = 5)
     Constant
       - (1, 2, 3)
       - (4, 5, 6)

--- a/test/sqllogictest/github-21244.slt
+++ b/test/sqllogictest/github-21244.slt
@@ -1,0 +1,28 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+# Regression test for
+# https://github.com/MaterializeInc/materialize/issues/21244.
+
+statement ok
+CREATE TABLE r(x bool);
+
+statement ok
+CREATE VIEW v AS SELECT nullif(to_jsonb(true), to_jsonb(x)) as y FROM r;
+
+
+# When the bug is present, the type of `y` is wrongly computed as `boolean` when
+# the `(true, _)` simplification of the `case` statement resulting from the
+# desugared `nullif` is triggered in `MirScalarExpr::reduce`.
+query TTT
+SHOW COLUMNS from v;
+----
+y  true  jsonb


### PR DESCRIPTION
In certain parts of the `MirScalarExpr` handling code we trigger term simplification when a term is known to be a `boolean` literal.

Unfortunately, due to the lack of a first-class internal representation for `Jsonb` data, functions like `MirScalarExpr::is_literal_true` will return `Datum::True` for both of the following cases:

```sql
SELECT true           -- input is literal `true: boolean`
SELECT to_jsonb(true) -- input is literal `true: jsonb`
```

Consequently, we might simplify a (well-typed) `jsonb` term into a term of type `boolean`. In order to avoid that, certain places where this might happen must be guarded with additional check of the term type.

### Motivation

  * This PR fixes a recognized bug.

Fixes #21244.

### Tips for reviewer

1. The first commit contains a fix and a test.
2. The next three commits contain improvements in the `explain` code that were needed in order to find the root cause of the issue.

[Nightlies build](https://buildkite.com/materialize/nightlies/builds/3603) to check for failing `soft_assert!` at the top of the `canonicalize_predicates` definition.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
