### PR TITLE
stash-debug: Add README

### DIFF
--- a/src/stash-debug/README.md
+++ b/src/stash-debug/README.md
@@ -1,0 +1,17 @@
+# `stash-debug`
+
+This tool allows us to debug an individual customer's Stash. It connects directly to CockroachDB so
+you will need a Cloud Admin to help you.
+
+> **Note**: If you plan on running `stash-debug` more than once or on a very large Stash, we'd
+recommend compiling it in release mode, e.g. `cargo run --release -- <args>`.
+
+### `upgrade-check`
+
+To use the `upgrade-check` command you'll need to provide a mapping from cluster replica sizes to
+resource specification. To get the latest mapping check the [Pulumi config in the Cloud Repo](https://github.com/MaterializeInc/cloud/blob/main/Pulumi.production.yaml), search for "cluster_replica_sizes".
+
+A nice oneliner for converting from YAML to JSON is:
+```
+python -c 'import sys,json,yaml; print(json.dumps(yaml.safe_load(sys.stdin.read())))'
+```

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -143,6 +143,7 @@ enum Action {
     /// non-zero. Can be used on a running environmentd. Operates without
     /// interfering with it or committing any data to that stash.
     UpgradeCheck {
+        /// Map of cluster name to resource specification. Check the README for latest values.
         cluster_replica_sizes: Option<String>,
     },
 }


### PR DESCRIPTION
This PR adds a README to the `stash-debug` crate with some guidance on how to run the tool. Concretely it adds an explainer for what the `cluster_replica_sizes` argument for upgrade check is, and what to populate it with.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
