### PR TITLE
adapter: improve handle_terminate debugability

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -647,6 +647,7 @@ impl SessionClient {
             .send_without_session(|tx| Command::Terminate {
                 conn_id,
                 tx: Some(tx),
+                source: "client terminate",
             })
             .await;
         if let Err(e) = res {
@@ -794,6 +795,7 @@ impl Drop for SessionClient {
                 inner.send(Command::Terminate {
                     conn_id: session.conn_id().clone(),
                     tx: None,
+                    source: "SessionClient drop",
                 })
             }
         }

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -122,6 +122,7 @@ pub enum Command {
     Terminate {
         conn_id: ConnectionId,
         tx: Option<oneshot::Sender<Result<(), AdapterError>>>,
+        source: &'static str,
     },
 
     /// Performs any cleanup and logging actions necessary for

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -87,6 +87,7 @@ impl<T: Transmittable + std::fmt::Debug> ClientTransmitter<T> {
                 .send(Message::Command(Command::Terminate {
                     conn_id: res.session.conn_id().clone(),
                     tx: None,
+                    source: "client transmitter unable to send",
                 }))
                 .expect("coordinator unexpectedly gone");
         }


### PR DESCRIPTION
Add a bit more context to attempt to identify what's causing unexpected termination.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a