### PR TITLE
mz: enable timing for the sql command

### DIFF
--- a/src/mz/src/error.rs
+++ b/src/mz/src/error.rs
@@ -99,4 +99,7 @@ pub enum Error {
     /// but `pg_isready` fails
     #[error("The region is not ready to accept SQL statements. `pg_isready` failed.")]
     NotPgReadyError,
+    /// Error that occurs when attempting to find the home directory.
+    #[error("An error occurred while trying to find the home directory.")]
+    HomeDirNotFoundError,
 }

--- a/src/mz/src/sql_client.rs
+++ b/src/mz/src/sql_client.rs
@@ -8,7 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use std::{
-    env, fs::OpenOptions,
+    env,
+    fs::OpenOptions,
     io::Write,
     path::{Path, PathBuf},
     process::Command,
@@ -81,7 +82,11 @@ impl Client {
 
     /// Creates and fills a file with content
     /// if it does not exists.
-    fn create_file_with_content_if_not_exists(&self, path: &PathBuf, content: Option<&[u8]>) -> Result<(), Error> {
+    fn create_file_with_content_if_not_exists(
+        &self,
+        path: &PathBuf,
+        content: Option<&[u8]>,
+    ) -> Result<(), Error> {
         // Create the new file and use `.create_new(true)` to avoid
         // race conditions: https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.create_new
         match OpenOptions::new().write(true).create_new(true).open(&path) {
@@ -94,7 +99,7 @@ impl Client {
                 if e.kind() == std::io::ErrorKind::AlreadyExists {
                     // Do nothing.
                 } else {
-                    return Err(Error::IOError(e))
+                    return Err(Error::IOError(e));
                 }
             }
         }
@@ -112,7 +117,10 @@ impl Client {
         };
         path.push(PG_PSQLRC_MZ_FILENAME);
 
-        let _ = self.create_file_with_content_if_not_exists(&path, Some(PG_PSQLRC_MZ_DEFAULT_CONTENT.as_bytes()));
+        let _ = self.create_file_with_content_if_not_exists(
+            &path,
+            Some(PG_PSQLRC_MZ_DEFAULT_CONTENT.as_bytes()),
+        );
 
         // Check if '.psqlrc' exists, if it doesn't, create one.
         // Otherwise the '\include ~/.psqlrc' line

--- a/src/mz/src/sql_client.rs
+++ b/src/mz/src/sql_client.rs
@@ -89,7 +89,7 @@ impl Client {
     ) -> Result<(), Error> {
         // Create the new file and use `.create_new(true)` to avoid
         // race conditions: https://doc.rust-lang.org/stable/std/fs/struct.OpenOptions.html#method.create_new
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
+        match OpenOptions::new().write(true).create_new(true).open(path) {
             Ok(mut file) => {
                 if let Some(content) = content {
                     let _ = file.write_all(content);

--- a/src/mz/tests/e2e.rs
+++ b/src/mz/tests/e2e.rs
@@ -75,7 +75,7 @@
 
 #[cfg(test)]
 mod tests {
-    use std::{fs, time::Duration};
+    use std::{fs, io::Read, path::Path, time::Duration};
 
     use assert_cmd::{assert::Assert, Command};
     use mz::{config_file::ConfigFile, ui::OptionalStr};
@@ -574,6 +574,24 @@ mod tests {
             .arg("\"SELECT 1\"")
             .assert()
             .success();
+
+        // Look for the '.psqlrc' file in the home dir.
+        let mut path = dirs::home_dir().expect("Error retrieving the home dir.");
+        path.push(".psqlrc-mz");
+
+        // Verify the content is ok
+        if Path::new(&path).exists() {
+            let mut file = fs::File::open(&path).expect("Error opening the '.psqlrc-mz' file.");
+            let mut content = String::new();
+            file.read_to_string(&mut content)
+                .expect("Error reading the '.psqlrc-mz' file.");
+
+            if content != "\\timing\n\\include ~/.psqlrc" {
+                panic!("Incorrect content in the '.psqlrc-mz' file.")
+            }
+        } else {
+            panic!("The configuration file '.psqlrc-mz', does not exists.")
+        }
 
         // TODO: Remove an app-password. Breaks the CLI config. The same if the app-password is invalid.
         // TODO: Add more tests for config_set and config_remove when you implement the actual commands.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR enables `\timing` by default for the `mz sql` command!

More context about the [implementation here.](https://github.com/MaterializeInc/materialize/issues/16878)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
