### PR TITLE
webhook: Fix papercut with reporting of webhook source statuses

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2012,7 +2012,11 @@ SELECT
     name,
     mz_sources.type,
     occurred_at as last_status_change_at,
-    coalesce(status, 'created') as status,
+    -- TODO(parkmycar): Report status of webhook source once #20036 is closed.
+    CASE
+        WHEN mz_sources.type = 'webhook' THEN 'running'
+        ELSE coalesce(status, 'created')
+    END status,
     error,
     details
 FROM mz_sources

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -309,6 +309,20 @@ statement error cannot create source in cluster containing indexes or materializ
 CREATE SOURCE webhook_on_compute_cluster IN CLUSTER compute_cluster FROM WEBHOOK
   BODY FORMAT BYTES;
 
+# Make sure we report webhook sources as running.
+
+query TTTT
+SELECT name, type, status, error FROM mz_internal.mz_source_statuses WHERE name = 'webhook_bytes'
+----
+webhook_bytes webhook running NULL
+
+statement ok
+DROP SOURCE webhook_bytes;
+
+query TTTT
+SELECT name, type, status, error FROM mz_internal.mz_source_statuses WHERE name = 'webhook_bytes'
+----
+
 # Cleanup.
 statement ok
 DROP CLUSTER webhook_cluster CASCADE;


### PR DESCRIPTION
This PR updates the `mz_source_statuses` BuiltinView to have a default status of "running" for webhook sources. It's known that webhook sources don't currently report any status since the mechanism to do so is within clusterd, meanwhile webhook sources run in environmentd. There is ongoing work to change this, see https://github.com/MaterializeInc/materialize/issues/20036.

For now to improve this UX papercut we change the default status of webhook sources to "running" instead of "created", since currently there is no distinction between the two for webhooks.

### Motivation

* This PR fixes a previously unreported bug.

In the `mz_source_statuses` BuiltinView which powers the web console, we report all webhook sources as "Created" whereas the healthy state for all sources is "Running". [Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1692724790997529)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Changes the user facing status of webhooks from "created" to "running" to unify the UX for source status reporting.
