### PR TITLE
adapter: Update RBAC defaults

### DIFF
--- a/doc/user/content/manage/access-control/_index.md
+++ b/doc/user/content/manage/access-control/_index.md
@@ -10,8 +10,6 @@ menu:
     weight: 15
 ---
 
-{{< private-preview />}}
-
 This page introduces role-based access management (RBAC) in Materialize. RBAC
 allows you to apply granular privileges to your Materialize objects and clusters. Organizations
 using RBAC can manage user roles and privileges to ensure there is not

--- a/doc/user/content/manage/access-control/manage-privileges.md
+++ b/doc/user/content/manage/access-control/manage-privileges.md
@@ -7,8 +7,6 @@ menu:
     weight: 20
 ---
 
-{{< private-preview />}}
-
 This page outlines how to assign and manage role privileges.
 
 ## Grant privileges

--- a/doc/user/content/manage/access-control/manage-roles.md
+++ b/doc/user/content/manage/access-control/manage-roles.md
@@ -7,8 +7,6 @@ menu:
     weight: 15
 ---
 
-{{< private-preview />}}
-
 This page outlines how to create and manage roles in Materialize.
 
 ## Create a role

--- a/doc/user/content/manage/access-control/rbac-terraform-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-terraform-tutorial.md
@@ -7,8 +7,6 @@ menu:
     weight: 25
 ---
 
-{{< private-preview />}}
-
 This tutorial walks you through managing roles in Materialize with [Terraform](https://www.terraform.io/). By the end of this tutorial you will:
 
 * Create two new roles in your Materialize

--- a/doc/user/content/manage/access-control/rbac-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-tutorial.md
@@ -7,8 +7,6 @@ menu:
     weight: 25
 ---
 
-{{< private-preview />}}
-
 This tutorial walks you through creating a new user and managing roles in Materialize. By
 the end of this tutorial you will:
 

--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -22,8 +22,6 @@ The `REVOKE` variant of `ALTER DEFAULT PRIVILEGES` is used to revoke previously 
 privileges on objects created in the future. It will not revoke any privileges on objects that have
 already been created.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "alter-default-privileges.svg" >}}

--- a/doc/user/content/sql/alter-owner.md
+++ b/doc/user/content/sql/alter-owner.md
@@ -8,8 +8,6 @@ menu:
 
 `ALTER ... OWNER` updates the owner of an item.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "alter-owner.svg" >}}

--- a/doc/user/content/sql/alter-role.md
+++ b/doc/user/content/sql/alter-role.md
@@ -8,8 +8,6 @@ menu:
 
 `ALTER ROLE` alters the attributes of an existing role.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "alter-role.svg" >}}

--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -11,8 +11,6 @@ menu:
 When you connect to Materialize, you must specify the name of a valid role in
 the system.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "create-role.svg" >}}

--- a/doc/user/content/sql/drop-role.md
+++ b/doc/user/content/sql/drop-role.md
@@ -8,8 +8,6 @@ menu:
 
 `DROP ROLE` removes a role from Materialize.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "drop-role.svg" >}}

--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -14,8 +14,6 @@ Privileges are cumulative: revoking a privilege from `PUBLIC` does not mean all
 roles have lost that privilege, if certain roles were explicitly granted that
 privilege.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "grant-privilege.svg" >}}

--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -9,8 +9,6 @@ menu:
 `GRANT` grants membership of one role to another role. Roles can be members of
 other roles, as well as inherit all the privileges of those roles.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "grant-role.svg" >}}

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -10,8 +10,6 @@ menu:
 be used to indicate that the privileges should be revoked from all roles
 (including roles that might not exist yet).
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "revoke-privilege.svg" >}}

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -10,8 +10,6 @@ menu:
 of other roles, as well as inherit all the privileges of those
 roles. This membership can also be revoked.
 
-{{< private-preview />}}
-
 ## Syntax
 
 {{< diagram "revoke-role.svg" >}}

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2379,7 +2379,11 @@ fn test_peek_on_dropped_cluster() {
         .unwrap();
 
     // Drop cluster that query is running on, and table that query is selecting from.
-    let mut drop_client = server.connect(postgres::NoTls).unwrap();
+    let mut drop_client = server
+        .pg_config_internal()
+        .user(&SYSTEM_USER.name)
+        .connect(postgres::NoTls)
+        .unwrap();
     drop_client.batch_execute("DROP CLUSTER default;").unwrap();
     drop_client.batch_execute("DROP TABLE t;").unwrap();
     handle.join().unwrap();

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1152,8 +1152,7 @@ static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> 
 
 pub const ENABLE_LD_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_ld_rbac_checks"),
-    // TODO(jkosh44) Once RBAC is complete, change this to `true`.
-    value: &false,
+    value: &true,
     description:
         "LD facing global boolean flag that allows turning RBAC off for everyone (Materialize).",
     internal: true,
@@ -1161,8 +1160,7 @@ pub const ENABLE_LD_RBAC_CHECKS: ServerVar<bool> = ServerVar {
 
 pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_rbac_checks"),
-    // TODO(jkosh44) Once RBAC is complete, change this to `true`.
-    value: &false,
+    value: &true,
     description: "User facing global boolean flag indicating whether to apply RBAC checks before \
     executing statements (Materialize).",
     internal: false,

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -46,5 +46,9 @@
   {
     "name": "objects_v35.proto",
     "md5": "7d989b1afbbf906cb6fcc72fab67aba2"
+  },
+  {
+    "name": "objects_v36.proto",
+    "md5": "7e7dabc91c90e5cdd22391e50c689c35"
   }
 ]

--- a/src/stash/protos/objects_v36.proto
+++ b/src/stash/protos/objects_v36.proto
@@ -1,0 +1,613 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+// This protobuf file defines the types we store in the Stash.
+//
+// Before and after modifying this file, make sure you have a snapshot of the before version,
+// e.g. a copy of this file named 'objects_v{STASH_VERSION}.proto', and a snapshot of the file
+// after your modifications, e.g. 'objects_v{STASH_VERSION + 1}.proto'. Then you can write a
+// migration using these two files, and no matter how they types change in the future, we'll always
+// have these snapshots to facilitate the migration.
+
+
+syntax = "proto3";
+
+package objects_v36;
+
+message ConfigKey {
+    string key = 1;
+}
+
+message ConfigValue {
+    uint64 value = 1;
+}
+
+message SettingKey {
+    string name = 1;
+}
+
+message SettingValue {
+    string value = 1;
+}
+
+message IdAllocKey {
+    string name = 1;
+}
+
+message IdAllocValue {
+    uint64 next_id = 1;
+}
+
+message GidMappingKey {
+    string schema_name = 1;
+    CatalogItemType object_type = 2;
+    string object_name = 3;
+}
+
+message GidMappingValue {
+    uint64 id = 1;
+    string fingerprint = 2;
+}
+
+message ClusterKey {
+    ClusterId id = 1;
+}
+
+message ClusterValue {
+    string name = 1;
+    GlobalId linked_object_id = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+    ClusterConfig config = 5;
+}
+
+message ClusterIntrospectionSourceIndexKey {
+    ClusterId cluster_id = 1;
+    string name = 2;
+}
+
+message ClusterIntrospectionSourceIndexValue {
+    uint64 index_id = 1;
+}
+
+message ClusterReplicaKey {
+    ReplicaId id = 1;
+}
+
+message ClusterReplicaValue {
+    ClusterId cluster_id = 1;
+    string name = 2;
+    ReplicaConfig config = 3;
+    RoleId owner_id = 4;
+}
+
+message DatabaseKey {
+    DatabaseId id = 1;
+}
+
+message DatabaseValue {
+    string name = 1;
+    RoleId owner_id = 2;
+    repeated MzAclItem privileges = 3;
+}
+
+message SchemaKey {
+    SchemaId id = 1;
+}
+
+message SchemaValue {
+    DatabaseId database_id = 1;
+    string name = 2;
+    RoleId owner_id = 3;
+    repeated MzAclItem privileges = 4;
+}
+
+message ItemKey {
+    GlobalId gid = 1;
+}
+
+message ItemValue {
+    SchemaId schema_id = 1;
+    string name = 2;
+    CatalogItem definition = 3;
+    RoleId owner_id = 4;
+    repeated MzAclItem privileges = 5;
+}
+
+message RoleKey {
+    RoleId id = 1;
+}
+
+message RoleValue {
+    string name = 1;
+    RoleAttributes attributes = 2;
+    RoleMembership membership = 3;
+}
+
+message TimestampKey {
+    string id = 1;
+}
+
+message TimestampValue {
+    Timestamp ts = 1;
+}
+
+message ServerConfigurationKey {
+    string name = 1;
+}
+
+message ServerConfigurationValue {
+    string value = 1;
+}
+
+message AuditLogKey {
+    oneof event {
+        AuditLogEventV1 v1 = 1;
+    }
+}
+
+message StorageUsageKey {
+    message StorageUsageV1 {
+        uint64 id = 1;
+        StringWrapper shard_id = 2;
+        uint64 size_bytes = 3;
+        EpochMillis collection_timestamp = 4;
+    }
+
+    oneof usage {
+        StorageUsageV1 v1 = 1;
+    }
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+message CommentKey {
+    // TODO(parkmycar): Support comments on more kinds of objects.
+    oneof object {
+        GlobalId table = 1;
+        GlobalId view = 2;
+    }
+    oneof sub_component {
+        uint64 column_pos = 3;
+    }
+}
+
+message CommentValue {
+    string comment = 1;
+}
+
+// ---- Common Types
+//
+// Note: Normally types like this would go in some sort of `common.proto` file, but we want to keep
+// our proto definitions in a single file to make snapshotting easier, hence them living here.
+
+message Empty { /* purposefully empty */ }
+
+// In protobuf a "None" string is the same thing as an empty string. To get the same semantics of
+// an `Option<String>` from Rust, we need to wrap a string in a message.
+message StringWrapper {
+    string inner = 1;
+}
+
+message Duration {
+    uint64 secs = 1;
+    uint32 nanos = 2;
+}
+
+message EpochMillis {
+    uint64 millis = 1;
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+enum CatalogItemType {
+    CATALOG_ITEM_TYPE_UNKNOWN = 0;
+    CATALOG_ITEM_TYPE_TABLE = 1;
+    CATALOG_ITEM_TYPE_SOURCE = 2;
+    CATALOG_ITEM_TYPE_SINK = 3;
+    CATALOG_ITEM_TYPE_VIEW = 4;
+    CATALOG_ITEM_TYPE_MATERIALIZED_VIEW = 5;
+    CATALOG_ITEM_TYPE_INDEX = 6;
+    CATALOG_ITEM_TYPE_TYPE = 7;
+    CATALOG_ITEM_TYPE_FUNC = 8;
+    CATALOG_ITEM_TYPE_SECRET = 9;
+    CATALOG_ITEM_TYPE_CONNECTION = 10;
+}
+
+message CatalogItem {
+    message V1 {
+        string create_sql = 1;
+    }
+
+    oneof value {
+        V1 v1 = 1;
+    }
+}
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        Empty explain = 4;
+    }
+}
+
+message ClusterId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message DatabaseId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message SchemaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+    }
+}
+
+message ReplicaLogging {
+    bool log_logging = 1;
+    Duration interval = 2;
+}
+
+message ReplicaMergeEffort {
+    uint32 effort = 1;
+}
+
+message ClusterConfig {
+    message ManagedCluster {
+        string size = 1;
+        uint32 replication_factor = 2;
+        repeated string availability_zones = 3;
+        ReplicaLogging logging = 4;
+        ReplicaMergeEffort idle_arrangement_merge_effort = 5;
+        bool disk = 6;
+    }
+
+    oneof variant {
+        Empty unmanaged = 1;
+        ManagedCluster managed = 2;
+    }
+}
+
+message ReplicaConfig {
+    message UnmanagedLocation {
+        repeated string storagectl_addrs = 1;
+        repeated string storage_addrs = 2;
+        repeated string computectl_addrs = 3;
+        repeated string compute_addrs = 4;
+        uint64 workers = 5;
+    }
+
+    message ManagedLocation {
+        string size = 1;
+        optional string availability_zone = 2;
+        bool disk = 4;
+    }
+
+    oneof location {
+        UnmanagedLocation unmanaged = 1;
+        ManagedLocation managed = 2;
+    }
+    ReplicaLogging logging = 3;
+    ReplicaMergeEffort idle_arrangement_merge_effort = 4;
+}
+
+message RoleId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        Empty public = 3;
+    }
+}
+
+message RoleAttributes {
+    bool inherit = 1;
+}
+
+message RoleMembership {
+    message Entry {
+        RoleId key = 1;
+        RoleId value = 2;
+    }
+
+    repeated Entry map = 1;
+}
+
+message AclMode {
+    // A bit flag representing all the privileges that can be granted to a role.
+    uint64 bitflags = 1;
+}
+
+message MzAclItem {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+    AclMode acl_mode = 3;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+enum ObjectType {
+    OBJECT_TYPE_UNKNOWN = 0;
+    OBJECT_TYPE_TABLE = 1;
+    OBJECT_TYPE_VIEW = 2;
+    OBJECT_TYPE_MATERIALIZED_VIEW = 3;
+    OBJECT_TYPE_SOURCE = 4;
+    OBJECT_TYPE_SINK = 5;
+    OBJECT_TYPE_INDEX = 6;
+    OBJECT_TYPE_TYPE = 7;
+    OBJECT_TYPE_ROLE = 8;
+    OBJECT_TYPE_CLUSTER = 9;
+    OBJECT_TYPE_CLUSTER_REPLICA = 10;
+    OBJECT_TYPE_SECRET = 11;
+    OBJECT_TYPE_CONNECTION = 12;
+    OBJECT_TYPE_DATABASE = 13;
+    OBJECT_TYPE_SCHEMA = 14;
+    OBJECT_TYPE_FUNC = 15;
+}
+
+message DefaultPrivilegesKey {
+    RoleId role_id = 1;
+    DatabaseId database_id = 2;
+    SchemaId schema_id = 3;
+    ObjectType object_type = 4;
+    RoleId grantee = 5;
+}
+
+message DefaultPrivilegesValue {
+    AclMode privileges = 1;
+}
+
+message SystemPrivilegesKey {
+    RoleId grantee = 1;
+    RoleId grantor = 2;
+}
+
+message SystemPrivilegesValue {
+    AclMode acl_mode = 1;
+}
+
+message AuditLogEventV1 {
+    enum EventType {
+        EVENT_TYPE_UNKNOWN = 0;
+        EVENT_TYPE_CREATE = 1;
+        EVENT_TYPE_DROP = 2;
+        EVENT_TYPE_ALTER = 3;
+        EVENT_TYPE_GRANT = 4;
+        EVENT_TYPE_REVOKE = 5;
+    }
+
+    enum ObjectType {
+        OBJECT_TYPE_UNKNOWN = 0;
+        OBJECT_TYPE_CLUSTER = 1;
+        OBJECT_TYPE_CLUSTER_REPLICA = 2;
+        OBJECT_TYPE_CONNECTION = 3;
+        OBJECT_TYPE_DATABASE = 4;
+        OBJECT_TYPE_FUNC = 5;
+        OBJECT_TYPE_INDEX = 6;
+        OBJECT_TYPE_MATERIALIZED_VIEW = 7;
+        OBJECT_TYPE_ROLE = 8;
+        OBJECT_TYPE_SECRET = 9;
+        OBJECT_TYPE_SCHEMA = 10;
+        OBJECT_TYPE_SINK = 11;
+        OBJECT_TYPE_SOURCE = 12;
+        OBJECT_TYPE_TABLE = 13;
+        OBJECT_TYPE_TYPE = 14;
+        OBJECT_TYPE_VIEW = 15;
+        OBJECT_TYPE_SYSTEM = 16;
+    }
+
+    message IdFullNameV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    message FullNameV1 {
+        string database = 1;
+        string schema = 2;
+        string item = 3;
+    }
+
+    message IdNameV1 {
+        string id = 1;
+        string name = 2;
+    }
+
+    message RenameClusterV1 {
+        string id = 1;
+        string old_name = 2;
+        string new_name = 3;
+    }
+
+    message RenameClusterReplicaV1 {
+        string cluster_id = 1;
+        string replica_id = 2;
+        string old_name = 3;
+        string new_name = 4;
+    }
+
+    message RenameItemV1 {
+        string id = 1;
+        FullNameV1 old_name = 2;
+        FullNameV1 new_name = 3;
+    }
+
+    message CreateClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+        string logical_size = 5;
+        bool disk = 6;
+    }
+
+    message DropClusterReplicaV1 {
+        string cluster_id = 1;
+        string cluster_name = 2;
+        StringWrapper replica_id = 3;
+        string replica_name = 4;
+    }
+
+    message CreateSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+    }
+
+    message CreateSourceSinkV2 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper size = 3;
+        string external_type = 4;
+    }
+
+    message AlterSourceSinkV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_size = 3;
+        StringWrapper new_size = 4;
+    }
+
+    message AlterSetClusterV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+        StringWrapper old_cluster = 3;
+        StringWrapper new_cluster = 4;
+    }
+
+    message GrantRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+    }
+
+    message GrantRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message RevokeRoleV1 {
+        string role_id = 1;
+        string member_id = 2;
+    }
+
+    message RevokeRoleV2 {
+        string role_id = 1;
+        string member_id = 2;
+        string grantor_id = 3;
+        string executed_by = 4;
+    }
+
+    message UpdatePrivilegeV1 {
+        string object_id = 1;
+        string grantee_id = 2;
+        string grantor_id = 3;
+        string privileges = 4;
+    }
+
+    message AlterDefaultPrivilegeV1 {
+        string role_id = 1;
+        StringWrapper database_id = 2;
+        StringWrapper schema_id = 3;
+        string grantee_id= 4;
+        string privileges = 5;
+    }
+
+    message UpdateOwnerV1 {
+        string object_id = 1;
+        string old_owner_id = 2;
+        string new_owner_id = 3;
+    }
+
+    message SchemaV1 {
+        string id = 1;
+        string name = 2;
+        string database_name = 3;
+    }
+
+    message SchemaV2 {
+        string id = 1;
+        string name = 2;
+        StringWrapper database_name = 3;
+    }
+
+    message UpdateItemV1 {
+        string id = 1;
+        FullNameV1 name = 2;
+    }
+
+    uint64 id = 1;
+    EventType event_type = 2;
+    ObjectType object_type = 3;
+    StringWrapper user = 4;
+    EpochMillis occurred_at = 5;
+
+    // next-id: 27
+    oneof details {
+        CreateClusterReplicaV1 create_cluster_replica_v1 = 6;
+        DropClusterReplicaV1 drop_cluster_replica_v1 = 7;
+        CreateSourceSinkV1 create_source_sink_v1 = 8;
+        CreateSourceSinkV2 create_source_sink_v2 = 9;
+        AlterSourceSinkV1 alter_source_sink_v1 = 10;
+        AlterSetClusterV1 alter_set_cluster_v1 = 25;
+        GrantRoleV1 grant_role_v1 = 11;
+        GrantRoleV2 grant_role_v2 = 12;
+        RevokeRoleV1 revoke_role_v1 = 13;
+        RevokeRoleV2 revoke_role_v2 = 14;
+        UpdatePrivilegeV1 update_privilege_v1 = 22;
+        AlterDefaultPrivilegeV1 alter_default_privilege_v1 = 23;
+        UpdateOwnerV1 update_owner_v1 = 24;
+        IdFullNameV1 id_full_name_v1 = 15;
+        RenameClusterV1 rename_cluster_v1 = 20;
+        RenameClusterReplicaV1 rename_cluster_replica_v1 = 21;
+        RenameItemV1 rename_item_v1 = 16;
+        IdNameV1 id_name_v1 = 17;
+        SchemaV1 schema_v1 = 18;
+        SchemaV2 schema_v2 = 19;
+        UpdateItemV1 update_item_v1 = 26;
+    }
+}

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 35;
+pub const STASH_VERSION: u64 = 36;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -918,6 +918,7 @@ impl Stash {
                             32 => upgrade::v32_to_v33::upgrade(&mut tx).await?,
                             33 => upgrade::v33_to_v34::upgrade(&mut tx).await?,
                             34 => upgrade::v34_to_v35::upgrade(&mut tx).await?,
+                            35 => upgrade::v35_to_v36::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -56,6 +56,7 @@ pub(crate) mod v31_to_v32;
 pub(crate) mod v32_to_v33;
 pub(crate) mod v33_to_v34;
 pub(crate) mod v34_to_v35;
+pub(crate) mod v35_to_v36;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v35_to_v36.rs
+++ b/src/stash/src/upgrade/v35_to_v36.rs
@@ -1,0 +1,196 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+
+use crate::objects::{wire_compatible, WireCompatible};
+use crate::upgrade::MigrationAction;
+use crate::{StashError, Transaction, TypedCollection};
+
+pub mod v35 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v35.rs"));
+}
+
+pub mod v36 {
+    include!(concat!(env!("OUT_DIR"), "/objects_v36.rs"));
+}
+
+wire_compatible!(v35::ServerConfigurationKey with v36::ServerConfigurationKey);
+wire_compatible!(v35::ServerConfigurationValue with v36::ServerConfigurationValue);
+
+const SYSTEM_CONFIGURATION_COLLECTION: TypedCollection<
+    v35::ServerConfigurationKey,
+    v35::ServerConfigurationValue,
+> = TypedCollection::new("system_configuration");
+
+const ENABLE_LD_RBAC_CHECKS_NAME: &str = "enable_ld_rbac_checks";
+const ENABLE_RBAC_CHECKS_NAME: &str = "enable_rbac_checks";
+
+/// Persist `false` for existing environments' RBAC flags, iff they're not already set.
+pub async fn upgrade(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    SYSTEM_CONFIGURATION_COLLECTION
+        .migrate_to(
+            tx,
+            |entries: &BTreeMap<v35::ServerConfigurationKey, v35::ServerConfigurationValue>| {
+                let mut updates = Vec::with_capacity(entries.len());
+                let mut found_ld_flag = false;
+                let mut found_user_flag = false;
+
+                for (key, value) in entries {
+                    if key.name == ENABLE_LD_RBAC_CHECKS_NAME {
+                        found_ld_flag = true;
+                    } else if key.name == ENABLE_RBAC_CHECKS_NAME {
+                        found_user_flag = true;
+                    }
+
+                    let new_key: v36::ServerConfigurationKey = WireCompatible::convert(key.clone());
+                    let new_value: v36::ServerConfigurationValue =
+                        WireCompatible::convert(value.clone());
+                    updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
+                }
+
+                if !found_ld_flag {
+                    updates.push(MigrationAction::Insert(
+                        v36::ServerConfigurationKey {
+                            name: ENABLE_LD_RBAC_CHECKS_NAME.to_string(),
+                        },
+                        v36::ServerConfigurationValue {
+                            value: false.to_string(),
+                        },
+                    ));
+                }
+
+                if !found_user_flag {
+                    updates.push(MigrationAction::Insert(
+                        v36::ServerConfigurationKey {
+                            name: ENABLE_RBAC_CHECKS_NAME.to_string(),
+                        },
+                        v36::ServerConfigurationValue {
+                            value: false.to_string(),
+                        },
+                    ));
+                }
+
+                updates
+            },
+        )
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DebugStashFactory;
+
+    use super::*;
+
+    const SYSTEM_CONFIGURATION_COLLECTION_V36: TypedCollection<
+        v36::ServerConfigurationKey,
+        v36::ServerConfigurationValue,
+    > = TypedCollection::new("system_configuration");
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test_existing_flags() {
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        SYSTEM_CONFIGURATION_COLLECTION
+            .insert_without_overwrite(
+                &mut stash,
+                vec![
+                    (
+                        v35::ServerConfigurationKey {
+                            name: ENABLE_LD_RBAC_CHECKS_NAME.to_string(),
+                        },
+                        v35::ServerConfigurationValue {
+                            value: true.to_string(),
+                        },
+                    ),
+                    (
+                        v35::ServerConfigurationKey {
+                            name: ENABLE_RBAC_CHECKS_NAME.to_string(),
+                        },
+                        v35::ServerConfigurationValue {
+                            value: true.to_string(),
+                        },
+                    ),
+                ],
+            )
+            .await
+            .unwrap();
+
+        // Run the migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let mut system_configs: Vec<_> = SYSTEM_CONFIGURATION_COLLECTION_V36
+            .peek_one(&mut stash)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(key, value)| (key.name, value.value))
+            .collect();
+        system_configs.sort();
+
+        assert_eq!(
+            system_configs,
+            vec![
+                (ENABLE_LD_RBAC_CHECKS_NAME.to_string(), true.to_string()),
+                (ENABLE_RBAC_CHECKS_NAME.to_string(), true.to_string()),
+            ]
+        );
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test_empty_flags() {
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open_debug().await;
+
+        SYSTEM_CONFIGURATION_COLLECTION
+            .insert_without_overwrite(&mut stash, vec![])
+            .await
+            .unwrap();
+
+        // Run the migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let mut system_configs: Vec<_> = SYSTEM_CONFIGURATION_COLLECTION_V36
+            .peek_one(&mut stash)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|(key, value)| (key.name, value.value))
+            .collect();
+        system_configs.sort();
+
+        assert_eq!(
+            system_configs,
+            vec![
+                (ENABLE_LD_RBAC_CHECKS_NAME.to_string(), false.to_string()),
+                (ENABLE_RBAC_CHECKS_NAME.to_string(), false.to_string()),
+            ]
+        );
+    }
+}

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -220,6 +220,10 @@ CommandComplete {"tag":"CREATE DATABASE"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for CLUSTER \"default\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for DATABASE \"materialize\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for SCHEMA \"materialize.public\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for SYSTEM"}]}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active database \"d4\" has been dropped"}]}
 CommandComplete {"tag":"DROP OWNED"}
 ReadyForQuery {"status":"I"}
@@ -280,6 +284,10 @@ CommandComplete {"tag":"CREATE CLUSTER"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"SET"}
 ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for CLUSTER \"default\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for DATABASE \"materialize\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for SCHEMA \"materialize.public\""}]}
+NoticeResponse {"fields":[{"typ":"S","value":"WARNING"},{"typ":"C","value":"01000"},{"typ":"M","value":"no privileges could be revoked for SYSTEM"}]}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"active cluster \"c4\" has been dropped"}]}
 CommandComplete {"tag":"DROP OWNED"}
 ReadyForQuery {"status":"I"}
@@ -301,7 +309,6 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"RBAC is disabled so no role attributes or object ownership will be considered when executing statements"}]}
 CommandComplete {"tag":"CREATE ROLE"}
 ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"CLUSTER \"foo\" does not exist, skipping"}]}

--- a/test/pgtest/notice.pt
+++ b/test/pgtest/notice.pt
@@ -57,7 +57,6 @@ NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"SCHEMA \"t\" does not exist, skipping"}]}
 CommandComplete {"tag":"DROP SCHEMA"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"RBAC is disabled so no role attributes or object ownership will be considered when executing statements"}]}
 CommandComplete {"tag":"CREATE ROLE"}
 ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"ROLE \"s\" does not exist, skipping"}]}
@@ -94,7 +93,6 @@ ReadyForQuery
 ReadyForQuery
 ReadyForQuery
 ----
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"RBAC is disabled so no role attributes or object ownership will be considered when executing statements"}]}
 CommandComplete {"tag":"CREATE ROLE"}
 ReadyForQuery {"status":"I"}
 NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"42704"},{"typ":"M","value":"DATABASE \"d\" does not exist, skipping"}]}


### PR DESCRIPTION
This PR updates the default value of the RBAC system variables to true.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Enable RBAC for all new environments.
