### PR TITLE
adapter: inline connections

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -33,6 +33,7 @@ use mz_sql::catalog::{
 use mz_sql::func::FuncImplCatalogDetails;
 use mz_sql::names::{CommentObjectId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier};
 use mz_sql_parser::ast::display::AstDisplay;
+use mz_storage_client::types::connections::inline::ReferencedConnection;
 use mz_storage_client::types::connections::KafkaConnection;
 use mz_storage_client::types::sinks::{KafkaSinkConnection, StorageSinkConnection};
 use mz_storage_client::types::sources::{
@@ -503,7 +504,7 @@ impl CatalogState {
     fn pack_postgres_source_update(
         &self,
         id: GlobalId,
-        postgres: &PostgresSourceConnection,
+        postgres: &PostgresSourceConnection<ReferencedConnection>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
@@ -519,7 +520,7 @@ impl CatalogState {
     fn pack_kafka_source_update(
         &self,
         id: GlobalId,
-        kafka: &KafkaSourceConnection,
+        kafka: &KafkaSourceConnection<ReferencedConnection>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         vec![BuiltinTableUpdate {
@@ -622,7 +623,7 @@ impl CatalogState {
     fn pack_kafka_connection_update(
         &self,
         id: GlobalId,
-        kafka: &KafkaConnection,
+        kafka: &KafkaConnection<ReferencedConnection>,
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let progress_topic_holder;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -111,6 +111,7 @@ use mz_sql::session::vars::ConnectionCounter;
 use mz_storage_client::controller::{
     CollectionDescription, CreateExportToken, DataSource, DataSourceOther, StorageError,
 };
+use mz_storage_client::types::connections::inline::{IntoInlineConnection, ReferencedConnection};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sinks::StorageSinkConnection;
 use mz_storage_client::types::sources::Timeline;
@@ -299,7 +300,7 @@ pub struct SinkConnectionReady {
     pub id: GlobalId,
     pub oid: u32,
     pub create_export_token: CreateExportToken,
-    pub result: Result<StorageSinkConnection, AdapterError>,
+    pub result: Result<StorageSinkConnection<ReferencedConnection>, AdapterError>,
 }
 
 #[derive(Debug)]
@@ -1187,15 +1188,20 @@ impl Coordinator {
         let mut collections_to_create = Vec::new();
 
         fn source_desc<T>(
+            catalog: &Catalog,
             source_status_collection_id: Option<GlobalId>,
             source: &Source,
         ) -> CollectionDescription<T> {
             let (data_source, status_collection_id) = match &source.data_source {
                 // Re-announce the source description.
-                DataSourceDesc::Ingestion(ingestion) => (
-                    DataSource::Ingestion(ingestion.clone()),
-                    source_status_collection_id,
-                ),
+                DataSourceDesc::Ingestion(ingestion) => {
+                    let ingestion = ingestion.clone().into_inline_connection(catalog.state());
+
+                    (
+                        DataSource::Ingestion(ingestion.clone()),
+                        source_status_collection_id,
+                    )
+                }
                 // Subsources use source statuses.
                 DataSourceDesc::Source => (
                     DataSource::Other(DataSourceOther::Source),
@@ -1217,33 +1223,34 @@ impl Coordinator {
             }
         }
 
+        let migratable_collections = entries
+            .iter()
+            .filter_map(|entry| match entry.item() {
+                CatalogItem::Source(source) => Some((
+                    entry.id(),
+                    source_desc(self.catalog(), source_status_collection_id, source),
+                )),
+                CatalogItem::Table(table) => {
+                    let collection_desc = CollectionDescription::from_desc(
+                        table.desc.clone(),
+                        DataSourceOther::TableWrites,
+                    );
+                    Some((entry.id(), collection_desc))
+                }
+                CatalogItem::MaterializedView(mview) => {
+                    let collection_desc = CollectionDescription::from_desc(
+                        mview.desc.clone(),
+                        DataSourceOther::Compute,
+                    );
+                    Some((entry.id(), collection_desc))
+                }
+                _ => None,
+            })
+            .collect();
+
         self.controller
             .storage
-            .migrate_collections(
-                entries
-                    .iter()
-                    .filter_map(|entry| match entry.item() {
-                        CatalogItem::Source(source) => {
-                            Some((entry.id(), source_desc(source_status_collection_id, source)))
-                        }
-                        CatalogItem::Table(table) => {
-                            let collection_desc = CollectionDescription::from_desc(
-                                table.desc.clone(),
-                                DataSourceOther::TableWrites,
-                            );
-                            Some((entry.id(), collection_desc))
-                        }
-                        CatalogItem::MaterializedView(mview) => {
-                            let collection_desc = CollectionDescription::from_desc(
-                                mview.desc.clone(),
-                                DataSourceOther::Compute,
-                            );
-                            Some((entry.id(), collection_desc))
-                        }
-                        _ => None,
-                    })
-                    .collect(),
-            )
+            .migrate_collections(migratable_collections)
             .await?;
 
         // Do a first pass looking for collections to create so we can call
@@ -1263,8 +1270,10 @@ impl Coordinator {
                 // User sources can have dependencies, so do avoid them in the
                 // batch.
                 CatalogItem::Source(source) if entry.id().is_system() => {
-                    collections_to_create
-                        .push((entry.id(), source_desc(source_status_collection_id, source)));
+                    collections_to_create.push((
+                        entry.id(),
+                        source_desc(self.catalog(), source_status_collection_id, source),
+                    ));
                 }
                 _ => {
                     // No collections to create.
@@ -1305,7 +1314,8 @@ impl Coordinator {
                 CatalogItem::Source(source) => {
                     // System sources were created above, add others here.
                     if !entry.id().is_system() {
-                        let source_desc = source_desc(source_status_collection_id, source);
+                        let source_desc =
+                            source_desc(self.catalog(), source_status_collection_id, source);
                         self.controller
                             .storage
                             .create_collections(vec![(entry.id(), source_desc)])
@@ -1452,6 +1462,9 @@ impl Coordinator {
                         .prepare_export(id, sink.from)
                         .unwrap_or_terminate("cannot fail to prepare export");
 
+                    let referenced_builder = builder.clone();
+                    let builder = builder.into_inline_connection(self.catalog().state());
+
                     task::spawn(
                         || format!("sink_connection_ready:{}", sink.from),
                         async move {
@@ -1459,10 +1472,12 @@ impl Coordinator {
                                 .max_tries(usize::MAX)
                                 .clamp_backoff(Duration::from_secs(60 * 10))
                                 .retry_async(|_| async {
+                                    let referenced_builder = referenced_builder.clone();
                                     let builder = builder.clone();
                                     let connection_context = connection_context.clone();
                                     mz_storage_client::sink::build_sink_connection(
                                         builder,
+                                        referenced_builder,
                                         connection_context,
                                     )
                                     .await

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -35,6 +35,7 @@ use mz_sql::session::vars::{
 use mz_storage_client::controller::{
     CreateExportToken, ExportDescription, ReadPolicy, StorageError,
 };
+use mz_storage_client::types::connections::inline::{IntoInlineConnection, ReferencedConnection};
 use mz_storage_client::types::sinks::{SinkAsOf, StorageSinkConnection};
 use mz_storage_client::types::sources::{GenericSourceConnection, Timeline};
 use serde_json::json;
@@ -136,6 +137,9 @@ impl Coordinator {
                             if let DataSourceDesc::Ingestion(ingestion) = &source.data_source {
                                 match &ingestion.desc.connection {
                                     GenericSourceConnection::Postgres(conn) => {
+                                        let conn = conn
+                                            .clone()
+                                            .into_inline_connection(self.catalog().state());
                                         let config = conn
                                             .connection
                                             .config(&*self.connection_context.secrets_reader)
@@ -758,8 +762,10 @@ impl Coordinator {
         &mut self,
         create_export_token: CreateExportToken,
         sink: &Sink,
-        connection: StorageSinkConnection,
+        connection: StorageSinkConnection<ReferencedConnection>,
     ) -> Result<(), AdapterError> {
+        let connection = connection.into_inline_connection(self.catalog().state());
+
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
@@ -817,7 +823,7 @@ impl Coordinator {
         &mut self,
         id: GlobalId,
         oid: u32,
-        connection: StorageSinkConnection,
+        connection: StorageSinkConnection<ReferencedConnection>,
         create_export_token: CreateExportToken,
         session: Option<&Session>,
     ) -> Result<(), AdapterError> {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -25,6 +25,7 @@ use mz_sql::plan::{
     FetchPlan, MutationKind, Params, Plan, PlanKind, RaisePlan, RotateKeysPlan,
 };
 use mz_sql_parser::ast::{Raw, Statement};
+use mz_storage_client::types::connections::inline::IntoInlineConnection;
 use tokio::sync::oneshot;
 use tracing::{event, Level};
 
@@ -527,8 +528,11 @@ impl Coordinator {
             }
             Plan::ValidateConnection(plan) => {
                 let connection_context = self.connection_context.clone();
+                let connection = plan
+                    .connection
+                    .into_inline_connection(self.catalog().state());
                 mz_ore::task::spawn(|| "coord::validate_connection", async move {
-                    let res = match plan.connection.validate(plan.id, &connection_context).await {
+                    let res = match connection.validate(plan.id, &connection_context).await {
                         Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
                         Err(err) => Err(err.into()),
                     };

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -32,6 +32,7 @@ use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_stash::objects::{proto, RustType, TryFromProtoError};
+use mz_storage_client::types::connections::inline::{ConnectionResolver, ReferencedConnection};
 use mz_storage_client::types::connections::Connection;
 use mz_storage_client::types::sources::SourceDesc;
 use once_cell::sync::Lazy;
@@ -80,7 +81,7 @@ use crate::session::vars::SystemVars;
 /// [`list_databases`]: Catalog::list_databases
 /// [`get_item`]: Catalog::resolve_item
 /// [`resolve_item`]: SessionCatalog::resolve_item
-pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync {
+pub trait SessionCatalog: fmt::Debug + ExprHumanizer + Send + Sync + ConnectionResolver {
     /// Returns the id of the role that is issuing the query.
     fn active_role_id(&self) -> &RoleId;
 
@@ -572,12 +573,12 @@ pub trait CatalogItem {
     ///
     /// If the catalog item is not of a type that contains a `SourceDesc`
     /// (i.e., anything other than sources), it returns an error.
-    fn source_desc(&self) -> Result<Option<&SourceDesc>, CatalogError>;
+    fn source_desc(&self) -> Result<Option<&SourceDesc<ReferencedConnection>>, CatalogError>;
 
     /// Returns the resolved connection.
     ///
     /// If the catalog item is not a connection, it returns an error.
-    fn connection(&self) -> Result<&Connection, CatalogError>;
+    fn connection(&self) -> Result<&Connection<ReferencedConnection>, CatalogError>;
 
     /// Returns the type of the catalog item.
     fn item_type(&self) -> CatalogItemType;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -48,6 +48,7 @@ use mz_sql_parser::ast::{
     AlterSourceAddSubsourceOption, CreateSourceSubsource, QualifiedReplica,
     TransactionIsolationLevel, TransactionMode, WithOptionValue,
 };
+use mz_storage_client::types::connections::inline::ReferencedConnection;
 use mz_storage_client::types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
 use mz_storage_client::types::sources::{SourceDesc, Timeline};
 use serde::{Deserialize, Serialize};
@@ -589,7 +590,7 @@ pub struct CreateConnectionPlan {
 pub struct ValidateConnectionPlan {
     pub id: GlobalId,
     /// The connection to validate.
-    pub connection: mz_storage_client::types::connections::Connection,
+    pub connection: mz_storage_client::types::connections::Connection<ReferencedConnection>,
 }
 
 #[derive(Debug)]
@@ -1137,7 +1138,7 @@ pub enum DataSourceDesc {
 
 #[derive(Clone, Debug)]
 pub struct Ingestion {
-    pub desc: SourceDesc,
+    pub desc: SourceDesc<ReferencedConnection>,
     pub source_imports: BTreeSet<GlobalId>,
     pub subsource_exports: BTreeMap<GlobalId, usize>,
     pub progress_subsource: GlobalId,
@@ -1194,7 +1195,7 @@ pub struct WebhookValidationSecret {
 #[derive(Clone, Debug)]
 pub struct Connection {
     pub create_sql: String,
-    pub connection: mz_storage_client::types::connections::Connection,
+    pub connection: mz_storage_client::types::connections::Connection<ReferencedConnection>,
 }
 
 #[derive(Clone, Debug)]
@@ -1207,7 +1208,7 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connection_builder: StorageSinkConnectionBuilder,
+    pub connection_builder: StorageSinkConnectionBuilder<ReferencedConnection>,
     pub envelope: SinkEnvelope,
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -41,6 +41,7 @@ use mz_sql_parser::ast::{
     UnresolvedSchemaName, Value,
 };
 use mz_storage_client::types::connections::aws::{AwsAssumeRole, AwsConfig, AwsCredentials};
+use mz_storage_client::types::connections::inline::ReferencedConnection;
 use mz_storage_client::types::connections::{
     AwsPrivatelink, AwsPrivatelinkConnection, Connection, CsrConnectionHttpAuth, KafkaConnection,
     KafkaSecurity, KafkaTlsConfig, SaslConfig, SshTunnel, StringOrSecret, TlsIdentity, Tunnel,
@@ -674,8 +675,8 @@ pub fn plan_create_source(
 
             let encoding = get_encoding(scx, format, &envelope, Some(connection))?;
 
-            let mut connection = KafkaSourceConnection {
-                connection: kafka_connection,
+            let mut connection = KafkaSourceConnection::<ReferencedConnection> {
+                connection: connection_item.id(),
                 connection_id: connection_item.id(),
                 topic,
                 start_offsets,
@@ -732,7 +733,7 @@ pub fn plan_create_source(
                 }
             }
 
-            let connection = GenericSourceConnection::from(connection);
+            let connection = GenericSourceConnection::Kafka(connection);
 
             (connection, encoding, None)
         }
@@ -953,13 +954,14 @@ pub fn plan_create_source(
             let publication_details = PostgresSourcePublicationDetails::from_proto(details)
                 .map_err(|e| sql_err!("{}", e))?;
 
-            let connection = GenericSourceConnection::from(PostgresSourceConnection {
-                connection,
-                connection_id: connection_item.id(),
-                table_casts,
-                publication: publication.expect("validated exists during purification"),
-                publication_details,
-            });
+            let connection =
+                GenericSourceConnection::<ReferencedConnection>::from(PostgresSourceConnection {
+                    connection: connection_item.id(),
+                    connection_id: connection_item.id(),
+                    table_casts,
+                    publication: publication.expect("validated exists during purification"),
+                    publication_details,
+                });
             // The postgres source only outputs data to its subsources. The catalog object
             // representing the source itself is just an empty relation with no columns
             let encoding = SourceDataEncoding::Single(DataEncoding::new(
@@ -1211,7 +1213,7 @@ pub fn plan_create_source(
         None => scx.catalog.config().timestamp_interval,
     };
 
-    let source_desc = SourceDesc {
+    let source_desc = SourceDesc::<ReferencedConnection> {
         connection: external_connection,
         encoding,
         envelope: envelope.clone(),
@@ -1564,7 +1566,7 @@ fn get_encoding(
     format: &CreateSourceFormat<Aug>,
     envelope: &Envelope,
     connection: Option<&CreateSourceConnection<Aug>>,
-) -> Result<SourceDataEncoding, PlanError> {
+) -> Result<SourceDataEncoding<ReferencedConnection>, PlanError> {
     let encoding = match format {
         CreateSourceFormat::None => sql_bail!("Source format must be specified"),
         CreateSourceFormat::Bare(format) => get_encoding_inner(scx, format)?,
@@ -1631,14 +1633,15 @@ generate_extracted_config!(AvroSchemaOption, (ConfluentWireFormat, bool, Default
 pub struct Schema {
     pub key_schema: Option<String>,
     pub value_schema: String,
-    pub csr_connection: Option<mz_storage_client::types::connections::CsrConnection>,
+    pub csr_connection:
+        Option<mz_storage_client::types::connections::CsrConnection<ReferencedConnection>>,
     pub confluent_wire_format: bool,
 }
 
 fn get_encoding_inner(
     scx: &StatementContext,
     format: &Format<Aug>,
-) -> Result<SourceDataEncodingInner, PlanError> {
+) -> Result<SourceDataEncodingInner<ReferencedConnection>, PlanError> {
     // Avro/CSR can return a `SourceDataEncoding::KeyValue`
     Ok(SourceDataEncodingInner::Single(match format {
         Format::Bytes => DataEncodingInner::Bytes,
@@ -1819,7 +1822,7 @@ fn get_encoding_inner(
 fn get_key_envelope(
     included_items: &[SourceIncludeMetadata],
     envelope: &Envelope,
-    encoding: &SourceDataEncoding,
+    encoding: &SourceDataEncoding<ReferencedConnection>,
 ) -> Result<KeyEnvelope, PlanError> {
     let key_definition = included_items
         .iter()
@@ -1852,7 +1855,9 @@ fn get_key_envelope(
 
 /// Gets the key envelope for a given key encoding when no name for the key has
 /// been requested by the user.
-fn get_unnamed_key_envelope(key: &DataEncoding) -> Result<KeyEnvelope, PlanError> {
+fn get_unnamed_key_envelope(
+    key: &DataEncoding<ReferencedConnection>,
+) -> Result<KeyEnvelope, PlanError> {
     // If the key is requested but comes from an unnamed type then it gets the name "key"
     //
     // Otherwise it gets the names of the columns in the type
@@ -2356,7 +2361,7 @@ fn kafka_sink_builder(
     key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     value_desc: RelationDesc,
     envelope: SinkEnvelope,
-) -> Result<StorageSinkConnectionBuilder, PlanError> {
+) -> Result<StorageSinkConnectionBuilder<ReferencedConnection>, PlanError> {
     let item = scx.get_item_by_resolved_name(&connection)?;
     // Get Kafka connection
     let mut connection = match item.connection()? {
@@ -3241,7 +3246,10 @@ impl KafkaConnectionOptionExtracted {
     pub fn get_brokers(
         &self,
         scx: &StatementContext,
-    ) -> Result<Vec<mz_storage_client::types::connections::KafkaBroker>, PlanError> {
+    ) -> Result<
+        Vec<mz_storage_client::types::connections::KafkaBroker<ReferencedConnection>>,
+        PlanError,
+    > {
         let mut brokers = match (&self.broker, &self.brokers) {
             (Some(_), Some(_)) => sql_bail!("invalid CONNECTION: cannot set BROKER and BROKERS"),
             (None, None) => sql_bail!("invalid CONNECTION: must set either BROKER or BROKERS"),
@@ -3307,9 +3315,9 @@ Instead, specify BROKERS using multiple strings, e.g. BROKERS ('kafka:9092', 'ka
                     };
                     let ssh_tunnel = scx.catalog.get_item(id);
                     match ssh_tunnel.connection()? {
-                        Connection::Ssh(connection) => Tunnel::Ssh(SshTunnel {
+                        Connection::Ssh(_connection) => Tunnel::Ssh(SshTunnel {
                             connection_id: *id,
-                            connection: connection.clone(),
+                            connection: *id,
                         }),
                         _ => {
                             sql_bail!("{} is not an SSH connection", ssh_tunnel.name().item)
@@ -3413,7 +3421,10 @@ impl KafkaConnectionOptionExtracted {
     fn to_connection(
         self,
         scx: &StatementContext,
-    ) -> Result<mz_storage_client::types::connections::KafkaConnection, PlanError> {
+    ) -> Result<
+        mz_storage_client::types::connections::KafkaConnection<ReferencedConnection>,
+        PlanError,
+    > {
         Ok(KafkaConnection {
             brokers: self.get_brokers(scx)?,
             security: Option::<KafkaSecurity>::try_from(&self)?,
@@ -3446,7 +3457,8 @@ impl CsrConnectionOptionExtracted {
     fn to_connection(
         self,
         scx: &StatementContext,
-    ) -> Result<mz_storage_client::types::connections::CsrConnection, PlanError> {
+    ) -> Result<mz_storage_client::types::connections::CsrConnection<ReferencedConnection>, PlanError>
+    {
         let url: reqwest::Url = match self.url {
             Some(url) => url
                 .parse()
@@ -3504,7 +3516,10 @@ impl PostgresConnectionOptionExtracted {
     fn to_connection(
         self,
         scx: &StatementContext,
-    ) -> Result<mz_storage_client::types::connections::PostgresConnection, PlanError> {
+    ) -> Result<
+        mz_storage_client::types::connections::PostgresConnection<ReferencedConnection>,
+        PlanError,
+    > {
         let cert = self.ssl_certificate;
         let key = self.ssl_key.map(|secret| secret.into());
         let tls_identity = match (cert, key) {

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -10,8 +10,12 @@ publish = false
 anyhow = "1.0.66"
 async-stream = "0.3.3"
 async-trait = "0.1.68"
-aws-config = { version = "0.55", default-features = false, features = ["native-tls"] }
-aws-credential-types = { version = "0.55", features = ["hardcoded-credentials"] }
+aws-config = { version = "0.55", default-features = false, features = [
+    "native-tls",
+] }
+aws-credential-types = { version = "0.55", features = [
+    "hardcoded-credentials",
+] }
 aws-types = "0.55"
 bytes = "1.3.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
@@ -43,20 +47,35 @@ mz-ssh-util = { path = "../ssh-util" }
 mz-stash = { path = "../stash" }
 mz-timely-util = { path = "../timely-util" }
 mz-tracing = { path = "../tracing" }
-openssh = { version = "0.9.8", default-features = false, features = ["native-mux"] }
+openssh = { version = "0.9.8", default-features = false, features = [
+    "native-mux",
+] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 prometheus = { version = "0.13.3", default-features = false }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
-rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = [
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
+] }
 regex = { version = "1.7.0" }
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 static_assertions = "1.1"
 thiserror = "1.0.37"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
+timely = { version = "0.12.0", default-features = false, features = [
+    "bincode",
+] }
+tokio = { version = "1.24.2", features = [
+    "fs",
+    "rt",
+    "sync",
+    "test-util",
+    "time",
+] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tonic = "0.9.2"

--- a/src/storage-client/src/types/connections.rs
+++ b/src/storage-client/src/types/connections.rs
@@ -43,6 +43,7 @@ use crate::ssh_tunnels::{ManagedSshTunnelHandle, SshTunnelManager};
 use crate::types::connections::aws::AwsConfig;
 
 pub mod aws;
+pub mod inline;
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -168,16 +169,31 @@ impl ConnectionContext {
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum Connection {
-    Kafka(KafkaConnection),
-    Csr(CsrConnection),
-    Postgres(PostgresConnection),
+pub enum Connection<C: ConnectionAccess = InlinedConnection> {
+    Kafka(KafkaConnection<C>),
+    Csr(CsrConnection<C>),
+    Postgres(PostgresConnection<C>),
     Ssh(SshConnection),
     Aws(AwsConfig),
     AwsPrivatelink(AwsPrivatelinkConnection),
 }
 
-impl Connection {
+impl<R: ConnectionResolver> IntoInlineConnection<Connection, R>
+    for Connection<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> Connection {
+        match self {
+            Connection::Kafka(kafka) => Connection::Kafka(kafka.into_inline_connection(r)),
+            Connection::Csr(csr) => Connection::Csr(csr.into_inline_connection(r)),
+            Connection::Postgres(pg) => Connection::Postgres(pg.into_inline_connection(r)),
+            Connection::Ssh(ssh) => Connection::Ssh(ssh),
+            Connection::Aws(aws) => Connection::Aws(aws),
+            Connection::AwsPrivatelink(awspl) => Connection::AwsPrivatelink(awspl),
+        }
+    }
+}
+
+impl<C: ConnectionAccess> Connection<C> {
     /// Whether this connection should be validated by default on creation.
     pub fn validate_by_default(&self) -> bool {
         match self {
@@ -189,7 +205,9 @@ impl Connection {
             Connection::AwsPrivatelink(conn) => conn.validate_by_default(),
         }
     }
+}
 
+impl Connection<InlinedConnection> {
     /// Validates this connection by attempting to connect to the upstream system.
     pub async fn validate(
         &self,
@@ -203,6 +221,27 @@ impl Connection {
             Connection::Ssh(conn) => conn.validate(id, connection_context).await,
             Connection::Aws(conn) => conn.validate(id, connection_context).await,
             Connection::AwsPrivatelink(conn) => conn.validate(id, connection_context).await,
+        }
+    }
+
+    pub fn unwrap_kafka(self) -> <InlinedConnection as ConnectionAccess>::Kafka {
+        match self {
+            Self::Kafka(conn) => conn,
+            o => unreachable!("{o:?} is not a Kafka connection"),
+        }
+    }
+
+    pub fn unwrap_pg(self) -> <InlinedConnection as ConnectionAccess>::Pg {
+        match self {
+            Self::Postgres(conn) => conn,
+            o => unreachable!("{o:?} is not a Postgres connection"),
+        }
+    }
+
+    pub fn unwrap_ssh(self) -> <InlinedConnection as ConnectionAccess>::Ssh {
+        match self {
+            Self::Ssh(conn) => conn,
+            o => unreachable!("{o:?} is not an SSH connection"),
         }
     }
 }
@@ -270,11 +309,23 @@ impl From<SaslConfig> for KafkaSecurity {
 
 /// Specifies a Kafka broker in a [`KafkaConnection`].
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct KafkaBroker {
+pub struct KafkaBroker<C: ConnectionAccess = InlinedConnection> {
     /// The address of the Kafka broker.
     pub address: String,
     /// An optional tunnel to use when connecting to the broker.
-    pub tunnel: Tunnel,
+    pub tunnel: Tunnel<C>,
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<KafkaBroker, R>
+    for KafkaBroker<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> KafkaBroker {
+        let KafkaBroker { address, tunnel } = self;
+        KafkaBroker {
+            address,
+            tunnel: tunnel.into_inline_connection(r),
+        }
+    }
 }
 
 impl RustType<ProtoKafkaBroker> for KafkaBroker {
@@ -296,11 +347,42 @@ impl RustType<ProtoKafkaBroker> for KafkaBroker {
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct KafkaConnection {
-    pub brokers: Vec<KafkaBroker>,
+pub struct KafkaConnection<C: ConnectionAccess = InlinedConnection> {
+    pub brokers: Vec<KafkaBroker<C>>,
     pub progress_topic: Option<String>,
     pub security: Option<KafkaSecurity>,
     pub options: BTreeMap<String, StringOrSecret>,
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<KafkaConnection, R>
+    for KafkaConnection<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> KafkaConnection {
+        let KafkaConnection {
+            brokers,
+            progress_topic,
+            security,
+            options,
+        } = self;
+
+        let brokers = brokers
+            .into_iter()
+            .map(|broker| broker.into_inline_connection(&r))
+            .collect();
+
+        KafkaConnection {
+            brokers,
+            progress_topic,
+            security,
+            options,
+        }
+    }
+}
+
+impl<C: ConnectionAccess> KafkaConnection<C> {
+    fn validate_by_default(&self) -> bool {
+        true
+    }
 }
 
 impl KafkaConnection {
@@ -444,10 +526,6 @@ impl KafkaConnection {
         .await??;
         Ok(())
     }
-
-    fn validate_by_default(&self) -> bool {
-        true
-    }
 }
 
 impl RustType<ProtoKafkaConnectionTlsConfig> for KafkaTlsConfig {
@@ -543,7 +621,7 @@ impl RustType<ProtoKafkaConnection> for KafkaConnection {
 
 /// A connection to a Confluent Schema Registry.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct CsrConnection {
+pub struct CsrConnection<C: ConnectionAccess = InlinedConnection> {
     /// The URL of the schema registry.
     pub url: Url,
     /// Trusted root TLS certificate in PEM format.
@@ -554,7 +632,34 @@ pub struct CsrConnection {
     /// Optional HTTP authentication credentials for the schema registry.
     pub http_auth: Option<CsrConnectionHttpAuth>,
     /// A tunnel through which to route traffic.
-    pub tunnel: Tunnel,
+    pub tunnel: Tunnel<C>,
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<CsrConnection, R>
+    for CsrConnection<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> CsrConnection {
+        let CsrConnection {
+            url,
+            tls_root_cert,
+            tls_identity,
+            http_auth,
+            tunnel,
+        } = self;
+        CsrConnection {
+            url,
+            tls_root_cert,
+            tls_identity,
+            http_auth,
+            tunnel: tunnel.into_inline_connection(r),
+        }
+    }
+}
+
+impl<C: ConnectionAccess> CsrConnection<C> {
+    fn validate_by_default(&self) -> bool {
+        true
+    }
 }
 
 impl CsrConnection {
@@ -699,10 +804,6 @@ impl CsrConnection {
         self.connect(connection_context).await?;
         Ok(())
     }
-
-    fn validate_by_default(&self) -> bool {
-        true
-    }
 }
 
 impl RustType<ProtoCsrConnection> for CsrConnection {
@@ -729,7 +830,7 @@ impl RustType<ProtoCsrConnection> for CsrConnection {
     }
 }
 
-impl Arbitrary for CsrConnection {
+impl<C: ConnectionAccess> Arbitrary for CsrConnection<C> {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
 
@@ -739,7 +840,7 @@ impl Arbitrary for CsrConnection {
             any::<Option<StringOrSecret>>(),
             any::<Option<TlsIdentity>>(),
             any::<Option<CsrConnectionHttpAuth>>(),
-            any::<Tunnel>(),
+            any::<Tunnel<C>>(),
         )
             .prop_map(
                 |(url, tls_root_cert, tls_identity, http_auth, tunnel)| CsrConnection {
@@ -809,7 +910,7 @@ impl RustType<ProtoCsrConnectionHttpAuth> for CsrConnectionHttpAuth {
 
 /// A connection to a PostgreSQL server.
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct PostgresConnection {
+pub struct PostgresConnection<C: ConnectionAccess = InlinedConnection> {
     /// The hostname of the server.
     pub host: String,
     /// The port of the server.
@@ -821,7 +922,7 @@ pub struct PostgresConnection {
     /// An optional password for authentication.
     pub password: Option<GlobalId>,
     /// A tunnel through which to route traffic.
-    pub tunnel: Tunnel,
+    pub tunnel: Tunnel<C>,
     /// Whether to use TLS for encryption, authentication, or both.
     pub tls_mode: SslMode,
     /// An optional root TLS certificate in PEM format, to verify the server's
@@ -831,7 +932,43 @@ pub struct PostgresConnection {
     pub tls_identity: Option<TlsIdentity>,
 }
 
-impl PostgresConnection {
+impl<R: ConnectionResolver> IntoInlineConnection<PostgresConnection, R>
+    for PostgresConnection<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> PostgresConnection {
+        let PostgresConnection {
+            host,
+            port,
+            database,
+            user,
+            password,
+            tunnel,
+            tls_mode,
+            tls_root_cert,
+            tls_identity,
+        } = self;
+
+        PostgresConnection {
+            host,
+            port,
+            database,
+            user,
+            password,
+            tunnel: tunnel.into_inline_connection(r),
+            tls_mode,
+            tls_root_cert,
+            tls_identity,
+        }
+    }
+}
+
+impl<C: ConnectionAccess> PostgresConnection<C> {
+    fn validate_by_default(&self) -> bool {
+        true
+    }
+}
+
+impl PostgresConnection<InlinedConnection> {
     pub async fn config(
         &self,
         secrets_reader: &dyn mz_secrets::SecretsReader,
@@ -893,10 +1030,6 @@ impl PostgresConnection {
         config.connect("connection validation").await?;
         Ok(())
     }
-
-    fn validate_by_default(&self) -> bool {
-        true
-    }
 }
 
 impl RustType<ProtoPostgresConnection> for PostgresConnection {
@@ -935,7 +1068,7 @@ impl RustType<ProtoPostgresConnection> for PostgresConnection {
     }
 }
 
-impl Arbitrary for PostgresConnection {
+impl<C: ConnectionAccess> Arbitrary for PostgresConnection<C> {
     type Strategy = BoxedStrategy<Self>;
     type Parameters = ();
 
@@ -946,7 +1079,7 @@ impl Arbitrary for PostgresConnection {
             any::<String>(),
             any::<StringOrSecret>(),
             any::<Option<GlobalId>>(),
-            any::<Tunnel>(),
+            any::<Tunnel<C>>(),
             any_ssl_mode(),
             any::<Option<StringOrSecret>>(),
             any::<Option<TlsIdentity>>(),
@@ -982,16 +1115,26 @@ impl Arbitrary for PostgresConnection {
 
 /// Specifies how to tunnel a connection.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub enum Tunnel {
+pub enum Tunnel<C: ConnectionAccess = InlinedConnection> {
     /// No tunneling.
     Direct,
     /// Via the specified SSH tunnel connection.
-    Ssh(SshTunnel),
+    Ssh(SshTunnel<C>),
     /// Via the specified AWS PrivateLink connection.
     AwsPrivatelink(AwsPrivatelink),
 }
 
-impl RustType<ProtoTunnel> for Tunnel {
+impl<R: ConnectionResolver> IntoInlineConnection<Tunnel, R> for Tunnel<ReferencedConnection> {
+    fn into_inline_connection(self, r: R) -> Tunnel {
+        match self {
+            Tunnel::Direct => Tunnel::Direct,
+            Tunnel::Ssh(ssh) => Tunnel::Ssh(ssh.into_inline_connection(r)),
+            Tunnel::AwsPrivatelink(awspl) => Tunnel::AwsPrivatelink(awspl),
+        }
+    }
+}
+
+impl RustType<ProtoTunnel> for Tunnel<InlinedConnection> {
     fn into_proto(&self) -> ProtoTunnel {
         use proto_tunnel::Tunnel as ProtoTunnelField;
         ProtoTunnel {
@@ -1024,6 +1167,11 @@ pub struct SshConnection {
 }
 
 use proto_ssh_connection::ProtoPublicKeys;
+
+use self::inline::{
+    ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
+    ReferencedConnection,
+};
 
 impl RustType<ProtoPublicKeys> for (String, String) {
     fn into_proto(&self) -> ProtoPublicKeys {
@@ -1092,14 +1240,28 @@ impl RustType<ProtoAwsPrivatelink> for AwsPrivatelink {
 
 /// Specifies an AWS PrivateLink service for a [`Tunnel`].
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
-pub struct SshTunnel {
+pub struct SshTunnel<C: ConnectionAccess = InlinedConnection> {
     /// id of the ssh connection
     pub connection_id: GlobalId,
     /// ssh connection object
-    pub connection: SshConnection,
+    pub connection: C::Ssh,
 }
 
-impl RustType<ProtoSshTunnel> for SshTunnel {
+impl<R: ConnectionResolver> IntoInlineConnection<SshTunnel, R> for SshTunnel<ReferencedConnection> {
+    fn into_inline_connection(self, r: R) -> SshTunnel {
+        let SshTunnel {
+            connection,
+            connection_id,
+        } = self;
+
+        SshTunnel {
+            connection: r.resolve_connection(connection).unwrap_ssh(),
+            connection_id,
+        }
+    }
+}
+
+impl RustType<ProtoSshTunnel> for SshTunnel<InlinedConnection> {
     fn into_proto(&self) -> ProtoSshTunnel {
         ProtoSshTunnel {
             connection_id: Some(self.connection_id.into_proto()),
@@ -1119,7 +1281,7 @@ impl RustType<ProtoSshTunnel> for SshTunnel {
     }
 }
 
-impl SshTunnel {
+impl SshTunnel<InlinedConnection> {
     /// Like [`SshTunnelConfig::connect`], but the SSH key is loaded from a
     /// secret.
     async fn connect(

--- a/src/storage-client/src/types/connections/inline.rs
+++ b/src/storage-client/src/types/connections/inline.rs
@@ -1,0 +1,97 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Contains traits and types to support inlining connection details.
+//!
+//! Because we ultimately want to support the ability to alter the details of a
+//! connection, we cannot simply inline their state into structs--we instead
+//! need a means of understanding which connection we're referring to and inline
+//! its current state when sending the struct off to be used to handle a
+//! connection to an external service.
+
+use std::fmt::Debug;
+use std::hash::Hash;
+
+use mz_repr::GlobalId;
+use proptest::prelude::Arbitrary;
+use proptest_derive::Arbitrary;
+use serde::{Deserialize, Serialize};
+
+use super::Connection;
+
+/// Permits any struct to take a `GlobalId` into an inlined connection.
+///
+/// It is safe to assume that if this `id` does not refer to a catalog
+/// connection, this function will panic.
+pub trait ConnectionResolver {
+    fn resolve_connection(&self, id: GlobalId) -> Connection<InlinedConnection>;
+}
+
+impl<R: ConnectionResolver + ?Sized> ConnectionResolver for &R {
+    fn resolve_connection(&self, id: GlobalId) -> Connection<InlinedConnection> {
+        (*self).resolve_connection(id)
+    }
+}
+
+/// Takes ~`T<ReferencedConnection>` to ~`T<InlinedConnection>` by recursively
+/// inlining connections and resolving any referenced connections into their
+/// inlined version.
+///
+/// Note that this trait is overly generic.
+// TODO: this trait could be derived for types that are generic over a type that
+// implements `ConnectionAccess`, e.g. `derive(IntoInlineConnection)`.
+pub trait IntoInlineConnection<T, R: ConnectionResolver + ?Sized> {
+    fn into_inline_connection(self, connection_resolver: R) -> T;
+}
+
+/// Expresses how a struct/enum can access details about any connections it
+/// uses. Meant to be used as a type constraint on structs that use connections.
+pub trait ConnectionAccess:
+    Arbitrary + Clone + Debug + Eq + PartialEq + Serialize + 'static
+{
+    type Kafka: Arbitrary
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + for<'a> Deserialize<'a>;
+    type Pg: Arbitrary + Clone + Debug + Eq + PartialEq + Hash + Serialize + for<'a> Deserialize<'a>;
+    type Ssh: Arbitrary
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + for<'a> Deserialize<'a>;
+}
+
+/// Expresses that the struct contains references to connections. Use a
+/// combination of [`IntoInlineConnection`] and [`ConnectionResolver`] to take
+/// this into [`InlinedConnection`].
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct ReferencedConnection;
+
+impl ConnectionAccess for ReferencedConnection {
+    type Kafka = GlobalId;
+    type Pg = GlobalId;
+    type Ssh = GlobalId;
+}
+
+/// Expresses that the struct contains an inlined definition of a connection.
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+pub struct InlinedConnection;
+
+impl ConnectionAccess for InlinedConnection {
+    type Kafka = super::KafkaConnection;
+    type Pg = super::PostgresConnection;
+    type Ssh = super::SshConnection;
+}


### PR DESCRIPTION
To support `ALTER CONNECTION`, we need to fetch connections' states from the catalog when they are shipped off to storage (and not before).

The approach I've taken here is modeled after `AstInfo`, which offers two stages with a set of associated types. Here we have:
- `ReferencedConnection`, indicating that the struct only contains a reference to a connection (i.e. it's `GlobalId`)
- `InlinedConnection`, indicating that the struct has values generated from the catalog's state for the connection.

Whenever structs that rely on connections move from the adapter to storage, the storage types all require `InlinedConnection`. To support this, structs that contain references implement `into_inlined_connection`, which takes as an argument a reference to an object that implements `ConnectionResolver`, which essentially just takes `Connection<ReferencedConnection>` to `Connection<InlinedConnection>` (i.e. inlining the connection's details).

I have left `IntoInlinedConnection` as a trait even though it's not technically necessary so that we can add a derivable proc macro (these could just be freestanding implementations). I started on the proc macro work but writing a very hygienic implementation was more work than I'd realized, so am putting this up for review before that's complete.

### Motivation

This PR adds a known-desirable feature. This is necessary to support `ALTER CONNECTION`.

### Tips for reviewer

The only code that really needs review is [storage: add interface for inlining connections](https://github.com/MaterializeInc/materialize/pull/21472/commits/6bd3b1807c6ffee5ed2d97f0915dc1b226299dc4)--everything else is just code movement and implementations of that interface.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
