### PR TITLE
persist: set pushdown flag defaults to true

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -46,8 +46,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "storage_persist_sink_minimum_batch_updates": "100",
     "persist_pubsub_push_diff_enabled": "true",
     "persist_pubsub_client_enabled": "true",
-    "persist_stats_filter_enabled": "true",
-    "persist_stats_collection_enabled": "true",
     "persist_stats_audit_percent": "100",
     "enable_ld_rbac_checks": "true",
     "enable_rbac_checks": "true",

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -246,9 +246,9 @@ impl PersistConfig {
     /// Default value for [`DynamicConfig::stats_audit_percent`].
     pub const DEFAULT_STATS_AUDIT_PERCENT: usize = 0;
     /// Default value for [`DynamicConfig::stats_collection_enabled`].
-    pub const DEFAULT_STATS_COLLECTION_ENABLED: bool = false;
+    pub const DEFAULT_STATS_COLLECTION_ENABLED: bool = true;
     /// Default value for [`DynamicConfig::stats_filter_enabled`].
-    pub const DEFAULT_STATS_FILTER_ENABLED: bool = false;
+    pub const DEFAULT_STATS_FILTER_ENABLED: bool = true;
     /// Default value for [`DynamicConfig::stats_budget_bytes`].
     pub const DEFAULT_STATS_BUDGET_BYTES: usize = 1024;
     /// Default value for [`DynamicConfig::pubsub_client_enabled`].


### PR DESCRIPTION
They've been on in prod for everyone for a few weeks now.

This is immediately motived by nervousness around `persistcli admin` commands not writing out stats (they don't talk to LD), but it also seems like a good idea.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
