### PR TITLE
ci: disable "Canary Deploy in Staging Cloud" on arbitrary branches

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -661,6 +661,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cloud-canary
+    branches: "main v*.*"
 
   - id: output-consistency-test
     label: "Output consistency test"


### PR DESCRIPTION
This will no longer trigger the step "Canary Deploy in Staging Cloud" for PRs when the Nightly build is triggered from the tests pipeline through "nightly-if-risky".

### Motivation

> this new automatic nightlies for risky PRs means that pushing a really broken draft PR now has the potential for cross talk to other staging envs (via a shared CRDB), which is worrisome

https://materializeinc.slack.com/archives/C02FWJ94HME/p1693408312673369?thread_ts=1693384239.191199&cid=C02FWJ94HME
