### PR TITLE
explain: support `EXPLAIN INDEX`

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2134,7 +2134,7 @@ WITH
     SELECT list_agg(id) AS replicas
     FROM mz_cluster_replicas
     GROUP BY cluster_id
-    -- Add a `{NULL}` list to accomodate collections that are not installed
+    -- Add a `{NULL}` list to accommodate collections that are not installed
     -- on a replica.
     UNION VALUES (LIST[NULL])
   ),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2795,7 +2795,6 @@ impl Coordinator {
             stage,
             format,
             config,
-            no_errors: _,
             explainee,
         } = plan;
 
@@ -2913,16 +2912,16 @@ impl Coordinator {
             stage,
             format,
             config,
-            no_errors,
             explainee,
         } = plan;
 
         let Explainee::Query {
             raw_plan,
             row_set_finishing,
+            broken,
         } = explainee
         else {
-            // This is currently asserted in the `sequence_explain` code that
+            // This is currently asserted in the `sequence_explain_plan` code that
             // calls this method.
             unreachable!()
         };
@@ -2935,7 +2934,7 @@ impl Coordinator {
         let pipeline_result = {
             self.explain_optimizer_pipeline(
                 raw_plan,
-                no_errors,
+                broken,
                 target_cluster,
                 ctx.session_mut(),
                 &row_set_finishing,
@@ -2949,7 +2948,7 @@ impl Coordinator {
                 (used_indexes, fast_path_plan, dataflow_metainfo)
             }
             Err(err) => {
-                if no_errors {
+                if broken {
                     tracing::error!("error while handling EXPLAIN statement: {}", err);
 
                     let used_indexes = UsedIndexes::default();

--- a/src/adapter/src/explain/mod.rs
+++ b/src/adapter/src/explain/mod.rs
@@ -14,6 +14,18 @@
 //! struct in order to provide alternate [`mz_repr::explain::Explain`]
 //! implementations for some structs (see the [`mir`]) module for details.
 
+use std::time::Duration;
+
+use mz_compute_client::types::dataflows::DataflowDescription;
+use mz_expr::explain::ExplainContext;
+use mz_repr::explain::{
+    Explain, ExplainConfig, ExplainError, ExplainFormat, ExprHumanizer, UsedIndexes,
+};
+use mz_transform::dataflow::DataflowMetainfo;
+use mz_transform::optimizer_notices::OptimizerNotice;
+
+use crate::AdapterError;
+
 pub(crate) mod fast_path;
 pub(crate) mod hir;
 pub(crate) mod lir;
@@ -28,4 +40,48 @@ impl<'a, T> Explainable<'a, T> {
     pub(crate) fn new(t: &'a mut T) -> Explainable<'a, T> {
         Explainable(t)
     }
+}
+
+/// Convenience method to derive an `ExplainContext` from the `index_imports` in
+/// the given `plan` and all other input parameters, wrap the `plan` in an
+/// `Explainable`, and finally compute and return the `explain(...)` result.
+pub(crate) fn explain_dataflow<T>(
+    mut plan: DataflowDescription<T>,
+    format: ExplainFormat,
+    config: &ExplainConfig,
+    humanizer: &dyn ExprHumanizer,
+    dataflow_metainfo: &DataflowMetainfo,
+) -> Result<String, AdapterError>
+where
+    for<'a> Explainable<'a, DataflowDescription<T>>: Explain<'a, Context = ExplainContext<'a>>,
+{
+    // Collect the list of indexes used by the dataflow at this point.
+    let used_indexes = UsedIndexes::new(
+        plan.index_imports
+            .iter()
+            .map(|(id, index_import)| {
+                (
+                    *id,
+                    index_import.usage_types.clone().expect(
+                        "prune_and_annotate_dataflow_index_imports should have been called already",
+                    ),
+                )
+            })
+            .collect(),
+    );
+
+    let optimizer_notices =
+        OptimizerNotice::explain(&dataflow_metainfo.optimizer_notices, humanizer)
+            .map_err(ExplainError::FormatError)?;
+
+    let context = ExplainContext {
+        config,
+        humanizer,
+        used_indexes,
+        finishing: None,
+        duration: Duration::default(),
+        optimizer_notices,
+    };
+
+    Ok(Explainable::new(&mut plan).explain(&format, &context)?)
 }

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -813,7 +813,6 @@ fn generate_required_privileges(
             stage: _,
             format: _,
             config: _,
-            no_errors: _,
             explainee: _,
         }) => generate_read_privileges(catalog, resolved_ids.0.iter().cloned(), role_id),
         Plan::ExplainTimestamp(plan::ExplainTimestampPlan {

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -257,8 +257,8 @@ pub enum Explainee {
     ///
     /// This variant is deprecated and will be removed in #18089.
     Dataflow(GlobalId),
-    /// The object to be explained is a one-off query and may or may not served
-    /// using a dataflow.
+    /// The object to be explained is a one-off query and may or may not be
+    /// served using a dataflow.
     Query,
 }
 

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2996,6 +2996,7 @@ impl_display!(ExplainStage);
 pub enum Explainee<T: AstInfo> {
     View(T::ItemName),
     MaterializedView(T::ItemName),
+    Index(T::ItemName),
     Query(Query<T>, bool),
 }
 
@@ -3008,6 +3009,10 @@ impl<T: AstInfo> AstDisplay for Explainee<T> {
             }
             Self::MaterializedView(name) => {
                 f.write_str("MATERIALIZED VIEW ");
+                f.write_node(name);
+            }
+            Self::Index(name) => {
+                f.write_str("INDEX ");
                 f.write_node(name);
             }
             Self::Query(query, broken) => {

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2641,7 +2641,6 @@ pub struct ExplainPlanStatement<T: AstInfo> {
     pub stage: ExplainStage,
     pub config_flags: Vec<Ident>,
     pub format: ExplainFormat,
-    pub no_errors: bool,
     pub explainee: Explainee<T>,
 }
 
@@ -2657,9 +2656,6 @@ impl<T: AstInfo> AstDisplay for ExplainPlanStatement<T> {
         f.write_str(" AS ");
         f.write_node(&self.format);
         f.write_str(" FOR ");
-        if self.no_errors {
-            f.write_str("BROKEN ");
-        }
         f.write_node(&self.explainee);
     }
 }
@@ -3000,7 +2996,7 @@ impl_display!(ExplainStage);
 pub enum Explainee<T: AstInfo> {
     View(T::ItemName),
     MaterializedView(T::ItemName),
-    Query(Query<T>),
+    Query(Query<T>, bool),
 }
 
 impl<T: AstInfo> AstDisplay for Explainee<T> {
@@ -3014,7 +3010,12 @@ impl<T: AstInfo> AstDisplay for Explainee<T> {
                 f.write_str("MATERIALIZED VIEW ");
                 f.write_node(name);
             }
-            Self::Query(query) => f.write_node(query),
+            Self::Query(query, broken) => {
+                if *broken {
+                    f.write_str("BROKEN ");
+                }
+                f.write_node(query);
+            }
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2951,7 +2951,7 @@ impl<T: AstInfo> AstDisplay for Assignment<T> {
 }
 impl_display_t!(Assignment);
 
-/// Specifies what [Statement::ExplainPlan] is actually explaining The new API
+/// Specifies what [Statement::ExplainPlan] is actually explained.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ExplainStage {
     /// The mz_sql::HirRelationExpr after parsing

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6768,11 +6768,13 @@ impl<'a> Parser<'a> {
             self.expect_keyword(FOR)?;
         }
 
-        // VIEW name | MATERIALIZED VIEW name | query
+        // VIEW name | MATERIALIZED VIEW name | INDEX name | query
         let explainee = if self.parse_keyword(VIEW) {
             Explainee::View(self.parse_raw_name()?)
         } else if self.parse_keywords(&[MATERIALIZED, VIEW]) {
             Explainee::MaterializedView(self.parse_raw_name()?)
+        } else if self.parse_keyword(INDEX) {
+            Explainee::Index(self.parse_raw_name()?)
         } else {
             let broken = self.parse_keyword(BROKEN);
             Explainee::Query(self.parse_query()?, broken)

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6700,7 +6700,7 @@ impl<'a> Parser<'a> {
         }
     }
 
-    /// Parse an `EXPLAIN` statement, assuming that the `EXPLAIN` token
+    /// Parse an `EXPLAIN ... PLAN` statement, assuming that the `EXPLAIN` token
     /// has already been consumed.
     fn parse_explain_plan(&mut self) -> Result<Statement<Raw>, ParserError> {
         let stage = match self.parse_one_of_keywords(&[
@@ -6710,7 +6710,6 @@ impl<'a> Parser<'a> {
             OPTIMIZED,
             PHYSICAL,
             OPTIMIZER,
-            QUERY,
         ]) {
             Some(PLAN) => {
                 // EXPLAIN PLAN = EXPLAIN OPTIMIZED PLAN

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6769,22 +6769,20 @@ impl<'a> Parser<'a> {
             self.expect_keyword(FOR)?;
         }
 
-        let no_errors = self.parse_keyword(BROKEN);
-
         // VIEW name | MATERIALIZED VIEW name | query
         let explainee = if self.parse_keyword(VIEW) {
             Explainee::View(self.parse_raw_name()?)
         } else if self.parse_keywords(&[MATERIALIZED, VIEW]) {
             Explainee::MaterializedView(self.parse_raw_name()?)
         } else {
-            Explainee::Query(self.parse_query()?)
+            let broken = self.parse_keyword(BROKEN);
+            Explainee::Query(self.parse_query()?, broken)
         };
 
         Ok(Statement::ExplainPlan(ExplainPlanStatement {
             stage: stage.unwrap_or(ExplainStage::OptimizedPlan),
             config_flags,
             format,
-            no_errors,
             explainee,
         }))
     }

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -23,84 +23,84 @@ EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN RAW PLAN FOR SELECT 665
 ----
 EXPLAIN RAW PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: RawPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: RawPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN DECORRELATED PLAN FOR SELECT 665
 ----
 EXPLAIN DECORRELATED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: DecorrelatedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: DecorrelatedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN PHYSICAL PLAN FOR SELECT 665
 ----
 EXPLAIN PHYSICAL PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: PhysicalPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: PhysicalPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN SELECT 665
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 665
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN FOR MATERIALIZED VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR MATERIALIZED VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [Ident("types")], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [Ident("types")], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(arity, typed) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(arity, typed) AS TEXT FOR VIEW foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [Ident("arity"), Ident("typed")], format: Text, no_errors: false, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [Ident("arity"), Ident("typed")], format: Text, explainee: View(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
 EXPLAIN ((SELECT 1))
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR SELECT 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 # regression test for #16029
 parse-statement
@@ -108,7 +108,7 @@ EXPLAIN WITH a AS (SELECT 1) SELECT * FROM a
 ----
 EXPLAIN OPTIMIZED PLAN AS TEXT FOR WITH a AS (SELECT 1) SELECT * FROM a
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, no_errors: false, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Query(Query { ctes: Simple([Cte { alias: TableAlias { name: Ident("a"), columns: [], strict: false }, id: (), query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("1")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("a")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN TIMESTAMP FOR SELECT 1
@@ -122,13 +122,13 @@ EXPLAIN AS JSON SELECT * FROM foo
 ----
 EXPLAIN OPTIMIZED PLAN AS JSON FOR SELECT * FROM foo
 =>
-ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Json, no_errors: false, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Json, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Wildcard], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("foo")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, false) })
 
 parse-statement
 EXPLAIN OPTIMIZER TRACE WITH (est_cost) AS TEXT FOR BROKEN SELECT 1 + 1
 ----
 EXPLAIN OPTIMIZER TRACE WITH(est_cost) AS TEXT FOR BROKEN SELECT 1 + 1
 =>
-ExplainPlan(ExplainPlanStatement { stage: Trace, config_flags: [Ident("est_cost")], format: Text, no_errors: true, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }) })
+ExplainPlan(ExplainPlanStatement { stage: Trace, config_flags: [Ident("est_cost")], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, true) })
 
 # TODO (#13299): Add negative tests for new explain API.

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -75,6 +75,13 @@ EXPLAIN OPTIMIZED PLAN AS TEXT FOR MATERIALIZED VIEW foo
 ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: MaterializedView(Name(UnresolvedItemName([Ident("foo")]))) })
 
 parse-statement
+EXPLAIN OPTIMIZED PLAN FOR INDEX foo
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR INDEX foo
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: Index(Name(UnresolvedItemName([Ident("foo")]))) })
+
+parse-statement
 EXPLAIN OPTIMIZED PLAN WITH(types) FOR VIEW foo
 ----
 EXPLAIN OPTIMIZED PLAN WITH(types) AS TEXT FOR VIEW foo

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -810,6 +810,8 @@ pub enum Explainee {
     MaterializedView(GlobalId),
     /// An existing index.
     Index(GlobalId),
+    /// The object to be explained is a one-off query and may or may not be
+    /// served using a dataflow.
     /// The object to be explained is a one-off query.
     ///
     /// THe query may be served using a dataflow or using a FastPathPlan.

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -800,7 +800,6 @@ pub struct ExplainPlanPlan {
     pub stage: ExplainStage,
     pub format: ExplainFormat,
     pub config: ExplainConfig,
-    pub no_errors: bool,
     pub explainee: Explainee,
 }
 
@@ -811,11 +810,18 @@ pub enum Explainee {
     MaterializedView(GlobalId),
     /// An existing index.
     Index(GlobalId),
-    /// The object to be explained is a one-off query and may or may not served
-    /// using a dataflow.
+    /// The object to be explained is a one-off query.
+    ///
+    /// THe query may be served using a dataflow or using a FastPathPlan.
+    ///
+    /// Queries that have their `broken` flag set are expected to cause a panic
+    /// in the optimizer code. In this case, pipeline execution will stop, but
+    /// panic will be intercepted and will not propagate to the caller. This is
+    /// useful when debugging queries that cause panics.
     Query {
         raw_plan: HirRelationExpr,
         row_set_finishing: Option<RowSetFinishing>,
+        broken: bool,
     },
 }
 

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -229,7 +229,7 @@ pub fn describe_explain_plan(
 
     Ok(
         StatementDesc::new(Some(relation_desc)).with_params(match explainee {
-            Explainee::Query(q) => {
+            Explainee::Query(q, _) => {
                 describe_select(
                     scx,
                     SelectStatement {
@@ -261,7 +261,6 @@ pub fn plan_explain_plan(
         stage,
         config_flags,
         format,
-        no_errors,
         explainee,
     }: ExplainPlanStatement<Aug>,
     params: &Params,
@@ -308,9 +307,7 @@ pub fn plan_explain_plan(
             }
             crate::plan::Explainee::MaterializedView(mview.id())
         }
-        Explainee::Query(query) => {
-            // Previously we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
-            // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
+        Explainee::Query(query, broken) => {
             let query::PlannedQuery {
                 expr: mut raw_plan,
                 desc,
@@ -328,6 +325,7 @@ pub fn plan_explain_plan(
             crate::plan::Explainee::Query {
                 raw_plan,
                 row_set_finishing,
+                broken,
             }
         }
     };
@@ -336,7 +334,6 @@ pub fn plan_explain_plan(
         stage,
         format,
         config,
-        no_errors,
         explainee,
     }))
 }

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -350,8 +350,6 @@ pub fn plan_explain_timestamp(
     };
 
     let raw_plan = {
-        // Previously we would bail here for ORDER BY and LIMIT; this has been relaxed to silently
-        // report the plan without the ORDER BY and LIMIT decorations (which are done in post).
         let query::PlannedQuery {
             expr: mut raw_plan,
             desc: _,

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -21,13 +21,18 @@ CREATE VIEW v AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 statement ok
-CREATE DEFAULT INDEX ON v
+CREATE INDEX v_a_idx ON v(a)
 
 statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 mode cockroach
+
+# EXPLAIN INDEX is not supported for decorrelated plans
+statement error cannot EXPLAIN DECORRELATED PLAN FOR INDEX
+EXPLAIN DECORRELATED PLAN AS TEXT FOR
+INDEX v_a_idx
 
 # Test constant error.
 query T multiline

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -36,7 +36,10 @@ CREATE VIEW iv AS
 SELECT * FROM t WHERE a IS NOT NULL;
 
 statement ok
-CREATE DEFAULT INDEX ON iv;
+CREATE INDEX iv_a_idx ON iv(a);
+
+statement ok
+CREATE INDEX iv_b_idx ON iv(b);
 
 statement ok
 CREATE MATERIALIZED VIEW mv AS
@@ -332,8 +335,7 @@ Explained Query:
             Join on=(#0 = #2) type=differential
               Get l2
               ArrangeBy keys=[[#1]]
-                Filter (#1) IS NOT NULL
-                  Get materialize.public.iv
+                Get materialize.public.iv
     cte l2 =
       ArrangeBy keys=[[#0]]
         Get l1
@@ -349,7 +351,7 @@ Source materialize.public.mv
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
-  - materialize.public.iv_primary_idx (*** full scan ***)
+  - materialize.public.iv_b_idx (differential join)
 
 EOF
 
@@ -422,6 +424,49 @@ Explained Query:
 
 Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed source
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+INDEX t_a_idx
+----
+materialize.public.t_a_idx:
+  ArrangeBy keys=[[#0]]
+    Get materialize.public.t
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (first index)
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+INDEX iv_a_idx;
+----
+materialize.public.iv_a_idx:
+  ArrangeBy keys=[[#0]]
+    Get materialize.public.iv
+
+materialize.public.iv:
+  Filter (#0) IS NOT NULL
+    Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (based on a prior index)
+query T multiline
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR
+INDEX iv_b_idx;
+----
+materialize.public.iv_b_idx:
+  ArrangeBy keys=[[#1]]
+    Get materialize.public.iv
+
+Used Indexes:
+  - materialize.public.iv_a_idx (*** full scan ***, index export)
 
 EOF
 

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -35,6 +35,12 @@ statement ok
 CREATE VIEW ov AS SELECT * FROM t ORDER BY b asc, a desc LIMIT 5
 
 statement ok
+CREATE INDEX ov_a_idx ON ov(a);
+
+statement ok
+CREATE INDEX ov_b_idx ON ov(b);
+
+statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
@@ -183,10 +189,17 @@ EOF
 # TopKBasic plan.
 query T multiline
 EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS TEXT FOR
-SELECT * FROM ov
+INDEX ov_a_idx
 ----
-Explained Query:
-  TopK::MonotonicTopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 must_consolidate
+materialize.public.ov_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    Get::PassArrangements materialize.public.ov
+      raw=true
+
+materialize.public.ov:
+  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
     ArrangeBy
       input_key=[#0]
       raw=true
@@ -202,7 +215,7 @@ EOF
 # MonotonicTopK plan.
 query T multiline
 EXPLAIN PHYSICAL PLAN WITH(no_fast_path) AS TEXT FOR
-SELECT * FROM ov
+SELECT * FROM (SELECT * FROM t ORDER BY b asc, a desc LIMIT 5)
 ----
 Explained Query:
   TopK::MonotonicTopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 must_consolidate
@@ -852,6 +865,69 @@ Used Indexes:
   - materialize.public.t_a_idx (*** full scan ***)
 
 EOF
+
+
+
+# Test EXPLAIN INDEX for an indexed source
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+INDEX t_a_idx
+----
+materialize.public.t_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    Get::PassArrangements materialize.public.t
+      raw=true
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (first index)
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+INDEX ov_a_idx;
+----
+materialize.public.ov_a_idx:
+  ArrangeBy
+    raw=true
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    Get::PassArrangements materialize.public.ov
+      raw=true
+
+materialize.public.ov:
+  TopK::Basic order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5
+    ArrangeBy
+      input_key=[#0]
+      raw=true
+      Get::PassArrangements materialize.public.t
+        raw=false
+        arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.t_a_idx (*** full scan ***)
+
+EOF
+
+# Test EXPLAIN INDEX for an indexed view (based on a prior index)
+query T multiline
+EXPLAIN PHYSICAL PLAN AS TEXT FOR
+INDEX ov_b_idx;
+----
+materialize.public.ov_b_idx:
+  ArrangeBy
+    input_key=[#0]
+    raw=false
+    arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+    arrangements[1]={ key=[#1], permutation={#0: #1, #1: #0}, thinning=(#0) }
+    Get::PassArrangements materialize.public.ov
+      raw=false
+      arrangements[0]={ key=[#0], permutation=id, thinning=(#1) }
+
+Used Indexes:
+  - materialize.public.ov_a_idx (*** full scan ***, index export)
+
+EOF
+
 
 # Test Join::Differential (acyclic).
 query T multiline

--- a/test/sqllogictest/explain/raw_plan_as_text.slt
+++ b/test/sqllogictest/explain/raw_plan_as_text.slt
@@ -26,13 +26,18 @@ CREATE VIEW v AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 statement ok
-CREATE DEFAULT INDEX ON v
+CREATE INDEX v_a_idx ON v(a)
 
 statement ok
 CREATE MATERIALIZED VIEW mv AS
 SELECT * FROM t WHERE a IS NOT NULL
 
 mode cockroach
+
+# EXPLAIN INDEX is not supported for raw plans
+statement error cannot EXPLAIN RAW PLAN FOR INDEX
+EXPLAIN RAW PLAN AS TEXT FOR
+INDEX v_a_idx
 
 # Test basic linear chains.
 query T multiline


### PR DESCRIPTION
Add support for `EXPLAIN [OPTIMIZED|PHYSICAL] PLAN FOR INDEX` queries.

### Motivation

  * This PR adds a known-desirable feature.

Part of #20652.

### Tips for reviewer

* Review commit-by-commit.
  * The first three commits are minor code refactors done in preparation.
  * The actual work is in the last four commits.
* This has minor conflicts with [#21463](21463) which I will resolve once [#21463](21463) lands.
* Regarding comments from previous reviews
  * [comment #1](https://github.com/MaterializeInc/materialize/pull/21261#discussion_r1304087049) - actually it was sufficient to simplify `export_ids_for` by removing the second `for` loop. I left a comment in the method explaining why this is the case. 
  * [comment #2](https://github.com/MaterializeInc/materialize/pull/21383#discussion_r1305586277) - I changed the notice. If we figure out that we actually need `EXPLAIN VIEW` I will add it back, but only for `OPTIMIZED PLAN` (the code path will render the `OptimizedMirRelationExpr` saved in the catalog).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
