### PR TITLE
webhook: Return notice that contains the URL on successful creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3457,6 +3457,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "uncased",
+ "url",
  "uuid",
  "workspace-hack",
 ]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -52,8 +52,8 @@ mz-transform = { path = "../transform" }
 mz-cloud-resources = { path = "../cloud-resources" }
 opentelemetry = { version = "0.20.0", features = ["rt-tokio", "trace"] }
 prometheus = { version = "0.13.3", default-features = false }
-proptest = { version = "1.0.0", default-features = false, features = ["std"]}
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 qcell = "0.5"
 rand = "0.8.5"
@@ -75,6 +75,7 @@ tracing-opentelemetry = { version = "0.20.0" }
 tracing-subscriber = "0.3.16"
 thiserror = "1.0.37"
 uncased = "0.9.7"
+url = "2.3.1"
 uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -69,6 +69,8 @@ pub struct Config<'a> {
     pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
     /// How long to retain storage usage records
     pub storage_usage_retention_period: Option<Duration>,
+    /// Host name or URL for connecting to the HTTP server of this instance.
+    pub http_host_name: Option<String>,
     /// Needed only for migrating PG source column metadata. If `None`, will
     /// skip any migrations that require it, which will likely cause tests to
     /// fail.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -503,6 +503,7 @@ pub struct Config {
     pub aws_account_id: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
+    pub http_host_name: Option<String>,
     pub tracing_handle: TracingHandle,
 }
 
@@ -1965,6 +1966,7 @@ pub async fn serve(
         aws_privatelink_availability_zones,
         system_parameter_sync_config,
         active_connection_count,
+        http_host_name,
         tracing_handle,
     }: Config,
 ) -> Result<(Handle, Client), AdapterError> {
@@ -2019,6 +2021,7 @@ pub async fn serve(
             storage_usage_retention_period,
             connection_context: Some(connection_context.clone()),
             active_connection_count,
+            http_host_name,
         })
         .await?;
     let session_id = catalog.config().session_id;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -242,7 +242,17 @@ impl Coordinator {
                             source_status_collection_id,
                         ),
                         DataSourceDesc::Progress => (DataSource::Progress, None),
-                        DataSourceDesc::Webhook { .. } => (DataSource::Webhook, None),
+                        DataSourceDesc::Webhook { .. } => {
+                            if let Some(url) = self
+                                .catalog()
+                                .state()
+                                .try_get_webhook_url(&source_id, Some(session.conn_id()))
+                            {
+                                session.add_notice(AdapterNotice::WebhookSourceCreated { url })
+                            }
+
+                            (DataSource::Webhook, None)
+                        }
                         DataSourceDesc::Introspection(_) => {
                             unreachable!("cannot create sources with introspection data sources")
                         }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -114,6 +114,9 @@ pub enum AdapterNotice {
         notice: String,
         hint: Option<String>,
     },
+    WebhookSourceCreated {
+        url: url::Url,
+    },
 }
 
 impl AdapterNotice {
@@ -193,6 +196,7 @@ impl AdapterNotice {
             },
             AdapterNotice::UnknownSessionDatabase(_) => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::OptimizerNotice { .. } => SqlState::SUCCESSFUL_COMPLETION,
+            AdapterNotice::WebhookSourceCreated { .. } => SqlState::WARNING,
         }
     }
 }
@@ -335,6 +339,9 @@ impl fmt::Display for AdapterNotice {
                 write!(f, "session database {} does not exist", name.quoted())
             }
             AdapterNotice::OptimizerNotice { notice, hint: _ } => notice.fmt(f),
+            AdapterNotice::WebhookSourceCreated { url } => {
+                write!(f, "URL to POST data is '{url}'")
+            }
         }
     }
 }

--- a/src/adapter/src/severity.rs
+++ b/src/adapter/src/severity.rs
@@ -153,6 +153,7 @@ impl Severity {
             },
             AdapterNotice::UnknownSessionDatabase(_) => Severity::Notice,
             AdapterNotice::OptimizerNotice { .. } => Severity::Notice,
+            AdapterNotice::WebhookSourceCreated { .. } => Severity::Notice,
         }
     }
 }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -584,6 +584,12 @@ pub struct Args {
     )]
     aws_secrets_controller_tags: Vec<KeyValueArg<String, String>>,
 
+    /// The external host name to connect to the HTTP server of this instance.
+    ///
+    /// Note: Primarily for user facing notices.
+    #[clap(long, env = "HTTP_HOST_NAME")]
+    http_host_name: Option<String>,
+
     #[clap(long, env = "DEPLOY_GENERATION")]
     deploy_generation: Option<u64>,
 
@@ -1022,6 +1028,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 config_sync_loop_interval: args.config_sync_loop_interval,
                 bootstrap_role: args.bootstrap_role,
                 deploy_generation: args.deploy_generation,
+                http_host_name: args.http_host_name,
             })
             .await
     })?;

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -207,6 +207,8 @@ pub struct Config {
     pub bootstrap_role: Option<String>,
     /// Generation we want deployed. Generally only present when doing a production deploy.
     pub deploy_generation: Option<u64>,
+    /// Host name or URL for connecting to the HTTP server of this instance.
+    pub http_host_name: Option<String>,
 
     // === Tracing options. ===
     /// The metrics registry to use.
@@ -513,6 +515,7 @@ impl Listeners {
             aws_account_id: config.aws_account_id,
             aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             active_connection_count: Arc::clone(&active_connection_count),
+            http_host_name: config.http_host_name,
             tracing_handle: config.tracing_handle,
         })
         .await?;

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -399,6 +399,7 @@ impl Listeners {
         } else {
             (TracingHandle::disabled(), None)
         };
+        let host_name = format!("localhost:{}", self.inner.http_local_addr().port());
 
         let inner = self.runtime.block_on(async {
             self.inner
@@ -460,6 +461,7 @@ impl Listeners {
                     config_sync_loop_interval: None,
                     bootstrap_role: config.bootstrap_role,
                     deploy_generation: config.deploy_generation,
+                    http_host_name: Some(host_name),
                 })
                 .await
         })?;

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -954,6 +954,7 @@ impl<'a> RunnerInner<'a> {
         let secrets_controller = Arc::clone(&orchestrator);
         let connection_context = ConnectionContext::for_tests(orchestrator.reader());
         let listeners = mz_environmentd::Listeners::bind_any_local().await?;
+        let host_name = format!("localhost:{}", listeners.http_local_addr().port());
         let server_config = mz_environmentd::Config {
             adapter_stash_url,
             controller: ControllerConfig {
@@ -1012,6 +1013,7 @@ impl<'a> RunnerInner<'a> {
             config_sync_loop_interval: None,
             bootstrap_role: Some("materialize".into()),
             deploy_generation: None,
+            http_host_name: Some(host_name),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -500,6 +500,7 @@ impl Usage {
             aws_privatelink_availability_zones: None,
             system_parameter_sync_config: None,
             storage_usage_retention_period: None,
+            http_host_name: None,
             connection_context: None,
             active_connection_count: Arc::new(Mutex::new(ConnectionCounter::new(0))),
         })


### PR DESCRIPTION
This PR adds a Notice when successfully creating a webhook source that contains the URL you can post data to:
```
materialize=> CREATE SOURCE my_webhook IN CLUSTER webhook_cluster FROM WEBHOOK
    BODY FORMAT TEXT;
NOTICE:  URL to POST data is 'https://localhost:55297/api/webhook/materialize/public/webhook-source%28with%20odd%2Fname'
```

### Motivation

* This PR fixes a previously unreported bug.

This is a papercut that folks have mentioned to me a few times in Slack

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR adds a notice for users when they create a webhook source.
