### PR TITLE
mz: print some diagnostics to stderr rather than stdout

### DIFF
--- a/src/mz/src/command/sql.rs
+++ b/src/mz/src/command/sql.rs
@@ -41,14 +41,14 @@ pub async fn run(
     let region_info = cx.get_region_info().await?;
     let email = claims.await?.email;
 
-    println!(
+    eprintln!(
         "Authenticated using profile '{}'.",
         cx.config_file().profile()
     );
     if let Some(cluster) = cluster.clone() {
-        println!("Connected to cluster '{}'.", cluster);
+        eprintln!("Connected to cluster '{}'.", cluster);
     } else {
-        println!("Connected to the default cluster.")
+        eprintln!("Connected to the default cluster.")
     }
 
     let _error = sql_client

--- a/src/mz/src/context.rs
+++ b/src/mz/src/context.rs
@@ -111,11 +111,11 @@ impl Context {
     // Prints a warning comment about the cloud endpoint
     /// TODO: Remove after releasing version 0.1.6 and give anyone using `mz` time to apply the fix.
     pub fn print_warning_comment(&self) {
-        println!("⚠️ \t Warning\t ⚠️ \nStarting from version 0.1.3, it is a must to include the 'api.' subdomain in the cloud endpoint.");
-        println!("\nWrong: cloud-endpoint = \"https://staging.cloud.materialize.com\"");
-        println!("Right: cloud-endpoint = \"https://api.staging.cloud.materialize.com\"");
-        println!("\nPlease address this in your config before upcoming releases.");
-        println!("Config path: ~/.config/materialize/mz.toml.\n");
+        eprintln!("⚠️ \t Warning\t ⚠️ \nStarting from version 0.1.3, it is a must to include the 'api.' subdomain in the cloud endpoint.");
+        eprintln!("\nWrong: cloud-endpoint = \"https://staging.cloud.materialize.com\"");
+        eprintln!("Right: cloud-endpoint = \"https://api.staging.cloud.materialize.com\"");
+        eprintln!("\nPlease address this in your config before upcoming releases.");
+        eprintln!("Config path: ~/.config/materialize/mz.toml.\n");
     }
 
     /// Verifies the cloud endpoint is ok.


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.
  
  @umanwizard, in Slack:

> Can we please make mz print all of this stuff:
> ```
>     Finished dev [unoptimized + debuginfo] target(s) in 0.56s
>      Running `target/debug/mz sql --profile=staging`
> :warning: 	 Warning	 :warning: 
> Starting from version 0.1.3, it is a must to include the 'api.' subdomain in the cloud endpoint.
>
> Wrong: cloud-endpoint = "https://staging.cloud.materialize.com"
> Right: cloud-endpoint = "https://api.staging.cloud.materialize.com"
>
> Please address this in your config before upcoming releases.
> Config path: ~/.config/materialize/mz.toml.
>
> psql (15.4, server 9.5.0)
> SSL connection (protocol: TLSv1.3, cipher: TLS_AES_256_GCM_SHA384, compression: off)
> Type "help" for help.
> ```
> to stderr instead of stdout? Otherwise, it can't be used in scripts as easily as psql can.