### PR TITLE
adapter: support params for SUBSCRIBE, DECLARE

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -256,7 +256,7 @@ impl Client {
         const EMPTY_PORTAL: &str = "";
         session_client.start_transaction(Some(1))?;
         session_client
-            .declare(EMPTY_PORTAL.into(), stmt, sql.to_string(), vec![])
+            .declare(EMPTY_PORTAL.into(), stmt, sql.to_string())
             .await?;
         match session_client
             .execute(EMPTY_PORTAL.into(), futures::future::pending(), None)
@@ -456,21 +456,11 @@ impl SessionClient {
         name: String,
         stmt: Statement<Raw>,
         sql: String,
-        param_types: Vec<Option<ScalarType>>,
     ) -> Result<(), AdapterError> {
         let catalog = self.catalog_snapshot().await;
-        self.declare_inner(&catalog, name, stmt, sql, param_types)
-    }
-
-    fn declare_inner(
-        &mut self,
-        catalog: &Catalog,
-        name: String,
-        stmt: Statement<Raw>,
-        sql: String,
-        param_types: Vec<Option<ScalarType>>,
-    ) -> Result<(), AdapterError> {
-        let desc = Coordinator::describe(catalog, self.session(), Some(stmt.clone()), param_types)?;
+        let param_types = vec![];
+        let desc =
+            Coordinator::describe(&catalog, self.session(), Some(stmt.clone()), param_types)?;
         let params = vec![];
         let result_formats = vec![mz_pgrepr::Format::Text; desc.arity()];
         let logging = self.session().mint_logging(sql);

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -411,8 +411,7 @@ impl Coordinator {
                 ctx.retire(ret);
             }
             Plan::Declare(plan) => {
-                let param_types = vec![];
-                self.declare(ctx, plan.name, plan.stmt, plan.sql, param_types);
+                self.declare(ctx, plan.name, plan.stmt, plan.sql, plan.params);
             }
             Plan::Fetch(FetchPlan {
                 name,

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -1119,6 +1119,7 @@ fn generate_required_privileges(
             name: _,
             stmt: _,
             sql: _,
+            params: _,
         })
         | Plan::Fetch(plan::FetchPlan {
             name: _,

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -228,7 +228,12 @@ pub fn describe(
                 .get_portal_unverified(name.as_str())
                 .map(|p| p.desc.clone())
             {
-                Some(desc) => Ok(desc),
+                Some(mut desc) => {
+                    // Parameters are already bound to the portal and will not be accepted through
+                    // FETCH.
+                    desc.param_types = Vec::new();
+                    Ok(desc)
+                }
                 None => Err(AdapterError::UnknownCursor(name.to_string())),
             }
         }

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -598,11 +598,10 @@ where
     async fn one_query(&mut self, stmt: Statement<Raw>, sql: String) -> Result<State, io::Error> {
         // Bind the portal. Note that this does not set the empty string prepared
         // statement.
-        let param_types = vec![];
         const EMPTY_PORTAL: &str = "";
         if let Err(e) = self
             .adapter_client
-            .declare(EMPTY_PORTAL.to_string(), stmt, sql, param_types)
+            .declare(EMPTY_PORTAL.to_string(), stmt, sql)
             .await
         {
             return self

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -991,6 +991,7 @@ pub struct DeclarePlan {
     pub name: String,
     pub stmt: Statement<Raw>,
     pub sql: String,
+    pub params: Params,
 }
 
 #[derive(Debug)]

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -193,7 +193,7 @@ pub fn describe(
         // SCL statements.
         Statement::Close(stmt) => scl::describe_close(&scx, stmt)?,
         Statement::Deallocate(stmt) => scl::describe_deallocate(&scx, stmt)?,
-        Statement::Declare(stmt) => scl::describe_declare(&scx, stmt)?,
+        Statement::Declare(stmt) => scl::describe_declare(&scx, stmt, param_types_in)?,
         Statement::Discard(stmt) => scl::describe_discard(&scx, stmt)?,
         Statement::Execute(stmt) => scl::describe_execute(&scx, stmt)?,
         Statement::Fetch(stmt) => scl::describe_fetch(&scx, stmt)?,
@@ -340,7 +340,7 @@ pub fn plan(
         Statement::ExplainTimestamp(stmt) => dml::plan_explain_timestamp(scx, stmt, params),
         Statement::Insert(stmt) => dml::plan_insert(scx, stmt, params),
         Statement::Select(stmt) => dml::plan_select(scx, stmt, params, None),
-        Statement::Subscribe(stmt) => dml::plan_subscribe(scx, stmt, None),
+        Statement::Subscribe(stmt) => dml::plan_subscribe(scx, stmt, params, None),
         Statement::Update(stmt) => dml::plan_update(scx, stmt, params),
 
         // `SHOW` statements.
@@ -371,7 +371,7 @@ pub fn plan(
         // SCL statements.
         Statement::Close(stmt) => scl::plan_close(scx, stmt),
         Statement::Deallocate(stmt) => scl::plan_deallocate(scx, stmt),
-        Statement::Declare(stmt) => scl::plan_declare(scx, stmt),
+        Statement::Declare(stmt) => scl::plan_declare(scx, stmt, params),
         Statement::Discard(stmt) => scl::plan_discard(scx, stmt),
         Statement::Execute(stmt) => scl::plan_execute(scx, stmt),
         Statement::Fetch(stmt) => scl::plan_fetch(scx, stmt),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -480,6 +480,7 @@ pub fn plan_subscribe(
         up_to,
         output,
     }: SubscribeStatement<Aug>,
+    params: &Params,
     copy_to: Option<CopyFormat>,
 ) -> Result<Plan, PlanError> {
     let (from, desc, scope) = match relation {
@@ -501,7 +502,7 @@ pub fn plan_subscribe(
             (SubscribeFrom::Id(entry.id()), desc.into_owned(), scope)
         }
         SubscribeRelation::Query(query) => {
-            let query = plan_query(scx, query, &Params::empty(), QueryLifetime::Subscribe)?;
+            let query = plan_query(scx, query, params, QueryLifetime::Subscribe)?;
             // There's no way to apply finishing operations to a `SUBSCRIBE` directly, so the
             // finishing should have already been turned into a `TopK` by
             // `plan_query` / `plan_root_query`, upon seeing the `QueryLifetime::Subscribe`.
@@ -769,7 +770,9 @@ pub fn plan_copy(
             CopyRelation::Select(stmt) => {
                 Ok(plan_select(scx, stmt, &Params::empty(), Some(format))?)
             }
-            CopyRelation::Subscribe(stmt) => Ok(plan_subscribe(scx, stmt, Some(format))?),
+            CopyRelation::Subscribe(stmt) => {
+                Ok(plan_subscribe(scx, stmt, &Params::empty(), Some(format))?)
+            }
         },
         (CopyDirection::From, CopyTarget::Stdin) => match relation {
             CopyRelation::Table { name, columns } => {


### PR DESCRIPTION
Fixes #21494

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Support SQL parameters in `SUBSCRIBE` and `DECLARE`.