### PR TITLE
doc/user: polish v0.67 release notes (+ patch v0.66)

### DIFF
--- a/doc/user/content/releases/v0.66.md
+++ b/doc/user/content/releases/v0.66.md
@@ -6,6 +6,12 @@ released: true
 
 ## v0.66.0
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+This release focuses on stabilization work and performance improvements. It does
+not introduce any new user-facing features. 👷
+
+#### Bug fixes and other improvements
+
+* Fix a bug that prevented [`ALTER SOURCE...`](/sql/alter-source/) from
+  completing in PostgreSQL sources when existing tables were listed in a
+  publication in a different order than that observed when Materialize first
+  processed them.

--- a/doc/user/content/releases/v0.67.md
+++ b/doc/user/content/releases/v0.67.md
@@ -1,0 +1,49 @@
+---
+title: "Materialize v0.67"
+date: 2023-08-30
+released: true
+patch: 3
+---
+
+## v0.67.0
+
+#### Sources and sinks
+
+[//]: # "NOTE(morsapaes) This feature was released in v0.53 behind a feature
+flag. The flag was raised in v0.67 for ENVELOPE UPSERT -— so mentioning it
+here."
+
+* Support upserts in the output of `SUBSCRIBE` via the new [`ENVELOPE UPSERT` clause](/sql/subscribe/#envelope-upsert).
+  This clause allows you to specify a `KEY` that Materialize uses to interpret the
+  rows as a series of inserts, updates and deletes within each distinct
+  timestamp. The output rows will have the following structure:
+
+  ```sql
+   SUBSCRIBE mview ENVELOPE UPSERT (KEY (key));
+
+   mz_timestamp | mz_state | key  | value
+   -------------|----------|------|--------
+   100          | upsert   | 1    | 2
+   100          | upsert   | 2    | 4
+  ```
+
+#### SQL
+
+* Add [`mz_internal.mz_compute_dependencies`](/sql/system-catalog/mz_internal/#mz_compute_dependencies)
+  to the system catalog. This table describes the dependency structure between
+  each compute object (index, materialized view, or subscription) and the
+  sources of its data.
+
+* Improve the output of [`EXPLAIN { OPTIMIZED | PHYSICAL } PLAN FOR MATERIALIZED VIEW`](/sql/explain/)
+  to return the plan generated at object creation time, rather than the plan that
+  would be generated if the object was created with the current catalog state.
+
+* Add support for [`TABLE`](/sql/table) expressions, which retrieve all rows
+  from the named SQL table.
+
+#### Bug fixes and other improvements
+
+* Extend `pg_catalog` and `information_schema` system catalog coverage for
+  compatibility with Power BI.
+
+* Increase in precision for the `AVG`, `VAR_*`, and `STDDEV*` functions.

--- a/doc/user/content/releases/v0.68.md
+++ b/doc/user/content/releases/v0.68.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.68"
+date: 2023-09-06
+released: false
+---
+
+## v0.68.0
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
Release notes for v0.67. 💆‍♀️ 

We overlooked that the PR for v0.66 had a commit that removed the actual release notes, so adding those back in.