### PR TITLE
Fix missing `expected_group_size` in top-level `TopK`

### DIFF
--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1675,7 +1675,11 @@ impl HirRelationExpr {
     /// Instead of directly applying the given `RowSetFinishing`, it converts the `RowSetFinishing`
     /// to a `TopK`, which it then places at the top of `self`. Additionally, it turns the given
     /// finishing into a trivial finishing.
-    pub fn finish_maintained(&mut self, finishing: &mut RowSetFinishing) {
+    pub fn finish_maintained(
+        &mut self,
+        finishing: &mut RowSetFinishing,
+        expected_group_size: Option<u64>,
+    ) {
         if !finishing.is_trivial(self.arity()) {
             let old_finishing =
                 mem::replace(finishing, RowSetFinishing::trivial(finishing.project.len()));
@@ -1691,7 +1695,7 @@ impl HirRelationExpr {
                 order_key: old_finishing.order_by,
                 limit: old_finishing.limit,
                 offset: old_finishing.offset,
-                expected_group_size: None,
+                expected_group_size,
             }
             .project(old_finishing.project)
         }

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -113,7 +113,7 @@ pub fn plan_root_query(
 ) -> Result<PlannedQuery<HirRelationExpr>, PlanError> {
     transform_ast::transform(scx, &mut query)?;
     let mut qcx = QueryContext::root(scx, lifetime);
-    let (mut expr, scope, mut finishing, _) = plan_query(&mut qcx, &query)?;
+    let (mut expr, scope, mut finishing, expected_group_size) = plan_query(&mut qcx, &query)?;
 
     // Attempt to push the finishing's ordering past its projection. This allows
     // data to be projected down on the workers rather than the coordinator. It
@@ -123,7 +123,7 @@ pub fn plan_root_query(
     try_push_projection_order_by(&mut expr, &mut finishing.project, &mut finishing.order_by);
 
     if lifetime.is_maintained() {
-        expr.finish_maintained(&mut finishing);
+        expr.finish_maintained(&mut finishing, expected_group_size);
     }
 
     let typ = qcx.relation_type(&expr);

--- a/test/sqllogictest/github-21501.slt
+++ b/test/sqllogictest/github-21501.slt
@@ -1,0 +1,54 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #21501.
+
+statement ok
+CREATE TABLE teachers (id INT, name TEXT);
+
+statement ok
+CREATE TABLE sections (id INT, teacher_id INT, course_id INT, schedule TEXT);
+
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (EXPECTED GROUP SIZE = 1000)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (EXPECTED GROUP SIZE = 1000)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+----
+Finish order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 output=[#0..=#2]
+  TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=1000
+    Reduce group_by=[#4, #5] aggregates=[max(#2)] exp_group_size=1000
+      Map (#0, #1)
+        Get materialize.public.sections
+
+EOF
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=1000
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=1000
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF


### PR DESCRIPTION
This PR fixes bug #21501 where the `EXPECTED GROUP SIZE` is ignored if it affects the root-level `TopK` of a maintained object. The change is to plumb through the `expected_group_size` to where the relevant HIR `TopK` is created.

Fixes #21501.

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/21501

### Tips for reviewer

The commits can be looked at individually.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
