### PR TITLE
Columnation for `DataflowError`

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2238,7 +2238,18 @@ impl FilterCharacteristics {
 }
 
 #[derive(
-    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
 )]
 pub enum DomainLimit {
     None,
@@ -2369,7 +2380,7 @@ pub enum EvalError {
         detail: Option<String>,
     },
     ArrayFillWrongArraySubscripts,
-    // TODO: propagate this check more widly throughout the expr crate
+    // TODO: propagate this check more widely throughout the expr crate
     MaxArraySizeExceeded(usize),
     DateDiffOverflow {
         unit: String,

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1931,10 +1931,10 @@ where
     Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
 )]
 pub struct ParseError {
-    pub(crate) kind: ParseErrorKind,
-    pub(crate) type_name: String,
-    pub(crate) input: String,
-    pub(crate) details: Option<String>,
+    pub kind: ParseErrorKind,
+    pub type_name: String,
+    pub input: String,
+    pub details: Option<String>,
 }
 
 #[derive(
@@ -2059,7 +2059,18 @@ impl RustType<ProtoParseError> for ParseError {
 }
 
 #[derive(
-    Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
+    Arbitrary,
+    Ord,
+    PartialOrd,
+    Copy,
+    Clone,
+    Debug,
+    Eq,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Hash,
+    MzReflect,
 )]
 pub enum ParseHexError {
     InvalidHexDigit(char),

--- a/src/storage-client/src/types/errors.proto
+++ b/src/storage-client/src/types/errors.proto
@@ -43,7 +43,7 @@ message ProtoSourceError {
 }
 
 message ProtoUpsertValueError {
-    ProtoDataflowError inner = 1;
+    ProtoDecodeError inner = 1;
     mz_repr.row.ProtoRow for_key = 2;
 }
 

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -204,7 +204,7 @@ impl Display for UpsertValueError {
 }
 
 /// A source contained a record with a NULL key, which we don't support.
-#[derive(Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Ord, PartialOrd, Copy, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
 pub struct UpsertNullKeyError {
     partition_id: Option<PartitionId>,
 }
@@ -412,22 +412,425 @@ pub enum DataflowError {
 impl Error for DataflowError {}
 
 mod columnation {
-    use crate::types::errors::DataflowError;
-    use timely::container::columnation::{CloneRegion, Columnation};
+    use std::iter::once;
+
+    use mz_expr::EvalError;
+    use mz_repr::adt::range::InvalidRangeError;
+    use mz_repr::strconv::ParseError;
+    use mz_repr::Row;
+    use timely::container::columnation::{Columnation, Region, StableRegion};
+
+    use crate::types::errors::{
+        DataflowError, DecodeError, DecodeErrorKind, EnvelopeError, SourceError,
+        SourceErrorDetails, UpsertError, UpsertValueError,
+    };
 
     impl Columnation for DataflowError {
-        // Discussion of `Region` for `DataflowError`: Although `DataflowError` contains pointers,
-        // we treat it as a type that doesn't and can simply be cloned. The reason for this is
-        // threefold:
-        // 1. Cloning the type does not violate correctness. It comes with the disadvantage that its
-        //    `heap_size` will not be accurate.
-        // 2. It is hard to implement a region allocator for `DataflowError`, because it contains
-        //    many pointers across various enum types. Some are boxed, and it contains a box to
-        //    itself, meaning we have to pass the outer region inwards to avoid creating recursive
-        //    regions.
-        // 3. We accept the performance implication of not storing the errors in a region allocator,
-        //    which should be similar to storing errors in vectors on the heap.
-        type InnerRegion = CloneRegion<DataflowError>;
+        type InnerRegion = DataflowErrorRegion;
+    }
+
+    #[derive(Default)]
+    pub struct DataflowErrorRegion {
+        decode_error_region: StableRegion<DecodeError>,
+        envelope_error_region: StableRegion<EnvelopeError>,
+        eval_error_region: StableRegion<EvalError>,
+        row_region: <Row as Columnation>::InnerRegion,
+        source_error_region: StableRegion<SourceError>,
+        string_region: <String as Columnation>::InnerRegion,
+        u8_region: <Vec<u8> as Columnation>::InnerRegion,
+    }
+
+    impl DataflowErrorRegion {
+        unsafe fn copy_decode_error(&mut self, decode_error: &DecodeError) -> DecodeError {
+            DecodeError {
+                kind: match &decode_error.kind {
+                    DecodeErrorKind::Text(string) => {
+                        DecodeErrorKind::Text(self.string_region.copy(string))
+                    }
+                    DecodeErrorKind::Bytes(string) => {
+                        DecodeErrorKind::Bytes(self.string_region.copy(string))
+                    }
+                },
+                raw: self.u8_region.copy(&decode_error.raw),
+            }
+        }
+    }
+
+    /// Compile-time assertion that a value is `Copy`.
+    fn assert_copy<T: Copy>(_: &T) {}
+
+    impl Region for DataflowErrorRegion {
+        type Item = DataflowError;
+
+        unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
+            match item {
+                DataflowError::DecodeError(err) => {
+                    let err = self.copy_decode_error(&*err);
+                    let reference = self.decode_error_region.copy_iter(once(err));
+                    let boxed = unsafe { Box::from_raw(reference.as_mut_ptr()) };
+                    DataflowError::DecodeError(boxed)
+                }
+                DataflowError::EvalError(err) => {
+                    let err: &EvalError = &*err;
+                    let err = match err {
+                        e @ EvalError::CharacterNotValidForEncoding(x) => {
+                            assert_copy(x);
+                            e.clone()
+                        }
+                        e @ EvalError::CharacterTooLargeForEncoding(x) => {
+                            assert_copy(x);
+                            e.clone()
+                        }
+                        EvalError::DateBinOutOfRange(string) => {
+                            EvalError::DateBinOutOfRange(self.string_region.copy(string))
+                        }
+                        e @ EvalError::DivisionByZero
+                        | e @ EvalError::FloatOverflow
+                        | e @ EvalError::FloatUnderflow
+                        | e @ EvalError::NumericFieldOverflow
+                        | e @ EvalError::MzTimestampStepOverflow
+                        | e @ EvalError::TimestampCannotBeNan
+                        | e @ EvalError::TimestampOutOfRange
+                        | e @ EvalError::NegSqrt
+                        | e @ EvalError::NullCharacterNotPermitted
+                        | e @ EvalError::UnterminatedLikeEscapeSequence
+                        | e @ EvalError::MultipleRowsFromSubquery
+                        | e @ EvalError::LikePatternTooLong
+                        | e @ EvalError::LikeEscapeTooLong
+                        | e @ EvalError::MultidimensionalArrayRemovalNotSupported
+                        | e @ EvalError::MultiDimensionalArraySearch
+                        | e @ EvalError::ArrayFillWrongArraySubscripts
+                        | e @ EvalError::DateOutOfRange
+                        | e @ EvalError::CharOutOfRange
+                        | e @ EvalError::InvalidBase64Equals
+                        | e @ EvalError::InvalidBase64EndSequence
+                        | e @ EvalError::InvalidTimezoneInterval
+                        | e @ EvalError::InvalidTimezoneConversion
+                        | e @ EvalError::LengthTooLarge => e.clone(),
+                        EvalError::Unsupported { feature, issue_no } => EvalError::Unsupported {
+                            feature: self.string_region.copy(feature),
+                            issue_no: *issue_no,
+                        },
+                        EvalError::Float32OutOfRange(string) => {
+                            EvalError::Float32OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::Float64OutOfRange(string) => {
+                            EvalError::Float64OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::Int16OutOfRange(string) => {
+                            EvalError::Int16OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::Int32OutOfRange(string) => {
+                            EvalError::Int32OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::Int64OutOfRange(string) => {
+                            EvalError::Int64OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::UInt16OutOfRange(string) => {
+                            EvalError::UInt16OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::UInt32OutOfRange(string) => {
+                            EvalError::UInt32OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::UInt64OutOfRange(string) => {
+                            EvalError::UInt64OutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::MzTimestampOutOfRange(string) => {
+                            EvalError::MzTimestampOutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::OidOutOfRange(string) => {
+                            EvalError::OidOutOfRange(self.string_region.copy(string))
+                        }
+                        EvalError::IntervalOutOfRange(string) => {
+                            EvalError::IntervalOutOfRange(self.string_region.copy(string))
+                        }
+                        e @ EvalError::IndexOutOfRange {
+                            provided,
+                            valid_end,
+                        } => {
+                            assert_copy(provided);
+                            assert_copy(valid_end);
+                            e.clone()
+                        }
+                        e @ EvalError::InvalidBase64Symbol(c) => {
+                            assert_copy(c);
+                            e.clone()
+                        }
+                        EvalError::InvalidTimezone(x) => {
+                            EvalError::InvalidTimezone(self.string_region.copy(x))
+                        }
+                        e @ EvalError::InvalidLayer { max_layer, val } => {
+                            assert_copy(max_layer);
+                            assert_copy(val);
+                            e.clone()
+                        }
+                        EvalError::InvalidArray(err) => EvalError::InvalidArray(*err),
+                        EvalError::InvalidEncodingName(x) => {
+                            EvalError::InvalidEncodingName(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidHashAlgorithm(x) => {
+                            EvalError::InvalidHashAlgorithm(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidByteSequence {
+                            byte_sequence,
+                            encoding_name,
+                        } => EvalError::InvalidByteSequence {
+                            byte_sequence: self.string_region.copy(byte_sequence),
+                            encoding_name: self.string_region.copy(encoding_name),
+                        },
+                        EvalError::InvalidJsonbCast { from, to } => EvalError::InvalidJsonbCast {
+                            from: self.string_region.copy(from),
+                            to: self.string_region.copy(to),
+                        },
+                        EvalError::InvalidRegex(x) => {
+                            EvalError::InvalidRegex(self.string_region.copy(x))
+                        }
+                        e @ EvalError::InvalidRegexFlag(x) => {
+                            assert_copy(x);
+                            e.clone()
+                        }
+                        EvalError::InvalidParameterValue(x) => {
+                            EvalError::InvalidParameterValue(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidDatePart(x) => {
+                            EvalError::InvalidDatePart(self.string_region.copy(x))
+                        }
+                        EvalError::UnknownUnits(x) => {
+                            EvalError::UnknownUnits(self.string_region.copy(x))
+                        }
+                        EvalError::UnsupportedUnits(x, y) => EvalError::UnsupportedUnits(
+                            self.string_region.copy(x),
+                            self.string_region.copy(y),
+                        ),
+                        EvalError::Parse(ParseError {
+                            kind,
+                            type_name,
+                            input,
+                            details,
+                        }) => EvalError::Parse(ParseError {
+                            kind: *kind,
+                            type_name: self.string_region.copy(type_name),
+                            input: self.string_region.copy(input),
+                            details: details
+                                .as_ref()
+                                .map(|details| self.string_region.copy(details)),
+                        }),
+                        e @ EvalError::ParseHex(x) => {
+                            assert_copy(x);
+                            e.clone()
+                        }
+                        EvalError::Internal(x) => EvalError::Internal(self.string_region.copy(x)),
+                        EvalError::InfinityOutOfDomain(x) => {
+                            EvalError::InfinityOutOfDomain(self.string_region.copy(x))
+                        }
+                        EvalError::NegativeOutOfDomain(x) => {
+                            EvalError::NegativeOutOfDomain(self.string_region.copy(x))
+                        }
+                        EvalError::ZeroOutOfDomain(x) => {
+                            EvalError::ZeroOutOfDomain(self.string_region.copy(x))
+                        }
+                        EvalError::OutOfDomain(x, y, z) => {
+                            assert_copy(x);
+                            assert_copy(y);
+                            EvalError::OutOfDomain(*x, *y, self.string_region.copy(z))
+                        }
+                        EvalError::ComplexOutOfRange(x) => {
+                            EvalError::ComplexOutOfRange(self.string_region.copy(x))
+                        }
+                        EvalError::Undefined(x) => EvalError::Undefined(self.string_region.copy(x)),
+                        EvalError::StringValueTooLong {
+                            target_type,
+                            length,
+                        } => EvalError::StringValueTooLong {
+                            target_type: self.string_region.copy(target_type),
+                            length: *length,
+                        },
+                        e @ EvalError::IncompatibleArrayDimensions { dims } => {
+                            assert_copy(dims);
+                            e.clone()
+                        }
+                        EvalError::TypeFromOid(x) => {
+                            EvalError::TypeFromOid(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidRange(x) => {
+                            let err = match x {
+                                e @ InvalidRangeError::MisorderedRangeBounds
+                                | e @ InvalidRangeError::InvalidRangeBoundFlags
+                                | e @ InvalidRangeError::DiscontiguousUnion
+                                | e @ InvalidRangeError::DiscontiguousDifference
+                                | e @ InvalidRangeError::NullRangeBoundFlags => e.clone(),
+                                InvalidRangeError::CanonicalizationOverflow(string) => {
+                                    InvalidRangeError::CanonicalizationOverflow(
+                                        self.string_region.copy(string),
+                                    )
+                                }
+                            };
+                            EvalError::InvalidRange(err)
+                        }
+                        EvalError::InvalidRoleId(x) => {
+                            EvalError::InvalidRoleId(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidPrivileges(x) => {
+                            EvalError::InvalidPrivileges(self.string_region.copy(x))
+                        }
+                        EvalError::LetRecLimitExceeded(x) => {
+                            EvalError::LetRecLimitExceeded(self.string_region.copy(x))
+                        }
+                        EvalError::MustNotBeNull(x) => {
+                            EvalError::MustNotBeNull(self.string_region.copy(x))
+                        }
+                        EvalError::InvalidIdentifier { ident, detail } => {
+                            EvalError::InvalidIdentifier {
+                                ident: self.string_region.copy(ident),
+                                detail: detail
+                                    .as_ref()
+                                    .map(|detail| self.string_region.copy(detail)),
+                            }
+                        }
+                        e @ EvalError::MaxArraySizeExceeded(x) => {
+                            assert_copy(x);
+                            e.clone()
+                        }
+                        EvalError::DateDiffOverflow { unit, a, b } => EvalError::DateDiffOverflow {
+                            unit: self.string_region.copy(unit),
+                            a: self.string_region.copy(a),
+                            b: self.string_region.copy(b),
+                        },
+                        EvalError::IfNullError(x) => {
+                            EvalError::IfNullError(self.string_region.copy(x))
+                        }
+                    };
+                    let reference = self.eval_error_region.copy_iter(once(err));
+                    let boxed = unsafe { Box::from_raw(reference.as_mut_ptr()) };
+                    DataflowError::EvalError(boxed)
+                }
+                DataflowError::SourceError(err) => {
+                    let err: &SourceError = &*err;
+                    let err = SourceError {
+                        source_id: err.source_id,
+                        error: match &err.error {
+                            SourceErrorDetails::Initialization(string) => {
+                                SourceErrorDetails::Initialization(self.string_region.copy(string))
+                            }
+                            SourceErrorDetails::Other(string) => {
+                                SourceErrorDetails::Other(self.string_region.copy(string))
+                            }
+                        },
+                    };
+                    let reference = self.source_error_region.copy_iter(once(err));
+                    let boxed = unsafe { Box::from_raw(reference.as_mut_ptr()) };
+                    DataflowError::SourceError(boxed)
+                }
+                DataflowError::EnvelopeError(err) => {
+                    let err: &EnvelopeError = &*err;
+                    let err = match err {
+                        EnvelopeError::Debezium(string) => {
+                            EnvelopeError::Debezium(self.string_region.copy(string))
+                        }
+                        EnvelopeError::Upsert(err) => {
+                            let err = match err {
+                                UpsertError::KeyDecode(err) => {
+                                    UpsertError::KeyDecode(self.copy_decode_error(err))
+                                }
+                                UpsertError::Value(err) => UpsertError::Value(UpsertValueError {
+                                    inner: self.copy_decode_error(&err.inner),
+                                    for_key: self.row_region.copy(&err.for_key),
+                                }),
+                                UpsertError::NullKey(err) => UpsertError::NullKey(*err),
+                            };
+                            EnvelopeError::Upsert(err)
+                        }
+                        EnvelopeError::Flat(string) => {
+                            EnvelopeError::Flat(self.string_region.copy(string))
+                        }
+                    };
+                    let reference = self.envelope_error_region.copy_iter(once(err));
+                    let boxed = unsafe { Box::from_raw(reference.as_mut_ptr()) };
+                    DataflowError::EnvelopeError(boxed)
+                }
+            }
+        }
+
+        fn clear(&mut self) {
+            let Self {
+                decode_error_region,
+                envelope_error_region,
+                eval_error_region,
+                row_region,
+                source_error_region,
+                string_region,
+                u8_region,
+            } = self;
+            decode_error_region.clear();
+            envelope_error_region.clear();
+            eval_error_region.clear();
+            row_region.clear();
+            source_error_region.clear();
+            string_region.clear();
+            u8_region.clear();
+        }
+
+        fn reserve_items<'a, I>(&mut self, items: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self::Item> + Clone,
+        {
+            self.decode_error_region.reserve(
+                items
+                    .clone()
+                    .filter(|x| matches!(x, DataflowError::DecodeError(_)))
+                    .count(),
+            );
+            self.envelope_error_region.reserve(
+                items
+                    .clone()
+                    .filter(|x| matches!(x, DataflowError::EnvelopeError(_)))
+                    .count(),
+            );
+            self.eval_error_region.reserve(
+                items
+                    .clone()
+                    .filter(|x| matches!(x, DataflowError::EvalError(_)))
+                    .count(),
+            );
+            self.source_error_region.reserve(
+                items
+                    .filter(|x| matches!(x, DataflowError::SourceError(_)))
+                    .count(),
+            );
+        }
+
+        fn reserve_regions<'a, I>(&mut self, regions: I)
+        where
+            Self: 'a,
+            I: Iterator<Item = &'a Self> + Clone,
+        {
+            self.row_region
+                .reserve_regions(regions.clone().map(|r| &r.row_region));
+            self.string_region
+                .reserve_regions(regions.clone().map(|r| &r.string_region));
+            self.u8_region
+                .reserve_regions(regions.clone().map(|r| &r.u8_region));
+        }
+
+        fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
+            let Self {
+                decode_error_region,
+                envelope_error_region,
+                eval_error_region,
+                row_region,
+                source_error_region,
+                string_region,
+                u8_region,
+            } = &self;
+            decode_error_region.heap_size(&mut callback);
+            envelope_error_region.heap_size(&mut callback);
+            eval_error_region.heap_size(&mut callback);
+            row_region.heap_size(&mut callback);
+            source_error_region.heap_size(&mut callback);
+            string_region.heap_size(&mut callback);
+            u8_region.heap_size(callback);
+        }
     }
 }
 

--- a/src/storage-client/src/types/errors.rs
+++ b/src/storage-client/src/types/errors.rs
@@ -463,7 +463,7 @@ mod columnation {
         type Item = DataflowError;
 
         unsafe fn copy(&mut self, item: &Self::Item) -> Self::Item {
-            match item {
+            let err = match item {
                 DataflowError::DecodeError(err) => {
                     let err = self.copy_decode_error(&*err);
                     let reference = self.decode_error_region.copy_iter(once(err));
@@ -748,7 +748,9 @@ mod columnation {
                     let boxed = unsafe { Box::from_raw(reference.as_mut_ptr()) };
                     DataflowError::EnvelopeError(boxed)
                 }
-            }
+            };
+            debug_assert_eq!(item, &err);
+            err
         }
 
         fn clear(&mut self) {

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -721,9 +721,9 @@ fn upsert_commands<G: Scope>(
                     Some(Ok(row_buf.clone()))
                 }
             },
-            Some(Err(err)) => Some(Err(UpsertError::Value(UpsertValueError {
+            Some(Err(inner)) => Some(Err(UpsertError::Value(UpsertValueError {
                 for_key: key_row,
-                inner: Box::new(DataflowError::DecodeError(Box::new(err))),
+                inner,
             }))),
             None => None,
         };

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -310,4 +310,20 @@ ALTER SYSTEM SET enable_arrangement_size_logging = false
 > SELECT records >= 1000 AND records <= 1001, batches > 0, size, capacity, allocations FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name='ii_t4'
 true true 0 0 0
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_arrangement_size_logging = true
+
 > DROP INDEX ii_t4
+
+# Test arrangement size logging for error dataflows
+
+> CREATE TABLE t5(a int)
+
+> INSERT INTO t5 SELECT -a FROM generate_series(1, 10000) g(a)
+
+> CREATE VIEW vt5 AS SELECT a::uint2 FROM t5
+
+> CREATE INDEX vt5_idx ON vt5(a)
+
+> SELECT records, (size/1024/1024)::int FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name='vt5_idx'
+10000 1


### PR DESCRIPTION
### Motivation

This PR fixes an unreported issue. Previously `DataflowError` would simply be cloned when storing in columnation regions. This is correct but heap-allocates any referenced data, for example the box serving as the first level of indirection. With this change, we region-allocate all referenced data.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
