### PR TITLE
turn off VLE for feature benchmark

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -659,7 +659,9 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
-          args: [--scenario=KafkaUpsertUnique]
+          args:
+            - --scenario=KafkaUpsertUnique
+            - --this-params=variable_length_row_encoding=false
     coverage: skip
 
   - id: deploy-website


### PR DESCRIPTION

### Motivation

  * This PR fixes a previously unreported bug.
  
  All of CI was switched to run with `variable_length_row_encoding=true` recently. However, this causes the Kafka feature benchmark to be flaky, as that flag makes row encoding and decoding a bit less efficient (as is expected). That flag is currently off in prod.
  
  This PR switches back to running that benchmark with the old row encoding strategy. If we decide that the query time regression is worth the memory regression for this feature, we'll need to revert this, and accept the failure of the feature benchmark (or adjust it to use the new baseline).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
