### PR TITLE
comments: Support all types

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -102,7 +102,7 @@ pub enum Statement<T: AstInfo> {
     AlterDefaultPrivileges(AlterDefaultPrivilegesStatement<T>),
     ReassignOwned(ReassignOwnedStatement<T>),
     ValidateConnection(ValidateConnectionStatement<T>),
-    Comment(CommentStatement),
+    Comment(CommentStatement<T>),
 }
 
 impl<T: AstInfo> AstDisplay for Statement<T> {
@@ -3784,12 +3784,12 @@ impl_display_t!(ReassignOwnedStatement);
 
 /// `COMMENT ON ...`
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct CommentStatement {
-    pub object: CommentObjectType,
+pub struct CommentStatement<T: AstInfo> {
+    pub object: CommentObjectType<T>,
     pub comment: Option<String>,
 }
 
-impl AstDisplay for CommentStatement {
+impl<T: AstInfo> AstDisplay for CommentStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("COMMENT ON ");
         f.write_node(&self.object);
@@ -3805,10 +3805,10 @@ impl AstDisplay for CommentStatement {
         }
     }
 }
-impl_display!(CommentStatement);
+impl_display_t!(CommentStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum CommentObjectType {
+pub enum CommentObjectType<T: AstInfo> {
     Table {
         name: UnresolvedItemName,
     },
@@ -3819,9 +3819,48 @@ pub enum CommentObjectType {
         relation_name: UnresolvedItemName,
         column_name: Ident,
     },
+    MaterializedView {
+        name: UnresolvedItemName,
+    },
+    Source {
+        name: UnresolvedItemName,
+    },
+    Sink {
+        name: UnresolvedItemName,
+    },
+    Index {
+        name: UnresolvedItemName,
+    },
+    Func {
+        name: UnresolvedItemName,
+    },
+    Connection {
+        name: UnresolvedItemName,
+    },
+    Type {
+        name: UnresolvedItemName,
+    },
+    Secret {
+        name: UnresolvedItemName,
+    },
+    Role {
+        name: Ident,
+    },
+    Database {
+        name: UnresolvedDatabaseName,
+    },
+    Schema {
+        name: UnresolvedSchemaName,
+    },
+    Cluster {
+        name: T::ClusterName,
+    },
+    ClusterReplica {
+        name: QualifiedReplica,
+    },
 }
 
-impl AstDisplay for CommentObjectType {
+impl<T: AstInfo> AstDisplay for CommentObjectType<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         use CommentObjectType::*;
 
@@ -3843,7 +3882,60 @@ impl AstDisplay for CommentObjectType {
                 f.write_str(".");
                 f.write_node(column_name);
             }
+            MaterializedView { name } => {
+                f.write_str("MATERIALIZED VIEW ");
+                f.write_node(name);
+            }
+            Source { name } => {
+                f.write_str("SOURCE ");
+                f.write_node(name);
+            }
+            Sink { name } => {
+                f.write_str("SINK ");
+                f.write_node(name);
+            }
+            Index { name } => {
+                f.write_str("INDEX ");
+                f.write_node(name);
+            }
+            Func { name } => {
+                f.write_str("FUNCTION ");
+                f.write_node(name);
+            }
+            Connection { name } => {
+                f.write_str("CONNECTION ");
+                f.write_node(name);
+            }
+            Type { name } => {
+                f.write_str("TYPE ");
+                f.write_node(name);
+            }
+            Secret { name } => {
+                f.write_str("SECRET ");
+                f.write_node(name);
+            }
+            Role { name } => {
+                f.write_str("ROLE ");
+                f.write_node(name);
+            }
+            Database { name } => {
+                f.write_str("DATABASE ");
+                f.write_node(name);
+            }
+            Schema { name } => {
+                f.write_str("SCHEMA ");
+                f.write_node(name);
+            }
+            Cluster { name } => {
+                f.write_str("CLUSTER ");
+                f.write_node(name);
+            }
+            ClusterReplica { name } => {
+                f.write_str("CLUSTER REPLICA ");
+                f.write_node(name);
+            }
         }
     }
 }
-impl_display!(CommentObjectType);
+
+impl_display_t!(CommentObjectType);

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7472,7 +7472,23 @@ impl<'a> Parser<'a> {
     fn parse_comment(&mut self) -> Result<Statement<Raw>, ParserError> {
         self.expect_keyword(ON)?;
 
-        let object = match self.expect_one_of_keywords(&[TABLE, VIEW, COLUMN])? {
+        let object = match self.expect_one_of_keywords(&[
+            TABLE,
+            VIEW,
+            COLUMN,
+            MATERIALIZED,
+            SOURCE,
+            SINK,
+            INDEX,
+            FUNCTION,
+            CONNECTION,
+            TYPE,
+            SECRET,
+            ROLE,
+            DATABASE,
+            SCHEMA,
+            CLUSTER,
+        ])? {
             TABLE => {
                 let name = self.parse_item_name()?;
                 CommentObjectType::Table { name }
@@ -7480,6 +7496,60 @@ impl<'a> Parser<'a> {
             VIEW => {
                 let name = self.parse_item_name()?;
                 CommentObjectType::View { name }
+            }
+            MATERIALIZED => {
+                self.expect_keyword(VIEW)?;
+                let name = self.parse_item_name()?;
+                CommentObjectType::MaterializedView { name }
+            }
+            SOURCE => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Source { name }
+            }
+            SINK => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Sink { name }
+            }
+            INDEX => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Index { name }
+            }
+            FUNCTION => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Func { name }
+            }
+            CONNECTION => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Connection { name }
+            }
+            TYPE => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Type { name }
+            }
+            SECRET => {
+                let name = self.parse_item_name()?;
+                CommentObjectType::Secret { name }
+            }
+            ROLE => {
+                let name = self.parse_identifier()?;
+                CommentObjectType::Role { name }
+            }
+            DATABASE => {
+                let name = self.parse_database_name()?;
+                CommentObjectType::Database { name }
+            }
+            SCHEMA => {
+                let name = self.parse_schema_name()?;
+                CommentObjectType::Schema { name }
+            }
+            CLUSTER => {
+                if self.parse_keyword(REPLICA) {
+                    let name = self.parse_cluster_replica_name()?;
+                    CommentObjectType::ClusterReplica { name }
+                } else {
+                    let name = self.parse_raw_ident()?;
+                    CommentObjectType::Cluster { name }
+                }
             }
             COLUMN => {
                 let start = self.peek_pos();

--- a/src/sql-parser/tests/testdata/comment
+++ b/src/sql-parser/tests/testdata/comment
@@ -61,3 +61,94 @@ COMMENT ON COLUMN cool_table.bad_column IS NULL
 COMMENT ON COLUMN cool_table.bad_column IS NULL
 =>
 Comment(CommentStatement { object: Column { relation_name: UnresolvedItemName([Ident("cool_table")]), column_name: Ident("bad_column") }, comment: None })
+
+parse-statement
+COMMENT ON MATERIALIZED VIEW mz IS 'hello world'
+----
+COMMENT ON MATERIALIZED VIEW mz IS 'hello world'
+=>
+Comment(CommentStatement { object: MaterializedView { name: UnresolvedItemName([Ident("mz")]) }, comment: Some("hello world") })
+
+parse-statement
+COMMENT ON SINK kool_kafka IS 'i wish kafka was easier'
+----
+COMMENT ON SINK kool_kafka IS 'i wish kafka was easier'
+=>
+Comment(CommentStatement { object: Sink { name: UnresolvedItemName([Ident("kool_kafka")]) }, comment: Some("i wish kafka was easier") })
+
+parse-statement
+COMMENT ON SOURCE pg_src IS 'ingest data all the time!'
+----
+COMMENT ON SOURCE pg_src IS 'ingest data all the time!'
+=>
+Comment(CommentStatement { object: Source { name: UnresolvedItemName([Ident("pg_src")]) }, comment: Some("ingest data all the time!") })
+
+parse-statement
+COMMENT ON INDEX my_db.x.fast IS 'this is a super fast index'
+----
+COMMENT ON INDEX my_db.x.fast IS 'this is a super fast index'
+=>
+Comment(CommentStatement { object: Index { name: UnresolvedItemName([Ident("my_db"), Ident("x"), Ident("fast")]) }, comment: Some("this is a super fast index") })
+
+parse-statement
+COMMENT ON FUNCTION ai_func IS 'ai in a bottle $$$'
+----
+COMMENT ON FUNCTION ai_func IS 'ai in a bottle $$$'
+=>
+Comment(CommentStatement { object: Func { name: UnresolvedItemName([Ident("ai_func")]) }, comment: Some("ai in a bottle $$$") })
+
+parse-statement
+COMMENT ON CONNECTION kafka_super_prod IS 'yep'
+----
+COMMENT ON CONNECTION kafka_super_prod IS 'yep'
+=>
+Comment(CommentStatement { object: Connection { name: UnresolvedItemName([Ident("kafka_super_prod")]) }, comment: Some("yep") })
+
+parse-statement
+COMMENT ON ROLE space_monkey IS 'should be our mascot'
+----
+COMMENT ON ROLE space_monkey IS 'should be our mascot'
+=>
+Comment(CommentStatement { object: Role { name: Ident("space_monkey") }, comment: Some("should be our mascot") })
+
+parse-statement
+COMMENT ON DATABASE "my_db" IS 'all of our prod data is here'
+----
+COMMENT ON DATABASE my_db IS 'all of our prod data is here'
+=>
+Comment(CommentStatement { object: Database { name: UnresolvedDatabaseName(Ident("my_db")) }, comment: Some("all of our prod data is here") })
+
+parse-statement
+COMMENT ON SCHEMA "my_db".important IS 'the important prod data'
+----
+COMMENT ON SCHEMA my_db.important IS 'the important prod data'
+=>
+Comment(CommentStatement { object: Schema { name: UnresolvedSchemaName([Ident("my_db"), Ident("important")]) }, comment: Some("the important prod data") })
+
+parse-statement
+COMMENT ON CLUSTER xl IS 'big compute'
+----
+COMMENT ON CLUSTER xl IS 'big compute'
+=>
+Comment(CommentStatement { object: Cluster { name: Unresolved(Ident("xl")) }, comment: Some("big compute") })
+
+parse-statement
+COMMENT ON CLUSTER REPLICA xl.r0 IS 'big computes main homie'
+----
+COMMENT ON CLUSTER REPLICA xl.r0 IS 'big computes main homie'
+=>
+Comment(CommentStatement { object: ClusterReplica { name: QualifiedReplica { cluster: Ident("xl"), replica: Ident("r0") } }, comment: Some("big computes main homie") })
+
+parse-statement
+COMMENT ON TYPE special_int IS 'not enough bits'
+----
+COMMENT ON TYPE special_int IS 'not enough bits'
+=>
+Comment(CommentStatement { object: Type { name: UnresolvedItemName([Ident("special_int")]) }, comment: Some("not enough bits") })
+
+parse-statement
+COMMENT ON SECRET api_key IS 'shhhhhh'
+----
+COMMENT ON SECRET api_key IS 'shhhhhh'
+=>
+Comment(CommentStatement { object: Secret { name: UnresolvedItemName([Ident("api_key")]) }, comment: Some("shhhhhh") })

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -43,9 +43,9 @@ use uuid::Uuid;
 
 use crate::func::Func;
 use crate::names::{
-    Aug, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName, QualifiedItemName,
-    QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds, SchemaId, SchemaSpecifier,
-    SystemObjectId,
+    Aug, CommentObjectId, DatabaseId, FullItemName, FullSchemaName, ObjectId, PartialItemName,
+    QualifiedItemName, QualifiedSchemaName, ResolvedDatabaseSpecifier, ResolvedIds, SchemaId,
+    SchemaSpecifier, SystemObjectId,
 };
 use crate::normalize;
 use crate::plan::statement::ddl::PlannedRoleAttributes;
@@ -1274,6 +1274,28 @@ impl From<mz_sql_parser::ast::ObjectType> for ObjectType {
             mz_sql_parser::ast::ObjectType::Database => ObjectType::Database,
             mz_sql_parser::ast::ObjectType::Schema => ObjectType::Schema,
             mz_sql_parser::ast::ObjectType::Func => ObjectType::Func,
+        }
+    }
+}
+
+impl From<CommentObjectId> for ObjectType {
+    fn from(value: CommentObjectId) -> ObjectType {
+        match value {
+            CommentObjectId::Table(_) => ObjectType::Table,
+            CommentObjectId::View(_) => ObjectType::View,
+            CommentObjectId::MaterializedView(_) => ObjectType::MaterializedView,
+            CommentObjectId::Source(_) => ObjectType::Source,
+            CommentObjectId::Sink(_) => ObjectType::Sink,
+            CommentObjectId::Index(_) => ObjectType::Index,
+            CommentObjectId::Func(_) => ObjectType::Func,
+            CommentObjectId::Connection(_) => ObjectType::Connection,
+            CommentObjectId::Type(_) => ObjectType::Type,
+            CommentObjectId::Secret(_) => ObjectType::Secret,
+            CommentObjectId::Role(_) => ObjectType::Role,
+            CommentObjectId::Database(_) => ObjectType::Database,
+            CommentObjectId::Schema(_) => ObjectType::Schema,
+            CommentObjectId::Cluster(_) => ObjectType::Cluster,
+            CommentObjectId::ClusterReplica(_) => ObjectType::ClusterReplica,
         }
     }
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -18,7 +18,7 @@ use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::LocalId;
 use mz_ore::cast::CastFrom;
 use mz_ore::str::StrExt;
-use mz_proto::ProtoType;
+use mz_proto::{IntoRustIfSome, ProtoType};
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql_parser::ast::{MutRecBlock, UnresolvedObjectName};
@@ -300,6 +300,35 @@ impl From<Option<DatabaseId>> for ResolvedDatabaseSpecifier {
     }
 }
 
+impl RustType<proto::ResolvedDatabaseSpecifier> for ResolvedDatabaseSpecifier {
+    fn into_proto(&self) -> proto::ResolvedDatabaseSpecifier {
+        let spec = match self {
+            ResolvedDatabaseSpecifier::Ambient => {
+                proto::resolved_database_specifier::Spec::Ambient(Default::default())
+            }
+            ResolvedDatabaseSpecifier::Id(database_id) => {
+                proto::resolved_database_specifier::Spec::Id(database_id.into_proto())
+            }
+        };
+        proto::ResolvedDatabaseSpecifier { spec: Some(spec) }
+    }
+
+    fn from_proto(proto: proto::ResolvedDatabaseSpecifier) -> Result<Self, TryFromProtoError> {
+        let spec = proto
+            .spec
+            .ok_or_else(|| TryFromProtoError::missing_field("ResolvedDatabaseSpecifier::spec"))?;
+        let spec = match spec {
+            proto::resolved_database_specifier::Spec::Ambient(_) => {
+                ResolvedDatabaseSpecifier::Ambient
+            }
+            proto::resolved_database_specifier::Spec::Id(database_id) => {
+                ResolvedDatabaseSpecifier::Id(database_id.into_rust()?)
+            }
+        };
+        Ok(spec)
+    }
+}
+
 /*
  * TODO(jkosh44) It's possible that in order to fix
  * https://github.com/MaterializeInc/materialize/issues/8805 we will need to assign temporary
@@ -378,6 +407,33 @@ impl From<SchemaSpecifier> for SchemaId {
             SchemaSpecifier::Temporary => SchemaId::User(SchemaSpecifier::TEMPORARY_SCHEMA_ID),
             SchemaSpecifier::Id(id) => id,
         }
+    }
+}
+
+impl RustType<proto::SchemaSpecifier> for SchemaSpecifier {
+    fn into_proto(&self) -> proto::SchemaSpecifier {
+        let spec = match self {
+            SchemaSpecifier::Temporary => {
+                proto::schema_specifier::Spec::Temporary(Default::default())
+            }
+            SchemaSpecifier::Id(schema_id) => {
+                proto::schema_specifier::Spec::Id(schema_id.into_proto())
+            }
+        };
+        proto::SchemaSpecifier { spec: Some(spec) }
+    }
+
+    fn from_proto(proto: proto::SchemaSpecifier) -> Result<Self, TryFromProtoError> {
+        let spec = proto
+            .spec
+            .ok_or_else(|| TryFromProtoError::missing_field("SchemaSpecifier::spec"))?;
+        let spec = match spec {
+            proto::schema_specifier::Spec::Temporary(_) => SchemaSpecifier::Temporary,
+            proto::schema_specifier::Spec::Id(schema_id) => {
+                SchemaSpecifier::Id(schema_id.into_rust()?)
+            }
+        };
+        Ok(spec)
     }
 }
 
@@ -1104,6 +1160,28 @@ impl From<&GlobalId> for ObjectId {
     }
 }
 
+impl From<CommentObjectId> for ObjectId {
+    fn from(id: CommentObjectId) -> Self {
+        match id {
+            CommentObjectId::Table(global_id)
+            | CommentObjectId::View(global_id)
+            | CommentObjectId::MaterializedView(global_id)
+            | CommentObjectId::Source(global_id)
+            | CommentObjectId::Sink(global_id)
+            | CommentObjectId::Index(global_id)
+            | CommentObjectId::Func(global_id)
+            | CommentObjectId::Connection(global_id)
+            | CommentObjectId::Type(global_id)
+            | CommentObjectId::Secret(global_id) => ObjectId::Item(global_id),
+            CommentObjectId::Role(id) => ObjectId::Role(id),
+            CommentObjectId::Database(id) => ObjectId::Database(id),
+            CommentObjectId::Schema(id) => ObjectId::Schema(id),
+            CommentObjectId::Cluster(id) => ObjectId::Cluster(id),
+            CommentObjectId::ClusterReplica(id) => ObjectId::ClusterReplica(id),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum SystemObjectId {
     /// The ID of a specific object.
@@ -1139,6 +1217,19 @@ impl From<ObjectId> for SystemObjectId {
 pub enum CommentObjectId {
     Table(GlobalId),
     View(GlobalId),
+    MaterializedView(GlobalId),
+    Source(GlobalId),
+    Sink(GlobalId),
+    Index(GlobalId),
+    Func(GlobalId),
+    Connection(GlobalId),
+    Type(GlobalId),
+    Secret(GlobalId),
+    Role(RoleId),
+    Database(DatabaseId),
+    Schema((ResolvedDatabaseSpecifier, SchemaSpecifier)),
+    Cluster(ClusterId),
+    ClusterReplica((ClusterId, ReplicaId)),
 }
 
 impl RustType<proto::comment_key::Object> for CommentObjectId {
@@ -1150,6 +1241,52 @@ impl RustType<proto::comment_key::Object> for CommentObjectId {
             CommentObjectId::View(global_id) => {
                 proto::comment_key::Object::View(global_id.into_proto())
             }
+            CommentObjectId::MaterializedView(global_id) => {
+                proto::comment_key::Object::MaterializedView(global_id.into_proto())
+            }
+            CommentObjectId::Source(global_id) => {
+                proto::comment_key::Object::Source(global_id.into_proto())
+            }
+            CommentObjectId::Sink(global_id) => {
+                proto::comment_key::Object::Sink(global_id.into_proto())
+            }
+            CommentObjectId::Index(global_id) => {
+                proto::comment_key::Object::Index(global_id.into_proto())
+            }
+            CommentObjectId::Func(global_id) => {
+                proto::comment_key::Object::Func(global_id.into_proto())
+            }
+            CommentObjectId::Connection(global_id) => {
+                proto::comment_key::Object::Connection(global_id.into_proto())
+            }
+            CommentObjectId::Type(global_id) => {
+                proto::comment_key::Object::Type(global_id.into_proto())
+            }
+            CommentObjectId::Secret(global_id) => {
+                proto::comment_key::Object::Secret(global_id.into_proto())
+            }
+            CommentObjectId::Role(role_id) => {
+                proto::comment_key::Object::Role(role_id.into_proto())
+            }
+            CommentObjectId::Database(database_id) => {
+                proto::comment_key::Object::Database(database_id.into_proto())
+            }
+            CommentObjectId::Schema((database, schema)) => {
+                proto::comment_key::Object::Schema(proto::ResolvedSchema {
+                    database: Some(database.into_proto()),
+                    schema: Some(schema.into_proto()),
+                })
+            }
+            CommentObjectId::Cluster(cluster_id) => {
+                proto::comment_key::Object::Cluster(cluster_id.into_proto())
+            }
+            CommentObjectId::ClusterReplica((cluster_id, replica_id)) => {
+                let cluster_replica_id = proto::ClusterReplicaId {
+                    cluster_id: Some(cluster_id.into_proto()),
+                    replica_id: Some(replica_id.into_proto()),
+                };
+                proto::comment_key::Object::ClusterReplica(cluster_replica_id)
+            }
         }
     }
 
@@ -1160,6 +1297,57 @@ impl RustType<proto::comment_key::Object> for CommentObjectId {
             }
             proto::comment_key::Object::View(global_id) => {
                 CommentObjectId::View(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::MaterializedView(global_id) => {
+                CommentObjectId::MaterializedView(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Source(global_id) => {
+                CommentObjectId::Source(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Sink(global_id) => {
+                CommentObjectId::Sink(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Index(global_id) => {
+                CommentObjectId::Index(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Func(global_id) => {
+                CommentObjectId::Func(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Connection(global_id) => {
+                CommentObjectId::Connection(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Type(global_id) => {
+                CommentObjectId::Type(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Secret(global_id) => {
+                CommentObjectId::Secret(global_id.into_rust()?)
+            }
+            proto::comment_key::Object::Role(role_id) => {
+                CommentObjectId::Role(role_id.into_rust()?)
+            }
+            proto::comment_key::Object::Database(database_id) => {
+                CommentObjectId::Database(database_id.into_rust()?)
+            }
+            proto::comment_key::Object::Schema(resolved_schema) => {
+                let database = resolved_schema
+                    .database
+                    .into_rust_if_some("ResolvedSchema::database")?;
+                let schema = resolved_schema
+                    .schema
+                    .into_rust_if_some("ResolvedSchema::schema")?;
+                CommentObjectId::Schema((database, schema))
+            }
+            proto::comment_key::Object::Cluster(cluster_id) => {
+                CommentObjectId::Cluster(cluster_id.into_rust()?)
+            }
+            proto::comment_key::Object::ClusterReplica(cluster_replica_id) => {
+                let cluster_id = cluster_replica_id
+                    .cluster_id
+                    .into_rust_if_some("ClusterReplicaId::cluster_id")?;
+                let replica_id = cluster_replica_id
+                    .replica_id
+                    .into_rust_if_some("ClusterReplicaId::replica_id")?;
+                CommentObjectId::ClusterReplica((cluster_id, replica_id))
             }
         };
         Ok(id)

--- a/src/stash/build.rs
+++ b/src/stash/build.rs
@@ -217,6 +217,8 @@ fn main() -> anyhow::Result<()> {
         .enum_attribute("ResolvedDatabaseSpecifier.value", ATTR)
         .enum_attribute("CommentKey.object", ATTR)
         .enum_attribute("CommentKey.sub_component", ATTR)
+        .enum_attribute("ResolvedDatabaseSpecifier.spec", ATTR)
+        .enum_attribute("SchemaSpecifier.spec", ATTR)
         // We derive Arbitrary for all protobuf types for wire compatibility testing.
         .message_attribute(".", ARBITRARY_ATTR)
         .enum_attribute(".", ARBITRARY_ATTR)

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "5d752c4a0df8fdaa6069ea47912a9995"
+    "md5": "6c96563888135516d1c2c1b164990eb5"
   },
   {
     "name": "objects_v25.proto",
@@ -50,5 +50,9 @@
   {
     "name": "objects_v36.proto",
     "md5": "7e7dabc91c90e5cdd22391e50c689c35"
+  },
+  {
+    "name": "objects_v37.proto",
+    "md5": "dc4c8ab26c13c3d695568446d91fe703"
   }
 ]

--- a/src/stash/protos/objects_v37.proto
+++ b/src/stash/protos/objects_v37.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v37;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 36;
+pub const STASH_VERSION: u64 = 37;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -919,6 +919,7 @@ impl Stash {
                             33 => upgrade::v33_to_v34::upgrade(&mut tx).await?,
                             34 => upgrade::v34_to_v35::upgrade(&mut tx).await?,
                             35 => upgrade::v35_to_v36::upgrade(&mut tx).await?,
+                            36 => upgrade::v36_to_v37::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -59,6 +59,7 @@ pub(crate) mod v32_to_v33;
 pub(crate) mod v33_to_v34;
 pub(crate) mod v34_to_v35;
 pub(crate) mod v35_to_v36;
+pub(crate) mod v36_to_v37;
 
 macro_rules! objects {
     ( $( $x:ident ),* ) => {

--- a/src/stash/src/upgrade/v36_to_v37.rs
+++ b/src/stash/src/upgrade/v36_to_v37.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for adding support for `COMMENT ON` for more types.
+pub fn upgrade() {}

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -18,6 +18,11 @@ ALTER SYSTEM SET enable_comment TO true;
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_webhook_sources = true
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 
@@ -73,6 +78,12 @@ statement error column "b.does_not_exist" does not exist
 COMMENT ON COLUMN b.does_not_exist IS 'foo';
 
 statement ok
+CREATE INDEX b_idx ON b (ts);
+
+statement ok
+COMMENT ON INDEX b_idx IS 'speed_up';
+
+statement ok
 CREATE VIEW c (col_1, col_2) AS VALUES ('a', 'b');
 
 statement ok
@@ -81,8 +92,214 @@ COMMENT ON VIEW c IS 'this_is_a_view';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u3  view  NULL  this_is_a_view
+u3  index NULL  speed_up
+u4  view  NULL  this_is_a_view
 
-# We could support this, but don't right now.
-statement error COMMENT on view not yet supported
-COMMENT ON COLUMN c.col_1 IS 'this_will_work_one_day';
+statement ok
+DROP TABLE b CASCADE;
+
+statement ok
+COMMENT ON COLUMN c.col_1 IS 'this_works';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u4  view  NULL  this_is_a_view
+u4  view  1  this_works
+
+statement ok
+CREATE MATERIALIZED VIEW mv ( x ) AS SELECT 1
+
+statement ok
+COMMENT ON COLUMN mv.x IS 'comment_mat_view_col';
+
+statement ok
+COMMENT ON MATERIALIZED VIEW mv IS 'mat_foo';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u4  view  NULL  this_is_a_view
+u4  view  1  this_works
+u5  materialized-view  NULL  mat_foo
+u5  materialized-view  1  comment_mat_view_col
+
+statement ok
+DROP VIEW c;
+
+statement ok
+DROP MATERIALIZED VIEW mv;
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+
+statement ok
+CREATE CLUSTER comment_cluster REPLICAS (r1 (SIZE '1'), r2 (SIZE '1'));
+
+statement ok
+COMMENT ON CLUSTER comment_cluster IS 'careful_now';
+
+statement ok
+COMMENT ON CLUSTER REPLICA comment_cluster.r2 IS 'second_replicator';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u2 cluster NULL careful_now
+u3 cluster-replica NULL second_replicator
+
+statement ok
+DROP CLUSTER REPLICA comment_cluster.r2;
+
+statement ok
+CREATE SOURCE my_webhook IN CLUSTER comment_cluster FROM WEBHOOK BODY FORMAT TEXT;
+
+statement ok
+COMMENT ON SOURCE my_webhook IS 'all_the_data';
+
+statement ok
+COMMENT ON COLUMN my_webhook.body IS 'json_blob';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u2 cluster NULL careful_now
+u6 source NULL all_the_data
+u6 source 1 json_blob
+
+statement ok
+CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
+
+statement ok
+COMMENT ON TYPE int4_list IS 'supercool_list';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u2 cluster NULL careful_now
+u6 source NULL all_the_data
+u7 type NULL supercool_list
+u6 source 1 json_blob
+
+statement ok
+DROP CLUSTER comment_cluster CASCADE;
+
+statement ok
+CREATE SECRET my_secret AS 'foobar';
+
+statement ok
+COMMENT ON SECRET my_secret IS 'supersecret';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u8 secret NULL supersecret
+u7 type NULL supercool_list
+
+statement ok
+CREATE DATABASE comment_on_db;
+
+statement ok
+CREATE SCHEMA comment_on_schema;
+
+statement ok
+COMMENT ON DATABASE comment_on_db IS 'this_is_my_db';
+
+statement ok
+COMMENT ON SCHEMA comment_on_schema IS 'this_is_my_schema';
+
+statement ok
+DROP SECRET my_secret;
+
+statement ok
+DROP TYPE int4_list;
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u2 database NULL this_is_my_db
+u7 schema NULL this_is_my_schema
+
+statement ok
+DROP DATABASE comment_on_db;
+
+statement ok
+DROP SCHEMA comment_on_schema;
+
+# Test RBAC.
+
+statement ok
+CREATE ROLE student;
+
+statement ok
+COMMENT ON ROLE student IS 'limited_role';
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u2 role NULL limited_role
+
+statement ok
+CREATE TABLE foo ( x int8 );
+
+simple conn=student,user=student
+COMMENT ON TABLE foo IS 'comment_from_student';
+----
+db error: ERROR: must be owner of TABLE materialize.public.foo
+
+statement ok
+CREATE ROLE teacher;
+
+simple conn=mz_system,user=mz_system
+GRANT CREATEROLE ON SYSTEM TO student;
+----
+COMPLETE 0
+
+simple conn=student,user=student
+COMMENT ON ROLE teacher IS 'foo';
+----
+COMPLETE 0
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u3 role NULL foo
+u2 role NULL limited_role
+
+simple conn=mz_system,user=mz_system
+REVOKE CREATEROLE ON SYSTEM FROM student;
+----
+COMPLETE 0
+
+# To comment on a Role you must have the CREATEROLE privilege.
+simple conn=student,user=student
+COMMENT ON ROLE teacher IS 'updated_teacher_comment';
+----
+db error: ERROR: permission denied for SYSTEM
+
+statement ok
+DROP ROLE student;
+
+statement ok
+DROP ROLE teacher;
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+
+statement error must be owner of DATABASE materialize
+COMMENT ON DATABASE materialize IS 'main_db';
+
+statement error must be owner of SCHEMA materialize.public
+COMMENT ON SCHEMA public IS 'everyone_has_access';
+
+simple conn=mz_system,user=mz_system
+COMMENT ON DATABASE materialize IS 'main_db';
+----
+COMPLETE 0
+
+query TTTT
+SELECT * FROM mz_internal.mz_comments;
+----
+u1 database NULL main_db


### PR DESCRIPTION
This PR implements support for `COMMENT ON` for all types of objects in Materialize. Specifically it adds support for:

```
COMMENT ON [ 
  MATERIALIZED VIEW | SOURCE | SINK | INDEX | FUNCTION | CONNECTION | TYPE | SECRET | ROLE | DATABASE | SCHEMA | CLUSTER | CLUSTER REPLICA
] ...
```

It also adds support for `COMMENT ON COLUMN <object>.<column_name>` where `<object>` can now be any kind of relation, i.e. a `TABLE`, `VIEW`, `MATERIALIZED VIEW`, or `SOURCE`.

### Motivation

Fixes: #21465 

### Tips for reviewer

By LoC there are a lot of changes in this PR but it's mostly just adding new enum variants to the existing comment types.

You should review each commit independently:

1. Stash/Protobuf updates for persisting the new comment types
2. SQL Parser changes to support the new types
3. ⭐️ Changes to planning, **please pay most attention to this commit**
4. More test cases added to `comment.slt`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR adds support for `COMMENT ON` for all object types, this feature is currently behind a LaunchDarkly flag `enable_comment`.
