### PR TITLE
guard source creation behind feature flag

### DIFF
--- a/misc/python/materialize/mzcompose/services.py
+++ b/misc/python/materialize/mzcompose/services.py
@@ -42,6 +42,7 @@ DEFAULT_MZ_VOLUMES = [
 DEFAULT_SYSTEM_PARAMETERS = {
     "persist_sink_minimum_batch_updates": "128",
     "enable_multi_worker_storage_persist_sink": "true",
+    "enable_create_source": "true",
     "storage_persist_sink_minimum_batch_updates": "100",
     "persist_pubsub_push_diff_enabled": "true",
     "persist_pubsub_client_enabled": "true",

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -582,6 +582,7 @@ fn test_pgtest_mz() {
             "enable_raise_statement",
             "enable_unmanaged_cluster_replicas",
             "enable_dangerous_functions",
+            "enable_create_source",
         ],
     );
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -130,6 +130,7 @@ fn test_persistence() {
 
     {
         let server = util::start_server(config.clone()).unwrap();
+        server.enable_feature_flags(&["enable_create_source"]);
         let mut client = server.connect(postgres::NoTls).unwrap();
         client
             .batch_execute(&format!(
@@ -228,7 +229,8 @@ fn setup_statement_logging(
 #[mz_ore::test]
 // Test that we log various kinds of statement whose execution terminates in the coordinator.
 fn test_statement_logging_immediate() {
-    let (_server, mut client) = setup_statement_logging(1.0, 1.0);
+    let (server, mut client) = setup_statement_logging(1.0, 1.0);
+    server.enable_feature_flags(&["enable_create_source"]);
     let successful_immediates: &[&str] = &[
         "CREATE VIEW v AS SELECT 1;",
         "CREATE DEFAULT INDEX i ON v;",
@@ -622,6 +624,7 @@ fn test_statement_logging_unsampled_metrics() {
 #[mz_ore::test]
 fn test_source_sink_size_required() {
     let server = util::start_server(util::Config::default()).unwrap();
+    server.enable_feature_flags(&["enable_create_source"]);
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Sources bail without an explicit size.
@@ -2138,7 +2141,7 @@ fn test_cancel_ws() {
 #[cfg_attr(miri, ignore)] // too slow
 fn smoketest_webhook_source() {
     let server = util::start_server(util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
+    server.enable_feature_flags(&["enable_webhook_sources", "enable_create_source"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -2325,7 +2328,7 @@ fn test_invalid_webhook_body() {
 #[cfg_attr(miri, ignore)] // too slow
 fn test_webhook_duplicate_headers() {
     let server = util::start_server(util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
+    server.enable_feature_flags(&["enable_webhook_sources", "enable_create_source"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     let http_client = Client::new();
@@ -2552,7 +2555,7 @@ fn test_http_metrics() {
 #[cfg_attr(miri, ignore)] // too slow
 fn webhook_concurrent_actions() {
     let server = util::start_server(util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
+    server.enable_feature_flags(&["enable_webhook_sources", "enable_create_source"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -2712,6 +2715,7 @@ fn webhook_concurrency_limit() {
     let server = util::start_server(config).unwrap();
     // Note: we need enable_unstable_dependencies to use mz_sleep.
     server.enable_feature_flags(&[
+        "enable_create_source",
         "enable_webhook_sources",
         "enable_unstable_dependencies",
         "enable_dangerous_functions",
@@ -2786,7 +2790,7 @@ fn webhook_concurrency_limit() {
 #[cfg_attr(miri, ignore)] // too slow
 fn webhook_too_large_request() {
     let server = util::start_server(util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
+    server.enable_feature_flags(&["enable_webhook_sources", "enable_create_source"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -2836,7 +2840,7 @@ fn webhook_too_large_request() {
 #[cfg_attr(miri, ignore)] // too slow
 fn test_webhook_url_notice() {
     let server = util::start_server(util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
+    server.enable_feature_flags(&["enable_webhook_sources", "enable_create_source"]);
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
 
     let mut client = server

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -171,6 +171,7 @@ fn test_no_block() {
     mz_ore::test::timeout(Duration::from_secs(120), || {
         println!("test_no_block: starting server");
         let server = util::start_server(util::Config::default()).unwrap();
+        server.enable_feature_flags(&["enable_create_source"]);
 
         server.runtime.block_on(async {
             println!("test_no_block: starting mock HTTP server");
@@ -245,6 +246,7 @@ fn test_no_block() {
 #[mz_ore::test]
 fn test_drop_connection_race() {
     let server = util::start_server(util::Config::default().unsafe_mode()).unwrap();
+    server.enable_feature_flags(&["enable_create_source"]);
     info!("test_drop_connection_race: server started");
 
     server.runtime.block_on(async {
@@ -1785,6 +1787,7 @@ fn test_timeline_read_holds() {
     };
     let config = util::Config::default().with_now(now_fn).unsafe_mode();
     let server = util::start_server(config).unwrap();
+    server.enable_feature_flags(&["enable_create_source"]);
     let mut mz_client = server.connect(postgres::NoTls).unwrap();
 
     let view_name = "v_hold";
@@ -1837,6 +1840,7 @@ fn test_linearizability() {
     };
     let config = util::Config::default().with_now(now_fn).unsafe_mode();
     let server = util::start_server(config).unwrap();
+    server.enable_feature_flags(&["enable_create_source"]);
     let mut mz_client = server.connect(postgres::NoTls).unwrap();
 
     let view_name = "v_lin";
@@ -2093,6 +2097,7 @@ fn test_concurrent_writes() {
 #[mz_ore::test]
 fn test_load_generator() {
     let server = util::start_server(util::Config::default().unsafe_mode()).unwrap();
+    server.enable_feature_flags(&["enable_create_source"]);
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     client
@@ -2704,7 +2709,10 @@ fn test_timelines_persist_after_failed_transaction() {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
 
-    server.enable_feature_flags(&["enable_create_source_denylist_with_options"]);
+    server.enable_feature_flags(&[
+        "enable_create_source",
+        "enable_create_source_denylist_with_options",
+    ]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -565,6 +565,8 @@ pub fn plan_create_source(
         progress_subsource,
     } = &stmt;
 
+    scx.require_feature_flag(&vars::ENABLE_CREATE_SOURCE)?;
+
     let envelope = envelope.clone().unwrap_or(Envelope::None);
 
     let allowed_with_options = vec![

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1569,6 +1569,7 @@ feature_flags!(
         enable_connection_validation_syntax,
         "CREATE CONNECTION .. WITH (VALIDATE) and VALIDATE CONNECTION syntax"
     ),
+    (enable_create_source, "executing CREATE SOURCE statements"),
     (
         enable_webhook_sources,
         "creating or pushing data to webhook sources"


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
