### PR TITLE
benchmark: disable variable_length_row_encoding

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -94,7 +94,11 @@ SERVICES = [
     Redpanda(),
     Cockroach(setup_materialize=True),
     Minio(setup_materialize=True),
-    Materialized(),
+    Materialized(
+        additional_system_parameter_defaults={
+            "variable_length_row_encoding": "true",
+        }
+    ),
     Testdrive(
         default_timeout=default_timeout,
         materialize_params={"statement_timeout": f"'{default_timeout}'"},


### PR DESCRIPTION
### Motivation

VLE is currently not enabled in prod.

### See also
https://materializeinc.slack.com/archives/C01LKF361MZ/p1693511387606219