### PR TITLE
Add estimated memory savings to `mz_expected_group_size_advice`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -957,6 +957,7 @@ hierarchical scheme for either aggregation or Top K computations.
 | `region_name`   | [`text`]             | The internal name of the root operator scope for the min/max aggregation or Top K.                        |
 | `levels`        | [`bigint`]           | The number of levels in the hierarchical scheme implemented by the region.                                |
 | `to_cut`        | [`bigint`]           | The number of levels that can be eliminated (cut) from the region's hierarchy.                            |
+| `savings`       | [`numeric`]          | A conservative estimate of the amount of memory in bytes to be saved by applying the hint.                |
 | `hint`          | [`double precision`] | The hint value for `EXPECTED GROUP SIZE` that will eliminate `to_cut` levels from the regions' hierarchy. |
 
 ### `mz_message_counts`

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -505,7 +505,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 4  region_name  text
 5  levels  bigint
 6  to_cut  bigint
-7  hint  double␠precision
+7  savings  numeric
+8  hint  double␠precision
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_message_counts' ORDER BY position

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -101,6 +101,11 @@
 "Dataflow: materialize.public.lineitem_by_suppkey" ReduceHierarchical 8 5 4095
 "Dataflow: materialize.public.lineitem_by_suppkey" TopK 8 5 4095
 
+# Validate that there are positive memory savings listed for the entries above.
+> SELECT COUNT(savings > 0)
+  FROM mz_internal.mz_expected_group_size_advice;
+8
+
 # Create partly hinted versions of the views and check that the advice gets revised accordingly.
 > DROP MATERIALIZED VIEW lineitem_by_suppkey;
 
@@ -137,3 +142,8 @@
 "Dataflow: materialize.public.lineitem_by_partkey" ReduceHierarchical 8 6 255
 "Dataflow: materialize.public.lineitem_by_partkey" TopK 8 6 255
 "Dataflow: materialize.public.lineitem_by_suppkey" TopK 8 5 4095
+
+# Validate that there are positive memory savings listed for the entries above.
+> SELECT COUNT(savings > 0)
+  FROM mz_internal.mz_expected_group_size_advice;
+6


### PR DESCRIPTION
This PR adds a new column to the introspection view `mz_expected_group_size_advice` providing an estimate of the memory savings that can be expected by applying the tuning hint. The memory savings are a conservative estimate based on the sizes of the input arrangements for each level to be cut. These arrangements should dominate the size of each level that can be cut, since the reduction gadget internal to the level does not remove much data at these levels.

Advances #21481 and MaterializeInc/console#718.

### Motivation

  * This PR adds a feature that has not yet been specified.

As part of #21481 and MaterializeInc/console#718, we would like to filter or rank the data in `mz_expected_group_size_advice` by impact, i.e., by the greatest opportunities to save memory by applying the hint suggestions present in this introspection view. However, `mz_expected_group_size_advice` does not reveal the IDs of the operators corresponding to the input arrangements that would get cut by applying the hint nor does it reveal their sizes. Since identifying these operators is part of the computation that `mz_expected_group_size_advice` already performs, it is natural to, as part of that computation, also carry along the arrangement sizes for the levels that would be cut from the hierarchy. The sum aggregate of these sizes is a conservative estimate of the memory savings expected by applying the hint and can be exposed as a new column in the view.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
