### PR TITLE
compute: move `mz_dataflow_initial_output_duration_seconds` metric to the controller

### DIFF
--- a/misc/python/materialize/cli/ci_coverage_pr_report.py
+++ b/misc/python/materialize/cli/ci_coverage_pr_report.py
@@ -31,8 +31,8 @@ SOURCE_RE = re.compile(
 # cases, so ignore such lines. Same for mz_ore::test
 IGNORE_RE = re.compile(
     r"""
-    ( #\[derive\(.*\)\]
-    | #\[mz_ore::test.*\]
+    ( \#\[derive\(.*\)\]
+    | \#\[mz_ore::test.*\]
     )
     """,
     re.VERBOSE,

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -651,7 +651,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
 
                 // Compensate what already was sent to logging sources.
                 if let Some(logger) = &compute_state.compute_logger {
-                    if let Some(time) = collection.reported_frontier().logging_time() {
+                    if let Some(time) = collection.reported_frontier.logging_time() {
                         logger.log(ComputeEvent::Frontier { id, time, diff: -1 });
                     }
                     if let Some(time) = new_reported_frontier.logging_time() {
@@ -659,7 +659,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                     }
                 }
 
-                collection.set_reported_frontier(new_reported_frontier);
+                collection.reported_frontier = new_reported_frontier;
 
                 // Sink tokens should be retained for retained dataflows, and dropped for dropped
                 // dataflows.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -10,6 +10,7 @@
 import json
 import re
 import time
+from copy import copy
 from datetime import datetime
 from textwrap import dedent
 from threading import Thread
@@ -84,6 +85,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-query-without-default-cluster",
         "test-clusterd-death-detection",
         "test-replica-metrics",
+        "test-compute-controller-metrics",
         "test-metrics-retention-across-restart",
     ]:
         with c.test_case(name):
@@ -2026,6 +2028,13 @@ class Metrics:
             key, value = line.split(maxsplit=1)
             self.metrics[key] = value
 
+    def for_instance(self, id: str) -> "Metrics":
+        new = copy(self)
+        new.metrics = {
+            k: v for k, v in self.metrics.items() if f'instance_id="{id}"' in k
+        }
+        return new
+
     def with_name(self, metric_name: str) -> dict[str, float]:
         items = {}
         for key, value in self.metrics.items():
@@ -2039,13 +2048,61 @@ class Metrics:
         assert len(values) == 1
         return values[0]
 
-    def get_command_count(self, command_type: str) -> float:
-        metrics = self.with_name("mz_compute_replica_history_command_count")
+    def get_command_count(self, metric: str, command_type: str) -> float:
+        metrics = self.with_name(metric)
         values = [
             v for k, v in metrics.items() if f'command_type="{command_type}"' in k
         ]
-        assert len(values) <= 1
+        assert len(values) == 1
         return values[0]
+
+    def get_response_count(self, metric: str, response_type: str) -> float:
+        metrics = self.with_name(metric)
+        values = [
+            v for k, v in metrics.items() if f'response_type="{response_type}"' in k
+        ]
+        assert len(values) == 1
+        return values[0]
+
+    def get_replica_history_command_count(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_compute_replica_history_command_count", command_type
+        )
+
+    def get_controller_history_command_count(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_compute_controller_history_command_count", command_type
+        )
+
+    def get_commands_total(self, command_type: str) -> float:
+        return self.get_command_count("mz_compute_commands_total", command_type)
+
+    def get_command_bytes_total(self, command_type: str) -> float:
+        return self.get_command_count(
+            "mz_compute_command_message_bytes_total", command_type
+        )
+
+    def get_responses_total(self, response_type: str) -> float:
+        return self.get_response_count("mz_compute_responses_total", response_type)
+
+    def get_response_bytes_total(self, response_type: str) -> float:
+        return self.get_response_count(
+            "mz_compute_response_message_bytes_total", response_type
+        )
+
+    def get_peeks_total(self, result: str) -> float:
+        metrics = self.with_name("mz_compute_peeks_total")
+        values = [v for k, v in metrics.items() if f'result="{result}"' in k]
+        assert len(values) == 1
+        return values[0]
+
+    def get_initial_output_duration(self, collection_id: str) -> float | None:
+        metrics = self.with_name("mz_dataflow_initial_output_duration_seconds")
+        values = [
+            v for k, v in metrics.items() if f'collection_id="{collection_id}"' in k
+        ]
+        assert len(values) <= 1
+        return next(iter(values), None)
 
 
 def workflow_test_replica_metrics(c: Composition) -> None:
@@ -2093,21 +2150,21 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     # Check that expected metrics exist and have sensible values.
     metrics = fetch_metrics()
 
-    count = metrics.get_command_count("create_timely")
+    count = metrics.get_replica_history_command_count("create_timely")
     assert count == 0, f"unexpected create_timely count: {count}"
-    count = metrics.get_command_count("create_instance")
+    count = metrics.get_replica_history_command_count("create_instance")
     assert count == 1, f"unexpected create_instance count: {count}"
-    count = metrics.get_command_count("allow_compaction")
+    count = metrics.get_replica_history_command_count("allow_compaction")
     assert count > 0, f"unexpected allow_compaction count: {count}"
-    count = metrics.get_command_count("create_dataflow")
+    count = metrics.get_replica_history_command_count("create_dataflow")
     assert count > 0, f"unexpected create_dataflow count: {count}"
-    count = metrics.get_command_count("peek")
+    count = metrics.get_replica_history_command_count("peek")
     assert count <= 2, f"unexpected peek count: {count}"
-    count = metrics.get_command_count("cancel_peek")
+    count = metrics.get_replica_history_command_count("cancel_peek")
     assert count <= 2, f"unexpected cancel_peek count: {count}"
-    count = metrics.get_command_count("initialization_complete")
+    count = metrics.get_replica_history_command_count("initialization_complete")
     assert count == 0, f"unexpected initialization_complete count: {count}"
-    count = metrics.get_command_count("update_configuration")
+    count = metrics.get_replica_history_command_count("update_configuration")
     assert count == 1, f"unexpected update_configuration count: {count}"
 
     count = metrics.get_value("mz_compute_replica_history_dataflow_count")
@@ -2115,6 +2172,155 @@ def workflow_test_replica_metrics(c: Composition) -> None:
 
     maintenance = metrics.get_value("mz_arrangement_maintenance_seconds_total")
     assert maintenance > 0, f"unexpected arrangement maintanence time: {maintenance}"
+
+
+def workflow_test_compute_controller_metrics(c: Composition) -> None:
+    """Test metrics exposed by the compute controller."""
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    def fetch_metrics() -> Metrics:
+        resp = c.exec(
+            "materialized", "curl", "localhost:6878/metrics", capture=True
+        ).stdout
+        return Metrics(resp).for_instance("u2")
+
+    # Set up a cluster with a couple dataflows.
+    c.sql(
+        """
+        CREATE CLUSTER test MANAGED, SIZE '1';
+        SET cluster = test;
+
+        CREATE TABLE t (a int);
+        INSERT INTO t SELECT generate_series(1, 10);
+
+        CREATE INDEX idx ON t (a);
+        CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+
+        SELECT * FROM t;
+        SELECT * FROM mv;
+        """
+    )
+
+    index_id = c.sql_query("SELECT id FROM mz_indexes WHERE name = 'idx'")[0][0]
+    mv_id = c.sql_query("SELECT id FROM mz_materialized_views WHERE name = 'mv'")[0][0]
+
+    # Check that expected metrics exist and have sensible values.
+    metrics = fetch_metrics()
+
+    # mz_compute_commands_total
+    count = metrics.get_commands_total("create_timely")
+    assert count == 1, f"got {count}"
+    count = metrics.get_commands_total("create_instance")
+    assert count == 1, f"got {count}"
+    count = metrics.get_commands_total("allow_compaction")
+    assert count > 0, f"got {count}"
+    count = metrics.get_commands_total("create_dataflow")
+    assert count == 3, f"got {count}"
+    count = metrics.get_commands_total("peek")
+    assert count == 2, f"got {count}"
+    count = metrics.get_commands_total("cancel_peek")
+    assert count == 2, f"got {count}"
+    count = metrics.get_commands_total("initialization_complete")
+    assert count == 1, f"got {count}"
+    count = metrics.get_commands_total("update_configuration")
+    assert count == 1, f"got {count}"
+
+    # mz_compute_command_message_bytes_total
+    count = metrics.get_command_bytes_total("create_timely")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("create_instance")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("allow_compaction")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("create_dataflow")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("peek")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("cancel_peek")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("initialization_complete")
+    assert count > 0, f"got {count}"
+    count = metrics.get_command_bytes_total("update_configuration")
+    assert count > 0, f"got {count}"
+
+    # mz_compute_responses_total
+    count = metrics.get_responses_total("frontier_upper")
+    assert count > 0, f"got {count}"
+    count = metrics.get_responses_total("peek_response")
+    assert count == 2, f"got {count}"
+    count = metrics.get_responses_total("subscribe_response")
+    assert count == 0, f"got {count}"
+
+    # mz_compute_response_message_bytes_total
+    count = metrics.get_response_bytes_total("frontier_upper")
+    assert count > 0, f"got {count}"
+    count = metrics.get_response_bytes_total("peek_response")
+    assert count > 0, f"got {count}"
+    count = metrics.get_response_bytes_total("subscribe_response")
+    assert count == 0, f"got {count}"
+
+    count = metrics.get_value("mz_compute_controller_replica_count")
+    assert count == 1, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_collection_count")
+    assert count > 0, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_peek_count")
+    assert count == 0, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_subscribe_count")
+    assert count == 0, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_command_queue_size")
+    assert count < 10, f"got {count}"
+    count = metrics.get_value("mz_compute_controller_response_queue_size")
+    assert count < 10, f"got {count}"
+
+    # mz_compute_controller_history_command_count
+    count = metrics.get_controller_history_command_count("create_timely")
+    assert count == 1, f"got {count}"
+    count = metrics.get_controller_history_command_count("create_instance")
+    assert count == 1, f"got {count}"
+    count = metrics.get_controller_history_command_count("allow_compaction")
+    assert count > 0, f"got {count}"
+    count = metrics.get_controller_history_command_count("create_dataflow")
+    assert count > 0, f"got {count}"
+    count = metrics.get_controller_history_command_count("peek")
+    assert count <= 2, f"got {count}"
+    count = metrics.get_controller_history_command_count("cancel_peek")
+    assert count <= 2, f"got {count}"
+    count = metrics.get_controller_history_command_count("initialization_complete")
+    assert count == 1, f"got {count}"
+    count = metrics.get_controller_history_command_count("update_configuration")
+    assert count == 1, f"got {count}"
+
+    count = metrics.get_value("mz_compute_controller_history_dataflow_count")
+    assert count >= 2, f"got {count}"
+
+    # mz_compute_peeks_total
+    count = metrics.get_peeks_total("rows")
+    assert count == 2, f"got {count}"
+    count = metrics.get_peeks_total("error")
+    assert count == 0, f"got {count}"
+    count = metrics.get_peeks_total("canceled")
+    assert count == 0, f"got {count}"
+
+    # mz_dataflow_initial_output_duration_seconds
+    duration = metrics.get_initial_output_duration(index_id)
+    assert duration, f"got {duration}"
+    duration = metrics.get_initial_output_duration(mv_id)
+    assert duration, f"got {duration}"
+
+    # Drop the dataflows.
+    c.sql(
+        """
+        DROP INDEX idx;
+        DROP MATERIALIZED VIEW mv;
+        """
+    )
+
+    # Check that the per-collection metrics have been cleaned up.
+    metrics = fetch_metrics()
+    assert metrics.get_initial_output_duration(index_id) is None
+    assert metrics.get_initial_output_duration(mv_id) is None
 
 
 def workflow_test_metrics_retention_across_restart(c: Composition) -> None:


### PR DESCRIPTION
This PR moves the `mz_dataflow_initial_output_duration_seconds` metric from being a replica export to a controller export. The main benefit we get from this is that the `worker_id` label is removed, which both makes the metric easier to use and greatly reduces its cardinality.

As part of this change, this PR:
* Removes the infrastructure for per-collection metrics from the replica code, as it would be unused otherwise. This mostly reverts https://github.com/MaterializeInc/materialize/pull/20126 (sorry for the churn!).
* Adds an mzcompose test for the controller-exposed metrics.

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/18745.
Design doc: https://github.com/MaterializeInc/materialize/pull/19717.

### Tips for reviewer

Look at the commits separately!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A