### PR TITLE
WireCompatible::convert takes reference

### DIFF
--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -39,6 +39,8 @@
 
 use std::collections::BTreeMap;
 
+use paste::paste;
+
 use crate::objects::proto::{ConfigKey, ConfigValue};
 use crate::objects::WireCompatible;
 use crate::{
@@ -57,6 +59,20 @@ pub(crate) mod v32_to_v33;
 pub(crate) mod v33_to_v34;
 pub(crate) mod v34_to_v35;
 pub(crate) mod v35_to_v36;
+
+macro_rules! objects {
+    ( $( $x:ident ),* ) => {
+        paste! {
+            $(
+                pub(crate) mod [<objects_ $x>] {
+                    include!(concat!(env!("OUT_DIR"), "/objects_", stringify!($x), ".rs"));
+                }
+            )*
+        }
+    }
+}
+
+objects!(v27, v28, v29, v31, v32, v33, v34, v35, v36);
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v27_to_v28.rs
+++ b/src/stash/src/upgrade/v27_to_v28.rs
@@ -9,15 +9,8 @@
 
 use crate::objects::wire_compatible;
 use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v27, objects_v28};
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod objects_v27 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v27.rs"));
-}
-
-pub mod objects_v28 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v28.rs"));
-}
 
 wire_compatible!(objects_v28::DefaultPrivilegesKey with objects_v27::DefaultPrivilegesKey);
 wire_compatible!(objects_v28::DefaultPrivilegesValue with objects_v27::DefaultPrivilegesValue);

--- a/src/stash/src/upgrade/v28_to_v29.rs
+++ b/src/stash/src/upgrade/v28_to_v29.rs
@@ -7,17 +7,11 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use crate::upgrade::MigrationAction;
-use crate::{StashError, Transaction, TypedCollection};
 use std::collections::BTreeSet;
 
-pub mod objects_v28 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v28.rs"));
-}
-
-pub mod objects_v29 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v29.rs"));
-}
+use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v28, objects_v29};
+use crate::{StashError, Transaction, TypedCollection};
 
 /// Remove dangling references from default privileges.
 ///

--- a/src/stash/src/upgrade/v31_to_v32.rs
+++ b/src/stash/src/upgrade/v31_to_v32.rs
@@ -8,14 +8,8 @@
 // by the Apache License, Version 2.0.
 
 use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v31, objects_v32};
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod objects_v31 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v31.rs"));
-}
-pub mod objects_v32 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v32.rs"));
-}
 
 /// Remove randomly selected az's.
 pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {

--- a/src/stash/src/upgrade/v32_to_v33.rs
+++ b/src/stash/src/upgrade/v32_to_v33.rs
@@ -9,15 +9,8 @@
 
 use crate::objects::wire_compatible;
 use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v32, objects_v33};
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod objects_v32 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v32.rs"));
-}
-
-pub mod objects_v33 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v33.rs"));
-}
 
 wire_compatible!(objects_v32::RoleKey with objects_v33::RoleKey);
 wire_compatible!(objects_v32::RoleValue with objects_v33::RoleValue);

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -94,7 +94,7 @@ async fn migrate_cluster_replicas(tx: &mut Transaction<'_>) -> Result<(), StashE
                 value: Some(new_id),
             }),
         };
-        let new_value = WireCompatible::convert(value.clone());
+        let new_value = WireCompatible::convert(value);
         MigrationAction::Update(key.clone(), (new_key, new_value))
     };
 

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -11,15 +11,8 @@ use std::collections::BTreeMap;
 
 use crate::objects::{wire_compatible, WireCompatible};
 use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v33 as v33, objects_v34 as v34};
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod v33 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v33.rs"));
-}
-
-pub mod v34 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v34.rs"));
-}
 
 wire_compatible!(v33::ClusterReplicaValue with v34::ClusterReplicaValue);
 wire_compatible!(v33::IdAllocKey with v34::IdAllocKey);

--- a/src/stash/src/upgrade/v34_to_v35.rs
+++ b/src/stash/src/upgrade/v34_to_v35.rs
@@ -7,11 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use crate::upgrade::objects_v35;
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod objects_v35 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v35.rs"));
-}
 
 /// Migration to initialize the comments collection (e.g. `COMMENT ON`).
 pub async fn upgrade(tx: &'_ mut Transaction<'_>) -> Result<(), StashError> {

--- a/src/stash/src/upgrade/v35_to_v36.rs
+++ b/src/stash/src/upgrade/v35_to_v36.rs
@@ -49,9 +49,8 @@ pub async fn upgrade(tx: &mut Transaction<'_>) -> Result<(), StashError> {
                         found_user_flag = true;
                     }
 
-                    let new_key: v36::ServerConfigurationKey = WireCompatible::convert(key.clone());
-                    let new_value: v36::ServerConfigurationValue =
-                        WireCompatible::convert(value.clone());
+                    let new_key: v36::ServerConfigurationKey = WireCompatible::convert(key);
+                    let new_value: v36::ServerConfigurationValue = WireCompatible::convert(value);
                     updates.push(MigrationAction::Update(key.clone(), (new_key, new_value)));
                 }
 

--- a/src/stash/src/upgrade/v35_to_v36.rs
+++ b/src/stash/src/upgrade/v35_to_v36.rs
@@ -11,15 +11,8 @@ use std::collections::BTreeMap;
 
 use crate::objects::{wire_compatible, WireCompatible};
 use crate::upgrade::MigrationAction;
+use crate::upgrade::{objects_v35 as v35, objects_v36 as v36};
 use crate::{StashError, Transaction, TypedCollection};
-
-pub mod v35 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v35.rs"));
-}
-
-pub mod v36 {
-    include!(concat!(env!("OUT_DIR"), "/objects_v36.rs"));
-}
 
 wire_compatible!(v35::ServerConfigurationKey with v36::ServerConfigurationKey);
 wire_compatible!(v35::ServerConfigurationValue with v36::ServerConfigurationValue);


### PR DESCRIPTION
### Motivation

Quality-of-life improvements in stash:
* `WireCompatible::convert` takes reference. This avoids some `clone` calls where the argument is only available as a reference.
* Import versioned object definitions only once instead of in every upgrade implementation. This might bring compile times and binary size down a bit, but I haven't tested it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
