### PR TITLE
adapter: Allow setting default compaction window

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -165,22 +165,6 @@ mod read_policy;
 mod sequencer;
 mod sql;
 
-// TODO: We can have only two consts here, instead of three, once there exists a `const` way to
-// convert between a `Timestamp` and a `Duration`, and unwrap a result in const contexts. Currently
-// unstable compiler features that would allow this are:
-// * `const_option`: https://github.com/rust-lang/rust/issues/67441
-// * `const_result`: https://github.com/rust-lang/rust/issues/82814
-// * `const_num_from_num`: https://github.com/rust-lang/rust/issues/87852
-// * `const_precise_live_drops`: https://github.com/rust-lang/rust/issues/73255
-
-/// `DEFAULT_LOGICAL_COMPACTION_WINDOW`, in milliseconds.
-/// The default is set to a second to track the default timestamp frequency for sources.
-const DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS: u64 = 1000;
-
-/// `DEFAULT_LOGICAL_COMPACTION_WINDOW` as an `EpochMillis` timestamp
-pub const DEFAULT_LOGICAL_COMPACTION_WINDOW_TS: mz_repr::Timestamp =
-    Timestamp::new(DEFAULT_LOGICAL_COMPACTION_WINDOW_MILLIS);
-
 #[derive(Debug)]
 pub enum Message<T = mz_repr::Timestamp> {
     Command(Command),
@@ -1022,7 +1006,6 @@ impl Coordinator {
         // Ultimately, it doesn't concretely matter today, because the type ends up just being
         // u64 anyway.
         let mut policies_to_set: BTreeMap<Timestamp, CollectionIdBundle> = Default::default();
-        policies_to_set.insert(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS, Default::default());
 
         info!("coordinator init: creating compute replicas");
         let mut replicas_to_start = vec![];

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -50,7 +50,7 @@ use crate::catalog::{
 use crate::coord::ddl::CatalogTxn;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::timestamp_selection::TimestampProvider;
-use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS};
+use crate::coord::Coordinator;
 use crate::session::{Session, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};
 use crate::util::{viewable_variables, ResultExt};
 use crate::{rbac, AdapterError};
@@ -182,7 +182,7 @@ impl Coordinator {
         self.initialize_compute_read_policies(
             plan.export_ids().collect(),
             instance,
-            Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+            Some(self.catalog().system_config().default_retention_timestamp()),
         )
         .await;
 

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -318,9 +318,7 @@ impl crate::coord::Coordinator {
         base_policies: Vec<(GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
     ) {
         let mut policies = Vec::with_capacity(base_policies.len());
-        tracing::info!("base_policies: {base_policies:?}");
         for (id, base_policy) in base_policies {
-            tracing::info!("processing id: {id:?}");
             let capability = self
                 .storage_read_capabilities
                 .get_mut(&id)
@@ -335,7 +333,6 @@ impl crate::coord::Coordinator {
         &mut self,
         mut base_policies: Vec<(ComputeInstanceId, GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
     ) {
-        tracing::info!("compute base_policies: {base_policies:?}");
         base_policies.sort_by_key(|&(cluster_id, _, _)| cluster_id);
         for (cluster_id, group) in &base_policies
             .into_iter()
@@ -351,7 +348,6 @@ impl crate::coord::Coordinator {
                     (id, capability.policy())
                 })
                 .collect::<Vec<_>>();
-            tracing::info!("compute group: {group:?}");
             self.controller
                 .active_compute()
                 .set_read_policy(cluster_id, group)

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -318,7 +318,9 @@ impl crate::coord::Coordinator {
         base_policies: Vec<(GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
     ) {
         let mut policies = Vec::with_capacity(base_policies.len());
+        tracing::info!("base_policies: {base_policies:?}");
         for (id, base_policy) in base_policies {
+            tracing::info!("processing id: {id:?}");
             let capability = self
                 .storage_read_capabilities
                 .get_mut(&id)
@@ -333,6 +335,7 @@ impl crate::coord::Coordinator {
         &mut self,
         mut base_policies: Vec<(ComputeInstanceId, GlobalId, ReadPolicy<mz_repr::Timestamp>)>,
     ) {
+        tracing::info!("compute base_policies: {base_policies:?}");
         base_policies.sort_by_key(|&(cluster_id, _, _)| cluster_id);
         for (cluster_id, group) in &base_policies
             .into_iter()
@@ -348,6 +351,7 @@ impl crate::coord::Coordinator {
                     (id, capability.policy())
                 })
                 .collect::<Vec<_>>();
+            tracing::info!("compute group: {group:?}");
             self.controller
                 .active_compute()
                 .set_read_policy(cluster_id, group)

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -31,7 +31,7 @@ use mz_sql::session::vars::{SystemVars, Var, MAX_REPLICAS_PER_CLUSTER};
 use crate::catalog::{
     ClusterConfig, ClusterVariant, ClusterVariantManaged, Op, SerializedReplicaLocation,
 };
-use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS};
+use crate::coord::Coordinator;
 use crate::session::Session;
 use crate::{catalog, AdapterError, ExecuteResponse};
 
@@ -369,7 +369,7 @@ impl Coordinator {
             self.initialize_compute_read_policies(
                 introspection_source_ids,
                 cluster_id,
-                Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                Some(self.catalog().system_config().default_retention_timestamp()),
             )
             .await;
         }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -100,7 +100,7 @@ use crate::coord::{
     peek, Coordinator, CreateConnectionValidationReady, ExecuteContext, Message, PeekStage,
     PeekStageFinish, PeekStageOptimize, PeekStageTimestamp, PeekStageValidate, PendingRead,
     PendingReadTxn, PendingTxn, PendingTxnResponse, PlanValidity, RealTimeRecencyContext,
-    SinkConnectionReady, TargetCluster, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS,
+    SinkConnectionReady, TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::explain::explain_dataflow;
@@ -266,7 +266,7 @@ impl Coordinator {
 
                 self.initialize_storage_read_policies(
                     source_ids,
-                    Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    Some(self.catalog().system_config().default_retention_timestamp()),
                 )
                 .await;
 
@@ -571,7 +571,7 @@ impl Coordinator {
 
                 self.initialize_storage_read_policies(
                     vec![table_id],
-                    Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    Some(self.catalog().system_config().default_retention_timestamp()),
                 )
                 .await;
 
@@ -1045,7 +1045,7 @@ impl Coordinator {
 
                 self.initialize_storage_read_policies(
                     vec![id],
-                    Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    Some(self.catalog().system_config().default_retention_timestamp()),
                 )
                 .await;
 
@@ -3830,11 +3830,9 @@ impl Coordinator {
         let mut options = Vec::with_capacity(plan.options.len());
         for o in plan.options {
             options.push(match o {
-                IndexOptionName::LogicalCompactionWindow => {
-                    IndexOption::LogicalCompactionWindow(Some(Duration::from_millis(
-                        DEFAULT_LOGICAL_COMPACTION_WINDOW_TS.into(),
-                    )))
-                }
+                IndexOptionName::LogicalCompactionWindow => IndexOption::LogicalCompactionWindow(
+                    Some(self.catalog().system_config().default_retention()),
+                ),
             });
         }
 
@@ -4431,7 +4429,7 @@ impl Coordinator {
 
                 self.initialize_storage_read_policies(
                     source_ids,
-                    Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                    Some(self.catalog().system_config().default_retention_timestamp()),
                 )
                 .await;
             }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As part of https://github.com/MaterializeInc/materialize/issues/19800 one problem that stood out was that the 1s compaction window is a little short when sources tick once a second. This adds a flag that let's us change the compaction window

TODO: need some tests, putting this out to get preliminary feedback

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
