### PR TITLE
catalog: Align signatures of catalog storage func

### DIFF
--- a/src/adapter/src/catalog/inner.rs
+++ b/src/adapter/src/catalog/inner.rs
@@ -138,7 +138,7 @@ impl Catalog {
             ..entry.clone()
         };
 
-        tx.update_item(id, &new_entry)?;
+        tx.update_item(id, new_entry.into())?;
 
         state.add_to_audit_log(
             oracle_write_ts,

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -565,6 +565,13 @@ impl PrivilegeMap {
         self.all_values().cloned()
     }
 
+    /// Consumes self and returns all contained [`MzAclItem`].
+    pub fn into_all_values(self) -> impl Iterator<Item = MzAclItem> {
+        self.0
+            .into_values()
+            .flat_map(|privileges| privileges.into_iter())
+    }
+
     /// Adds an [`MzAclItem`] to this map.
     pub fn grant(&mut self, privilege: MzAclItem) {
         let grantee_privileges = self.0.entry(privilege.grantee).or_default();


### PR DESCRIPTION
This commit updates the public catalog storage functions, so they all take the `catalog::storage` defined structs for object types. This helps make all the signatures consistent and removes a dependency from `catalog::storage` on `catalog`.

Works towards resolving #20953

### Motivation

This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
