### PR TITLE
adapter: Catalog Consistency Checks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4994,6 +4994,7 @@ dependencies = [
  "once_cell",
  "postgres-protocol",
  "regex",
+ "reqwest",
  "serde_json",
  "shell-words",
  "tempfile",

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -1,0 +1,254 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Internal consistency checks that validate invariants of [`CatalogState`].
+
+use mz_controller::clusters::{ClusterId, ReplicaId};
+use mz_repr::role_id::RoleId;
+use mz_repr::GlobalId;
+use mz_sql::catalog::DefaultPrivilegeObject;
+use mz_sql::names::{CommentObjectId, DatabaseId, SchemaId};
+use serde::Serialize;
+
+use super::CatalogState;
+
+#[derive(Debug, Default, Serialize)]
+pub struct CatalogInconsistencies {
+    /// Inconsistencies found with internal fields, if any.
+    internal_fields: Vec<InternalFieldsInconsistency>,
+    /// Inconsistencies found with roles, if any.
+    roles: Vec<RoleInconsistency>,
+    /// Inconsistencies found with comments, if any.
+    comments: Vec<CommentInconsistency>,
+}
+
+impl CatalogInconsistencies {
+    pub fn is_empty(&self) -> bool {
+        self.internal_fields.is_empty() && self.roles.is_empty() && self.comments.is_empty()
+    }
+}
+
+impl CatalogState {
+    /// Checks the [`CatalogState`] to make sure we're internally consistent.
+    pub fn check_consistency(&self) -> Result<(), CatalogInconsistencies> {
+        let mut inconsistencies = CatalogInconsistencies::default();
+
+        if let Err(internal_fields) = self.check_internal_fields() {
+            inconsistencies.internal_fields = internal_fields;
+        }
+        if let Err(roles) = self.check_roles() {
+            inconsistencies.roles = roles;
+        }
+        if let Err(comments) = self.check_comments() {
+            inconsistencies.comments = comments;
+        }
+
+        if inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(inconsistencies)
+        }
+    }
+
+    /// # Invariants:
+    ///
+    /// * Any fields within [`CatalogState`] that reference another field need to be kept in sync.
+    ///
+    /// TODO(parkmycar): Check the reverse direction for these collections, e.g. all of the
+    /// `DatabaseId`s in `database_by_id` also exist in `database_by_name`.
+    fn check_internal_fields(&self) -> Result<(), Vec<InternalFieldsInconsistency>> {
+        let mut inconsistencies = Vec::new();
+        for (name, id) in &self.database_by_name {
+            if self.database_by_id.get(id).is_none() {
+                inconsistencies.push(InternalFieldsInconsistency::Database(name.clone(), *id));
+            }
+        }
+        for (name, id) in &self.ambient_schemas_by_name {
+            if self.ambient_schemas_by_id.get(id).is_none() {
+                inconsistencies.push(InternalFieldsInconsistency::AmbientSchema(
+                    name.clone(),
+                    *id,
+                ));
+            }
+        }
+        for (name, id) in &self.clusters_by_name {
+            if self.clusters_by_id.get(id).is_none() {
+                inconsistencies.push(InternalFieldsInconsistency::Cluster(name.clone(), *id));
+            }
+        }
+        for (global_id, cluster_id) in &self.clusters_by_linked_object_id {
+            if self.clusters_by_id.get(cluster_id).is_none() {
+                inconsistencies.push(InternalFieldsInconsistency::ClusterLinkedObjects(
+                    *global_id,
+                    *cluster_id,
+                ));
+            }
+        }
+        for (name, role_id) in &self.roles_by_name {
+            if self.roles_by_id.get(role_id).is_none() {
+                inconsistencies.push(InternalFieldsInconsistency::Role(name.clone(), *role_id))
+            }
+        }
+
+        if inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(inconsistencies)
+        }
+    }
+
+    /// # Invariants:
+    ///
+    /// * All RoleIds referenced from other objects must exist.
+    ///
+    fn check_roles(&self) -> Result<(), Vec<RoleInconsistency>> {
+        let mut inconsistencies = Vec::new();
+        for (database_id, database) in &self.database_by_id {
+            if self.roles_by_id.get(&database.owner_id).is_none() {
+                inconsistencies.push(RoleInconsistency::Database(*database_id, database.owner_id));
+            }
+            for (schema_id, schema) in &database.schemas_by_id {
+                if self.roles_by_id.get(&schema.owner_id).is_none() {
+                    inconsistencies.push(RoleInconsistency::Schema(*schema_id, schema.owner_id));
+                }
+            }
+        }
+        for (global_id, entry) in &self.entry_by_id {
+            if self.roles_by_id.get(&entry.owner_id).is_none() {
+                inconsistencies.push(RoleInconsistency::Entry(*global_id, entry.owner_id));
+            }
+        }
+        for (cluster_id, cluster) in &self.clusters_by_id {
+            if self.roles_by_id.get(&cluster.owner_id).is_none() {
+                inconsistencies.push(RoleInconsistency::Cluster(*cluster_id, cluster.owner_id));
+            }
+            for (replica_id, replica) in &cluster.replicas_by_id {
+                if self.roles_by_id.get(&replica.owner_id).is_none() {
+                    inconsistencies.push(RoleInconsistency::ClusterReplica(
+                        *cluster_id,
+                        *replica_id,
+                        cluster.owner_id,
+                    ));
+                }
+            }
+        }
+        for (default_priv, privileges) in self.default_privileges.iter() {
+            if self.roles_by_id.get(&default_priv.role_id).is_none() {
+                inconsistencies.push(RoleInconsistency::DefaultPrivilege(default_priv.clone()));
+            }
+            for acl_item in privileges {
+                if self.roles_by_id.get(&acl_item.grantee).is_none() {
+                    inconsistencies.push(RoleInconsistency::DefaultPrivilegeItem {
+                        grantor: default_priv.role_id,
+                        grantee: acl_item.grantee,
+                    });
+                }
+            }
+        }
+        for acl in self.system_privileges.all_values() {
+            let grantor = self.roles_by_id.get(&acl.grantor);
+            let grantee = self.roles_by_id.get(&acl.grantee);
+
+            let inconsistency = match (grantor, grantee) {
+                (None, None) => RoleInconsistency::SystemPrivilege {
+                    grantor: Some(acl.grantor),
+                    grantee: Some(acl.grantee),
+                },
+                (Some(_), None) => RoleInconsistency::SystemPrivilege {
+                    grantor: None,
+                    grantee: Some(acl.grantee),
+                },
+                (None, Some(_)) => RoleInconsistency::SystemPrivilege {
+                    grantor: Some(acl.grantor),
+                    grantee: None,
+                },
+                (Some(_), Some(_)) => continue,
+            };
+            inconsistencies.push(inconsistency);
+        }
+
+        if inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(inconsistencies)
+        }
+    }
+
+    /// # Invariants:
+    ///
+    /// * Comments should only reference existing objects.
+    /// * A comment should only have a column position if it references a relation.
+    ///
+    fn check_comments(&self) -> Result<(), Vec<CommentInconsistency>> {
+        let mut comment_inconsistencies = Vec::new();
+        for (comment_object_id, col_pos, _comment) in self.comments.iter() {
+            match comment_object_id {
+                CommentObjectId::Table(global_id) | CommentObjectId::View(global_id) => {
+                    let entry = self.entry_by_id.get(&global_id);
+                    match entry {
+                        None => comment_inconsistencies
+                            .push(CommentInconsistency::Dangling(comment_object_id)),
+                        Some(entry) => {
+                            // TODO: Refactor this to use if-let chains, once they're stable.
+                            #[allow(clippy::unnecessary_unwrap)]
+                            if !entry.is_relation() && col_pos.is_some() {
+                                let col_pos = col_pos.expect("checked above");
+                                comment_inconsistencies.push(CommentInconsistency::NonRelation(
+                                    comment_object_id,
+                                    col_pos,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if comment_inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(comment_inconsistencies)
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+enum InternalFieldsInconsistency {
+    Database(String, DatabaseId),
+    AmbientSchema(String, SchemaId),
+    Cluster(String, ClusterId),
+    ClusterLinkedObjects(GlobalId, ClusterId),
+    Role(String, RoleId),
+}
+
+#[derive(Debug, Serialize)]
+enum RoleInconsistency {
+    Database(DatabaseId, RoleId),
+    Schema(SchemaId, RoleId),
+    Entry(GlobalId, RoleId),
+    Cluster(ClusterId, RoleId),
+    ClusterReplica(ClusterId, ReplicaId, RoleId),
+    DefaultPrivilege(DefaultPrivilegeObject),
+    DefaultPrivilegeItem {
+        grantor: RoleId,
+        grantee: RoleId,
+    },
+    SystemPrivilege {
+        grantor: Option<RoleId>,
+        grantee: Option<RoleId>,
+    },
+}
+
+#[derive(Debug, Serialize)]
+enum CommentInconsistency {
+    /// A comment was found for an object that no longer exists.
+    Dangling(CommentObjectId),
+    /// A comment with a column position was found on a non-relation.
+    NonRelation(CommentObjectId, usize),
+}

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -564,6 +564,16 @@ impl SessionClient {
         catalog.dump().map_err(AdapterError::from)
     }
 
+    /// Checks the catalog for internal consistency, returning a JSON object describing the
+    /// inconsistencies, if there are any.
+    ///
+    /// No authorization is performed, so access to this function must be limited to internal
+    /// servers or superusers.
+    pub async fn check_catalog(&mut self) -> Result<(), serde_json::Value> {
+        let catalog = self.catalog_snapshot().await;
+        catalog.check_consistency()
+    }
+
     /// Tells the coordinator a statement has finished execution, in the cases
     /// where we have no other reason to communicate with the coordinator.
     pub fn retire_execute(

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -516,6 +516,10 @@ impl Coordinator {
             }
         }
 
+        // Note: It's important that we keep the function call inside macro, this way we only run
+        // the consistency checks if sort assertions are enabled.
+        mz_ore::soft_assert_eq!(self.catalog().check_consistency(), Ok(()));
+
         Ok(result)
     }
 

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -395,8 +395,12 @@ impl InternalHttpServer {
             )
             .route("/api/tracing", routing::get(mz_http_util::handle_tracing))
             .route(
-                "/api/catalog",
-                routing::get(catalog::handle_internal_catalog),
+                "/api/catalog/dump",
+                routing::get(catalog::handle_catalog_dump),
+            )
+            .route(
+                "/api/catalog/check",
+                routing::get(catalog::handle_catalog_check),
             )
             .layer(Extension(AuthedUser(SYSTEM_USER.clone())))
             .layer(Extension(adapter_client_rx.shared()))

--- a/src/environmentd/src/http/catalog.rs
+++ b/src/environmentd/src/http/catalog.rs
@@ -16,9 +16,17 @@ use http::StatusCode;
 
 use crate::http::AuthedClient;
 
-pub async fn handle_internal_catalog(mut client: AuthedClient) -> impl IntoResponse {
+pub async fn handle_catalog_dump(mut client: AuthedClient) -> impl IntoResponse {
     match client.client.dump_catalog().await.map(|c| c.into_string()) {
         Ok(res) => Ok((TypedHeader(ContentType::json()), res)),
         Err(e) => Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string())),
     }
+}
+
+pub async fn handle_catalog_check(mut client: AuthedClient) -> impl IntoResponse {
+    let response = match client.client.check_catalog().await {
+        Ok(_) => serde_json::Value::String("".to_string()),
+        Err(inconsistencies) => serde_json::json!({ "err": inconsistencies }),
+    };
+    (TypedHeader(ContentType::json()), response.to_string())
 }

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1135,7 +1135,7 @@ impl From<ObjectId> for SystemObjectId {
 /// to represent these different types and their IDs (e.g. [`GlobalId`] and [`RoleId`]), as well as
 /// the inner kind of object that is represented, e.g. [`GlobalId`] is used to identify both Tables
 /// and Views. No other kind of ID encapsulates all of this, hence this new "*Id" type.
-#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize)]
 pub enum CommentObjectId {
     Table(GlobalId),
     View(GlobalId),

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -36,6 +36,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-cloud-resources = { path = "../cloud-resources" }
 postgres-protocol = { version = "0.6.5" }
 regex = "1.7.0"
+reqwest = { version = "0.11.13", features = ["json"] }
 shell-words = "1.1.0"
 serde_json = "1.0.89"
 tempfile = "3.2.0"


### PR DESCRIPTION
This PR adds a basic "consistency checker" to the `Catalog` that checks internal invariants. For example, it checks that for all comments, the referenced object exists. It also extends the sqllogictest and testdrive frameworks to run these checks after every file, and adds an endpoint to the internal HTTP server so we can run these consistency checks remotely on an environment.

To start the only invariants we check are:

1. Internal fields that reference one another (e.g. `database_by_id` and `database_by_name`) are consistent.
2. All referenced `RoleId`s exists (e.g. `owner_id` for `CatalogEntry`s)
3. All referenced objects from comments exist.

### Motivation

* This PR adds a feature that has not yet been specified.

When adding support for `COMMENT` I wanted to make sure some invariants were checked at the end of each test run.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
