### PR TITLE
cargo: Set build-jobs to default for CI

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -16,6 +16,9 @@ dag: true
 
 env:
   CI_BUILDER_SCCACHE: 1
+  # Note: In .cargo/config we set the default build jobs to -1 so on developer machines we keep
+  # a single core open when compiling. But we want to use all of CI's resources, hence setting the
+  # build jobs to "default" which will use all cores.
   CARGO_BUILD_JOBS: "default"
 
 steps:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -16,6 +16,7 @@ dag: true
 
 env:
   CI_BUILDER_SCCACHE: 1
+  CARGO_BUILD_JOBS: "default"
 
 steps:
   - id: build-x86_64


### PR DESCRIPTION
Previously we had set the number of build jobs Cargo will run concurrently to -1, so by default it will leave one core open so our dev machines aren't entirely pinned. This had the adverse effect that CI isn't building as fast as possible, but that the time the tradeoff was deemed worth it.

Now in Rust v1.72 they support a build jobs option of "default" which sets the value back to the total number of CPUs, so CI can again build at full speed.

### Motivation

* This PR fixes a recognized bug.

Fixes: https://github.com/MaterializeInc/materialize/issues/19711

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
