### PR TITLE
Revert "storage: only messages should drive generator capability"

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1453,7 +1453,7 @@ generate_extracted_config!(
     LoadGeneratorOption,
     (TickInterval, Interval),
     (ScaleFactor, f64),
-    (MaxCardinality, u64)
+    (MaxCardinality, i64)
 );
 
 pub(crate) fn load_generator_ast_to_generator(
@@ -1472,6 +1472,11 @@ pub(crate) fn load_generator_ast_to_generator(
             let LoadGeneratorOptionExtracted {
                 max_cardinality, ..
             } = options.to_vec().try_into()?;
+            if let Some(max_cardinality) = max_cardinality {
+                if max_cardinality < 0 {
+                    sql_bail!("unsupported max cardinality {max_cardinality}");
+                }
+            }
             LoadGenerator::Counter { max_cardinality }
         }
         mz_sql_parser::ast::LoadGenerator::Marketing => LoadGenerator::Marketing,

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -222,7 +222,9 @@ message ProtoTestScriptSourceConnection {
 }
 
 message ProtoCounterLoadGenerator {
-    optional uint64 max_cardinality = 1;
+    // Must be non-negative,
+    // but kept as int64 to make downstream logic simpler
+    optional int64 max_cardinality = 1;
 }
 
 message ProtoTpchLoadGenerator {

--- a/src/storage-client/src/types/sources.rs
+++ b/src/storage-client/src/types/sources.rs
@@ -41,7 +41,6 @@ use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use prost::Message;
 use serde::{Deserialize, Serialize};
-use timely::dataflow::operators::to_stream::Event;
 use timely::order::{PartialOrder, TotalOrder};
 use timely::progress::timestamp::Refines;
 use timely::progress::{PathSummary, Timestamp};
@@ -2311,7 +2310,10 @@ pub enum LoadGenerator {
         /// How many values will be emitted
         /// before old ones are retracted, or `None` for
         /// an append-only collection.
-        max_cardinality: Option<u64>,
+        ///
+        /// This is verified by the planner to be nonnegative. We encode it as
+        /// an `i64` to make the code in `Counter::by_seed` simpler.
+        max_cardinality: Option<i64>,
     },
     Datums,
     Marketing,
@@ -2600,8 +2602,13 @@ pub trait Generator {
         &self,
         now: NowFn,
         seed: Option<u64>,
-        resume_offset: MzOffset,
-    ) -> Box<dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>>;
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>>;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum GeneratorMessageType {
+    InProgress,
+    Finalized,
 }
 
 impl RustType<ProtoLoadGeneratorSourceConnection> for LoadGeneratorSourceConnection {

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -13,14 +13,15 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use differential_dataflow::{AsCollection, Collection};
+use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Diff, Row};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::{
-    Generator, LoadGenerator, LoadGeneratorSourceConnection, MzOffset, SourceTimestamp,
+    Generator, GeneratorMessageType, LoadGenerator, LoadGeneratorSourceConnection, MzOffset,
+    SourceTimestamp,
 };
 use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
-use timely::dataflow::operators::to_stream::Event;
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -110,44 +111,42 @@ impl SourceRender for LoadGeneratorSourceConnection {
                     .map(MzOffset::decode_row),
             );
 
-            let Some(resume_offset) = resume_upper.into_option() else {
+            let Some(mut offset) = resume_upper.into_option() else {
                 return;
             };
+            cap.downgrade(&offset);
 
-            let mut rows = as_generator(&self.load_generator, self.tick_micros).by_seed(
-                mz_ore::now::SYSTEM_TIME.clone(),
-                None,
-                resume_offset,
-            );
+            let mut rows = as_generator(&self.load_generator, self.tick_micros)
+                .by_seed(mz_ore::now::SYSTEM_TIME.clone(), None);
+
+            // Skip forward to the requested offset.
+            let tx_count = usize::cast_from(offset.offset);
+            let txns = rows
+                .by_ref()
+                .filter(|(_, typ, _, _)| matches!(typ, GeneratorMessageType::Finalized))
+                .take(tx_count)
+                .count();
+            assert_eq!(txns, tx_count, "produced wrong number of transactions");
 
             let tick = Duration::from_micros(self.tick_micros.unwrap_or(1_000_000));
 
-            while let Some((output, event)) = rows.next() {
-                match event {
-                    Event::Message(offset, (value, diff)) => {
-                        let message = (
-                            output,
-                            Ok(SourceMessage {
-                                upstream_time_millis: None,
-                                key: (),
-                                value,
-                                headers: None,
-                            }),
-                        );
-                        data_output.give(&cap, (message, offset, diff)).await;
-                    }
-                    Event::Progress(Some(offset)) => {
-                        cap.downgrade(&offset);
-                        // We only sleep if we have surpassed the resume offset so that we can
-                        // quickly go over any historical updates that a generator might choose to
-                        // emit.
-                        // TODO(petrosagg): Remove the sleep below and make generators return an
-                        // async stream so that they can drive the rate of production directly
-                        if resume_offset < offset {
-                            tokio::time::sleep(tick).await;
-                        }
-                    }
-                    Event::Progress(None) => return,
+            while let Some((output, typ, value, diff)) = rows.next() {
+                let message = (
+                    output,
+                    Ok(SourceMessage {
+                        upstream_time_millis: None,
+                        key: (),
+                        value,
+                        headers: None,
+                    }),
+                );
+
+                data_output.give(&cap, (message, offset, diff)).await;
+
+                if matches!(typ, GeneratorMessageType::Finalized) {
+                    offset += 1;
+                    cap.downgrade(&offset);
+                    tokio::time::sleep(tick).await;
                 }
             }
         });

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -11,8 +11,7 @@ use std::iter;
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
-use mz_storage_client::types::sources::{Generator, MzOffset};
-use timely::dataflow::operators::to_stream::Event;
+use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
 
 pub struct Datums {}
 
@@ -24,8 +23,7 @@ impl Generator for Datums {
         &self,
         _: NowFn,
         _seed: Option<u64>,
-        _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()
@@ -47,29 +45,22 @@ impl Generator for Datums {
                 .collect(),
         );
         let mut idx = 0;
-        let mut offset = 0;
-        Box::new(
-            iter::from_fn(move || {
-                if idx == len {
-                    return None;
-                }
-                let mut row = Row::with_capacity(datums.len());
-                let mut packer = row.packer();
-                for d in &datums {
-                    packer.push(d[idx]);
-                }
-                let msg = (0, Event::Message(MzOffset::from(offset), (row, 1)));
-
-                idx += 1;
-                let progress = if idx == len {
-                    offset += 1;
-                    Some((0, Event::Progress(Some(MzOffset::from(offset)))))
-                } else {
-                    None
-                };
-                Some(std::iter::once(msg).chain(progress))
-            })
-            .flatten(),
-        )
+        Box::new(iter::from_fn(move || {
+            if idx == len {
+                return None;
+            }
+            let mut row = Row::with_capacity(datums.len());
+            let mut packer = row.packer();
+            for d in &datums {
+                packer.push(d[idx]);
+            }
+            idx += 1;
+            let message = if idx == len {
+                GeneratorMessageType::Finalized
+            } else {
+                GeneratorMessageType::InProgress
+            };
+            Some((0, message, row, 1))
+        }))
     }
 }

--- a/src/storage/src/source/generator/marketing.rs
+++ b/src/storage/src/source/generator/marketing.rs
@@ -14,9 +14,8 @@ use std::{
 
 use mz_ore::now::to_datetime;
 use mz_repr::{Datum, Row};
-use mz_storage_client::types::sources::{Generator, MzOffset};
+use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
 use rand::{distributions::Standard, rngs::SmallRng, Rng, SeedableRng};
-use timely::dataflow::operators::to_stream::Event;
 
 const CUSTOMERS_OUTPUT: usize = 1;
 const IMPRESSIONS_OUTPUT: usize = 2;
@@ -38,8 +37,16 @@ impl Generator for Marketing {
         &self,
         now: mz_ore::now::NowFn,
         seed: Option<u64>,
-        _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<
+        dyn Iterator<
+            Item = (
+                usize,
+                mz_storage_client::types::sources::GeneratorMessageType,
+                mz_repr::Row,
+                i64,
+            ),
+        >,
+    > {
         let mut rng: SmallRng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let mut counter = 0;
@@ -60,143 +67,136 @@ impl Generator for Marketing {
             })
             .collect();
 
-        let mut offset = 0;
-        Box::new(
-            iter::from_fn(move || {
-                if pending.is_empty() {
-                    let mut impression = Row::with_capacity(4);
-                    let mut packer = impression.packer();
+        Box::new(iter::from_fn(move || {
+            if pending.is_empty() {
+                let mut impression = Row::with_capacity(4);
+                let mut packer = impression.packer();
 
-                    let impression_id = counter;
-                    counter += 1;
+                let impression_id = counter;
+                counter += 1;
+
+                packer.push(Datum::Int64(impression_id));
+                packer.push(Datum::Int64(
+                    rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
+                ));
+                packer.push(Datum::Int64(rng.gen_range(0..20i64)));
+                let impression_time = now();
+                packer.push(Datum::TimestampTz(
+                    to_datetime(impression_time)
+                        .try_into()
+                        .expect("timestamp must fit"),
+                ));
+
+                pending.push((IMPRESSIONS_OUTPUT, impression, 1));
+
+                // 1 in 10 impressions have a click. Making us the
+                // most successful marketing organization in the world.
+                if rng.gen_range(0..10) == 1 {
+                    let mut click = Row::with_capacity(2);
+                    let mut packer = click.packer();
+
+                    let click_time = impression_time + rng.gen_range(20000..40000);
 
                     packer.push(Datum::Int64(impression_id));
-                    packer.push(Datum::Int64(
-                        rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
-                    ));
-                    packer.push(Datum::Int64(rng.gen_range(0..20i64)));
-                    let impression_time = now();
                     packer.push(Datum::TimestampTz(
-                        to_datetime(impression_time)
+                        to_datetime(click_time)
                             .try_into()
                             .expect("timestamp must fit"),
                     ));
 
-                    pending.push((IMPRESSIONS_OUTPUT, impression, 1));
+                    future_updates.insert(click_time, (CLICK_OUTPUT, click, 1));
+                }
 
-                    // 1 in 10 impressions have a click. Making us the
-                    // most successful marketing organization in the world.
-                    if rng.gen_range(0..10) == 1 {
-                        let mut click = Row::with_capacity(2);
-                        let mut packer = click.packer();
+                let mut updates = future_updates.retrieve(now());
+                pending.append(&mut updates);
 
-                        let click_time = impression_time + rng.gen_range(20000..40000);
+                for _ in 0..rng.gen_range(1..2) {
+                    let id = counter;
+                    counter += 1;
 
-                        packer.push(Datum::Int64(impression_id));
-                        packer.push(Datum::TimestampTz(
-                            to_datetime(click_time)
-                                .try_into()
-                                .expect("timestamp must fit"),
-                        ));
+                    let mut lead = Lead {
+                        id,
+                        customer_id: rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
+                        created_at: now(),
+                        converted_at: None,
+                        conversion_amount: None,
+                    };
 
-                        future_updates.insert(click_time, (CLICK_OUTPUT, click, 1));
-                    }
+                    pending.push((LEADS_OUTPUT, lead.to_row(), 1));
 
-                    let mut updates = future_updates.retrieve(now());
-                    pending.append(&mut updates);
+                    // a highly scientific statistical model
+                    // predicting the likelyhood of a conversion
+                    let score = rng.sample::<f64, _>(Standard);
+                    let label = score > 0.5f64;
 
-                    for _ in 0..rng.gen_range(1..2) {
+                    let bucket = if lead.id % 10 <= 1 {
+                        CONTROL
+                    } else {
+                        EXPERIMENT
+                    };
+
+                    let mut prediction = Row::with_capacity(4);
+                    let mut packer = prediction.packer();
+
+                    packer.push(Datum::Int64(lead.id));
+                    packer.push(Datum::String(bucket));
+                    packer.push(Datum::TimestampTz(
+                        to_datetime(now()).try_into().expect("timestamp must fit"),
+                    ));
+                    packer.push(Datum::Float64(score.into()));
+
+                    pending.push((CONVERSIONS_PREDICTIONS_OUTPUT, prediction, 1));
+
+                    let mut sent_coupon = false;
+                    if !label && bucket == EXPERIMENT {
+                        sent_coupon = true;
+                        let amount = rng.gen_range(500..5000);
+
+                        let mut coupon = Row::with_capacity(4);
+                        let mut packer = coupon.packer();
+
                         let id = counter;
                         counter += 1;
-
-                        let mut lead = Lead {
-                            id,
-                            customer_id: rng.gen_range(0..CUSTOMERS.len()).try_into().unwrap(),
-                            created_at: now(),
-                            converted_at: None,
-                            conversion_amount: None,
-                        };
-
-                        pending.push((LEADS_OUTPUT, lead.to_row(), 1));
-
-                        // a highly scientific statistical model
-                        // predicting the likelyhood of a conversion
-                        let score = rng.sample::<f64, _>(Standard);
-                        let label = score > 0.5f64;
-
-                        let bucket = if lead.id % 10 <= 1 {
-                            CONTROL
-                        } else {
-                            EXPERIMENT
-                        };
-
-                        let mut prediction = Row::with_capacity(4);
-                        let mut packer = prediction.packer();
-
+                        packer.push(Datum::Int64(id));
                         packer.push(Datum::Int64(lead.id));
-                        packer.push(Datum::String(bucket));
                         packer.push(Datum::TimestampTz(
                             to_datetime(now()).try_into().expect("timestamp must fit"),
                         ));
-                        packer.push(Datum::Float64(score.into()));
+                        packer.push(Datum::Int64(amount));
 
-                        pending.push((CONVERSIONS_PREDICTIONS_OUTPUT, prediction, 1));
+                        pending.push((COUPONS_OUTPUT, coupon, 1));
+                    }
 
-                        let mut sent_coupon = false;
-                        if !label && bucket == EXPERIMENT {
-                            sent_coupon = true;
-                            let amount = rng.gen_range(500..5000);
+                    // Decide if a lead will convert. We assume our model is fairly
+                    // accurate and correlates with conversions. We also assume
+                    // that coupons make leads a little more liekly to convert.
+                    let mut converted = rng.sample::<f64, _>(Standard) < score;
+                    if sent_coupon && !converted {
+                        converted = rng.sample::<f64, _>(Standard) < score;
+                    }
 
-                            let mut coupon = Row::with_capacity(4);
-                            let mut packer = coupon.packer();
+                    if converted {
+                        let converted_at = now() + rng.gen_range(1..30);
 
-                            let id = counter;
-                            counter += 1;
-                            packer.push(Datum::Int64(id));
-                            packer.push(Datum::Int64(lead.id));
-                            packer.push(Datum::TimestampTz(
-                                to_datetime(now()).try_into().expect("timestamp must fit"),
-                            ));
-                            packer.push(Datum::Int64(amount));
+                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), -1));
 
-                            pending.push((COUPONS_OUTPUT, coupon, 1));
-                        }
+                        lead.converted_at = Some(converted_at);
+                        lead.conversion_amount = Some(rng.gen_range(1000..25000));
 
-                        // Decide if a lead will convert. We assume our model is fairly
-                        // accurate and correlates with conversions. We also assume
-                        // that coupons make leads a little more liekly to convert.
-                        let mut converted = rng.sample::<f64, _>(Standard) < score;
-                        if sent_coupon && !converted {
-                            converted = rng.sample::<f64, _>(Standard) < score;
-                        }
-
-                        if converted {
-                            let converted_at = now() + rng.gen_range(1..30);
-
-                            future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), -1));
-
-                            lead.converted_at = Some(converted_at);
-                            lead.conversion_amount = Some(rng.gen_range(1000..25000));
-
-                            future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), 1));
-                        }
+                        future_updates.insert(converted_at, (LEADS_OUTPUT, lead.to_row(), 1));
                     }
                 }
+            }
 
-                pending.pop().map(|(output, row, diff)| {
-                    let msg = (output, Event::Message(MzOffset::from(offset), (row, diff)));
-
-                    let progress = if pending.is_empty() {
-                        offset += 1;
-                        Some((output, Event::Progress(Some(MzOffset::from(offset)))))
-                    } else {
-                        None
-                    };
-                    std::iter::once(msg).chain(progress)
-                })
+            pending.pop().map(|(output, row, diff)| {
+                let typ = if pending.is_empty() {
+                    GeneratorMessageType::Finalized
+                } else {
+                    GeneratorMessageType::InProgress
+                };
+                (output, typ, row, diff)
             })
-            .flatten(),
-        )
+        }))
     }
 }
 

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -7,7 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::collections::VecDeque;
 use std::fmt::Display;
 use std::iter;
 use std::ops::RangeInclusive;
@@ -19,13 +18,12 @@ use mz_ore::now::NowFn;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric};
 use mz_repr::{Datum, Row};
-use mz_storage_client::types::sources::{Generator, MzOffset};
+use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
-use timely::dataflow::operators::to_stream::Event;
 
 #[derive(Clone, Debug)]
 pub struct Tpch {
@@ -51,8 +49,7 @@ impl Generator for Tpch {
         &self,
         _: NowFn,
         seed: Option<u64>,
-        _resume_offset: MzOffset,
-    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
+    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
         let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
         let mut ctx = Context {
             tpch: self.clone(),
@@ -77,163 +74,197 @@ impl Generator for Tpch {
 
         // Some rows need to generate other rows from their values; hold those
         // here.
-        let mut pending = VecDeque::new();
+        let mut pending = Vec::new();
 
         // All orders and their lineitems, so they can be retracted during
         // streaming.
         let mut active_orders = Vec::new();
 
-        let mut offset = 0;
         Box::new(iter::from_fn(move || {
-            if let Some(pending) = pending.pop_front() {
+            if let Some(pending) = pending.pop() {
                 return Some(pending);
             }
-            if let Some((output, key)) = rows.next() {
-                let key_usize = usize::try_from(key).expect("key known to be non-negative");
-                let row = match output {
-                    SUPPLIER_OUTPUT => {
-                        let nation = rng.gen_range(0..count_nation);
-                        Row::pack_slice(&[
-                            Datum::Int64(key),
-                            Datum::String(&pad_nine("Supplier", key)),
-                            Datum::String(&v_string(&mut rng, 10, 40)), // address
-                            Datum::Int64(nation),
-                            Datum::String(&phone(&mut rng, nation)),
-                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
-                            // TODO: add customer complaints and recommends, see 4.2.3.
-                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 25, 100)),
-                        ])
-                    }
-                    PART_OUTPUT => {
-                        let name: String = PARTNAMES
-                            .choose_multiple(&mut rng, 5)
-                            .cloned()
-                            .collect::<Vec<_>>()
-                            .join("  ");
-                        let m = rng.gen_range(1..=5);
-                        let n = rng.gen_range(1..=5);
-                        for _ in 1..=4 {
-                            let suppkey = (key
-                                + (rng.gen_range(0..=3)
-                                    * ((ctx.tpch.count_supplier / 4)
-                                        + (key - 1) / ctx.tpch.count_supplier)))
-                                % ctx.tpch.count_supplier
-                                + 1;
-                            let row = Row::pack_slice(&[
+            rows.next()
+                .map(|(output, key)| {
+                    let key_usize = usize::try_from(key).expect("key known to be non-negative");
+                    let row = match output {
+                        SUPPLIER_OUTPUT => {
+                            let nation = rng.gen_range(0..count_nation);
+                            Row::pack_slice(&[
                                 Datum::Int64(key),
-                                Datum::Int64(suppkey),
-                                Datum::Int32(rng.gen_range(1..=9_999)), // availqty
-                                Datum::Numeric(decimal(&mut rng, &mut ctx.cx, 1_00, 1_000_00, 100)), // supplycost
+                                Datum::String(&pad_nine("Supplier", key)),
+                                Datum::String(&v_string(&mut rng, 10, 40)), // address
+                                Datum::Int64(nation),
+                                Datum::String(&phone(&mut rng, nation)),
+                                Datum::Numeric(decimal(
+                                    &mut rng,
+                                    &mut ctx.cx,
+                                    -999_99,
+                                    9_999_99,
+                                    100,
+                                )), // acctbal
+                                // TODO: add customer complaints and recommends, see 4.2.3.
+                                Datum::String(text_string(
+                                    &mut rng,
+                                    &ctx.text_string_source,
+                                    25,
+                                    100,
+                                )),
+                            ])
+                        }
+                        PART_OUTPUT => {
+                            let name: String = PARTNAMES
+                                .choose_multiple(&mut rng, 5)
+                                .cloned()
+                                .collect::<Vec<_>>()
+                                .join("  ");
+                            let m = rng.gen_range(1..=5);
+                            let n = rng.gen_range(1..=5);
+                            for _ in 1..=4 {
+                                let suppkey = (key
+                                    + (rng.gen_range(0..=3)
+                                        * ((ctx.tpch.count_supplier / 4)
+                                            + (key - 1) / ctx.tpch.count_supplier)))
+                                    % ctx.tpch.count_supplier
+                                    + 1;
+                                let row = Row::pack_slice(&[
+                                    Datum::Int64(key),
+                                    Datum::Int64(suppkey),
+                                    Datum::Int32(rng.gen_range(1..=9_999)), // availqty
+                                    Datum::Numeric(decimal(
+                                        &mut rng,
+                                        &mut ctx.cx,
+                                        1_00,
+                                        1_000_00,
+                                        100,
+                                    )), // supplycost
+                                    Datum::String(text_string(
+                                        &mut rng,
+                                        &ctx.text_string_source,
+                                        49,
+                                        198,
+                                    )),
+                                ]);
+                                pending.push((
+                                    PARTSUPP_OUTPUT,
+                                    GeneratorMessageType::InProgress,
+                                    row,
+                                    1,
+                                ));
+                            }
+                            Row::pack_slice(&[
+                                Datum::Int64(key),
+                                Datum::String(&name),
+                                Datum::String(&format!("Manufacturer#{m}")),
+                                Datum::String(&format!("Brand#{m}{n}")),
+                                Datum::String(&syllables(&mut rng, TYPES)),
+                                Datum::Int32(rng.gen_range(1..=50)), // size
+                                Datum::String(&syllables(&mut rng, CONTAINERS)),
+                                Datum::Numeric(partkey_retailprice(key)),
                                 Datum::String(text_string(
                                     &mut rng,
                                     &ctx.text_string_source,
                                     49,
                                     198,
                                 )),
-                            ]);
-                            pending.push_back((
-                                PARTSUPP_OUTPUT,
-                                Event::Message(MzOffset::from(offset), (row, 1)),
-                            ));
+                            ])
                         }
-                        Row::pack_slice(&[
-                            Datum::Int64(key),
-                            Datum::String(&name),
-                            Datum::String(&format!("Manufacturer#{m}")),
-                            Datum::String(&format!("Brand#{m}{n}")),
-                            Datum::String(&syllables(&mut rng, TYPES)),
-                            Datum::Int32(rng.gen_range(1..=50)), // size
-                            Datum::String(&syllables(&mut rng, CONTAINERS)),
-                            Datum::Numeric(partkey_retailprice(key)),
-                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 49, 198)),
-                        ])
-                    }
-                    CUSTOMER_OUTPUT => {
-                        let nation = rng.gen_range(0..count_nation);
-                        Row::pack_slice(&[
-                            Datum::Int64(key),
-                            Datum::String(&pad_nine("Customer", key)),
-                            Datum::String(&v_string(&mut rng, 10, 40)), // address
-                            Datum::Int64(nation),
-                            Datum::String(&phone(&mut rng, nation)),
-                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
-                            Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
-                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 29, 116)),
-                        ])
-                    }
-                    ORDERS_OUTPUT => {
-                        let seed = rng.gen();
-                        let (order, lineitems) = ctx.order_row(seed, key);
-                        for row in lineitems {
-                            pending.push_back((
-                                LINEITEM_OUTPUT,
-                                Event::Message(MzOffset::from(offset), (row, 1)),
-                            ));
+                        CUSTOMER_OUTPUT => {
+                            let nation = rng.gen_range(0..count_nation);
+                            Row::pack_slice(&[
+                                Datum::Int64(key),
+                                Datum::String(&pad_nine("Customer", key)),
+                                Datum::String(&v_string(&mut rng, 10, 40)), // address
+                                Datum::Int64(nation),
+                                Datum::String(&phone(&mut rng, nation)),
+                                Datum::Numeric(decimal(
+                                    &mut rng,
+                                    &mut ctx.cx,
+                                    -999_99,
+                                    9_999_99,
+                                    100,
+                                )), // acctbal
+                                Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
+                                Datum::String(text_string(
+                                    &mut rng,
+                                    &ctx.text_string_source,
+                                    29,
+                                    116,
+                                )),
+                            ])
                         }
-                        if !ctx.tpch.tick.is_zero() {
-                            active_orders.push((key, seed));
+                        ORDERS_OUTPUT => {
+                            let seed = rng.gen();
+                            let (order, lineitems) = ctx.order_row(seed, key);
+                            for row in lineitems {
+                                pending.push((
+                                    LINEITEM_OUTPUT,
+                                    GeneratorMessageType::InProgress,
+                                    row,
+                                    1,
+                                ));
+                            }
+                            if !ctx.tpch.tick.is_zero() {
+                                active_orders.push((key, seed));
+                            }
+                            order
                         }
-                        order
-                    }
-                    NATION_OUTPUT => {
-                        let (name, region) = NATIONS[key_usize];
-                        Row::pack_slice(&[
+                        NATION_OUTPUT => {
+                            let (name, region) = NATIONS[key_usize];
+                            Row::pack_slice(&[
+                                Datum::Int64(key),
+                                Datum::String(name),
+                                Datum::Int64(region),
+                                Datum::String(text_string(
+                                    &mut rng,
+                                    &ctx.text_string_source,
+                                    31,
+                                    114,
+                                )),
+                            ])
+                        }
+                        REGION_OUTPUT => Row::pack_slice(&[
                             Datum::Int64(key),
-                            Datum::String(name),
-                            Datum::Int64(region),
-                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 114)),
-                        ])
+                            Datum::String(REGIONS[key_usize]),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 115)),
+                        ]),
+                        _ => unreachable!("{output}"),
+                    };
+                    let typ = if rows.peek().is_some() {
+                        GeneratorMessageType::InProgress
+                    } else {
+                        GeneratorMessageType::Finalized
+                    };
+                    (output, typ, row, 1)
+                })
+                .or_else(|| {
+                    if ctx.tpch.tick.is_zero() {
+                        return None;
                     }
-                    REGION_OUTPUT => Row::pack_slice(&[
-                        Datum::Int64(key),
-                        Datum::String(REGIONS[key_usize]),
-                        Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 115)),
-                    ]),
-                    _ => unreachable!("{output}"),
-                };
+                    let idx = rng.gen_range(0..active_orders.len());
+                    let (key, old_seed) = active_orders.swap_remove(idx);
+                    let (old_order, old_lineitems) = ctx.order_row(old_seed, key);
+                    // Fill pending with old lineitem retractions, new lineitem
+                    // additions, and finally the new order. Return the old
+                    // order to start the batch.
+                    for row in old_lineitems {
+                        pending.push((LINEITEM_OUTPUT, GeneratorMessageType::InProgress, row, -1));
+                    }
+                    let new_seed = rng.gen();
+                    let (new_order, new_lineitems) = ctx.order_row(new_seed, key);
+                    for row in new_lineitems {
+                        pending.push((LINEITEM_OUTPUT, GeneratorMessageType::InProgress, row, 1));
+                    }
+                    pending.push((ORDERS_OUTPUT, GeneratorMessageType::Finalized, new_order, 1));
+                    active_orders.push((key, new_seed));
 
-                pending.push_back((output, Event::Message(MzOffset::from(offset), (row, 1))));
-                if rows.peek().is_none() {
-                    offset += 1;
-                    pending.push_back((output, Event::Progress(Some(MzOffset::from(offset)))));
-                }
-            } else {
-                if ctx.tpch.tick.is_zero() {
-                    return None;
-                }
-                let idx = rng.gen_range(0..active_orders.len());
-                let (key, old_seed) = active_orders.swap_remove(idx);
-                let (old_order, old_lineitems) = ctx.order_row(old_seed, key);
-                // Fill pending with old lineitem retractions, new lineitem
-                // additions, and finally the new order. Return the old
-                // order to start the batch.
-                for row in old_lineitems {
-                    pending.push_back((
-                        LINEITEM_OUTPUT,
-                        Event::Message(MzOffset::from(offset), (row, -1)),
-                    ));
-                }
-                let new_seed = rng.gen();
-                let (new_order, new_lineitems) = ctx.order_row(new_seed, key);
-                for row in new_lineitems {
-                    pending.push_back((
-                        LINEITEM_OUTPUT,
-                        Event::Message(MzOffset::from(offset), (row, 1)),
-                    ));
-                }
-                pending.push_back((
-                    ORDERS_OUTPUT,
-                    Event::Message(MzOffset::from(offset), (old_order, -1)),
-                ));
-                pending.push_back((
-                    ORDERS_OUTPUT,
-                    Event::Message(MzOffset::from(offset), (new_order, 1)),
-                ));
-                offset += 1;
-                pending.push_back((ORDERS_OUTPUT, Event::Progress(Some(MzOffset::from(offset)))));
-                active_orders.push((key, new_seed));
-            }
-            pending.pop_front()
+                    Some((
+                        ORDERS_OUTPUT,
+                        GeneratorMessageType::InProgress,
+                        old_order,
+                        -1,
+                    ))
+                })
         }))
     }
 }

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -95,11 +95,11 @@ false
 true
 > SELECT mz_internal.mz_sleep(1)
 <null>
-> SELECT count(*) FROM mz_internal.mz_dataflow_operators
-0
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
 > DROP MATERIALIZED VIEW q14
-> SELECT count(*)  FROM mz_internal.mz_dataflow_operators
-0
+> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
+false
 
 # Clean up.
 > DROP CLUSTER test CASCADE

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -67,7 +67,7 @@ materialize.public.accounts "CREATE SUBSOURCE \"materialize\".\"public\".\"accou
 
 # Check that negative max cardinalities are rejected
 ! CREATE SOURCE counter2 FROM LOAD GENERATOR COUNTER (MAX CARDINALITY -1)
-contains:invalid MAX CARDINALITY: invalid unsigned numeric value: invalid digit found in string
+contains: unsupported max cardinality
 
 > CREATE SOURCE counter3 FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 0)
 


### PR DESCRIPTION
This reverts the 2 commits that changed loadgen, as decided in https://materializeinc.slack.com/archives/CTESPM7FU/p1693594749821249

This reverts commit https://github.com/guswynn/materialize/commit/97217a180dd571a18d013b1703507642c96f260d.
AND
This reverts commit https://github.com/guswynn/materialize/commit/a2b04ad44489737eadf7692e041154814544f359.

