### PR TITLE
Remove vim-specific files from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ __pycache__
 venv
 node_modules
 coverage
-**/*.swp
 test/feature-benchmark/tmp/*.td
 test/zippy/tmp/*.td
 test/**/tmp_*.toml


### PR DESCRIPTION
Editor-specific files should go in personal git exclude files, as described [here](https://tekin.co.uk/2020/03/maintain-a-global-git-ignore-file).
