### PR TITLE
sql: support regexp_replace

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -348,6 +348,17 @@
       `needle`, in order. If `flags` is set to the string `i` matches
       case-insensitively.
 
+  - signature: 'regexp_replace(source: str, pattern: str, replacement: str [, flags: str]]) -> str'
+    description: >-
+      Replaces the first occurrence of `pattern` with `replacement` in `source`.
+      No match will return `source` unchanged.
+      If `flags` contains the string `g` all occurrences are replaced.
+      If `flags` contains the string `i` matches case-insensitively.
+      `$N` or `$name` in `replacement` can be used to match capture groups.
+      `${N}` must be used to disambiguate capture group indexes from names if other characters follow `N`.
+      A `$$` in `replacement` will write a literal `$`.
+      See the [rust regex docs](https://docs.rs/regex/latest/regex/struct.Regex.html#method.replace) for more details about replacement.
+
   - signature: 'regexp_split_to_array(text: str, pattern: str [, flags: str]]) -> str[]'
     description: >-
       Splits `text` by the regular expression `pattern` into an array.

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -673,6 +673,7 @@ message ProtoVariadicFunc {
         google.protobuf.Empty timezone_time = 37;
         google.protobuf.Empty make_acl_item = 38;
         google.protobuf.Empty regexp_split_to_array = 39;
+        google.protobuf.Empty regexp_replace = 40;
     }
 }
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3220,6 +3220,10 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(String, String, String) => sql_impl_table_func("
                 SELECT unnest(regexp_split_to_array($1, $2, $3))
             ") => ReturnType::set_of(String.into()), 2766;
+        },
+        "regexp_replace" => Scalar {
+            params!(String, String, String) => VariadicFunc::RegexpReplace => String, 2284;
+            params!(String, String, String, String) => VariadicFunc::RegexpReplace => String, 2285;
         }
     };
 

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3224,6 +3224,8 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "regexp_replace" => Scalar {
             params!(String, String, String) => VariadicFunc::RegexpReplace => String, 2284;
             params!(String, String, String, String) => VariadicFunc::RegexpReplace => String, 2285;
+            // TODO: PostgreSQL supports additional five and six argument forms of this function which
+            // allow controlling where to start the replacement and how many replacements to make.
         }
     };
 

--- a/test/sqllogictest/regex.slt
+++ b/test/sqllogictest/regex.slt
@@ -455,3 +455,23 @@ query T
 SELECT regexp_split_to_table('no match', 'nope')
 ----
 no match
+
+query T
+SELECT regexp_replace('foobarbaz', 'b..', 'X')
+----
+fooXbaz
+
+query T
+SELECT regexp_replace('foobarbaz', 'b..', 'X', 'g')
+----
+fooXX
+
+query T
+SELECT regexp_replace('foobarbaz', 'b(..)', 'X${1}Y', 'g')
+----
+fooXarYXazY
+
+query T
+SELECT regexp_replace('foobarbaz', 'no match', 'X')
+----
+foobarbaz


### PR DESCRIPTION
Closes #21411

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ xThis PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ xIf this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ xIf this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `regexp_replace` function.