### PR TITLE
compute-client: fix a bug in frontier tracking

### DIFF
--- a/src/compute-client/src/service.rs
+++ b/src/compute-client/src/service.rs
@@ -270,8 +270,8 @@ where
                 let old_upper = frontier.frontier().to_owned();
                 let shard_upper = &mut shard_frontiers[shard_id];
                 frontier.update_iter(shard_upper.iter().map(|t| (t.clone(), -1)));
-                frontier.update_iter(new_shard_upper.iter().map(|t| (t.clone(), 1)));
                 shard_upper.join_assign(&new_shard_upper);
+                frontier.update_iter(shard_upper.iter().map(|t| (t.clone(), 1)));
 
                 let new_upper = frontier.frontier();
 


### PR DESCRIPTION
This PR fixes a bug in the frontier tracking logic of the partitioned compute client.

Previously, the handling of regressing shard frontiers was incorrect. If we received a shard frontier that was before the frontier previously reported for that shard, we would add it to the `MutableAntichain` that tracks the global frontier, but we would not keep the tracked per-shard frontier the same. As a result, on further frontier updates we would retract the wrong per-shard frontier from the `MutableAntichain`, corrupting its state in the process. This would lead to the global frontier becoming stuck.

This PR also adds trace logging to the partitioned client, to give us a chance to find issues like this in the future.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

I found this while digging for a possible cause for https://github.com/MaterializeInc/cloud/issues/7160. I don't think this bug is that cause, or at least I couldn't explain how it could produce the observed symptoms. Given that replicas are careful to avoid regressions in the frontiers they report, this bug should never be triggered. But we should fix it anyway.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
