### PR TITLE
catalog: Clean up some messy code

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1984,7 +1984,7 @@ pub struct Schema {
 }
 
 impl Schema {
-    fn to_durable_schema(self, database_id: Option<DatabaseId>) -> storage::Schema {
+    fn into_durable_schema(self, database_id: Option<DatabaseId>) -> storage::Schema {
         storage::Schema {
             id: self.id.into(),
             name: self.name.schema,
@@ -7115,7 +7115,7 @@ impl Catalog {
                                 tx.update_schema(
                                     database_id,
                                     schema_id,
-                                    schema.clone().to_durable_schema(database_id.clone()),
+                                    schema.clone().into_durable_schema(database_id),
                                 )?;
                                 builtin_table_updates.push(state.pack_schema_update(
                                     database_spec,
@@ -7540,9 +7540,9 @@ impl Catalog {
                                 ResolvedDatabaseSpecifier::Id(id) => Some(id),
                             };
                             tx.update_schema(
-                                database_id.cloned(),
+                                database_id.copied(),
                                 schema_id,
-                                schema.clone().to_durable_schema(database_id.cloned()),
+                                schema.clone().into_durable_schema(database_id.copied()),
                             )?;
                             builtin_table_updates.push(state.pack_schema_update(
                                 database_spec,


### PR DESCRIPTION
### Motivation
   * This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
