### PR TITLE
catalog: Remove SerializedX items from catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3789,6 +3789,7 @@ dependencies = [
  "mz-proto",
  "mz-repr",
  "mz-service",
+ "mz-stash",
  "mz-storage-client",
  "mz-timely-util",
  "mz-tracing",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -97,7 +97,6 @@ use mz_storage_client::types::sources::{
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::Optimizer;
 use once_cell::sync::Lazy;
-use proptest_derive::Arbitrary;
 use regex::Regex;
 use serde::ser::SerializeSeq;
 use serde::{Deserialize, Serialize};

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -8475,23 +8475,6 @@ pub enum ClusterVariant {
     Unmanaged,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub enum SerializedReplicaLocation {
-    Unmanaged {
-        storagectl_addrs: Vec<String>,
-        storage_addrs: Vec<String>,
-        computectl_addrs: Vec<String>,
-        compute_addrs: Vec<String>,
-        workers: usize,
-    },
-    Managed {
-        size: String,
-        /// `Some(az)` if the AZ was specified by the user and must be respected;
-        availability_zone: Option<String>,
-        disk: bool,
-    },
-}
-
 impl ConnCatalog<'_> {
     fn resolve_item_name(
         &self,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2157,7 +2157,7 @@ impl From<ClusterReplica> for storage::ClusterReplica {
             cluster_id: replica.cluster_id,
             replica_id: replica.replica_id,
             name: replica.name,
-            serialized_config: replica.config.into(),
+            config: replica.config.into(),
             owner_id: replica.owner_id,
         }
     }
@@ -2202,7 +2202,7 @@ impl From<CatalogEntry> for storage::Item {
         storage::Item {
             id: entry.id,
             name: entry.name,
-            definition: entry.item.into_serialized(),
+            create_sql: entry.item.into_serialized(),
             owner_id: entry.owner_id,
             privileges: entry.privileges.into_all_values().collect(),
         }
@@ -2902,88 +2902,46 @@ impl CatalogItem {
         }
     }
 
-    pub(crate) fn to_serialized(&self) -> SerializedCatalogItem {
+    pub(crate) fn to_serialized(&self) -> String {
         match self {
-            CatalogItem::Table(table) => SerializedCatalogItem::V1 {
-                create_sql: table.create_sql.clone(),
-            },
+            CatalogItem::Table(table) => table.create_sql.clone(),
             CatalogItem::Log(_) => unreachable!("builtin logs cannot be serialized"),
             CatalogItem::Source(source) => {
                 assert!(
-                    match source.data_source {
-                        DataSourceDesc::Introspection(_) => false,
-                        _ => true,
-                    },
+                    !matches!(source.data_source, DataSourceDesc::Introspection(_)),
                     "cannot serialize introspection/builtin sources",
                 );
-                SerializedCatalogItem::V1 {
-                    create_sql: source.create_sql.clone(),
-                }
+                source.create_sql.clone()
             }
-            CatalogItem::View(view) => SerializedCatalogItem::V1 {
-                create_sql: view.create_sql.clone(),
-            },
-            CatalogItem::MaterializedView(mview) => SerializedCatalogItem::V1 {
-                create_sql: mview.create_sql.clone(),
-            },
-            CatalogItem::Index(index) => SerializedCatalogItem::V1 {
-                create_sql: index.create_sql.clone(),
-            },
-            CatalogItem::Sink(sink) => SerializedCatalogItem::V1 {
-                create_sql: sink.create_sql.clone(),
-            },
-            CatalogItem::Type(typ) => SerializedCatalogItem::V1 {
-                create_sql: typ.create_sql.clone(),
-            },
-            CatalogItem::Secret(secret) => SerializedCatalogItem::V1 {
-                create_sql: secret.create_sql.clone(),
-            },
-            CatalogItem::Connection(connection) => SerializedCatalogItem::V1 {
-                create_sql: connection.create_sql.clone(),
-            },
+            CatalogItem::View(view) => view.create_sql.clone(),
+            CatalogItem::MaterializedView(mview) => mview.create_sql.clone(),
+            CatalogItem::Index(index) => index.create_sql.clone(),
+            CatalogItem::Sink(sink) => sink.create_sql.clone(),
+            CatalogItem::Type(typ) => typ.create_sql.clone(),
+            CatalogItem::Secret(secret) => secret.create_sql.clone(),
+            CatalogItem::Connection(connection) => connection.create_sql.clone(),
             CatalogItem::Func(_) => unreachable!("cannot serialize functions yet"),
         }
     }
 
-    pub(crate) fn into_serialized(self) -> SerializedCatalogItem {
+    pub(crate) fn into_serialized(self) -> String {
         match self {
-            CatalogItem::Table(table) => SerializedCatalogItem::V1 {
-                create_sql: table.create_sql,
-            },
+            CatalogItem::Table(table) => table.create_sql,
             CatalogItem::Log(_) => unreachable!("builtin logs cannot be serialized"),
             CatalogItem::Source(source) => {
                 assert!(
-                    match source.data_source {
-                        DataSourceDesc::Introspection(_) => false,
-                        _ => true,
-                    },
+                    !matches!(source.data_source, DataSourceDesc::Introspection(_)),
                     "cannot serialize introspection/builtin sources",
                 );
-                SerializedCatalogItem::V1 {
-                    create_sql: source.create_sql,
-                }
+                source.create_sql
             }
-            CatalogItem::View(view) => SerializedCatalogItem::V1 {
-                create_sql: view.create_sql,
-            },
-            CatalogItem::MaterializedView(mview) => SerializedCatalogItem::V1 {
-                create_sql: mview.create_sql,
-            },
-            CatalogItem::Index(index) => SerializedCatalogItem::V1 {
-                create_sql: index.create_sql,
-            },
-            CatalogItem::Sink(sink) => SerializedCatalogItem::V1 {
-                create_sql: sink.create_sql,
-            },
-            CatalogItem::Type(typ) => SerializedCatalogItem::V1 {
-                create_sql: typ.create_sql,
-            },
-            CatalogItem::Secret(secret) => SerializedCatalogItem::V1 {
-                create_sql: secret.create_sql,
-            },
-            CatalogItem::Connection(connection) => SerializedCatalogItem::V1 {
-                create_sql: connection.create_sql,
-            },
+            CatalogItem::View(view) => view.create_sql,
+            CatalogItem::MaterializedView(mview) => mview.create_sql,
+            CatalogItem::Index(index) => index.create_sql,
+            CatalogItem::Sink(sink) => sink.create_sql,
+            CatalogItem::Type(typ) => typ.create_sql,
+            CatalogItem::Secret(secret) => secret.create_sql,
+            CatalogItem::Connection(connection) => connection.create_sql,
             CatalogItem::Func(_) => unreachable!("cannot serialize functions yet"),
         }
     }
@@ -4055,23 +4013,23 @@ impl Catalog {
             cluster_id,
             replica_id,
             name,
-            serialized_config,
+            config,
             owner_id,
         } in replicas
         {
             let logging = ReplicaLogging {
-                log_logging: serialized_config.logging.log_logging,
-                interval: serialized_config.logging.interval,
+                log_logging: config.logging.log_logging,
+                interval: config.logging.interval,
             };
             let config = ReplicaConfig {
                 location: catalog.concretize_replica_location(
-                    serialized_config.location,
+                    config.location,
                     &vec![],
                     cluster_azs.get(&cluster_id).map(|zones| &**zones),
                 )?,
                 compute: ComputeReplicaConfig {
                     logging,
-                    idle_arrangement_merge_effort: serialized_config.idle_arrangement_merge_effort,
+                    idle_arrangement_merge_effort: config.idle_arrangement_merge_effort,
                 },
             };
 
@@ -4079,7 +4037,13 @@ impl Catalog {
             catalog
                 .storage()
                 .await
-                .set_replica_config(replica_id, cluster_id, name.clone(), &config, owner_id)
+                .set_replica_config(
+                    replica_id,
+                    cluster_id,
+                    name.clone(),
+                    config.clone().into(),
+                    owner_id,
+                )
                 .await?;
 
             catalog
@@ -4926,7 +4890,7 @@ impl Catalog {
         let mut awaiting_name_dependencies: BTreeMap<String, Vec<_>> = BTreeMap::new();
         let mut items: VecDeque<_> = tx.loaded_items().into_iter().collect();
         while let Some(item) = items.pop_front() {
-            let d_c = item.definition.clone();
+            let d_c = item.create_sql.clone();
             // TODO(benesch): a better way of detecting when a view has depended
             // upon a non-existent logging view. This is fine for now because
             // the only goal is to produce a nicer error message; we'll bail out
@@ -5002,7 +4966,7 @@ impl Catalog {
             let storage::Item {
                 id,
                 name,
-                definition: _,
+                create_sql: _,
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
@@ -5021,7 +4985,7 @@ impl Catalog {
             let storage::Item {
                 id,
                 name,
-                definition: _,
+                create_sql: _,
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
@@ -5669,12 +5633,12 @@ impl Catalog {
 
     pub fn concretize_replica_location(
         &self,
-        location: SerializedReplicaLocation,
+        location: storage::ReplicaLocation,
         allowed_sizes: &Vec<String>,
         allowed_availability_zones: Option<&[String]>,
     ) -> Result<ReplicaLocation, AdapterError> {
         let location = match location {
-            SerializedReplicaLocation::Unmanaged {
+            storage::ReplicaLocation::Unmanaged {
                 storagectl_addrs,
                 storage_addrs,
                 computectl_addrs,
@@ -5695,7 +5659,7 @@ impl Catalog {
                     workers,
                 })
             }
-            SerializedReplicaLocation::Managed {
+            storage::ReplicaLocation::Managed {
                 size,
                 availability_zone,
                 disk,
@@ -7914,7 +7878,7 @@ impl Catalog {
     fn deserialize_item(
         &self,
         id: GlobalId,
-        SerializedCatalogItem::V1 { create_sql }: SerializedCatalogItem,
+        create_sql: String,
     ) -> Result<CatalogItem, AdapterError> {
         // TODO - The `None` needs to be changed if we ever allow custom
         // logical compaction windows in user-defined objects.
@@ -8490,11 +8454,6 @@ pub enum Op {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Arbitrary)]
-pub enum SerializedCatalogItem {
-    V1 { create_sql: String },
-}
-
 #[derive(Clone, Debug, Deserialize, Serialize, PartialOrd, PartialEq, Eq, Ord)]
 pub struct ClusterConfig {
     pub variant: ClusterVariant,
@@ -8504,7 +8463,7 @@ pub struct ClusterConfig {
 pub struct ClusterVariantManaged {
     pub size: String,
     pub availability_zones: Vec<String>,
-    pub logging: SerializedReplicaLogging,
+    pub logging: ReplicaLogging,
     pub idle_arrangement_merge_effort: Option<u32>,
     pub replication_factor: u32,
     pub disk: bool,
@@ -8514,48 +8473,6 @@ pub struct ClusterVariantManaged {
 pub enum ClusterVariant {
     Managed(ClusterVariantManaged),
     Unmanaged,
-}
-
-/// Serialized (stored alongside the replica) logging configuration of
-/// a replica. Serialized variant of `ReplicaLogging`.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
-pub struct SerializedReplicaLogging {
-    pub(crate) log_logging: bool,
-    pub(crate) interval: Option<Duration>,
-}
-
-impl From<ReplicaLogging> for SerializedReplicaLogging {
-    fn from(
-        ReplicaLogging {
-            log_logging,
-            interval,
-        }: ReplicaLogging,
-    ) -> Self {
-        Self {
-            log_logging,
-            interval,
-        }
-    }
-}
-
-/// A [`ReplicaConfig`] that is serialized as JSON and persisted to the catalog
-/// stash. This is a separate type to allow us to evolve the on-disk format
-/// independently from the SQL layer.
-#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
-pub struct SerializedReplicaConfig {
-    pub location: SerializedReplicaLocation,
-    pub logging: SerializedReplicaLogging,
-    pub idle_arrangement_merge_effort: Option<u32>,
-}
-
-impl From<ReplicaConfig> for SerializedReplicaConfig {
-    fn from(config: ReplicaConfig) -> Self {
-        SerializedReplicaConfig {
-            location: config.location.into(),
-            logging: config.compute.logging.into(),
-            idle_arrangement_merge_effort: config.compute.idle_arrangement_merge_effort,
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
@@ -8573,42 +8490,6 @@ pub enum SerializedReplicaLocation {
         availability_zone: Option<String>,
         disk: bool,
     },
-}
-
-impl From<ReplicaLocation> for SerializedReplicaLocation {
-    fn from(loc: ReplicaLocation) -> Self {
-        match loc {
-            ReplicaLocation::Unmanaged(UnmanagedReplicaLocation {
-                storagectl_addrs,
-                storage_addrs,
-                computectl_addrs,
-                compute_addrs,
-                workers,
-            }) => Self::Unmanaged {
-                storagectl_addrs,
-                storage_addrs,
-                computectl_addrs,
-                compute_addrs,
-                workers,
-            },
-            ReplicaLocation::Managed(ManagedReplicaLocation {
-                allocation: _,
-                size,
-                availability_zones,
-                disk,
-            }) => SerializedReplicaLocation::Managed {
-                size,
-                availability_zone: if let ManagedReplicaAvailabilityZones::FromReplica(Some(az)) =
-                    availability_zones
-                {
-                    Some(az)
-                } else {
-                    None
-                },
-                disk,
-            },
-        }
-    }
 }
 
 impl ConnCatalog<'_> {

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -21,7 +21,7 @@ use semver::Version;
 use tracing::info;
 
 use crate::catalog::storage::Transaction;
-use crate::catalog::{storage, Catalog, ConnCatalog, SerializedCatalogItem};
+use crate::catalog::{storage, Catalog, ConnCatalog};
 
 /// A flag to indicate whether or not we've already run the migration to rename existing uses of
 /// the AVG(...) function. Runs in versions <=0.66.
@@ -42,17 +42,11 @@ where
     let mut updated_items = BTreeMap::new();
     let items = tx.loaded_items();
     for mut item in items {
-        let create_sql = match &item.definition {
-            SerializedCatalogItem::V1 { create_sql } => create_sql,
-        };
-        let mut stmt = mz_sql::parse::parse(create_sql)?.into_element().ast;
+        let mut stmt = mz_sql::parse::parse(&item.create_sql)?.into_element().ast;
 
         f(tx, &cat, &mut stmt).await?;
 
-        let serialized_item = SerializedCatalogItem::V1 {
-            create_sql: stmt.to_ast_string_stable(),
-        };
-        item.definition = serialized_item;
+        item.create_sql = stmt.to_ast_string_stable();
 
         updated_items.insert(item.id, item);
     }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
-use mz_controller::clusters::{ClusterId, ReplicaConfig, ReplicaId};
+use mz_controller::clusters::{ClusterId, ReplicaId, ReplicaLogging};
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NowFn;
 use mz_ore::retry::Retry;
@@ -45,8 +45,7 @@ use crate::catalog::error::{Error, ErrorKind};
 use crate::catalog::storage::stash::DEPLOY_GENERATION;
 use crate::catalog::{
     is_reserved_name, ClusterConfig, ClusterVariant, DefaultPrivilegeAclItem,
-    DefaultPrivilegeObject, RoleMembership, SerializedCatalogItem, SerializedReplicaConfig,
-    SerializedReplicaLocation, SerializedReplicaLogging, SystemObjectMapping,
+    DefaultPrivilegeObject, RoleMembership, SystemObjectMapping,
 };
 use crate::coord::timeline;
 
@@ -153,9 +152,9 @@ fn add_new_builtin_cluster_replicas_migration(
     Ok(())
 }
 
-fn builtin_cluster_replica_config(bootstrap_args: &BootstrapArgs) -> SerializedReplicaConfig {
-    SerializedReplicaConfig {
-        location: SerializedReplicaLocation::Managed {
+fn builtin_cluster_replica_config(bootstrap_args: &BootstrapArgs) -> ReplicaConfig {
+    ReplicaConfig {
+        location: ReplicaLocation::Managed {
             size: bootstrap_args.builtin_cluster_replica_size.clone(),
             availability_zone: None,
             disk: false,
@@ -165,8 +164,8 @@ fn builtin_cluster_replica_config(bootstrap_args: &BootstrapArgs) -> SerializedR
     }
 }
 
-fn default_logging_config() -> SerializedReplicaLogging {
-    SerializedReplicaLogging {
+fn default_logging_config() -> ReplicaLogging {
+    ReplicaLogging {
         log_logging: false,
         interval: Some(Duration::from_secs(1)),
     }
@@ -474,7 +473,7 @@ impl Connection {
                     cluster_id: v.cluster_id,
                     replica_id: k.id,
                     name: v.name,
-                    serialized_config: v.config,
+                    config: v.config,
                     owner_id: v.owner_id,
                 },
             )
@@ -732,14 +731,14 @@ impl Connection {
         replica_id: ReplicaId,
         cluster_id: ClusterId,
         name: String,
-        config: &ReplicaConfig,
+        config: ReplicaConfig,
         owner_id: RoleId,
     ) -> Result<(), Error> {
         let key = ClusterReplicaKey { id: replica_id }.into_proto();
         let val = ClusterReplicaValue {
             cluster_id,
             name,
-            config: config.clone().into(),
+            config,
             owner_id,
         }
         .into_proto();
@@ -1055,7 +1054,7 @@ impl<'a> Transaction<'a> {
                     },
                     item: v.name.clone(),
                 },
-                definition: v.definition.clone(),
+                create_sql: v.create_sql.clone(),
                 owner_id: v.owner_id,
                 privileges: v.privileges.clone(),
             });
@@ -1309,7 +1308,7 @@ impl<'a> Transaction<'a> {
         cluster_id: ClusterId,
         replica_id: ReplicaId,
         replica_name: &str,
-        config: &SerializedReplicaConfig,
+        config: &ReplicaConfig,
         owner_id: RoleId,
     ) -> Result<(), Error> {
         if let Err(_) = self.cluster_replicas.insert(
@@ -1367,7 +1366,7 @@ impl<'a> Transaction<'a> {
         id: GlobalId,
         schema_id: SchemaId,
         item_name: &str,
-        item: SerializedCatalogItem,
+        create_sql: String,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
     ) -> Result<(), Error> {
@@ -1376,7 +1375,7 @@ impl<'a> Transaction<'a> {
             ItemValue {
                 schema_id,
                 name: item_name.to_string(),
-                definition: item,
+                create_sql,
                 owner_id,
                 privileges,
             },
@@ -1525,7 +1524,7 @@ impl<'a> Transaction<'a> {
                 Some(ItemValue {
                     schema_id: v.schema_id,
                     name: item.name.item,
-                    definition: item.definition,
+                    create_sql: item.create_sql,
                     owner_id: item.owner_id,
                     privileges: item.privileges,
                 })
@@ -1559,7 +1558,7 @@ impl<'a> Transaction<'a> {
                 Some(ItemValue {
                     schema_id: v.schema_id,
                     name: item.name.item.clone(),
-                    definition: item.definition.clone(),
+                    create_sql: item.create_sql.clone(),
                     owner_id: item.owner_id.clone(),
                     privileges: item.privileges.clone(),
                 })
@@ -1683,7 +1682,7 @@ impl<'a> Transaction<'a> {
                 Some(ClusterReplicaValue {
                     cluster_id,
                     name: replica.name,
-                    config: replica.serialized_config,
+                    config: replica.config,
                     owner_id: replica.owner_id,
                 })
             } else {
@@ -2037,15 +2036,110 @@ pub struct ClusterReplica {
     pub cluster_id: ClusterId,
     pub replica_id: ReplicaId,
     pub name: String,
-    pub serialized_config: SerializedReplicaConfig,
+    pub config: ReplicaConfig,
     pub owner_id: RoleId,
+}
+
+// The on-disk replica configuration does not match the in-memory replica configuration, so we need
+// separate structs. As of writing this comment, it is mainly due to the fact that we don't persist
+// the replica allocation.
+
+#[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
+pub struct ReplicaConfig {
+    pub location: ReplicaLocation,
+    pub logging: ReplicaLogging,
+    pub idle_arrangement_merge_effort: Option<u32>,
+}
+
+impl From<mz_controller::clusters::ReplicaConfig> for ReplicaConfig {
+    fn from(config: mz_controller::clusters::ReplicaConfig) -> Self {
+        Self {
+            location: config.location.into(),
+            logging: config.compute.logging.into(),
+            idle_arrangement_merge_effort: config.compute.idle_arrangement_merge_effort,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Ord)]
+pub enum ReplicaLocation {
+    Unmanaged {
+        storagectl_addrs: Vec<String>,
+        storage_addrs: Vec<String>,
+        computectl_addrs: Vec<String>,
+        compute_addrs: Vec<String>,
+        workers: usize,
+    },
+    Managed {
+        size: String,
+        /// `Some(az)` if the AZ was specified by the user and must be respected;
+        availability_zone: Option<String>,
+        disk: bool,
+    },
+}
+
+impl From<mz_controller::clusters::ReplicaLocation> for ReplicaLocation {
+    fn from(loc: mz_controller::clusters::ReplicaLocation) -> Self {
+        match loc {
+            mz_controller::clusters::ReplicaLocation::Unmanaged(
+                mz_controller::clusters::UnmanagedReplicaLocation {
+                    storagectl_addrs,
+                    storage_addrs,
+                    computectl_addrs,
+                    compute_addrs,
+                    workers,
+                },
+            ) => Self::Unmanaged {
+                storagectl_addrs,
+                storage_addrs,
+                computectl_addrs,
+                compute_addrs,
+                workers,
+            },
+            mz_controller::clusters::ReplicaLocation::Managed(
+                mz_controller::clusters::ManagedReplicaLocation {
+                    allocation: _,
+                    size,
+                    availability_zones,
+                    disk,
+                },
+            ) => ReplicaLocation::Managed {
+                size,
+                availability_zone:
+                    if let mz_controller::clusters::ManagedReplicaAvailabilityZones::FromReplica(
+                        Some(az),
+                    ) = availability_zones
+                    {
+                        Some(az)
+                    } else {
+                        None
+                    },
+                disk,
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ComputeReplicaLogging {
+    pub log_logging: bool,
+    pub interval: Option<Duration>,
+}
+
+impl From<mz_compute_client::controller::ComputeReplicaLogging> for ComputeReplicaLogging {
+    fn from(logging: mz_compute_client::controller::ComputeReplicaLogging) -> Self {
+        ComputeReplicaLogging {
+            log_logging: logging.log_logging,
+            interval: logging.interval,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
 pub struct Item {
     pub id: GlobalId,
     pub name: QualifiedItemName,
-    pub definition: SerializedCatalogItem,
+    pub create_sql: String,
     pub owner_id: RoleId,
     pub privileges: Vec<MzAclItem>,
 }
@@ -2119,7 +2213,7 @@ pub struct ClusterReplicaKey {
 pub struct ClusterReplicaValue {
     cluster_id: ClusterId,
     name: String,
-    config: SerializedReplicaConfig,
+    config: ReplicaConfig,
     owner_id: RoleId,
 }
 
@@ -2157,7 +2251,7 @@ pub struct ItemKey {
 pub struct ItemValue {
     schema_id: SchemaId,
     name: String,
-    definition: SerializedCatalogItem,
+    create_sql: String,
     owner_id: RoleId,
     privileges: Vec<MzAclItem>,
 }

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -2126,15 +2126,6 @@ pub struct ComputeReplicaLogging {
     pub interval: Option<Duration>,
 }
 
-impl From<mz_compute_client::controller::ComputeReplicaLogging> for ComputeReplicaLogging {
-    fn from(logging: mz_compute_client::controller::ComputeReplicaLogging) -> Self {
-        ComputeReplicaLogging {
-            log_logging: logging.log_logging,
-            interval: logging.interval,
-        }
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Item {
     pub id: GlobalId,

--- a/src/adapter/src/catalog/storage.rs
+++ b/src/adapter/src/catalog/storage.rs
@@ -2055,7 +2055,7 @@ impl From<mz_controller::clusters::ReplicaConfig> for ReplicaConfig {
     fn from(config: mz_controller::clusters::ReplicaConfig) -> Self {
         Self {
             location: config.location.into(),
-            logging: config.compute.logging.into(),
+            logging: config.compute.logging,
             idle_arrangement_merge_effort: config.compute.idle_arrangement_merge_effort,
         }
     }

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -61,7 +61,7 @@ impl Coordinator {
                 ClusterVariant::Managed(ClusterVariantManaged {
                     size: plan.size.clone(),
                     availability_zones: plan.availability_zones.clone(),
-                    logging: logging.into(),
+                    logging,
                     idle_arrangement_merge_effort: plan.compute.idle_arrangement_merge_effort,
                     replication_factor: plan.replication_factor,
                     disk: plan.disk,
@@ -527,7 +527,7 @@ impl Coordinator {
                 new_config.variant = Managed(ClusterVariantManaged {
                     size,
                     availability_zones: Default::default(),
-                    logging: logging.into(),
+                    logging,
                     idle_arrangement_merge_effort: None,
                     replication_factor: 1,
                     disk,

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -28,9 +28,7 @@ use mz_sql::plan::{
 };
 use mz_sql::session::vars::{SystemVars, Var, MAX_REPLICAS_PER_CLUSTER};
 
-use crate::catalog::{
-    ClusterConfig, ClusterVariant, ClusterVariantManaged, Op, SerializedReplicaLocation,
-};
+use crate::catalog::{ClusterConfig, ClusterVariant, ClusterVariantManaged, Op};
 use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS};
 use crate::session::Session;
 use crate::{catalog, AdapterError, ExecuteResponse};
@@ -170,7 +168,7 @@ impl Coordinator {
         disk: bool,
         owner_id: RoleId,
     ) -> Result<(), AdapterError> {
-        let location = SerializedReplicaLocation::Managed {
+        let location = catalog::storage::ReplicaLocation::Managed {
             size: size.clone(),
             availability_zone: None,
             disk,
@@ -272,7 +270,7 @@ impl Coordinator {
                     workers,
                     compute,
                 } => {
-                    let location = SerializedReplicaLocation::Unmanaged {
+                    let location = catalog::storage::ReplicaLocation::Unmanaged {
                         storagectl_addrs,
                         storage_addrs,
                         computectl_addrs,
@@ -287,7 +285,7 @@ impl Coordinator {
                     compute,
                     disk,
                 } => {
-                    let location = SerializedReplicaLocation::Managed {
+                    let location = catalog::storage::ReplicaLocation::Managed {
                         size: size.clone(),
                         availability_zone,
                         disk,
@@ -395,7 +393,7 @@ impl Coordinator {
                 workers,
                 compute,
             } => {
-                let location = SerializedReplicaLocation::Unmanaged {
+                let location = catalog::storage::ReplicaLocation::Unmanaged {
                     storagectl_addrs,
                     storage_addrs,
                     computectl_addrs,
@@ -417,7 +415,7 @@ impl Coordinator {
                     }
                     None => None,
                 };
-                let location = SerializedReplicaLocation::Managed {
+                let location = catalog::storage::ReplicaLocation::Managed {
                     size,
                     availability_zone,
                     disk,

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -22,9 +22,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::SourceSinkClusterConfig;
 
-use crate::catalog::{
-    self, ClusterConfig, ClusterVariant, SerializedReplicaLocation, LINKED_CLUSTER_REPLICA_NAME,
-};
+use crate::catalog::{self, ClusterConfig, ClusterVariant, LINKED_CLUSTER_REPLICA_NAME};
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 use crate::session::Session;
@@ -82,7 +80,7 @@ impl Coordinator {
         ops: &mut Vec<catalog::Op>,
         owner_id: RoleId,
     ) -> Result<(), AdapterError> {
-        let location = SerializedReplicaLocation::Managed {
+        let location = catalog::storage::ReplicaLocation::Managed {
             size: size.to_string(),
             availability_zone: None,
             disk,

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -28,6 +28,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 mz-service = { path = "../service" }
+mz-stash = { path = "../stash" }
 mz-storage-client = { path = "../storage-client" }
 mz-timely-util = { path = "../timely-util" }
 mz-tracing = { path = "../tracing" }


### PR DESCRIPTION
Previously, the catalog had structs of the form 'SerializedX', such as
SerializedItem. They were used to persist catalog objects to the stash
while allowing us to evolve the on disk state independently of the in
memory state.
    
Now that we use protobuf to persist objects to the stash, the
SerializedX structs are no longer necessary. This commit removes these
structs from the catalog. Some of the structs are still necessary to
use as arguments for catalog::storage functions, so those were moved
to the catalog::storage module.


### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
