### PR TITLE
ci/deploy_mz: upload file containing latest mz version as string

### DIFF
--- a/ci/deploy_mz/pipeline.yml
+++ b/ci/deploy_mz/pipeline.yml
@@ -8,6 +8,14 @@
 # by the Apache License, Version 2.0.
 
 steps:
+  - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.version
+    timeout_in_minutes: 30
+    concurrency: 1
+    concurrency_group: deploy-mz/version
+    retry:
+      manual:
+        permit_on_passed: true
+
   - id: linux-x86_64
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.linux
     timeout_in_minutes: 30

--- a/ci/deploy_mz/version.py
+++ b/ci/deploy_mz/version.py
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import boto3
+
+from .deploy_util import BINARIES_BUCKET, VERSION
+
+
+def main() -> None:
+    print("--- Uploading version file")
+    boto3.client("s3").put_object(
+        Body=f"{VERSION}\n",
+        Bucket=BINARIES_BUCKET,
+        Key="mz.version",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
To provide a simple HTTP API for determining the latest mz version:

    curl https://binaries.materialize.com/mz-latest.version

mz will learn to use this API to automatically notify the user when an upgrade is available. See #21459.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

It's likely this won't work on the first try. It may take us one or two releases of `mz` to really get this logic right.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
