### PR TITLE
sqlsmith: Remove workaround for explain refactor

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -155,7 +155,6 @@ known_errors = [
     "csv_extract number of columns too large",
     "coalesce types text and oid cannot be matched",  # with ACL-related functions
     "coalesce types oid and text cannot be matched",  # with ACL-related functions
-    "Expected FOR, found WITH",  # introduced by the EXPLAIN refactor in #21383
 ]
 
 


### PR DESCRIPTION
Fixed properly in https://github.com/MaterializeInc/sqlsmith/commit/0b1d46679ad935c5a0d4ed185111c20f6d2569cd

Follow-up to #21383

I'll run CI on this and check if anything else is broken in SQLsmith currently, will only merge if it's green: https://buildkite.com/materialize/nightlies/builds/3754

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
