### PR TITLE
storage: teach load generator sources to resume V2

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1453,7 +1453,7 @@ generate_extracted_config!(
     LoadGeneratorOption,
     (TickInterval, Interval),
     (ScaleFactor, f64),
-    (MaxCardinality, i64)
+    (MaxCardinality, u64)
 );
 
 pub(crate) fn load_generator_ast_to_generator(
@@ -1472,11 +1472,6 @@ pub(crate) fn load_generator_ast_to_generator(
             let LoadGeneratorOptionExtracted {
                 max_cardinality, ..
             } = options.to_vec().try_into()?;
-            if let Some(max_cardinality) = max_cardinality {
-                if max_cardinality < 0 {
-                    sql_bail!("unsupported max cardinality {max_cardinality}");
-                }
-            }
             LoadGenerator::Counter { max_cardinality }
         }
         mz_sql_parser::ast::LoadGenerator::Marketing => LoadGenerator::Marketing,

--- a/src/storage-client/src/types/sources.proto
+++ b/src/storage-client/src/types/sources.proto
@@ -222,9 +222,7 @@ message ProtoTestScriptSourceConnection {
 }
 
 message ProtoCounterLoadGenerator {
-    // Must be non-negative,
-    // but kept as int64 to make downstream logic simpler
-    optional int64 max_cardinality = 1;
+    optional uint64 max_cardinality = 1;
 }
 
 message ProtoTpchLoadGenerator {

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -13,15 +13,14 @@ use std::rc::Rc;
 use std::time::Duration;
 
 use differential_dataflow::{AsCollection, Collection};
-use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Diff, Row};
 use mz_storage_client::types::connections::ConnectionContext;
 use mz_storage_client::types::sources::{
-    Generator, GeneratorMessageType, LoadGenerator, LoadGeneratorSourceConnection, MzOffset,
-    SourceTimestamp,
+    Generator, LoadGenerator, LoadGeneratorSourceConnection, MzOffset, SourceTimestamp,
 };
 use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+use timely::dataflow::operators::to_stream::Event;
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -111,42 +110,38 @@ impl SourceRender for LoadGeneratorSourceConnection {
                     .map(MzOffset::decode_row),
             );
 
-            let Some(mut offset) = resume_upper.into_option() else {
+            let Some(resume_offset) = resume_upper.into_option() else {
                 return;
             };
-            cap.downgrade(&offset);
+            cap.downgrade(&resume_offset);
 
-            let mut rows = as_generator(&self.load_generator, self.tick_micros)
-                .by_seed(mz_ore::now::SYSTEM_TIME.clone(), None);
-
-            // Skip forward to the requested offset.
-            let tx_count = usize::cast_from(offset.offset);
-            let txns = rows
-                .by_ref()
-                .filter(|(_, typ, _, _)| matches!(typ, GeneratorMessageType::Finalized))
-                .take(tx_count)
-                .count();
-            assert_eq!(txns, tx_count, "produced wrong number of transactions");
+            let mut rows = as_generator(&self.load_generator, self.tick_micros).by_seed(
+                mz_ore::now::SYSTEM_TIME.clone(),
+                None,
+                resume_offset,
+            );
 
             let tick = Duration::from_micros(self.tick_micros.unwrap_or(1_000_000));
 
-            while let Some((output, typ, value, diff)) = rows.next() {
-                let message = (
-                    output,
-                    Ok(SourceMessage {
-                        upstream_time_millis: None,
-                        key: (),
-                        value,
-                        headers: None,
-                    }),
-                );
-
-                data_output.give(&cap, (message, offset, diff)).await;
-
-                if matches!(typ, GeneratorMessageType::Finalized) {
-                    offset += 1;
-                    cap.downgrade(&offset);
-                    tokio::time::sleep(tick).await;
+            while let Some((output, event)) = rows.next() {
+                match event {
+                    Event::Message(offset, (value, diff)) => {
+                        let message = (
+                            output,
+                            Ok(SourceMessage {
+                                upstream_time_millis: None,
+                                key: (),
+                                value,
+                                headers: None,
+                            }),
+                        );
+                        data_output.give(&cap, (message, offset, diff)).await;
+                    }
+                    Event::Progress(Some(offset)) => {
+                        cap.downgrade(&offset);
+                        tokio::time::sleep(tick).await;
+                    }
+                    Event::Progress(None) => return,
                 }
             }
         });

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -134,7 +134,13 @@ impl SourceRender for LoadGeneratorSourceConnection {
                                 headers: None,
                             }),
                         );
-                        data_output.give(&cap, (message, offset, diff)).await;
+
+                        // Some generators always reproduce their TVC from the beginning which can
+                        // generate a significant amount of data that will overwhelm the dataflow.
+                        // Since those are not required downstream we eagerly ignore them here.
+                        if resume_offset <= offset {
+                            data_output.give(&cap, (message, offset, diff)).await;
+                        }
                     }
                     Event::Progress(Some(offset)) => {
                         cap.downgrade(&offset);

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -113,7 +113,6 @@ impl SourceRender for LoadGeneratorSourceConnection {
             let Some(resume_offset) = resume_upper.into_option() else {
                 return;
             };
-            cap.downgrade(&resume_offset);
 
             let mut rows = as_generator(&self.load_generator, self.tick_micros).by_seed(
                 mz_ore::now::SYSTEM_TIME.clone(),
@@ -139,7 +138,14 @@ impl SourceRender for LoadGeneratorSourceConnection {
                     }
                     Event::Progress(Some(offset)) => {
                         cap.downgrade(&offset);
-                        tokio::time::sleep(tick).await;
+                        // We only sleep if we have surpassed the resume offset so that we can
+                        // quickly go over any historical updates that a generator might choose to
+                        // emit.
+                        // TODO(petrosagg): Remove the sleep below and make generators return an
+                        // async stream so that they can drive the rate of production directly
+                        if resume_offset < offset {
+                            tokio::time::sleep(tick).await;
+                        }
                     }
                     Event::Progress(None) => return,
                 }

--- a/src/storage/src/source/generator/auction.rs
+++ b/src/storage/src/source/generator/auction.rs
@@ -12,10 +12,11 @@ use std::iter;
 
 use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{Datum, Row};
-use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
+use mz_storage_client::types::sources::{Generator, MzOffset};
 use rand::prelude::{Rng, SmallRng};
 use rand::seq::SliceRandom;
 use rand::SeedableRng;
+use timely::dataflow::operators::to_stream::Event;
 
 /// CREATE TABLE organizations
 ///   (
@@ -74,7 +75,8 @@ impl Generator for Auction {
         &self,
         now: NowFn,
         seed: Option<u64>,
-    ) -> Box<(dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>)> {
+        _resume_offset: MzOffset,
+    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let mut rng = SmallRng::seed_from_u64(seed.unwrap_or_default());
 
         let organizations = COMPANIES.iter().enumerate().map(|(offset, name)| {
@@ -115,57 +117,64 @@ impl Generator for Auction {
         let mut pending: VecDeque<(usize, Row)> =
             organizations.chain(users).chain(accounts).collect();
 
-        Box::new(iter::from_fn(move || {
-            {
-                if pending.is_empty() {
-                    counter += 1;
-                    let now = to_datetime(now());
-                    let mut auction = Row::with_capacity(4);
-                    let mut packer = auction.packer();
-                    packer.push(Datum::Int64(counter)); // auction id
-                    let max_seller_id =
-                        i64::try_from(CELEBRETIES.len()).expect("demo entries less than i64::MAX");
-                    packer.push(Datum::Int64(rng.gen_range(1..=max_seller_id))); // seller
-                    packer.push(Datum::String(AUCTIONS.choose(&mut rng).unwrap())); // item
-                    packer.push(Datum::TimestampTz(
-                        (now + chrono::Duration::seconds(10))
-                            .try_into()
-                            .expect("timestamp must fit"),
-                    )); // end time
-                    pending.push_back((AUCTIONS_OUTPUT, auction));
-                    const MAX_BIDS: i64 = 10;
-                    for i in 0..rng.gen_range(2..MAX_BIDS) {
-                        let bid_id = Datum::Int64(counter * MAX_BIDS + i);
-                        let bid = {
-                            let mut bid = Row::with_capacity(5);
-                            let mut packer = bid.packer();
-                            packer.push(bid_id);
-                            packer.push(Datum::Int64(rng.gen_range(1..=max_seller_id))); // buyer
-                            packer.push(Datum::Int64(counter)); // auction id
-                            packer.push(Datum::Int32(rng.gen_range(1..100))); // amount
-                            packer.push(Datum::TimestampTz(
-                                (now + chrono::Duration::seconds(i))
-                                    .try_into()
-                                    .expect("timestamp must fit"),
-                            )); // bid time
-                            bid
-                        };
-                        pending.push_back((BIDS_OUTPUT, bid));
+        let mut offset = 0;
+        Box::new(
+            iter::from_fn(move || {
+                {
+                    if pending.is_empty() {
+                        counter += 1;
+                        let now = to_datetime(now());
+                        let mut auction = Row::with_capacity(4);
+                        let mut packer = auction.packer();
+                        packer.push(Datum::Int64(counter)); // auction id
+                        let max_seller_id = i64::try_from(CELEBRETIES.len())
+                            .expect("demo entries less than i64::MAX");
+                        packer.push(Datum::Int64(rng.gen_range(1..=max_seller_id))); // seller
+                        packer.push(Datum::String(AUCTIONS.choose(&mut rng).unwrap())); // item
+                        packer.push(Datum::TimestampTz(
+                            (now + chrono::Duration::seconds(10))
+                                .try_into()
+                                .expect("timestamp must fit"),
+                        )); // end time
+                        pending.push_back((AUCTIONS_OUTPUT, auction));
+                        const MAX_BIDS: i64 = 10;
+                        for i in 0..rng.gen_range(2..MAX_BIDS) {
+                            let bid_id = Datum::Int64(counter * MAX_BIDS + i);
+                            let bid = {
+                                let mut bid = Row::with_capacity(5);
+                                let mut packer = bid.packer();
+                                packer.push(bid_id);
+                                packer.push(Datum::Int64(rng.gen_range(1..=max_seller_id))); // buyer
+                                packer.push(Datum::Int64(counter)); // auction id
+                                packer.push(Datum::Int32(rng.gen_range(1..100))); // amount
+                                packer.push(Datum::TimestampTz(
+                                    (now + chrono::Duration::seconds(i))
+                                        .try_into()
+                                        .expect("timestamp must fit"),
+                                )); // bid time
+                                bid
+                            };
+                            pending.push_back((BIDS_OUTPUT, bid));
+                        }
                     }
+                    // Pop from the front so auctions always appear before bids.
+                    let pend = pending.pop_front();
+                    pend.map(|(output, row)| {
+                        let msg = (output, Event::Message(MzOffset::from(offset), (row, 1)));
+
+                        // The first batch (orgs, users, accounts) is a single txn, all others (auctions and bids) are separate.
+                        let progress = if counter != 0 || pending.is_empty() {
+                            offset += 1;
+                            Some((output, Event::Progress(Some(MzOffset::from(offset)))))
+                        } else {
+                            None
+                        };
+                        std::iter::once(msg).chain(progress)
+                    })
                 }
-                // Pop from the front so auctions always appear before bids.
-                let pend = pending.pop_front();
-                pend.map(|(output, row)| {
-                    // The first batch (orgs, users, accounts) is a single txn, all others (auctions and bids) are separate.
-                    let typ = if counter != 0 || pending.is_empty() {
-                        GeneratorMessageType::Finalized
-                    } else {
-                        GeneratorMessageType::InProgress
-                    };
-                    (output, typ, row, 1)
-                })
-            }
-        }))
+            })
+            .flatten(),
+        )
     }
 }
 

--- a/src/storage/src/source/generator/counter.rs
+++ b/src/storage/src/source/generator/counter.rs
@@ -7,11 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::iter;
-
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row};
-use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
+use mz_storage_client::types::sources::{Generator, MzOffset};
+use timely::dataflow::operators::to_stream::Event;
 
 pub struct Counter {
     /// How many values will be emitted before old ones are retracted,
@@ -19,10 +18,7 @@ pub struct Counter {
     /// behavior is changed,
     /// `mz_storage_client::types::sources::LoadGenerator::is_monotonic`
     /// must be updated.
-    ///
-    /// This is verified by the planner to be nonnegative. We encode it as
-    /// an `i64` to make the code in `Counter::by_seed` simpler.
-    pub max_cardinality: Option<i64>,
+    pub max_cardinality: Option<u64>,
 }
 
 impl Generator for Counter {
@@ -30,50 +26,39 @@ impl Generator for Counter {
         &self,
         _now: NowFn,
         _seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
-        let mut counter = 0;
+        resume_offset: MzOffset,
+    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let max_cardinality = self.max_cardinality;
+
         Box::new(
-            iter::repeat_with(move || {
-                let to_retract = match max_cardinality {
-                    Some(max) => {
-                        if max <= counter {
-                            Some(counter - max + 1)
-                        } else {
-                            None
+            (resume_offset.offset..)
+                .map(move |offset| {
+                    let retraction = match max_cardinality {
+                        // At offset `max` we must start retracting the value of `offset - max`. For
+                        // example if max_cardinality is 2 then the collection should contain:
+                        // (1, 0, +1)
+                        // (2, 1, +1)
+                        // (1, 2, -1) <- Here offset becomes >= max and we retract the value that was
+                        // (3, 2, +1)    emitted at (offset - max), which equals (offset - max + 1).
+                        // (2, 3, -1)
+                        // (4, 3, +1)
+                        Some(max) if offset >= max => {
+                            let retracted_value = i64::try_from(offset - max + 1).unwrap();
+                            let row = Row::pack_slice(&[Datum::Int64(retracted_value)]);
+                            Some((0, Event::Message(MzOffset::from(offset), (row, -1))))
                         }
-                    }
-                    None => None,
-                };
-                counter += 1;
-                // NB: we could get rid of this allocation with
-                // judicious use of itertools::Either, if it were
-                // important to highly optimize this code path.
-                if let Some(to_retract) = to_retract {
-                    vec![
-                        (
-                            0,
-                            GeneratorMessageType::InProgress,
-                            Row::pack_slice(&[Datum::Int64(counter)]),
-                            1,
-                        ),
-                        (
-                            0,
-                            GeneratorMessageType::Finalized,
-                            Row::pack_slice(&[Datum::Int64(to_retract)]),
-                            -1,
-                        ),
-                    ]
-                } else {
-                    vec![(
-                        0,
-                        GeneratorMessageType::Finalized,
-                        Row::pack_slice(&[Datum::Int64(counter)]),
-                        1,
-                    )]
-                }
-            })
-            .flatten(),
+                        _ => None,
+                    };
+
+                    let inserted_value = i64::try_from(offset + 1).unwrap();
+                    let row = Row::pack_slice(&[Datum::Int64(inserted_value)]);
+                    let insertion = [
+                        (0, Event::Message(MzOffset::from(offset), (row, 1))),
+                        (0, Event::Progress(Some(MzOffset::from(offset + 1)))),
+                    ];
+                    retraction.into_iter().chain(insertion)
+                })
+                .flatten(),
         )
     }
 }

--- a/src/storage/src/source/generator/datums.rs
+++ b/src/storage/src/source/generator/datums.rs
@@ -11,7 +11,8 @@ use std::iter;
 
 use mz_ore::now::NowFn;
 use mz_repr::{Datum, Row, ScalarType};
-use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
+use mz_storage_client::types::sources::{Generator, MzOffset};
+use timely::dataflow::operators::to_stream::Event;
 
 pub struct Datums {}
 
@@ -23,7 +24,8 @@ impl Generator for Datums {
         &self,
         _: NowFn,
         _seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
+        _resume_offset: MzOffset,
+    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let typs = ScalarType::enumerate();
         let mut datums: Vec<Vec<Datum>> = typs
             .iter()
@@ -45,22 +47,29 @@ impl Generator for Datums {
                 .collect(),
         );
         let mut idx = 0;
-        Box::new(iter::from_fn(move || {
-            if idx == len {
-                return None;
-            }
-            let mut row = Row::with_capacity(datums.len());
-            let mut packer = row.packer();
-            for d in &datums {
-                packer.push(d[idx]);
-            }
-            idx += 1;
-            let message = if idx == len {
-                GeneratorMessageType::Finalized
-            } else {
-                GeneratorMessageType::InProgress
-            };
-            Some((0, message, row, 1))
-        }))
+        let mut offset = 0;
+        Box::new(
+            iter::from_fn(move || {
+                if idx == len {
+                    return None;
+                }
+                let mut row = Row::with_capacity(datums.len());
+                let mut packer = row.packer();
+                for d in &datums {
+                    packer.push(d[idx]);
+                }
+                let msg = (0, Event::Message(MzOffset::from(offset), (row, 1)));
+
+                idx += 1;
+                let progress = if idx == len {
+                    offset += 1;
+                    Some((0, Event::Progress(Some(MzOffset::from(offset)))))
+                } else {
+                    None
+                };
+                Some(std::iter::once(msg).chain(progress))
+            })
+            .flatten(),
+        )
     }
 }

--- a/src/storage/src/source/generator/tpch.rs
+++ b/src/storage/src/source/generator/tpch.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::collections::VecDeque;
 use std::fmt::Display;
 use std::iter;
 use std::ops::RangeInclusive;
@@ -18,12 +19,13 @@ use mz_ore::now::NowFn;
 use mz_repr::adt::date::Date;
 use mz_repr::adt::numeric::{self, DecimalLike, Numeric};
 use mz_repr::{Datum, Row};
-use mz_storage_client::types::sources::{Generator, GeneratorMessageType};
+use mz_storage_client::types::sources::{Generator, MzOffset};
 use once_cell::sync::Lazy;
 use rand::distributions::{Alphanumeric, DistString};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
 use rand::{Rng, SeedableRng};
+use timely::dataflow::operators::to_stream::Event;
 
 #[derive(Clone, Debug)]
 pub struct Tpch {
@@ -49,7 +51,8 @@ impl Generator for Tpch {
         &self,
         _: NowFn,
         seed: Option<u64>,
-    ) -> Box<dyn Iterator<Item = (usize, GeneratorMessageType, Row, i64)>> {
+        _resume_offset: MzOffset,
+    ) -> Box<(dyn Iterator<Item = (usize, Event<Option<MzOffset>, (Row, i64)>)>)> {
         let mut rng = StdRng::seed_from_u64(seed.unwrap_or_default());
         let mut ctx = Context {
             tpch: self.clone(),
@@ -74,197 +77,163 @@ impl Generator for Tpch {
 
         // Some rows need to generate other rows from their values; hold those
         // here.
-        let mut pending = Vec::new();
+        let mut pending = VecDeque::new();
 
         // All orders and their lineitems, so they can be retracted during
         // streaming.
         let mut active_orders = Vec::new();
 
+        let mut offset = 0;
         Box::new(iter::from_fn(move || {
-            if let Some(pending) = pending.pop() {
+            if let Some(pending) = pending.pop_front() {
                 return Some(pending);
             }
-            rows.next()
-                .map(|(output, key)| {
-                    let key_usize = usize::try_from(key).expect("key known to be non-negative");
-                    let row = match output {
-                        SUPPLIER_OUTPUT => {
-                            let nation = rng.gen_range(0..count_nation);
-                            Row::pack_slice(&[
+            if let Some((output, key)) = rows.next() {
+                let key_usize = usize::try_from(key).expect("key known to be non-negative");
+                let row = match output {
+                    SUPPLIER_OUTPUT => {
+                        let nation = rng.gen_range(0..count_nation);
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(&pad_nine("Supplier", key)),
+                            Datum::String(&v_string(&mut rng, 10, 40)), // address
+                            Datum::Int64(nation),
+                            Datum::String(&phone(&mut rng, nation)),
+                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
+                            // TODO: add customer complaints and recommends, see 4.2.3.
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 25, 100)),
+                        ])
+                    }
+                    PART_OUTPUT => {
+                        let name: String = PARTNAMES
+                            .choose_multiple(&mut rng, 5)
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join("  ");
+                        let m = rng.gen_range(1..=5);
+                        let n = rng.gen_range(1..=5);
+                        for _ in 1..=4 {
+                            let suppkey = (key
+                                + (rng.gen_range(0..=3)
+                                    * ((ctx.tpch.count_supplier / 4)
+                                        + (key - 1) / ctx.tpch.count_supplier)))
+                                % ctx.tpch.count_supplier
+                                + 1;
+                            let row = Row::pack_slice(&[
                                 Datum::Int64(key),
-                                Datum::String(&pad_nine("Supplier", key)),
-                                Datum::String(&v_string(&mut rng, 10, 40)), // address
-                                Datum::Int64(nation),
-                                Datum::String(&phone(&mut rng, nation)),
-                                Datum::Numeric(decimal(
-                                    &mut rng,
-                                    &mut ctx.cx,
-                                    -999_99,
-                                    9_999_99,
-                                    100,
-                                )), // acctbal
-                                // TODO: add customer complaints and recommends, see 4.2.3.
-                                Datum::String(text_string(
-                                    &mut rng,
-                                    &ctx.text_string_source,
-                                    25,
-                                    100,
-                                )),
-                            ])
-                        }
-                        PART_OUTPUT => {
-                            let name: String = PARTNAMES
-                                .choose_multiple(&mut rng, 5)
-                                .cloned()
-                                .collect::<Vec<_>>()
-                                .join("  ");
-                            let m = rng.gen_range(1..=5);
-                            let n = rng.gen_range(1..=5);
-                            for _ in 1..=4 {
-                                let suppkey = (key
-                                    + (rng.gen_range(0..=3)
-                                        * ((ctx.tpch.count_supplier / 4)
-                                            + (key - 1) / ctx.tpch.count_supplier)))
-                                    % ctx.tpch.count_supplier
-                                    + 1;
-                                let row = Row::pack_slice(&[
-                                    Datum::Int64(key),
-                                    Datum::Int64(suppkey),
-                                    Datum::Int32(rng.gen_range(1..=9_999)), // availqty
-                                    Datum::Numeric(decimal(
-                                        &mut rng,
-                                        &mut ctx.cx,
-                                        1_00,
-                                        1_000_00,
-                                        100,
-                                    )), // supplycost
-                                    Datum::String(text_string(
-                                        &mut rng,
-                                        &ctx.text_string_source,
-                                        49,
-                                        198,
-                                    )),
-                                ]);
-                                pending.push((
-                                    PARTSUPP_OUTPUT,
-                                    GeneratorMessageType::InProgress,
-                                    row,
-                                    1,
-                                ));
-                            }
-                            Row::pack_slice(&[
-                                Datum::Int64(key),
-                                Datum::String(&name),
-                                Datum::String(&format!("Manufacturer#{m}")),
-                                Datum::String(&format!("Brand#{m}{n}")),
-                                Datum::String(&syllables(&mut rng, TYPES)),
-                                Datum::Int32(rng.gen_range(1..=50)), // size
-                                Datum::String(&syllables(&mut rng, CONTAINERS)),
-                                Datum::Numeric(partkey_retailprice(key)),
+                                Datum::Int64(suppkey),
+                                Datum::Int32(rng.gen_range(1..=9_999)), // availqty
+                                Datum::Numeric(decimal(&mut rng, &mut ctx.cx, 1_00, 1_000_00, 100)), // supplycost
                                 Datum::String(text_string(
                                     &mut rng,
                                     &ctx.text_string_source,
                                     49,
                                     198,
                                 )),
-                            ])
+                            ]);
+                            pending.push_back((
+                                PARTSUPP_OUTPUT,
+                                Event::Message(MzOffset::from(offset), (row, 1)),
+                            ));
                         }
-                        CUSTOMER_OUTPUT => {
-                            let nation = rng.gen_range(0..count_nation);
-                            Row::pack_slice(&[
-                                Datum::Int64(key),
-                                Datum::String(&pad_nine("Customer", key)),
-                                Datum::String(&v_string(&mut rng, 10, 40)), // address
-                                Datum::Int64(nation),
-                                Datum::String(&phone(&mut rng, nation)),
-                                Datum::Numeric(decimal(
-                                    &mut rng,
-                                    &mut ctx.cx,
-                                    -999_99,
-                                    9_999_99,
-                                    100,
-                                )), // acctbal
-                                Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
-                                Datum::String(text_string(
-                                    &mut rng,
-                                    &ctx.text_string_source,
-                                    29,
-                                    116,
-                                )),
-                            ])
-                        }
-                        ORDERS_OUTPUT => {
-                            let seed = rng.gen();
-                            let (order, lineitems) = ctx.order_row(seed, key);
-                            for row in lineitems {
-                                pending.push((
-                                    LINEITEM_OUTPUT,
-                                    GeneratorMessageType::InProgress,
-                                    row,
-                                    1,
-                                ));
-                            }
-                            if !ctx.tpch.tick.is_zero() {
-                                active_orders.push((key, seed));
-                            }
-                            order
-                        }
-                        NATION_OUTPUT => {
-                            let (name, region) = NATIONS[key_usize];
-                            Row::pack_slice(&[
-                                Datum::Int64(key),
-                                Datum::String(name),
-                                Datum::Int64(region),
-                                Datum::String(text_string(
-                                    &mut rng,
-                                    &ctx.text_string_source,
-                                    31,
-                                    114,
-                                )),
-                            ])
-                        }
-                        REGION_OUTPUT => Row::pack_slice(&[
+                        Row::pack_slice(&[
                             Datum::Int64(key),
-                            Datum::String(REGIONS[key_usize]),
-                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 115)),
-                        ]),
-                        _ => unreachable!("{output}"),
-                    };
-                    let typ = if rows.peek().is_some() {
-                        GeneratorMessageType::InProgress
-                    } else {
-                        GeneratorMessageType::Finalized
-                    };
-                    (output, typ, row, 1)
-                })
-                .or_else(|| {
-                    if ctx.tpch.tick.is_zero() {
-                        return None;
+                            Datum::String(&name),
+                            Datum::String(&format!("Manufacturer#{m}")),
+                            Datum::String(&format!("Brand#{m}{n}")),
+                            Datum::String(&syllables(&mut rng, TYPES)),
+                            Datum::Int32(rng.gen_range(1..=50)), // size
+                            Datum::String(&syllables(&mut rng, CONTAINERS)),
+                            Datum::Numeric(partkey_retailprice(key)),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 49, 198)),
+                        ])
                     }
-                    let idx = rng.gen_range(0..active_orders.len());
-                    let (key, old_seed) = active_orders.swap_remove(idx);
-                    let (old_order, old_lineitems) = ctx.order_row(old_seed, key);
-                    // Fill pending with old lineitem retractions, new lineitem
-                    // additions, and finally the new order. Return the old
-                    // order to start the batch.
-                    for row in old_lineitems {
-                        pending.push((LINEITEM_OUTPUT, GeneratorMessageType::InProgress, row, -1));
+                    CUSTOMER_OUTPUT => {
+                        let nation = rng.gen_range(0..count_nation);
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(&pad_nine("Customer", key)),
+                            Datum::String(&v_string(&mut rng, 10, 40)), // address
+                            Datum::Int64(nation),
+                            Datum::String(&phone(&mut rng, nation)),
+                            Datum::Numeric(decimal(&mut rng, &mut ctx.cx, -999_99, 9_999_99, 100)), // acctbal
+                            Datum::String(SEGMENTS.choose(&mut rng).unwrap()),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 29, 116)),
+                        ])
                     }
-                    let new_seed = rng.gen();
-                    let (new_order, new_lineitems) = ctx.order_row(new_seed, key);
-                    for row in new_lineitems {
-                        pending.push((LINEITEM_OUTPUT, GeneratorMessageType::InProgress, row, 1));
+                    ORDERS_OUTPUT => {
+                        let seed = rng.gen();
+                        let (order, lineitems) = ctx.order_row(seed, key);
+                        for row in lineitems {
+                            pending.push_back((
+                                LINEITEM_OUTPUT,
+                                Event::Message(MzOffset::from(offset), (row, 1)),
+                            ));
+                        }
+                        if !ctx.tpch.tick.is_zero() {
+                            active_orders.push((key, seed));
+                        }
+                        order
                     }
-                    pending.push((ORDERS_OUTPUT, GeneratorMessageType::Finalized, new_order, 1));
-                    active_orders.push((key, new_seed));
+                    NATION_OUTPUT => {
+                        let (name, region) = NATIONS[key_usize];
+                        Row::pack_slice(&[
+                            Datum::Int64(key),
+                            Datum::String(name),
+                            Datum::Int64(region),
+                            Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 114)),
+                        ])
+                    }
+                    REGION_OUTPUT => Row::pack_slice(&[
+                        Datum::Int64(key),
+                        Datum::String(REGIONS[key_usize]),
+                        Datum::String(text_string(&mut rng, &ctx.text_string_source, 31, 115)),
+                    ]),
+                    _ => unreachable!("{output}"),
+                };
 
-                    Some((
-                        ORDERS_OUTPUT,
-                        GeneratorMessageType::InProgress,
-                        old_order,
-                        -1,
-                    ))
-                })
+                pending.push_back((output, Event::Message(MzOffset::from(offset), (row, 1))));
+                if rows.peek().is_none() {
+                    offset += 1;
+                    pending.push_back((output, Event::Progress(Some(MzOffset::from(offset)))));
+                }
+            } else {
+                if ctx.tpch.tick.is_zero() {
+                    return None;
+                }
+                let idx = rng.gen_range(0..active_orders.len());
+                let (key, old_seed) = active_orders.swap_remove(idx);
+                let (old_order, old_lineitems) = ctx.order_row(old_seed, key);
+                // Fill pending with old lineitem retractions, new lineitem
+                // additions, and finally the new order. Return the old
+                // order to start the batch.
+                for row in old_lineitems {
+                    pending.push_back((
+                        LINEITEM_OUTPUT,
+                        Event::Message(MzOffset::from(offset), (row, -1)),
+                    ));
+                }
+                let new_seed = rng.gen();
+                let (new_order, new_lineitems) = ctx.order_row(new_seed, key);
+                for row in new_lineitems {
+                    pending.push_back((
+                        LINEITEM_OUTPUT,
+                        Event::Message(MzOffset::from(offset), (row, 1)),
+                    ));
+                }
+                pending.push_back((
+                    ORDERS_OUTPUT,
+                    Event::Message(MzOffset::from(offset), (old_order, -1)),
+                ));
+                pending.push_back((
+                    ORDERS_OUTPUT,
+                    Event::Message(MzOffset::from(offset), (new_order, 1)),
+                ));
+                offset += 1;
+                pending.push_back((ORDERS_OUTPUT, Event::Progress(Some(MzOffset::from(offset)))));
+                active_orders.push((key, new_seed));
+            }
+            pending.pop_front()
         }))
     }
 }

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -95,11 +95,11 @@ false
 true
 > SELECT mz_internal.mz_sleep(1)
 <null>
-> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
-false
+> SELECT count(*) FROM mz_internal.mz_dataflow_operators
+0
 > DROP MATERIALIZED VIEW q14
-> SELECT count(*) > 0 FROM mz_internal.mz_dataflow_operators
-false
+> SELECT count(*)  FROM mz_internal.mz_dataflow_operators
+0
 
 # Clean up.
 > DROP CLUSTER test CASCADE

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -67,7 +67,7 @@ materialize.public.accounts "CREATE SUBSOURCE \"materialize\".\"public\".\"accou
 
 # Check that negative max cardinalities are rejected
 ! CREATE SOURCE counter2 FROM LOAD GENERATOR COUNTER (MAX CARDINALITY -1)
-contains: unsupported max cardinality
+contains:invalid MAX CARDINALITY: invalid unsigned numeric value: invalid digit found in string
 
 > CREATE SOURCE counter3 FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 0)
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
    
The work to add resumption to generators implemented in #21482 had the unforeseen sideeffect that all the data emitted by generators would enter the dataflow. Since some generators always generate all of their data from the beginning of time this could lead to a large amount of data being emitted without yielding, since yielding only happens after we've reached the resumption frontier.
    
To address this issue this PR additionally filters the messages that are not beyond the resumption frontier.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Only the last commit is new code. The other two are the commits that were reverted in #21546
<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
