### PR TITLE
adapter: add system indexes for dependency graph

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -4876,6 +4876,33 @@ ON mz_internal.mz_object_lifetimes (id)",
     is_retained_metrics_object: false,
 };
 
+pub const MZ_OBJECT_DEPENDENCIES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_object_dependencies_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_object_dependencies_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_object_dependencies (object_id)",
+    is_retained_metrics_object: false,
+};
+
+pub const MZ_COMPUTE_DEPENDENCIES_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_compute_dependencies_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_compute_dependencies_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_compute_dependencies (object_id)",
+    is_retained_metrics_object: false,
+};
+
+pub const MZ_GLOBAL_FRONTIERS_IND: BuiltinIndex = BuiltinIndex {
+    name: "mz_global_frontiers_ind",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE INDEX mz_global_frontiers_ind
+IN CLUSTER mz_introspection
+ON mz_internal.mz_global_frontiers (object_id)",
+    is_retained_metrics_object: false,
+};
+
 pub static MZ_SYSTEM_ROLE: Lazy<BuiltinRole> = Lazy::new(|| BuiltinRole {
     name: &*SYSTEM_USER.name,
     attributes: RoleAttributes::new().with_all(),
@@ -5268,6 +5295,9 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Index(&MZ_CLUSTER_REPLICA_STATUSES_IND),
         Builtin::Index(&MZ_CLUSTER_REPLICA_METRICS_IND),
         Builtin::Index(&MZ_OBJECT_LIFETIMES_IND),
+        Builtin::Index(&MZ_OBJECT_DEPENDENCIES_IND),
+        Builtin::Index(&MZ_COMPUTE_DEPENDENCIES_IND),
+        Builtin::Index(&MZ_GLOBAL_FRONTIERS_IND),
     ]);
 
     builtins

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -299,6 +299,7 @@ mz_cluster_replica_statuses_ind                             mz_cluster_replica_s
 mz_cluster_replicas_ind                                     mz_cluster_replicas                          mz_introspection    {id}
 mz_clusters_ind                                             mz_clusters                                  mz_introspection    {id}
 mz_compute_delays_histogram_raw_s2_primary_idx              mz_compute_delays_histogram_raw              mz_introspection    {export_id,import_id,worker_id,delay_ns}
+mz_compute_dependencies_ind                                 mz_compute_dependencies                      mz_introspection    {object_id}
 mz_compute_exports_per_worker_s2_primary_idx                mz_compute_exports_per_worker                mz_introspection    {export_id,worker_id}
 mz_compute_frontiers_per_worker_s2_primary_idx              mz_compute_frontiers_per_worker              mz_introspection    {export_id,worker_id,time}
 mz_compute_import_frontiers_per_worker_s2_primary_idx       mz_compute_import_frontiers_per_worker       mz_introspection    {export_id,import_id,worker_id,time}
@@ -308,10 +309,12 @@ mz_dataflow_channels_per_worker_s2_primary_idx              mz_dataflow_channels
 mz_dataflow_operator_reachability_raw_s2_primary_idx        mz_dataflow_operator_reachability_raw        mz_introspection    {address,port,worker_id,update_type,time}
 mz_dataflow_operators_per_worker_s2_primary_idx             mz_dataflow_operators_per_worker             mz_introspection    {id,worker_id}
 mz_dataflow_shutdown_durations_histogram_raw_s2_primary_idx mz_dataflow_shutdown_durations_histogram_raw mz_introspection    {worker_id,duration_ns}
+mz_global_frontiers_ind                                     mz_global_frontiers                          mz_introspection    {object_id}
 mz_message_batch_counts_received_raw_s2_primary_idx         mz_message_batch_counts_received_raw         mz_introspection    {channel_id,from_worker_id,to_worker_id}
 mz_message_batch_counts_sent_raw_s2_primary_idx             mz_message_batch_counts_sent_raw             mz_introspection    {channel_id,from_worker_id,to_worker_id}
 mz_message_counts_received_raw_s2_primary_idx               mz_message_counts_received_raw               mz_introspection    {channel_id,from_worker_id,to_worker_id}
 mz_message_counts_sent_raw_s2_primary_idx                   mz_message_counts_sent_raw                   mz_introspection    {channel_id,from_worker_id,to_worker_id}
+mz_object_dependencies_ind                                  mz_object_dependencies                       mz_introspection    {object_id}
 mz_object_lifetimes_ind                                     mz_object_lifetimes                          mz_introspection    {id}
 mz_peek_durations_histogram_raw_s2_primary_idx              mz_peek_durations_histogram_raw              mz_introspection    {worker_id,duration_ns}
 mz_scheduling_elapsed_raw_s2_primary_idx                    mz_scheduling_elapsed_raw                    mz_introspection    {id,worker_id}


### PR DESCRIPTION
The "dependency graph" console feature currently reads from three unindexed collections:
 * `mz_object_dependencies`
 * `mz_compute_dependencies`
 * `mz_global_frontiers`

This PR adds indexes on each of these collections to make serving the dependency graph more efficient.

### Motivation

  * This PR adds a feature that has not yet been specified.

Add system indexes to support the new dependency graph feature in the console.

### Tips for reviewer

This takes the approach of indexing all relations used by the dependency graph, on the assumption that we never want to have the console make requests to unindexed collections. That assumption might be wrong and we might instead want to avoid the additional memory and CPU requirements of these indexes (particularly `mz_global_frontiers` which gets updated every second, causing significant churn).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
