### PR TITLE
output consistency: add support for timestamp precision

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/date_time_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/date_time_operations_provider.py
@@ -17,6 +17,7 @@ from materialize.output_consistency.input_data.params.date_time_operation_param 
 from materialize.output_consistency.input_data.params.enum_constant_operation_params import (
     DATE_TIME_COMPONENT_PARAM,
     ISO8601_TIMESTAMP_PARAM,
+    PRECISION_PARAM,
     TIME_ZONE_PARAM,
     TYPE_FORMAT_PARAM,
 )
@@ -238,5 +239,23 @@ DATE_TIME_OPERATION_TYPES.append(
         "justify_interval",
         [TimeIntervalOperationParam()],
         DateTimeReturnTypeSpec(INTERVAL_TYPE_IDENTIFIER),
+    )
+)
+
+# change precision for TIMESTAMP
+DATE_TIME_OPERATION_TYPES.append(
+    DbOperation(
+        "$::TIMESTAMP($)",
+        [DateTimeOperationParam(), PRECISION_PARAM],
+        DateTimeReturnTypeSpec(TIMESTAMP_TYPE_IDENTIFIER),
+    )
+)
+
+# change precision for TIMESTAMPTZ
+DATE_TIME_OPERATION_TYPES.append(
+    DbOperation(
+        "$::TIMESTAMPTZ($)",
+        [DateTimeOperationParam(), PRECISION_PARAM],
+        DateTimeReturnTypeSpec(TIMESTAMPTZ_TYPE_IDENTIFIER),
     )
 )

--- a/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
+++ b/misc/python/materialize/output_consistency/input_data/params/enum_constant_operation_params.py
@@ -55,3 +55,7 @@ TEXT_TRIM_SPEC_PARAM = EnumConstantOperationParam(
 REPETITIONS_PARAM = EnumConstantOperationParam(
     {"0", "1", "2", "10", "100", "-2"}, add_quotes=False
 )
+
+PRECISION_PARAM = EnumConstantOperationParam(
+    {"0", "1", "2", "3", "6", "9"}, add_quotes=False
+)

--- a/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/types/date_time_types_provider.py
@@ -52,7 +52,7 @@ TIMESTAMP_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    ["2023-06-01 11:22:33"],
+    ["2023-06-01 11:22:33.44444"],
 )
 TIMESTAMPTZ_TYPE = DateTimeDataType(
     TIMESTAMPTZ_TYPE_IDENTIFIER,
@@ -60,7 +60,7 @@ TIMESTAMPTZ_TYPE = DateTimeDataType(
     # BC, AD not working, see: https://github.com/MaterializeInc/materialize/issues/19637
     "0001-01-01 00:00:00",
     "99999-12-31 23:59:59",
-    ["2023-06-01 11:22:33"],
+    ["2023-06-01 11:22:33.44444", "2023-09-01 14:00:02.46464646"],
     has_time_zone=True,
 )
 INTERVAL_TYPE = DateTimeDataType(


### PR DESCRIPTION
This extends the output consistency test framework with tests for https://github.com/MaterializeInc/materialize/pull/21570.

### Merge preconditions
* https://github.com/MaterializeInc/materialize/pull/21570 is merged and https://github.com/MaterializeInc/materialize/pull/21570#issuecomment-1705009437 is resolved
* output consistency test in Nightly passes

