### PR TITLE
compute: cancel served peeks

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -1177,20 +1177,14 @@ where
             }
         };
 
-        // Forward the peek response, if we didn't already forward a response
-        // to this peek previously. If the peek is targeting a replica, only
-        // forward the response from that replica.
-        // TODO: we could collect the other responses to assert equivalence?
-        // Trades resources (memory) for reassurances; idk which is best.
+        // Forward the peek response, if we didn't already forward a response to this peek
+        // previously. If the peek is targeting a replica, only forward the response from that
+        // replica.
         //
-        // NOTE: we use the `otel_ctx` from the response, not the
-        // pending peek, because we currently want the parent
-        // to be whatever the compute worker did with this peek. We
-        // still `take` the pending peek's `otel_ctx` to mark it as
-        // served.
-        //
-        // Additionally, we just use the `otel_ctx` from the first worker to
-        // respond.
+        // NOTE: We use the `otel_ctx` from the response, not the pending peek, because we
+        // currently want the parent to be whatever the compute worker did with this peek. We still
+        // `take` the pending peek's `otel_ctx` to mark it as served.
+
         let replica_targeted = peek.target_replica.unwrap_or(replica_id) == replica_id;
         let controller_response = if replica_targeted && peek.otel_ctx.take().is_some() {
             let duration = peek.requested_at.elapsed();
@@ -1209,6 +1203,12 @@ where
         peek.unfinished.remove(&replica_id);
         if peek.is_finished() {
             self.remove_peeks(&[uuid].into());
+        }
+
+        // If we are serving a response to the peek, enqueue a `CancelPeek` command to allow other
+        // replicas to stop spending resources on computing this peek.
+        if controller_response.is_some() {
+            self.compute.send(ComputeCommand::CancelPeek { uuid });
         }
 
         controller_response

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2115,7 +2115,7 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     count = metrics.get_command_count("peek")
     assert count <= 2, f"unexpected peek count: {count}"
     count = metrics.get_command_count("cancel_peek")
-    assert count == 0, f"unexpected cancel_peek count: {count}"
+    assert count <= 2, f"unexpected cancel_peek count: {count}"
     count = metrics.get_command_count("initialization_complete")
     assert count == 0, f"unexpected initialization_complete count: {count}"
     count = metrics.get_command_count("update_configuration")


### PR DESCRIPTION
This PR makes the compute client explicitly send `CancelPeek` commands for peeks it doesn't need a response for anymore (because it already saw one). This allows late replicas to clean up any state they hold for this peek.

### Motivation

  * This PR adds a known-desirable feature.

Closes #16641.

The main motivation for implementing this now is to avoid queuing up a large amount of peeks at hydrating replicas while there is already a healthy replica running.

### Tips for reviewer

I don't know of a good way to test this, except from making sure that all the existing tests pass. LMK if you know one!

Merging this will allow us to take another shot at aggressively dropping read holds for peeks (#16288). We had to revert this because of #16615. I refrained from not adding the revert-revert to this PR, to not accumulate too much risk in a single one. Instead I'm opening a follow-up PR: #21587.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A