### PR TITLE
compute: simplify peek handling

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -167,9 +167,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     pub fn handle_compute_command(&mut self, cmd: ComputeCommand) {
         use ComputeCommand::*;
 
-        self.compute_state
-            .command_history
-            .push(cmd.clone(), &self.compute_state.pending_peeks);
+        self.compute_state.command_history.push(cmd.clone());
 
         match cmd {
             CreateTimely { .. } => panic!("CreateTimely must be captured before"),

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -478,9 +478,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
         if let Some(compute_state) = &mut self.compute_state {
             // Reduce the installed commands.
             // Importantly, act as if all peeks may have been retired (as we cannot know otherwise).
-            compute_state
-                .command_history
-                .retain_peeks(&BTreeMap::<_, ()>::default());
+            compute_state.command_history.discard_peeks();
             compute_state.command_history.reduce();
 
             // At this point, we need to sort out which of the *certainly installed* dataflows are
@@ -691,7 +689,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             let mut command_history =
                 ComputeCommandHistory::new(self.metrics.for_history(worker_id));
             for command in new_commands.iter() {
-                command_history.push(command.clone(), &compute_state.pending_peeks);
+                command_history.push(command.clone());
             }
             compute_state.command_history = command_history;
         }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -87,6 +87,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             "pg-snapshot-partial-failure",
             "test-system-table-indexes",
             "test-replica-targeted-subscribe-abort",
+            "test-replica-targeted-select-abort",
             "test-compute-reconciliation-reuse",
             "test-compute-reconciliation-no-errors",
             "test-mz-subscriptions",
@@ -1556,6 +1557,91 @@ def workflow_test_replica_targeted_subscribe_abort(c: Composition) -> None:
         assert "target replica failed or was dropped" in e.args[0]["M"], e
     else:
         assert False, "SUBSCRIBE didn't return the expected error"
+
+    killer.join()
+
+
+def workflow_test_replica_targeted_select_abort(c: Composition) -> None:
+    """
+    Test that a replica-targeted SELECT is aborted when the target
+    replica disconnects.
+    """
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+    c.up("clusterd1")
+    c.up("clusterd2")
+
+    c.sql(
+        "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+        port=6877,
+        user="mz_system",
+    )
+
+    c.sql(
+        """
+        DROP CLUSTER IF EXISTS cluster1 CASCADE;
+        CREATE CLUSTER cluster1 REPLICAS (
+            replica1 (
+                STORAGECTL ADDRESSES ['clusterd1:2100'],
+                STORAGE ADDRESSES ['clusterd1:2103'],
+                COMPUTECTL ADDRESSES ['clusterd1:2101'],
+                COMPUTE ADDRESSES ['clusterd1:2102'],
+                WORKERS 2
+            ),
+            replica2 (
+                STORAGECTL ADDRESSES ['clusterd2:2100'],
+                STORAGE ADDRESSES ['clusterd2:2103'],
+                COMPUTECTL ADDRESSES ['clusterd2:2101'],
+                COMPUTE ADDRESSES ['clusterd2:2102'],
+                WORKERS 2
+            )
+        );
+        CREATE TABLE t (a int);
+        """
+    )
+
+    def drop_replica_with_delay() -> None:
+        time.sleep(2)
+        c.sql("DROP CLUSTER REPLICA cluster1.replica1;")
+
+    dropper = Thread(target=drop_replica_with_delay)
+    dropper.start()
+
+    try:
+        c.sql(
+            """
+            SET cluster = cluster1;
+            SET cluster_replica = replica1;
+            SELECT * FROM t AS OF 18446744073709551615;
+            """
+        )
+    except ProgrammingError as e:
+        assert "target replica failed or was dropped" in e.args[0]["M"], e
+    else:
+        assert False, "SELECT didn't return the expected error"
+
+    dropper.join()
+
+    def kill_replica_with_delay() -> None:
+        time.sleep(2)
+        c.kill("clusterd2")
+
+    killer = Thread(target=kill_replica_with_delay)
+    killer.start()
+
+    try:
+        c.sql(
+            """
+            SET cluster = cluster1;
+            SET cluster_replica = replica2;
+            SELECT * FROM t AS OF 18446744073709551615;
+            """
+        )
+    except ProgrammingError as e:
+        assert "target replica failed or was dropped" in e.args[0]["M"], e
+    else:
+        assert False, "SELECT didn't return the expected error"
 
     killer.join()
 

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -157,6 +157,7 @@ known_errors = [
     "out of valid range",
     '" does not exist',  # role does not exist
     "csv_extract number of columns too large",
+    "target replica failed or was dropped",  # expected on replica OoMs with #21587
 ]
 
 


### PR DESCRIPTION
This PR simplifies the way we handle peeks in the compute controller and the compute command history. Those simplifications are possible thanks to the proactive cancellation of peeks added in #21585.

The PR consists of three commits:

* The first two reinstate the early dropping of peek read holds that was previously merged in https://github.com/MaterializeInc/materialize/pull/16288 but had to be reverted because it triggered a "cannot serve requested as_of" bug (#16615). This bug is now avoided, as explained in [this comment](https://github.com/MaterializeInc/materialize/issues/16615#issuecomment-1351351738).
* The third commit simplifies reduction of peeks in the `ComputeCommandHistory` by canceling `Peek` commands against `CancelPeek` commands, rather than requiring callers to pass in a list of active peeks.

### Motivation

   * This PR refactors existing code.

With this PR peek handling becomes both simpler and more efficient as read holds and resources are dropped earlier than previously.

  * This PR fixes a known bug.

Fixes #21983.

### Tips for reviewer

Look at the commits separately.

Commit 2 makes the decision to abort replica-targeted peeks when the replica fails and needs to be rehydrated. It does so mostly to keep the implementation simple (by not having to differentiate between replica dropping and rehydration). LMK if you think it would be worthwhile to complicate the code in exchange for having targeted peeks survive replica failure.

Commit 2 is also what fixes #21983 and is therefore critical to get into the next release. We can split commit 3 into a new PR if needed.

In support of commit 3, here is a [Slack thread on cancelling out `Peek`s with `CancelPeek`s in the history.](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1693834447327619)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A