### PR TITLE
New `GROUP SIZE` hints

### DIFF
--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -3524,8 +3524,8 @@ pub const MZ_EXPECTED_GROUP_SIZE_ADVICE: BuiltinView = BuiltinView {
     sql: "CREATE VIEW
     mz_internal.mz_expected_group_size_advice
     AS
-        -- The mz_expected_group_size_advice view provides tuning suggestions for the EXPECTED
-        -- GROUP SIZE. This tuning hint is effective for min/max/top-k patterns, where a stack
+        -- The mz_expected_group_size_advice view provides tuning suggestions for the GROUP SIZE
+        -- query hints. This tuning hint is effective for min/max/top-k patterns, where a stack
         -- of arrangements must be built. For each dataflow and region corresponding to one
         -- such pattern, we look for how many levels can be eliminated without hitting a level
         -- that actually substantially filters the input. The advice is constructed so that
@@ -3581,7 +3581,7 @@ pub const MZ_EXPECTED_GROUP_SIZE_ADVICE: BuiltinView = BuiltinView {
                     WHERE
                         o2.dataflow_id = o1.dataflow_id
                         AND o2.region_id = o1.region_id
-                    OPTIONS (EXPECTED GROUP SIZE = 8)
+                    OPTIONS (AGGREGATE INPUT GROUP SIZE = 8)
                 )
         ),
         -- The fourth CTE, candidates, will look for operators where the number of records
@@ -3620,7 +3620,7 @@ pub const MZ_EXPECTED_GROUP_SIZE_ADVICE: BuiltinView = BuiltinView {
         -- cutting the height of the hierarchy further. This is because we will have way less
         -- groups in the next level, so there should be even further reduction happening or there
         -- is some substantial skew in the data. But if the latter is the case, then we should not
-        -- tune the EXPECTED GROUP SIZE down anyway to avoid hurting latency upon updates directed
+        -- tune the GROUP SIZE hints down anyway to avoid hurting latency upon updates directed
         -- at these unusually large groups. In addition to selecting the levels to cut, we also
         -- compute a conservative estimate of the memory savings in bytes that will result from
         -- cutting these levels from the hierarchy. The estimate is based on the sizes of the

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -27,6 +27,7 @@ Access
 Acks
 Add
 Addresses
+Aggregate
 All
 Alter
 And
@@ -177,6 +178,7 @@ Info
 Inherit
 Inline
 Inner
+Input
 Insert
 Inspect
 Int

--- a/src/sql-parser/src/ast/defs/query.rs
+++ b/src/sql-parser/src/ast/defs/query.rs
@@ -190,12 +190,18 @@ impl_display!(SetOperator);
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum SelectOptionName {
     ExpectedGroupSize,
+    AggregateInputGroupSize,
+    DistinctOnInputGroupSize,
+    LimitInputGroupSize,
 }
 
 impl AstDisplay for SelectOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str(match self {
             SelectOptionName::ExpectedGroupSize => "EXPECTED GROUP SIZE",
+            SelectOptionName::AggregateInputGroupSize => "AGGREGATE INPUT GROUP SIZE",
+            SelectOptionName::DistinctOnInputGroupSize => "DISTINCT ON INPUT GROUP SIZE",
+            SelectOptionName::LimitInputGroupSize => "LIMIT INPUT GROUP SIZE",
         })
     }
 }

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -5883,8 +5883,25 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_select_option(&mut self) -> Result<SelectOption<Raw>, ParserError> {
-        self.expect_keywords(&[EXPECTED, GROUP, SIZE])?;
-        let name = SelectOptionName::ExpectedGroupSize;
+        let name = match self.expect_one_of_keywords(&[EXPECTED, AGGREGATE, DISTINCT, LIMIT])? {
+            EXPECTED => {
+                self.expect_keywords(&[GROUP, SIZE])?;
+                SelectOptionName::ExpectedGroupSize
+            }
+            AGGREGATE => {
+                self.expect_keywords(&[INPUT, GROUP, SIZE])?;
+                SelectOptionName::AggregateInputGroupSize
+            }
+            DISTINCT => {
+                self.expect_keywords(&[ON, INPUT, GROUP, SIZE])?;
+                SelectOptionName::DistinctOnInputGroupSize
+            }
+            LIMIT => {
+                self.expect_keywords(&[INPUT, GROUP, SIZE])?;
+                SelectOptionName::LimitInputGroupSize
+            }
+            _ => unreachable!(),
+        };
         Ok(SelectOption {
             name,
             value: self.parse_optional_option_value()?,

--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1272,28 +1272,28 @@ Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { 
 parse-statement
 SELECT * FROM foo OPTIONS (bar = 7)
 ----
-error: Expected EXPECTED, found identifier "bar"
+error: Expected one of EXPECTED or AGGREGATE or DISTINCT or LIMIT, found identifier "bar"
 SELECT * FROM foo OPTIONS (bar = 7)
                            ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
 ----
-error: Expected EXPECTED, found identifier "bar"
+error: Expected one of EXPECTED or AGGREGATE or DISTINCT or LIMIT, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 7)
                                                     ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
 ----
-error: Expected EXPECTED, found identifier "bar"
+error: Expected one of EXPECTED or AGGREGATE or DISTINCT or LIMIT, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar = 'baz')
                                                     ^
 
 parse-statement
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
 ----
-error: Expected EXPECTED, found identifier "bar"
+error: Expected one of EXPECTED or AGGREGATE or DISTINCT or LIMIT, found identifier "bar"
 SELECT a, b, min(c) FROM foo GROUP BY a, b OPTIONS (bar)
                                                     ^
 
@@ -1504,6 +1504,41 @@ parse-statement roundtrip
 SELECT 1 OPTIONS (EXPECTED GROUP SIZE = 1)
 ----
 SELECT 1 OPTIONS (EXPECTED GROUP SIZE = 1)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1)
+----
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 1)
+----
+SELECT 1 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 1)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (LIMIT INPUT GROUP SIZE = 1)
+----
+SELECT 1 OPTIONS (LIMIT INPUT GROUP SIZE = 1)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, DISTINCT ON INPUT GROUP SIZE = 2)
+----
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, DISTINCT ON INPUT GROUP SIZE = 2)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, LIMIT INPUT GROUP SIZE = 3)
+----
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, LIMIT INPUT GROUP SIZE = 3)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 2, LIMIT INPUT GROUP SIZE = 3)
+----
+SELECT 1 OPTIONS (DISTINCT ON INPUT GROUP SIZE = 2, LIMIT INPUT GROUP SIZE = 3)
+
+parse-statement roundtrip
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, DISTINCT ON INPUT GROUP SIZE = 2, LIMIT INPUT GROUP SIZE = 3)
+----
+SELECT 1 OPTIONS (AGGREGATE INPUT GROUP SIZE = 1, DISTINCT ON INPUT GROUP SIZE = 2, LIMIT INPUT GROUP SIZE = 3)
 
 parse-statement roundtrip
 SELECT 1 AS "FOO"

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -224,6 +224,7 @@ pub enum PlanError {
         max: Duration,
         requested: Duration,
     },
+    InvalidGroupSizeHints,
     // TODO(benesch): eventually all errors should be structured.
     Unstructured(String),
 }
@@ -592,6 +593,9 @@ impl fmt::Display for PlanError {
             Self::InvalidTimestampInterval { min, max, requested } => {
                 write!(f, "invalid timestamp interval of {}ms, must be in the range [{}ms, {}ms]", requested.as_millis(), min.as_millis(), max.as_millis())
             }
+            Self::InvalidGroupSizeHints => f.write_str("EXPECTED GROUP SIZE cannot be provided \
+                simultaneously with any of AGGREGATE INPUT GROUP SIZE, DISTINCT ON INPUT GROUP SIZE, \
+                or LIMIT INPUT GROUP SIZE"),
         }
     }
 }

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -38,6 +38,8 @@ use crate::plan::query::ExprContext;
 use crate::plan::typeconv::{self, CastContext};
 use crate::plan::Params;
 
+use super::plan_utils::GroupSizeHints;
+
 #[allow(missing_debug_implementations)]
 pub struct Hir;
 
@@ -1678,7 +1680,7 @@ impl HirRelationExpr {
     pub fn finish_maintained(
         &mut self,
         finishing: &mut RowSetFinishing,
-        expected_group_size: Option<u64>,
+        group_size_hints: GroupSizeHints,
     ) {
         if !finishing.is_trivial(self.arity()) {
             let old_finishing =
@@ -1695,7 +1697,7 @@ impl HirRelationExpr {
                 order_key: old_finishing.order_by,
                 limit: old_finishing.limit,
                 offset: old_finishing.offset,
-                expected_group_size,
+                expected_group_size: group_size_hints.limit_input_group_size,
             }
             .project(old_finishing.project)
         }

--- a/src/sql/src/plan/plan_utils.rs
+++ b/src/sql/src/plan/plan_utils.rs
@@ -15,6 +15,7 @@ use mz_repr::RelationDesc;
 
 use crate::ast::Ident;
 use crate::normalize;
+use crate::plan::query::SelectOptionExtracted;
 use crate::plan::PlanError;
 
 /// Renames the columns in `desc` with the names in `column_names` if
@@ -65,6 +66,54 @@ impl fmt::Display for JoinSide {
         match self {
             JoinSide::Left => f.write_str("left"),
             JoinSide::Right => f.write_str("right"),
+        }
+    }
+}
+
+/// Specifies a bundle of group size query hints.
+///
+/// This struct bridges from old to new syntax for group size query hints,
+/// making it easier to pass these hints along and make use of a group size
+/// hint configuration.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GroupSizeHints {
+    pub aggregate_input_group_size: Option<u64>,
+    pub distinct_on_input_group_size: Option<u64>,
+    pub limit_input_group_size: Option<u64>,
+}
+
+impl TryFrom<SelectOptionExtracted> for GroupSizeHints {
+    type Error = PlanError;
+
+    /// Creates group size hints from extracted `SELECT` `OPTIONS` validating that
+    /// either the old `EXPECTED GROUP SIZE` syntax was used or alternatively the
+    /// new syntax with `AGGREGATE INPUT GROUP SIZE`, `DISTINCT ON INPUT GROUP SIZE`,
+    /// and `LIMIT INPUT GROUP SIZE`. If the two syntax versions are mixed in the
+    /// same `OPTIONS` clause, an error is returned.[^1]
+    /// [^1] <https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230829_topk_size_hint.md>
+    fn try_from(select_option_extracted: SelectOptionExtracted) -> Result<Self, Self::Error> {
+        let SelectOptionExtracted {
+            expected_group_size,
+            aggregate_input_group_size,
+            distinct_on_input_group_size,
+            limit_input_group_size,
+            ..
+        } = select_option_extracted;
+        if expected_group_size.is_some()
+            && (aggregate_input_group_size.is_some()
+                || distinct_on_input_group_size.is_some()
+                || limit_input_group_size.is_some())
+        {
+            Err(PlanError::InvalidGroupSizeHints)
+        } else {
+            let aggregate_input_group_size = aggregate_input_group_size.or(expected_group_size);
+            let distinct_on_input_group_size = distinct_on_input_group_size.or(expected_group_size);
+            let limit_input_group_size = limit_input_group_size.or(expected_group_size);
+            Ok(GroupSizeHints {
+                aggregate_input_group_size,
+                distinct_on_input_group_size,
+                limit_input_group_size,
+            })
         }
     }
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -663,7 +663,7 @@ def workflow_test_github_15496(c: Composition) -> None:
             -- generating a SQL-level error, given the partial fix to bucketed
             -- aggregates introduced in PR #17918.
             CREATE MATERIALIZED VIEW sum_and_max AS
-            SELECT SUM(data), MAX(data) FROM data OPTIONS (EXPECTED GROUP SIZE = 1);
+            SELECT SUM(data), MAX(data) FROM data OPTIONS (AGGREGATE INPUT GROUP SIZE = 1);
             """
         )
         c.testdrive(
@@ -934,8 +934,9 @@ def workflow_test_github_17509(c: Composition) -> None:
     assertions are turned off.
 
     This is a partial regression test for https://github.com/MaterializeInc/materialize/issues/17509.
-    It is still possible to trigger the behavior described in the issue by opting into
-    a smaller group size with a query hint (e.g., OPTIONS (EXPECTED GROUP SIZE = 1)).
+    The checks here are extended by opting into a smaller group size with a query hint (e.g.,
+    OPTIONS (AGGREGATE INPUT GROUP SIZE = 1)) in workflow test-github-15496. This scenario was
+    initially not covered, but eventually got supported as well.
     """
 
     c.down(destroy_volumes=True)

--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -107,18 +107,18 @@ SELECT a, count(b), min(b), sum(b), max(b) FROM t GROUP BY a
 
 # Test that hinting the group size works
 query II rowsort
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE 100)
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (AGGREGATE INPUT GROUP SIZE 100)
 ----
 1 3
 2 3
 3 1
 
 # unless hint is bad
-query error invalid EXPECTED GROUP SIZE: cannot use value as number
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE = 'foo')
+query error invalid AGGREGATE INPUT GROUP SIZE: cannot use value as number
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (AGGREGATE INPUT GROUP SIZE = 'foo')
 
 query error
-SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (EXPECTED GROUP SIZE = 0.1)
+SELECT a, sum(b) AS a FROM t GROUP BY a OPTIONS (AGGREGATE INPUT  GROUP SIZE = 0.1)
 
 # Test that an ordinal in a GROUP BY that refers to a column that is an
 # expression, rather than a simple column reference, works.

--- a/test/sqllogictest/github-21501.slt
+++ b/test/sqllogictest/github-21501.slt
@@ -8,6 +8,9 @@
 # by the Apache License, Version 2.0.
 
 # Regression test for #21501.
+# Note that this test employs the old syntax with the EXPECTED GROUP SIZE because the behavior
+# tested is exactly the backwards-compatible one of assigning the hinted value to all operators
+# in the same query block.
 
 statement ok
 CREATE TABLE teachers (id INT, name TEXT);

--- a/test/sqllogictest/group_size_hints.slt
+++ b/test/sqllogictest/group_size_hints.slt
@@ -1,0 +1,300 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests the new syntax for GROUP SIZE query hints proposed in:
+# https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230829_topk_size_hint.md
+# Additionally, the tests below include scenarios that validate backwards compability in the
+# hint syntax according to what is described in the design doc.
+
+statement ok
+CREATE TABLE teachers (id INT, name TEXT);
+
+statement ok
+CREATE TABLE sections (id INT, teacher_id INT, course_id INT, schedule TEXT);
+
+# Illustrates that the old hint applies to multiple operators in a single query block.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (EXPECTED GROUP SIZE = 1000)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=1000
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=1000
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates a workaround with the old hint to apply different values to different operators in
+# a single query block.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT id, teacher_id, max_course_id
+  FROM (
+    SELECT DISTINCT ON(teacher_id) id, teacher_id, max_course_id
+    FROM (
+        SELECT id, teacher_id, MAX(course_id) AS max_course_id
+        FROM sections
+        GROUP BY id, teacher_id
+        OPTIONS (EXPECTED GROUP SIZE = 1000)
+    )
+    OPTIONS (EXPECTED GROUP SIZE = 60)
+    ORDER BY teacher_id, id
+  )
+  OPTIONS (EXPECTED GROUP SIZE = 50)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=50
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=60
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates that new hints apply cleanly without ambiguity to different query blocks.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT id, teacher_id, max_course_id
+  FROM (
+    SELECT DISTINCT ON(teacher_id) id, teacher_id, max_course_id
+    FROM (
+        SELECT id, teacher_id, MAX(course_id) AS max_course_id
+        FROM sections
+        GROUP BY id, teacher_id
+        OPTIONS (AGGREGATE INPUT GROUP SIZE = 1000)
+    )
+    OPTIONS (DISTINCT ON INPUT GROUP SIZE = 60)
+    ORDER BY teacher_id, id
+  )
+  OPTIONS (LIMIT INPUT GROUP SIZE = 50)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=50
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=60
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates that new hints apply without ambiguity in a single query block.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (
+      AGGREGATE INPUT GROUP SIZE = 1000,
+      DISTINCT ON INPUT GROUP SIZE = 60,
+      LIMIT INPUT GROUP SIZE = 50)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=50
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=60
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates that partial combinations of the new hints in a single query block,
+# namely AGGREGATE and LIMIT INPUT GROUP SIZE.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (
+      AGGREGATE INPUT GROUP SIZE = 1000,
+      LIMIT INPUT GROUP SIZE = 50)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=50
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1
+      Reduce group_by=[#0, #1] aggregates=[max(#2)] exp_group_size=1000
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates that partial combinations of the new hints in a single query block,
+# namely LIMIT and DISTINCT ON INPUT GROUP SIZE.
+statement ok
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (
+      LIMIT INPUT GROUP SIZE = 50,
+      DISTINCT ON INPUT GROUP SIZE = 60)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW distinct_on_group_by_limit;
+----
+materialize.public.distinct_on_group_by_limit:
+  TopK order_by=[#1 asc nulls_last, #0 asc nulls_last] limit=2 exp_group_size=50
+    TopK group_by=[#1] order_by=[#0 asc nulls_last] limit=1 exp_group_size=60
+      Reduce group_by=[#0, #1] aggregates=[max(#2)]
+        Project (#0..=#2)
+          Get materialize.public.sections
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW distinct_on_group_by_limit;
+
+# Illustrates that mixing of the old and new syntax for hints raises an error.
+statement error EXPECTED GROUP SIZE cannot be provided simultaneously with any of AGGREGATE INPUT GROUP SIZE, DISTINCT ON INPUT GROUP SIZE, or LIMIT INPUT GROUP SIZE
+CREATE MATERIALIZED VIEW distinct_on_group_by_limit AS
+  SELECT DISTINCT ON(teacher_id) id, teacher_id, MAX(course_id)
+  FROM sections
+  GROUP BY id, teacher_id
+  OPTIONS (
+      LIMIT INPUT GROUP SIZE = 50,
+      EXPECTED GROUP SIZE = 1000)
+  ORDER BY teacher_id, id
+  LIMIT 2;
+
+# Illustrates that the new syntax for hints can be used with a LATERAL top-k pattern.
+statement ok
+CREATE MATERIALIZED VIEW sections_of_top_3_courses_per_teacher AS
+SELECT id AS teacher_id, section_id
+FROM teachers grp,
+     LATERAL (SELECT id AS section_id
+              FROM sections
+              WHERE teacher_id = grp.id
+              OPTIONS (LIMIT INPUT GROUP SIZE = 1000)
+              ORDER BY course_id DESC
+              LIMIT 3);
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW sections_of_top_3_courses_per_teacher;
+----
+materialize.public.sections_of_top_3_courses_per_teacher:
+  Project (#0, #2)
+    Join on=(#0 = #1) type=differential
+      ArrangeBy keys=[[#0]]
+        Project (#0)
+          Get materialize.public.teachers
+      ArrangeBy keys=[[#0]]
+        Project (#0, #1)
+          TopK group_by=[#0] order_by=[#2 desc nulls_first] limit=3 exp_group_size=1000
+            Project (#0, #1, #3)
+              Join on=(#0 = #2) type=differential
+                ArrangeBy keys=[[#0]]
+                  Distinct group_by=[#0]
+                    Project (#0)
+                      Filter (#0) IS NOT NULL
+                        Get materialize.public.teachers
+                ArrangeBy keys=[[#1]]
+                  Project (#0..=#2)
+                    Filter (#1) IS NOT NULL
+                      Get materialize.public.sections
+
+Source materialize.public.sections
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW sections_of_top_3_courses_per_teacher;
+
+# Illustrates that the new syntax for hints can be used with a LATERAL top-k pattern
+# and in conjunction with a min/max aggregation in the same query block.
+statement ok
+CREATE MATERIALIZED VIEW max_sections_of_top_3_courses_per_teacher AS
+SELECT id AS teacher_id, max_section_id
+FROM teachers grp,
+     LATERAL (SELECT course_id, MAX(id) AS max_section_id
+              FROM sections
+              WHERE teacher_id = grp.id
+              GROUP BY course_id
+              OPTIONS (AGGREGATE INPUT GROUP SIZE = 1000, LIMIT INPUT GROUP SIZE = 20)
+              ORDER BY course_id DESC
+              LIMIT 3);
+
+query T multiline
+EXPLAIN PLAN FOR MATERIALIZED VIEW max_sections_of_top_3_courses_per_teacher;
+----
+materialize.public.max_sections_of_top_3_courses_per_teacher:
+  Project (#0, #2)
+    Join on=(#0 = #1) type=differential
+      ArrangeBy keys=[[#0]]
+        Project (#0)
+          Get materialize.public.teachers
+      ArrangeBy keys=[[#0]]
+        Project (#0, #2)
+          TopK group_by=[#0] order_by=[#1 desc nulls_first] limit=3 exp_group_size=20
+            Reduce group_by=[#0, #2] aggregates=[max(#1)] exp_group_size=1000
+              Project (#0, #1, #3)
+                Join on=(#0 = #2) type=differential
+                  ArrangeBy keys=[[#0]]
+                    Distinct group_by=[#0]
+                      Project (#0)
+                        Filter (#0) IS NOT NULL
+                          Get materialize.public.teachers
+                  ArrangeBy keys=[[#1]]
+                    Project (#0..=#2)
+                      Filter (#1) IS NOT NULL
+                        Get materialize.public.sections
+
+Source materialize.public.sections
+  filter=((#1) IS NOT NULL)
+
+EOF
+
+statement ok
+DROP MATERIALIZED VIEW max_sections_of_top_3_courses_per_teacher;

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -60,12 +60,12 @@ TX  Houston
 TX  San_Antonio
 TX  Dallas
 
-# EXPECTED GROUP SIZE hint should not affect the results
+# LIMIT INPUT GROUP SIZE hint should not affect the results
 query TT rowsort
 SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (SELECT name FROM cities WHERE state = grp.state
-             OPTIONS (EXPECTED GROUP SIZE = 1)
+             OPTIONS (LIMIT INPUT GROUP SIZE = 1)
              ORDER BY pop DESC NULLS LAST LIMIT 3)
 ----
 AZ  Phoenix
@@ -156,7 +156,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT state, name FROM
     (SELECT DISTINCT state FROM cities) grp,
     LATERAL (SELECT name FROM cities WHERE state = grp.state
-             OPTIONS (EXPECTED GROUP SIZE = 1)
+             OPTIONS (LIMIT INPUT GROUP SIZE = 1)
              ORDER BY pop DESC NULLS LAST LIMIT 3)
 ----
 Explained Query:

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -118,7 +118,7 @@
         LIMIT 1)
   FROM lineitem l1
   GROUP BY l1.l_suppkey
-  OPTIONS (EXPECTED GROUP SIZE = 4095);
+  OPTIONS (AGGREGATE INPUT GROUP SIZE = 4095);
 
 > DROP MATERIALIZED VIEW IF EXISTS lineitem_by_orderkey;
 
@@ -127,7 +127,7 @@
         MAX(l1.l_extendedprice),
         (SELECT l2.l_quantity FROM lineitem l2
         WHERE l2.l_orderkey = l1.l_orderkey
-        OPTIONS (EXPECTED GROUP SIZE = 15)
+        OPTIONS (LIMIT INPUT GROUP SIZE = 15)
         ORDER BY l2.l_extendedprice DESC
         LIMIT 1)
   FROM lineitem l1


### PR DESCRIPTION
This PR implements the new `GROUP SIZE` query hint syntax proposed in  design doc #21500. The syntax comprises three new query hints: `AGGREGATE INPUT GROUP SIZE`, `DISTINCT ON INPUT GROUP SIZE`, and `LIMIT INPUT GROUP SIZE`. These hints apply to the syntax constructs they refer to, as opposed to `EXPECTED GROUP SIZE`, which applies to all constructs in a query block. The new syntax cannot be mixed with the old `EXPECTED GROUP SIZE` query hint, so an error is raised in case an invalid combination is detected.

Fixes #18883.
The above is done in accordance with [the relevant design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230829_topk_size_hint.md).

### Motivation

  * This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/18883

### Tips for reviewer

The commits can be looked at individually. The first commit comprises the lion's share of the changes, while subsequent commits primarily adjust existing usages or provide new tests.

Note that a separate PR will be created for the changes to documentation. This is because the merging of the documentation PR needs to be delayed until the changes in this PR get released.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20230829_topk_size_hint.md).
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label. N/A
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)). N/A
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Provides a new syntax for query hints,  `AGGREGATE INPUT GROUP SIZE`, `DISTINCT ON INPUT GROUP SIZE`, and `LIMIT INPUT GROUP SIZE`, that more directly targets SQL clauses and avoids ambiguity in a single query block.
