### PR TITLE
platform-checks: Longer timeout for slow inserts

### DIFF
--- a/misc/python/materialize/checks/large_tables.py
+++ b/misc/python/materialize/checks/large_tables.py
@@ -56,6 +56,7 @@ class ManyRows(Check):
                 """
                 > CREATE TABLE many_rows (f1 TEXT);
                 > CREATE DEFAULT INDEX ON many_rows;
+                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT 'a' || generate_series FROM generate_series(1, 1000000);
                 """
             )
@@ -66,6 +67,7 @@ class ManyRows(Check):
             Testdrive(dedent(s))
             for s in [
                 """
+                > SET statement_timeout = '120s';
                 > INSERT INTO many_rows SELECT 'b' || generate_series FROM generate_series(1, 1000000);
                 """,
                 """


### PR DESCRIPTION
Causes failures in coverage: https://buildkite.com/materialize/coverage/builds/216#018a64b6-58a5-4360-8d76-924ab8eb8fa6
```
> INSERT INTO many_rows SELECT 'b' || generate_series FROM generate_series(1, 1000000);
rows didn't match; sleeping to see if dataflow catches up 50ms 75ms 113ms 169ms 253ms 380ms 570ms 854ms 1s 2s 3s 4s 6s 10s 15s 22s 33s 49s 2:1: error: executing query failed: db error: ERROR: canceling statement due to statement timeout HINT: Consider increasing the maximum allowed statement duration for this session by setting the statement_timeout session variable. For example, `SET statement_timeout = '60s'`.: ERROR: canceling statement due to statement timeout
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
