### PR TITLE
Notice for indexes with empty key

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1600,6 +1600,11 @@ feature_flags!(
         "emitting notices for IndexTooWideForLiteralConstraints (doesn't affect EXPLAIN)",
         false
     ),
+    (
+        enable_notices_for_index_empty_key,
+        "emitting notices for indexes with an empty key (doesn't affect EXPLAIN)",
+        true
+    ),
 );
 
 /// Represents the input to a variable.

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -941,6 +941,7 @@ impl IndexUsageContext {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DataflowMetainfo {
     /// Notices that the optimizer wants to show to users.
+    /// For pushing a new element, use `push_optimizer_notice_dedup`.
     pub optimizer_notices: Vec<OptimizerNotice>,
 }
 

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -1278,3 +1278,24 @@ Used Indexes:
   - materialize.public.t_a_idx_1 (*** full scan ***)
 
 EOF
+
+# Index with an empty key.
+
+statement ok
+CREATE INDEX t_idx_empty_key ON t();
+
+query T multiline
+EXPLAIN INDEX t_idx_empty_key;
+----
+materialize.public.t_idx_empty_key:
+  ArrangeBy keys=[[]]
+    Get materialize.public.t
+
+Used Indexes:
+  - materialize.public.t_a_idx_1 (*** full scan ***, index export)
+
+Notices:
+  - Notice: Empty index key. The index will be completely skewed to one worker thread, which can lead to performance problems.
+    Hint: CREATE DEFAULT INDEX is almost always better than an index with an empty key. (Except for cross joins with big inputs, which are better to avoid anyway.)
+
+EOF


### PR DESCRIPTION
This PR adds a notice when a user creates an index with an empty key (#21329). An index with an empty key
- usually creates a hard-to-debug performance problem,
- usually offers 0 benefit compared to `CREATE DEFAULT INDEX`,
- sometimes can offer a slight benefit for cross joins, but this is not the typical order-of-magnitude benefit that we can get when we index the input of a normal (non-cross) join.

See further discussion in code comments.

The PR is adding a feature flag for disabling this notice, but I would like to enable this one by default (as opposed to the feature flag of the `IndexTooWideForLiteralConstraints` notice, which might have more false positives, so is disabled by default). This is open for debate, [see discussion on Slack](https://materializeinc.slack.com/archives/CQM08AP9V/p1693509072685499?thread_ts=1693388342.390429&cid=CQM08AP9V). (cc @uce)

### Motivation

  * This PR adds a known-desirable feature: #21329

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
