### PR TITLE
coverage: Ignore environmentd segfaults

### DIFF
--- a/misc/python/materialize/checks/text_bytea_types.py
+++ b/misc/python/materialize/checks/text_bytea_types.py
@@ -33,6 +33,7 @@ class TextByteaTypes(Check):
                   FROM text_bytea_types_table
                   WHERE text_col >= ''::TEXT AND bytea_col >= ''::BYTEA;
 
+                > SET statement_timeout = '60s';
                 > INSERT INTO text_bytea_types_table SELECT DISTINCT text_col, bytea_col FROM text_bytea_types_table;
                 """,
                 """
@@ -41,6 +42,7 @@ class TextByteaTypes(Check):
                   FROM text_bytea_types_table
                   WHERE text_col >= ''::TEXT AND bytea_col >= ''::BYTEA;
 
+                > SET statement_timeout = '60s';
                 > INSERT INTO text_bytea_types_table SELECT DISTINCT text_col, bytea_col FROM text_bytea_types_table;
                 """,
             ]

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -18,7 +18,7 @@ from typing import Any
 
 import requests
 
-from materialize import ci_util, spawn
+from materialize import ci_util, spawn, ui
 
 CI_RE = re.compile("ci-regexp: (.*)")
 CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
@@ -204,6 +204,14 @@ def get_error_logs(log_files: list[str]) -> list[ErrorLog]:
             for line_nr, line in enumerate(f):
                 match = ERROR_RE.search(line)
                 if match:
+                    # environmentd segfaults during normal shutdown in coverage builds, see #20016
+                    # Ignoring this in regular ways would still be quite spammy.
+                    if (
+                        "environmentd" in line
+                        and "segfault at" in line
+                        and ui.env_is_truthy("CI_COVERAGE_ENABLED")
+                    ):
+                        continue
                     error_logs.append(ErrorLog(line, log_file, line_nr + 1))
     # TODO: Only report multiple errors once?
     return error_logs


### PR DESCRIPTION
Disabling jemalloc didn't work

Fixes: #20016

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
