### PR TITLE
webhooks: Add `mz_internal.mz_webhook_sources` table

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -64,7 +64,15 @@ Column     | Type                        | Optional?                            
 
 ## Webhook URL
 
-After creating a webhook source, send **POST** requests to `https://<HOST>/api/webhook/<database>/<schema>/<src_name>`.
+The URL which can be used to **POST** events to your webhook source is stored in the
+[`mz_internal.mz_webhook_sources`](/sql/system-catalog/mz_internal/#mz_webhook_sources) system table.
+
+In general these URLs have the following format:
+
+```
+https://<HOST>/api/webhook/<database>/<schema>/<src_name>
+```
+
 Where `<HOST>` is the URL for your Materialize instance, which can be found on the [Materialize Web
 Console](https://console.materialize.com/). Then `<database>` and `<schema>` are the database and
 schema where you created your source, and `<src_name>` is the name you provided for your source at

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1067,6 +1067,17 @@ The `mz_comments` table stores optional comments (descriptions) for objects in t
 | `sub_id`       | [`uint8`]   | For a comment on a column of a relation, this is the column number. For all other object types this column is `NULL`. |
 | `comment`      | [`text`]    | The comment itself.                                                                          |
 
+### `mz_webhook_sources`
+
+The `mz_webhook_sources` table contains a row for each webhook source in the system.
+
+<!-- RELATION_SPEC mz_internal.mz_webhook_sources -->
+| Field          | Type        | Meaning                                                                                      |
+| -------------- |-------------| --------                                                                                     |
+| `id`           | [`text`]    | The ID of the webhook source. Corresponds to [`mz_sources.id`](../mz_catalog/#mz_sources).   |
+| `name`         | [`text`]    | The name of the webhook source.                                                              |
+| `url`          | [`text`]    | The URL which can be used to send events to the source.                                      |
+
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list
 [`boolean`]: /sql/types/boolean

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -751,13 +751,9 @@ impl CatalogState {
     /// source.
     ///
     /// Note: Identifiers for the source, e.g. item name, are URL encoded.
-    pub fn try_get_webhook_url(
-        &self,
-        id: &GlobalId,
-        conn_id: Option<&ConnectionId>,
-    ) -> Option<url::Url> {
+    pub fn try_get_webhook_url(&self, id: &GlobalId) -> Option<url::Url> {
         let entry = self.try_get_entry(id)?;
-        let name = self.resolve_full_name(entry.name(), conn_id);
+        let name = self.resolve_full_name(entry.name(), entry.conn_id());
         let host_name = self
             .http_host_name
             .as_ref()

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -758,7 +758,7 @@ impl CatalogState {
             .http_host_name
             .as_ref()
             .map(|x| x.as_str())
-            .unwrap_or_else(|| "<HOST>");
+            .unwrap_or_else(|| "HOST");
 
         let RawDatabaseSpecifier::Name(database) = name.database else {
             return None;

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -753,7 +753,8 @@ impl CatalogState {
     /// Note: Identifiers for the source, e.g. item name, are URL encoded.
     pub fn try_get_webhook_url(&self, id: &GlobalId) -> Option<url::Url> {
         let entry = self.try_get_entry(id)?;
-        let name = self.resolve_full_name(entry.name(), entry.conn_id());
+        // Note: Webhook sources can never be created in the temporary schema, hence passing None.
+        let name = self.resolve_full_name(entry.name(), None);
         let host_name = self
             .http_host_name
             .as_ref()

--- a/src/adapter/src/catalog/builtin.rs
+++ b/src/adapter/src/catalog/builtin.rs
@@ -2254,6 +2254,16 @@ pub static MZ_SESSION_HISTORY: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     is_retained_metrics_object: false,
 });
 
+pub static MZ_WEBHOOKS_SOURCES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_webhook_sources",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty()
+        .with_column("id", ScalarType::String.nullable(false))
+        .with_column("name", ScalarType::String.nullable(false))
+        .with_column("url", ScalarType::String.nullable(false)),
+    is_retained_metrics_object: false,
+});
+
 // These will be replaced with per-replica tables once source/sink multiplexing on
 // a single cluster is supported.
 pub static MZ_SOURCE_STATISTICS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
@@ -5115,6 +5125,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_PREPARED_STATEMENT_HISTORY),
         Builtin::Table(&MZ_STATEMENT_EXECUTION_HISTORY),
         Builtin::Table(&MZ_COMMENTS),
+        Builtin::Table(&MZ_WEBHOOKS_SOURCES),
         Builtin::View(&MZ_RELATIONS),
         Builtin::View(&MZ_OBJECTS),
         Builtin::View(&MZ_OBJECT_FULLY_QUALIFIED_NAMES),

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1585,7 +1585,7 @@ impl CatalogState {
             id: self.resolve_builtin_table(&MZ_WEBHOOKS_SOURCES),
             row: Row::pack_slice(&[
                 Datum::String(&id_str),
-                Datum::String(&name),
+                Datum::String(name),
                 Datum::String(&url),
             ]),
             diff,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -246,10 +246,8 @@ impl Coordinator {
                         ),
                         DataSourceDesc::Progress => (DataSource::Progress, None),
                         DataSourceDesc::Webhook { .. } => {
-                            if let Some(url) = self
-                                .catalog()
-                                .state()
-                                .try_get_webhook_url(&source_id, Some(session.conn_id()))
+                            if let Some(url) =
+                                self.catalog().state().try_get_webhook_url(&source_id)
                             {
                                 session.add_notice(AdapterNotice::WebhookSourceCreated { url })
                             }

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -567,6 +567,13 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 3  sub_id  uint8
 4  comment  text
 
+query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_webhook_sources' ORDER BY position
+----
+1  id  text
+2  name  text
+3  url  text
+
 query T
 SELECT DISTINCT object FROM objects WHERE schema IN ('mz_internal') ORDER BY object
 ----
@@ -688,3 +695,4 @@ mz_subscriptions
 mz_type_pg_metadata
 mz_view_foreign_keys
 mz_view_keys
+mz_webhook_sources

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -704,6 +704,10 @@ mz_internal
 mz_view_keys
 BASE TABLE
 materialize
+mz_internal
+mz_webhook_sources
+BASE TABLE
+materialize
 pg_catalog
 pg_aggregate
 VIEW

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -39,19 +39,19 @@ SHOW COLUMNS FROM webhook_bytes
 ----
 body false bytea
 
-query TTT
-SELECT id, name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
+query TT
+SELECT name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
 ----
-u1 webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
+webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
 
 statement ok
 CREATE SOURCE "weird-name-(]%/'" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES
 
-query TTT
-SELECT id, name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
+query TT
+SELECT name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
 ----
-u1 webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
-u2 weird-name-(]%/' {/api/webhook/materialize/public/weird-name-(]%25%2F'}
+webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
+weird-name-(]%/' {/api/webhook/materialize/public/weird-name-(]%25%2F'}
 
 statement ok
 DROP SOURCE "weird-name-(]%/'"

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -39,6 +39,28 @@ SHOW COLUMNS FROM webhook_bytes
 ----
 body false bytea
 
+query TTT
+SELECT id, name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
+----
+u1 webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
+
+statement ok
+CREATE SOURCE "weird-name-(]%/'" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT BYTES
+
+query TTT
+SELECT id, name, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
+----
+u1 webhook_bytes {/api/webhook/materialize/public/webhook_bytes}
+u2 weird-name-(]%/' {/api/webhook/materialize/public/weird-name-(]%25%2F'}
+
+statement ok
+DROP SOURCE "weird-name-(]%/'"
+
+query TT
+SELECT id, regexp_match(url, '(/api/webhook/.*)') FROM mz_internal.mz_webhook_sources
+----
+u1 {/api/webhook/materialize/public/webhook_bytes}
+
 statement ok
 CREATE SOURCE webhook_bytes_include_headers IN CLUSTER webhook_cluster FROM WEBHOOK
     BODY FORMAT BYTES

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -656,7 +656,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-52
+53
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -569,6 +569,7 @@ mz_type_pg_metadata
 mz_view_foreign_keys
 mz_view_keys
 mz_object_dependencies
+mz_webhook_sources
 
 > SHOW VIEWS FROM mz_internal
 name


### PR DESCRIPTION
This PR adds a new builtin table to the `mz_internal` schema named `mz_webhook_sources`. It contains a row for each webhook source, and the url for pushing data to that source.

It also updates the webhook source docs to let users know that the URL for a source is available via this table.

### Motivation

Fixes #21343 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR adds a new table to the `mz_internal` schema called `mz_webhook_sources` that contains the URLs for pushing data to a webhook source.
