### PR TITLE
catalog: Move RBAC structs to the sql crate

### DIFF
--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -15,7 +15,7 @@ use crate::catalog::storage::{
     CommentValue, DefaultPrivilegesKey, DefaultPrivilegesValue, ReplicaConfig, ReplicaLocation,
     SystemPrivilegesKey, SystemPrivilegesValue,
 };
-use crate::catalog::{ClusterConfig, ClusterVariant, ClusterVariantManaged, RoleMembership};
+use crate::catalog::{ClusterConfig, ClusterVariant, ClusterVariantManaged};
 
 use super::{
     AuditLogKey, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,
@@ -549,36 +549,6 @@ impl RustType<proto::RoleKey> for RoleKey {
     fn from_proto(proto: proto::RoleKey) -> Result<Self, TryFromProtoError> {
         Ok(RoleKey {
             id: proto.id.into_rust_if_some("RoleKey::id")?,
-        })
-    }
-}
-
-impl RustType<proto::RoleMembership> for RoleMembership {
-    fn into_proto(&self) -> proto::RoleMembership {
-        proto::RoleMembership {
-            map: self
-                .map
-                .iter()
-                .map(|(key, val)| proto::role_membership::Entry {
-                    key: Some(key.into_proto()),
-                    value: Some(val.into_proto()),
-                })
-                .collect(),
-        }
-    }
-
-    fn from_proto(proto: proto::RoleMembership) -> Result<Self, TryFromProtoError> {
-        Ok(RoleMembership {
-            map: proto
-                .map
-                .into_iter()
-                .map(|e| {
-                    let key = e.key.into_rust_if_some("RoleMembership::Entry::key")?;
-                    let val = e.value.into_rust_if_some("RoleMembership::Entry::value")?;
-
-                    Ok((key, val))
-                })
-                .collect::<Result<_, TryFromProtoError>>()?,
         })
     }
 }

--- a/src/adapter/src/catalog/storage/stash.rs
+++ b/src/adapter/src/catalog/storage/stash.rs
@@ -15,7 +15,7 @@ use mz_ore::now::EpochMillis;
 use mz_proto::ProtoType;
 use mz_repr::adt::mz_acl_item::AclMode;
 use mz_repr::role_id::RoleId;
-use mz_sql::catalog::{RoleAttributes, SystemObjectType};
+use mz_sql::catalog::{RoleAttributes, RoleMembership, SystemObjectType};
 use mz_sql::names::{
     DatabaseId, ObjectId, ResolvedDatabaseSpecifier, SchemaId, SchemaSpecifier, PUBLIC_ROLE_NAME,
 };
@@ -26,9 +26,9 @@ use mz_storage_client::types::sources::Timeline;
 use crate::catalog::builtin::{MZ_SUPPORT_ROLE, MZ_SYSTEM_ROLE};
 use crate::catalog::object_type_to_audit_object_type;
 use crate::catalog::storage::{
-    BootstrapArgs, DefaultPrivilegesKey, DefaultPrivilegesValue, RoleMembership,
-    SystemPrivilegesKey, SystemPrivilegesValue, AUDIT_LOG_ID_ALLOC_KEY, DATABASE_ID_ALLOC_KEY,
-    MZ_SUPPORT_ROLE_ID, MZ_SYSTEM_ROLE_ID, SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY,
+    BootstrapArgs, DefaultPrivilegesKey, DefaultPrivilegesValue, SystemPrivilegesKey,
+    SystemPrivilegesValue, AUDIT_LOG_ID_ALLOC_KEY, DATABASE_ID_ALLOC_KEY, MZ_SUPPORT_ROLE_ID,
+    MZ_SYSTEM_ROLE_ID, SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY,
     SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, USER_CLUSTER_ID_ALLOC_KEY,
     USER_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
 };

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -26,6 +26,7 @@ use mz_controller::clusters::{ClusterId, ReplicaId};
 use mz_expr::MirScalarExpr;
 use mz_ore::now::{EpochMillis, NowFn};
 use mz_ore::str::StrExt;
+use mz_proto::IntoRustIfSome;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
@@ -1452,6 +1453,83 @@ impl Display for ErrorMessageObjectDescription {
             }
             ErrorMessageObjectDescription::System => f.write_str("SYSTEM"),
         }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
+// These attributes are needed because the key of a map must be a string. We also
+// get the added benefit of flattening this struct in it's serialized form.
+#[serde(into = "BTreeMap<String, RoleId>")]
+#[serde(try_from = "BTreeMap<String, RoleId>")]
+/// Represents the grantee and a grantor of a role membership.
+pub struct RoleMembership {
+    /// Key is the role that some role is a member of, value is the grantor role ID.
+    // TODO(jkosh44) This structure does not allow a role to have multiple of the same membership
+    // from different grantors. This isn't a problem now since we don't implement ADMIN OPTION, but
+    // we should figure this out before implementing ADMIN OPTION. It will likely require a messy
+    // migration.
+    pub map: BTreeMap<RoleId, RoleId>,
+}
+
+impl RoleMembership {
+    /// Creates a new [`RoleMembership`].
+    pub fn new() -> RoleMembership {
+        RoleMembership {
+            map: BTreeMap::new(),
+        }
+    }
+}
+
+impl From<RoleMembership> for BTreeMap<String, RoleId> {
+    fn from(value: RoleMembership) -> Self {
+        value
+            .map
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect()
+    }
+}
+
+impl TryFrom<BTreeMap<String, RoleId>> for RoleMembership {
+    type Error = anyhow::Error;
+
+    fn try_from(value: BTreeMap<String, RoleId>) -> Result<Self, Self::Error> {
+        Ok(RoleMembership {
+            map: value
+                .into_iter()
+                .map(|(k, v)| Ok((RoleId::from_str(&k)?, v)))
+                .collect::<Result<_, anyhow::Error>>()?,
+        })
+    }
+}
+
+impl RustType<proto::RoleMembership> for RoleMembership {
+    fn into_proto(&self) -> proto::RoleMembership {
+        proto::RoleMembership {
+            map: self
+                .map
+                .iter()
+                .map(|(key, val)| proto::role_membership::Entry {
+                    key: Some(key.into_proto()),
+                    value: Some(val.into_proto()),
+                })
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: proto::RoleMembership) -> Result<Self, TryFromProtoError> {
+        Ok(RoleMembership {
+            map: proto
+                .map
+                .into_iter()
+                .map(|e| {
+                    let key = e.key.into_rust_if_some("RoleMembership::Entry::key")?;
+                    let val = e.value.into_rust_if_some("RoleMembership::Entry::value")?;
+
+                    Ok((key, val))
+                })
+                .collect::<Result<_, TryFromProtoError>>()?,
+        })
     }
 }
 


### PR DESCRIPTION
This commit moves RBAC related structs from the mz_adapter::catalog crate/module to the mz_sql::catalog crate/module. This will help in the effort to extract catalog::storage into its own crate.

Works towards resolving #20953

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
