### PR TITLE
storage: enrich upsert snapshotting errors

### DIFF
--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -68,6 +68,7 @@
 
 use std::collections::hash_map::Drain;
 use std::collections::HashMap;
+use std::fmt;
 use std::num::Wrapping;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -145,6 +146,16 @@ pub struct Snapshotting {
     len_sum: Wrapping<i64>,
     checksum_sum: Wrapping<i64>,
     diff_sum: Wrapping<i64>,
+}
+
+impl fmt::Display for Snapshotting {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.debug_struct("Snapshotting")
+            .field("len_sum", &self.len_sum)
+            .field("checksum_sum", &self.checksum_sum)
+            .field("diff_sum", &self.checksum_sum)
+            .finish_non_exhaustive()
+    }
 }
 
 impl From<UpsertValue> for StateValue {
@@ -243,31 +254,68 @@ impl StateValue {
     #[allow(clippy::as_conversions)]
     pub fn ensure_decoded(&mut self, bincode_opts: BincodeOpts) {
         match self {
-            StateValue::Snapshotting(Snapshotting {
-                value_xor,
-                len_sum,
-                checksum_sum,
-                diff_sum,
-            }) => match diff_sum.0 {
-                1 => {
-                    let len = usize::try_from(len_sum.0).expect("invalid upsert state");
-                    let value = &value_xor[..len];
-                    // Truncation is fine (using `as`) as this is just a checksum
-                    assert_eq!(
-                        checksum_sum.0,
-                        // Hash the value, not the full buffer, which may have extra 0's
-                        seahash::hash(value) as i64,
-                        "invalid upsert state"
-                    );
-                    *self = Self::Decoded(bincode_opts.deserialize(value).unwrap());
+            StateValue::Snapshotting(snapshotting) => {
+                match snapshotting.diff_sum.0 {
+                    1 => {
+                        let len = usize::try_from(snapshotting.len_sum.0)
+                            .map_err(|_| {
+                                format!(
+                                    "len_sum can't be made into a usize, state: {}",
+                                    snapshotting
+                                )
+                            })
+                            .expect("invalid upsert state");
+                        let value = &snapshotting
+                            .value_xor
+                            .get(..len)
+                            .ok_or_else(|| {
+                                format!(
+                                    "value_xor is not the same length ({}) as len ({}), state: {}",
+                                    snapshotting.value_xor.len(),
+                                    len,
+                                    snapshotting
+                                )
+                            })
+                            .expect("invalid upsert state");
+                        // Truncation is fine (using `as`) as this is just a checksum
+                        assert_eq!(
+                            snapshotting.checksum_sum.0,
+                            // Hash the value, not the full buffer, which may have extra 0's
+                            seahash::hash(value) as i64,
+                            "invalid upsert state: checksum_sum does not match, state: {}",
+                            snapshotting
+                        );
+                        *self = Self::Decoded(bincode_opts.deserialize(value).unwrap());
+                    }
+                    0 => {
+                        assert_eq!(
+                            snapshotting.len_sum.0, 0,
+                            "invalid upsert state: len_sum is non-0, state: {}",
+                            snapshotting
+                        );
+                        assert_eq!(
+                            snapshotting.checksum_sum.0, 0,
+                            "invalid upsert state: checksum_sum is non-0, state: {}",
+                            snapshotting
+                        );
+                        assert!(
+                            snapshotting.value_xor.iter().all(|&x| x == 0),
+                            "invalid upsert state: value_xor not all 0s with 0 diff. \
+                            Non-zero positions: {:?}, state: {}",
+                            snapshotting
+                                .value_xor
+                                .iter()
+                                .positions(|&x| x != 0)
+                                .collect::<Vec<_>>(),
+                            snapshotting
+                        );
+                    }
+                    other => panic!(
+                        "invalid upsert state: non 0/1 diff_sum: {}, state: {}",
+                        other, snapshotting
+                    ),
                 }
-                0 => {
-                    assert_eq!(len_sum.0, 0, "invalid upsert state");
-                    assert_eq!(checksum_sum.0, 0, "invalid upsert state");
-                    assert!(value_xor.iter().all(|&x| x == 0), "invalid upsert state");
-                }
-                _ => panic!("invalid upsert state"),
-            },
+            }
             _ => {}
         }
     }
@@ -922,6 +970,60 @@ mod tests {
         s.merge_update(longer_row, 1, opts, &mut buf);
 
         // Assert that the `Snapshotting` value is fully merged.
+        s.ensure_decoded(opts);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(
+        expected = "invalid upsert state: len_sum is non-0, state: Snapshotting { len_sum: 1"
+    )]
+    fn test_merge_update_len_0_assert() {
+        let mut buf = Vec::new();
+        let opts = upsert_bincode_opts();
+
+        let mut s = StateValue::Snapshotting(Snapshotting::default());
+
+        let small_row = Ok(mz_repr::Row::default());
+        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
+        s.merge_update(longer_row.clone(), 1, opts, &mut buf);
+        s.merge_update(small_row.clone(), -1, opts, &mut buf);
+
+        s.ensure_decoded(opts);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(
+        expected = "invalid upsert state: \"value_xor is not the same length (3) as len (4), state: Snapshotting { len_sum: 4"
+    )]
+    fn test_merge_update_len_to_long_assert() {
+        let mut buf = Vec::new();
+        let opts = upsert_bincode_opts();
+
+        let mut s = StateValue::Snapshotting(Snapshotting::default());
+
+        let small_row = Ok(mz_repr::Row::default());
+        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Null]));
+        s.merge_update(longer_row.clone(), 1, opts, &mut buf);
+        s.merge_update(small_row.clone(), -1, opts, &mut buf);
+        s.merge_update(longer_row.clone(), 1, opts, &mut buf);
+
+        s.ensure_decoded(opts);
+    }
+
+    #[mz_ore::test]
+    #[should_panic(expected = "invalid upsert state: checksum_sum does not match")]
+    fn test_merge_update_checksum_doesnt_match() {
+        let mut buf = Vec::new();
+        let opts = upsert_bincode_opts();
+
+        let mut s = StateValue::Snapshotting(Snapshotting::default());
+
+        let small_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(2)]));
+        let longer_row = Ok(mz_repr::Row::pack([mz_repr::Datum::Int64(1)]));
+        s.merge_update(longer_row.clone(), 1, opts, &mut buf);
+        s.merge_update(small_row.clone(), -1, opts, &mut buf);
+        s.merge_update(longer_row.clone(), 1, opts, &mut buf);
+
         s.ensure_decoded(opts);
     }
 }


### PR DESCRIPTION
As discussed here: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1693937679088959, there seems to be some series of errors/situations that leaves the upsert state in an invalid state. This pr simply enriches the errors in those cases with more information, and adds more pathological tests to trigger them


### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.
related to https://github.com/MaterializeInc/materialize/issues/21600 and https://github.com/MaterializeInc/materialize/issues/21605


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
