### PR TITLE
rbac: Fix privilege requirement for SHOW CREATE

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -616,7 +616,9 @@ impl Coordinator {
                     // Checks if the session is authorized to purify a statement. Usually
                     // authorization is checked after planning, however purification happens before
                     // planning, which may require the use of some connections and secrets.
-                    if let Err(e) = rbac::check_item_usage(&catalog, ctx.session(), &resolved_ids) {
+                    if let Err(e) =
+                        rbac::check_item_usage(&catalog, ctx.session(), &resolved_ids, None)
+                    {
                         return ctx.retire(Err(e));
                     }
 

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -25,7 +25,7 @@ use mz_sql::names::{
     SystemObjectId,
 };
 use mz_sql::plan;
-use mz_sql::plan::{MutationKind, Plan, SourceSinkClusterConfig, UpdatePrivilege};
+use mz_sql::plan::{Explainee, MutationKind, Plan, SourceSinkClusterConfig, UpdatePrivilege};
 use mz_sql::session::user::{SUPPORT_USER, SYSTEM_USER};
 use mz_sql::session::vars::SystemVars;
 use mz_sql_parser::ast::QualifiedReplica;
@@ -116,8 +116,13 @@ pub fn check_item_usage(
     catalog: &impl SessionCatalog,
     session: &Session,
     resolved_ids: &ResolvedIds,
+    plan: Option<&Plan>,
 ) -> Result<(), AdapterError> {
     rbac_preamble!(catalog, session);
+
+    if matches!(plan, Some(plan) if !requires_item_usage_privileges(plan)) {
+        return Ok(());
+    }
 
     // Obtain all roles that the current session is a member of.
     let current_role_id = session.current_role_id();
@@ -146,6 +151,86 @@ pub fn check_item_usage(
     Ok(())
 }
 
+fn requires_item_usage_privileges(plan: &Plan) -> bool {
+    match plan {
+        Plan::CreateConnection(_)
+        | Plan::CreateDatabase(_)
+        | Plan::CreateSchema(_)
+        | Plan::CreateRole(_)
+        | Plan::CreateCluster(_)
+        | Plan::CreateClusterReplica(_)
+        | Plan::CreateSource(_)
+        | Plan::CreateSources(_)
+        | Plan::CreateSecret(_)
+        | Plan::CreateSink(_)
+        | Plan::CreateTable(_)
+        | Plan::CreateView(_)
+        | Plan::CreateMaterializedView(_)
+        | Plan::CreateIndex(_)
+        | Plan::CreateType(_)
+        | Plan::Comment(_)
+        | Plan::DiscardTemp
+        | Plan::DiscardAll
+        | Plan::DropObjects(_)
+        | Plan::DropOwned(_)
+        | Plan::EmptyQuery
+        | Plan::ShowAllVariables
+        | Plan::ShowColumns(_)
+        | Plan::ShowVariable(_)
+        | Plan::InspectShard(_)
+        | Plan::SetVariable(_)
+        | Plan::ResetVariable(_)
+        | Plan::SetTransaction(_)
+        | Plan::StartTransaction(_)
+        | Plan::CommitTransaction(_)
+        | Plan::AbortTransaction(_)
+        | Plan::Select(_)
+        | Plan::Subscribe(_)
+        | Plan::CopyFrom(_)
+        | Plan::ExplainTimestamp(_)
+        | Plan::Insert(_)
+        | Plan::AlterCluster(_)
+        | Plan::AlterNoop(_)
+        | Plan::AlterIndexSetOptions(_)
+        | Plan::AlterIndexResetOptions(_)
+        | Plan::AlterSetCluster(_)
+        | Plan::AlterSink(_)
+        | Plan::AlterSource(_)
+        | Plan::PurifiedAlterSource { .. }
+        | Plan::AlterClusterRename(_)
+        | Plan::AlterClusterReplicaRename(_)
+        | Plan::AlterItemRename(_)
+        | Plan::AlterSecret(_)
+        | Plan::AlterSystemSet(_)
+        | Plan::AlterSystemReset(_)
+        | Plan::AlterSystemResetAll(_)
+        | Plan::AlterRole(_)
+        | Plan::AlterOwner(_)
+        | Plan::Declare(_)
+        | Plan::Fetch(_)
+        | Plan::Close(_)
+        | Plan::ReadThenWrite(_)
+        | Plan::Prepare(_)
+        | Plan::Execute(_)
+        | Plan::Deallocate(_)
+        | Plan::Raise(_)
+        | Plan::RotateKeys(_)
+        | Plan::GrantRole(_)
+        | Plan::RevokeRole(_)
+        | Plan::GrantPrivileges(_)
+        | Plan::RevokePrivileges(_)
+        | Plan::AlterDefaultPrivileges(_)
+        | Plan::ReassignOwned(_)
+        | Plan::SideEffectingFunc(_)
+        | Plan::ValidateConnection(_) => true,
+        Plan::ShowCreate(_) => false,
+        Plan::ExplainPlan(plan) => match plan.explainee {
+            Explainee::MaterializedView(_) | Explainee::Index(_) => false,
+            Explainee::Query { .. } => true,
+        },
+    }
+}
+
 /// Checks if a session is authorized to execute a plan. If not, an error is returned.
 pub fn check_plan(
     coord: &Coordinator,
@@ -157,7 +242,7 @@ pub fn check_plan(
 ) -> Result<(), AdapterError> {
     rbac_preamble!(catalog, session);
 
-    check_item_usage(catalog, session, resolved_ids)?;
+    check_item_usage(catalog, session, resolved_ids, Some(plan))?;
 
     // Obtain all roles that the current session is a member of.
     let current_role_id = session.current_role_id();

--- a/src/adapter/src/rbac.rs
+++ b/src/adapter/src/rbac.rs
@@ -905,7 +905,7 @@ fn generate_required_privileges(
             explainee,
         }) => match explainee {
             Explainee::MaterializedView(id) | Explainee::Index(id) => {
-                let item = catalog.get_item(&id);
+                let item = catalog.get_item(id);
                 let schema_id: ObjectId = item.name().qualifiers.clone().into();
                 vec![(SystemObjectId::Object(schema_id), AclMode::USAGE, role_id)]
             }

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1328,6 +1328,48 @@ DROP TABLE t;
 ----
 COMPLETE 0
 
+simple conn=mz_system,user=mz_system
+CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL 'https://google.com');
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+SHOW CREATE CONNECTION csr_conn;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=child,user=child
+SHOW CREATE CONNECTION csr_conn;
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO joe;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+SHOW CREATE CONNECTION csr_conn;
+----
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
+COMPLETE 1
+
+simple conn=child,user=child
+SHOW CREATE CONNECTION csr_conn;
+----
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
+COMPLETE 1
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SCHEMA materialize.public FROM joe;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP CONNECTION csr_conn;
+----
+COMPLETE 0
+
 # SELECT
 
 ## Table

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1854,6 +1854,88 @@ DROP ROLE view_owner;
 ----
 COMPLETE 0
 
+## EXPLAIN MATERIALIZED VIEW
+
+### We use the materialize role for these tests because we need the multiline functionality
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SCHEMA materialize.public FROM materialize;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE MATERIALIZED VIEW mv IN CLUSTER default AS SELECT 1
+----
+COMPLETE 0
+
+query error permission denied for SCHEMA "materialize.public"
+EXPLAIN MATERIALIZED VIEW mv;
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO materialize;
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN MATERIALIZED VIEW mv;
+----
+materialize.public.mv:
+  Constant
+    - (1)
+
+EOF
+
+simple conn=mz_system,user=mz_system
+DROP MATERIALIZED VIEW mv
+----
+COMPLETE 0
+
+## EXPLAIN INDEX
+
+### We use the materialize role for these tests because we need the multiline functionality
+
+simple conn=mz_system,user=mz_system
+REVOKE USAGE ON SCHEMA materialize.public FROM materialize;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE TABLE t (a INT)
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE INDEX i IN CLUSTER default ON t(a)
+----
+COMPLETE 0
+
+query error permission denied for SCHEMA "materialize.public"
+EXPLAIN INDEX i;
+
+simple conn=mz_system,user=mz_system
+GRANT USAGE ON SCHEMA materialize.public TO materialize;
+----
+COMPLETE 0
+
+query T multiline
+EXPLAIN INDEX i;
+----
+materialize.public.i:
+  ArrangeBy keys=[[#0]]
+    Get materialize.public.t
+
+EOF
+
+simple conn=mz_system,user=mz_system
+DROP INDEX i
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP TABLE t
+----
+COMPLETE 0
+
 # INSERT
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
`SHOW CREATE <object-type> <object>` statements should only require USAGE privileges on the schema that contains <object>. That means that unlike all other statement types, SHOW CREATE can reference an object without having USAGE privileges on the object itself.

Previously, the RBAC logic mistakenly required USAGE privileges on <object>, if USAGE was a valid privilege for <object>. This commit fixes SHOW CREATE statements so that USAGE is not required on <object>.

Fixes #21549

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix privilege requirements for SHOW CREATE.
