### PR TITLE
[persist] Fast-path peek prototype

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5325,6 +5325,7 @@ dependencies = [
  "mz-kafka-util",
  "mz-ore",
  "mz-persist-client",
+ "mz-persist-types",
  "mz-proto",
  "mz-repr",
  "mz-service",

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -499,6 +499,7 @@ impl crate::coord::Coordinator {
                 .snapshot_cursor(id, timestamp)
                 .await?;
 
+            let metrics = self.metrics.clone();
             let handle: JoinHandle<Result<PeekResponseUnary, String>> =
                 mz_ore::task::spawn(|| "persist::peek", async move {
                     let mut limit_remaining = finishing.limit.unwrap_or(usize::MAX);
@@ -541,6 +542,9 @@ impl crate::coord::Coordinator {
 
                     let res = finishing.finish(accum, max_result_size)?;
                     let total_duration = start.elapsed();
+                    metrics
+                        .persist_peek_seconds
+                        .observe(total_duration.as_secs_f64());
                     info!(
                         collection =? id,
                         fetch_duration =? last_fetch,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3377,7 +3377,12 @@ impl Coordinator {
                 |r| prep_relation_expr(state, r, style),
                 |s| prep_scalar_expr(state, s, style),
             )?;
-            peek::create_fast_path_plan(&mut dataflow, GlobalId::Explain, finishing.as_ref())?
+            peek::create_fast_path_plan(
+                &mut dataflow,
+                GlobalId::Explain,
+                finishing.as_ref(),
+                self.catalog.system_config().persist_fast_path_limit(),
+            )?
         };
 
         if let Some(fast_path_plan) = &fast_path_plan {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -92,7 +92,7 @@ impl Metrics {
             )),
             persist_peek_seconds: registry.register(metric!(
                 name: "mz_persist_peek_seconds",
-                help: "The total number of canceled peeks since process start.",
+                help: "Time spent in (experimental) Persist fast-path peeks.",
                 buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
             linearize_message_seconds: registry.register(metric!(

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -13,7 +13,7 @@ use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
 use mz_sql_parser::ast::statement_kind_label_value;
-use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
+use prometheus::{Histogram, HistogramVec, IntCounterVec, IntGaugeVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
@@ -27,6 +27,7 @@ pub struct Metrics {
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
     pub canceled_peeks: IntCounterVec,
+    pub persist_peek_seconds: Histogram,
     pub linearize_message_seconds: HistogramVec,
     pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
@@ -88,6 +89,11 @@ impl Metrics {
             canceled_peeks: registry.register(metric!(
                 name: "mz_canceled_peeks_total",
                 help: "The total number of canceled peeks since process start.",
+            )),
+            persist_peek_seconds: registry.register(metric!(
+                name: "mz_persist_peek_seconds",
+                help: "The total number of canceled peeks since process start.",
+                buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
             linearize_message_seconds: registry.register(metric!(
                 name: "mz_linearize_message_seconds",

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -33,6 +33,9 @@ pub enum StatementExecutionStrategy {
     /// The statement was executed by reading from an existing
     /// arrangement.
     FastPath,
+    /// Experimental: The statement was executed by reading from an existing
+    /// persist collection.
+    PersistFastPath,
     /// The statement was determined to be constant by
     /// environmentd, and not sent to a cluster.
     Constant,
@@ -43,6 +46,7 @@ impl StatementExecutionStrategy {
         match self {
             Self::Standard => "standard",
             Self::FastPath => "fast-path",
+            Self::PersistFastPath => "persist-fast-path",
             Self::Constant => "constant",
         }
     }

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -360,10 +360,7 @@ pub(crate) enum SerdeLeasedBatchPartMetadata {
 ///
 /// In any other circumstance, dropping `LeasedBatchPart` panics.
 #[derive(Debug)]
-pub struct LeasedBatchPart<T>
-where
-    T: Timestamp + Codec64,
-{
+pub struct LeasedBatchPart<T> {
     pub(crate) metrics: Arc<Metrics>,
     pub(crate) shard_id: ShardId,
     pub(crate) reader_id: LeasedReaderId,
@@ -443,10 +440,7 @@ where
     }
 }
 
-impl<T> Drop for LeasedBatchPart<T>
-where
-    T: Timestamp + Codec64,
-{
+impl<T> Drop for LeasedBatchPart<T> {
     /// For details, see [`LeasedBatchPart`].
     fn drop(&mut self) {
         self.metrics.lease.dropped_part.inc()

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -57,7 +57,7 @@ fn clone_tuple<T, D>((k, v, t, d): TupleRef<T, D>) -> Tuple<T, D> {
 /// The data needed to fetch a batch part, bundled up to make it easy
 /// to send between threads.
 #[derive(Debug)]
-pub(crate) enum FetchData<T: Timestamp + Codec64> {
+pub(crate) enum FetchData<T> {
     Unleased {
         shard_id: ShardId,
         blob: Arc<dyn Blob + Send + Sync>,
@@ -143,7 +143,7 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
 }
 
 #[derive(Debug)]
-pub(crate) enum ConsolidationPart<T: Timestamp + Codec64, D> {
+pub(crate) enum ConsolidationPart<T, D> {
     Queued {
         data: FetchData<T>,
     },
@@ -210,7 +210,7 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
 /// client should call `next` until it returns `None`, which signals all data has been returned...
 /// but it's also free to abandon the instance at any time if it eg. only needs a few entries.
 #[derive(Debug)]
-pub(crate) struct Consolidator<T: Timestamp + Codec64, D> {
+pub(crate) struct Consolidator<T, D> {
     metrics: Arc<Metrics>,
     runs: Vec<VecDeque<(ConsolidationPart<T, D>, usize)>>,
     filter: FetchBatchFilter<T>,

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -645,6 +645,16 @@ const PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("persist_fast_path_limit"),
+    value: &0,
+    description:
+        "An exclusive upper bound on the number of results we may return from a Persist fast-path peek; \
+        queries that may return more results will follow the normal / slow path. \
+        Setting this to 0 disables the feature.",
+    internal: true,
+};
+
 /// The default for the `DISK` option when creating managed clusters and cluster replicas.
 const DISK_CLUSTER_REPLICAS_DEFAULT: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("disk_cluster_replicas_default"),
@@ -2379,6 +2389,7 @@ impl SystemVars {
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+            .with_var(&PERSIST_FAST_PATH_LIMIT)
             .with_var(&PERSIST_STATS_AUDIT_PERCENT)
             .with_var(&PERSIST_STATS_COLLECTION_ENABLED)
             .with_var(&PERSIST_STATS_FILTER_ENABLED)
@@ -2863,6 +2874,10 @@ impl SystemVars {
     /// Returns the `persist_next_listen_batch_retryer_clamp` configuration parameter.
     pub fn persist_next_listen_batch_retryer_clamp(&self) -> Duration {
         *self.expect_value(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+    }
+
+    pub fn persist_fast_path_limit(&self) -> usize {
+        *self.expect_value(&PERSIST_FAST_PATH_LIMIT)
     }
 
     pub fn persist_reader_lease_duration(&self) -> Duration {
@@ -4779,6 +4794,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP.name()
+        || name == PERSIST_FAST_PATH_LIMIT.name()
         || name == PERSIST_STATS_AUDIT_PERCENT.name()
         || name == PERSIST_STATS_COLLECTION_ENABLED.name()
         || name == PERSIST_STATS_FILTER_ENABLED.name()

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -20,6 +20,7 @@ mz-cluster-client = { path = "../cluster-client" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-persist-types = { path = "../persist-types" }
 mz-proto = { path = "../proto", features = ["tokio-postgres"] }
 mz-repr = { path = "../repr" }
 mz-service = { path = "../service" }

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -876,10 +876,9 @@ CREATE TABLE t(x int, y int);
 query T multiline
 EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10) LIMIT 8;
 ----
-Explained Query:
+Explained Query (fast path):
   Finish limit=8 output=[#0, #1]
-    TopK limit=10
-      ReadStorage materialize.public.t
+    PersistPeek materialize.public.t
 
 EOF
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -876,9 +876,10 @@ CREATE TABLE t(x int, y int);
 query T multiline
 EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10) LIMIT 8;
 ----
-Explained Query (fast path):
+Explained Query:
   Finish limit=8 output=[#0, #1]
-    PersistPeek materialize.public.t
+    TopK limit=10
+      ReadStorage materialize.public.t
 
 EOF
 

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -1,0 +1,166 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET persist_fast_path_limit = 100
+----
+COMPLETE 0
+
+# Verify that the persist fast path only kicks in when it's expected to do so.
+
+# Generate a table, with multiple batches of data and some partial overlaps
+statement ok
+CREATE TABLE numbers (
+    value int
+);
+
+# Applies when the limit is below some threshold. Mapping and
+# projecting is fine.
+
+query T multiline
+EXPLAIN SELECT * from numbers limit 10;
+----
+Explained Query (fast path):
+  Finish limit=10 output=[#0]
+    PeekPersist materialize.public.numbers
+
+EOF
+
+query T multiline
+EXPLAIN SELECT value + 1000 from numbers LIMIT 10;
+----
+Explained Query (fast path):
+  Finish limit=10 output=[#0]
+    Project (#1)
+      Map ((#0 + 1000))
+        PeekPersist materialize.public.numbers
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * from numbers LIMIT 10 OFFSET 10;
+----
+Explained Query (fast path):
+  Finish limit=10 offset=10 output=[#0]
+    PeekPersist materialize.public.numbers
+
+EOF
+
+# Check that some fast-path queries succeed.
+
+statement ok
+INSERT INTO numbers SELECT generate_series(1, 3);
+
+statement ok
+INSERT INTO numbers SELECT generate_series(1, 10);
+
+# The ordering here is technically nondeterministic, but in practice unlikely to change.
+# Feel free to rewrite or remove if this causes trouble.
+
+query T
+SELECT value from numbers LIMIT 20;
+----
+1
+1
+2
+2
+3
+3
+4
+5
+6
+7
+8
+9
+10
+
+query T
+SELECT value from numbers LIMIT 20 OFFSET 6;
+----
+4
+5
+6
+7
+8
+9
+10
+
+statement ok
+INSERT INTO numbers SELECT generate_series(5, 100);
+
+statement ok
+INSERT INTO numbers SELECT generate_series(50, 1000);
+
+statement ok
+INSERT INTO numbers SELECT generate_series(500, 10000);
+
+# Since we don't guarantee which of the rows are returned, transform the results
+# in a way that doesn't depend on the specific values.
+
+query T
+SELECT value < 999999 from numbers LIMIT 5;
+----
+true
+true
+true
+true
+true
+
+# Does not apply when the limit is high, or when mixed with features
+# that might require a full scan.
+
+query T multiline
+EXPLAIN SELECT * from numbers LIMIT 1000;
+----
+Explained Query:
+  Finish limit=1000 output=[#0]
+    ReadStorage materialize.public.numbers
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * from numbers ORDER BY value LIMIT 10;
+----
+Explained Query:
+  Finish order_by=[#0 asc nulls_last] limit=10 output=[#0]
+    ReadStorage materialize.public.numbers
+
+EOF
+
+query T multiline
+EXPLAIN SELECT * from numbers WHERE value > mz_now() LIMIT 10;
+----
+Explained Query:
+  Finish limit=10 output=[#0]
+    Filter (integer_to_mz_timestamp(#0) > mz_now())
+      ReadStorage materialize.public.numbers
+
+Source materialize.public.numbers
+  filter=((integer_to_mz_timestamp(#0) > mz_now()))
+
+EOF
+
+# Does not apply when an index exists.
+
+statement ok
+CREATE DEFAULT INDEX ON numbers;
+
+query T multiline
+EXPLAIN SELECT * from numbers LIMIT 10;
+----
+Explained Query (fast path):
+  Finish limit=10 output=[#0]
+    ReadIndex on=materialize.public.numbers numbers_primary_idx=[*** full scan ***]
+
+Used Indexes:
+  - materialize.public.numbers_primary_idx (fast path limit)
+
+EOF


### PR DESCRIPTION
This introduces a new type of fast-path peek, which will read data from Persist directly instead of spinning up a dataflow.

### Motivation

See #20708 for the design and https://github.com/MaterializeInc/materialize/issues/21265 for the epic.

### Tips for reviewer

~I haven't benchmarked this properly yet, but the overall results seem promising: in testing I'm often seeing roughly an order-of-magnitude improvement on my little staging cluster. (For example: 2s vs 16s for a 4m-row table.)~ I've done a bit more testing: the latency seems to be dominated by the slowest part fetch plus the cost of sorting individual parts, since my test dataset (perhaps unrealistically) includes some large unconsolidated parts. I feel like we could probably drive this latency down further, but mostly with changes unrelated to this PR, and the speedup is already pretty good....

One interesting thing to note is that most of the savings seem to be due to serde and not to less data being fetched, since only massive shards tend to have more than one part per run. Leverage our `key_lower` stats, which lets us skip some runs entirely, may push this down further.

Known limitations:
- These fast-path peeks are not cancellable.
- There is no global limit on the number of fast-path peeks that can be running at once, and thus no limit on memory use.

For this reason I don't want to enable the flag right away, but it seems like I ought to have it enabled somewhere. So I've enabled it in testdrive only. And it's possible we decide both these things are fine?

A version of this branch with the fast-path unconditionally enabled passes nightlies, which is good to see.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
