### PR TITLE
Remove references to unmanaged clusters

### DIFF
--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -34,16 +34,12 @@ Alter cluster to size `xsmall`:
 ALTER CLUSTER c1 SET (SIZE 'xsmall');
 ```
 
-### Converting managed to unmanaged clusters
-Alter the `managed` status of a cluster to unmanaged:
+## Converting unmanaged to managed clusters
 
-```sql
-ALTER CLUSTER c1 SET (MANAGED false);
-```
+Unmanaged clusters are a legacy artifact of Materialize that 
+forced users to manually create and drop cluster replicas.
 
-### Converting unmanaged to managed clusters
-
-Alter the `managed` status of a cluster to unmanaged:
+Alter the `managed` status of a cluster to managed:
 
 ```sql
 ALTER CLUSTER c1 SET (MANAGED);
@@ -69,6 +65,5 @@ The privileges required to execute this statement are:
 ## See also
 
 - [`CREATE CLUSTER`](/sql/create-cluster/)
-- [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)
 - [`CREATE SINK`](/sql/create-sink/)
 - [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -7,6 +7,10 @@ menu:
     parent: commands
 ---
 
+{{< warning >}}
+`CREATE CLUSTER REPLICA` is for working with legacy unmanaged clusters. Consider migrating your cluster to [managed](/sql/alter-cluster/#converting-unmanaged-to-managed-clusters) instead.
+{{< /warning >}}
+
 `CREATE CLUSTER REPLICA` provisions physical resources to perform computations.
 
 ## Conceptual framework
@@ -55,30 +59,6 @@ between availability zones, see [Availability zone assignment](/sql/create-clust
 
 ## Details
 
-### Sizes
-
-Valid `size` options are:
-
-- `3xsmall`
-- `2xsmall`
-- `xsmall`
-- `small`
-- `medium`
-- `large`
-- `xlarge`
-- `2xlarge`
-- `3xlarge`
-- `4xlarge`
-- `5xlarge`
-- `6xlarge`
-
-The [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes) table lists the CPU, memory, and disk allocation for each replica size.
-
-{{< warning >}}
-The values in the `mz_internal.mz_cluster_replica_sizes` may change at any time.
-You should not rely on them for any kind of capacity planning.
-{{< /warning >}}
-
 ### Disk-attached replicas
 
 {{< private-preview />}}
@@ -91,23 +71,7 @@ non-disk-attached replicas. In the future, disk-attached replicas will likely
 consume credits at a faster rate.
 {{< /warning >}}
 
-The `DISK` option attaches a disk to the replica.
-
-Attaching a disk allows you to trade off performance for cost. A replica of a
-given size has access to several times more disk than memory, allowing the
-processing of larger data sets at that replica size. Operations on a disk,
-however, are much slower than operations in memory, and so a workload that
-spills to disk will perform more slowly than a workload that does not. Note that
-exact storage medium for the attached disk is not specified, and its performance
-characteristics are subject to change.
-
-Consider attaching a disk to replicas that contain sources that use the
-[upsert envelope](/sql/create-source/#upsert-envelope) or the
-[Debezium envelope](/sql/create-source/#debezium-envelope). When you place
-these sources on a replica with an attached disk, they will automatically spill
-state to disk. These sources will therefore use less memory but may ingest
-data more slowly. See [Sizing a source](/sql/create-source/#sizing-a-source) for details.
-
+Disk-attached replicas work identically to [disk-attached clusters](/sql/create-cluster/#disk-attached-clusters), except they apply only to a single replica.
 
 ### Deployment options
 
@@ -121,6 +85,10 @@ Action | Outcome
 ---------|---------
 Increase all replicas' sizes | Ability to maintain more dataflows or more complex dataflows
 Add replicas to a cluster | Greater tolerance to replica failure
+
+### Sizes
+
+Cluster replica sizes work identically to [cluster sizes](/sql/create-cluster/#cluster-size), except they apply only to a single replica.
 
 ### Homogeneous vs. heterogeneous hardware provisioning
 

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -88,7 +88,7 @@ The `mz_clusters` table contains a row for each cluster in the system.
 | `name`               | [`text`]             | The name of the cluster.                                                                                                                 |
 | `owner_id`           | [`text`]             | The role ID of the owner of the cluster. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).                       |
 | `privileges`         | [`mz_aclitem array`] | The privileges belonging to the cluster.                                                                                                 |
-| `managed`            | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/#managed-clusters) with automatically managed replicas.                   |
+| `managed`            | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/) with automatically managed replicas.                   |
 | `size`               | [`text`]             | If the cluster is managed, the desired size of the cluster's replicas. `NULL` for unmanaged clusters.                                    |
 | `replication_factor` | [`uint4`]            | If the cluster is managed, the desired number of replicas of the cluster. `NULL` for unmanaged clusters.                                 |
 | `disk`               | [`boolean`]          | **Unstable** If the cluster is managed, `true` if the replicas have the `DISK` option . `NULL` for unmanaged clusters.                   |


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

De-emphasize unmanaged clusters in the documentation. This is a first step towards deprecation. 

This PR adds a known-desirable feature.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * 
    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
