### PR TITLE
sql: remove map -> array operator

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -442,6 +442,7 @@ message ProtoBinaryFunc {
     }
 
     reserved 93; // timezone_time
+    reserved 108; // map_get_values
     reserved "timezone_time";
     oneof kind {
         google.protobuf.Empty add_int16 = 46;
@@ -548,7 +549,6 @@ message ProtoBinaryFunc {
         google.protobuf.Empty jsonb_delete_string = 105;
         google.protobuf.Empty map_contains_key = 106;
         google.protobuf.Empty map_get_value = 107;
-        google.protobuf.Empty map_get_values = 108;
         google.protobuf.Empty map_contains_all_keys = 109;
         google.protobuf.Empty map_contains_any_keys = 110;
         google.protobuf.Empty map_contains_map = 111;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -4251,12 +4251,11 @@ pub static OP_IMPLS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|| {
             params!(ListElementAnyCompatible, ListAnyCompatible) => ElementListConcat => ListAnyCompatible, oid::OP_CONCAT_ELEMENY_LIST_OID;
         },
 
-        //JSON, MAP, RANGE
+        // JSON, MAP, RANGE
         "->" => Scalar {
             params!(Jsonb, Int64) => JsonbGetInt64 { stringify: false } => Jsonb, 3212;
             params!(Jsonb, String) => JsonbGetString { stringify: false } => Jsonb, 3211;
             params!(MapAny, String) => MapGetValue => Any, oid::OP_GET_VALUE_MAP_OID;
-            params!(MapAny, ScalarType::Array(Box::new(ScalarType::String))) => MapGetValues => ArrayAnyCompatible, oid::OP_GET_VALUES_MAP_OID;
         },
         "->>" => Scalar {
             params!(Jsonb, Int64) => JsonbGetInt64 { stringify: true } => String, 3481;

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -425,31 +425,6 @@ SELECT '{a=>true, b=>false}'::map[text=>bool] -> 'b'
 false
 
 query T
-SELECT ('{a=>true, b=>false}'::map[text=>bool] -> ARRAY[]::text[])::text
-----
-{}
-
-query T
-SELECT ('{a=>true, b=>false}'::map[text=>bool] -> ARRAY['']::text[])::text
-----
-{NULL}
-
-query T
-SELECT ('{a=>1, b=>2}'::map[text=>int] -> ARRAY['a'])::text
-----
-{1}
-
-query T
-SELECT ('{a=>1, b=>2}'::map[text=>int] -> ARRAY['b', 'a'])::text
-----
-{2,1}
-
-query T
-SELECT ('{a=>1, b=>2}'::map[text=>int] -> ARRAY['b', 'a', 'c'])::text
-----
-{2,1,NULL}
-
-query T
 SELECT ('{hello=>{world=>nested}, another=>{map=>here}}'::map[text=>map[text=>text]] -> 'missing'::text)::text
 ----
 NULL
@@ -466,9 +441,6 @@ nested
 
 query error operator is not unique: unknown \-> text
 SELECT NULL -> 'hello'::text
-
-query error could not determine polymorphic type because input has type unknown
-SELECT NULL -> '{a}'::text[]
 
 # 🔬 CREATE TYPE .. AS MAP
 


### PR DESCRIPTION
This operator previously could create arrays of arrays, which we could
prevent. However we now think it's better to remove this for now (it's
probably unused; it is undocumented) and add a version later that works
on lists in the future.

Fixes #20655

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove the `map -> text[]` operator variant which could erroneously create arrays of arrays.