### PR TITLE
compute,storage: move variable_length_row_encoding flag into CreateTimely

### DIFF
--- a/src/cluster-client/src/client.proto
+++ b/src/cluster-client/src/client.proto
@@ -21,4 +21,5 @@ message ProtoTimelyConfig {
     uint64 process = 2;
     repeated string addresses = 3;
     uint32 idle_arrangement_merge_effort = 4;
+    bool variable_length_row_encoding = 5;
 }

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -139,6 +139,8 @@ pub struct TimelyConfig {
     ///
     /// See `differential_dataflow::Config::idle_merge_effort`.
     pub idle_arrangement_merge_effort: u32,
+    /// Whether to enable variable-length row encoding.
+    pub variable_length_row_encoding: bool,
 }
 
 impl RustType<ProtoTimelyConfig> for TimelyConfig {
@@ -148,6 +150,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             addresses: self.addresses.into_proto(),
             process: self.process.into_proto(),
             idle_arrangement_merge_effort: self.idle_arrangement_merge_effort,
+            variable_length_row_encoding: self.variable_length_row_encoding,
         }
     }
 
@@ -157,6 +160,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             workers: proto.workers.into_rust()?,
             addresses: proto.addresses.into_rust()?,
             idle_arrangement_merge_effort: proto.idle_arrangement_merge_effort,
+            variable_length_row_encoding: proto.variable_length_row_encoding,
         })
     }
 }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -17,7 +17,7 @@ use differential_dataflow::lattice::Lattice;
 use futures::stream::FuturesUnordered;
 use futures::{future, StreamExt};
 use mz_build_info::BuildInfo;
-use mz_cluster_client::client::ClusterStartupEpoch;
+use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig};
 use mz_expr::RowSetFinishing;
 use mz_ore::cast::CastFrom;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -302,14 +302,16 @@ where
         };
 
         instance.send(ComputeCommand::CreateTimely {
-            config: Default::default(),
+            config: TimelyConfig {
+                variable_length_row_encoding,
+                ..Default::default()
+            },
             epoch: ClusterStartupEpoch::new(envd_epoch, 0),
         });
 
         let dummy_logging_config = Default::default();
         instance.send(ComputeCommand::CreateInstance(InstanceConfig {
             logging: dummy_logging_config,
-            variable_length_row_encoding,
         }));
 
         instance

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -308,7 +308,7 @@ where
 
         let dummy_logging_config = Default::default();
         instance.send(ComputeCommand::CreateInstance(InstanceConfig {
-            logging_config: dummy_logging_config,
+            logging: dummy_logging_config,
             variable_length_row_encoding,
         }));
 

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -260,11 +260,7 @@ where
     /// Most `ComputeCommand`s are independent of the target replica, but some
     /// contain replica-specific fields that must be adjusted before sending.
     fn specialize_command(&self, command: &mut ComputeCommand<T>) {
-        if let ComputeCommand::CreateInstance(InstanceConfig {
-            logging,
-            variable_length_row_encoding: _,
-        }) = command
-        {
+        if let ComputeCommand::CreateInstance(InstanceConfig { logging }) = command {
             *logging = self.config.logging.clone();
         }
 
@@ -274,6 +270,7 @@ where
                 process: 0,
                 addresses: self.config.location.dataflow_addrs.clone(),
                 idle_arrangement_merge_effort: self.config.idle_arrangement_merge_effort,
+                variable_length_row_encoding: config.variable_length_row_encoding,
             };
             *epoch = self.epoch;
         }

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -261,11 +261,11 @@ where
     /// contain replica-specific fields that must be adjusted before sending.
     fn specialize_command(&self, command: &mut ComputeCommand<T>) {
         if let ComputeCommand::CreateInstance(InstanceConfig {
-            logging_config,
+            logging,
             variable_length_row_encoding: _,
         }) = command
         {
-            *logging_config = self.config.logging.clone();
+            *logging = self.config.logging.clone();
         }
 
         if let ComputeCommand::CreateTimely { config, epoch } = command {

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -47,7 +47,6 @@ message ProtoComputeCommand {
 
 message ProtoInstanceConfig {
     logging.ProtoLoggingConfig logging = 1;
-    bool variable_length_row_encoding = 2;
 }
 
 message ProtoPeek {

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -33,11 +33,6 @@ message ProtoComputeCommand {
         mz_cluster_client.client.ProtoClusterStartupEpoch epoch = 2;
     }
 
-    message ProtoInstanceConfig {
-        logging.ProtoLoggingConfig logging_config = 1;
-        bool variable_length_row_encoding = 2;
-    }
-
     oneof kind {
         ProtoCreateTimely create_timely = 1;
         ProtoInstanceConfig create_instance = 2;
@@ -48,6 +43,11 @@ message ProtoComputeCommand {
         google.protobuf.Empty initialization_complete = 7;
         ProtoComputeParameters update_configuration = 8;
     }
+}
+
+message ProtoInstanceConfig {
+    logging.ProtoLoggingConfig logging = 1;
+    bool variable_length_row_encoding = 2;
 }
 
 message ProtoPeek {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -316,14 +316,12 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Arbitrary)]
 pub struct InstanceConfig {
     pub logging: LoggingConfig,
-    pub variable_length_row_encoding: bool,
 }
 
 impl RustType<ProtoInstanceConfig> for InstanceConfig {
     fn into_proto(&self) -> ProtoInstanceConfig {
         ProtoInstanceConfig {
             logging: Some(self.logging.into_proto()),
-            variable_length_row_encoding: self.variable_length_row_encoding.into_proto(),
         }
     }
 
@@ -332,7 +330,6 @@ impl RustType<ProtoInstanceConfig> for InstanceConfig {
             logging: proto
                 .logging
                 .into_rust_if_some("ProtoCreateInstance::logging")?,
-            variable_length_row_encoding: proto.variable_length_row_encoding.into_rust()?,
         })
     }
 }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -35,15 +35,6 @@ include!(concat!(
     "/mz_compute_client.protocol.command.rs"
 ));
 
-/// Configuration for a replica, passed with the `CreateInstance`. Replicas should halt
-/// if the controller attempt to reconcile them with different values
-/// for anything in this struct.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct InstanceConfig {
-    pub logging_config: LoggingConfig,
-    pub variable_length_row_encoding: bool,
-}
-
 /// Compute protocol commands, sent by the compute controller to replicas.
 ///
 /// Command sequences sent by the compute controller must be valid according to the [Protocol
@@ -240,13 +231,7 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
                     config: Some(config.into_proto()),
                     epoch: Some(epoch.into_proto()),
                 }),
-                ComputeCommand::CreateInstance(InstanceConfig {
-                    logging_config,
-                    variable_length_row_encoding,
-                }) => CreateInstance(ProtoInstanceConfig {
-                    logging_config: Some(logging_config.into_proto()),
-                    variable_length_row_encoding: *variable_length_row_encoding,
-                }),
+                ComputeCommand::CreateInstance(config) => CreateInstance(config.into_proto()),
                 ComputeCommand::InitializationComplete => InitializationComplete(()),
                 ComputeCommand::UpdateConfiguration(params) => {
                     UpdateConfiguration(params.into_proto())
@@ -274,14 +259,7 @@ impl RustType<ProtoComputeCommand> for ComputeCommand<mz_repr::Timestamp> {
                     epoch: epoch.into_rust_if_some("ProtoCreateTimely::epoch")?,
                 })
             }
-            Some(CreateInstance(ProtoInstanceConfig {
-                logging_config,
-                variable_length_row_encoding,
-            })) => Ok(ComputeCommand::CreateInstance(InstanceConfig {
-                logging_config: logging_config
-                    .into_rust_if_some("ProtoCreateInstance::logging_config")?,
-                variable_length_row_encoding,
-            })),
+            Some(CreateInstance(config)) => Ok(ComputeCommand::CreateInstance(config.into_rust()?)),
             Some(InitializationComplete(())) => Ok(ComputeCommand::InitializationComplete),
             Some(UpdateConfiguration(params)) => {
                 Ok(ComputeCommand::UpdateConfiguration(params.into_rust()?))
@@ -312,13 +290,8 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
 
     fn arbitrary_with(_: Self::Parameters) -> Self::Strategy {
         Union::new(vec![
-            (any::<LoggingConfig>(), any::<bool>())
-                .prop_map(|(logging_config, variable_length_row_encoding)| {
-                    ComputeCommand::CreateInstance(InstanceConfig {
-                        logging_config,
-                        variable_length_row_encoding,
-                    })
-                })
+            any::<InstanceConfig>()
+                .prop_map(ComputeCommand::CreateInstance)
                 .boxed(),
             any::<ComputeParameters>()
                 .prop_map(ComputeCommand::UpdateConfiguration)
@@ -334,6 +307,33 @@ impl Arbitrary for ComputeCommand<mz_repr::Timestamp> {
                 .prop_map(|uuid| ComputeCommand::CancelPeek { uuid })
                 .boxed(),
         ])
+    }
+}
+
+/// Configuration for a replica, passed with the `CreateInstance`. Replicas should halt
+/// if the controller attempt to reconcile them with different values
+/// for anything in this struct.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Arbitrary)]
+pub struct InstanceConfig {
+    pub logging: LoggingConfig,
+    pub variable_length_row_encoding: bool,
+}
+
+impl RustType<ProtoInstanceConfig> for InstanceConfig {
+    fn into_proto(&self) -> ProtoInstanceConfig {
+        ProtoInstanceConfig {
+            logging: Some(self.logging.into_proto()),
+            variable_length_row_encoding: self.variable_length_row_encoding.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: ProtoInstanceConfig) -> Result<Self, TryFromProtoError> {
+        Ok(Self {
+            logging: proto
+                .logging
+                .into_rust_if_some("ProtoCreateInstance::logging")?,
+            variable_length_row_encoding: proto.variable_length_row_encoding.into_rust()?,
+        })
     }
 }
 

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -11,7 +11,7 @@ use std::collections::BTreeMap;
 use std::num::NonZeroUsize;
 use std::ops::DerefMut;
 use std::rc::Rc;
-use std::sync::{atomic, Arc};
+use std::sync::Arc;
 
 use bytesize::ByteSize;
 use differential_dataflow::trace::TraceReader;
@@ -186,16 +186,8 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         }
     }
 
-    fn handle_create_instance(
-        &mut self,
-        InstanceConfig {
-            logging,
-            variable_length_row_encoding,
-        }: InstanceConfig,
-    ) {
-        mz_repr::VARIABLE_LENGTH_ROW_ENCODING
-            .store(variable_length_row_encoding, atomic::Ordering::SeqCst);
-        self.initialize_logging(&logging);
+    fn handle_create_instance(&mut self, config: InstanceConfig) {
+        self.initialize_logging(&config.logging);
     }
 
     fn handle_update_configuration(&mut self, params: ComputeParameters) {

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -189,13 +189,13 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
     fn handle_create_instance(
         &mut self,
         InstanceConfig {
-            logging_config,
+            logging,
             variable_length_row_encoding,
         }: InstanceConfig,
     ) {
         mz_repr::VARIABLE_LENGTH_ROW_ENCODING
             .store(variable_length_row_encoding, atomic::Ordering::SeqCst);
-        self.initialize_logging(&logging_config);
+        self.initialize_logging(&logging);
     }
 
     fn handle_update_configuration(&mut self, params: ComputeParameters) {

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -239,7 +239,8 @@ where
         config: ClusterConfig,
         variable_length_row_encoding: bool,
     ) -> Result<(), anyhow::Error> {
-        self.storage.create_instance(id);
+        self.storage
+            .create_instance(id, variable_length_row_encoding);
         self.compute
             .create_instance(id, config.arranged_logs, variable_length_row_encoding)?;
         Ok(())

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -273,7 +273,7 @@ pub trait StorageController: Debug + Send {
     /// created with zero replicas.
     ///
     /// Panics if a storage instance with the given ID already exists.
-    fn create_instance(&mut self, id: StorageInstanceId);
+    fn create_instance(&mut self, id: StorageInstanceId, variable_length_row_encoding: bool);
 
     /// Drops the storage instance with the given ID.
     ///
@@ -1198,12 +1198,13 @@ where
         Box::new(self.state.collections.iter())
     }
 
-    fn create_instance(&mut self, id: StorageInstanceId) {
+    fn create_instance(&mut self, id: StorageInstanceId, variable_length_row_encoding: bool) {
         let mut client = RehydratingStorageClient::new(
             self.build_info,
             self.metrics.for_instance(id),
             self.state.envd_epoch,
             self.state.config.grpc_client.clone(),
+            variable_length_row_encoding,
         );
         if self.state.initialized {
             client.send(StorageCommand::InitializationComplete);


### PR DESCRIPTION
This PR moves the `variable_length_row_encoding` feature flag, which controls whether or not to enable variable-length row encoding, from `CreateInstance` into the `CreateTimely` command. In contrast to `CreateInstance`, `CreateTimely` is also part of the storage protocol. So the move ensures that the `variable_length_row_encoding` flag is     applied by both the compute and the storage parts of a replica.

Prior to this change, storage would be oblivious to the `variable_length_row_encoding` flag and would never enable row encoding. This could lead to a problematic sequence where storage would start up and begin hydrating a source, then later compute would process its `CreateInstance` command and change the global variable-length row encoding configuration. The storage source would start performing variable-length encoding mid-hydration, which would mess up its invariants and lead to panics.

The first commit of this PR contains some minor cleanup around compute's `InstanceConfig` type.

h/t to @guswynn [for coming up with the diagnosis](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1693955892057169)!

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/materialize/issues/21605.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A