### PR TITLE
CODEOWNERS: adapt to the {qa->testing} team name change

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,7 @@
 /.devcontainer                      @mjibson
 /.github                            @benesch
 /bin
-/ci                                 @MaterializeInc/qa
+/ci                                 @MaterializeInc/testing
 /doc/user                           @MaterializeInc/docs
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage
@@ -91,11 +91,11 @@
 /src/stash-debug                    @MaterializeInc/adapter
 /src/storage                        @MaterializeInc/storage
 /src/storage-client                 @MaterializeInc/storage
-/src/test-macro                     @MaterializeInc/qa
-/src/testdrive                      @MaterializeInc/qa
+/src/test-macro                     @MaterializeInc/testing
+/src/testdrive                      @MaterializeInc/testing
 /src/timely-util                    @MaterializeInc/compute
 /src/transform                      @MaterializeInc/compute
 /src/walkabout                      @benesch
 /src/workspace-hack                 @benesch
 /test
-/misc/python/materialize/cloudtest  @MaterializeInc/cloud @MaterializeInc/qa
+/misc/python/materialize/cloudtest  @MaterializeInc/cloud @MaterializeInc/testing


### PR DESCRIPTION
It seems like the handle of the testing team in Github has changed from @MaterializeInc/qa to @MaterializeInc/testing recently. This PR updates the CODEOWNERS file accordingly. 

### Motivation

   * This PR fixes the CODEOWNERS file.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A