### PR TITLE
nightly: Reenable parallel-workload-cancel and allow retrying of faily tests

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -686,6 +686,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
           args: [--max-joins=1, --runtime=3000]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -697,6 +701,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
           args: [--max-joins=15, --explain-only, --runtime=3000]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: sqlancer-pqs
     label: "SQLancer PQS"
@@ -708,6 +716,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=PQS, --no-qpg]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"
@@ -719,6 +731,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=NOREC]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: sqlancer-query-partitioning
     label: "SQLancer QueryPartitioning"
@@ -730,6 +746,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=QUERY_PARTITIONING]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: sqlancer-having
     label: "SQLancer Having"
@@ -741,6 +761,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=HAVING]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"
@@ -769,6 +793,10 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: data-ingest
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: parallel-workload-dml
     label: "Parallel Workload (DML)"
@@ -780,6 +808,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000, --complexity=dml, --threads=16]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: parallel-workload
     label: "Parallel Workload"
@@ -791,6 +823,10 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   - id: parallel-workload-100-threads
     label: "Parallel Workload (100 threads)"
@@ -802,18 +838,25 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000, --threads=100]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
-  # TODO(def-) Enable after https://github.com/MaterializeInc/materialize/issues/20404 is fixed
-  #- id: parallel-workload-cancel
-  #  label: "Parallel Workload (cancel)"
-  #  artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-  #  timeout_in_minutes: 60
-  #  agents:
-  #    queue: builder-linux-x86_64
-  #  plugins:
-  #    - ./ci/plugins/mzcompose:
-  #        composition: parallel-workload
-  #        args: [--runtime=3000, --scenario=cancel]
+  - id: parallel-workload-cancel
+    label: "Parallel Workload (cancel)"
+    artifact_paths: [junit_*.xml, parallel-workload-queries.log]
+    timeout_in_minutes: 60
+    agents:
+      queue: builder-linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: parallel-workload
+          args: [--runtime=3000, --scenario=cancel]
+    # Allow retrying generally flaky tests even when they are green
+    retry:
+      manual:
+        permit_on_passed: true
 
   # TODO(def-) Enable after figuring out restoring catalog
   #- id: parallel-workload-kill
@@ -826,6 +869,10 @@ steps:
   #    - ./ci/plugins/mzcompose:
   #        composition: parallel-workload
   #        args: [--runtime=3000, --scenario=kill]
+  #  # Allow retrying generally flaky tests even when they are green
+  #  retry:
+  #    manual:
+  #      permit_on_passed: true
 
   - wait: ~
     continue_on_failure: true


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
