### PR TITLE
BILLED AS for unmanaged replicas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3893,6 +3893,7 @@ name = "mz-controller"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "bytesize",
  "chrono",
  "differential-dataflow",
  "futures",

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -138,6 +138,15 @@ each replica, including the times at which it was created and dropped
 | `dropped_at`          | [`timestamp with time zone`] | The time at which the replica was dropped, or `NULL` if it still exists.                                                                  |
 | `credits_per_hour`    | [`numeric`]                  | The number of compute credits consumed per hour. Corresponds to [`mz_cluster_replica_sizes.credits_per_hour`](#mz_cluster_replica_sizes). |
 
+### `mz_internal_cluster_replicas`
+
+The `mz_internal_cluster_replicas` table lists the replicas that are created and maintained by Materialize support.
+
+<!-- RELATION_SPEC mz_internal.mz_internal_cluster_replicas -->
+| Field      | Type     | Meaning                                                                                                     |
+|------------|----------|-------------------------------------------------------------------------------------------------------------|
+| id         | [`text`] | The ID of a cluster replica. Corresponds to [`mz_cluster_replicas.id`](../mz_catalog/#mz_cluster_replicas). |
+
 ### `mz_comments`
 
 The `mz_comments` table stores optional comments (descriptions) for objects in the database.

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -50,12 +50,12 @@ use mz_catalog::builtin::{
     MZ_CLUSTERS, MZ_CLUSTER_LINKS, MZ_CLUSTER_REPLICAS, MZ_CLUSTER_REPLICA_HEARTBEATS,
     MZ_CLUSTER_REPLICA_METRICS, MZ_CLUSTER_REPLICA_SIZES, MZ_CLUSTER_REPLICA_STATUSES, MZ_COLUMNS,
     MZ_COMMENTS, MZ_COMPUTE_DEPENDENCIES, MZ_CONNECTIONS, MZ_DATABASES, MZ_DEFAULT_PRIVILEGES,
-    MZ_EGRESS_IPS, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_KAFKA_CONNECTIONS,
-    MZ_KAFKA_SINKS, MZ_KAFKA_SOURCES, MZ_LIST_TYPES, MZ_MAP_TYPES, MZ_MATERIALIZED_VIEWS,
-    MZ_OBJECT_DEPENDENCIES, MZ_OPERATORS, MZ_POSTGRES_SOURCES, MZ_PSEUDO_TYPES, MZ_ROLES,
-    MZ_ROLE_MEMBERS, MZ_SCHEMAS, MZ_SECRETS, MZ_SESSIONS, MZ_SINKS, MZ_SOURCES,
-    MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD, MZ_SUBSCRIPTIONS, MZ_SYSTEM_PRIVILEGES,
-    MZ_TABLES, MZ_TYPES, MZ_TYPE_PG_METADATA, MZ_VIEWS, MZ_WEBHOOKS_SOURCES,
+    MZ_EGRESS_IPS, MZ_FUNCTIONS, MZ_INDEXES, MZ_INDEX_COLUMNS, MZ_INTERNAL_CLUSTER_REPLICAS,
+    MZ_KAFKA_CONNECTIONS, MZ_KAFKA_SINKS, MZ_KAFKA_SOURCES, MZ_LIST_TYPES, MZ_MAP_TYPES,
+    MZ_MATERIALIZED_VIEWS, MZ_OBJECT_DEPENDENCIES, MZ_OPERATORS, MZ_POSTGRES_SOURCES,
+    MZ_PSEUDO_TYPES, MZ_ROLES, MZ_ROLE_MEMBERS, MZ_SCHEMAS, MZ_SECRETS, MZ_SESSIONS, MZ_SINKS,
+    MZ_SOURCES, MZ_SSH_TUNNEL_CONNECTIONS, MZ_STORAGE_USAGE_BY_SHARD, MZ_SUBSCRIPTIONS,
+    MZ_SYSTEM_PRIVILEGES, MZ_TABLES, MZ_TYPES, MZ_TYPE_PG_METADATA, MZ_VIEWS, MZ_WEBHOOKS_SOURCES,
 };
 
 /// An update to a built-in table.
@@ -226,12 +226,12 @@ impl CatalogState {
         cluster_id: ClusterId,
         name: &str,
         diff: Diff,
-    ) -> BuiltinTableUpdate {
+    ) -> Vec<BuiltinTableUpdate> {
         let cluster = &self.clusters_by_id[&cluster_id];
         let id = cluster.replica_id_by_name[name];
         let replica = &cluster.replicas_by_id[&id];
 
-        let (size, disk, az) = match &replica.config.location {
+        let (size, disk, az, internal) = match &replica.config.location {
             // TODO(guswynn): The column should be `availability_zones`, not
             // `availability_zone`.
             ReplicaLocation::Managed(ManagedReplicaLocation {
@@ -239,17 +239,21 @@ impl CatalogState {
                 availability_zones: ManagedReplicaAvailabilityZones::FromReplica(Some(az)),
                 allocation: _,
                 disk,
-            }) => (Some(&**size), Some(*disk), Some(az.as_str())),
+                billed_as: _,
+                internal,
+            }) => (Some(&**size), Some(*disk), Some(az.as_str()), *internal),
             ReplicaLocation::Managed(ManagedReplicaLocation {
                 size,
                 availability_zones: _,
                 allocation: _,
                 disk,
-            }) => (Some(&**size), Some(*disk), None),
-            _ => (None, None, None),
+                billed_as: _,
+                internal,
+            }) => (Some(&**size), Some(*disk), None, *internal),
+            _ => (None, None, None, false),
         };
 
-        BuiltinTableUpdate {
+        let cluster_replica_update = BuiltinTableUpdate {
             id: self.resolve_builtin_table(&MZ_CLUSTER_REPLICAS),
             row: Row::pack_slice(&[
                 Datum::String(&id.to_string()),
@@ -261,7 +265,20 @@ impl CatalogState {
                 Datum::from(disk),
             ]),
             diff,
+        };
+
+        let mut updates = vec![cluster_replica_update];
+
+        if internal {
+            let update = BuiltinTableUpdate {
+                id: self.resolve_builtin_table(&MZ_INTERNAL_CLUSTER_REPLICAS),
+                row: Row::pack_slice(&[Datum::String(&id.to_string())]),
+                diff,
+            };
+            updates.push(update);
         }
+
+        updates
     }
 
     pub(super) fn pack_cluster_link_update(
@@ -1207,6 +1224,7 @@ impl CatalogState {
             .cluster_replica_sizes
             .0
             .iter()
+            .filter(|(_, a)| !a.disabled)
             .map(
                 |(
                     size,
@@ -1217,6 +1235,7 @@ impl CatalogState {
                         scale,
                         workers,
                         credits_per_hour,
+                        disabled: _,
                     },
                 )| {
                     // Just invent something when the limits are `None`,

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -228,8 +228,8 @@ impl CatalogState {
         diff: Diff,
     ) -> Vec<BuiltinTableUpdate> {
         let cluster = &self.clusters_by_id[&cluster_id];
-        let id = cluster.replica_id_by_name[name];
-        let replica = &cluster.replicas_by_id[&id];
+        let id = cluster.replica_id(name).expect("Must exist");
+        let replica = cluster.replica(id).expect("Must exist");
 
         let (size, disk, az, internal) = match &replica.config.location {
             // TODO(guswynn): The column should be `availability_zones`, not

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -85,6 +85,13 @@ pub struct Config<'a> {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ClusterReplicaSizeMap(pub BTreeMap<String, ReplicaAllocation>);
 
+impl ClusterReplicaSizeMap {
+    /// Iterate all enabled (not disabled) replica allocations, with their name.
+    pub fn enabled_allocations(&self) -> impl Iterator<Item = (&String, &ReplicaAllocation)> {
+        self.0.iter().filter(|(_, a)| !a.disabled)
+    }
+}
+
 impl Default for ClusterReplicaSizeMap {
     // Used for testing and local purposes. This default value should not be used in production.
     //
@@ -124,6 +131,7 @@ impl Default for ClusterReplicaSizeMap {
                         scale: 1,
                         workers: workers.into(),
                         credits_per_hour: 1.into(),
+                        disabled: false,
                     },
                 )
             })
@@ -140,6 +148,7 @@ impl Default for ClusterReplicaSizeMap {
                     scale,
                     workers: 1,
                     credits_per_hour: scale.into(),
+                    disabled: false,
                 },
             );
 
@@ -152,6 +161,7 @@ impl Default for ClusterReplicaSizeMap {
                     scale,
                     workers: scale.into(),
                     credits_per_hour: scale.into(),
+                    disabled: false,
                 },
             );
 
@@ -164,6 +174,7 @@ impl Default for ClusterReplicaSizeMap {
                     scale: 1,
                     workers: 8,
                     credits_per_hour: 1.into(),
+                    disabled: false,
                 },
             );
         }
@@ -177,6 +188,20 @@ impl Default for ClusterReplicaSizeMap {
                 scale: 2,
                 workers: 4,
                 credits_per_hour: 2.into(),
+                disabled: false,
+            },
+        );
+
+        inner.insert(
+            "free".to_string(),
+            ReplicaAllocation {
+                memory_limit: None,
+                cpu_limit: None,
+                disk_limit: None,
+                scale: 0,
+                workers: 0,
+                credits_per_hour: 0.into(),
+                disabled: true,
             },
         );
         Self(inner)

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -138,11 +138,11 @@ impl CatalogState {
             if self.roles_by_id.get(&cluster.owner_id).is_none() {
                 inconsistencies.push(RoleInconsistency::Cluster(*cluster_id, cluster.owner_id));
             }
-            for (replica_id, replica) in &cluster.replicas_by_id {
+            for replica in cluster.replicas() {
                 if self.roles_by_id.get(&replica.owner_id).is_none() {
                     inconsistencies.push(RoleInconsistency::ClusterReplica(
                         *cluster_id,
-                        *replica_id,
+                        replica.replica_id,
                         cluster.owner_id,
                     ));
                 }
@@ -275,7 +275,7 @@ impl CatalogState {
                     let replica = self
                         .clusters_by_id
                         .get(&cluster_id)
-                        .and_then(|cluster| cluster.replicas_by_id.get(&replica_id));
+                        .and_then(|cluster| cluster.replica(replica_id));
                     if replica.is_none() {
                         comment_inconsistencies
                             .push(CommentInconsistency::Dangling(comment_object_id));

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1577,8 +1577,7 @@ impl CatalogState {
             None => {
                 let (size, _allocation) = self
                     .cluster_replica_sizes
-                    .0
-                    .iter()
+                    .enabled_allocations()
                     .min_by_key(|(_, a)| (a.scale, a.workers, a.memory_limit))
                     .expect("should have at least one valid cluster replica size");
                 size.clone()

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -475,7 +475,7 @@ impl PlanValidity {
             };
 
             if let Some(replica_id) = self.replica_id {
-                if !cluster.replicas_by_id.contains_key(&replica_id) {
+                if cluster.replica(replica_id).is_none() {
                     return Err(AdapterError::ChangedPlan);
                 }
             }
@@ -1086,13 +1086,13 @@ impl Coordinator {
                 },
                 self.variable_length_row_encoding,
             )?;
-            for (replica_id, replica) in instance.replicas_by_id.clone() {
+            for replica in instance.replicas() {
                 let role = instance.role();
                 replicas_to_start.push(CreateReplicaConfig {
                     cluster_id: instance.id,
-                    replica_id,
+                    replica_id: replica.replica_id,
                     role,
-                    config: replica.config,
+                    config: replica.config.clone(),
                 });
             }
         }

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -949,7 +949,7 @@ impl Coordinator {
                             .catalog()
                             .cluster_replica_sizes()
                             .0
-                            .get(&location.size)
+                            .get(location.size_for_billing())
                             .expect("location size is validated against the cluster replica sizes");
                         new_credit_consumption_rate += replica_allocation.credits_per_hour
                     }
@@ -1005,7 +1005,7 @@ impl Coordinator {
                                 .catalog()
                                 .cluster_replica_sizes()
                                 .0
-                                .get(&location.size)
+                                .get(location.size_for_billing())
                                 .expect(
                                     "location size is validated against the cluster replica sizes",
                                 );
@@ -1193,7 +1193,7 @@ impl Coordinator {
             .catalog()
             .user_cluster_replicas()
             .filter_map(|replica| match &replica.config.location {
-                ReplicaLocation::Managed(location) => Some(&location.size),
+                ReplicaLocation::Managed(location) => Some(location.size_for_billing()),
                 ReplicaLocation::Unmanaged(_) => None,
             })
             .map(|size| {

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1179,7 +1179,7 @@ impl Coordinator {
             let current_amount = self
                 .catalog()
                 .try_get_cluster(cluster_id)
-                .map(|instance| instance.replicas_by_id.len())
+                .map(|instance| instance.replicas().count())
                 .unwrap_or(0);
             self.validate_resource_limit(
                 current_amount,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -621,7 +621,7 @@ impl Coordinator {
         let Some(cluster) = self.catalog().try_get_cluster(event.cluster_id) else {
             return;
         };
-        let Some(replica) = cluster.replicas_by_id.get(&event.replica_id) else {
+        let Some(replica) = cluster.replica(event.replica_id) else {
             return;
         };
 
@@ -638,7 +638,7 @@ impl Coordinator {
             .unwrap_or_terminate("updating cluster status cannot fail");
 
             let cluster = self.catalog().get_cluster(event.cluster_id);
-            let replica = &cluster.replicas_by_id[&event.replica_id];
+            let replica = cluster.replica(event.replica_id).expect("Replica exists");
             let new_status = replica.status();
 
             if old_status != new_status {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1374,7 +1374,7 @@ impl Coordinator {
                 &cluster_id,
                 &catalog,
             );
-            for replica in cluster.replicas_by_id.values() {
+            for replica in cluster.replicas() {
                 if let Some(role_name) = dropped_roles.get(&replica.owner_id) {
                     let replica_id =
                         SystemObjectId::Object((replica.cluster_id(), replica.replica_id()).into());
@@ -1610,10 +1610,8 @@ impl Coordinator {
                     if !clusters_to_drop.contains(cluster_id) {
                         let cluster = self.catalog.get_cluster(*cluster_id);
                         if cluster.is_managed() {
-                            let replica = cluster
-                                .replicas_by_id
-                                .get(replica_id)
-                                .expect("Catalog out of sync");
+                            let replica =
+                                cluster.replica(*replica_id).expect("Catalog out of sync");
                             if !replica.config.location.internal() {
                                 coord_bail!("cannot drop replica of managed cluster");
                             }
@@ -2148,16 +2146,16 @@ impl Coordinator {
         let target_replica_name = session.vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {
-                cluster.replica_id_by_name.get(name).copied().ok_or(
-                    AdapterError::UnknownClusterReplica {
+                cluster
+                    .replica_id(name)
+                    .ok_or(AdapterError::UnknownClusterReplica {
                         cluster_name: cluster.name.clone(),
                         replica_name: name.to_string(),
-                    },
-                )
+                    })
             })
             .transpose()?;
 
-        if cluster.replicas_by_id.is_empty() {
+        if cluster.replicas().next().is_none() {
             return Err(AdapterError::NoClusterReplicasAvailable(
                 cluster.name.clone(),
             ));
@@ -2740,12 +2738,12 @@ impl Coordinator {
         let target_replica_name = ctx.session().vars().cluster_replica();
         let mut target_replica = target_replica_name
             .map(|name| {
-                cluster.replica_id_by_name.get(name).copied().ok_or(
-                    AdapterError::UnknownClusterReplica {
+                cluster
+                    .replica_id(name)
+                    .ok_or(AdapterError::UnknownClusterReplica {
                         cluster_name: cluster.name.clone(),
                         replica_name: name.to_string(),
-                    },
-                )
+                    })
             })
             .transpose()?;
 
@@ -5297,13 +5295,10 @@ impl Coordinator {
                 // Alter owner cascades down to linked clusters and replicas.
                 if let Some(cluster) = self.catalog().get_linked_cluster(*global_id) {
                     let linked_cluster_replica_ops =
-                        cluster
-                            .replicas_by_id
-                            .keys()
-                            .map(|id| catalog::Op::UpdateOwner {
-                                id: ObjectId::ClusterReplica((cluster.id(), *id)),
-                                new_owner,
-                            });
+                        cluster.replicas().map(|r| catalog::Op::UpdateOwner {
+                            id: ObjectId::ClusterReplica((cluster.id(), r.replica_id)),
+                            new_owner,
+                        });
                     ops.extend(linked_cluster_replica_ops);
                     ops.push(catalog::Op::UpdateOwner {
                         id: ObjectId::Cluster(cluster.id()),
@@ -5326,13 +5321,10 @@ impl Coordinator {
                 let cluster = self.catalog().get_cluster(*cluster_id);
                 // Alter owner cascades down to cluster replicas.
                 let managed_cluster_replica_ops =
-                    cluster
-                        .replicas_by_id
-                        .keys()
-                        .map(|replica_id| catalog::Op::UpdateOwner {
-                            id: ObjectId::ClusterReplica((cluster.id(), *replica_id)),
-                            new_owner,
-                        });
+                    cluster.replicas().map(|replica| catalog::Op::UpdateOwner {
+                        id: ObjectId::ClusterReplica((cluster.id(), replica.replica_id())),
+                        new_owner,
+                    });
                 ops.extend(managed_cluster_replica_ops);
             }
             _ => {}
@@ -5487,10 +5479,10 @@ where
     // Reading from log sources on replicated clusters is only allowed if a
     // target replica is selected. Otherwise, we have no way of knowing which
     // replica we read the introspection data from.
-    let num_replicas = cluster.replicas_by_id.len();
+    let num_replicas = cluster.replicas().count();
     if target_replica.is_none() {
         if num_replicas == 1 {
-            *target_replica = cluster.replicas_by_id.keys().next().copied();
+            *target_replica = cluster.replicas().map(|r| r.replica_id).next();
         } else {
             return Err(AdapterError::UntargetedLogRead { log_names });
         }
@@ -5499,7 +5491,7 @@ where
     // Ensure that logging is initialized for the target replica, lest
     // we try to read from a non-existing arrangement.
     let replica_id = target_replica.expect("set to `Some` above");
-    let replica = &cluster.replicas_by_id[&replica_id];
+    let replica = &cluster.replica(replica_id).expect("Replica must exist");
     if !replica.config.compute.logging.enabled() {
         return Err(AdapterError::IntrospectionDisabled { log_names });
     }

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -130,10 +130,10 @@ impl Coordinator {
                 coord_bail!("cannot change the size of a source or sink created with IN CLUSTER");
             }
             Some(linked_cluster) => {
-                for id in linked_cluster.replicas_by_id.keys() {
+                for replica in linked_cluster.replicas() {
                     ops.extend(
                         self.catalog()
-                            .cluster_replica_dependents(linked_cluster.id(), *id)
+                            .cluster_replica_dependents(linked_cluster.id(), replica.replica_id)
                             .into_iter()
                             .map(catalog::Op::DropObject),
                     );
@@ -202,12 +202,9 @@ impl Coordinator {
             // `catalog_transact`, both from the catalog state and from the
             // controller. The new replicas will be in the catalog state, and
             // need to be recreated in the controller.
-            let cluster_id = cluster.id;
             let replicas: Vec<_> = cluster
-                .replicas_by_id
-                .keys()
-                .copied()
-                .map(|r| (cluster_id, r))
+                .replicas()
+                .map(|r| (r.cluster_id, r.replica_id))
                 .collect();
             self.create_cluster_replicas(&replicas).await;
         }

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -82,6 +82,8 @@ impl Coordinator {
             size: size.to_string(),
             availability_zone: None,
             disk,
+            billed_as: None,
+            internal: false,
         };
         let location = self.catalog().concretize_replica_location(
             location,
@@ -165,8 +167,7 @@ impl Coordinator {
             let mut entries = self
                 .catalog()
                 .cluster_replica_sizes()
-                .0
-                .iter()
+                .enabled_allocations()
                 .collect::<Vec<_>>();
             entries.sort_by_key(
                 |(

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -531,6 +531,8 @@ pub struct CreateClusterReplicaV1 {
     pub replica_name: String,
     pub logical_size: String,
     pub disk: bool,
+    pub billed_as: Option<String>,
+    pub internal: bool,
 }
 
 impl RustType<proto::audit_log_event_v1::CreateClusterReplicaV1> for CreateClusterReplicaV1 {
@@ -544,6 +546,8 @@ impl RustType<proto::audit_log_event_v1::CreateClusterReplicaV1> for CreateClust
             replica_name: self.replica_name.to_string(),
             logical_size: self.logical_size.to_string(),
             disk: self.disk,
+            billed_as: self.billed_as.clone(),
+            internal: self.internal,
         }
     }
 
@@ -557,6 +561,8 @@ impl RustType<proto::audit_log_event_v1::CreateClusterReplicaV1> for CreateClust
             replica_name: proto.replica_name,
             logical_size: proto.logical_size,
             disk: proto.disk,
+            billed_as: proto.billed_as,
+            internal: proto.internal,
         })
     }
 }

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1932,6 +1932,7 @@ pub static MZ_SECRETS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         ),
     is_retained_metrics_object: false,
 });
+
 pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_cluster_replicas",
     schema: MZ_CATALOG_SCHEMA,
@@ -1946,6 +1947,13 @@ pub static MZ_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
         .with_column("owner_id", ScalarType::String.nullable(false))
         .with_column("disk", ScalarType::Bool.nullable(true)),
     is_retained_metrics_object: true,
+});
+
+pub static MZ_INTERNAL_CLUSTER_REPLICAS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
+    name: "mz_internal_cluster_replicas",
+    schema: MZ_INTERNAL_SCHEMA,
+    desc: RelationDesc::empty().with_column("id", ScalarType::String.nullable(false)),
+    is_retained_metrics_object: false,
 });
 
 pub static MZ_CLUSTER_REPLICA_STATUSES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -5131,6 +5139,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Table(&MZ_CLUSTER_REPLICA_SIZES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_STATUSES),
         Builtin::Table(&MZ_CLUSTER_REPLICA_HEARTBEATS),
+        Builtin::Table(&MZ_INTERNAL_CLUSTER_REPLICAS),
         Builtin::Table(&MZ_AUDIT_EVENTS),
         Builtin::Table(&MZ_STORAGE_USAGE_BY_SHARD),
         Builtin::Table(&MZ_EGRESS_IPS),

--- a/src/catalog/src/initialize.rs
+++ b/src/catalog/src/initialize.rs
@@ -634,6 +634,8 @@ pub async fn initialize(
                 replica_id: Some(DEFAULT_USER_REPLICA_ID.to_string().into()),
                 logical_size: options.default_cluster_replica_size.to_string(),
                 disk: false,
+                billed_as: None,
+                internal: false,
             },
         ),
     ));
@@ -882,6 +884,8 @@ fn default_replica_config(args: &BootstrapArgs) -> proto::ReplicaConfig {
                 size: args.default_cluster_replica_size.to_string(),
                 availability_zone: None,
                 disk: false,
+                internal: false,
+                billed_as: None,
             },
         )),
         logging: Some(proto::ReplicaLogging {

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -203,6 +203,8 @@ pub enum ReplicaLocation {
         /// `Some(az)` if the AZ was specified by the user and must be respected;
         availability_zone: Option<String>,
         disk: bool,
+        internal: bool,
+        billed_as: Option<String>,
     },
 }
 
@@ -230,6 +232,8 @@ impl From<mz_controller::clusters::ReplicaLocation> for ReplicaLocation {
                     size,
                     availability_zones,
                     disk,
+                    billed_as,
+                    internal,
                 },
             ) => ReplicaLocation::Managed {
                 size,
@@ -243,6 +247,8 @@ impl From<mz_controller::clusters::ReplicaLocation> for ReplicaLocation {
                         None
                     },
                 disk,
+                internal,
+                billed_as,
             },
         }
     }
@@ -270,10 +276,14 @@ impl RustType<proto::replica_config::Location> for ReplicaLocation {
                 size,
                 availability_zone,
                 disk,
+                billed_as,
+                internal,
             } => proto::replica_config::Location::Managed(proto::replica_config::ManagedLocation {
                 size: size.to_string(),
                 availability_zone: availability_zone.clone(),
                 disk: *disk,
+                billed_as: billed_as.clone(),
+                internal: *internal,
             }),
         }
     }
@@ -290,9 +300,11 @@ impl RustType<proto::replica_config::Location> for ReplicaLocation {
                 })
             }
             proto::replica_config::Location::Managed(location) => Ok(ReplicaLocation::Managed {
-                size: location.size,
                 availability_zone: location.availability_zone,
+                billed_as: location.billed_as,
                 disk: location.disk,
+                internal: location.internal,
+                size: location.size,
             }),
         }
     }

--- a/src/catalog/src/transaction.rs
+++ b/src/catalog/src/transaction.rs
@@ -123,9 +123,11 @@ pub(crate) fn add_new_builtin_cluster_replicas_migration(
 pub(crate) fn builtin_cluster_replica_config(bootstrap_args: &BootstrapArgs) -> ReplicaConfig {
     ReplicaConfig {
         location: ReplicaLocation::Managed {
-            size: bootstrap_args.builtin_cluster_replica_size.clone(),
             availability_zone: None,
+            billed_as: None,
             disk: false,
+            internal: false,
+            size: bootstrap_args.builtin_cluster_replica_size.clone(),
         },
         logging: default_logging_config(),
         idle_arrangement_merge_effort: None,

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -37,5 +37,8 @@ tracing = "0.1.37"
 uuid = { version = "1.2.2" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
+[dev-dependencies]
+bytesize = "1.1.0"
+
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -46,6 +46,7 @@ Aws
 Begin
 Between
 Bigint
+Billed
 Body
 Boolean
 Both
@@ -184,6 +185,7 @@ Insert
 Inspect
 Int
 Integer
+Internal
 Intersect
 Interval
 Into

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1733,6 +1733,8 @@ impl_display_t!(CreateClusterReplicaStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ReplicaOptionName {
+    /// The `BILLED AS [=] <value>` option.
+    BilledAs,
     /// The `SIZE [[=] <size>]` option.
     Size,
     /// The `AVAILABILITY ZONE [[=] <id>]` option.
@@ -1745,8 +1747,10 @@ pub enum ReplicaOptionName {
     ComputectlAddresses,
     /// The `COMPUTE ADDRESSES` option.
     ComputeAddresses,
-    /// The `WORKERS` option
+    /// The `WORKERS` option.
     Workers,
+    /// The `INTERNAL` option.
+    Internal,
     /// The `INTROSPECTION INTERVAL [[=] <interval>]` option.
     IntrospectionInterval,
     /// The `INTROSPECTION DEBUGGING [[=] <enabled>]` option.
@@ -1760,6 +1764,7 @@ pub enum ReplicaOptionName {
 impl AstDisplay for ReplicaOptionName {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         match self {
+            ReplicaOptionName::BilledAs => f.write_str("BILLED AS"),
             ReplicaOptionName::Size => f.write_str("SIZE"),
             ReplicaOptionName::AvailabilityZone => f.write_str("AVAILABILITY ZONE"),
             ReplicaOptionName::StorageAddresses => f.write_str("STORAGE ADDRESSES"),
@@ -1767,6 +1772,7 @@ impl AstDisplay for ReplicaOptionName {
             ReplicaOptionName::ComputectlAddresses => f.write_str("COMPUTECTL ADDRESSES"),
             ReplicaOptionName::ComputeAddresses => f.write_str("COMPUTE ADDRESSES"),
             ReplicaOptionName::Workers => f.write_str("WORKERS"),
+            ReplicaOptionName::Internal => f.write_str("INTERNAL"),
             ReplicaOptionName::IntrospectionInterval => f.write_str("INTROSPECTION INTERVAL"),
             ReplicaOptionName::IntrospectionDebugging => f.write_str("INTROSPECTION DEBUGGING"),
             ReplicaOptionName::IdleArrangementMergeEffort => {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3565,10 +3565,12 @@ impl<'a> Parser<'a> {
     fn parse_replica_option(&mut self) -> Result<ReplicaOption<Raw>, ParserError> {
         let name = match self.expect_one_of_keywords(&[
             AVAILABILITY,
+            BILLED,
             COMPUTE,
             COMPUTECTL,
             DISK,
             IDLE,
+            INTERNAL,
             INTROSPECTION,
             SIZE,
             STORAGE,
@@ -3578,6 +3580,10 @@ impl<'a> Parser<'a> {
             AVAILABILITY => {
                 self.expect_keyword(ZONE)?;
                 ReplicaOptionName::AvailabilityZone
+            }
+            BILLED => {
+                self.expect_keyword(AS)?;
+                ReplicaOptionName::BilledAs
             }
             COMPUTE => {
                 self.expect_keyword(ADDRESSES)?;
@@ -3592,6 +3598,7 @@ impl<'a> Parser<'a> {
                 self.expect_keywords(&[ARRANGEMENT, MERGE, EFFORT])?;
                 ReplicaOptionName::IdleArrangementMergeEffort
             }
+            INTERNAL => ReplicaOptionName::Internal,
             INTROSPECTION => match self.expect_one_of_keywords(&[DEBUGGING, INTERVAL])? {
                 DEBUGGING => ReplicaOptionName::IntrospectionDebugging,
                 INTERVAL => ReplicaOptionName::IntrospectionInterval,

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1627,6 +1627,34 @@ CREATE CLUSTER REPLICA default.replica SIZE = 'small'
 CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }] } })
 
 parse-statement
+CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL, BILLED AS 'free'
+----
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', INTERNAL, BILLED AS = 'free'
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: None }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL = true, BILLED AS 'free'
+----
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', INTERNAL = true, BILLED AS = 'free'
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(true))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica SIZE 'small', INTERNAL = false, BILLED AS 'free'
+----
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', INTERNAL = false, BILLED AS = 'free'
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: Internal, value: Some(Value(Boolean(false))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+
+parse-statement
+CREATE CLUSTER REPLICA default.replica SIZE 'small', BILLED AS 'free'
+----
+CREATE CLUSTER REPLICA default.replica SIZE = 'small', BILLED AS = 'free'
+=>
+CreateClusterReplica(CreateClusterReplicaStatement { of_cluster: Ident("default"), definition: ReplicaDefinition { name: Ident("replica"), options: [ReplicaOption { name: Size, value: Some(Value(String("small"))) }, ReplicaOption { name: BilledAs, value: Some(Value(String("free"))) }] } })
+
+parse-statement
 CREATE CLUSTER REPLICA default.replica SIZE 'small', AVAILABILITY ZONE 'a'
 ----
 CREATE CLUSTER REPLICA default.replica SIZE = 'small', AVAILABILITY ZONE = 'a'

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -533,6 +533,8 @@ pub enum ReplicaConfig {
         availability_zone: Option<String>,
         compute: ComputeReplicaConfig,
         disk: bool,
+        internal: bool,
+        billed_as: Option<String>,
     },
 }
 

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -116,6 +116,7 @@ pub enum PlanError {
     InvalidTimestampPrecision(InvalidTimestampPrecisionError),
     InvalidSecret(Box<ResolvedItemName>),
     InvalidTemporarySchema,
+    MangedReplicaName(String),
     ParserStatement(ParserStatementError),
     Parser(ParserError),
     DropViewOnMaterializedView(String),
@@ -547,6 +548,9 @@ impl fmt::Display for PlanError {
             Self::KafkaSourcePurification(e) => write!(f, "KAFKA source validation: {}", e),
             Self::TestScriptSourcePurification(e) => write!(f, "TEST SCRIPT source validation: {}", e),
             Self::LoadGeneratorSourcePurification(e) => write!(f, "LOAD GENERATOR source validation: {}", e),
+            Self::MangedReplicaName(name) => {
+                write!(f, "{name} is reserved for replicas of managed clusters")
+            }
         }
     }
 }

--- a/src/stash/protos/hashes.json
+++ b/src/stash/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "4883ab72d975458772e4a3bed58b0e3a"
+    "md5": "5d9b643479290ad46a91165aadf5ddb4"
   },
   {
     "name": "objects_v25.proto",
@@ -62,5 +62,9 @@
   {
     "name": "objects_v39.proto",
     "md5": "30b5e2154b986e166603a98d1582a887"
+  },
+  {
+    "name": "objects_v40.proto",
+    "md5": "19d354a8768359fa8f9346bf3920bff2"
   }
 ]

--- a/src/stash/protos/objects_v40.proto
+++ b/src/stash/protos/objects_v40.proto
@@ -18,7 +18,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v40;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -109,7 +109,7 @@ pub use crate::transaction::{Transaction, INSERT_BATCH_SPLIT_SIZE};
 /// We will initialize new [`Stash`]es with this version, and migrate existing [`Stash`]es to this
 /// version. Whenever the [`Stash`] changes, e.g. the protobufs we serialize in the [`Stash`]
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 39;
+pub const STASH_VERSION: u64 = 40;
 
 /// The minimum [`Stash`] version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -924,7 +924,7 @@ impl Stash {
                             36 => upgrade::v36_to_v37::upgrade(),
                             37 => upgrade::v37_to_v38::upgrade(&mut tx).await?,
                             38 => upgrade::v38_to_v39::upgrade(&mut tx).await?,
-                            39 => upgrade::v39_to_v40::upgrade(),
+                            39 => upgrade::v39_to_v40::upgrade(&mut tx).await?,
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -924,6 +924,7 @@ impl Stash {
                             36 => upgrade::v36_to_v37::upgrade(),
                             37 => upgrade::v37_to_v38::upgrade(&mut tx).await?,
                             38 => upgrade::v38_to_v39::upgrade(&mut tx).await?,
+                            39 => upgrade::v39_to_v40::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -62,6 +62,7 @@ pub(crate) mod v35_to_v36;
 pub(crate) mod v36_to_v37;
 pub(crate) mod v37_to_v38;
 pub(crate) mod v38_to_v39;
+pub(crate) mod v39_to_v40;
 
 macro_rules! objects {
     ( $( $x:ident ),* ) => {
@@ -75,7 +76,7 @@ macro_rules! objects {
     }
 }
 
-objects!(v27, v28, v29, v31, v32, v33, v34, v35, v36, v37, v38, v39);
+objects!(v27, v28, v29, v31, v32, v33, v34, v35, v36, v37, v38, v39, v40);
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v39_to_v40.rs
+++ b/src/stash/src/upgrade/v39_to_v40.rs
@@ -7,5 +7,472 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-/// No-op migration for adding support for overriding the replica billing size.
-pub fn upgrade() {}
+use crate::objects::{wire_compatible, WireCompatible};
+use crate::upgrade::{objects_v39 as v39, objects_v40 as v40, MigrationAction};
+use crate::{StashError, Transaction, TypedCollection};
+
+wire_compatible!(v39::ClusterId with v40::ClusterId);
+wire_compatible!(v39::ClusterReplicaKey with v40::ClusterReplicaKey);
+wire_compatible!(v39::EpochMillis with v40::EpochMillis);
+wire_compatible!(v39::ReplicaLogging with v40::ReplicaLogging);
+wire_compatible!(v39::ReplicaMergeEffort with v40::ReplicaMergeEffort);
+wire_compatible!(v39::RoleId with v40::RoleId);
+wire_compatible!(v39::StringWrapper with v40::StringWrapper);
+wire_compatible!(v39::replica_config::UnmanagedLocation with v40::replica_config::UnmanagedLocation);
+
+const AUDIT_LOG_COLLECTION: TypedCollection<v39::AuditLogKey, ()> =
+    TypedCollection::new("audit_log");
+
+pub const CLUSTER_REPLICA_COLLECTION: TypedCollection<
+    v39::ClusterReplicaKey,
+    v39::ClusterReplicaValue,
+> = TypedCollection::new("compute_replicas");
+
+/// Migrate replicas to include internal/billed-as information.
+pub async fn upgrade(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    migrate_cluster_replicas(tx).await?;
+    migrate_audit_log(tx).await
+}
+
+/// Migrate replicas in the "cluster_replicas" collection.
+async fn migrate_cluster_replicas(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    let action = |(key, value): (&v39::ClusterReplicaKey, &v39::ClusterReplicaValue)| {
+        let new_key: v40::ClusterReplicaKey = WireCompatible::convert(key);
+        let new_value = v40::ClusterReplicaValue {
+            cluster_id: value.cluster_id.as_ref().map(WireCompatible::convert),
+            config: value.config.as_ref().map(|config| {
+                let logging = config.logging.as_ref().map(WireCompatible::convert);
+                let idle_arrangement_merge_effort = config
+                    .idle_arrangement_merge_effort
+                    .as_ref()
+                    .map(WireCompatible::convert);
+                let location = config.location.as_ref().map(|config| match config.clone() {
+                    v39::replica_config::Location::Managed(
+                        v39::replica_config::ManagedLocation {
+                            availability_zone,
+                            disk,
+                            size,
+                        },
+                    ) => v40::replica_config::Location::Managed(
+                        v40::replica_config::ManagedLocation {
+                            availability_zone,
+                            disk,
+                            size,
+                            billed_as: None,
+                            internal: false,
+                        },
+                    ),
+                    v39::replica_config::Location::Unmanaged(unmanaged) => {
+                        v40::replica_config::Location::Unmanaged(WireCompatible::convert(
+                            &unmanaged,
+                        ))
+                    }
+                });
+                v40::ReplicaConfig {
+                    logging,
+                    idle_arrangement_merge_effort,
+                    location,
+                }
+            }),
+            name: value.name.clone(),
+            owner_id: value.owner_id.as_ref().map(WireCompatible::convert),
+        };
+        MigrationAction::Update(key.clone(), (new_key, new_value))
+    };
+
+    CLUSTER_REPLICA_COLLECTION
+        .migrate_to::<_, v40::ClusterReplicaValue>(tx, |entries| {
+            entries.iter().map(action).collect()
+        })
+        .await
+}
+
+/// Migrate the audit log to the new replica billed-as and internal.
+async fn migrate_audit_log(tx: &mut Transaction<'_>) -> Result<(), StashError> {
+    let action = |key: &v39::AuditLogKey| {
+        let v39::audit_log_key::Event::V1(event) = key.event.as_ref()?;
+        let details = event.details.as_ref()?;
+        match details {
+            v39::audit_log_event_v1::Details::CreateClusterReplicaV1(details) => {
+                let create_event = v40::AuditLogEventV1 {
+                    id: event.id,
+                    event_type: v40::audit_log_event_v1::EventType::Create.into(),
+                    object_type: v40::audit_log_event_v1::ObjectType::ClusterReplica.into(),
+                    details: Some(v40::audit_log_event_v1::Details::CreateClusterReplicaV1(
+                        v40::audit_log_event_v1::CreateClusterReplicaV1 {
+                            cluster_id: details.cluster_id.clone(),
+                            cluster_name: details.cluster_name.clone(),
+                            replica_id: details.replica_id.as_ref().map(WireCompatible::convert),
+                            replica_name: details.replica_name.clone(),
+                            logical_size: details.logical_size.clone(),
+                            disk: details.disk,
+                            internal: false,
+                            billed_as: None,
+                        },
+                    )),
+                    user: event.user.as_ref().map(WireCompatible::convert),
+                    occurred_at: event.occurred_at.as_ref().map(WireCompatible::convert),
+                };
+
+                let new_key = v40::AuditLogKey {
+                    event: Some(v40::audit_log_key::Event::V1(create_event)),
+                };
+                Some(MigrationAction::Update(key.clone(), (new_key, ())))
+            }
+            _ => None,
+        }
+    };
+    AUDIT_LOG_COLLECTION
+        .migrate_to(tx, |entries| entries.keys().flat_map(action).collect())
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::DebugStashFactory;
+
+    const AUDIT_LOG_COLLECTION_V40: TypedCollection<v40::AuditLogKey, ()> =
+        TypedCollection::new("audit_log");
+
+    pub const CLUSTER_REPLICA_COLLECTION_V40: TypedCollection<
+        v40::ClusterReplicaKey,
+        v40::ClusterReplicaValue,
+    > = TypedCollection::new("compute_replicas");
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test_cluster_replica_migration() {
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open().await;
+
+        CLUSTER_REPLICA_COLLECTION
+            .insert_without_overwrite(
+                &mut stash,
+                [
+                    (
+                        v39::ClusterReplicaKey {
+                            id: Some(v39::ReplicaId {
+                                value: Some(v39::replica_id::Value::User(123)),
+                            }),
+                        },
+                        v39::ClusterReplicaValue {
+                            cluster_id: Some(v39::ClusterId {
+                                value: Some(v39::cluster_id::Value::User(456)),
+                            }),
+                            config: Some(v39::ReplicaConfig {
+                                idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
+                                    effort: 321,
+                                }),
+                                location: Some(v39::replica_config::Location::Managed(
+                                    v39::replica_config::ManagedLocation {
+                                        availability_zone: Some("unavailability_zone".to_owned()),
+                                        disk: false,
+                                        size: "huge".to_owned(),
+                                    },
+                                )),
+                                logging: Some(v39::ReplicaLogging {
+                                    interval: Some(v39::Duration {
+                                        nanos: 1234,
+                                        secs: 13,
+                                    }),
+                                    log_logging: true,
+                                }),
+                            }),
+                            name: "moritz".to_owned(),
+                            owner_id: Some(v39::RoleId {
+                                value: Some(v39::role_id::Value::User(987)),
+                            }),
+                        },
+                    ),
+                    (
+                        v39::ClusterReplicaKey {
+                            id: Some(v39::ReplicaId {
+                                value: Some(v39::replica_id::Value::User(234)),
+                            }),
+                        },
+                        v39::ClusterReplicaValue {
+                            cluster_id: Some(v39::ClusterId {
+                                value: Some(v39::cluster_id::Value::User(345)),
+                            }),
+                            config: Some(v39::ReplicaConfig {
+                                idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
+                                    effort: 432,
+                                }),
+                                location: Some(v39::replica_config::Location::Managed(
+                                    v39::replica_config::ManagedLocation {
+                                        availability_zone: Some("Verfügbar".to_owned()),
+                                        disk: false,
+                                        size: "groß".to_owned(),
+                                    },
+                                )),
+                                logging: Some(v39::ReplicaLogging {
+                                    interval: Some(v39::Duration {
+                                        nanos: 4312,
+                                        secs: 11,
+                                    }),
+                                    log_logging: true,
+                                }),
+                            }),
+                            name: "someone".to_owned(),
+                            owner_id: Some(v39::RoleId {
+                                value: Some(v39::role_id::Value::User(876)),
+                            }),
+                        },
+                    ),
+                ],
+            )
+            .await
+            .expect("insert success");
+
+        // Run the migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let roles = CLUSTER_REPLICA_COLLECTION_V40
+            .peek_one(&mut stash)
+            .await
+            .expect("read v40");
+        insta::assert_debug_snapshot!(roles, @r###"
+        {
+            ClusterReplicaKey {
+                id: Some(
+                    ReplicaId {
+                        value: Some(
+                            User(
+                                123,
+                            ),
+                        ),
+                    },
+                ),
+            }: ClusterReplicaValue {
+                cluster_id: Some(
+                    ClusterId {
+                        value: Some(
+                            User(
+                                456,
+                            ),
+                        ),
+                    },
+                ),
+                name: "moritz",
+                config: Some(
+                    ReplicaConfig {
+                        logging: Some(
+                            ReplicaLogging {
+                                log_logging: true,
+                                interval: Some(
+                                    Duration {
+                                        secs: 13,
+                                        nanos: 1234,
+                                    },
+                                ),
+                            },
+                        ),
+                        idle_arrangement_merge_effort: Some(
+                            ReplicaMergeEffort {
+                                effort: 321,
+                            },
+                        ),
+                        location: Some(
+                            Managed(
+                                ManagedLocation {
+                                    size: "huge",
+                                    availability_zone: Some(
+                                        "unavailability_zone",
+                                    ),
+                                    disk: false,
+                                    internal: false,
+                                    billed_as: None,
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                owner_id: Some(
+                    RoleId {
+                        value: Some(
+                            User(
+                                987,
+                            ),
+                        ),
+                    },
+                ),
+            },
+            ClusterReplicaKey {
+                id: Some(
+                    ReplicaId {
+                        value: Some(
+                            User(
+                                234,
+                            ),
+                        ),
+                    },
+                ),
+            }: ClusterReplicaValue {
+                cluster_id: Some(
+                    ClusterId {
+                        value: Some(
+                            User(
+                                345,
+                            ),
+                        ),
+                    },
+                ),
+                name: "someone",
+                config: Some(
+                    ReplicaConfig {
+                        logging: Some(
+                            ReplicaLogging {
+                                log_logging: true,
+                                interval: Some(
+                                    Duration {
+                                        secs: 11,
+                                        nanos: 4312,
+                                    },
+                                ),
+                            },
+                        ),
+                        idle_arrangement_merge_effort: Some(
+                            ReplicaMergeEffort {
+                                effort: 432,
+                            },
+                        ),
+                        location: Some(
+                            Managed(
+                                ManagedLocation {
+                                    size: "groß",
+                                    availability_zone: Some(
+                                        "Verfügbar",
+                                    ),
+                                    disk: false,
+                                    internal: false,
+                                    billed_as: None,
+                                },
+                            ),
+                        ),
+                    },
+                ),
+                owner_id: Some(
+                    RoleId {
+                        value: Some(
+                            User(
+                                876,
+                            ),
+                        ),
+                    },
+                ),
+            },
+        }
+        "###);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+    async fn smoke_test_audit_log_migration() {
+        let factory = DebugStashFactory::new().await;
+        let mut stash = factory.open().await;
+
+        AUDIT_LOG_COLLECTION
+            .insert_without_overwrite(
+                &mut stash,
+                [(
+                    v39::AuditLogKey {
+                        event: Some(v39::audit_log_key::Event::V1(v39::AuditLogEventV1 {
+                            id: 1234,
+                            user: Some(v39::StringWrapper {
+                                inner: "name".to_owned(),
+                            }),
+                            event_type: 2,
+                            object_type: 3,
+                            details: Some(
+                                v39::audit_log_event_v1::Details::CreateClusterReplicaV1(
+                                    v39::audit_log_event_v1::CreateClusterReplicaV1 {
+                                        cluster_id: "u23".to_owned(),
+                                        cluster_name: "my_cluster".to_owned(),
+                                        disk: false,
+                                        replica_id: Some(v39::StringWrapper {
+                                            inner: "u123".to_owned(),
+                                        }),
+                                        logical_size: "too small".to_owned(),
+                                        replica_name: "my_replica".to_owned(),
+                                    },
+                                ),
+                            ),
+                            occurred_at: Some(v39::EpochMillis { millis: 1600000 }),
+                        })),
+                    },
+                    (),
+                )],
+            )
+            .await
+            .expect("insert success");
+
+        // Run the migration.
+        stash
+            .with_transaction(|mut tx| {
+                Box::pin(async move {
+                    upgrade(&mut tx).await?;
+                    Ok(())
+                })
+            })
+            .await
+            .unwrap();
+
+        let roles = AUDIT_LOG_COLLECTION_V40
+            .peek_one(&mut stash)
+            .await
+            .expect("read v40");
+        insta::assert_debug_snapshot!(roles, @r###"
+        {
+            AuditLogKey {
+                event: Some(
+                    V1(
+                        AuditLogEventV1 {
+                            id: 1234,
+                            event_type: Create,
+                            object_type: ClusterReplica,
+                            user: Some(
+                                StringWrapper {
+                                    inner: "name",
+                                },
+                            ),
+                            occurred_at: Some(
+                                EpochMillis {
+                                    millis: 1600000,
+                                },
+                            ),
+                            details: Some(
+                                CreateClusterReplicaV1(
+                                    CreateClusterReplicaV1 {
+                                        cluster_id: "u23",
+                                        cluster_name: "my_cluster",
+                                        replica_id: Some(
+                                            StringWrapper {
+                                                inner: "u123",
+                                            },
+                                        ),
+                                        replica_name: "my_replica",
+                                        logical_size: "too small",
+                                        disk: false,
+                                        billed_as: None,
+                                        internal: false,
+                                    },
+                                ),
+                            ),
+                        },
+                    ),
+                ),
+            }: (),
+        }
+        "###);
+    }
+}

--- a/src/stash/src/upgrade/v39_to_v40.rs
+++ b/src/stash/src/upgrade/v39_to_v40.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for adding support for overriding the replica billing size.
+pub fn upgrade() {}

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
@@ -18,7 +18,7 @@ materialize_public_upgrade_kafka_sink  linked
 # currently see additional `drop` and `create` events for each replica that
 # existed before the migration. Those events don't have a user attached, so we
 # can recognize them and filter them out.
-> SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id'
+> SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id' - 'billed_as' - 'internal'
   FROM mz_audit_events
   WHERE (
     details->>'name' = 'materialize_public_upgrade_kafka_sink' OR

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
@@ -47,7 +47,7 @@ materialize_public_kafka_source  linked
 # currently see additional `drop` and `create` events for each replica that
 # existed before the migration. Those events don't have a user attached, so we
 # can recognize them and filter them out.
-> SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id', user
+> SELECT event_type, object_type, details - 'id' - 'cluster_id' - 'replica_id' - 'billed_as' - 'internal', user
   FROM mz_audit_events
   WHERE (
     details->>'name' = 'materialize_public_kafka_source' OR

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -102,7 +102,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 11  create  cluster  {"id":"u1","name":"default"}  NULL
 12  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
 13  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
-14  create  cluster-replica  {"cluster_id":"u1","cluster_name":"default","disk":false,"logical_size":"1","replica_id":"u1","replica_name":"r1"}  NULL
+14  create  cluster-replica  {"billed_as":null,"cluster_id":"u1","cluster_name":"default","disk":false,"internal":false,"logical_size":"1","replica_id":"u1","replica_name":"r1"}  NULL
 15  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 16  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 17  create  database  {"id":"u2","name":"test"}  materialize
@@ -116,7 +116,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  role  {"id":"u2","name":"foo"}  materialize
 26  drop  role  {"id":"u2","name":"foo"}  materialize
 27  create  cluster  {"id":"u2","name":"foo"}  materialize
-28  create  cluster-replica  {"cluster_id":"u2","cluster_name":"foo","disk":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
+28  create  cluster-replica  {"billed_as":null,"cluster_id":"u2","cluster_name":"foo","disk":false,"internal":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
 29  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
 30  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
 31  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
@@ -129,10 +129,10 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 38  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
 39  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
 40  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-41  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
+41  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"internal":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
 42  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
 43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u3","replica_name":"linked"}  materialize
-44  create  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
+44  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"internal":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
 45  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 46  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
 47  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
@@ -145,7 +145,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 54  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
 55  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
 56  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-57  create  cluster-replica  {"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
+57  create  cluster-replica  {"billed_as":null,"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"internal":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
 58  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
 59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"u2"}  materialize
 60  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -91,6 +91,11 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 7  credits_per_hour  numeric
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_internal_cluster_replicas' ORDER BY position
+----
+1  id           text
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_comments' ORDER BY position
 ----
 1  id  text
@@ -635,6 +640,7 @@ mz_dataflows_per_worker
 mz_expected_group_size_advice
 mz_frontiers
 mz_global_frontiers
+mz_internal_cluster_replicas
 mz_kafka_sources
 mz_message_batch_counts_received_raw
 mz_message_batch_counts_sent_raw

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -642,3 +642,157 @@ DROP CLUSTER foo CASCADE
 
 # Restore pristine server state
 reset-server
+
+# Tests for BILLED AS replicas
+
+statement ok
+CREATE CLUSTER t1 SIZE '1'
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.free SIZE '2', BILLED AS 'free'
+----
+db error: ERROR: cannot modify managed cluster t1
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.r1234 SIZE '2', INTERNAL, BILLED AS 'free'
+----
+db error: ERROR: r1234 is reserved for replicas of managed clusters
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.billed SIZE '2', INTERNAL
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.free SIZE '2', INTERNAL, BILLED AS 'free'
+----
+COMPLETE 0
+
+statement error db error: ERROR: cannot modify managed cluster t1
+CREATE CLUSTER REPLICA t1.free2 SIZE '2', BILLED AS 'free'
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER REPLICA t1.free2 SIZE '2', INTERNAL
+
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.invalid SIZE '2'
+----
+db error: ERROR: cannot modify managed cluster t1
+
+query TTTT
+SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
+----
+create  cluster-replica  {"billed_as":"free","cluster_id":"u2","cluster_name":"t1","disk":false,"internal":true,"logical_size":"2","replica_id":"u4","replica_name":"free"}  mz_system
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.r123 SIZE '2', BILLED AS 'free'
+----
+db error: ERROR: cannot modify managed cluster t1
+
+query TTTTT
+SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
+----
+u1  r1  u1  1  s1
+u2  r1  u2  1  u1
+u4  free  u2  2  u1
+u3  billed  u2  2  u1
+
+query T
+SELECT id FROM mz_internal.mz_internal_cluster_replicas WHERE id LIKE 'u%'
+----
+u3
+u4
+
+statement error db error: ERROR: cannot modify managed cluster t1
+CREATE CLUSTER REPLICA t1.free2 SIZE '2', BILLED AS 'free'
+
+statement ok
+ALTER CLUSTER t1 SET (MANAGED false);
+
+statement ok
+ALTER CLUSTER t1 SET (MANAGED);
+
+statement ok
+DROP CLUSTER REPLICA t1.free;
+
+statement error db error: ERROR: cannot drop replica of managed cluster
+DROP CLUSTER REPLICA t1.r1;
+
+statement ok
+DROP CLUSTER t1
+
+statement ok
+CREATE CLUSTER t1 SIZE '1'
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.free SIZE '2', INTERNAL, BILLED AS 'free'
+----
+COMPLETE 0
+
+statement ok
+DROP CLUSTER t1
+
+statement ok
+CREATE CLUSTER t1 REPLICAS (r1 (SIZE '1'))
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.free SIZE '2', BILLED AS 'free', INTERNAL
+----
+COMPLETE 0
+
+query TTTT
+SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
+----
+create  cluster-replica  {"billed_as":"free","cluster_id":"u4","cluster_name":"t1","disk":false,"internal":true,"logical_size":"2","replica_id":"u8","replica_name":"free"}  mz_system
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.internal_r2 SIZE '2', INTERNAL
+----
+COMPLETE 0
+
+statement ok
+DROP CLUSTER REPLICA t1.internal_r2
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.r2 SIZE '2'
+----
+COMPLETE 0
+
+statement ok
+DROP CLUSTER REPLICA t1.r2
+
+query TTTTT
+SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
+----
+u1  r1  u1  1  s1
+u7  r1  u4  1  u1
+u8  free  u4  2  u1
+
+simple conn=mz_system,user=mz_system
+CREATE CLUSTER REPLICA t1.r3 SIZE '2', BILLED AS 'free'
+----
+db error: ERROR: must specify INTERNAL when specifying BILLED AS
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER REPLICA t1.free2 SIZE '2', BILLED AS 'free'
+
+statement error db error: ERROR: cannot specify INTERNAL or BILLED AS as non\-internal user
+CREATE CLUSTER REPLICA t1.free2 SIZE '2', INTERNAL
+
+statement ok
+ALTER CLUSTER t1 SET (MANAGED);
+
+statement ok
+ALTER CLUSTER t1 SET (MANAGED false);
+
+statement ok
+DROP CLUSTER REPLICA t1.free;
+
+statement ok
+DROP CLUSTER REPLICA t1.r1;
+
+statement ok
+DROP CLUSTER t1
+
+reset-server

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -465,6 +465,10 @@ mz_global_frontiers
 VIEW
 materialize
 mz_internal
+mz_internal_cluster_replicas
+BASE TABLE
+materialize
+mz_internal
 mz_kafka_sources
 BASE TABLE
 materialize

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -204,7 +204,7 @@ foo  r3  u5
 mz_introspection  r1  s2
 mz_system  r1  s1
 
-statement error db error: ERROR: cannot modify managed cluster foo
+statement error db error: ERROR: cannot drop replica of managed cluster
 DROP CLUSTER REPLICA foo.r1
 
 statement error db error: ERROR: cannot modify managed cluster foo
@@ -294,7 +294,7 @@ SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name L
 ----
 u5  foo  true  1  1
 
-statement error db error: ERROR: cannot modify managed cluster foo
+statement error db error: ERROR: cannot drop replica of managed cluster
 DROP CLUSTER REPLICA foo.r1
 
 statement ok

--- a/test/testdrive/audit-log.td
+++ b/test/testdrive/audit-log.td
@@ -21,7 +21,7 @@ $ kafka-create-topic topic=test
   (TOPIC 'testdrive-test-${testdrive.seed}')
   FORMAT CSV WITH 2 COLUMNS
 
-> SELECT event_type, object_type, details - 'replica_id', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
+> SELECT event_type, object_type, details - 'replica_id' - 'billed_as' - 'internal', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
 create  cluster "{\"id\":\"<GID>\",\"name\":\"materialize_public_kafka_src\"}"  materialize
 create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_kafka_src\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
 create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"kafka_src\",\"schema\":\"public\",\"size\":\"${arg.default-storage-size}\",\"type\":\"kafka\"}"  materialize
@@ -29,7 +29,7 @@ create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"kafka
 > CREATE SOURCE counter_src
   FROM LOAD GENERATOR COUNTER;
 
-> SELECT event_type, object_type, details - 'replica_id', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
+> SELECT event_type, object_type, details - 'replica_id' - 'billed_as' - 'internal', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
 create  cluster "{\"id\":\"<GID>\",\"name\":\"materialize_public_counter_src\"}"  materialize
 create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_counter_src\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
 create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"counter_src\",\"schema\":\"public\",\"size\":\"${arg.default-storage-size}\",\"type\":\"load-generator\"}"  materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -560,7 +560,9 @@ mz_cluster_replica_sizes
 mz_cluster_replica_statuses
 mz_comments
 mz_compute_dependencies
+mz_internal_cluster_replicas
 mz_kafka_sources
+mz_object_dependencies
 mz_postgres_sources
 mz_sessions
 mz_storage_usage_by_shard
@@ -568,7 +570,6 @@ mz_subscriptions
 mz_type_pg_metadata
 mz_view_foreign_keys
 mz_view_keys
-mz_object_dependencies
 mz_webhook_sources
 
 > SHOW VIEWS FROM mz_internal
@@ -658,7 +659,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-50
+51
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'


### PR DESCRIPTION
### Motivation

This PR adds a known-desirable feature: #20317

Implement unbilled replicas by providing support for the following syntax for internal users:

```
CREATE CLUSTER REPLICA clsname.replica_name SIZE '2', BILLED AS 'free', INTERNAL;
```

Regular users do not have access to this syntax and instead will receive an error message.

There are two new concepts in the above line:
* `BILLED AS` allows us to override the size at which a replica is billed. This syntax is only available to internal users.
* `INTERNAL` marks a replica as an internal replica, which can never be part of a managed cluster configuration. We need to this to distinguish the set of replicas of a managed cluster from additional replicas in the event of changing a managed to an unmanaged cluster. Otherwise, we would consider all replicas as part of the managed configuration when switching back to managed, which---if at all possible---seems very odd.

TODO:
* [ ] Cloud changes to include `free` replica size, disabled, once this lands in production.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
