### PR TITLE
persist-txn: pull another batch of work out of the integration branch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4458,7 +4458,7 @@ dependencies = [
  "mz-ore",
  "mz-persist-client",
  "mz-persist-types",
- "serde_json",
+ "prost",
  "timely",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4455,6 +4455,7 @@ name = "mz-persist-txn"
 version = "0.0.0"
 dependencies = [
  "differential-dataflow",
+ "futures",
  "mz-ore",
  "mz-persist-client",
  "mz-persist-types",

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -232,7 +232,7 @@ impl Transactor {
                 .expect("data schema shouldn't change");
             let res = self.txns.register(init_ts, data_write).await;
             match res {
-                Ok(()) => {
+                Ok(_) => {
                     self.data_reads.insert(*data_id, (init_ts, data_read));
                     return init_ts;
                 }

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -17,6 +17,7 @@ tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
+futures = "0.3.25"
 tokio = { version = "1.24.2", default-features = false, features = ["rt", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -11,7 +11,7 @@ differential-dataflow = "0.12.0"
 mz-ore = { path = "../ore" }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
-serde_json = "1.0.89"
+prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist-txn/src/error.rs
+++ b/src/persist-txn/src/error.rs
@@ -13,6 +13,7 @@ use mz_persist_client::ShardId;
 
 /// The data shard was not registered.
 #[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub struct NotRegistered<T> {
     /// The data shard that was not registered.
     pub data_id: ShardId,

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -17,6 +17,7 @@ use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use mz_persist_client::ShardId;
 use mz_persist_types::{Codec, Codec64};
+use prost::Message;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use tracing::debug;
@@ -136,8 +137,7 @@ where
                     .await
                     .expect("valid usage");
                 let batch = batch.into_transmittable_batch();
-                // TODO(txn): Proto not serde_json.
-                let batch_raw = serde_json::to_string(&batch).expect("valid json");
+                let batch_raw = batch.encode_to_vec();
                 let batch = data_write.batch_from_transmittable_batch(batch);
                 txn_batches.push(batch);
                 debug!(

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -218,6 +218,14 @@ where
         }
     }
 
+    /// Merges the staged writes in the other txn into this one.
+    pub fn merge(&mut self, other: Self) {
+        for (data_id, writes) in other.writes {
+            self.writes.entry(data_id).or_default().extend(writes);
+        }
+        self.tidy.merge(other.tidy);
+    }
+
     /// Merges the work represented by given tidy into this txn.
     ///
     /// If this txn commits, the tidy work will be written at the commit ts.
@@ -235,6 +243,7 @@ where
 /// A token representing the asynchronous "apply" work expected to be promptly
 /// performed by a txn committer.
 #[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
 pub struct TxnApply<T> {
     is_empty: bool,
     pub(crate) commit_ts: T,
@@ -265,15 +274,230 @@ impl<T> TxnApply<T> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::time::{Duration, SystemTime};
 
+    use futures::stream::FuturesUnordered;
+    use futures::StreamExt;
     use mz_persist_client::PersistClient;
-    use mz_persist_types::codec_impls::{UnitSchema, VecU8Schema};
 
     use crate::tests::writer;
-    use crate::TxnsCodecDefault;
+    use crate::txn_read::TxnsCache;
 
     use super::*;
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn commit_at() {
+        let client = PersistClient::new_for_tests().await;
+        let mut txns = TxnsHandle::expect_open(client.clone()).await;
+        let mut cache = TxnsCache::expect_open(0, &txns).await;
+        let d0 = txns.expect_register(1).await;
+        let d1 = txns.expect_register(2).await;
+
+        // Can merge two txns. Can have multiple data shards in a txn.
+        let mut txn = txns.begin();
+        txn.write(&d0, "0".into(), (), 1).await;
+        let mut other = txns.begin();
+        other.write(&d0, "1".into(), (), 1).await;
+        other.write(&d1, "A".into(), (), 1).await;
+        txn.merge(other);
+        txn.commit_at(&mut txns, 3).await.unwrap();
+
+        // Can commit an empty txn. Can "skip" timestamps.
+        txns.begin().commit_at(&mut txns, 5).await.unwrap();
+
+        // Txn cannot be committed at a closed out time. The Err includes the
+        // earliest committable time. Failed txn can commit on retry.
+        let mut txn = txns.begin();
+        txn.write(&d0, "2".into(), (), 1).await;
+        assert_eq!(txn.commit_at(&mut txns, 4).await, Err(6));
+        txn.commit_at(&mut txns, 6).await.unwrap();
+        txns.apply_le(&6).await;
+
+        let expected_d0 = vec!["0".to_owned(), "1".to_owned(), "2".to_owned()];
+        let actual_d0 = cache.expect_snapshot(&client, d0, 6).await;
+        assert_eq!(actual_d0, expected_d0);
+
+        let expected_d1 = vec!["A".to_owned()];
+        let actual_d1 = cache.expect_snapshot(&client, d1, 6).await;
+        assert_eq!(actual_d1, expected_d1);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn apply_and_tidy() {
+        let mut txns = TxnsHandle::expect_open(PersistClient::new_for_tests().await).await;
+        let mut cache = TxnsCache::expect_open(0, &txns).await;
+        let d0 = txns.expect_register(1).await;
+
+        // Non-empty txn means non-empty apply. Min unapplied ts is the commit
+        // ts.
+        let mut txn = txns.begin();
+        txn.write(&d0, "2".into(), (), 1).await;
+        let apply_2 = txn.commit_at(&mut txns, 2).await.unwrap();
+        assert_eq!(apply_2.is_empty(), false);
+        cache.update_gt(&2).await;
+        assert_eq!(cache.min_unapplied_ts(), &2);
+        assert_eq!(cache.unapplied_batches().count(), 1);
+
+        // Running the apply unblocks reads but does not advance the min
+        // unapplied ts.
+        let tidy_2 = apply_2.apply(&mut txns).await;
+        assert_eq!(cache.min_unapplied_ts(), &2);
+
+        // Running the tidy advances the min unapplied ts.
+        txns.tidy_at(3, tidy_2).await.unwrap();
+        cache.update_gt(&3).await;
+        assert_eq!(cache.min_unapplied_ts(), &4);
+        assert_eq!(cache.unapplied_batches().count(), 0);
+
+        // We can also sneak the tidy into a normal txn. Tidies copy across txn
+        // merges.
+        let tidy_4 = txns.expect_commit_at(4, d0, &["4"]).await;
+        cache.update_gt(&4).await;
+        assert_eq!(cache.min_unapplied_ts(), &4);
+        let mut txn0 = txns.begin();
+        txn0.write(&d0, "5".into(), (), 1).await;
+        txn0.tidy(tidy_4);
+        let mut txn1 = txns.begin();
+        txn1.merge(txn0);
+        let apply_5 = txn1.commit_at(&mut txns, 5).await.unwrap();
+        cache.update_gt(&5).await;
+        assert_eq!(cache.min_unapplied_ts(), &5);
+        let tidy_5 = apply_5.apply(&mut txns).await;
+
+        // It's fine to drop a tidy, someone else will do it eventually.
+        let tidy_6 = txns.expect_commit_at(6, d0, &["6"]).await;
+        txns.tidy_at(7, tidy_6).await.unwrap();
+        cache.update_gt(&7).await;
+        assert_eq!(cache.min_unapplied_ts(), &8);
+
+        // Also fine if we don't drop it, but instead do it late (no-op but
+        // consumes a ts).
+        txns.tidy_at(8, tidy_5).await.unwrap();
+        cache.update_gt(&8).await;
+        assert_eq!(cache.min_unapplied_ts(), &9);
+
+        // Tidies can be merged and also can be stolen back out of a txn.
+        let tidy_9 = txns.expect_commit_at(9, d0, &["9"]).await;
+        let tidy_10 = txns.expect_commit_at(10, d0, &["10"]).await;
+        let mut txn = txns.begin();
+        txn.tidy(tidy_9);
+        let mut tidy_9 = txn.take_tidy();
+        tidy_9.merge(tidy_10);
+        txns.tidy_at(11, tidy_9).await.unwrap();
+        cache.update_gt(&11).await;
+        assert_eq!(cache.min_unapplied_ts(), &12);
+
+        // Can't tidy at an already committed ts.
+        let tidy_12 = txns.expect_commit_at(12, d0, &["12"]).await;
+        assert_eq!(txns.tidy_at(12, tidy_12).await, Err(13));
+    }
+
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn conflicting_writes() {
+        fn jitter() -> u64 {
+            // We could also use something like `rand`.
+            let time = SystemTime::UNIX_EPOCH.elapsed().unwrap();
+            u64::from(time.subsec_micros() % 20)
+        }
+
+        let client = PersistClient::new_for_tests().await;
+        let mut txns = TxnsHandle::expect_open(client.clone()).await;
+        let mut cache = TxnsCache::expect_open(0, &txns).await;
+        let d0 = txns.expect_register(1).await;
+
+        const NUM_WRITES: usize = 25;
+        let tasks = FuturesUnordered::new();
+        for idx in 0..NUM_WRITES {
+            let mut txn = txns.begin();
+            txn.write(&d0, format!("{:05}", idx), (), 1).await;
+            let (txns_id, client) = (txns.txns_id(), client.clone());
+
+            let task = async move {
+                let data_write = writer(&client, d0).await;
+                let mut txns = TxnsHandle::expect_open_id(client.clone(), txns_id).await;
+                let register_ts = txns.register(1, data_write).await.unwrap();
+                debug!("{} registered at {}", idx, register_ts);
+
+                // Add some jitter to the commit timestamps (to create gaps) and
+                // to the execution (to create interleaving).
+                let jitter_ms = jitter();
+                let mut commit_ts = register_ts + 1 + jitter_ms;
+                let apply = loop {
+                    let () = tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                    match txn.commit_at(&mut txns, commit_ts).await {
+                        Ok(apply) => break apply,
+                        Err(new_commit_ts) => commit_ts = new_commit_ts,
+                    }
+                };
+                debug!("{} committed at {}", idx, commit_ts);
+
+                // Ditto sleep before apply.
+                let () = tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                let tidy = apply.apply(&mut txns).await;
+
+                // Ditto jitter the tidy timestamps and execution.
+                let jitter_ms = jitter();
+                let mut txn = txns.begin();
+                txn.tidy(tidy);
+                let mut tidy_ts = commit_ts + jitter_ms;
+                loop {
+                    let () = tokio::time::sleep(Duration::from_millis(jitter_ms)).await;
+                    match txn.commit_at(&mut txns, tidy_ts).await {
+                        Ok(apply) => {
+                            debug!("{} tidied at {}", idx, tidy_ts);
+                            assert!(apply.is_empty());
+                            return commit_ts;
+                        }
+                        Err(new_tidy_ts) => tidy_ts = new_tidy_ts,
+                    }
+                }
+            };
+            tasks.push(task)
+        }
+
+        let max_commit_ts = tasks
+            .collect::<Vec<_>>()
+            .await
+            .into_iter()
+            .max()
+            .unwrap_or_default();
+
+        let expected = (0..NUM_WRITES)
+            .map(|x| format!("{:05}", x))
+            .collect::<Vec<_>>();
+        let actual = cache.expect_snapshot(&client, d0, max_commit_ts).await;
+        assert_eq!(actual, expected);
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn tidy_race() {
+        let client = PersistClient::new_for_tests().await;
+        let mut txns0 = TxnsHandle::expect_open(client.clone()).await;
+        let d0 = txns0.expect_register(1).await;
+
+        // Commit something and apply it, but don't tidy yet.
+        let tidy0 = txns0.expect_commit_at(2, d0, &["foo"]).await;
+
+        // Now open an independent TxnsHandle, commit, apply, and tidy.
+        let mut txns1 = TxnsHandle::expect_open_id(client.clone(), txns0.txns_id()).await;
+        let d1 = txns1.expect_register(3).await;
+        let tidy1 = txns1.expect_commit_at(4, d1, &["foo"]).await;
+        let () = txns1.tidy_at(5, tidy1).await.unwrap();
+
+        // Now try the original tidy0. tidy1 has already done the retraction for
+        // it, so this needs to be careful not to double-retract.
+        let () = txns0.tidy_at(6, tidy0).await.unwrap();
+
+        // Replay a cache from the beginning and make sure we don't see a
+        // double retraction.
+        let mut cache = TxnsCache::expect_open(0, &txns0).await;
+        cache.update_gt(&6).await;
+        assert_eq!(cache.validate(), Ok(()));
+    }
 
     // Regression test for a bug caught during code review, where it was
     // possible to commit to an unregistered data shard.
@@ -281,17 +505,8 @@ mod tests {
     #[should_panic(expected = "should be registered")]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn commit_unregistered_table() {
-        let client = PersistClient::new_for_tests().await;
-        let mut txns = TxnsHandle::<Vec<u8>, (), u64, i64, TxnsCodecDefault>::open(
-            0,
-            client.clone(),
-            ShardId::new(),
-            Arc::new(VecU8Schema),
-            Arc::new(UnitSchema),
-        )
-        .await;
-        let d0 = ShardId::new();
-        txns.register(2, writer(&client, d0).await).await.unwrap();
+        let mut txns = TxnsHandle::expect_open(PersistClient::new_for_tests().await).await;
+        let d0 = txns.expect_register(2).await;
 
         let mut txn = txns.begin();
         txn.write(&d0, "foo".into(), (), 1).await;


### PR DESCRIPTION
Part 2 of at least 3, probably 4, hopefully not 5. See individual commits for details.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

Definitely recommend going commit-by-commit. Feel free to mostly scan "serialize batches as protobuf instead of json" because 90% of it gets overwritten in the next commit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
