### PR TITLE
compute,adapter: provide introspection for dataflow error counts

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -797,6 +797,21 @@ The `mz_compute_delays_histogram` view describes a histogram of the wall-clock d
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_compute_delays_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_compute_delays_histogram_raw -->
 
+### `mz_compute_error_counts`
+
+The `mz_compute_error_counts` view describes the counts of errors in objects exported by [dataflows][dataflow] in the system.
+
+Dataflow exports that don't have any errors are not included in this view.
+
+<!-- RELATION_SPEC mz_internal.mz_compute_error_counts -->
+| Field        | Type        | Meaning                                                                                              |
+| ------------ |-------------| --------                                                                                             |
+| `export_id`  | [`text`]    | The ID of the dataflow export. Corresponds to [`mz_compute_exports.export_id`](#mz_compute_exports). |
+| `count`      | [`numeric`] | The count of errors present in this dataflow export.                                                 |
+
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_compute_error_counts_per_worker -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_compute_error_counts_raw -->
+
 ### `mz_compute_exports`
 
 The `mz_compute_exports` view describes the objects exported by [dataflows][dataflow] in the system.

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1396,6 +1396,12 @@ pub const MZ_SCHEDULING_PARKS_HISTOGRAM_RAW: BuiltinLog = BuiltinLog {
     variant: LogVariant::Timely(TimelyLog::Parks),
 };
 
+pub const MZ_ARRANGEMENT_RECORDS_RAW: BuiltinLog = BuiltinLog {
+    name: "mz_arrangement_records_raw",
+    schema: MZ_INTERNAL_SCHEMA,
+    variant: LogVariant::Differential(DifferentialLog::ArrangementRecords),
+};
+
 pub const MZ_ARRANGEMENT_BATCHES_RAW: BuiltinLog = BuiltinLog {
     name: "mz_arrangement_batches_raw",
     schema: MZ_INTERNAL_SCHEMA,
@@ -1430,6 +1436,12 @@ pub const MZ_COMPUTE_DELAYS_HISTOGRAM_RAW: BuiltinLog = BuiltinLog {
     name: "mz_compute_delays_histogram_raw",
     schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Compute(ComputeLog::FrontierDelay),
+};
+
+pub const MZ_COMPUTE_ERROR_COUNTS_RAW: BuiltinLog = BuiltinLog {
+    name: "mz_compute_error_counts_raw",
+    schema: MZ_INTERNAL_SCHEMA,
+    variant: LogVariant::Compute(ComputeLog::ErrorCount),
 };
 
 pub const MZ_ACTIVE_PEEKS_PER_WORKER: BuiltinLog = BuiltinLog {
@@ -1496,12 +1508,6 @@ pub const MZ_DATAFLOW_OPERATOR_REACHABILITY_RAW: BuiltinLog = BuiltinLog {
     name: "mz_dataflow_operator_reachability_raw",
     schema: MZ_INTERNAL_SCHEMA,
     variant: LogVariant::Timely(TimelyLog::Reachability),
-};
-
-pub const MZ_ARRANGEMENT_RECORDS_RAW: BuiltinLog = BuiltinLog {
-    name: "mz_arrangement_records_raw",
-    schema: MZ_INTERNAL_SCHEMA,
-    variant: LogVariant::Differential(DifferentialLog::ArrangementRecords),
 };
 
 pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -3242,6 +3248,26 @@ SELECT
     pg_catalog.sum(count) AS count
 FROM mz_internal.mz_compute_delays_histogram_per_worker
 GROUP BY export_id, import_id, delay_ns",
+};
+
+pub const MZ_COMPUTE_ERROR_COUNTS_PER_WORKER: BuiltinView = BuiltinView {
+    name: "mz_compute_error_counts_per_worker",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_compute_error_counts_per_worker AS
+SELECT export_id, worker_id, count
+FROM mz_internal.mz_compute_error_counts_raw",
+};
+
+pub const MZ_COMPUTE_ERROR_COUNTS: BuiltinView = BuiltinView {
+    name: "mz_compute_error_counts",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_compute_error_counts AS
+SELECT
+    export_id,
+    pg_catalog.sum(count) AS count
+FROM mz_internal.mz_compute_error_counts_per_worker
+GROUP BY export_id
+HAVING pg_catalog.sum(count) != 0",
 };
 
 pub const MZ_MESSAGE_COUNTS_PER_WORKER: BuiltinView = BuiltinView {
@@ -5175,6 +5201,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Log(&MZ_COMPUTE_FRONTIERS_PER_WORKER),
         Builtin::Log(&MZ_COMPUTE_IMPORT_FRONTIERS_PER_WORKER),
         Builtin::Log(&MZ_COMPUTE_DELAYS_HISTOGRAM_RAW),
+        Builtin::Log(&MZ_COMPUTE_ERROR_COUNTS_RAW),
         Builtin::Table(&MZ_KAFKA_SINKS),
         Builtin::Table(&MZ_KAFKA_CONNECTIONS),
         Builtin::Table(&MZ_KAFKA_SOURCES),
@@ -5271,6 +5298,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::View(&MZ_SCHEDULING_PARKS_HISTOGRAM),
         Builtin::View(&MZ_COMPUTE_DELAYS_HISTOGRAM_PER_WORKER),
         Builtin::View(&MZ_COMPUTE_DELAYS_HISTOGRAM),
+        Builtin::View(&MZ_COMPUTE_ERROR_COUNTS_PER_WORKER),
+        Builtin::View(&MZ_COMPUTE_ERROR_COUNTS),
         Builtin::View(&MZ_SHOW_SOURCES),
         Builtin::View(&MZ_SHOW_SINKS),
         Builtin::View(&MZ_SHOW_MATERIALIZED_VIEWS),

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -56,6 +56,7 @@ message ProtoComputeLog {
         google.protobuf.Empty arrangement_heap_capacity = 9;
         google.protobuf.Empty arrangement_heap_allocations = 10;
         google.protobuf.Empty shutdown_duration = 11;
+        google.protobuf.Empty error_count = 12;
     }
 }
 message ProtoLogVariant {

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -229,6 +229,7 @@ pub enum ComputeLog {
     ArrangementHeapCapacity,
     ArrangementHeapAllocations,
     ShutdownDuration,
+    ErrorCount,
 }
 
 impl RustType<ProtoComputeLog> for ComputeLog {
@@ -246,6 +247,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
                 ComputeLog::ArrangementHeapCapacity => ArrangementHeapCapacity(()),
                 ComputeLog::ArrangementHeapAllocations => ArrangementHeapAllocations(()),
                 ComputeLog::ShutdownDuration => ShutdownDuration(()),
+                ComputeLog::ErrorCount => ErrorCount(()),
             }),
         }
     }
@@ -263,6 +265,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
             Some(ArrangementHeapCapacity(())) => Ok(ComputeLog::ArrangementHeapCapacity),
             Some(ArrangementHeapAllocations(())) => Ok(ComputeLog::ArrangementHeapAllocations),
             Some(ShutdownDuration(())) => Ok(ComputeLog::ShutdownDuration),
+            Some(ErrorCount(())) => Ok(ComputeLog::ErrorCount),
             None => Err(TryFromProtoError::missing_field("ProtoComputeLog::kind")),
         }
     }
@@ -405,13 +408,15 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::FrontierCurrent) => RelationDesc::empty()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("time", ScalarType::MzTimestamp.nullable(false)),
+                .with_column("time", ScalarType::MzTimestamp.nullable(false))
+                .with_key(vec![0, 1]),
 
             LogVariant::Compute(ComputeLog::ImportFrontierCurrent) => RelationDesc::empty()
                 .with_column("export_id", ScalarType::String.nullable(false))
                 .with_column("import_id", ScalarType::String.nullable(false))
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
-                .with_column("time", ScalarType::MzTimestamp.nullable(false)),
+                .with_column("time", ScalarType::MzTimestamp.nullable(false))
+                .with_key(vec![0, 1, 2]),
 
             LogVariant::Compute(ComputeLog::FrontierDelay) => RelationDesc::empty()
                 .with_column("export_id", ScalarType::String.nullable(false))
@@ -433,6 +438,12 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::ShutdownDuration) => RelationDesc::empty()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
+
+            LogVariant::Compute(ComputeLog::ErrorCount) => RelationDesc::empty()
+                .with_column("export_id", ScalarType::String.nullable(false))
+                .with_column("worker_id", ScalarType::UInt64.nullable(false))
+                .with_column("count", ScalarType::Int64.nullable(false))
+                .with_key(vec![0, 1]),
         }
     }
 }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -189,6 +189,7 @@ pub(super) fn construct<A: Allocate + 'static>(
         let (mut arrangement_heap_capacity_out, arrangement_heap_capacity) = demux.new_output();
         let (mut arrangement_heap_allocations_out, arrangement_heap_allocations) =
             demux.new_output();
+        let (mut error_count_out, error_count) = demux.new_output();
 
         let mut demux_state = DemuxState::new(worker2);
         let mut demux_buffer = Vec::new();
@@ -204,6 +205,7 @@ pub(super) fn construct<A: Allocate + 'static>(
                 let mut arrangement_heap_size = arrangement_heap_size_out.activate();
                 let mut arrangement_heap_capacity = arrangement_heap_capacity_out.activate();
                 let mut arrangement_heap_allocations = arrangement_heap_allocations_out.activate();
+                let mut error_count = error_count_out.activate();
 
                 input.for_each(|cap, data| {
                     data.swap(&mut demux_buffer);
@@ -219,6 +221,7 @@ pub(super) fn construct<A: Allocate + 'static>(
                         arrangement_heap_size: arrangement_heap_size.session(&cap),
                         arrangement_heap_capacity: arrangement_heap_capacity.session(&cap),
                         arrangement_heap_allocations: arrangement_heap_allocations.session(&cap),
+                        error_count: error_count.session(&cap),
                     };
 
                     for (time, logger_id, event) in demux_buffer.drain(..) {
@@ -328,6 +331,17 @@ pub(super) fn construct<A: Allocate + 'static>(
             .as_collection()
             .map(arrangement_heap_datum_to_row);
 
+        let error_count = error_count.as_collection().map({
+            let mut scratch = String::new();
+            move |datum| {
+                Row::pack_slice(&[
+                    make_string_datum(datum.export_id, &mut scratch),
+                    Datum::UInt64(u64::cast_from(worker_id)),
+                    Datum::Int64(datum.count),
+                ])
+            }
+        });
+
         use ComputeLog::*;
         let logs = [
             (DataflowCurrent, dataflow_current),
@@ -340,6 +354,7 @@ pub(super) fn construct<A: Allocate + 'static>(
             (ArrangementHeapSize, arrangement_heap_size),
             (ArrangementHeapCapacity, arrangement_heap_capacity),
             (ArrangementHeapAllocations, arrangement_heap_allocations),
+            (ErrorCount, error_count),
         ];
 
         // Build the output arrangements.
@@ -399,10 +414,8 @@ where
 struct DemuxState<A: Allocate> {
     /// The worker hosting this operator.
     worker: Worker<A>,
-    /// Maps dataflow exports to dataflow IDs.
-    export_dataflows: BTreeMap<GlobalId, usize>,
-    /// Maps dataflow exports to their imports and frontier delay tracking state.
-    export_imports: BTreeMap<GlobalId, BTreeMap<GlobalId, FrontierDelayState>>,
+    /// State tracked per dataflow export.
+    exports: BTreeMap<GlobalId, ExportState>,
     /// Maps live dataflows to counts of their exports.
     dataflow_export_counts: BTreeMap<usize, u32>,
     /// Maps dropped dataflows to their drop time.
@@ -419,13 +432,35 @@ impl<A: Allocate> DemuxState<A> {
     fn new(worker: Worker<A>) -> Self {
         Self {
             worker,
-            export_dataflows: Default::default(),
-            export_imports: Default::default(),
+            exports: Default::default(),
             dataflow_export_counts: Default::default(),
             dataflow_drop_times: Default::default(),
             shutdown_dataflows: Default::default(),
             peek_stash: Default::default(),
             arrangement_size: Default::default(),
+        }
+    }
+}
+
+/// State tracked for each dataflow export.
+struct ExportState {
+    /// The ID of the dataflow maintaining this export.
+    dataflow_id: usize,
+    /// Imports feeding this export, and their frontier delay tracking state.
+    imports: BTreeMap<GlobalId, FrontierDelayState>,
+    /// Number of errors in this export.
+    ///
+    /// This must be a signed integer, since per-worker error counts can be negative, only the
+    /// cross-worker total has to sum up to a non-negative value.
+    error_count: i64,
+}
+
+impl ExportState {
+    fn new(dataflow_id: usize) -> Self {
+        Self {
+            dataflow_id,
+            imports: Default::default(),
+            error_count: 0,
         }
     }
 }
@@ -439,6 +474,14 @@ struct FrontierDelayState {
     time_deque: VecDeque<(Timestamp, Duration)>,
     /// A histogram of emitted delays (bucket size to bucket_count).
     delay_map: BTreeMap<u128, i64>,
+}
+
+/// State for tracking arrangement sizes.
+#[derive(Default)]
+struct ArrangementSizeState {
+    size: isize,
+    capacity: isize,
+    count: isize,
 }
 
 type Update<D> = (D, Timestamp, Diff);
@@ -457,6 +500,7 @@ struct DemuxOutput<'a> {
     arrangement_heap_size: OutputSession<'a, ArrangementHeapDatum>,
     arrangement_heap_capacity: OutputSession<'a, ArrangementHeapDatum>,
     arrangement_heap_allocations: OutputSession<'a, ArrangementHeapDatum>,
+    error_count: OutputSession<'a, ErrorCountDatum>,
 }
 
 #[derive(Clone)]
@@ -490,11 +534,13 @@ struct ArrangementHeapDatum {
     operator_id: usize,
 }
 
-#[derive(Default)]
-struct ArrangementSizeState {
-    size: isize,
-    capacity: isize,
-    count: isize,
+#[derive(Clone)]
+struct ErrorCountDatum {
+    export_id: GlobalId,
+    // Normally we would use DD's diff field to encode counts, but in this case we can't: The total
+    // per-worker error count might be negative and at the SQL level having negative multiplicities
+    // is treated as an error.
+    count: i64,
 }
 
 /// Event handler of the demux operator.
@@ -556,7 +602,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
                 self.handle_arrangement_heap_size_operator_dropped(operator)
             }
             DataflowShutdown { dataflow_index } => self.handle_dataflow_shutdown(dataflow_index),
-            ErrorCount { .. } => { /* TODO */ }
+            ErrorCount { export_id, diff } => self.handle_error_count(export_id, diff),
         }
     }
 
@@ -565,8 +611,7 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         let datum = ExportDatum { id, dataflow_id };
         self.output.export.give((datum, ts, 1));
 
-        self.state.export_dataflows.insert(id, dataflow_id);
-        self.state.export_imports.insert(id, BTreeMap::new());
+        self.state.exports.insert(id, ExportState::new(dataflow_id));
         *self
             .state
             .dataflow_export_counts
@@ -575,46 +620,51 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
     }
 
     fn handle_export_dropped(&mut self, id: GlobalId) {
-        let ts = self.ts();
-        if let Some(dataflow_id) = self.state.export_dataflows.remove(&id) {
-            let datum = ExportDatum { id, dataflow_id };
-            self.output.export.give((datum, ts, -1));
-
-            match self.state.dataflow_export_counts.get_mut(&dataflow_id) {
-                entry @ Some(0) | entry @ None => {
-                    error!(
-                        export = ?id,
-                        dataflow = ?dataflow_id,
-                        "invalid dataflow_export_counts entry at time of export drop: {entry:?}",
-                    );
-                }
-                Some(1) => self.handle_dataflow_dropped(dataflow_id),
-                Some(count) => *count -= 1,
-            }
-        } else {
+        let Some(export) = self.state.exports.remove(&id) else {
             error!(
                 export = ?id,
-                "missing export_dataflows entry at time of export drop"
+                "missing exports entry at time of export drop"
             );
+            return;
+        };
+
+        let ts = self.ts();
+        let dataflow_id = export.dataflow_id;
+
+        let datum = ExportDatum { id, dataflow_id };
+        self.output.export.give((datum, ts, -1));
+
+        match self.state.dataflow_export_counts.get_mut(&dataflow_id) {
+            entry @ Some(0) | entry @ None => {
+                error!(
+                    export = ?id,
+                    dataflow = ?dataflow_id,
+                    "invalid dataflow_export_counts entry at time of export drop: {entry:?}",
+                );
+            }
+            Some(1) => self.handle_dataflow_dropped(dataflow_id),
+            Some(count) => *count -= 1,
         }
 
         // Remove frontier delay logging for this export.
-        if let Some(imports) = self.state.export_imports.remove(&id) {
-            for (import_id, delay_state) in imports {
-                for (delay_pow, count) in delay_state.delay_map {
-                    let datum = FrontierDelayDatum {
-                        export_id: id,
-                        import_id,
-                        delay_pow,
-                    };
-                    self.output.frontier_delay.give((datum, ts, -count));
-                }
+        for (import_id, delay_state) in export.imports {
+            for (delay_pow, count) in delay_state.delay_map {
+                let datum = FrontierDelayDatum {
+                    export_id: id,
+                    import_id,
+                    delay_pow,
+                };
+                self.output.frontier_delay.give((datum, ts, -count));
             }
-        } else {
-            error!(
-                export = ?id,
-                "missing export_imports entry at time of export drop"
-            );
+        }
+
+        // Remove error count logging for this export.
+        if export.error_count != 0 {
+            let datum = ErrorCountDatum {
+                export_id: id,
+                count: export.error_count,
+            };
+            self.output.error_count.give((datum, ts, -1));
         }
     }
 
@@ -648,6 +698,36 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
                 error!(dataflow = ?id, "dataflow already shutdown");
             }
         }
+    }
+
+    fn handle_error_count(&mut self, export_id: GlobalId, diff: i64) {
+        let ts = self.ts();
+
+        let Some(export) = self.state.exports.get_mut(&export_id) else {
+            // The export might have already been dropped, in which case we are no longer
+            // interested in its errors.
+            return;
+        };
+
+        let old_count = export.error_count;
+        let new_count = old_count + diff;
+
+        if old_count != 0 {
+            let datum = ErrorCountDatum {
+                export_id,
+                count: old_count,
+            };
+            self.output.error_count.give((datum, ts, -1));
+        }
+        if new_count != 0 {
+            let datum = ErrorCountDatum {
+                export_id,
+                count: new_count,
+            };
+            self.output.error_count.give((datum, ts, 1));
+        }
+
+        export.error_count = new_count;
     }
 
     fn handle_peek_install(&mut self, peek: Peek) {
@@ -696,8 +776,8 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
 
         // Check if we have imports associated to this export and report frontier advancement
         // delays.
-        if let Some(import_map) = self.state.export_imports.get_mut(&export_id) {
-            for (&import_id, delay_state) in import_map {
+        if let Some(export) = self.state.exports.get_mut(&export_id) {
+            for (&import_id, delay_state) in &mut export.imports {
                 let FrontierDelayState {
                     time_deque,
                     delay_map,
@@ -746,11 +826,11 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         }
 
         // Note that it is possible that we receive frontier updates for exports no longer present
-        // in `export_imports`. This behavior arises because `ImportFrontier` events are generated
+        // in `exports`. This behavior arises because `ImportFrontier` events are generated
         // by a dataflow `inspect_container` operator, which may outlive the corresponding trace or
         // sink recording in the current `ComputeState` until Timely eventually drops it.
-        if let Some(import_map) = self.state.export_imports.get_mut(&export_id) {
-            let delay_state = import_map.entry(import_id).or_default();
+        if let Some(export) = self.state.exports.get_mut(&export_id) {
+            let delay_state = export.imports.entry(import_id).or_default();
             delay_state.time_deque.push_back((frontier, self.time));
         }
     }

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -424,6 +424,12 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 4  count  numeric
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_compute_error_counts' ORDER BY position
+----
+1  export_id  text
+2  count  numeric
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_compute_exports' ORDER BY position
 ----
 1  export_id  text
@@ -607,6 +613,9 @@ mz_compute_delays_histogram
 mz_compute_delays_histogram_per_worker
 mz_compute_delays_histogram_raw
 mz_compute_dependencies
+mz_compute_error_counts
+mz_compute_error_counts_per_worker
+mz_compute_error_counts_raw
 mz_compute_exports
 mz_compute_exports_per_worker
 mz_compute_frontiers

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -203,15 +203,15 @@ bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  2  import_id  NULL  false
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  3  worker_id  NULL  false
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  4  delay_ns  NULL  false
+bar  mz_compute_error_counts_raw  mz_compute_error_counts_raw_u7_primary_idx  1  export_id  NULL  false
+bar  mz_compute_error_counts_raw  mz_compute_error_counts_raw_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_compute_exports_per_worker  mz_compute_exports_per_worker_u7_primary_idx  1  export_id  NULL  false
 bar  mz_compute_exports_per_worker  mz_compute_exports_per_worker_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_compute_frontiers_per_worker  mz_compute_frontiers_per_worker_u7_primary_idx  1  export_id  NULL  false
 bar  mz_compute_frontiers_per_worker  mz_compute_frontiers_per_worker_u7_primary_idx  2  worker_id  NULL  false
-bar  mz_compute_frontiers_per_worker  mz_compute_frontiers_per_worker_u7_primary_idx  3  time  NULL  false
 bar  mz_compute_import_frontiers_per_worker  mz_compute_import_frontiers_per_worker_u7_primary_idx  1  export_id  NULL  false
 bar  mz_compute_import_frontiers_per_worker  mz_compute_import_frontiers_per_worker_u7_primary_idx  2  import_id  NULL  false
 bar  mz_compute_import_frontiers_per_worker  mz_compute_import_frontiers_per_worker_u7_primary_idx  3  worker_id  NULL  false
-bar  mz_compute_import_frontiers_per_worker  mz_compute_import_frontiers_per_worker_u7_primary_idx  4  time  NULL  false
 bar  mz_compute_operator_durations_histogram_raw  mz_compute_operator_durations_histogram_raw_u7_primary_idx  1  id  NULL  false
 bar  mz_compute_operator_durations_histogram_raw  mz_compute_operator_durations_histogram_raw_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_compute_operator_durations_histogram_raw  mz_compute_operator_durations_histogram_raw_u7_primary_idx  3  duration_ns  NULL  false
@@ -396,7 +396,7 @@ DROP CLUSTER foo, foo2, foo3, foo4 CASCADE
 query I
 SELECT COUNT(name) FROM mz_indexes WHERE cluster_id = 'u1';
 ----
-24
+25
 
 query I
 SELECT COUNT(name) FROM mz_indexes WHERE cluster_id <> 'u1' AND cluster_id NOT LIKE 's%';
@@ -409,7 +409,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-132
+136
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -417,7 +417,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-108
+111
 
 simple conn=mz_system,user=mz_system
 ALTER CLUSTER default OWNER TO materialize

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -333,6 +333,18 @@ mz_compute_dependencies
 BASE TABLE
 materialize
 mz_internal
+mz_compute_error_counts
+VIEW
+materialize
+mz_internal
+mz_compute_error_counts_per_worker
+VIEW
+materialize
+mz_internal
+mz_compute_error_counts_raw
+SOURCE
+materialize
+mz_internal
 mz_compute_exports
 VIEW
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -523,6 +523,7 @@ mz_arrangement_heap_size_raw                 log   <null>   <null>
 mz_arrangement_heap_capacity_raw             log   <null>   <null>
 mz_arrangement_heap_allocations_raw          log   <null>   <null>
 mz_compute_delays_histogram_raw              log   <null>   <null>
+mz_compute_error_counts_raw                  log   <null>   <null>
 mz_compute_exports_per_worker                log   <null>   <null>
 mz_compute_frontiers_per_worker              log   <null>   <null>
 mz_compute_import_frontiers_per_worker       log   <null>   <null>
@@ -582,6 +583,8 @@ mz_cluster_replica_history
 mz_cluster_replica_utilization
 mz_compute_delays_histogram
 mz_compute_delays_histogram_per_worker
+mz_compute_error_counts
+mz_compute_error_counts_per_worker
 mz_compute_exports
 mz_compute_frontiers
 mz_compute_import_frontiers
@@ -661,7 +664,7 @@ test_table
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'
-108
+111
 
 # Create a second schema with the same table name as above
 > CREATE SCHEMA tester2

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -80,6 +80,9 @@ contains: canceling statement due to statement timeout
 > SELECT count(*) FROM mz_internal.mz_compute_delays_histogram_raw
 0
 
+> SELECT count(*) FROM mz_internal.mz_compute_error_counts_raw
+0
+
 > SELECT count(*) FROM mz_internal.mz_compute_exports_per_worker
 0
 
@@ -87,7 +90,7 @@ contains: canceling statement due to statement timeout
 > SELECT count(*)
   FROM mz_internal.mz_compute_frontiers_per_worker
   WHERE worker_id = 0
-24
+25
 
 > SELECT count(*) FROM mz_internal.mz_compute_import_frontiers_per_worker
 0

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -302,9 +302,10 @@ mz_cluster_replicas_ind                                     mz_cluster_replicas 
 mz_clusters_ind                                             mz_clusters                                  mz_introspection    {id}
 mz_compute_delays_histogram_raw_s2_primary_idx              mz_compute_delays_histogram_raw              mz_introspection    {export_id,import_id,worker_id,delay_ns}
 mz_compute_dependencies_ind                                 mz_compute_dependencies                      mz_introspection    {dependency_id}
+mz_compute_error_counts_raw_s2_primary_idx                  mz_compute_error_counts_raw                  mz_introspection    {export_id,worker_id}
 mz_compute_exports_per_worker_s2_primary_idx                mz_compute_exports_per_worker                mz_introspection    {export_id,worker_id}
-mz_compute_frontiers_per_worker_s2_primary_idx              mz_compute_frontiers_per_worker              mz_introspection    {export_id,worker_id,time}
-mz_compute_import_frontiers_per_worker_s2_primary_idx       mz_compute_import_frontiers_per_worker       mz_introspection    {export_id,import_id,worker_id,time}
+mz_compute_frontiers_per_worker_s2_primary_idx              mz_compute_frontiers_per_worker              mz_introspection    {export_id,worker_id}
+mz_compute_import_frontiers_per_worker_s2_primary_idx       mz_compute_import_frontiers_per_worker       mz_introspection    {export_id,import_id,worker_id}
 mz_compute_operator_durations_histogram_raw_s2_primary_idx  mz_compute_operator_durations_histogram_raw  mz_introspection    {id,worker_id,duration_ns}
 mz_dataflow_addresses_per_worker_s2_primary_idx             mz_dataflow_addresses_per_worker             mz_introspection    {id,worker_id}
 mz_dataflow_channels_per_worker_s2_primary_idx              mz_dataflow_channels_per_worker              mz_introspection    {id,worker_id}

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -328,6 +328,8 @@ ALTER SYSTEM SET enable_arrangement_size_logging = true
 > SELECT records, (size/1024/1024)::int FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%vt5_idx'
 10000 1
 
+> DROP TABLE t5 CASCADE
+
 # Test that `mz_dataflow_arrangement_sizes` shows dataflows not contained in the catalog.
 
 > CREATE TABLE t6 (a int)
@@ -340,3 +342,87 @@ ALTER SYSTEM SET enable_arrangement_size_logging = true
 > SELECT name, records > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t6%'
 "Dataflow: materialize.public.ii_t6"        true
 "Dataflow: materialize.public.ii_t6_plus_1" true
+
+# Test dataflow error introspection.
+#
+# Note that we are not able to see errors in index dataflows that just reuse
+# existing indexes (`idx2_div_by_zero`), because we are not able to attach a
+# logging operator to the reused arrangement.
+
+> CREATE TABLE zeros (a int)
+> CREATE VIEW v_div_by_zero AS SELECT 1 / a AS x FROM zeros
+> CREATE INDEX idx1_div_by_zero ON v_div_by_zero (x)
+> CREATE INDEX idx2_div_by_zero ON v_div_by_zero (x)
+> CREATE MATERIALIZED VIEW mv_div_by_zero AS SELECT 1 / a AS x FROM zeros
+> CREATE INDEX idx3_div_by_zero ON mv_div_by_zero (x)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+
+> INSERT INTO zeros VALUES (0)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx1_div_by_zero 1
+idx3_div_by_zero 1
+mv_div_by_zero   1
+
+> INSERT INTO zeros VALUES (0), (0)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx1_div_by_zero 3
+idx3_div_by_zero 3
+mv_div_by_zero   3
+
+> DELETE FROM zeros
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+
+# Test that error logging is retracted when objects are dropped.
+
+> INSERT INTO zeros VALUES (0), (0)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx1_div_by_zero 2
+idx3_div_by_zero 2
+mv_div_by_zero   2
+
+> DROP INDEX idx1_div_by_zero
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx3_div_by_zero 2
+mv_div_by_zero   2
+
+> DROP TABLE zeros CASCADE
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+
+# Test logging of errors in things that advance to the empty frontier.
+
+> CREATE MATERIALIZED VIEW mv_zero AS SELECT 0 AS x
+> CREATE MATERIALIZED VIEW mv2_div_by_zero AS SELECT 1 / x FROM mv_zero
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+mv2_div_by_zero 1

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -344,17 +344,12 @@ ALTER SYSTEM SET enable_arrangement_size_logging = true
 "Dataflow: materialize.public.ii_t6_plus_1" true
 
 # Test dataflow error introspection.
-#
-# Note that we are not able to see errors in index dataflows that just reuse
-# existing indexes (`idx2_div_by_zero`), because we are not able to attach a
-# logging operator to the reused arrangement.
 
 > CREATE TABLE zeros (a int)
 > CREATE VIEW v_div_by_zero AS SELECT 1 / a AS x FROM zeros
 > CREATE INDEX idx1_div_by_zero ON v_div_by_zero (x)
-> CREATE INDEX idx2_div_by_zero ON v_div_by_zero (x)
 > CREATE MATERIALIZED VIEW mv_div_by_zero AS SELECT 1 / a AS x FROM zeros
-> CREATE INDEX idx3_div_by_zero ON mv_div_by_zero (x)
+> CREATE INDEX idx2_div_by_zero ON mv_div_by_zero (x)
 
 > SELECT name, count
   FROM mz_internal.mz_compute_error_counts c
@@ -368,7 +363,7 @@ ALTER SYSTEM SET enable_arrangement_size_logging = true
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 idx1_div_by_zero 1
-idx3_div_by_zero 1
+idx2_div_by_zero 1
 mv_div_by_zero   1
 
 > INSERT INTO zeros VALUES (0), (0)
@@ -378,7 +373,7 @@ mv_div_by_zero   1
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 idx1_div_by_zero 3
-idx3_div_by_zero 3
+idx2_div_by_zero 3
 mv_div_by_zero   3
 
 > DELETE FROM zeros
@@ -397,7 +392,7 @@ mv_div_by_zero   3
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 idx1_div_by_zero 2
-idx3_div_by_zero 2
+idx2_div_by_zero 2
 mv_div_by_zero   2
 
 > DROP INDEX idx1_div_by_zero
@@ -406,10 +401,10 @@ mv_div_by_zero   2
   FROM mz_internal.mz_compute_error_counts c
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
-idx3_div_by_zero 2
+idx2_div_by_zero 2
 mv_div_by_zero   2
 
-> DROP TABLE zeros CASCADE
+> DROP MATERIALIZED VIEW mv_div_by_zero
 
 > SELECT name, count
   FROM mz_internal.mz_compute_error_counts c
@@ -426,3 +421,36 @@ mv_div_by_zero   2
   JOIN mz_objects o ON (c.export_id = o.id)
   ORDER BY name
 mv2_div_by_zero 1
+
+> DROP MATERIALIZED VIEW mv_zero CASCADE
+
+# Test logging of errors in reused indexes.
+
+> CREATE INDEX idx1_div_by_zero ON v_div_by_zero (x)
+> CREATE INDEX idx2_div_by_zero ON v_div_by_zero (x)
+> CREATE INDEX idx3_div_by_zero ON v_div_by_zero (x)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx1_div_by_zero 2
+idx2_div_by_zero 2
+idx3_div_by_zero 2
+
+> INSERT INTO zeros VALUES (0)
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name
+idx1_div_by_zero 3
+idx2_div_by_zero 3
+idx3_div_by_zero 3
+
+> DROP TABLE zeros CASCADE
+
+> SELECT name, count
+  FROM mz_internal.mz_compute_error_counts c
+  JOIN mz_objects o ON (c.export_id = o.id)
+  ORDER BY name

--- a/test/testdrive/logging.td
+++ b/test/testdrive/logging.td
@@ -66,6 +66,9 @@ $ set-regex match=s\d+ replacement=SID
 > SELECT count(*) FROM (SELECT count (*) FROM mz_internal.mz_compute_delays_histogram);
 1
 
+> SELECT count(*) FROM (SELECT count (*) FROM mz_internal.mz_compute_error_counts);
+1
+
 > SELECT count(*) FROM (SELECT count (*) FROM mz_internal.mz_active_peeks);
 1
 
@@ -208,3 +211,13 @@ SID   export_id   1           text
 SID   import_id   2           text
 SID   worker_id   3           uint8
 SID   time        4           mz_timestamp
+
+> SELECT mz_columns.id, mz_columns.name, position, type
+  FROM mz_views JOIN mz_columns USING (id)
+  WHERE mz_views.name = 'mz_compute_error_counts_per_worker'
+  ORDER BY position
+id      name        position    type
+--------------------------------------
+SID   export_id   1           text
+SID   worker_id   2           uint8
+SID   count       3           bigint

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -864,6 +864,7 @@ CREATE CLUSTER REPLICA default.replica SIZE = '2', INTROSPECTION DEBUGGING = tru
 "ArrangeByKey Compute(ArrangementHeapCapacity)"
 "ArrangeByKey Compute(ArrangementHeapSize)"
 "ArrangeByKey Compute(DataflowCurrent)"
+"ArrangeByKey Compute(ErrorCount)"
 "ArrangeByKey Compute(FrontierCurrent)"
 "ArrangeByKey Compute(FrontierDelay)"
 "ArrangeByKey Compute(ImportFrontierCurrent)"


### PR DESCRIPTION
This PR adds logging of error counts in dataflow exports to compute, as well as a set of `mz_compute_error_counts` introspection sources/views to surface the logged data. The intent is to provide an easy way for users to find out if any of their dataflows have errors, and for Mz support to be able to monitor error in users' dataflows.

### Motivation

  * This PR adds a known-desirable feature.

Closes #21453

### Tips for reviewer

You can look at the commit separately.

The main tests for these new sources live in `introspection-sources.td`. I tried to think of all the edge cases, but LMK if you find more!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add an `mz_internal.mz_compute_error_counts` introspection view that surfaces errors in indexes and materialized views.
