### PR TITLE
explain: implement `Display` for humanized `MirScalarExpr`s

### DIFF
--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -112,7 +112,7 @@ pub enum AdapterNotice {
     UnknownSessionDatabase(String),
     OptimizerNotice {
         notice: String,
-        hint: Option<String>,
+        hint: String,
     },
     WebhookSourceCreated {
         url: url::Url,
@@ -153,7 +153,7 @@ impl AdapterNotice {
                  List available databases with SHOW DATABASES."
                     .into(),
             ),
-            AdapterNotice::OptimizerNotice { notice: _, hint } => hint.clone(),
+            AdapterNotice::OptimizerNotice { notice: _, hint } => Some(hint.clone()),
             _ => None
         }
     }

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -28,7 +28,7 @@ use crate::{
     AccessStrategy, Id, LocalId, MapFilterProject, MirRelationExpr, MirScalarExpr, RowSetFinishing,
 };
 
-pub use crate::explain::text::display_singleton_row;
+pub use crate::explain::text::{display_singleton_row, HumanizedExpr};
 
 mod json;
 mod text;

--- a/src/transform/src/optimizer_notices.rs
+++ b/src/transform/src/optimizer_notices.rs
@@ -13,7 +13,7 @@ use std::fmt::{Error, Write};
 
 use itertools::Itertools;
 
-use mz_expr::explain::display_singleton_row;
+use mz_expr::explain::{display_singleton_row, Humanized};
 use mz_expr::MirScalarExpr;
 use mz_ore::str::separated;
 use mz_repr::explain::ExprHumanizer;
@@ -64,7 +64,7 @@ impl OptimizerNotice {
                         exprs
                             .clone()
                             .into_iter()
-                            .map(|expr| expr.to_string_with_col_names(&col_names)),
+                            .map(|expr| Humanized::new(&expr, &col_names).to_string()),
                     )
                 };
                 let index_key_display = display_exprs(index_key);
@@ -73,7 +73,7 @@ impl OptimizerNotice {
 
                 let usable_subset = usable_subset
                     .into_iter()
-                    .map(|expr| expr.clone().to_string_with_col_names(&col_names))
+                    .map(|expr| Humanized::new(expr, &col_names).to_string())
                     .collect_vec();
                 let usable_literal_constraints_display = if usable_subset.len() == 1 {
                     if literal_values.len() == 1 {

--- a/src/transform/src/optimizer_notices.rs
+++ b/src/transform/src/optimizer_notices.rs
@@ -9,11 +9,11 @@
 
 //! Notices that the optimizer wants to show to users.
 
-use std::fmt::{Error, Write};
+use std::fmt::{self, Error, Write};
 
-use itertools::Itertools;
+use itertools::{zip_eq, Itertools};
 
-use mz_expr::explain::{display_singleton_row, Humanized};
+use mz_expr::explain::{display_singleton_row, HumanizedExpr};
 use mz_expr::MirScalarExpr;
 use mz_ore::str::separated;
 use mz_repr::explain::ExprHumanizer;
@@ -37,99 +37,33 @@ pub enum OptimizerNotice {
     IndexKeyEmpty,
 }
 
+/// An index could be used for some literal constraints if the index included only a subset of its
+/// columns.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct IndexTooWideForLiteralConstraints {
+    /// The id of the index.
+    pub index_id: GlobalId,
+    /// The key of the index.
+    pub index_key: Vec<MirScalarExpr>,
+    /// A subset of the index keys. If the index were only on these keys, then it could have been
+    /// used for a lookup.
+    pub usable_subset: Vec<MirScalarExpr>,
+    /// Literal values that we would have looked up in the index, if it were on `usable_subset`.
+    pub literal_values: Vec<Row>,
+    /// The id of the object that the index is on.
+    pub index_on_id: GlobalId,
+    /// Our recommendation for what key should a new index have. Note that this might include more
+    /// columns than `usable_subset`.
+    pub recommended_key: Vec<MirScalarExpr>,
+}
+
 impl OptimizerNotice {
     /// Turns the `OptimizerNotice` into a string, using the given `ExprHumanizer`.
-    pub fn to_string(&self, humanizer: &dyn ExprHumanizer) -> (String, Option<String>) {
-        match self {
-            OptimizerNotice::IndexTooWideForLiteralConstraints(
-                IndexTooWideForLiteralConstraints {
-                    index_id,
-                    index_key,
-                    usable_subset,
-                    literal_values,
-                    index_on_id,
-                    recommended_key,
-                },
-            ) => {
-                let index_name = humanizer
-                    .humanize_id(*index_id)
-                    .unwrap_or_else(|| index_id.to_string());
-                let index_on_id_name = humanizer
-                    .humanize_id_unqualified(*index_on_id)
-                    .unwrap_or_else(|| index_on_id.to_string());
-                let col_names = humanizer.column_names_for_id(*index_on_id);
-                let display_exprs = |exprs: &Vec<MirScalarExpr>| {
-                    separated(
-                        ", ",
-                        exprs
-                            .clone()
-                            .into_iter()
-                            .map(|expr| Humanized::new(&expr, &col_names).to_string()),
-                    )
-                };
-                let index_key_display = display_exprs(index_key);
-                let usable_subset_display = display_exprs(usable_subset);
-                let recommended_cols_display = display_exprs(recommended_key);
-
-                let usable_subset = usable_subset
-                    .into_iter()
-                    .map(|expr| Humanized::new(expr, &col_names).to_string())
-                    .collect_vec();
-                let usable_literal_constraints_display = if usable_subset.len() == 1 {
-                    if literal_values.len() == 1 {
-                        format!(
-                            "{} = {}",
-                            usable_subset[0],
-                            display_singleton_row(literal_values[0].clone())
-                        )
-                    } else {
-                        format!(
-                            "{} IN ({})",
-                            usable_subset[0],
-                            separated(
-                                ", ",
-                                literal_values
-                                    .iter()
-                                    .map(|r| display_singleton_row(r.clone()))
-                            )
-                        )
-                    }
-                } else {
-                    if literal_values.len() == 1 {
-                        format!(
-                            "{}",
-                            separated(
-                                " AND ",
-                                usable_subset
-                                    .into_iter()
-                                    .zip_eq(literal_values[0].into_iter())
-                                    .map(|(key_field, value)| {
-                                        format!("{} = {}", key_field, value)
-                                    })
-                            )
-                        )
-                    } else {
-                        format!(
-                            "({}) IN ({})",
-                            usable_subset_display,
-                            separated(", ", literal_values)
-                        )
-                    }
-                };
-
-                // TODO: Also print whether the index is used elsewhere (for something that is not a
-                // full scan), so that the user knows whether to delete the old index.
-                (
-                    format!("Index {index_name} on {index_on_id_name}({index_key_display}) is too wide to use for literal equalities `{usable_literal_constraints_display}`."),
-                    Some(format!("If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: ({recommended_cols_display}).")),
-                )
-            }
-            OptimizerNotice::IndexKeyEmpty =>
-                (
-                    "Empty index key. The index will be completely skewed to one worker thread, which can lead to performance problems.".to_string(),
-                    Some("CREATE DEFAULT INDEX is almost always better than an index with an empty key. (Except for cross joins with big inputs, which are better to avoid anyway.)".to_string()),
-                )
-        }
+    pub fn to_string(&self, humanizer: &dyn ExprHumanizer) -> (String, String) {
+        (
+            HumanizedNoticeMsg::new(self, humanizer).to_string(),
+            HumanizedNoticeHint::new(self, humanizer).to_string(),
+        )
     }
 
     /// Turns a `Vec<OptimizerNotice>` into a String that can be used in EXPLAIN.
@@ -140,13 +74,11 @@ impl OptimizerNotice {
         let mut notice_strings = Vec::new();
         for notice in notices {
             if notice.is_valid(humanizer) {
-                let (notice, hint) = notice.to_string(humanizer);
                 let mut s = String::new();
-                write!(s, "  - Notice: {}", notice)?;
-                match hint {
-                    Some(hint) => write!(s, "\n    Hint: {}", hint)?,
-                    None => {}
-                }
+                let msg = HumanizedNoticeMsg::new(notice, humanizer);
+                let hint = HumanizedNoticeHint::new(notice, humanizer);
+                write!(s, "  - Notice: {}\n", msg)?;
+                write!(s, "    Hint: {}", hint)?;
                 notice_strings.push(s);
             }
         }
@@ -168,22 +100,159 @@ impl OptimizerNotice {
     }
 }
 
-/// An index could be used for some literal constraints if the index included only a subset of its
-/// columns.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct IndexTooWideForLiteralConstraints {
-    /// The id of the index.
-    pub index_id: GlobalId,
-    /// The key of the index.
-    pub index_key: Vec<MirScalarExpr>,
-    /// A subset of the index keys. If the index were only on these keys, then it could have been
-    /// used for a lookup.
-    pub usable_subset: Vec<MirScalarExpr>,
-    /// Literal values that we would have looked up in the index, if it were on `usable_subset`.
-    pub literal_values: Vec<Row>,
-    /// The id of the object that the index is on.
-    pub index_on_id: GlobalId,
-    /// Our recommendation for what key should a new index have. Note that this might include more
-    /// columns than `usable_subset`.
-    pub recommended_key: Vec<MirScalarExpr>,
+#[derive(Debug)]
+struct HumanizedNoticeMsg<'a> {
+    notice: &'a OptimizerNotice,
+    humanizer: &'a dyn ExprHumanizer,
+}
+
+impl<'a> HumanizedNoticeMsg<'a> {
+    fn new(notice: &'a OptimizerNotice, humanizer: &'a dyn ExprHumanizer) -> Self {
+        Self { notice, humanizer }
+    }
+}
+
+impl<'a> fmt::Display for HumanizedNoticeMsg<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.notice {
+            OptimizerNotice::IndexTooWideForLiteralConstraints(
+                IndexTooWideForLiteralConstraints {
+                    index_id,
+                    index_key,
+                    usable_subset,
+                    literal_values,
+                    index_on_id,
+                    ..
+                },
+            ) => {
+                let col_names = self.humanizer.column_names_for_id(*index_on_id);
+
+                let index_name = self
+                    .humanizer
+                    .humanize_id(*index_id)
+                    .unwrap_or_else(|| index_id.to_string());
+
+                let index_on_id_name = self
+                    .humanizer
+                    .humanize_id_unqualified(*index_on_id)
+                    .unwrap_or_else(|| index_on_id.to_string());
+
+                let index_key = separated(
+                    ", ",
+                    index_key
+                        .iter()
+                        .map(|expr| HumanizedExpr::new(expr, &col_names)),
+                );
+                let usable_subset_display = separated(
+                    ", ",
+                    usable_subset
+                        .iter()
+                        .map(|expr| HumanizedExpr::new(expr, &col_names)),
+                );
+
+                write!(f, "Index {index_name} on {index_on_id_name}({index_key}) is too wide to use for literal equalities `")?;
+                {
+                    let usable_subset = usable_subset
+                        .into_iter()
+                        .map(|expr| HumanizedExpr::new(expr, &col_names))
+                        .collect_vec();
+                    if usable_subset.len() == 1 {
+                        if literal_values.len() == 1 {
+                            write!(
+                                f,
+                                "{} = {}",
+                                usable_subset[0],
+                                display_singleton_row(literal_values[0].clone())
+                            )?;
+                        } else {
+                            write!(
+                                f,
+                                "{} IN ({})",
+                                usable_subset[0],
+                                separated(
+                                    ", ",
+                                    literal_values
+                                        .iter()
+                                        .map(|r| display_singleton_row(r.clone()))
+                                )
+                            )?;
+                        }
+                    } else {
+                        if literal_values.len() == 1 {
+                            write!(
+                                f,
+                                "{}",
+                                separated(
+                                    " AND ",
+                                    zip_eq(
+                                        usable_subset.into_iter(),
+                                        literal_values[0].into_iter()
+                                    )
+                                    .map(
+                                        |(key_field, value)| {
+                                            format!("{} = {}", key_field, value)
+                                        }
+                                    )
+                                )
+                            )?;
+                        } else {
+                            write!(
+                                f,
+                                "({}) IN ({})",
+                                usable_subset_display,
+                                separated(", ", literal_values)
+                            )?;
+                        }
+                    };
+                }
+                write!(f, "`.")
+            }
+            OptimizerNotice::IndexKeyEmpty => {
+                write!(f, "Empty index key. The index will be completely skewed to one worker thread, which can lead to performance problems.")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+struct HumanizedNoticeHint<'a> {
+    notice: &'a OptimizerNotice,
+    humanizer: &'a dyn ExprHumanizer,
+}
+
+impl<'a> HumanizedNoticeHint<'a> {
+    fn new(notice: &'a OptimizerNotice, humanizer: &'a dyn ExprHumanizer) -> Self {
+        Self { notice, humanizer }
+    }
+}
+
+impl<'a> fmt::Display for HumanizedNoticeHint<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.notice {
+            OptimizerNotice::IndexTooWideForLiteralConstraints(
+                IndexTooWideForLiteralConstraints {
+                    index_on_id,
+                    recommended_key,
+                    ..
+                },
+            ) => {
+                let col_names = self.humanizer.column_names_for_id(*index_on_id);
+                let recommended_key = {
+                    separated(
+                        ", ",
+                        recommended_key
+                            .iter()
+                            .map(|expr| HumanizedExpr::new(expr, &col_names)),
+                    )
+                };
+
+                // TODO: Also print whether the index is used elsewhere (for something that is not a
+                // full scan), so that the user knows whether to delete the old index.
+                write!(f, "If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: ({recommended_key}).")
+            }
+            OptimizerNotice::IndexKeyEmpty => {
+                write!(f, "CREATE DEFAULT INDEX is almost always better than an index with an empty key. (Except for cross joins with big inputs, which are better to avoid anyway.)")
+            }
+        }
+    }
 }


### PR DESCRIPTION
Some follow-ups from #18089.

### Motivation

   * This PR refactors existing code.

Addresses leftover TODOs from #18089.

### Tips for reviewer

See commit messages for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
