### PR TITLE
persist: downgrade force apply hostname diff error

### DIFF
--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1051,6 +1051,7 @@ pub struct StateMetrics {
     pub(crate) fetch_recent_live_diffs_slow_path: IntCounter,
     pub(crate) writer_added: IntCounter,
     pub(crate) writer_removed: IntCounter,
+    pub(crate) force_apply_hostname_total: IntCounter,
 }
 
 impl StateMetrics {
@@ -1111,6 +1112,10 @@ impl StateMetrics {
             writer_removed: registry.register(metric!(
                 name: "mz_persist_state_writer_removed",
                 help: "count of writers removed from the state",
+            )),
+            force_apply_hostname_total: registry.register(metric!(
+                name: "mz_persist_state_force_apply_hostname_total",
+                help: "count of when hostname diffs needed to be force applied",
             )),
         }
     }

--- a/src/persist-client/src/internal/metrics.rs
+++ b/src/persist-client/src/internal/metrics.rs
@@ -1051,7 +1051,7 @@ pub struct StateMetrics {
     pub(crate) fetch_recent_live_diffs_slow_path: IntCounter,
     pub(crate) writer_added: IntCounter,
     pub(crate) writer_removed: IntCounter,
-    pub(crate) force_apply_hostname_total: IntCounter,
+    pub(crate) force_apply_hostname: IntCounter,
 }
 
 impl StateMetrics {
@@ -1113,8 +1113,8 @@ impl StateMetrics {
                 name: "mz_persist_state_writer_removed",
                 help: "count of writers removed from the state",
             )),
-            force_apply_hostname_total: registry.register(metric!(
-                name: "mz_persist_state_force_apply_hostname_total",
+            force_apply_hostname: registry.register(metric!(
+                name: "mz_persist_state_force_applied_hostname",
                 help: "count of when hostname diffs needed to be force applied",
             )),
         }

--- a/src/persist-client/src/internal/state_diff.rs
+++ b/src/persist-client/src/internal/state_diff.rs
@@ -492,7 +492,7 @@ fn force_apply_diff_single<X: PartialEq + Debug>(
                     "{}: update didn't match: {:?} vs {:?}, continuing to force apply diff to {:?} for shard {} and seqno {}",
                     name, single, &from, &to, shard_id, seqno
                 );
-                metrics.state.force_apply_hostname_total.inc();
+                metrics.state.force_apply_hostname.inc();
             }
             *single = to
         }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This error has gotten noisy because it reoccurs when reading old states (like during shard finalization, which currently doesn't work so we keep rereading the same old diffs). Replacing with a `debug!` line we can toggle on to find examples / a metric to double check if it's still happening when we get around to fixing this.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
