### PR TITLE
sqlsmith: Only print out panics once

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -273,10 +273,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     for frozen_key, errors in new_errors.items():
         key = dict(frozen_key)
-        occurences = f" ({len(errors)} occurences)" if len(errors) > 1 else ""
-        print(
-            f"--- [SQLsmith] {key['type']} {key['sqlstate']}: {key['message']}{occurences}"
-        )
+        occurrences = f" ({len(errors)} occurrences)" if len(errors) > 1 else ""
+        # Print out crashes differently so that we don't get notified twice in ci_logged_errors_detect
+        if "server closed the connection unexpectedly" in key["message"]:
+            print(f"--- Server crash, check panics and segfaults {occurrences}")
+        else:
+            print(
+                f"--- [SQLsmith] {key['type']} {key['sqlstate']}: {key['message']}{occurrences}"
+            )
         if len(errors) > 1:
             from_time = datetime.fromtimestamp(errors[0]["timestamp"]).strftime(
                 "%H:%M:%S"


### PR DESCRIPTION
Reduces noise in nightlies

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
