### PR TITLE
ci: All platform-checks run for 60 min

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -401,7 +401,7 @@ steps:
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -423,7 +423,7 @@ steps:
 
   - id: checks-parallel-restart-entire-mz
     label: "Checks parallel + restart of the entire Mz"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -434,7 +434,7 @@ steps:
 
   - id: checks-parallel-restart-environmentd-clusterd-storage
     label: "Checks parallel + restart of environmentd & storage clusterd"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -445,7 +445,7 @@ steps:
 
   - id: checks-parallel-kill-clusterd-storage
     label: "Checks parallel + kill storage clusterd"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
@@ -456,7 +456,7 @@ steps:
 
   - id: checks-parallel-restart-redpanda
     label: "Checks parallel + restart Redpanda & Debezium"
-    timeout_in_minutes: 30
+    timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
     artifact_paths: junit_*.xml


### PR DESCRIPTION
Caused timeouts again: https://buildkite.com/materialize/nightlies/builds/3854#_

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
