### PR TITLE
[persist] Allow passing leased runs to the consolidator

### DIFF
--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -687,6 +687,7 @@ where
         );
 
         let mut consolidator = Consolidator::new(
+            Arc::clone(&metrics),
             FetchBatchFilter::Compaction {
                 since: desc.since().clone(),
             },

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -710,7 +710,7 @@ where
             metrics.compaction.not_all_prefetched.inc();
         }
 
-        while let Some(updates) = consolidator.next().await {
+        while let Some(updates) = consolidator.next().await? {
             for (k, v, t, d) in updates.take(cfg.compaction_yield_after_n_updates) {
                 batch
                     .add(&real_schemas, &k.to_vec(), &v.to_vec(), &t, &d)

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -9,13 +9,12 @@
 
 //! Code for iterating through one or more parts, including streaming consolidation.
 
+use anyhow::bail;
 use std::cmp::Reverse;
 use std::collections::binary_heap::PeekMut;
 use std::collections::{BinaryHeap, VecDeque};
-use std::future::Future;
 use std::marker::PhantomData;
 use std::mem;
-use std::pin::Pin;
 use std::sync::Arc;
 
 use differential_dataflow::consolidation::consolidate_updates;
@@ -32,6 +31,7 @@ use tracing::{debug_span, Instrument};
 
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart, FetchBatchFilter, LeasedBatchPart};
 use crate::internal::metrics::{BatchPartReadMetrics, ReadMetrics, ShardMetrics};
+use crate::internal::paths::PartialBatchKey;
 use crate::internal::state::HollowBatchPart;
 use crate::metrics::Metrics;
 use crate::read::SubscriptionLeaseReturner;
@@ -48,14 +48,92 @@ fn clone_tuple<T, D>((k, v, t, d): TupleRef<T, D>) -> Tuple<T, D> {
     ((k.to_vec(), v.to_vec()), t, d)
 }
 
-pub(crate) enum ConsolidationPart<T, D> {
-    Queued {
-        future: Pin<Box<dyn Future<Output = anyhow::Result<EncodedPart<T>>> + Send>>,
+/// The data needed to fetch a batch part, bundled up to make it easy
+/// to send between threads.
+#[derive(Debug)]
+pub(crate) enum FetchData<T: Timestamp + Codec64> {
+    Unleased {
+        shard_id: ShardId,
+        blob: Arc<dyn Blob + Send + Sync>,
         metrics: Arc<Metrics>,
+        read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
+        shard_metrics: Arc<ShardMetrics>,
+        part_key: PartialBatchKey,
+        part_desc: Description<T>,
+    },
+    Leased {
+        blob: Arc<dyn Blob + Send + Sync>,
+        read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
+        shard_metrics: Arc<ShardMetrics>,
+        lease_returner: SubscriptionLeaseReturner,
+        part: LeasedBatchPart<T>,
+    },
+    AlreadyFetched,
+}
+
+impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
+    fn take(&mut self) -> Self {
+        mem::replace(self, FetchData::AlreadyFetched)
+    }
+
+    async fn fetch(self) -> anyhow::Result<EncodedPart<T>> {
+        match self {
+            FetchData::Unleased {
+                shard_id,
+                blob,
+                metrics,
+                read_metrics,
+                shard_metrics,
+                part_key,
+                part_desc,
+            } => {
+                fetch_batch_part(
+                    &shard_id,
+                    &*blob,
+                    &metrics,
+                    &shard_metrics,
+                    read_metrics(&metrics.read),
+                    &part_key,
+                    &part_desc,
+                )
+                .await
+            }
+            FetchData::Leased {
+                blob,
+                read_metrics,
+                shard_metrics,
+                mut lease_returner,
+                part,
+            } => {
+                // We do not use fetch_leased_part, since that requires more type info
+                // than we have available here.
+                let fetched = fetch_batch_part(
+                    &part.shard_id,
+                    &*blob,
+                    &part.metrics,
+                    &*shard_metrics,
+                    read_metrics(&part.metrics.read),
+                    &part.key,
+                    &part.desc,
+                )
+                .await;
+                lease_returner.return_leased_part(part);
+                fetched
+            }
+            FetchData::AlreadyFetched => {
+                bail!("Fetched already-fetched part!")
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum ConsolidationPart<T: Timestamp + Codec64, D> {
+    Queued {
+        data: FetchData<T>,
     },
     Prefetched {
         handle: JoinHandle<anyhow::Result<EncodedPart<T>>>,
-        metrics: Arc<Metrics>,
     },
     Encoded {
         part: EncodedPart<T>,
@@ -65,15 +143,6 @@ pub(crate) enum ConsolidationPart<T, D> {
         data: Vec<((Vec<u8>, Vec<u8>), T, D)>,
         index: usize,
     },
-}
-
-impl<T, D> Default for ConsolidationPart<T, D> {
-    fn default() -> Self {
-        Self::Sorted {
-            data: vec![],
-            index: 0,
-        }
-    }
 }
 
 impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> ConsolidationPart<T, D> {
@@ -93,22 +162,6 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
         let mut data: Vec<_> = data.into_iter().map(clone_tuple).collect();
         consolidate_updates(&mut data);
         Self::Sorted { data, index: 0 }
-    }
-
-    async fn join(&mut self, filter: &'a FetchBatchFilter<T>) -> anyhow::Result<()> {
-        match self {
-            ConsolidationPart::Queued { future, metrics } => {
-                metrics.compaction.parts_waited.inc();
-                let part = future.await;
-                *self = Self::from_encoded(part?, filter);
-            }
-            ConsolidationPart::Prefetched { handle, metrics } => {
-                metrics.compaction.parts_waited.inc();
-                *self = Self::from_encoded(handle.await??, filter);
-            }
-            ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
-        }
-        Ok(())
     }
 
     /// This requires a mutable pointer because the cursor may need to scan ahead to find the next
@@ -136,7 +189,9 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
 /// return  an iterator over a consolidated subset of the data. To read an entire dataset, the
 /// client should call `next` until it returns `None`, which signals all data has been returned...
 /// but it's also free to abandon the instance at any time if it eg. only needs a few entries.
-pub(crate) struct Consolidator<T, D> {
+#[derive(Debug)]
+pub(crate) struct Consolidator<T: Timestamp + Codec64, D> {
+    metrics: Arc<Metrics>,
     runs: Vec<VecDeque<(ConsolidationPart<T, D>, usize)>>,
     filter: FetchBatchFilter<T>,
     budget: usize,
@@ -156,8 +211,13 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
     /// Create a new [Self] instance with the given prefetch budget. This budget is a "soft limit"
     /// on the size of the parts that the consolidator will fetch... we'll try and stay below the
     /// limit, but may burst above it if that's necessary to make progress.
-    pub fn new(filter: FetchBatchFilter<T>, prefetch_budget_bytes: usize) -> Self {
+    pub fn new(
+        metrics: Arc<Metrics>,
+        filter: FetchBatchFilter<T>,
+        prefetch_budget_bytes: usize,
+    ) -> Self {
         Self {
+            metrics,
             runs: vec![],
             filter,
             budget: prefetch_budget_bytes,
@@ -186,25 +246,16 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         let run = parts
             .into_iter()
             .map(|part: &HollowBatchPart| {
-                let part_key = part.key.clone();
-                let blob = Arc::clone(blob);
-                let metrics = Arc::clone(metrics);
-                let shard_metrics = Arc::clone(shard_metrics);
-                let desc = desc.clone();
                 let c_part = ConsolidationPart::Queued {
-                    metrics: Arc::clone(&metrics),
-                    future: Box::pin(async move {
-                        fetch_batch_part(
-                            &shard_id,
-                            &*blob,
-                            &metrics,
-                            &shard_metrics,
-                            read_metrics(&metrics.read),
-                            &part_key,
-                            &desc,
-                        )
-                        .await
-                    }),
+                    data: FetchData::Unleased {
+                        shard_id,
+                        blob: Arc::clone(blob),
+                        metrics: Arc::clone(metrics),
+                        read_metrics,
+                        shard_metrics: Arc::clone(shard_metrics),
+                        part_key: part.key.clone(),
+                        part_desc: desc.clone(),
+                    },
                 };
                 (c_part, part.encoded_size_bytes)
             })
@@ -218,40 +269,23 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         blob: &Arc<dyn Blob + Send + Sync>,
         read_metrics: fn(&BatchPartReadMetrics) -> &ReadMetrics,
         shard_metrics: &Arc<ShardMetrics>,
-        lease_returner: SubscriptionLeaseReturner,
+        lease_returner: &SubscriptionLeaseReturner,
         parts: impl IntoIterator<Item = LeasedBatchPart<T>>,
     ) {
         let run = parts
             .into_iter()
             .map(|part: LeasedBatchPart<T>| {
-                let size_bytes = part.encoded_size_bytes;
-                let blob = Arc::clone(blob);
-                let metrics = Arc::clone(&part.metrics);
-                let shard_metrics = Arc::clone(shard_metrics);
-                let mut lease_returner = lease_returner.clone();
-                let future = async move {
-                    // We do not use fetch_leased_part, since that requires more type info
-                    // than we have available here.
-                    let fetched = fetch_batch_part(
-                        &part.shard_id,
-                        &*blob,
-                        &part.metrics,
-                        &*shard_metrics,
-                        read_metrics(&part.metrics.read),
-                        &part.key,
-                        &part.desc,
-                    )
-                    .await;
-                    lease_returner.return_leased_part(part);
-                    fetched
-                };
-                (
-                    ConsolidationPart::Queued {
-                        future: Box::pin(future),
-                        metrics,
+                let size = part.encoded_size_bytes;
+                let queued = ConsolidationPart::Queued {
+                    data: FetchData::Leased {
+                        blob: Arc::clone(blob),
+                        read_metrics,
+                        shard_metrics: Arc::clone(shard_metrics),
+                        lease_returner: lease_returner.clone(),
+                        part,
                     },
-                    size_bytes,
-                )
+                };
+                (queued, size)
             })
             .collect();
         self.runs.push(run);
@@ -321,11 +355,21 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
             .runs
             .iter_mut()
             .map(|run| async {
-                run.front_mut()
-                    .expect("trimmed run should be nonempty")
-                    .0
-                    .join(&self.filter)
-                    .await
+                let part = &mut run.front_mut().expect("trimmed run should be nonempty").0;
+                match part {
+                    ConsolidationPart::Queued { data } => {
+                        self.metrics.compaction.parts_waited.inc();
+                        *part = ConsolidationPart::from_encoded(
+                            data.take().fetch().await?,
+                            &self.filter,
+                        );
+                    }
+                    ConsolidationPart::Prefetched { handle } => {
+                        *part = ConsolidationPart::from_encoded(handle.await??, &self.filter);
+                    }
+                    ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
+                }
+                Ok::<(), anyhow::Error>(())
             })
             .collect();
         let () = futures.try_collect().await?;
@@ -377,20 +421,22 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         let max_run_len = self.runs.iter().map(|x| x.len()).max().unwrap_or_default();
         for idx in 0..max_run_len {
             for run in self.runs.iter_mut() {
-                if let Some((c_part @ ConsolidationPart::Queued { .. }, size)) = run.get_mut(idx) {
-                    check_budget(*size)?;
-
-                    let ConsolidationPart::Queued { future, metrics } = mem::take(c_part) else {
-                        panic!("just checked this");
+                if let Some((c_part, size)) = run.get_mut(idx) {
+                    let data = match c_part {
+                        ConsolidationPart::Queued { data } => {
+                            check_budget(*size)?;
+                            data.take()
+                        }
+                        _ => continue,
                     };
+                    self.metrics.compaction.parts_prefetched.inc();
 
                     let span = debug_span!("compaction::prefetch");
-                    metrics.compaction.parts_prefetched.inc();
                     let handle = mz_ore::task::spawn(
                         || "persist::compaction::prefetch",
-                        async move { future.await }.instrument(span),
+                        data.fetch().instrument(span),
                     );
-                    *c_part = ConsolidationPart::Prefetched { handle, metrics };
+                    *c_part = ConsolidationPart::Prefetched { handle };
                 }
             }
         }
@@ -646,8 +692,13 @@ mod tests {
                 rows
             };
             let streaming = {
+                let metrics = Arc::new(Metrics::new(
+                    &PersistConfig::new_for_tests(),
+                    &MetricsRegistry::new(),
+                ));
                 // Toy compaction loop!
                 let mut consolidator = Consolidator {
+                    metrics,
                     // Generated runs of data that are sorted, but not necessarily consolidated.
                     // This is because timestamp-advancement may cause us to have duplicate KVTs,
                     // including those that span runs.
@@ -723,6 +774,7 @@ mod tests {
             let shard_metrics = metrics.shards.shard(&shard_id, "");
 
             let mut consolidator: Consolidator<u64, i64> = Consolidator::new(
+                Arc::clone(&metrics),
                 FetchBatchFilter::Compaction {
                     since: desc.since().clone(),
                 },

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -1110,6 +1110,7 @@ where
         let batches = self.machine.snapshot(&as_of).await?;
 
         let mut consolidator = Consolidator::new(
+            Arc::clone(&self.metrics),
             FetchBatchFilter::Snapshot {
                 as_of: as_of.clone(),
             },
@@ -1132,7 +1133,7 @@ where
                     &self.blob,
                     |m| &m.snapshot,
                     &self.machine.applier.shard_metrics,
-                    self.lease_returner.clone(),
+                    &self.lease_returner,
                     leased_parts.into_iter(),
                 );
             }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -19,6 +19,7 @@ use std::time::{Duration, SystemTime};
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::trace::Description;
 use futures::stream::{FuturesUnordered, StreamExt};
 use futures::{FutureExt, Stream};
 use mz_ore::now::EpochMillis;
@@ -42,7 +43,7 @@ use crate::fetch::{
 use crate::internal::encoding::Schemas;
 use crate::internal::machine::Machine;
 use crate::internal::metrics::{Metrics, MetricsRetryStream};
-use crate::internal::state::{HollowBatch, Since};
+use crate::internal::state::{HollowBatch, HollowBatchPart, Since};
 use crate::internal::watch::StateWatch;
 use crate::iter::Consolidator;
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
@@ -732,23 +733,35 @@ where
         Ok(Subscribe::new(snapshot_parts, listen))
     }
 
-    fn lease_batch_parts(
+    fn lease_batch_part(
         &mut self,
-        batch: HollowBatch<T>,
+        desc: Description<T>,
+        part: HollowBatchPart,
         metadata: SerdeLeasedBatchPartMetadata,
-    ) -> impl Iterator<Item = LeasedBatchPart<T>> + '_ {
-        batch.parts.into_iter().map(move |part| LeasedBatchPart {
+    ) -> LeasedBatchPart<T> {
+        LeasedBatchPart {
             metrics: Arc::clone(&self.metrics),
             shard_id: self.machine.shard_id(),
             reader_id: self.reader_id.clone(),
-            metadata: metadata.clone(),
-            desc: batch.desc.clone(),
+            metadata,
+            desc,
             key: part.key,
             stats: part.stats,
             encoded_size_bytes: part.encoded_size_bytes,
             leased_seqno: Some(self.lease_seqno()),
             filter_pushdown_audit: false,
-        })
+        }
+    }
+
+    fn lease_batch_parts(
+        &mut self,
+        batch: HollowBatch<T>,
+        metadata: SerdeLeasedBatchPartMetadata,
+    ) -> impl Iterator<Item = LeasedBatchPart<T>> + '_ {
+        batch
+            .parts
+            .into_iter()
+            .map(move |part| self.lease_batch_part(batch.desc.clone(), part, metadata.clone()))
     }
 
     /// Tracks that the `ReadHandle`'s machine's current `SeqNo` is being
@@ -1103,23 +1116,31 @@ where
             self.cfg.dynamic.compaction_memory_bound_bytes(),
         );
 
+        let metadata = SerdeLeasedBatchPartMetadata::Snapshot {
+            as_of: as_of.iter().map(T::encode).collect(),
+        };
+
         for batch in batches {
             for run in batch.runs() {
-                consolidator.enqueue_run(
-                    self.machine.shard_id(),
+                let leased_parts: Vec<_> = run
+                    .into_iter()
+                    .map(|part| {
+                        self.lease_batch_part(batch.desc.clone(), part.clone(), metadata.clone())
+                    })
+                    .collect();
+                consolidator.enqueue_leased_run(
                     &self.blob,
-                    &self.metrics,
                     |m| &m.snapshot,
                     &self.machine.applier.shard_metrics,
-                    &batch.desc,
-                    run,
+                    self.lease_returner.clone(),
+                    leased_parts.into_iter(),
                 );
             }
         }
 
         let mut contents = Vec::new();
 
-        while let Some(iter) = consolidator.next().await {
+        while let Some(iter) = consolidator.next().await.expect("fetching a leased part") {
             contents.extend(iter.map(|(k, v, t, d)| ((K::decode(k), V::decode(v)), t, d)))
         }
 


### PR DESCRIPTION
We now hang onto a boxed future instead of the raw fetch data, so we can swap in different fetch implementations for different cases.

### Motivation

Bug - see https://github.com/MaterializeInc/materialize/issues/17338#issuecomment-1708248494.

### Tips for reviewer

I'm a little unclear why this could cause failures in `snapshot_and_fetch_streaming`, since we're holding a unique ref to our handle for the full call, which I would have thought would prevent us from advancing the since too far ahead. But in any case it seems like the right thing is to match the behaviour of the non-streaming path, and the non-streaming path leases.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
