### PR TITLE
ci: Don't fail parallel-workload runs

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -77,7 +77,7 @@ steps:
           - { value: parallel-workload-dml }
           - { value: parallel-workload }
           - { value: parallel-workload-100-threads }
-          #- { value: parallel-workload-cancel }
+          - { value: parallel-workload-cancel }
           #- { value: parallel-workload-kill }
         multiple: true
         required: false

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -26,17 +26,24 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     print(f"--- Random seed is {args.seed}")
     c.up("cockroach", "materialized")
-    run(
-        "localhost",
-        c.default_port("materialized"),
-        c.port("materialized", 6877),
-        args.seed,
-        args.runtime,
-        Complexity(args.complexity),
-        Scenario(args.scenario),
-        args.threads,
-        c,
-    )
+    try:
+        run(
+            "localhost",
+            c.default_port("materialized"),
+            c.port("materialized", 6877),
+            args.seed,
+            args.runtime,
+            Complexity(args.complexity),
+            Scenario(args.scenario),
+            args.threads,
+            c,
+        )
+    except Exception as e:
+        print("--- Execution of parallel-workload failed")
+        print(e)
+        # Don't fail the entire run. We ran into a crash,
+        # ci-logged-errors-detect will handle this if it's an unknown failure.
+        return
     # Restart mz
     c.kill("materialized")
     c.up("materialized")


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
