### PR TITLE
ci: Fail test when unknown errors are logged

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -90,8 +90,7 @@ associated open Github issues in Materialize repository.""",
     parser.add_argument("log_files", nargs="+", help="log files to search in")
     args = parser.parse_args()
 
-    annotate_logged_errors(args.log_files)
-    return 0
+    return annotate_logged_errors(args.log_files)
 
 
 def annotate_errors(errors: list[str], title: str, style: str) -> None:
@@ -123,11 +122,17 @@ def annotate_errors(errors: list[str], title: str, style: str) -> None:
     )
 
 
-def annotate_logged_errors(log_files: list[str]) -> None:
+def annotate_logged_errors(log_files: list[str]) -> int:
+    """
+    Returns the number of unknown errors, 0 when all errors are known or there
+    were no errors logged. This will be used to fail a test even if the test
+    itself succeeded, as long as it had any unknown error logs.
+    """
+
     error_logs = get_error_logs(log_files)
 
     if not error_logs:
-        return
+        return 0
 
     step_key: str = os.getenv("BUILDKITE_STEP_KEY", "")
     buildkite_label: str = os.getenv("BUILDKITE_LABEL", "")
@@ -195,6 +200,8 @@ def annotate_logged_errors(log_files: list[str]) -> None:
         "error",
     )
     annotate_errors(known_errors, "Known errors in logs, ignoring", "info")
+
+    return len(unknown_errors)
 
 
 def get_error_logs(log_files: list[str]) -> list[ErrorLog]:


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
