### PR TITLE
Make coalesce's nullability more precise

### DIFF
--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -568,8 +568,8 @@ query T multiline
 EXPLAIN WITH(arity, types) SELECT COALESCE(field, '') FROM (SELECT data->>'field' AS field FROM json_table);
 ----
 Explained Query:
-  Project (#1) // { arity: 1, types: "(text?)" }
-    Map (coalesce((#0 ->> "field"), "")) // { arity: 2, types: "(jsonb?, text?)" }
+  Project (#1) // { arity: 1, types: "(text)" }
+    Map (coalesce((#0 ->> "field"), "")) // { arity: 2, types: "(jsonb?, text)" }
       ReadStorage materialize.public.json_table // { arity: 1, types: "(jsonb?)" }
 
 EOF

--- a/test/sqllogictest/types.slt
+++ b/test/sqllogictest/types.slt
@@ -1102,3 +1102,73 @@ true
 true
 true
 true
+
+## coalesce nullability
+
+statement ok
+CREATE TABLE t1(key int, val int, n int NOT NULL);
+
+# coalesce's output type should be non-nullable when any of its input types are non-nullable
+query T multiline
+EXPLAIN WITH(types)
+SELECT coalesce(key, 0)
+FROM t1;
+----
+Explained Query:
+  Project (#3) // { types: "(integer)" }
+    Map (coalesce(#0, 0)) // { types: "(integer?, integer?, integer, integer)" }
+      ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+EOF
+
+query T multiline
+EXPLAIN WITH(types)
+SELECT coalesce(key, n)
+FROM t1;
+----
+Explained Query:
+  Project (#3) // { types: "(integer)" }
+    Map (coalesce(#0, #2)) // { types: "(integer?, integer?, integer, integer)" }
+      ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+EOF
+
+query T multiline
+EXPLAIN WITH(types)
+SELECT coalesce(key, 0), sum(val)
+FROM t1
+GROUP BY key;
+----
+Explained Query:
+  Project (#2, #1) // { types: "(integer, bigint?)" }
+    Map (coalesce(#0, 0)) // { types: "(integer?, bigint?, integer)" }
+      Reduce group_by=[#0] aggregates=[sum(#1)] // { types: "(integer?, bigint?)" }
+        Project (#0, #1) // { types: "(integer?, integer?)" }
+          ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+EOF
+
+# coalesce's output type should be nullable when all of its input types are nullable
+query T multiline
+EXPLAIN WITH(types)
+SELECT coalesce(key, val)
+FROM t1;
+----
+Explained Query:
+  Project (#3) // { types: "(integer?)" }
+    Map (coalesce(#0, #1)) // { types: "(integer?, integer?, integer, integer?)" }
+      ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+EOF
+
+query T multiline
+EXPLAIN WITH(types)
+SELECT coalesce(key, val + 5)
+FROM t1;
+----
+Explained Query:
+  Project (#3) // { types: "(integer?)" }
+    Map (coalesce(#0, (#1 + 5))) // { types: "(integer?, integer?, integer, integer?)" }
+      ReadStorage materialize.public.t1 // { types: "(integer?, integer?, integer)" }
+
+EOF

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -144,7 +144,7 @@ name                nullable    type
  rolsuper           true        boolean
  rolinherit         false       boolean
  rolcreaterole      true        boolean
- rolcreatedb        true        boolean
+ rolcreatedb        false        boolean
  rolcanlogin        true        boolean
  rolreplication     false       boolean
  rolbypassrls       false       boolean


### PR DESCRIPTION
@benesch [observed](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1694154723215209) that `coalesce`'s output type is nullable even when one of its arguments is a non-null literal. This PR makes coalesce's nullability more precise: if any of its input types is non-nullable (e.g., a literal), then the output type will also be non-nullable.

### Motivation

  * This PR fixes a recognized bug: https://materializeinc.slack.com/archives/C02PPB50ZHS/p1694154723215209

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
