### PR TITLE
cloudtests: allow configuring SSL mode for pgwire

### DIFF
--- a/misc/python/materialize/cloudtest/util/authentication.py
+++ b/misc/python/materialize/cloudtest/util/authentication.py
@@ -27,6 +27,8 @@ class AuthConfig:
 
     refresh_fn: Callable[[AuthConfig], None]
 
+    pgwire_ssl_mode: str = "require"
+
     def refresh(self) -> None:
         self.refresh_fn(self)
 

--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -57,7 +57,7 @@ def pgwire_sql_conn(auth: AuthConfig, environment: Environment) -> Connection[An
         password=auth.app_password,
         host=pgwire_host,
         port=pgwire_port,
-        sslmode="require",
+        sslmode=auth.pgwire_ssl_mode,
     )
     conn.autocommit = True
     return conn


### PR DESCRIPTION
It will be possible with https://github.com/MaterializeInc/cloud/pull/7467 to use pgwire without Frontegg. The connection needs to be initiated without SSL. This PR allows configuring that.
