### PR TITLE
docs: JSON to SQL widget

### DIFF
--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -937,6 +937,116 @@ p+p {
     }
 }
 
+div.json_widget {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+
+    position: relative;
+
+    .input_container {
+        display: inline-flex;
+        flex-direction: row;
+
+        margin: 16px;
+
+        .input_container-text {
+            display: inline-flex;
+            flex-direction: column;
+            flex-grow: 3;
+
+            input {
+                width: 100%;
+
+                border: 1px solid #E0DEE3;
+                border-radius: 8px;
+                margin: 8px 0;
+                padding: 8px;
+
+                background-color: #F7F7F8;
+                box-shadow: none;
+                font-size: 16px;
+            }
+
+            input::placeholder {
+                color: #BCB9C0;
+            }
+        }
+
+        .input_container-radio {
+            display: inline-flex;
+            flex-direction: column;
+            flex-grow: 1;
+            justify-content: center;
+
+            margin: 0 16px 12px;
+            padding: 16px;
+
+            border: 1px solid #E0DEE3;
+            border-radius: 8px;
+
+            legend {
+                padding: 0 4px;
+            }
+        }
+    }
+
+    .json {
+        display: flex;
+        position: relative;
+        width: 100%;
+
+        textarea {
+            height: 400px;
+            width: 100%;
+            resize: none;
+
+            border: 1px solid #E0DEE3;
+            border-radius: 8px;
+            margin: 16px;
+            padding: 8px;
+        }
+
+        textarea::placeholder {
+            opacity: 0.1;
+            font-size: 4vw;
+            text-align: center;
+            line-height: 350px;
+        }
+
+        .error {
+            position: absolute;
+            bottom: 32px;
+            left: 50%;
+            transform: translateX(-50%);
+
+            opacity: 80%;
+            width: calc(100% - 64px);
+
+            p {
+                background-color: rgba(229, 6, 68, 0.4);
+                border-radius: 8px;
+                color: #803737;
+                font-weight: 500;
+                padding: 8px;
+            }
+        }
+
+        .error-visible {
+            opacity: 1;
+            transition: opacity 100ms ease-in;
+        }
+
+        .error-hidden {
+            opacity: 0;
+            transition: opacity 100ms ease-in;
+        }
+    }
+
+    .sql_output {
+        margin: 16px;
+    }
+}
 
 .notify_button {
     font-size: 1rem;

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -1017,6 +1017,8 @@ div.json_widget {
         .error {
             position: absolute;
             bottom: 32px;
+
+            // Hack to center the error dialog.
             left: 50%;
             transform: translateX(-50%);
 

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -968,6 +968,13 @@ div.json_widget {
                 font-size: 16px;
             }
 
+            .light & input {
+                background-color: #F7F7F8;
+            }
+            .dark & input {
+                background-color: #000000;
+            }
+
             input::placeholder {
                 color: #BCB9C0;
             }
@@ -1030,9 +1037,16 @@ div.json_widget {
             p {
                 background-color: rgba(229, 6, 68, 0.4);
                 border-radius: 8px;
-                color: #803737;
                 font-weight: 500;
                 padding: 8px;
+            }
+
+            .light & p {
+                color: #803737;
+            }
+
+            .dark & p {
+                color: #fe1d5e;
             }
         }
 

--- a/doc/user/assets/sass/_content.scss
+++ b/doc/user/assets/sass/_content.scss
@@ -996,6 +996,8 @@ div.json_widget {
         position: relative;
         width: 100%;
 
+        margin-top: 16px;
+
         textarea {
             height: 400px;
             width: 100%;

--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -1,0 +1,234 @@
+---
+title: "JSON to SQL"
+description: "Create a view from sample JSON data."
+menu:
+  main:
+    parent: 'transform'
+    name: JSON
+    weight: 20
+---
+
+Working with JSON formatted data in SQL can be tedious, because you need to constantly deconstruct
+the JSON blob. The below tool accepts a JSON sample and will generate a SQL view with the
+individual fields mapped to columns.
+
+
+<div class="json_widget">
+
+<span class="input_container">
+
+<span class="input_container-text">
+<input id="view_name" placeholder="View Name">
+<input id="source_name" placeholder="Relation Name">
+<input id="column_name" placeholder="JSON Column Name">
+</span>
+
+<fieldset class="input_container-radio">
+<legend>Kind of SQL Object</legend>
+<span>
+<input type="radio" id="view" name="type_view" value="view"/>
+<label for="view">View</label>
+</span>
+<span>
+<input type="radio" id="materialized-view" name="type_view" value="materialized-view"/>
+<label for="materialized-view">Materialized View</label>
+</span>
+</fieldset>
+
+</span>
+
+<div class="json">
+
+<textarea id="json_sample" placeholder="JSON Sample"></textarea>
+<div id="error_span" class="error">
+<p id="error_text"></p>
+</div>
+
+</div>
+
+<pre class="sql_output">
+<code id="output" class="sql_output-code"></code>
+</pre>
+
+</div>
+
+<script>
+
+/* Helper Methods
+
+If this wasn't a simple script these would be in a `utils.js` or come from lodash.
+*/
+
+function escapeString(s) {
+    return s.replace(`'`, `''`);
+}
+
+function escapeIdent(s) {
+    return s.replace(`"`, `""`);
+}
+
+function clone(x) {
+    return JSON.parse(JSON.stringify(x))
+}
+
+function debounce(callback, wait) {
+    let timeout;
+    return (...args) => {
+        const context = this;
+        clearTimeout(timeout);
+        timeout = setTimeout(() => callback.apply(context, args), wait);
+    }
+}
+
+/* JSON Parsing and SQL conversion */
+
+const error_span = $("#error_span");
+const error_text = $("#error_text");
+
+const json_input = $("#json_sample");
+const sql_output = $("#output");
+
+/// Flattens a JSON objects into a list of fields, and their chain of parents.
+function handleJson(source, sample, column_name) {
+    if (!column_name) {
+        column_name = "body"
+    }
+
+    let selectItems = [];
+    const json_object = JSON.parse(sample);
+
+    // Format the JSON for the user.
+    const pretty_json = JSON.stringify(json_object, null, 2);
+    json_input.val(pretty_json);
+
+    expandObject(json_object, [column_name], selectItems);
+
+    return selectItems;
+}
+
+/// Recursively iterates through the provided object, tracking the chain
+/// of parent fields for later use in naming and desctructuring.
+function expandObject(object, parents, columns) {
+    for (const [name, value] of Object.entries(object)) {
+        const subscript = escapeString(name);
+        const columnName = escapeIdent(name);
+
+        let cast = "";
+        switch (typeof value) {
+            case "boolean":
+                cast = "::bool";
+                break;
+            case "number":
+                cast = "::numeric";
+                break;
+            case "string":
+                if (Date.parse(value)) {
+                    cast = "::timestamp";
+                }
+                break;
+            case "object":
+                parents.push(name);
+                expandObject(value, parents, columns)
+                parents.pop()
+                continue;
+        }
+
+        columns.push([name, cast, clone(parents)]);
+    }
+}
+
+/// Given a list of fields/select items, forms a SQL query.
+function formSql(selectItems, view_name, source_name, object_type) {
+    const FIELD_SEPERATOR = "\n    ";
+
+    if (!view_name) {
+        view_name = "my_view";
+    }
+    if (!source_name) {
+        source_name = "my_source";
+    }
+
+    let type = "VIEW";
+    if (object_type === "materialized-view") {
+        type = "MATERIALIZED VIEW";
+    }
+
+    let selects = selectItems.map(([name, cast, parents]) => {
+        // Note: The first "parent" is the JSON column.
+        const formattedName = [...parents.slice(1), name].join("_");
+
+        const parentPath = [parents[0], ...parents.slice(1).map((p) => `'${p}'`)].join("->");
+        const formattedPath = parentPath.concat(`->>'${name}'`);
+
+        let item = formattedPath;
+        if (cast) {
+            item = `(${item})${cast}`;
+        }
+
+        return `${item} AS ${formattedName}`;
+    })
+    .join(`,${FIELD_SEPERATOR}`);
+
+    if (selectItems.length > 1) {
+        selects = `${FIELD_SEPERATOR}${selects}`;
+    }
+
+    const sql = `CREATE ${type} ${view_name} AS SELECT ${selects}\nFROM ${source_name};`
+
+    return sql;
+}
+
+function errorClear() {
+    error_span.attr('class', 'error error-hidden');
+}
+
+function errorSet(e) {
+    error_text.text(e.message);
+    error_span.attr('class', 'error error-visible');
+}
+
+function sqlClear() {
+    sql_output.text("");
+}
+
+function render() {
+    errorClear();
+    sqlClear();
+
+    const view_name = $("#view_name").val();
+    const source_name = $("#source_name").val();
+    const column_name = $("#column_name").val();
+    const object_type = $("input[name='type_view']:checked").val();
+
+    const json_sample = json_input.val();
+
+    try {
+        const items = handleJson(source_name, json_sample, column_name);
+        const sql = formSql(items, view_name, source_name, object_type);
+        sql_output.text(sql);
+
+        errorClear();
+    } catch (e) {
+        if (json_sample) {
+            console.log(e);
+            errorSet(e);
+        } else {
+            errorClear();
+        }
+    }
+}
+
+render();
+
+// Debounce at a quicker rate since these generally cannot generate errors.
+$("#view_name").keyup(debounce(render, 200));
+$("#source_name").keyup(debounce(render, 200));
+$("#column_name").keyup(debounce(render, 200));
+$("input[name='type_view']").change(render);
+
+// Debounce relatively slowly on the JSON sample since it can generate parsing errors.
+$("#json_sample").keyup(debounce(render, 600));
+
+</script>
+
+

--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -225,5 +225,3 @@ $("input[name='type_view']").change(render);
 $("#json_sample").keyup(debounce(render, 600));
 
 </script>
-
-

--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -38,9 +38,7 @@ individual fields mapped to columns.
             <p id="error_text"></p>
         </div>
     </div>
-    <pre class="sql_output">
-        <code id="output" class="sql_output-code"></code>
-    </pre>
+    <pre class="sql_output"><code id="output" class="sql_output-code"></code></pre>
 </div>
 
 <script>
@@ -178,6 +176,10 @@ function errorSet(e) {
     error_span.attr('class', 'error error-visible');
 }
 
+function sqlSet(sql) {
+    sql_output.text(sql.trim());
+}
+
 function sqlClear() {
     sql_output.text("");
 }
@@ -196,7 +198,7 @@ function render() {
     try {
         const items = handleJson(source_name, json_sample, column_name);
         const sql = formSql(items, view_name, source_name, object_type);
-        sql_output.text(sql);
+        sqlSet(sql);
 
         errorClear();
     } catch (e) {

--- a/doc/user/content/transform-data/json.md
+++ b/doc/user/content/transform-data/json.md
@@ -14,42 +14,33 @@ individual fields mapped to columns.
 
 
 <div class="json_widget">
-
-<span class="input_container">
-
-<span class="input_container-text">
-<input id="view_name" placeholder="View Name">
-<input id="source_name" placeholder="Relation Name">
-<input id="column_name" placeholder="JSON Column Name">
-</span>
-
-<fieldset class="input_container-radio">
-<legend>Kind of SQL Object</legend>
-<span>
-<input type="radio" id="view" name="type_view" value="view"/>
-<label for="view">View</label>
-</span>
-<span>
-<input type="radio" id="materialized-view" name="type_view" value="materialized-view"/>
-<label for="materialized-view">Materialized View</label>
-</span>
-</fieldset>
-
-</span>
-
-<div class="json">
-
-<textarea id="json_sample" placeholder="JSON Sample"></textarea>
-<div id="error_span" class="error">
-<p id="error_text"></p>
-</div>
-
-</div>
-
-<pre class="sql_output">
-<code id="output" class="sql_output-code"></code>
-</pre>
-
+    <span class="input_container">
+        <span class="input_container-text">
+            <input id="view_name" placeholder="View Name">
+            <input id="source_name" placeholder="Relation Name">
+            <input id="column_name" placeholder="JSON Column Name">
+        </span>
+    <fieldset class="input_container-radio">
+        <legend>Kind of SQL Object</legend>
+        <span>
+            <input type="radio" id="view" name="type_view" value="view"/>
+            <label for="view">View</label>
+        </span>
+        <span>
+            <input type="radio" id="materialized-view" name="type_view" value="materialized-view"/>
+            <label for="materialized-view">Materialized View</label>
+        </span>
+    </fieldset>
+    </span>
+    <div class="json">
+        <textarea id="json_sample" placeholder="JSON Sample"></textarea>
+        <div id="error_span" class="error">
+            <p id="error_text"></p>
+        </div>
+    </div>
+    <pre class="sql_output">
+        <code id="output" class="sql_output-code"></code>
+    </pre>
 </div>
 
 <script>


### PR DESCRIPTION
# [Preview Docs](https://preview.materialize.com/materialize/21677/transform-data/json/)

This PR adds a new page to our docs, which contains a little widget for converting a sample JSON blob into a SQL view. We recursively iterate through the JSON blob and map each field to a column. When mapping fields to columns, we map certain Javascript types to SQL casts, specifically:

* `boolean` -> `bool`
* `number` -> `numberic`
* `Date.parse(text)` -> `timestamp`

Otherwise all fields will get the SQL type of `text`.

Right now the tool is on it's own page, I think we can make it a Hugo "shortcode" which would make it embed-able in other pages, but I'll defer to someone on Devex for what we should do here.

### Motivation

Closes https://github.com/MaterializeInc/materialize/issues/21632

### Tips for reviewer

In my limited testing the tool is responsive to different screen sizes, and is navigable via the keyboard, but I'm definitely not up-to-date with the latest standards here, so if anyone has any tips for improvement I'm all ears!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds a tool to our docs to help users deconstruct their JSON blobs into SQL views.
