### PR TITLE
docs: Identify webhooks as being in public preview

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -10,7 +10,7 @@ menu:
     weight: 40
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 {{% create-source/intro %}}
 Webhook sources expose a public URL that allow your other applications to push data into Materialize.


### PR DESCRIPTION
Once v0.69 gets released we're going to move webhook sources to "public preview". I put up this PR as a reminder to myself to make the change.

[Slack discussion](https://materializeinc.slack.com/archives/C03QLQK1Q3A/p1694049344404629)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates our docs to denote that webhooks are in public preview
