### PR TITLE
rbac: Fix mz_acl_item_contains_privilege

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -1938,7 +1938,7 @@ fn mz_acl_item_contains_privilege(a: Datum<'_>, b: Datum<'_>) -> Result<Datum<'s
     let privileges = b.unwrap_str();
     let acl_mode = AclMode::parse_multiple_privileges(privileges)
         .map_err(|e: anyhow::Error| EvalError::InvalidPrivileges(e.to_string()))?;
-    let contains = !mz_acl_item.acl_mode.union(acl_mode).is_empty();
+    let contains = !mz_acl_item.acl_mode.intersection(acl_mode).is_empty();
     Ok(contains.into())
 }
 

--- a/test/sqllogictest/aclitem.slt
+++ b/test/sqllogictest/aclitem.slt
@@ -178,6 +178,16 @@ SELECT mz_internal.mz_acl_item_contains_privilege(NULL, NULL)
 ----
 NULL
 
+query B
+SELECT mz_internal.mz_acl_item_contains_privilege(mz_internal.make_mz_aclitem('u1', 'u2', 'USAGE'), 'CREATE');
+----
+false
+
+query B
+SELECT mz_internal.mz_acl_item_contains_privilege(mz_internal.make_mz_aclitem('u1', 'u2', 'USAGE'), 'USAGE');
+----
+true
+
 # Test aclitem type and functions
 
 statement ok

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -1220,7 +1220,7 @@ ty  =U/materialize
 ty  materialize=U/materialize
 
 query B
-SELECT has_type_privilege('joe', 'ty', 'SELECT')
+SELECT has_type_privilege('joe', 'ty', 'USAGE')
 ----
 true
 
@@ -2262,17 +2262,17 @@ mz_system=RBN/mz_system
 query B
 SELECT has_system_privilege('joe', 'CREATEDB')
 ----
-true
+false
 
 query B
 SELECT has_system_privilege('child', 'CREATEDB')
 ----
-true
+false
 
 query B
 SELECT has_system_privilege((SELECT oid FROM mz_roles WHERE name = 'joe'), 'CREATEDB')
 ----
-true
+false
 
 ### Duplicate revokes have no effect
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
The implementation of mz_acl_item_contains_privilege was incorrectly
checking if the union of two aclmodes were empty instead of checking if
the intersection of two aclmodes were empty. Therefore, it was
incorrectly reporting true on many usages. This was also causing
functions that relied on mz_acl_item_contains_privilege for their
implementation to return the wrong result.

Fixes #21680

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix RBAC privilege functions.
