### PR TITLE
Remove references to unmanaged clusters, 🌶️ version

### DIFF
--- a/doc/user/content/free-trial-faqs.md
+++ b/doc/user/content/free-trial-faqs.md
@@ -11,17 +11,17 @@ When you [sign up for Materialize](https://materialize.com/register/), you get a
 
 ## What are the limits of a free trial?
 
-In Materialize, [cluster replicas](/get-started/key-concepts/#cluster-replicas) are the physical resources for doing computational work. Cluster replicas come in various sizes, and each size has a [credit consumption rate](https://materialize.com/pricing/).
+In Materialize, [clusters](/get-started/key-concepts/#clusters) are the pools of compute resources for running your workloads. The size and replication factor of each cluster determines its [credit usage](/sql/create-cluster/#credit-usage).
 
-During your free trial, your credit consumption rate across all replicas in a region cannot exceed 4 credits per hour at any point in time. This limit should accommodate most trial scenarios.
+During your free trial, the credit consumption rate across all clusters in a region cannot exceed 4 credits per hour at any point in time. This limit should accommodate most trial scenarios.
 
 For example, let's say you have 3 clusters in a region:
 
-Cluster | Replicas | Credits per hour
---------|----------|-----------------
-`ingest`| 1 `2xsmall` | 0.5
-`compute` | 2 `2xsmall` | 1 (0.5 each)
-`default` | 1 `2xsmall` | 0.5
+Cluster   | Size      | Replication factor | Credits per hour
+----------|-----------|--------------------|-----------------
+`ingest`  | `2xsmall` | 1                  | 0.5
+`compute` | `2xsmall` | 2                  | 1 (0.5 each)
+`default` | `2xsmall` | 1                  | 0.5
 
 In this case, your credit consumption rate would be 2 credits per hour, which is under the rate limit of 4 credits per hour.
 

--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -79,9 +79,9 @@ If you already have a Materialize account, skip to the [next step](#step-2-creat
 
 ## Step 2. Create clusters
 
-In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its physical compute resource (i.e., [replica](/get-started/key-concepts/#cluster-replicas)) based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
+In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its compute resource allocation based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
 
-For this guide, you'll create 2 clusters, one for ingesting source data and the other for computing and serving query results. For now, each cluster will get a single `2xsmall` physical compute resource. Later, you'll explore how to use replication to increase tolerance to failure.
+For this guide, you'll create 2 clusters, one for ingesting source data and the other for computing and serving query results. For now, each cluster will have a size of `2xsmall`. Later, you'll explore how to use replication to increase tolerance to failure.
 
 1. In the [Materialize UI](https://console.materialize.com/), enable the region where you want to run Materialize.
 
@@ -107,7 +107,7 @@ For this guide, you'll create 2 clusters, one for ingesting source data and the 
 
     The `2xsmall` size is sufficient for the data ingestion and computation in this getting started scenario.
 
-1. The physical compute resources in your clusters are called [`replicas`](/get-started/key-concepts/#cluster-replicas). Use the [`SHOW CLUSTER REPLICAS`](https://materialize.com/docs/sql/show-cluster-replicas/) command to check the status of the replicas:
+1. Each instance of your cluster is called a replica. By default, each cluster has exactly one replica. Use the [`SHOW CLUSTER REPLICAS`](https://materialize.com/docs/sql/show-cluster-replicas/) command to check the status of your replicas:
 
     ```sql
     SHOW CLUSTER REPLICAS WHERE cluster IN ('compute_qck', 'ingest_qck');

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -34,16 +34,12 @@ Alter cluster to size `xsmall`:
 ALTER CLUSTER c1 SET (SIZE 'xsmall');
 ```
 
-### Converting managed to unmanaged clusters
-Alter the `managed` status of a cluster to unmanaged:
+## Converting unmanaged to managed clusters
 
-```sql
-ALTER CLUSTER c1 SET (MANAGED false);
-```
+Unmanaged clusters are a legacy artifact of Materialize that 
+forced users to manually create and drop cluster replicas.
 
-### Converting unmanaged to managed clusters
-
-Alter the `managed` status of a cluster to unmanaged:
+Alter the `managed` status of a cluster to managed:
 
 ```sql
 ALTER CLUSTER c1 SET (MANAGED);
@@ -69,6 +65,5 @@ The privileges required to execute this statement are:
 ## See also
 
 - [`CREATE CLUSTER`](/sql/create-cluster/)
-- [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica)
 - [`CREATE SINK`](/sql/create-sink/)
 - [`SHOW SINKS`](/sql/show-sinks)

--- a/doc/user/content/sql/alter-cluster.md
+++ b/doc/user/content/sql/alter-cluster.md
@@ -36,8 +36,13 @@ ALTER CLUSTER c1 SET (SIZE 'xsmall');
 
 ## Converting unmanaged to managed clusters
 
-Unmanaged clusters are a legacy artifact of Materialize that 
-forced users to manually create and drop cluster replicas.
+{{< warning >}}
+[Unmanaged clusters](/sql/create-cluster-replica) are a deprecated feature of
+Materialize that required manual management of cluster replicas.
+
+We recommend converting any unmanaged clusters to managed clusters
+by following the instructions below.
+{{< /warning >}}
 
 Alter the `managed` status of a cluster to managed:
 

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -7,6 +7,10 @@ menu:
     parent: commands
 ---
 
+{{< warning >}}
+`CREATE CLUSTER REPLICA` is for working with legacy unmanaged clusters. Consider migrating your cluster to [managed](/sql/alter-cluster/#converting-unmanaged-to-managed-clusters) instead.
+{{< /warning >}}
+
 `CREATE CLUSTER REPLICA` provisions physical resources to perform computations.
 
 ## Conceptual framework
@@ -55,30 +59,6 @@ between availability zones, see [Availability zone assignment](/sql/create-clust
 
 ## Details
 
-### Sizes
-
-Valid `size` options are:
-
-- `3xsmall`
-- `2xsmall`
-- `xsmall`
-- `small`
-- `medium`
-- `large`
-- `xlarge`
-- `2xlarge`
-- `3xlarge`
-- `4xlarge`
-- `5xlarge`
-- `6xlarge`
-
-The [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes) table lists the CPU, memory, and disk allocation for each replica size.
-
-{{< warning >}}
-The values in the `mz_internal.mz_cluster_replica_sizes` may change at any time.
-You should not rely on them for any kind of capacity planning.
-{{< /warning >}}
-
 ### Disk-attached replicas
 
 {{< private-preview />}}
@@ -91,23 +71,7 @@ non-disk-attached replicas. In the future, disk-attached replicas will likely
 consume credits at a faster rate.
 {{< /warning >}}
 
-The `DISK` option attaches a disk to the replica.
-
-Attaching a disk allows you to trade off performance for cost. A replica of a
-given size has access to several times more disk than memory, allowing the
-processing of larger data sets at that replica size. Operations on a disk,
-however, are much slower than operations in memory, and so a workload that
-spills to disk will perform more slowly than a workload that does not. Note that
-exact storage medium for the attached disk is not specified, and its performance
-characteristics are subject to change.
-
-Consider attaching a disk to replicas that contain sources that use the
-[upsert envelope](/sql/create-source/#upsert-envelope) or the
-[Debezium envelope](/sql/create-source/#debezium-envelope). When you place
-these sources on a replica with an attached disk, they will automatically spill
-state to disk. These sources will therefore use less memory but may ingest
-data more slowly. See [Sizing a source](/sql/create-source/#sizing-a-source) for details.
-
+Disk-attached replicas work identically to [disk-attached clusters](/sql/create-cluster/#disk-attached-clusters), except they apply only to a single replica.
 
 ### Deployment options
 
@@ -121,6 +85,10 @@ Action | Outcome
 ---------|---------
 Increase all replicas' sizes | Ability to maintain more dataflows or more complex dataflows
 Add replicas to a cluster | Greater tolerance to replica failure
+
+### Sizes
+
+Cluster replica sizes work identically to [cluster sizes](/sql/create-cluster/#cluster-size), except they apply only to a single replica.
 
 ### Homogeneous vs. heterogeneous hardware provisioning
 

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -1,122 +1,118 @@
 ---
 title: "CREATE CLUSTER"
-description: "`CREATE CLUSTER` creates a logical cluster, which contains indexes."
+description: "`CREATE CLUSTER` creates a new cluster."
 pagerank: 40
 menu:
   main:
     parent: commands
 ---
 
-`CREATE CLUSTER` creates a logical [cluster](/get-started/key-concepts#clusters),
-which contains dataflow-powered objects.
-By default, each new environment contains cluster called `default` with a replication factor of `1`.
-
-To switch your active cluster, use the `SET` command:
-
-```sql
-SET cluster = other_cluster;
-```
+`CREATE CLUSTER` creates a new [cluster](/get-started/key-concepts#clusters).
 
 ## Conceptual framework
 
-A cluster is a set of compute resources in Materialize, providing CPU, memory, and temporary storage.
-Materialize uses a cluster for performing the following operations: 
+A cluster is a pool of compute resources (CPU, memory, and,
+optionally, scratch disk space) for running your workloads.
 
-- Execute SQL [SELECT](/sql/select/) statements that require compute resources.
-- Maintaining [indexes](#indexes) and [materialized views](#materialized-views). 
-- Running [sources](#sources), [sinks](#sinks), and [subscribes](/sql/subscribe/). 
+The following operations require compute resources in Materialize, and so need
+to be associated with a cluster:
 
-{{< note >}}
-A given cluster may contain any number of indexes and materialized views *or*
-any number of sources and sinks, but not both types of objects. For example,
-you may not create a cluster with a source and an index.
+- Executing [`SELECT`] and [`SUBSCRIBE`] statements.
+- Maintaining [indexes](/get-started/key-concepts#indexes) and [materialized views](/get-started/key-concepts#materialized-views).
+- Maintaining [sources](/get-started/key-concepts#sources) and [sinks](/get-started/key-concepts#sinks).
 
-We plan to remove this restriction in a future version of Materialize.
-{{< /note >}}
-
-When running any of the above operations, you must specify which cluster you want to use.
-Not explicitly naming a cluster uses your session's default cluster.
-
-
-### Syntax
+## Syntax
 
 {{< diagram "create-managed-cluster.svg" >}}
 
-#### `CLUSTER` options
+### Options
 
 {{% cluster-options %}}
 
 ## Details
 
-### Cluster Size 
+### Initial state
 
-Size specifies the amount of compute resources available per cluster in a cluster.
-Materialize supports the following cluster sizes:
+Each Materialize region initially contains a cluster named `default` with a size
+of `xsmall` and a replication factor of `1`. You can drop or alter this cluster
+to suit your needs.
 
-| Size | Credits / Hour |
-|------|----------------|
-| 3xsmall | 0.25 |
-| 2xsmall | 0.5 |
-| xsmall | 1|
-| small | 2 |
-| medium | 4 |
-| large | 8 |
-| xlarge | 16 |
-| 2xlarge | 32 |
-| 3xlarge | 64 |
-| 4xlarge | 128 |
-| 5xlarge | 256 |
-| 6xlarge | 512 |
+### Choosing a cluster
 
-The [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes) table lists the CPU, memory, and disk allocation for each cluster size.
+When performing an operation that requires a cluster, you must specify which
+cluster you want to use. Not explicitly naming a cluster uses your session's
+active cluster.
+
+To show your session's active cluster, use the [`SHOW`](/sql/show) command:
+
+```sql
+SHOW cluster;
+```
+
+To switch your session's active cluster, use the [`SET`](/sql/set) command:
+
+```sql
+SET cluster = other_cluster;
+```
+
+### Resource isolation
+
+Clusters provide **resource isolation.** Each cluster provisions a dedicated
+pool of CPU, memory, and, optionally, scratch disk space.
+
+All workloads on a given cluster will compete for access to these compute
+resources. However, workloads on different clusters are strictly isolated from
+one another. A given workload has access only to the CPU, memory, and scratch
+disk of the cluster that it is running on.
+
+Clusters are commonly used to isolate different classes of workloads. For
+example, you could place your development workloads in a cluster named
+`dev` and your production workloads in a cluster named `prod`.
+
+### Size
+
+The `SIZE` option determines the amount of compute resources (CPU, memory, and
+disk) available to the cluster. Valid sizes are:
+
+* `3xsmall`
+* `2xsmall`
+* `xsmall`
+* `small`
+* `medium`
+* `large`
+* `xlarge`
+* `2xlarge`
+* `3xlarge`
+* `4xlarge`
+* `5xlarge`
+* `6xlarge`
+
+Clusters of larger sizes can process data faster and handle larger data volumes.
+You can use [`ALTER CLUSTER`] to resize the cluster in order to respond to
+changes in the resource requirements of your workload.
+
+The resource allocations for a given size are twice the resource allocations of
+the previous size. To determine the specific resource allocations for a size,
+query the [`mz_internal.mz_cluster_replica_sizes`] table.
 
 {{< warning >}}
-The values in the `mz_internal.mz_cluster_replica_sizes` may change at any time.
-You should not rely on them for any kind of capacity planning.
+The values in the `mz_internal.mz_cluster_replica_sizes` table may change at any
+time. You should not rely on them for any kind of capacity planning.
 {{< /warning >}}
 
-### Replication Factor
-
-{{< note >}}
-Clusters containing sources and sinks can only have a replication factor of 0 or 1.
-
-We plan to remove this restriction in a future version of Materialize.
-{{< /note >}}
-
-A clusters replication factor dictates the number of [cluster replicas](/get-started/key-concepts/#cluster-replicas) spawned for a cluster.
-Cluster replicas are the physical counterpart to clusters and inherit the cluster's size and configurations.
-Materialize ensures the replica set matches the declared size and replication factor.
-The replicas of a cluster are visible in the system catalog but cannot be directly modified by users.
-
-Each replica receives a copy of all data from sources its dataflows use and uses the data to perform identical computations.
-This design provides Materialize with active replication, and so long as one replica is still reachable, the cluster continues making progress.
-
-This also means that a cluster's dataflows contend for the same resources on each replica. 
-For instance, instead of placing many complex materialized views on the same cluster, you choose another distribution or resize the cluster to provide you with more powerful machines.
-
-### Availability zone assignment
-
-Materialize guarantees the following when scheduling each replica when a cluster has a replication factor greater than 1.
-
-- Different replicas are _never_ scheduled on the same node.
-- Different replicas are _always_ spread evenly across availability
-  zones. **Known limitation:** replicas with more than 1 process are excluded
-  from this constraint. See [`mz_internal.mz_cluster_replica_sizes`](/sql/system-catalog/mz_internal/#mz_cluster_replica_sizes)
-  to determine if that is the case for your replicas.
-
-### Disk-attached clusters
+### Disk
 
 {{< private-preview />}}
 
 {{< warning >}}
-
 **Pricing for this feature is likely to change.**
-Disk-attached clusters currently consume credits at the same rate as
-non-disk-attached clusters. In the future, disk-attached clusters will likely
-consume credits at a faster rate.
+
+Clusters with disks currently consume credits at the same rate as clusters
+without disks. In the future, clusters with disks will likely consume credits
+at a faster rate than clusters without disks.
 {{< /warning >}}
 
-The `DISK` option attaches a disk to the cluster.
+The `DISK` option attaches a scratch disk to the cluster.
 
 Attaching a disk allows you to trade off performance for cost. A cluster of a
 given size has access to several times more disk than memory, allowing the
@@ -133,11 +129,114 @@ these sources on a cluster with an attached disk, they will automatically spill
 state to disk. These sources will therefore use less memory but may ingest
 data more slowly. See [Sizing a source](/sql/create-source/#sizing-a-source) for details.
 
+### Replication factor
+
+The `REPLICATION FACTOR` option determines the number of replicas provisioned
+for the cluster. Each replica of the cluster provisions a new pool of compute
+resources to perform exactly the same computations on exactly the same data.
+
+Provisioning more than one replica improves **fault tolerance**. Clusters with
+multiple replicas can tolerate failures of the underlying hardware that cause a
+replica to become unreachable. As long as one replica of the cluster remains
+available, the cluster can continue to maintain dataflows and serve queries.
+
+Materialize makes the following guarantees when provisioning replicas:
+
+- Replicas of a given cluster are never provisioned on the same underlying
+  hardware.
+- Replicas of a given cluster are spread as evenly as possible across the
+  underlying cloud provider's availability zones.
+
+Materialize automatically assigns names to replicas like `r1`, `r2`, etc. You
+can view information about individual replicas in the console and the system
+catalog, but you cannot directly modify individual replicas.
+
+You can pause a cluster's work by specifying a replication factor of `0`. Doing
+so removes all replicas of the cluster. Any indexes, materialized views,
+sources, and sinks on the cluster will cease to make progress, and any queries
+directed to the cluster will block. You can later resume the cluster's work by
+using [`ALTER CLUSTER`] to set a nonzero replication factor.
+
+{{< note >}}
+A common misconception is that increasing a cluster's replication
+factor will increase its capacity for work. This is not the case. Increasing
+the replication factor increases the **fault tolerance** of the cluster, not its
+capacity for work. Replicas are exact copies of one another: each replica must
+do exactly the same work (i.e., maintain the same dataflows and process the same
+queries) as all the other replicas of the cluster.
+
+To increase a cluster's capacity, you should instead increase the cluster's
+[size](#size).
+{{< /note >}}
+
+### Credit usage
+
+Each [replica](#replication-factor) of the cluster consumes credits at a rate
+determined by the cluster's size:
+
+Size    | Credits per replica per hour
+--------|-----------------------------
+3xsmall | 0.25
+2xsmall | 0.5
+xsmall  | 1
+small   | 2
+medium  | 4
+large   | 8
+xlarge  | 16
+2xlarge | 32
+3xlarge | 64
+4xlarge | 128
+5xlarge | 256
+6xlarge | 512
+
+Credit usage is measured at a one second granularity. For a given replica,
+credit usage begins when a `CREATE CLUSTER` or [`ALTER CLUSTER`] statement
+provisions the replica and ends when an [`ALTER CLUSTER`] or [`DROP CLUSTER`]
+statement deprovisions the replica.
+
+A cluster with a [replication factor](#replication-factor) of zero uses no
+credits.
+
+As an example, consider the following sequence of events:
+
+Time                | Event
+--------------------|---------------------------------------------------------
+2023-08-29 3:45:00  | `CREATE CLUSTER c (SIZE 'medium', REPLICATION FACTOR 2)`
+2023-08-29 3:45:45  | `ALTER CLUSTER c SET (REPLICATION FACTOR 1)`
+2023-08-29 3:47:15  | `DROP CLUSTER c`
+
+Cluster `c` will have consumed 0.4 credits in total:
+
+  * Replica `c.r1` was provisioned from 3:45:00 to 3:47:15, consuming 0.3
+    credits.
+  * Replica `c.r2` was provisioned from 3:45:00 to 3:45:45, consuming 0.1
+    credits.
+
+### Known limitations
+
+Clusters have several known limitations:
+
+* Clusters containing sources and sinks can only have a replication factor of
+  `0` or `1`.
+
+* A given cluster may contain any number of indexes and materialized views *or*
+  any number of sources and sinks, but not both types of objects. For example,
+  you may not create a cluster with a source and an index.
+
+* You cannot run `SELECT` or `SUBSCRIBE` statements on a cluster containing
+  sources or sinks.
+
+* When a cluster of size `2xlarge` or larger uses multiple replicas, those
+  replicas are not guaranteed to be spread evenly across the underlying
+  cloud provider's availability zones.
+
+We plan to remove these restrictions in future versions of Materialize.
+
 ## Examples
 
 ### Basic
 
-Create a cluster with two medium replicas:
+Create a cluster with two `medium` replicas:
 
 ```sql
 CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
@@ -148,7 +247,7 @@ CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
 Create a cluster with a single replica and introspection disabled:
 
 ```sql
-CREATE CLUSTER c  SIZE = 'xsmall', INTROSPECTION INTERVAL = 0;
+CREATE CLUSTER c SIZE = 'xsmall', INTROSPECTION INTERVAL = 0;
 ```
 
 Disabling introspection can yield a small performance improvement, but you lose
@@ -163,7 +262,7 @@ Create a cluster with no replicas:
 CREATE CLUSTER c1 SIZE 'xsmall', REPLICATION FACTOR = 0;
 ```
 
-You can later add replicas to this cluster with [`ALTER CLUSTER`](/sql/alter-cluster/).
+You can later add replicas to this cluster with [`ALTER CLUSTER`].
 
 ## Privileges
 
@@ -173,7 +272,12 @@ The privileges required to execute this statement are:
 
 ## See also
 
-- [`ALTER CLUSTER`](/sql/alter-cluster/)
-- [`DROP CLUSTER`](/sql/drop-cluster/)
+- [`ALTER CLUSTER`]
+- [`DROP CLUSTER`]
 
 [AWS availability zone IDs]: https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html
+[`ALTER CLUSTER`]: /sql/alter-cluster/
+[`DROP CLUSTER`]: /sql/drop-cluster/
+[`SELECT`]: /sql/select
+[`SUBSCRIBE`]: /sql/subscribe
+[`mz_internal.mz_cluster_replica_sizes`]: /sql/system-catalog/mz_internal/#mz_cluster_replica_sizes

--- a/doc/user/content/sql/create-source/_index.md
+++ b/doc/user/content/sql/create-source/_index.md
@@ -232,8 +232,8 @@ It's a good idea to size up a source when:
     keys.
 
     In this case, it's also possible to enable _spill to disk_ to accommodate
-    larger state sizes without sizing up. See [`Disk-attached replicas`](/sql/create-cluster-replica#disk-attached-replicas)
-    for more details.
+    larger state sizes without sizing up. See the [`CREATE CLUSTER`: Disk](/sql/create-cluster#disk)
+    documentation for more details.
 
 Sources that specify the `SIZE` option are linked to a single-purpose cluster
 dedicated to maintaining that source.

--- a/doc/user/content/sql/drop-cluster-replica.md
+++ b/doc/user/content/sql/drop-cluster-replica.md
@@ -7,7 +7,16 @@ menu:
 
 ---
 
-`DROP CLUSTER REPLICA` removes an existing replica for the specified cluster. To remove all active replicas for a cluster, use the [`DROP CLUSTER`](/sql/drop-cluster) command.
+{{< warning >}}
+`DROP CLUSTER REPLICA` is deprecated.
+
+We recommend migrating to a [managed
+cluster](/sql/alter-cluster/#converting-unmanaged-to-managed-clusters) instead
+of manually creating and dropping replicas.
+{{< /warning >}}
+
+`DROP CLUSTER REPLICA` deprovisions an existing replica of the specified cluster. To remove
+the cluster itself, use the [`DROP CLUSTER`](/sql/drop-cluster) command.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-cluster-replicas.md
+++ b/doc/user/content/sql/show-cluster-replicas.md
@@ -7,7 +7,8 @@ menu:
 
 ---
 
-`SHOW CLUSTER REPLICAS` lists the [replicas](/get-started/key-concepts/#cluster-replicas) for each cluster configured in Materialize. A cluster named `default` with a single replica named `r1` will exist in every environment; this cluster can be dropped at any time.
+`SHOW CLUSTER REPLICAS` lists the [replicas](/sql/create-cluster#replication-factor) for each
+cluster configured in Materialize.
 
 ## Syntax
 

--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -21,9 +21,9 @@ pre-installed.
 
 ### `default` cluster
 
-A cluster named `default` with a single `xsmall` [replica](/get-started/key-concepts/#cluster-replicas)
-named `r1` will be pre-installed in every environment. You can modify or drop
-this cluster or its replicas at any time.
+A cluster named `default` with a size of `xsmall` and a replication factor of
+`1` will be pre-installed in every environment. You can modify or drop this
+cluster at any time.
 
 {{< note >}}
 The default value for the `cluster` session parameter is `default`.

--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -88,7 +88,7 @@ The `mz_clusters` table contains a row for each cluster in the system.
 | `name`               | [`text`]             | The name of the cluster.                                                                                                                 |
 | `owner_id`           | [`text`]             | The role ID of the owner of the cluster. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).                       |
 | `privileges`         | [`mz_aclitem array`] | The privileges belonging to the cluster.                                                                                                 |
-| `managed`            | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/#managed-clusters) with automatically managed replicas.                   |
+| `managed`            | [`boolean`]          | Whether the cluster is a [managed cluster](/sql/create-cluster/) with automatically managed replicas.                   |
 | `size`               | [`text`]             | If the cluster is managed, the desired size of the cluster's replicas. `NULL` for unmanaged clusters.                                    |
 | `replication_factor` | [`uint4`]            | If the cluster is managed, the desired number of replicas of the cluster. `NULL` for unmanaged clusters.                                 |
 | `disk`               | [`boolean`]          | **Unstable** If the cluster is managed, `true` if the replicas have the `DISK` option . `NULL` for unmanaged clusters.                   |

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -37,7 +37,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `process_id`        | [`uint8`]    | An identifier of a compute process within a replica.                                                                                                         |
 | `cpu_nano_cores`    | [`uint8`]    | Approximate CPU usage, in billionths of a vCPU core.                                                                                                         |
 | `memory_bytes`      | [`uint8`]    | Approximate RAM usage, in bytes.                                                                                                                             |
-| `disk_bytes`        | [`uint8`]    | Approximate disk usage in bytes, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
+| `disk_bytes`        | [`uint8`]    | Approximate disk usage in bytes, if the replica has a [disk](/sql/create-cluster#disk) attached. `NULL` otherwise. |
 
 ### `mz_cluster_replica_sizes`
 
@@ -57,7 +57,7 @@ any kind of capacity planning.
 | `workers`              | [`uint8`]   | The number of Timely Dataflow workers per process.                                                                                                           |
 | `cpu_nano_cores`       | [`uint8`]   | The CPU allocation per process, in billionths of a vCPU core.                                                                                                |
 | `memory_bytes`         | [`uint8`]   | The RAM allocation per process, in billionths of a vCPU core.                                                                                                |
-| `disk_bytes`           | [`uint8`]   | The disk allocation per process, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
+| `disk_bytes`           | [`uint8`]   | The disk allocation per process, if the replica has a [disk](/sql/create-cluster#disk) attached. `NULL` otherwise. |
 | `credits_per_hour`     | [`numeric`] | The number of compute credits consumed per hour.                                                                                                             |
 
 ### `mz_cluster_links`
@@ -108,7 +108,7 @@ At this time, we do not make any guarantees about the exactness or freshness of 
 | `process_id`     | [`uint8`]            | An identifier of a compute process within a replica.                                                                                                                                   |
 | `cpu_percent`    | [`double precision`] | Approximate CPU usage in percent of the total allocation.                                                                                                                              |
 | `memory_percent` | [`double precision`] | Approximate RAM usage in percent of the total allocation.                                                                                                                              |
-| `disk_percent`   | [`double precision`] | Approximate disk usage in percent of the total allocation, if the replica is configured with an [attached disk](/sql/create-cluster-replica#disk-attached-replicas). `NULL` otherwise. |
+| `disk_percent`   | [`double precision`] | Approximate disk usage in percent of the total allocation, if the replica has a [disk](/sql/create-cluster#disk) attached. `NULL` otherwise. |
 
 ### `mz_cluster_replica_heartbeats`
 

--- a/doc/user/layouts/shortcodes/cluster-options.html
+++ b/doc/user/layouts/shortcodes/cluster-options.html
@@ -1,9 +1,9 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
-`MANAGED`                           | `bool`     | Default: `true`. Indicates whether the cluster is a [managed cluster](/sql/create-cluster/#managed-and-unmanaged-clusters). We infer the value for `MANAGED` to be true unless you specify replicas manually.
-`SIZE`                              | `text`     | The size of the cluster replicas. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
-`REPLICATION FACTOR`                | `text`     | The replication factor of the cluster. Can be 0 to disable computations.
-`INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
-`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Indicates whether to introspect the gathering of the introspection data.
-`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*
-`DISK`                              | `bool`     | **Private preview** Default: `false`. Whether to attach a disk to the cluster replicas. See [Disk-attached replicas](/sql/create-cluster-replica/#disk-attached-replicas) for details.
+`SIZE`                              | `text`     | The size of the resource allocations for the cluster. See [Size](/sql/create-cluster#size) for details.
+`REPLICATION FACTOR`                | `text`     | The number of replicas to provision for the cluster. See [Replication factor](/sql/create-cluster#replication-factor) for details.<br>Default: `1`
+`INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.<br>Default: `1s`
+`INTROSPECTION DEBUGGING`           | `bool`     | Indicates whether to introspect the gathering of the introspection data.<br>Default: `FALSE`
+`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | ***Unstable.** This option may be changed or removed at any time.*<br>The amount of effort the replica should exert on compacting arrangements during idle periods.
+`DISK`                              | `bool`     | ***Private preview.** This option has known performance or stability issues and is under active development.*<br>Whether to attach a disk to the cluster. See [Disk](/sql/create-cluster/#disk) for details.<br>Default: `FALSE`
+`MANAGED`                           | `bool`     | Whether to automatically manage the cluster's replicas based on the configured size and replication factor. If `FALSE`, enables the use of the deprecated [`CREATE CLUSTER REPLICA`](/sql/create-cluster-replica) command.<br>Default: `TRUE`

--- a/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
@@ -1,4 +1,4 @@
-In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its physical compute resource (i.e., [replica](/get-started/key-concepts/#cluster-replicas)) based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
+In Materialize, a [cluster](/get-started/key-concepts/#clusters) is an isolated environment, similar to a virtual warehouse in Snowflake. When you create a cluster, you choose the size of its compute resource allocation based on the work you need the cluster to do, whether ingesting data from a source, computing always-up-to-date query results, serving results to clients, or a combination.
 
 In this case, you'll create 1 new cluster containing 1 `medium` replica for ingesting source data from your PostgreSQL database.
 
@@ -8,4 +8,4 @@ In this case, you'll create 1 new cluster containing 1 `medium` replica for inge
     CREATE CLUSTER ingest_postgres SIZE = 'medium';
     ```
 
-    We recommend starting with a `medium` [size](/sql/create-cluster-replica/#sizes) replica or larger. This will help Materialize more quickly process the initial snapshot of the tables in your publication. Once the snapshot is finished, you'll right-size the cluster.
+    We recommend starting with a `medium` [size](/sql/create-cluster/#size) replica or larger. This will help Materialize more quickly process the initial snapshot of the tables in your publication. Once the snapshot is finished, you'll right-size the cluster.

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -1,8 +1,8 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
-`SIZE`                              | `text`     | The size of the replica. For valid sizes, see [cluster replica sizes](/sql/create-cluster-replica#sizes).
-`AVAILABILITY ZONE`                 | `text`     | If you want the replica to reside in a specific availability zone. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that we expect the zone's ID, rather than its name.
-`INTROSPECTION INTERVAL`            | `interval` | Default: `1s`. The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.
-`INTROSPECTION DEBUGGING`           | `bool`     | Default: `false`. Whether to introspect the gathering of the introspection data.
-`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | The amount of effort the replica should exert on compacting arrangements during idle periods. *This is an unstable option! It may be changed or removed at any time.*
-`DISK`                              | `bool`     | **Private preview** Default: `false`. Whether to attach a disk to the replica. See [Disk-attached replicas](/sql/create-cluster-replica/#disk-attached-replicas) for details.
+`SIZE`                              | `text`     | The size of the replica. For valid sizes, see [Size](/sql/create-cluster-replica#size).
+`AVAILABILITY ZONE`                 | `text`     | The availability zone of the underlying clodu provider in which to provision the replica. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that you must use the zone's ID, not its name.
+`INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.<br>Default: `1s`
+`INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data.<br>Default: `FALSE`
+`IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | ***Unstable.** This option may be changed or removed at any time.*<br>The amount of effort the replica should exert on compacting arrangements during idle periods.
+`DISK`                              | `bool`     | ***Private preview.** This option has known performance or stability issues and is under active development.*<br>Whether to attach a disk to the replica. See [Disk](/sql/create-cluster-replica/#disk) for details.<br>Default: `FALSE`


### PR DESCRIPTION
This is an even 🌶️-ier version of #21616.

> De-emphasize unmanaged clusters in the documentation. This is a first step towards deprecation.

### Motivation

   * This PR improves documentation.

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
