### PR TITLE
catalog: Refactor storage dependencies

### DIFF
--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -11,7 +11,6 @@ use std::fmt;
 
 use mz_ore::str::StrExt;
 use mz_proto::TryFromProtoError;
-use mz_repr::GlobalId;
 use mz_sql::catalog::CatalogError as SqlCatalogError;
 
 #[derive(Debug, thiserror::Error)]
@@ -25,24 +24,10 @@ pub struct Error {
 pub enum ErrorKind {
     #[error("corrupt catalog: {detail}")]
     Corruption { detail: String },
-    #[error("id counter overflows i64")]
-    IdExhaustion,
     #[error("oid counter overflows i64")]
     OidExhaustion,
     #[error(transparent)]
     Sql(#[from] SqlCatalogError),
-    #[error("database '{0}' already exists")]
-    DatabaseAlreadyExists(String),
-    #[error("schema '{0}' already exists")]
-    SchemaAlreadyExists(String),
-    #[error("role '{0}' already exists")]
-    RoleAlreadyExists(String),
-    #[error("cluster '{0}' already exists")]
-    ClusterAlreadyExists(String),
-    #[error("cannot create multiple replicas named '{0}' on cluster '{1}'")]
-    DuplicateReplica(String, String),
-    #[error("catalog item '{1}' already exists")]
-    ItemAlreadyExists(GlobalId, String),
     #[error("unacceptable schema name '{0}'")]
     ReservedSchemaName(String),
     #[error("role name {} is reserved", .0.quoted())]
@@ -79,8 +64,6 @@ pub enum ErrorKind {
         this_version: &'static str,
         cause: String,
     },
-    #[error("failed to migrate schema of builtin objects: {0}")]
-    FailedBuiltinSchemaMigration(String),
     #[error("failpoint {0} reached)")]
     FailpointReached(String),
     #[error("{0}")]
@@ -151,6 +134,15 @@ impl From<TryFromProtoError> for Error {
 impl From<uuid::Error> for Error {
     fn from(e: uuid::Error) -> Error {
         Error::new(ErrorKind::from(e))
+    }
+}
+
+impl From<crate::catalog::storage::Error> for Error {
+    fn from(e: crate::catalog::storage::Error) -> Self {
+        match e {
+            crate::catalog::storage::Error::Catalog(e) => Error::new(ErrorKind::from(e)),
+            crate::catalog::storage::Error::Stash(e) => Error::new(ErrorKind::from(e)),
+        }
     }
 }
 

--- a/src/adapter/src/catalog/storage/objects.rs
+++ b/src/adapter/src/catalog/storage/objects.rs
@@ -12,10 +12,10 @@ use mz_proto::{IntoRustIfSome, ProtoType};
 use mz_stash::objects::{proto, RustType, TryFromProtoError};
 
 use crate::catalog::storage::{
-    CommentValue, DefaultPrivilegesKey, DefaultPrivilegesValue, ReplicaConfig, ReplicaLocation,
-    SystemPrivilegesKey, SystemPrivilegesValue,
+    ClusterConfig, ClusterVariant, ClusterVariantManaged, CommentValue, DefaultPrivilegesKey,
+    DefaultPrivilegesValue, ReplicaConfig, ReplicaLocation, SystemPrivilegesKey,
+    SystemPrivilegesValue,
 };
-use crate::catalog::{ClusterConfig, ClusterVariant, ClusterVariantManaged};
 
 use super::{
     AuditLogKey, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -145,8 +145,6 @@ pub enum AdapterError {
     Canceled,
     /// An idle session in a transaction has timed out.
     IdleInTransactionSessionTimeout,
-    /// An error occurred in a SQL catalog operation.
-    SqlCatalog(mz_sql::catalog::CatalogError),
     /// The transaction is in single-subscribe mode.
     SubscribeOnlyTransaction,
     /// An error occurred in the MIR stage of the optimizer.
@@ -300,7 +298,6 @@ impl AdapterError {
                     .to_string(),
             ),
             AdapterError::Catalog(c) => c.hint(),
-            AdapterError::SqlCatalog(e) => e.hint(),
             AdapterError::Eval(e) => e.hint(),
             AdapterError::InvalidClusterReplicaAz { expected, az: _ } => {
                 Some(if expected.is_empty() {
@@ -409,7 +406,6 @@ impl AdapterError {
             AdapterError::ResourceExhaustion { .. } => SqlState::INSUFFICIENT_RESOURCES,
             AdapterError::ResultSize(_) => SqlState::OUT_OF_MEMORY,
             AdapterError::SafeModeViolation(_) => SqlState::INTERNAL_ERROR,
-            AdapterError::SqlCatalog(_) => SqlState::INTERNAL_ERROR,
             AdapterError::SubscribeOnlyTransaction => SqlState::INVALID_TRANSACTION_STATE,
             AdapterError::Transform(_) => SqlState::INTERNAL_ERROR,
             AdapterError::UnallowedOnCluster { .. } => {
@@ -577,7 +573,6 @@ impl fmt::Display for AdapterError {
             AdapterError::SafeModeViolation(feature) => {
                 write!(f, "cannot create {} in safe mode", feature)
             }
-            AdapterError::SqlCatalog(e) => e.fmt(f),
             AdapterError::SubscribeOnlyTransaction => {
                 f.write_str("SUBSCRIBE in transactions must be the only read statement")
             }
@@ -689,6 +684,12 @@ impl From<catalog::Error> for AdapterError {
     }
 }
 
+impl From<catalog::storage::Error> for AdapterError {
+    fn from(e: catalog::storage::Error) -> Self {
+        catalog::Error::from(e).into()
+    }
+}
+
 impl From<EvalError> for AdapterError {
     fn from(e: EvalError) -> AdapterError {
         AdapterError::Eval(e)
@@ -706,7 +707,7 @@ impl From<ExplainError> for AdapterError {
 
 impl From<mz_sql::catalog::CatalogError> for AdapterError {
     fn from(e: mz_sql::catalog::CatalogError) -> AdapterError {
-        AdapterError::SqlCatalog(e)
+        AdapterError::Catalog(catalog::Error::from(e))
     }
 }
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -301,6 +301,15 @@ impl ShouldHalt for crate::catalog::Error {
     }
 }
 
+impl ShouldHalt for crate::catalog::storage::Error {
+    fn should_halt(&self) -> bool {
+        match &self {
+            Self::Stash(e) => e.should_halt(),
+            _ => false,
+        }
+    }
+}
+
 impl ShouldHalt for StashError {
     fn should_halt(&self) -> bool {
         self.is_unrecoverable()


### PR DESCRIPTION
This commit refactors the mz_adapter::catalog::storage dependencies so that it no longer relies on mz_adapter::catalog. This will help in the effort to extract catalog::storage into its own crate.

Works towards resolving #20953

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
