### PR TITLE
ci: add crate dependency linting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,7 @@
 /.github                            @benesch
 /bin
 /ci                                 @MaterializeInc/testing
+/ci/test/lint-deps.toml             @danhhz @benesch
 /doc/user                           @MaterializeInc/docs
 /doc/developer/reference/compute    @MaterializeInc/compute
 /doc/developer/reference/storage    @MaterializeInc/storage

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -177,6 +177,7 @@ RUN mkdir rust \
     && cargo install --root /usr/local --version "=0.5.2" --locked cargo-about \
     && cargo install --root /usr/local --version "=1.40.5" --locked cargo-deb \
     && cargo install --root /usr/local --version "=0.12.2" --locked cargo-deny \
+    && cargo install --root /usr/local --version "=0.1.0" --locked cargo-deplint \
     && cargo install --root /usr/local --version ="0.9.18" --locked cargo-hakari \
     && cargo install --root /usr/local --version "=0.9.44" --locked cargo-nextest \
     && cargo install --root /usr/local --version "=0.5.18" --locked cargo-llvm-cov \

--- a/ci/test/lint-deps.toml
+++ b/ci/test/lint-deps.toml
@@ -1,0 +1,68 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Configuration file for cargo-deplint
+#
+# If you find yourself here because CI failed on a PR, please don't blindly edit
+# out lints :D. Danhhz is always happy to discuss crate structure if you need
+# help fitting a change into these rules.
+
+# Keep various large crates from depending on frequently changing ones, so that
+# development iteration doesn't invalidate them.
+[[deny]]
+name = "mz-transform"
+dependencies = [
+    "mz-compute-client",
+    "mz-storage-client",
+]
+
+[[deny]]
+name = "mz-sql"
+dependencies = [
+    "mz-compute-client",
+    "mz-storage-client",
+]
+
+[[deny]]
+name = "mz-compute"
+dependencies = [
+    # TODO: "mz-storage-controller",
+    "mz-storage",
+]
+
+[[deny]]
+name = "mz-storage"
+dependencies = [
+    # TODO: "mz-storage-controller",
+    "mz-compute",
+]
+
+# Keep various crates in only one of environmentd or clusterd.
+[[deny]]
+name = "mz-environmentd"
+dependencies = [
+    "mz-compute",
+    "mz-rocksdb",
+    "mz-storage",
+    "mz-storage-operators",
+]
+
+[[deny]]
+name = "mz-clusterd"
+dependencies = [
+    # TODO: "mz-storage-controller",
+]
+
+# Persist is meant to be a strong enough abstraction that it doesn't depend on
+# mz internals like Row.
+[[deny]]
+name = "mz-persist-client"
+dependencies = [
+    "mz-repr",
+]

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -21,6 +21,7 @@ ci_try cargo --locked fmt -- --check
 ci_try cargo --locked deny check licenses bans sources
 ci_try cargo hakari generate --diff
 ci_try cargo hakari manage-deps --dry-run
+ci_try cargo deplint Cargo.lock ci/test/lint-deps.toml
 
 # Smoke out failures in generating the license metadata page, even though we
 # don't care about its output in the test pipeline, so that we don't only


### PR DESCRIPTION
A bunch of these crate deps were recently removed in #21554 in an effort to improve development iteration times (by creating fewer invalidations when changing commonly worked on crates). Keep them from accidentally coming back by adding a CI lint.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
