### PR TITLE
ci: reorder checks in lint-slow.sh

### DIFF
--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -15,10 +15,11 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-ci_try bin/xcompile cargo test --locked --doc
 ci_try cargo clippy --all-targets -- -D warnings
 
 ci_try bin/doc
 ci_try bin/doc --document-private-items
+
+ci_try bin/xcompile cargo test --locked --doc
 
 ci_status_report


### PR DESCRIPTION
Previously, the first step was running all the doctests, but that's the slowest of the three steps and the least likely to fail on a PR, so put it last. Clippy is the fastest and the most likely to fail, so keep it first.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
