### PR TITLE
Convert the default cluster to a managed cluster

### DIFF
--- a/doc/developer/platform-checks.md
+++ b/doc/developer/platform-checks.md
@@ -149,9 +149,9 @@ class DropCreateDefaultReplica(Action):
     def execute(self, c: Composition) -> None:
         c.sql(
             """
-           DROP CLUSTER REPLICA default.r1;
-           CREATE CLUSTER REPLICA default.r1 SIZE '1';
-        """
+            ALTER CLUSTER default SET (REPLICATION FACTOR 0);
+            ALTER CLUSTER default SET (SIZE '1', REPLICATION FACTOR 1);
+            """
         )
 ```
 

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -164,7 +164,7 @@ class UseClusterdCompute(MzcomposeAction):
 
         c.sql(
             f"""
-
+            ALTER CLUSTER default SET (MANAGED = false);
             DROP CLUSTER REPLICA default.r1;
             CREATE CLUSTER REPLICA default.r1
                 {storage_addresses},
@@ -244,8 +244,9 @@ class DropCreateDefaultReplica(MzcomposeAction):
 
         c.sql(
             """
-           DROP CLUSTER REPLICA default.r1;
-           CREATE CLUSTER REPLICA default.r1 SIZE '1';
+            ALTER CLUSTER default SET (MANAGED = false);
+            DROP CLUSTER REPLICA default.r1;
+            CREATE CLUSTER REPLICA default.r1 SIZE '1';
             """,
             port=6877,
             user="mz_system",

--- a/misc/python/materialize/zippy/replica_actions.py
+++ b/misc/python/materialize/zippy/replica_actions.py
@@ -30,6 +30,7 @@ class DropDefaultReplica(Action):
             dedent(
                 """
             $ postgres-execute connection=postgres://mz_system:materialize@materialized:6877
+            ALTER CLUSTER default SET (MANAGED = false)
             DROP CLUSTER REPLICA default.r1
             """
             )

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -424,6 +424,9 @@ ALTER CLUSTER default OWNER TO materialize
 ----
 COMPLETE 0
 
+statement ok
+ALTER CLUSTER default SET (MANAGED = false);
+
 statement error invalid SIZE: must provide a string value
 CREATE CLUSTER REPLICA default.size_1 SIZE;
 

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -55,7 +55,7 @@ SELECT id, name, managed, replication_factor, size FROM mz_clusters
 ----
 s1  mz_system  false  NULL  NULL
 s2  mz_introspection  false  NULL  NULL
-u1  default  false  NULL  NULL
+u1  default  true  1  1
 
 
 query T rowsort

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -819,6 +819,7 @@ ReduceMinsMaxes
 # Check dataflows of our logging infrastructure with log_logging
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET log_filter = 'debug'
+ALTER CLUSTER default SET (MANAGED = false);
 CREATE CLUSTER REPLICA default.replica SIZE = '2', INTROSPECTION DEBUGGING = true;
 
 > SET cluster_replica = replica;


### PR DESCRIPTION
### Motivation

Leftover work for #19976: Convert the default cluster with a managed cluster.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
