### PR TITLE
platform checks: Better error reporting

### DIFF
--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -99,18 +99,29 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     args = parser.parse_args()
 
-    scenarios = (
-        [globals()[args.scenario]] if args.scenario else Scenario.__subclasses__()
-    )
+    if args.scenario:
+        assert args.scenario in globals(), f"scenario {args.scenario} does not exist"
+        scenarios = [globals()[args.scenario]]
+    else:
+        scenarios = Scenario.__subclasses__()
 
-    checks = (
-        [globals()[check] for check in args.check]
-        if args.check
-        else Check.__subclasses__()
-    )
+    if args.check:
+        for check in args.check:
+            assert check in globals(), f"check {check} does not exist"
+            assert issubclass(
+                globals()[check], Check
+            ), f"{check} is not a Check. Maybe you meant to specify a Scenario via --scenario ?"
+
+        checks = [globals()[check] for check in args.check]
+    else:
+        checks = Check.__subclasses__()
 
     executor = MzcomposeExecutor(composition=c)
     for scenario_class in scenarios:
+        assert issubclass(
+            scenario_class, Scenario
+        ), f"{scenario_class} is not a Scenario. Maybe you meant to specify a Check via --check ?"
+
         print(f"Testing scenario {scenario_class}...")
 
         executor_class = (


### PR DESCRIPTION
Better error messages for various common mistakes, e.g. an invalid Check or Scenario name or using a Check in the place of a Scenario or vice versa.

### Motivation

People are running into the same set of common errors when trying to run the platform checks framework.