### PR TITLE
Update documentation on the default cluster

### DIFF
--- a/doc/user/content/sql/show-clusters.md
+++ b/doc/user/content/sql/show-clusters.md
@@ -23,7 +23,7 @@ pre-installed.
 
 A cluster named `default` with a single `xsmall` [replica](/get-started/key-concepts/#cluster-replicas)
 named `r1` will be pre-installed in every environment. You can modify or drop
-this cluster or its replicas at any time.
+this cluster at any time.
 
 {{< note >}}
 The default value for the `cluster` session parameter is `default`.


### PR DESCRIPTION
Since #21698 the default cluster is a managed cluster. Update the documentation to match this by not mentioning that individual replicas can be added or removed. It is still possible to convert the default cluster to an unmanaged one, should it be needed.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
