### PR TITLE
Give a notice when dropping an in-use index

### DIFF
--- a/src/adapter/src/severity.rs
+++ b/src/adapter/src/severity.rs
@@ -154,6 +154,7 @@ impl Severity {
             AdapterNotice::UnknownSessionDatabase(_) => Severity::Notice,
             AdapterNotice::OptimizerNotice { .. } => Severity::Notice,
             AdapterNotice::WebhookSourceCreated { .. } => Severity::Notice,
+            AdapterNotice::DroppedInUseIndex { .. } => Severity::Notice,
         }
     }
 }

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -216,6 +216,17 @@ impl<T> ComputeController<T> {
             storage,
         }
     }
+
+    /// List compute collections that depend on the given collection.
+    pub fn collection_reverse_dependencies(
+        &self,
+        instance_id: ComputeInstanceId,
+        id: GlobalId,
+    ) -> Result<impl Iterator<Item = &GlobalId>, InstanceMissing> {
+        Ok(self
+            .instance(instance_id)?
+            .collection_reverse_dependencies(id))
+    }
 }
 
 impl<T> ComputeController<T>

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -262,6 +262,17 @@ impl<T> Instance<T> {
         };
         self.ready_responses.push_back(resp);
     }
+
+    /// List compute collections that depend on the given collection.
+    pub fn collection_reverse_dependencies(&self, id: GlobalId) -> impl Iterator<Item = &GlobalId> {
+        self.collections_iter().filter_map(move |(id2, state)| {
+            if state.compute_dependencies.contains(&id) {
+                Some(id2)
+            } else {
+                None
+            }
+        })
+    }
 }
 
 impl<T> Instance<T>

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -1,5 +1,90 @@
 # Test various NOTICE expectations.
 
+send
+Query {"query": "create table t(a int, b int)"}
+Query {"query": "create index t_idx_a on t(a)"}
+Query {"query": "create materialized view mv1 as select * from t where b=7"}
+Query {"query": "create view v1 as select * from t union select * from t"}
+Query {"query": "create index v1_idx_a on v1(a)"}
+Query {"query": "drop index v1_idx_a"}
+Query {"query": "drop index t_idx_a"}
+Query {"query": "drop materialized view mv1"}
+Query {"query": "create index v1_idx_a on v1(a)"}
+Query {"query": "create materialized view mv2 as select * from t where a=5"}
+Query {"query": "drop index v1_idx_a"}
+Query {"query": "drop materialized view mv2"}
+Query {"query": "create index t_idx_a on t(a)"}
+Query {"query": "create materialized view mv2 as select * from t where a=5"}
+Query {"query": "drop index t_idx_a"}
+Query {"query": "create index t_idx_a on t(a)"}
+Query {"query": "create index v1_idx_a on v1(a)"}
+Query {"query": "drop index t_idx_a"}
+Query {"query": "drop index v1_idx_a"}
+----
+
+until
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+CommandComplete {"tag":"CREATE TABLE"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE MATERIALIZED VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv1. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP MATERIALIZED VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE MATERIALIZED VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP MATERIALIZED VIEW"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE MATERIALIZED VIEW"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv2. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"CREATE INDEX"}
+ReadyForQuery {"status":"I"}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.v1_idx_a. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+CommandComplete {"tag":"DROP INDEX"}
+ReadyForQuery {"status":"I"}
+
 # Test setting session variables to nonexistant values
 # Scenarios tested: nonexistant values, exstant values, capitalized variables
 # double quotes, single quotes, default values


### PR DESCRIPTION
This is the first step of addressing https://github.com/MaterializeInc/materialize/issues/20334: We give a notice when the user drops an index that is in use.

I'm planning to open a follow-up PR that will add some documentation about this situation, and will link to that in the notice message.

Note that the computation of `reverse_compute_dependencies` is not very efficient, because it goes through all collections. But we [decided with Jan that this is ok](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1693996386951679?thread_ts=1693938513.297449&cid=C02PPB50ZHS), and it's not worth it to make it more complicated for efficiency, because this should still take less than 1 ms, and dropping an index is not performance critical.

### Motivation

  * This PR adds a known-desirable feature: First step of https://github.com/MaterializeInc/materialize/issues/20334

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
  - [x] Nightly: https://buildkite.com/materialize/nightlies/builds/4102
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
