### PR TITLE
explain: add `humanized_exprs` option

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -76,7 +76,7 @@ pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
     thinned_arity: usize,
 }
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Ord, PartialOrd)]
 pub enum FastPathPlan {
     /// The view evaluates to a constant result that can be returned.
     ///

--- a/src/adapter/src/explain/mir/mod.rs
+++ b/src/adapter/src/explain/mir/mod.rs
@@ -132,13 +132,8 @@ impl<'a> Explainable<'a, DataflowDescription<OptimizedMirRelationExpr>> {
             .source_imports
             .iter_mut()
             .filter_map(|(id, (source_desc, _))| {
-                source_desc.arguments.operators.as_ref().map(|op| {
-                    let id = context
-                        .humanizer
-                        .humanize_id(*id)
-                        .unwrap_or_else(|| id.to_string());
-                    ExplainSource::new(id, op, context)
-                })
+                let op = source_desc.arguments.operators.as_ref();
+                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
             })
             .collect::<Vec<_>>();
 

--- a/src/compute-types/src/explain/mod.rs
+++ b/src/compute-types/src/explain/mod.rs
@@ -70,13 +70,8 @@ impl<'a> DataflowDescription<Plan> {
             .source_imports
             .iter_mut()
             .filter_map(|(id, (source_desc, _))| {
-                source_desc.arguments.operators.as_ref().map(|op| {
-                    let id = context
-                        .humanizer
-                        .humanize_id(*id)
-                        .unwrap_or_else(|| id.to_string());
-                    ExplainSource::new(id, op, context)
-                })
+                let op = source_desc.arguments.operators.as_ref();
+                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
             })
             .collect::<Vec<_>>();
 
@@ -143,13 +138,8 @@ impl<'a> DataflowDescription<OptimizedMirRelationExpr> {
             .source_imports
             .iter_mut()
             .filter_map(|(id, (source_desc, _))| {
-                source_desc.arguments.operators.as_ref().map(|op| {
-                    let id = context
-                        .humanizer
-                        .humanize_id(*id)
-                        .unwrap_or_else(|| id.to_string());
-                    ExplainSource::new(id, op, context)
-                })
+                let op = source_desc.arguments.operators.as_ref();
+                op.map(|op| ExplainSource::new(*id, op, context.config.filter_pushdown))
             })
             .collect::<Vec<_>>();
 

--- a/src/compute-types/src/plan/join/delta_join.rs
+++ b/src/compute-types/src/plan/join/delta_join.rs
@@ -36,7 +36,7 @@ use crate::plan::AvailableCollections;
 /// in arrangements for other join inputs. These lookups require specific
 /// instructions about which expressions to use as keys. Along the way,
 /// various closures are applied to filter and project as early as possible.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DeltaJoinPlan {
     /// The set of path plans.
     ///
@@ -71,7 +71,7 @@ impl RustType<ProtoDeltaJoinPlan> for DeltaJoinPlan {
 }
 
 /// A delta query path is implemented by a sequences of stages,
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DeltaPathPlan {
     /// The relation whose updates seed the dataflow path.
     pub source_relation: usize,
@@ -138,7 +138,7 @@ impl RustType<ProtoDeltaPathPlan> for DeltaPathPlan {
 }
 
 /// A delta query stage performs a stream lookup into an arrangement.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct DeltaStagePlan {
     /// The relation index into which we will look up.
     pub lookup_relation: usize,

--- a/src/compute-types/src/plan/join/linear_join.rs
+++ b/src/compute-types/src/plan/join/linear_join.rs
@@ -30,7 +30,7 @@ use crate::plan::AvailableCollections;
 ///
 /// A linear join is a sequence of stages, each of which introduces
 /// a new collection. Each stage is represented by a [LinearStagePlan].
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LinearJoinPlan {
     /// The source relation from which we start the join.
     pub source_relation: usize,
@@ -114,7 +114,7 @@ impl RustType<ProtoMirScalarVec> for Vec<MirScalarExpr> {
 /// Each stage is a binary join between the current accumulated
 /// join results, and a new collection. The former is referred to
 /// as the "stream" and the latter the "lookup".
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct LinearStagePlan {
     /// The index of the relation into which we will look up.
     pub lookup_relation: usize,

--- a/src/compute-types/src/plan/join/mod.rs
+++ b/src/compute-types/src/plan/join/mod.rs
@@ -45,7 +45,7 @@ pub use linear_join::LinearJoinPlan;
 include!(concat!(env!("OUT_DIR"), "/mz_compute_types.plan.join.rs"));
 
 /// A complete enumeration of possible join plans to render.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum JoinPlan {
     /// A join implemented by a linear join.
     Linear(LinearJoinPlan),
@@ -82,7 +82,7 @@ impl RustType<ProtoJoinPlan> for JoinPlan {
 /// as there is a relationship between the borrowed lifetime of the closed-over
 /// state and the arguments it takes when invoked. It was not clear how to do
 /// this with a Rust closure (glorious battle was waged, but ultimately lost).
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct JoinClosure {
     pub ready_equivalences: Vec<Vec<MirScalarExpr>>,
     pub before: mz_expr::SafeMfpPlan,

--- a/src/compute-types/src/plan/mod.rs
+++ b/src/compute-types/src/plan/mod.rs
@@ -85,7 +85,9 @@ include!(concat!(env!("OUT_DIR"), "/mz_compute_types.plan.rs"));
 /// when creating arrangements, and permute by the hashmap when reading them,
 /// the contract of the function where they are generated (`mz_expr::permutation_for_arrangement`)
 /// ensures that the correct values will be read.
-#[derive(Arbitrary, Default, Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[derive(
+    Arbitrary, Clone, Debug, Default, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize,
+)]
 pub struct AvailableCollections {
     /// Whether the collection exists in unarranged form.
     pub raw: bool,
@@ -161,7 +163,7 @@ impl AvailableCollections {
 }
 
 /// A rendering plan with as much conditional logic as possible removed.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Eq, Ord, PartialEq, PartialOrd, Serialize)]
 pub enum Plan<T = mz_repr::Timestamp> {
     /// A collection containing a pre-determined collection.
     Constant {
@@ -887,7 +889,7 @@ impl RustType<proto_plan::ProtoRowDiffVec> for Vec<(Row, mz_repr::Timestamp, i64
 }
 
 /// How a `Get` stage will be rendered.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum GetPlan {
     /// Simply pass input arrangements on to the next stage.
     PassArrangements,

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -145,7 +145,7 @@ impl TryFrom<&ReducePlan> for ReductionType {
 /// shape / general computation of the rendered dataflow graph
 /// in this plan, and then make actually rendering the graph
 /// be as simple (and compiler verifiable) as possible.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ReducePlan {
     /// Plan for not computing any aggregations, just determining the set of
     /// distinct keys.
@@ -244,7 +244,7 @@ impl RustType<ProtoReducePlan> for ReducePlan {
 /// apply only to the distinct set of values. We need
 /// to apply a distinct operator to those before we
 /// combine them with everything else.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct AccumulablePlan {
     /// All of the aggregations we were asked to compute, stored
     /// in order.
@@ -301,7 +301,7 @@ impl RustType<ProtoAccumulablePlan> for AccumulablePlan {
 /// with monotonic plans, but otherwise, we need to render
 /// them with a reduction tree that splits the inputs into
 /// small, and then progressively larger, buckets
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum HierarchicalPlan {
     /// Plan hierarchical aggregations under monotonic inputs.
     Monotonic(MonotonicPlan),
@@ -358,7 +358,7 @@ impl RustType<ProtoHierarchicalPlan> for HierarchicalPlan {
 /// append only, so we can change our computation to
 /// only retain the "best" value in the diff field, instead
 /// of holding onto all values.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MonotonicPlan {
     /// All of the aggregations we were asked to compute.
     pub aggr_funcs: Vec<AggregateFunc>,
@@ -403,7 +403,7 @@ impl RustType<ProtoMonotonicPlan> for MonotonicPlan {
 /// fraction of the original input) and redo the reduction in another
 /// layer. Effectively, we'll construct a min / max heap out of a series
 /// of reduce operators (each one is a separate layer).
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BucketedPlan {
     /// All of the aggregations we were asked to compute.
     pub aggr_funcs: Vec<AggregateFunc>,
@@ -459,7 +459,7 @@ impl RustType<ProtoBucketedPlan> for BucketedPlan {
 /// were only asked to compute a single aggregation, we can skip
 /// that step and return the arrangement provided by computing the aggregation
 /// directly.
-#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum BasicPlan {
     /// Plan for rendering a single basic aggregation. Here, the
     /// first element denotes the index in the set of inputs
@@ -530,7 +530,7 @@ impl RustType<ProtoBasicPlan> for BasicPlan {
 /// types.
 ///
 /// TODO: could we express this as a delta join
-#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct CollationPlan {
     /// Accumulable aggregation results to collate, if any.
     pub accumulable: Option<AccumulablePlan>,
@@ -760,7 +760,7 @@ impl ReducePlan {
 }
 
 /// Plan for extracting keys and values in preparation for a reduction.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct KeyValPlan {
     /// Extracts the columns used as the key.
     pub key_plan: mz_expr::SafeMfpPlan,

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -38,7 +38,7 @@ include!(concat!(
 ));
 
 /// A plan describing how to compute a threshold operation.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ThresholdPlan {
     /// Basic threshold maintains all positive inputs.
     Basic(BasicThresholdPlan),
@@ -118,7 +118,7 @@ impl ThresholdPlan {
 }
 
 /// A plan to maintain all inputs with positive counts.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BasicThresholdPlan {
     /// Description of how the input has been arranged, and how to arrange the output
     #[proptest(strategy = "any_arranged_thin()")]
@@ -127,7 +127,7 @@ pub struct BasicThresholdPlan {
 
 /// A plan to maintain all inputs with negative counts, which are subtracted from the output
 /// in order to maintain an equivalent collection compared to [BasicThresholdPlan].
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct RetractionsThresholdPlan {
     /// Description of how the input has been arranged
     #[proptest(strategy = "any_arranged_thin()")]

--- a/src/compute-types/src/plan/top_k.rs
+++ b/src/compute-types/src/plan/top_k.rs
@@ -27,7 +27,7 @@ use crate::plan::bucketing_of_expected_group_size;
 include!(concat!(env!("OUT_DIR"), "/mz_compute_types.plan.top_k.rs"));
 
 /// A plan encapsulating different variants to compute a TopK operation.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub enum TopKPlan {
     /// A plan for Top1 for monotonic inputs.
     MonotonicTop1(MonotonicTop1Plan),
@@ -165,7 +165,7 @@ impl RustType<ProtoTopKPlan> for TopKPlan {
 /// differential's semantics. (2) is especially interesting because Kafka is
 /// monotonic with an ENVELOPE of NONE, which is the default for ENVELOPE in
 /// Materialize and commonly used by users.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MonotonicTop1Plan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -200,7 +200,7 @@ impl RustType<ProtoMonotonicTop1Plan> for MonotonicTop1Plan {
 }
 
 /// A plan for monotonic TopKs with an offset of 0 and an arbitrary limit.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct MonotonicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,
@@ -244,7 +244,7 @@ impl RustType<ProtoMonotonicTopKPlan> for MonotonicTopKPlan {
 }
 
 /// A plan for generic TopKs that don't fit any more specific category.
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
 pub struct BasicTopKPlan {
     /// The columns that form the key for each group.
     pub group_key: Vec<usize>,

--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -66,13 +66,20 @@ pub struct PushdownInfo<'a> {
     pub pushdown: Vec<&'a MirScalarExpr>,
 }
 
-impl<C: AsMut<Indent>> DisplayText<C> for PushdownInfo<'_> {
+impl<'a, C: AsMut<Indent>> DisplayText<C> for PushdownInfo<'a> {
     fn fmt_text(&self, f: &mut Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
-        let Self { pushdown } = self;
+        HumanizedExpr::new(self, None).fmt_text(f, ctx)
+    }
+}
+
+impl<'a, C: AsMut<Indent>> DisplayText<C> for HumanizedExpr<'a, PushdownInfo<'a>> {
+    fn fmt_text(&self, f: &mut Formatter<'_>, ctx: &mut C) -> std::fmt::Result {
+        let PushdownInfo { pushdown } = self.expr;
 
         if !pushdown.is_empty() {
-            let separated = separated(" AND ", pushdown);
-            writeln!(f, "{}pushdown=({})", ctx.as_mut(), separated)?;
+            let pushdown = pushdown.iter().map(|e| HumanizedExpr::new(*e, self.cols));
+            let pushdown = separated(" AND ", pushdown);
+            writeln!(f, "{}pushdown=({})", ctx.as_mut(), pushdown)?;
         }
 
         Ok(())

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -912,26 +912,33 @@ where
 }
 
 impl MirScalarExpr {
-    pub fn format(&self, f: &mut fmt::Formatter<'_>, cols: &Option<Vec<String>>) -> fmt::Result {
+    pub fn format(&self, f: &mut fmt::Formatter<'_>, cols: Option<&Vec<String>>) -> fmt::Result {
         fmt::Display::fmt(&HumanizedExpr::new(self, cols), f)
     }
 }
 
 impl fmt::Display for MirScalarExpr {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.format(f, &None)
+        self.format(f, None)
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct HumanizedExpr<'a, T> {
     expr: &'a T,
-    cols: &'a Option<Vec<String>>,
+    cols: Option<&'a Vec<String>>,
 }
 
 impl<'a, T> HumanizedExpr<'a, T> {
-    pub fn new(expr: &'a T, cols: &'a Option<Vec<String>>) -> Self {
+    pub fn new(expr: &'a T, cols: Option<&'a Vec<String>>) -> Self {
         Self { expr, cols }
+    }
+
+    pub fn seq<'i>(
+        exprs: &'i [T],
+        cols: Option<&'i Vec<String>>,
+    ) -> impl Iterator<Item = HumanizedExpr<'i, T>> + Clone {
+        exprs.iter().map(move |expr| HumanizedExpr::new(expr, cols))
     }
 
     fn child<U>(&self, expr: &'a U) -> HumanizedExpr<'a, U> {

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -16,8 +16,8 @@ use mz_ore::soft_assert;
 use mz_ore::str::{bracketed, closure_to_display, separated, Indent, IndentLike, StrExt};
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{
-    CompactScalarSeq, ExprHumanizer, IndexUsageType, Indices, PlanRenderingContext,
-    RenderingContext,
+    CompactScalarSeq, ExprHumanizer, HumanizedAttributes, IndexUsageType, Indices,
+    PlanRenderingContext, RenderingContext,
 };
 use mz_repr::{GlobalId, Row};
 
@@ -790,9 +790,9 @@ impl MirRelationExpr {
     ) -> fmt::Result {
         if ctx.config.requires_attributes() {
             if let Some(attrs) = ctx.annotations.get(self) {
-                writeln!(f, " {}", attrs)
+                writeln!(f, " {}", HumanizedAttributes::new(attrs, ctx))
             } else {
-                writeln!(f, " # error: no attrs for subtree in map")
+                writeln!(f, " // error: no attrs for subtree in map")
             }
         } else {
             writeln!(f)

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -34,7 +34,7 @@ include!(concat!(env!("OUT_DIR"), "/mz_expr.linear.rs"));
 /// expressions in `self.expressions`, even though this is not something
 /// we can directly evaluate. The plan creation methods will defensively
 /// ensure that the right thing happens.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, Ord, PartialOrd)]
 pub struct MapFilterProject {
     /// A sequence of expressions that should be appended to the row.
     ///
@@ -1441,7 +1441,7 @@ pub mod plan {
     };
 
     /// A wrapper type which indicates it is safe to simply evaluate all expressions.
-    #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+    #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq, Ord, PartialOrd)]
     pub struct SafeMfpPlan {
         pub(crate) mfp: MapFilterProject,
     }

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -33,6 +33,7 @@ use mz_repr::{ColumnName, ColumnType, Datum, Diff, GlobalId, RelationType, Row, 
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
+use crate::explain::HumanizedExpr;
 use crate::relation::func::{AggregateFunc, LagLeadType, TableFunc};
 use crate::visit::{Visit, VisitChildren};
 use crate::Id::Local;
@@ -2269,13 +2270,19 @@ impl RustType<ProtoColumnOrder> for ColumnOrder {
 
 impl fmt::Display for ColumnOrder {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        HumanizedExpr::new(self, None).fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for HumanizedExpr<'a, ColumnOrder> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         // If you modify this, then please also attend to Display for ColumnOrderWithExpr!
         write!(
             f,
-            "#{} {} {}",
-            self.column,
-            if self.desc { "desc" } else { "asc" },
-            if self.nulls_last {
+            "{} {} {}",
+            self.child(&self.expr.column),
+            if self.expr.desc { "desc" } else { "asc" },
+            if self.expr.nulls_last {
                 "nulls_last"
             } else {
                 "nulls_first"

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -181,6 +181,8 @@ pub struct ExplainConfig {
     pub cardinality: bool,
     /// Show inferred column names.
     pub column_names: bool,
+    /// Use inferred column names when rendering scalar and aggregate expressions.
+    pub humanized_exprs: bool,
 }
 
 impl Default for ExplainConfig {
@@ -200,6 +202,7 @@ impl Default for ExplainConfig {
             filter_pushdown: false,
             cardinality: false,
             column_names: false,
+            humanized_exprs: false,
         }
     }
 }
@@ -240,6 +243,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             filter_pushdown: flags.remove("filter_pushdown") || flags.remove("mfp_pushdown"),
             cardinality: flags.remove("cardinality"),
             column_names: flags.remove("column_names"),
+            humanized_exprs: flags.remove("humanized_exprs") && !flags.contains("raw_plans"),
         };
         if flags.is_empty() {
             Ok(result)
@@ -812,6 +816,7 @@ mod tests {
             filter_pushdown: false,
             cardinality: false,
             column_names: false,
+            humanized_exprs: false,
         };
         let context = ExplainContext {
             env,

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -519,37 +519,90 @@ pub struct Attributes {
     pub non_negative: Option<bool>,
     pub subtree_size: Option<usize>,
     pub arity: Option<usize>,
-    pub types: Option<String>,
-    pub keys: Option<String>,
+    pub types: Option<Option<Vec<ColumnType>>>,
+    pub keys: Option<Vec<Vec<usize>>>,
     pub cardinality: Option<String>,
     pub column_names: Option<Vec<String>>,
 }
 
-impl fmt::Display for Attributes {
+#[derive(Debug, Clone)]
+pub struct HumanizedAttributes<'a> {
+    attrs: &'a Attributes,
+    humanizer: &'a dyn ExprHumanizer,
+    config: &'a ExplainConfig,
+}
+
+impl<'a> HumanizedAttributes<'a> {
+    pub fn new<T>(attrs: &'a Attributes, ctx: &PlanRenderingContext<'a, T>) -> Self {
+        Self {
+            attrs,
+            humanizer: ctx.humanizer,
+            config: ctx.config,
+        }
+    }
+}
+
+impl<'a> fmt::Display for HumanizedAttributes<'a> {
+    // Attribute rendering is guarded by the ExplainConfig flag for each
+    // attribute. This is needed because we might have derived attributes that
+    // are not explicitly requested (such as column_names), in which case we
+    // don't want to display them.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut builder = f.debug_struct("//");
-        if let Some(subtree_size) = &self.subtree_size {
-            builder.field("subtree_size", subtree_size);
+
+        if self.config.subtree_size {
+            let subtree_size = self.attrs.subtree_size.expect("subtree_size");
+            builder.field("subtree_size", &subtree_size);
         }
-        if let Some(non_negative) = &self.non_negative {
-            builder.field("non_negative", non_negative);
+
+        if self.config.non_negative {
+            let non_negative = self.attrs.non_negative.expect("non_negative");
+            builder.field("non_negative", &non_negative);
         }
-        if let Some(arity) = &self.arity {
-            builder.field("arity", arity);
+
+        if self.config.arity {
+            let arity = self.attrs.arity.expect("arity");
+            builder.field("arity", &arity);
         }
-        if let Some(types) = &self.types {
-            builder.field("types", types);
+
+        if self.config.types {
+            let types = match self.attrs.types.as_ref().expect("types") {
+                Some(types) => {
+                    let types = types
+                        .into_iter()
+                        .map(|c| self.humanizer.humanize_column_type(c))
+                        .collect::<Vec<_>>();
+
+                    bracketed("(", ")", separated(", ", types)).to_string()
+                }
+                None => "(<error>)".to_string(),
+            };
+            builder.field("types", &types);
         }
-        if let Some(keys) = &self.keys {
-            builder.field("keys", keys);
+
+        if self.config.keys {
+            let keys = self
+                .attrs
+                .keys
+                .as_ref()
+                .expect("keys")
+                .into_iter()
+                .map(|key| bracketed("[", "]", separated(", ", key)).to_string());
+            let keys = bracketed("(", ")", separated(", ", keys)).to_string();
+            builder.field("keys", &keys);
         }
-        if let Some(cardinality) = &self.cardinality {
+
+        if self.config.cardinality {
+            let cardinality = self.attrs.cardinality.as_ref().expect("cardinality");
             builder.field("cardinality", cardinality);
         }
-        if let Some(column_names) = &self.column_names {
+
+        if self.config.column_names {
+            let column_names = self.attrs.column_names.as_ref().expect("column_names");
             let column_names = bracketed("(", ")", separated(", ", column_names)).to_string();
             builder.field("column_names", &column_names);
         }
+
         builder.finish()
     }
 }

--- a/src/transform/tests/test_transforms/humanized_exprs.spec
+++ b/src/transform/tests/test_transforms/humanized_exprs.spec
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0
+  - c0: bigint
+  - c1: bigint
+----
+Source defined as t0
+
+# Constant
+explain with=humanized_exprs
+Constant // { types: "(bigint, bigint)" }
+  - (1, 2)
+  - (1, 3)
+----
+Constant
+  - (1, 2)
+  - (1, 3)
+
+# Global Get
+explain with=humanized_exprs
+Get t0
+----
+Get t0
+
+# Local Get in a Let block
+explain with=humanized_exprs
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+----
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+
+# Local Get in a LetRec block
+explain with=humanized_exprs
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint, bigint)" }
+    Get t0
+----
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 =
+    Get t0
+
+# Project
+explain with=humanized_exprs
+Project (#1, #0, #1)
+  Get t0
+----
+Project (#1, #0, #1)
+  Get t0
+
+# Map
+explain with=humanized_exprs
+Map (#1, #0 + #1, #0)
+  Get t0
+----
+Map (c1, (c0 + c1), c0)
+  Get t0
+
+# FlatMap
+explain with=humanized_exprs
+FlatMap generate_series(#0, #1, 1)
+  Get t0
+----
+FlatMap generate_series(c0, c1, 1)
+  Get t0
+
+# Filter
+explain with=humanized_exprs
+Filter (#0 > #1 + 42)
+  Get t0
+----
+Filter (c0 > (c1 + 42))
+  Get t0
+
+# Reduce
+explain with=humanized_exprs
+Reduce group_by=[#0, 42] aggregates=[min(#1), max(#1)]
+  Get t0
+----
+Reduce group_by=[c0, 42] aggregates=[min(c1), max(c1)]
+  Get t0
+
+# TopK
+explain with=humanized_exprs
+TopK group_by=[#1] order_by=[#0 desc nulls_first] limit=3
+  Get t0
+----
+TopK group_by=[c1] order_by=[c0 desc nulls_first] limit=3
+  Get t0
+
+# Negate
+explain with=humanized_exprs
+Negate
+  Get t0
+----
+Negate
+  Get t0
+
+# Threshold
+explain with=humanized_exprs
+Threshold
+  Get t0
+----
+Threshold
+  Get t0
+
+# ArrangeBy
+explain with=humanized_exprs
+ArrangeBy keys=[[#1], [#1, #0]]
+  Get t0
+----
+ArrangeBy keys=[[c1], [c1, c0]]
+  Get t0
+
+# Union (anonymous last)
+explain with=humanized_exprs
+Union
+  Get t0
+  Constant <empty> // { types: "(bigint, bigint)" }
+----
+Union
+  Get t0
+  Constant <empty>
+
+# Union (anonymous first)
+explain with=humanized_exprs
+Union
+  Constant <empty> // { types: "(bigint, bigint)" }
+  Get t0
+----
+Union
+  Constant <empty>
+  Get t0
+
+# Join
+explain with=humanized_exprs
+Join on=(#1 = #2)
+  Get t0
+  Get t0
+----
+Join on=(c1 = c0)
+  Get t0
+  Get t0

--- a/test/sqllogictest/explain/optimized_plan_as_json.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_json.slt
@@ -432,7 +432,9 @@ SELECT 1, a + b as c FROM mv WHERE a > 0 and b < 0 and a + b > 0
   ],
   "sources": [
     {
-      "id": "materialize.public.mv",
+      "id": {
+        "User": 8
+      },
       "op": {
         "expressions": [],
         "predicates": [
@@ -2865,7 +2867,9 @@ SELECT (SELECT iv.a FROM iv WHERE iv.b = t.b LIMIT 1), (SELECT mv.a FROM mv WHER
   ],
   "sources": [
     {
-      "id": "materialize.public.mv",
+      "id": {
+        "User": 8
+      },
       "op": {
         "expressions": [],
         "predicates": [
@@ -5596,7 +5600,9 @@ SELECT s FROM t2 WHERE s ~ 'a.*';
   ],
   "sources": [
     {
-      "id": "materialize.public.t2",
+      "id": {
+        "User": 13
+      },
       "op": {
         "expressions": [],
         "predicates": [

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -371,7 +371,9 @@ SELECT c + d, 1 FROM u
   ],
   "sources": [
     {
-      "id": "materialize.public.u",
+      "id": {
+        "User": 2
+      },
       "op": {
         "expressions": [
           {
@@ -645,7 +647,9 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
   ],
   "sources": [
     {
-      "id": "materialize.public.mv",
+      "id": {
+        "User": 7
+      },
       "op": {
         "expressions": [],
         "predicates": [],
@@ -1034,7 +1038,9 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
   ],
   "sources": [
     {
-      "id": "materialize.public.mv",
+      "id": {
+        "User": 7
+      },
       "op": {
         "expressions": [],
         "predicates": [],
@@ -1304,7 +1310,9 @@ SELECT x * 5 FROM cte WHERE x = 5
   ],
   "sources": [
     {
-      "id": "materialize.public.mv",
+      "id": {
+        "User": 7
+      },
       "op": {
         "expressions": [],
         "predicates": [
@@ -6292,7 +6300,9 @@ WHERE a = c AND d = e AND b + d > 42
   ],
   "sources": [
     {
-      "id": "materialize.public.u",
+      "id": {
+        "User": 2
+      },
       "op": {
         "expressions": [],
         "predicates": [
@@ -6345,7 +6355,9 @@ WHERE a = c AND d = e AND b + d > 42
       }
     },
     {
-      "id": "materialize.public.v",
+      "id": {
+        "User": 3
+      },
       "op": {
         "expressions": [],
         "predicates": [

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -31,7 +31,7 @@ CREATE TABLE events (
 );
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT count(*)
 FROM events
 WHERE mz_now() >= insert_ms
@@ -52,17 +52,17 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[count(*)]
         Project ()
-          Filter (mz_now() < numeric_to_mz_timestamp(#2)) AND (mz_now() >= numeric_to_mz_timestamp(#1))
+          Filter (mz_now() < numeric_to_mz_timestamp(delete_ms)) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms))
             ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp(#2)))
-  pushdown=((mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp(#2)))
+  filter=((mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp(delete_ms)))
+  pushdown=((mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp(delete_ms)))
 
 EOF
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear in only one interval of duration `10000`.
@@ -74,18 +74,18 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
 Explained Query:
   Project (#0, #1)
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3))))
-      Map ((#1 / 10000))
+      Map ((insert_ms / 10000))
         ReadStorage materialize.public.events
 
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
-  map=((#1 / 10000))
+  map=((insert_ms / 10000))
   pushdown=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear in `6` intervals each of width `10000`.
@@ -97,18 +97,18 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
 Explained Query:
   Project (#0, #1)
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3))))
-      Map ((#1 / 10000))
+      Map ((insert_ms / 10000))
         ReadStorage materialize.public.events
 
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
-  map=((#1 / 10000))
+  map=((insert_ms / 10000))
   pushdown=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms
 FROM events
 -- The event should appear inside the interval that begins at
@@ -120,29 +120,29 @@ WHERE mz_now() >= insert_ms
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (mz_now() >= numeric_to_mz_timestamp(#1)) AND (mz_now() < numeric_to_mz_timestamp((#1 + 30000)))
+    Filter (mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp((insert_ms + 30000)))
       ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() < numeric_to_mz_timestamp((#1 + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1)))
-  pushdown=((mz_now() < numeric_to_mz_timestamp((#1 + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1)))
+  filter=((mz_now() < numeric_to_mz_timestamp((insert_ms + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms)))
+  pushdown=((mz_now() < numeric_to_mz_timestamp((insert_ms + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms)))
 
 EOF
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() >= insert_ms + 60000
   AND mz_now() < delete_ms + 60000;
 ----
 Explained Query:
-  Filter (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((#1 + 60000)))
+  Filter (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000)))
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() >= numeric_to_mz_timestamp((#1 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))))
-  pushdown=((mz_now() >= numeric_to_mz_timestamp((#1 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))))
+  filter=((mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))))
+  pushdown=((mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))))
 
 EOF
 
@@ -152,23 +152,23 @@ EOF
 # function _does_ report pushdown even when the argument list is long.
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE COALESCE(delete_ms, insert_ms) < mz_now();
 ----
 Explained Query:
-  Filter (numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now())
+  Filter (numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now())
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now()))
-  pushdown=((numeric_to_mz_timestamp(coalesce(#2, #1)) < mz_now()))
+  filter=((numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now()))
+  pushdown=((numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now()))
 
 EOF
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, insert_ms, delete_ms
 FROM events
 WHERE mz_now() < delete_ms + 10000
@@ -182,12 +182,12 @@ WHERE mz_now() < delete_ms + 10000
   AND mz_now() < delete_ms + 90000;
 ----
 Explained Query:
-  Filter (mz_now() < numeric_to_mz_timestamp((#2 + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 90000)))
+  Filter (mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000)))
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() < numeric_to_mz_timestamp((#2 + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 90000))))
-  pushdown=((mz_now() < numeric_to_mz_timestamp((#2 + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2 + 90000))))
+  filter=((mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000))))
+  pushdown=((mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000))))
 
 EOF
 
@@ -199,19 +199,19 @@ CREATE TABLE events_timestamped (
 );
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, inserted_at
 FROM events_timestamped
 WHERE EXTRACT(YEAR FROM inserted_at) = 2021;
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (2021 = extract_year_ts(#1))
+    Filter (2021 = extract_year_ts(inserted_at))
       ReadStorage materialize.public.events_timestamped
 
 Source materialize.public.events_timestamped
-  filter=((2021 = extract_year_ts(#1)))
-  pushdown=((2021 = extract_year_ts(#1)))
+  filter=((2021 = extract_year_ts(inserted_at)))
+  pushdown=((2021 = extract_year_ts(inserted_at)))
 
 EOF
 
@@ -224,18 +224,18 @@ ALTER SYSTEM SET enable_try_parse_monotonic_iso8601_timestamp = true;
 COMPLETE 0
 
 query T multiline
-EXPLAIN WITH(filter_pushdown)
+EXPLAIN WITH(humanized_exprs, filter_pushdown)
 SELECT content, inserted_at
 FROM events_timestamped
 WHERE mz_now() < try_parse_monotonic_iso8601_timestamp(content);
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0)))
+    Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content)))
       ReadStorage materialize.public.events_timestamped
 
 Source materialize.public.events_timestamped
-  filter=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0))))
-  pushdown=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0))))
+  filter=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content))))
+  pushdown=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content))))
 
 EOF

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -405,7 +405,7 @@ CREATE OR REPLACE VIEW Post_View AS
 # \set datetime '\'2010-06-11T09:21:46.000+00:00\'::TIMESTAMP'
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   message_count AS (
     SELECT 0.0 + count(*) AS cnt
       FROM Message
@@ -440,14 +440,14 @@ Explained Query:
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
         Map ((#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end)), (bigint_to_numeric(#4) / #3)) // { arity: 9 }
-          Reduce group_by=[#1..=#4] aggregates=[count(*), sum(integer_to_bigint(#0)), count(integer_to_bigint(#0))] // { arity: 7 }
+          Reduce group_by=[#1, #2, #3, #4] aggregates=[count(*), sum(integer_to_bigint(length)), count(integer_to_bigint(length))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]U » %0:message[×]if
               ArrangeBy keys=[[]] // { arity: 4 }
                 Project (#8, #13..=#15) // { arity: 4 }
-                  Filter (#0 < 2010-06-11 09:21:46 UTC) AND (#4) IS NOT NULL // { arity: 16 }
-                    Map (extract_year_tstz(#0), (#12) IS NOT NULL, case when (#8 < 40) then 0 else case when (#8 < 80) then 1 else case when (#8 < 160) then 2 else 3 end end end) // { arity: 16 }
+                  Filter (creationdate < 2010-06-11 09:21:46 UTC) AND (content) IS NOT NULL // { arity: 16 }
+                    Map (extract_year_tstz(creationdate), (parentmessageid) IS NOT NULL, case when (length < 40) then 0 else case when (length < 80) then 1 else case when (length < 160) then 2 else 3 end end end) // { arity: 16 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Project (#1) // { arity: 1 }
@@ -465,7 +465,7 @@ Explained Query:
       cte l0 =
         Reduce aggregates=[count(*)] // { arity: 1 }
           Project () // { arity: 0 }
-            Filter (#0 < 2010-06-11 09:21:46 UTC) // { arity: 13 }
+            Filter (creationdate < 2010-06-11 09:21:46 UTC) // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -481,7 +481,7 @@ EOF
 # \set tagClass '\'ChristianBishop\''
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
 MyTag AS (
 SELECT Tag.id AS id, Tag.name AS name
   FROM TagClass
@@ -511,7 +511,7 @@ SELECT t.name AS "tag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, name asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
         Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
@@ -527,39 +527,39 @@ Explained Query:
     With
       cte l2 =
         Project (#1, #3, #4) // { arity: 3 }
-          Join on=(#0 = #2) type=differential // { arity: 5 }
+          Join on=(id = id) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[id]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
-              Reduce group_by=[#0] aggregates=[count(case when (#2 < 2010-09-16 00:00:00 UTC) then #1 else null end), count(case when (#2 >= 2010-09-16 00:00:00 UTC) then #1 else null end)] // { arity: 3 }
+            ArrangeBy keys=[[id]] // { arity: 3 }
+              Reduce group_by=[id] aggregates=[count(case when (creationdate < 2010-09-16 00:00:00 UTC) then messageid else null end), count(case when (creationdate >= 2010-09-16 00:00:00 UTC) then messageid else null end)] // { arity: 3 }
                 Project (#0, #2, #4) // { arity: 3 }
-                  Filter (#4 < 2010-12-25 00:00:00 UTC) AND (#4 >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
-                    Join on=(#0 = #3 AND #2 = #5) type=delta // { arity: 17 }
+                  Filter (creationdate < 2010-12-25 00:00:00 UTC) AND (creationdate >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
+                    Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 17 }
                       implementation
                         %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif
                         %1:message_hastag_tag » %2:message[#1]KAiif » %0:l1[#0]KA
                         %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                      ArrangeBy keys=[[id]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+                      ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                      ArrangeBy keys=[[#1]] // { arity: 13 }
+                      ArrangeBy keys=[[messageid]] // { arity: 13 }
                         ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
-        Filter (#0) IS NOT NULL // { arity: 2 }
+        Filter (id) IS NOT NULL // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#5, #6) // { arity: 2 }
-          Filter (#0) IS NOT NULL // { arity: 9 }
-            Join on=(#0 = #8) type=differential // { arity: 9 }
+          Filter (id) IS NOT NULL // { arity: 9 }
+            Join on=(id = typetagclassid) type=differential // { arity: 9 }
               implementation
                 %0:tagclass[#0]KAe » %1:tag[#3]KAe
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[id]] // { arity: 5 }
                 ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-              ArrangeBy keys=[[#3]] // { arity: 4 }
+              ArrangeBy keys=[[typetagclassid]] // { arity: 4 }
                 ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -579,7 +579,7 @@ EOF
 # \set country '\'China\''
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) SELECT Forum.id                AS "forum.id"
+EXPLAIN WITH(humanized_exprs, arity, join_impls) SELECT Forum.id                AS "forum.id"
      , Forum.title             AS "forum.title"
      , Forum.creationDate      AS "forum.creationDate"
      , Forum.ModeratorPersonId AS "person.id"
@@ -607,37 +607,37 @@ ORDER BY messageCount DESC, Forum.id
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=20 output=[#0..=#4]
-    Reduce group_by=[#0, #2, #1, #3] aggregates=[count(*)] // { arity: 5 }
+  Finish order_by=[#4 desc nulls_first, containerforumid asc nulls_last] limit=20 output=[#0..=#4]
+    Reduce group_by=[containerforumid, title, creationdate, moderatorpersonid] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (#33 = "China") AND (#10) IS NOT NULL AND (#16) IS NOT NULL AND (#25) IS NOT NULL AND (#31) IS NOT NULL // { arity: 37 }
-          Join on=(#1 = #36 AND #10 = #14 AND #16 = #18 AND #25 = #28 AND #31 = #32) type=differential // { arity: 37 }
+        Filter (name = "China") AND (containerforumid) IS NOT NULL AND (moderatorpersonid) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 37 }
+          Join on=(messageid = messageid AND containerforumid = id AND moderatorpersonid = id AND locationcityid = id AND partofcountryid = id) type=differential // { arity: 37 }
             implementation
               %5[#0]UKA » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
-            ArrangeBy keys=[[#1]] // { arity: 13 }
+            ArrangeBy keys=[[messageid]] // { arity: 13 }
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[#1]] // { arity: 4 }
+            ArrangeBy keys=[[id]] // { arity: 4 }
               ReadIndex on=forum forum_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[#1]] // { arity: 11 }
+            ArrangeBy keys=[[id]] // { arity: 11 }
               ReadIndex on=person person_id=[differential join] // { arity: 11 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
+            ArrangeBy keys=[[id]] // { arity: 4 }
               ReadIndex on=city city_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
+            ArrangeBy keys=[[id]] // { arity: 4 }
               ReadIndex on=country country_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[messageid]] // { arity: 1 }
+              Distinct group_by=[messageid] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (#0) IS NOT NULL AND (#5) IS NOT NULL // { arity: 12 }
-                    Join on=(#0 = #8 AND #5 = #11) type=delta // { arity: 12 }
+                  Filter (id) IS NOT NULL AND (id) IS NOT NULL // { arity: 12 }
+                    Join on=(id = typetagclassid AND id = tagid) type=delta // { arity: 12 }
                       implementation
                         %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
                         %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
                         %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
-                      ArrangeBy keys=[[#0]] // { arity: 5 }
+                      ArrangeBy keys=[[id]] // { arity: 5 }
                         ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                      ArrangeBy keys=[[#0], [#3]] // { arity: 4 }
+                      ArrangeBy keys=[[id], [typetagclassid]] // { arity: 4 }
                         ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[#2]] // { arity: 3 }
+                      ArrangeBy keys=[[tagid]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -685,7 +685,7 @@ statement ok
 CREATE INDEX Top100PopularForumsQ04_id ON Top100PopularForumsQ04 (id);
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   Top100_Popular_Forums AS (
     SELECT id, creationDate, maxNumberOfMembers
     FROM Top100PopularForumsQ04
@@ -723,20 +723,20 @@ ORDER BY messageCount DESC, au.id
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Reduce group_by=[#1..=#3, #0] aggregates=[count(#4)] // { arity: 5 }
+      Reduce group_by=[id, firstname, lastname, creationdate] aggregates=[count(messageid)] // { arity: 5 }
         Union // { arity: 5 }
           Map (null) // { arity: 5 }
             Union // { arity: 4 }
               Negate // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
-                  Join on=(#1 = #4) type=differential // { arity: 5 }
+                  Join on=(id = id) type=differential // { arity: 5 }
                     implementation
                       %1[#0]UKA » %0:l2[#1]K
                     Get l2 // { arity: 4 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                    ArrangeBy keys=[[id]] // { arity: 1 }
+                      Distinct group_by=[id] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           Get l3 // { arity: 5 }
               Get l1 // { arity: 4 }
@@ -744,52 +744,52 @@ Explained Query:
     With
       cte l3 =
         Project (#0..=#3, #5) // { arity: 5 }
-          Join on=(#1 = #13 AND eq(#14, #17, #18)) type=differential // { arity: 19 }
+          Join on=(id = creatorpersonid AND eq(containerforumid, containerforumid, id)) type=differential // { arity: 19 }
             implementation
               %0:l2[#1]K » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
             Get l2 // { arity: 4 }
-            ArrangeBy keys=[[#9]] // { arity: 13 }
+            ArrangeBy keys=[[creatorpersonid]] // { arity: 13 }
               ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[containerforumid]] // { arity: 1 }
+              Distinct group_by=[containerforumid] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (#10) IS NOT NULL // { arity: 13 }
+                  Filter (containerforumid) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Get l0 // { arity: 1 }
       cte l2 =
-        ArrangeBy keys=[[#1]] // { arity: 4 }
+        ArrangeBy keys=[[id]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(eq(#1, #11, #12)) type=delta // { arity: 13 }
+          Join on=(eq(id, id, personid)) type=delta // { arity: 13 }
             implementation
               %0:person » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:person[#1]KA
               %2 » %1[#0]UKA » %0:person[#1]KA
-            ArrangeBy keys=[[#1]] // { arity: 11 }
+            ArrangeBy keys=[[id]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#1) IS NOT NULL // { arity: 11 }
+                  Filter (id) IS NOT NULL // { arity: 11 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[personid]] // { arity: 1 }
+              Distinct group_by=[personid] // { arity: 1 }
                 Project (#3) // { arity: 1 }
-                  Join on=(#0 = #2) type=differential // { arity: 4 }
+                  Join on=(id = forumid) type=differential // { arity: 4 }
                     implementation
                       %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
+                    ArrangeBy keys=[[id]] // { arity: 1 }
                       Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[#1]] // { arity: 3 }
+                    ArrangeBy keys=[[forumid]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0) // { arity: 1 }
-          TopK order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 // { arity: 2 }
+          TopK order_by=[maxnumberofmembers desc nulls_first, id asc nulls_last] limit=100 // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
-              Filter (#1 > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+              Filter (creationdate > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
@@ -808,7 +808,7 @@ EOF
 
 # TODO(mgree) predicate push down anomaly on Tag.name
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH detail AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH detail AS (
 SELECT Message.CreatorPersonId AS CreatorPersonId
      , sum(coalesce(Cs.c, 0))  AS replyCount
      , sum(coalesce(Plm.c, 0)) AS likeCount
@@ -833,10 +833,10 @@ SELECT CreatorPersonId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
-        Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
+        Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
@@ -849,13 +849,13 @@ Explained Query:
     With
       cte l3 =
         Project (#1, #2, #4) // { arity: 3 }
-          Join on=(#0 = #3) type=differential // { arity: 5 }
+          Join on=(messageid = messageid) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 3 }
+            ArrangeBy keys=[[messageid]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[messageid]] // { arity: 2 }
+              Reduce group_by=[messageid] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
                   ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l2 =
@@ -869,29 +869,29 @@ Explained Query:
           Get l1 // { arity: 3 }
       cte l1 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(#0 = #2) type=differential // { arity: 4 }
+          Join on=(messageid = parentmessageid) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l0[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[messageid]] // { arity: 2 }
               Get l0 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[parentmessageid]] // { arity: 2 }
+              Reduce group_by=[parentmessageid] aggregates=[count(*)] // { arity: 2 }
                 Project (#12) // { arity: 1 }
-                  Filter (#12) IS NOT NULL // { arity: 13 }
+                  Filter (parentmessageid) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0) IS NOT NULL // { arity: 21 }
-            Join on=(#0 = #7 AND #6 = #9) type=delta // { arity: 21 }
+          Filter (id) IS NOT NULL // { arity: 21 }
+            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[id]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Sikh_Empire")] // { arity: 5 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1]] // { arity: 13 }
+              ArrangeBy keys=[[messageid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -924,7 +924,7 @@ CREATE INDEX PopularityScoreQ06_person2id ON PopularityScoreQ06 (person2id);
 
 # rewritten query to manually push filter down
 query T multiline
-EXPLAIN WITH(arity, join_impls)
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
 WITH applicable_posts AS (
        SELECT message1.MessageId,
               message1.CreatorPersonId AS person1id
@@ -955,9 +955,9 @@ LIMIT 100
 ;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0))] // { arity: 2 }
+      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -970,27 +970,27 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 4 }
+          Join on=(personid = person2id) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[personid]] // { arity: 2 }
+              Filter (personid) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(#0 = #2) type=differential // { arity: 3 }
+                    Join on=(messageid = messageid) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[messageid]] // { arity: 1 }
+                        Distinct group_by=[messageid] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -999,28 +999,28 @@ Explained Query:
               Get l2 // { arity: 3 }
       cte l2 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(#0 = #4) type=differential // { arity: 5 }
+          Join on=(messageid = messageid) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
             Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2]] // { arity: 3 }
+            ArrangeBy keys=[[messageid]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[#0]] // { arity: 2 }
+        ArrangeBy keys=[[messageid]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0) IS NOT NULL // { arity: 21 }
-            Join on=(#0 = #7 AND #6 = #9) type=delta // { arity: 21 }
+          Filter (id) IS NOT NULL // { arity: 21 }
+            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[id]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1]] // { arity: 13 }
+              ArrangeBy keys=[[messageid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1036,7 +1036,7 @@ EOF
 
 # Gábor's version, yields identical output
 query T multiline
-EXPLAIN WITH(arity, join_impls)
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
 WITH poster_w_liker AS (
         SELECT DISTINCT
             message1.CreatorPersonId AS person1id,
@@ -1060,9 +1060,9 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0))] // { arity: 2 }
+      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -1075,27 +1075,27 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 4 }
+          Join on=(personid = person2id) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[personid]] // { arity: 2 }
+              Filter (personid) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(#0 = #2) type=differential // { arity: 3 }
+                    Join on=(messageid = messageid) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[messageid]] // { arity: 1 }
+                        Distinct group_by=[messageid] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -1104,28 +1104,28 @@ Explained Query:
               Get l2 // { arity: 3 }
       cte l2 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(#0 = #4) type=differential // { arity: 5 }
+          Join on=(messageid = messageid) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
             Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#2]] // { arity: 3 }
+            ArrangeBy keys=[[messageid]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[#0]] // { arity: 2 }
+        ArrangeBy keys=[[messageid]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (#0) IS NOT NULL // { arity: 21 }
-            Join on=(#0 = #7 AND #6 = #9) type=delta // { arity: 21 }
+          Filter (id) IS NOT NULL // { arity: 21 }
+            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[id]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1]] // { arity: 13 }
+              ArrangeBy keys=[[messageid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1141,7 +1141,7 @@ EOF
 # TODO(mgree) predicate push down anomaly on Tag.name
 # original umbra query
 query T multiline
-EXPLAIN WITH(arity, join_impls)
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
 WITH poster_w_liker AS (
         SELECT DISTINCT
             message1.CreatorPersonId AS person1id,
@@ -1166,9 +1166,9 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[sum(coalesce(#1, 0))] // { arity: 2 }
+      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -1181,61 +1181,61 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(#1 = #2) type=differential // { arity: 4 }
+          Join on=(personid = person2id) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 2 }
-              Filter (#1) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[personid]] // { arity: 2 }
+              Filter (personid) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(#0 = #2) type=differential // { arity: 3 }
+                    Join on=(messageid = messageid) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
-                      ArrangeBy keys=[[#0]] // { arity: 2 }
+                      ArrangeBy keys=[[messageid]] // { arity: 2 }
                         Project (#1, #2) // { arity: 2 }
                           Get l2 // { arity: 3 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[messageid]] // { arity: 1 }
+                        Distinct group_by=[messageid] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             Get l1 // { arity: 4 }
                 Project (#2) // { arity: 1 }
                   Get l2 // { arity: 3 }
             Project (#2, #3) // { arity: 2 }
-              Filter (#0 = "Bob_Geldof") // { arity: 4 }
+              Filter (name = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l2 =
-        Filter (#0 = "Bob_Geldof") // { arity: 3 }
+        Filter (name = "Bob_Geldof") // { arity: 3 }
           Get l0 // { arity: 3 }
       cte l1 =
         Project (#0..=#2, #4) // { arity: 4 }
-          Join on=(#1 = #5) type=differential // { arity: 6 }
+          Join on=(messageid = messageid) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 3 }
+            ArrangeBy keys=[[messageid]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#2]] // { arity: 3 }
+            ArrangeBy keys=[[messageid]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#1, #5, #16) // { arity: 3 }
-          Filter (#0) IS NOT NULL // { arity: 20 }
-            Join on=(#0 = #6 AND #5 = #8) type=delta // { arity: 20 }
+          Filter (id) IS NOT NULL // { arity: 20 }
+            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 20 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1]] // { arity: 13 }
+              ArrangeBy keys=[[messageid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1256,7 +1256,7 @@ EOF
 
 # TODO(mgree) predicate push down anomaly on Tag.name
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MyMessage AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MyMessage AS (
   SELECT m.MessageId
   FROM Message_hasTag_Tag m, Tag
   WHERE Tag.name = 'Slovenia' and m.TagId = Tag.Id
@@ -1282,59 +1282,59 @@ SELECT RelatedTag.name AS "relatedTag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, name asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[name] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Join on=(#0 = #2) type=differential // { arity: 3 }
+          Join on=(messageid = messageid) type=differential // { arity: 3 }
             implementation
               %0:l1[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[messageid]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[messageid]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Join on=(#0 = #1) type=differential // { arity: 2 }
+                    Join on=(messageid = messageid) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
+                      ArrangeBy keys=[[messageid]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[messageid]] // { arity: 1 }
+                        Distinct group_by=[messageid] // { arity: 1 }
                           Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[messageid] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
-          Filter (#0) IS NOT NULL AND (#16) IS NOT NULL // { arity: 21 }
-            Join on=(#0 = #13 AND #2 = #15 AND #16 = #17) type=delta // { arity: 21 }
+          Filter (messageid) IS NOT NULL AND (tagid) IS NOT NULL // { arity: 21 }
+            Join on=(messageid = parentmessageid AND messageid = messageid AND tagid = id) type=delta // { arity: 21 }
               implementation
                 %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
                 %1:message » %0:l0[#0]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
                 %2:message_hastag_tag » %1:message[#1]KA » %0:l0[#0]KA » %3:tag[#0]KA
                 %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]KA
-              ArrangeBy keys=[[#0]] // { arity: 1 }
+              ArrangeBy keys=[[messageid]] // { arity: 1 }
                 Get l0 // { arity: 1 }
-              ArrangeBy keys=[[#1], [#12]] // { arity: 13 }
+              ArrangeBy keys=[[messageid], [parentmessageid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#2) IS NOT NULL // { arity: 8 }
-            Join on=(#2 = #3) type=differential // { arity: 8 }
+          Filter (tagid) IS NOT NULL // { arity: 8 }
+            Join on=(tagid = id) type=differential // { arity: 8 }
               implementation
                 %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-              ArrangeBy keys=[[#2]] // { arity: 3 }
+              ArrangeBy keys=[[tagid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[id]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
@@ -1356,7 +1356,7 @@ EOF
 # \set endDate '\'2010-06-28\''::timestamp
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH Person_interested_in_Tag AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH Person_interested_in_Tag AS (
     SELECT Person.id AS PersonId
       FROM Person
       JOIN Person_hasInterest_Tag
@@ -1410,13 +1410,13 @@ Explained Query:
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(#2 = #3) type=differential // { arity: 4 }
+                    Join on=(person2id = person2id) type=differential // { arity: 4 }
                       implementation
                         %1[#0]UKA » %0:l10[#2]K
-                      ArrangeBy keys=[[#2]] // { arity: 3 }
+                      ArrangeBy keys=[[person2id]] // { arity: 3 }
                         Get l10 // { arity: 3 }
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[person2id]] // { arity: 1 }
+                        Distinct group_by=[person2id] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l11 // { arity: 4 }
                 Project (#0, #1) // { arity: 2 }
@@ -1426,11 +1426,11 @@ Explained Query:
     With
       cte l11 =
         Project (#0..=#2, #4) // { arity: 4 }
-          Join on=(#2 = #3) type=differential // { arity: 5 }
+          Join on=(person2id = #3) type=differential // { arity: 5 }
             implementation
               %0:l10[#2]K » %1:l8[#0]K
-            ArrangeBy keys=[[#2]] // { arity: 3 }
-              Filter (#2) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[person2id]] // { arity: 3 }
+              Filter (person2id) IS NOT NULL // { arity: 3 }
                 Get l10 // { arity: 3 }
             Get l8 // { arity: 2 }
       cte l10 =
@@ -1452,11 +1452,11 @@ Explained Query:
           Get l9 // { arity: 3 }
       cte l9 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(#0 = #3) type=differential // { arity: 5 }
+          Join on=(#0 = person1id) type=differential // { arity: 5 }
             implementation
               %1:person_knows_person[#1]KA » %0:l8[#0]K
             Get l8 // { arity: 2 }
-            ArrangeBy keys=[[#1]] // { arity: 3 }
+            ArrangeBy keys=[[person1id]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
       cte l8 =
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1464,19 +1464,19 @@ Explained Query:
             Get l7 // { arity: 2 }
       cte l7 =
         Project (#3, #4) // { arity: 2 }
-          Map (coalesce(#0, #1), (integer_to_bigint(case when (#0) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
+          Map (coalesce(id, creatorpersonid), (integer_to_bigint(case when (id) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
             Union // { arity: 3 }
               Project (#2, #0, #1) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
                       Project (#0, #1) // { arity: 2 }
-                        Join on=(#0 = #2) type=differential // { arity: 3 }
+                        Join on=(creatorpersonid = id) type=differential // { arity: 3 }
                           implementation
                             %0:l4[#0]UKA » %1[#0]UKA
                           Get l4 // { arity: 2 }
-                          ArrangeBy keys=[[#0]] // { arity: 1 }
-                            Distinct group_by=[#0] // { arity: 1 }
+                          ArrangeBy keys=[[id]] // { arity: 1 }
+                            Distinct group_by=[id] // { arity: 1 }
                               Get l6 // { arity: 1 }
                     Get l3 // { arity: 2 }
               Map (null, null) // { arity: 3 }
@@ -1491,46 +1491,46 @@ Explained Query:
           Get l5 // { arity: 2 }
       cte l5 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(#0 = #1) type=differential // { arity: 3 }
+          Join on=(id = creatorpersonid) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
               Get l2 // { arity: 1 }
             Get l4 // { arity: 2 }
       cte l4 =
-        ArrangeBy keys=[[#0]] // { arity: 2 }
+        ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
           Get l3 // { arity: 2 }
       cte l3 =
-        Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+        Reduce group_by=[creatorpersonid] aggregates=[count(*)] // { arity: 2 }
           Project (#17) // { arity: 1 }
-            Filter (#8 < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8) AND (#0) IS NOT NULL AND (#17) IS NOT NULL // { arity: 32 }
-              Join on=(#0 = #7 AND #6 = #9 AND #17 = #22) type=delta // { arity: 32 }
+            Filter (creationdate < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < creationdate) AND (id) IS NOT NULL AND (creatorpersonid) IS NOT NULL // { arity: 32 }
+              Join on=(id = tagid AND messageid = messageid AND creatorpersonid = id) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
                   %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
                   %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
                   %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
                 Get l1 // { arity: 5 }
-                ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+                ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
                   ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+                ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
                   ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
                 Get l0 // { arity: 11 }
       cte l2 =
         Project (#1) // { arity: 1 }
-          Filter (#1) IS NOT NULL AND (#13) IS NOT NULL // { arity: 19 }
-            Join on=(#1 = #12 AND #13 = #14) type=differential // { arity: 19 }
+          Filter (id) IS NOT NULL AND (tagid) IS NOT NULL // { arity: 19 }
+            Join on=(id = personid AND tagid = id) type=differential // { arity: 19 }
               implementation
                 %2:l1[#0]KAe » %1:person_hasinterest_tag[#2]KAe » %0:l0[#1]KAe
               Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#2]] // { arity: 3 }
+              ArrangeBy keys=[[tagid]] // { arity: 3 }
                 ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[differential join] // { arity: 3 }
               Get l1 // { arity: 5 }
       cte l1 =
-        ArrangeBy keys=[[#0]] // { arity: 5 }
+        ArrangeBy keys=[[id]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
       cte l0 =
-        ArrangeBy keys=[[#1]] // { arity: 11 }
+        ArrangeBy keys=[[id]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join, delta join lookup] // { arity: 11 }
 
 Used Indexes:
@@ -1553,7 +1553,7 @@ EOF
 # \set endDate '\'2012-11-24\''::timestamp
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
 MPP AS (SELECT RootPostId, count(*) as MessageCount FROM Message WHERE Message.creationDate BETWEEN '2012-08-29'::TIMESTAMP AND '2012-11-24'::TIMESTAMP GROUP BY RootPostId)
 SELECT Person.id AS "person.id"
      , Person.firstName AS "person.firstName"
@@ -1571,23 +1571,23 @@ SELECT Person.id AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[#0..=#2] aggregates=[count(*), sum(#3)] // { arity: 5 }
+  Finish order_by=[#4 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#4]
+    Reduce group_by=[id, firstname, lastname] aggregates=[count(*), sum(#3)] // { arity: 5 }
       Project (#1..=#3, #25) // { arity: 4 }
-        Filter (#23) IS NULL AND (#11 <= 2012-11-24 00:00:00 UTC) AND (#11 >= 2012-08-29 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 26 }
-          Join on=(#1 = #20 AND #12 = #24) type=delta // { arity: 26 }
+        Filter (parentmessageid) IS NULL AND (creationdate <= 2012-11-24 00:00:00 UTC) AND (creationdate >= 2012-08-29 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 26 }
+          Join on=(id = creatorpersonid AND messageid = rootpostid) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9]KAniif » %2[#0]UKA
               %1:message » %2[#0]UKA » %0:person[#1]KA
               %2 » %1:message[#1]KAniif » %0:person[#1]KA
-            ArrangeBy keys=[[#1]] // { arity: 11 }
+            ArrangeBy keys=[[id]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+            ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[rootpostid]] // { arity: 2 }
+              Reduce group_by=[rootpostid] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
-                  Filter (#0 <= 2012-11-24 00:00:00 UTC) AND (#0 >= 2012-08-29 00:00:00 UTC) AND (#2) IS NOT NULL // { arity: 13 }
+                  Filter (creationdate <= 2012-11-24 00:00:00 UTC) AND (creationdate >= 2012-08-29 00:00:00 UTC) AND (rootpostid) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -1608,7 +1608,7 @@ EOF
 # \set maxPathDistance 4 -- fixed value
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH friends AS
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH friends AS
   (SELECT Person2Id
      FROM Person_knows_Person
     WHERE Person1Id = 6597069770479
@@ -1679,84 +1679,84 @@ SELECT m.friendId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #1 asc nulls_last, #0 asc nulls_last] limit=100 output=[#0..=#2]
+  Finish order_by=[#2 desc nulls_first, name asc nulls_last, person2id asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+      Reduce group_by=[person2id, name] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #9) // { arity: 2 }
-          Filter (#7) IS NOT NULL // { arity: 12 }
-            Join on=(eq(#0, #1, #2) AND eq(#3, #4, #6) AND #7 = #8) type=differential // { arity: 12 }
+          Filter (tagid) IS NOT NULL // { arity: 12 }
+            Join on=(eq(person2id, id, creatorpersonid) AND eq(messageid, messageid, messageid) AND tagid = id) type=differential // { arity: 12 }
               implementation
                 %0[#0]UKA » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[person2id]] // { arity: 1 }
+                Distinct group_by=[person2id] // { arity: 1 }
                   Threshold // { arity: 1 }
                     Union // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct group_by=[person2id] // { arity: 1 }
                         Project (#6) // { arity: 1 }
-                          Join on=(#0 = #2 AND #3 = #5) type=differential // { arity: 7 }
+                          Join on=(person2id = person1id AND person2id = person1id) type=differential // { arity: 7 }
                             implementation
                               %0:l2[#0]UKA » %1:l0[#1]KA » %2:l0[#1]KA
-                            ArrangeBy keys=[[#0]] // { arity: 1 }
+                            ArrangeBy keys=[[person2id]] // { arity: 1 }
                               Get l2 // { arity: 1 }
                             Get l0 // { arity: 3 }
                             Get l0 // { arity: 3 }
                       Negate // { arity: 1 }
                         Get l2 // { arity: 1 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[id]] // { arity: 1 }
+                Distinct group_by=[id] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#16 = "Italy") AND (#1) IS NOT NULL AND (#8) IS NOT NULL AND (#14) IS NOT NULL // { arity: 19 }
-                      Join on=(#8 = #11 AND #14 = #15) type=delta // { arity: 19 }
+                    Filter (name = "Italy") AND (id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 19 }
+                      Join on=(locationcityid = id AND partofcountryid = id) type=delta // { arity: 19 }
                         implementation
                           %0:person » %1:city[#0]KA » %2:country[#0]KAef
                           %1:city » %2:country[#0]KAef » %0:person[#8]KA
                           %2:country » %1:city[#3]KA » %0:person[#8]KA
-                        ArrangeBy keys=[[#8]] // { arity: 11 }
+                        ArrangeBy keys=[[locationcityid]] // { arity: 11 }
                           ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                        ArrangeBy keys=[[#0], [#3]] // { arity: 4 }
+                        ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
                           ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 4 }
+                        ArrangeBy keys=[[id]] // { arity: 4 }
                           ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Distinct group_by=[#1, #0] // { arity: 2 }
+              ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
+                Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
                   Project (#1, #9) // { arity: 2 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[messageid]] // { arity: 1 }
+                Distinct group_by=[messageid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#2) IS NOT NULL AND (#6) IS NOT NULL // { arity: 12 }
-                      Join on=(#2 = #3 AND #6 = #7) type=delta // { arity: 12 }
+                    Filter (tagid) IS NOT NULL AND (typetagclassid) IS NOT NULL // { arity: 12 }
+                      Join on=(tagid = id AND typetagclassid = id) type=delta // { arity: 12 }
                         implementation
                           %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
                           %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
                           %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
-                        ArrangeBy keys=[[#2]] // { arity: 3 }
+                        ArrangeBy keys=[[tagid]] // { arity: 3 }
                           ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                        ArrangeBy keys=[[#0], [#3]] // { arity: 4 }
+                        ArrangeBy keys=[[id], [typetagclassid]] // { arity: 4 }
                           ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 5 }
+                        ArrangeBy keys=[[id]] // { arity: 5 }
                           ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-              ArrangeBy keys=[[#1]] // { arity: 3 }
+              ArrangeBy keys=[[messageid]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[differential join] // { arity: 4 }
     With
       cte l2 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[person2id] // { arity: 1 }
           Union // { arity: 1 }
             Get l1 // { arity: 1 }
             Project (#3) // { arity: 1 }
-              Join on=(#0 = #2) type=differential // { arity: 4 }
+              Join on=(person2id = person1id) type=differential // { arity: 4 }
                 implementation
                   %1:l0[#1]KA » %0:l1[#0]Ke
-                ArrangeBy keys=[[#0]] // { arity: 1 }
+                ArrangeBy keys=[[person2id]] // { arity: 1 }
                   Get l1 // { arity: 1 }
                 Get l0 // { arity: 3 }
       cte l1 =
         Project (#2) // { arity: 1 }
           ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
       cte l0 =
-        ArrangeBy keys=[[#1]] // { arity: 3 }
+        ArrangeBy keys=[[person1id]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, lookup] // { arity: 3 }
 
 Used Indexes:
@@ -1783,7 +1783,7 @@ EOF
 # \set endDate '\'2013-01-10\''::timestamp
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH Persons_of_country_w_friends AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH Persons_of_country_w_friends AS (
     SELECT Person.id AS PersonId
          , Person_knows_Person.Person2Id AS FriendId
          , Person_knows_Person.creationDate AS creationDate
@@ -1827,34 +1827,34 @@ Explained Query:
     cte l2 =
       Reduce aggregates=[count(*)] // { arity: 1 }
         Project () // { arity: 0 }
-          Join on=(#0 = #5 AND #1 = #2 AND #3 = #4) type=differential // { arity: 6 }
+          Join on=(id = person2id AND person2id = id AND person2id = id) type=differential // { arity: 6 }
             implementation
               %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
-            ArrangeBy keys=[[#1]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[id]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
               Get l0 // { arity: 2 }
     cte l1 =
-      Filter (#0 < #1) // { arity: 2 }
+      Filter (id < person2id) // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
       Project (#1, #21) // { arity: 2 }
-        Filter (#16 = "India") AND (#19 <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19) AND (#1) IS NOT NULL AND (#8) IS NOT NULL AND (#14) IS NOT NULL // { arity: 22 }
-          Join on=(#1 = #20 AND #8 = #11 AND #14 = #15) type=delta // { arity: 22 }
+        Filter (name = "India") AND (creationdate <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= creationdate) AND (id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 22 }
+          Join on=(id = person1id AND locationcityid = id AND partofcountryid = id) type=delta // { arity: 22 }
             implementation
               %0:person » %3:person_knows_person[#1]KAiif » %1:city[#0]KA » %2:country[#0]KAef
               %1:city » %2:country[#0]KAef » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %2:country » %1:city[#3]KA » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %3:person_knows_person » %0:person[#1]KA » %1:city[#0]KA » %2:country[#0]KAef
-            ArrangeBy keys=[[#1], [#8]] // { arity: 11 }
+            ArrangeBy keys=[[id], [locationcityid]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[#0], [#3]] // { arity: 4 }
+            ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
               ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
+            ArrangeBy keys=[[id]] // { arity: 4 }
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[#1]] // { arity: 3 }
+            ArrangeBy keys=[[person1id]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -1876,7 +1876,7 @@ EOF
 # \set languages '\'{es, ta, pt}\''::varchar[]
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   matching_message AS (
     SELECT MessageId,
            CreatorPersonId
@@ -1908,18 +1908,18 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+          Reduce group_by=[id] aggregates=[count(messageid)] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Join on=(#1 = #11) type=differential // { arity: 12 }
+                      Join on=(id = id) type=differential // { arity: 12 }
                         implementation
                           %1[#0]UKA » %0:l0[#1]KA
                         Get l0 // { arity: 11 }
-                        ArrangeBy keys=[[#0]] // { arity: 1 }
-                          Distinct group_by=[#0] // { arity: 1 }
+                        ArrangeBy keys=[[id]] // { arity: 1 }
+                          Distinct group_by=[id] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
@@ -1928,15 +1928,15 @@ Explained Query:
     With
       cte l1 =
         Project (#1, #12) // { arity: 2 }
-          Filter (#19 < 120) AND (#11 > 2012-06-03 00:00:00 UTC) AND (#1) IS NOT NULL AND (#15) IS NOT NULL // { arity: 25 }
-            Join on=(#1 = #20) type=differential // { arity: 25 }
+          Filter (length < 120) AND (creationdate > 2012-06-03 00:00:00 UTC) AND (id) IS NOT NULL AND (content) IS NOT NULL // { arity: 25 }
+            Join on=(id = creatorpersonid) type=differential // { arity: 25 }
               implementation
                 %1:message[#9]KAeiif » %0:l0[#1]KAeiif
               Get l0 // { arity: 11 }
-              ArrangeBy keys=[[#9]] // { arity: 14 }
+              ArrangeBy keys=[[creatorpersonid]] // { arity: 14 }
                 ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
       cte l0 =
-        ArrangeBy keys=[[#1]] // { arity: 11 }
+        ArrangeBy keys=[[id]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
 
 Used Indexes:
@@ -1948,7 +1948,7 @@ EOF
 
 # original version
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH person_w_posts AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH person_w_posts AS (
     SELECT Person.id, count(Message.MessageId) as messageCount
       FROM Person
       LEFT JOIN Message
@@ -1974,41 +1974,41 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+          Reduce group_by=[id] aggregates=[count(messageid)] // { arity: 2 }
             Union // { arity: 2 }
               Project (#1, #11) // { arity: 2 }
                 Get l1 // { arity: 12 }
               Project (#1, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
-                  Join on=(#0 = #11 AND #1 = #12 AND #2 = #13 AND #3 = #14 AND #4 = #15 AND #5 = #16 AND #6 = #17 AND #7 = #18 AND #8 = #19 AND #9 = #20 AND #10 = #21) type=differential // { arity: 22 }
+                  Join on=(creationdate = creationdate AND id = id AND firstname = firstname AND lastname = lastname AND gender = gender AND birthday = birthday AND locationip = locationip AND browserused = browserused AND locationcityid = locationcityid AND speaks = speaks AND email = email) type=differential // { arity: 22 }
                     implementation
                       %0[#0..=#10]KKKKKKKKKKK » %1:person[#0..=#10]KKKKKKKKKKK
-                    ArrangeBy keys=[[#0..=#10]] // { arity: 11 }
+                    ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
-                          Distinct group_by=[#0..=#10] // { arity: 11 }
+                          Distinct group_by=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
                             Project (#0..=#10) // { arity: 11 }
                               Get l1 // { arity: 12 }
-                        Distinct group_by=[#0..=#10] // { arity: 11 }
+                        Distinct group_by=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-                    ArrangeBy keys=[[#0..=#10]] // { arity: 11 }
+                    ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
     With
       cte l1 =
         Project (#0..=#11) // { arity: 12 }
-          Join on=(#12 = #13) type=differential // { arity: 14 }
+          Join on=(rootpostlanguage = rootpostlanguage) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
-            ArrangeBy keys=[[#12]] // { arity: 13 }
+            ArrangeBy keys=[[rootpostlanguage]] // { arity: 13 }
               Project (#0..=#10, #12, #13) // { arity: 13 }
-                Filter (#15 < 120) AND (#11 > 2012-06-03 00:00:00 UTC) AND (#14) IS NOT NULL AND (#1 = #16) // { arity: 17 }
+                Filter (length < 120) AND (creationdate > 2012-06-03 00:00:00 UTC) AND (content) IS NOT NULL AND (id = creatorpersonid) // { arity: 17 }
                   Get l0 // { arity: 17 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[rootpostlanguage]] // { arity: 1 }
+              Distinct group_by=[rootpostlanguage] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#0 = varchar_to_text(#1)) // { arity: 2 }
+                  Filter (rootpostlanguage = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct group_by=[rootpostlanguage] // { arity: 1 }
                         Project (#13) // { arity: 1 }
                           Get l0 // { arity: 17 }
       cte l0 =
@@ -2035,7 +2035,7 @@ EOF
 # \set endDate '\'2012-11-09\''::timestamp
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH Zombies AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH Zombies AS (
     SELECT Person.id AS zombieid
       FROM Country
       JOIN City
@@ -2068,7 +2068,7 @@ SELECT Z.zombieid AS "zombie.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0 asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
         Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
@@ -2083,19 +2083,19 @@ Explained Query:
     With
       cte l8 =
         Project (#0, #2, #3) // { arity: 3 }
-          Join on=(#0 = #1) type=differential // { arity: 4 }
+          Join on=(id = creatorpersonid) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
             Get l4 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
-              Reduce group_by=[#0] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
+            ArrangeBy keys=[[creatorpersonid]] // { arity: 3 }
+              Reduce group_by=[creatorpersonid] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
                 Project (#1, #3) // { arity: 2 }
-                  Join on=(#0 = #2) type=differential // { arity: 4 }
+                  Join on=(id = id) type=differential // { arity: 4 }
                     implementation
                       %0:l5[#0]K » %1[#0]K
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
+                    ArrangeBy keys=[[id]] // { arity: 2 }
                       Get l5 // { arity: 2 }
-                    ArrangeBy keys=[[#0]] // { arity: 2 }
+                    ArrangeBy keys=[[id]] // { arity: 2 }
                       Union // { arity: 2 }
                         Map (true) // { arity: 2 }
                           Get l7 // { arity: 1 }
@@ -2106,88 +2106,88 @@ Explained Query:
                             Get l6 // { arity: 1 }
       cte l7 =
         Project (#0) // { arity: 1 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
+          Join on=(id = id) type=differential // { arity: 2 }
             implementation
               %0:l6[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
               Get l6 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Get l3 // { arity: 1 }
       cte l6 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[id] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l5 // { arity: 2 }
       cte l5 =
         Project (#1, #23) // { arity: 2 }
-          Filter (#0 < 2012-11-09 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 28 }
-            Join on=(#1 = #12 AND #13 = #15 AND #23 = #27) type=delta // { arity: 28 }
+          Filter (creationdate < 2012-11-09 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 28 }
+            Join on=(id = personid AND messageid = messageid AND creatorpersonid = id) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]KA
                 %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]KA
                 %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]KA
                 %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
-              ArrangeBy keys=[[#1]] // { arity: 11 }
+              ArrangeBy keys=[[id]] // { arity: 11 }
                 ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-              ArrangeBy keys=[[#1], [#2]] // { arity: 3 }
+              ArrangeBy keys=[[personid], [messageid]] // { arity: 3 }
                 ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+              ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
               Get l4 // { arity: 1 }
       cte l4 =
-        ArrangeBy keys=[[#0]] // { arity: 1 }
+        ArrangeBy keys=[[id]] // { arity: 1 }
           Get l3 // { arity: 1 }
       cte l3 =
-        Filter (#0) IS NOT NULL // { arity: 1 }
+        Filter (id) IS NOT NULL // { arity: 1 }
           Get l2 // { arity: 1 }
       cte l2 =
         Project (#0) // { arity: 1 }
-          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(#1)) + extract_month_tstz(#1))) + 1)) // { arity: 3 }
-            Reduce group_by=[#1, #0] aggregates=[count(#2)] // { arity: 3 }
+          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(creationdate)) + extract_month_tstz(creationdate))) + 1)) // { arity: 3 }
+            Reduce group_by=[id, creationdate] aggregates=[count(messageid)] // { arity: 3 }
               Union // { arity: 3 }
                 Project (#6, #7, #16) // { arity: 3 }
                   Get l1 // { arity: 17 }
                 Project (#6, #7, #32) // { arity: 3 }
                   Map (null) // { arity: 33 }
-                    Join on=(#0 = #16 AND #1 = #17 AND #2 = #18 AND #3 = #19 AND #4 = #20 AND #5 = #21 AND #6 = #22 AND #7 = #23 AND #8 = #24 AND #9 = #25 AND #10 = #26 AND #11 = #27 AND #12 = #28 AND #13 = #29 AND #14 = #30 AND #15 = #31) type=differential // { arity: 32 }
+                    Join on=(id = id AND url = url AND partofcontinentid = partofcontinentid AND id = id AND name = name AND url = url AND creationdate = creationdate AND id = id AND firstname = firstname AND lastname = lastname AND gender = gender AND birthday = birthday AND locationip = locationip AND browserused = browserused AND speaks = speaks AND email = email) type=differential // { arity: 32 }
                       implementation
                         %0[#0..=#15]KKKKKKKKKKKKKKKK » %1:l0[#0..=#15]KKKKKKKKKKKKKKKK
-                      ArrangeBy keys=[[#0..=#15]] // { arity: 16 }
+                      ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
-                            Distinct group_by=[#0..=#15] // { arity: 16 }
+                            Distinct group_by=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
                               Project (#0..=#15) // { arity: 16 }
-                                Filter (#0 = #0) AND (#3 = #3) // { arity: 17 }
+                                Filter (id = id) AND (id = id) // { arity: 17 }
                                   Get l1 // { arity: 17 }
-                          Distinct group_by=[#0..=#15] // { arity: 16 }
-                            Filter (#0 = #0) AND (#3 = #3) // { arity: 16 }
+                          Distinct group_by=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
+                            Filter (id = id) AND (id = id) // { arity: 16 }
                               Get l0 // { arity: 16 }
-                      ArrangeBy keys=[[#0..=#15]] // { arity: 16 }
+                      ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
                         Get l0 // { arity: 16 }
       cte l1 =
         Project (#0..=#15, #17) // { arity: 17 }
-          Filter (#16 <= 2012-11-09 00:00:00 UTC) AND (#16 >= #6) // { arity: 29 }
-            Join on=(#7 = #25) type=differential // { arity: 29 }
+          Filter (creationdate <= 2012-11-09 00:00:00 UTC) AND (creationdate >= creationdate) // { arity: 29 }
+            Join on=(id = creatorpersonid) type=differential // { arity: 29 }
               implementation
                 %1:message[#9]KAif » %0:l0[#7]Kif
-              ArrangeBy keys=[[#7]] // { arity: 16 }
-                Filter (#7) IS NOT NULL // { arity: 16 }
+              ArrangeBy keys=[[id]] // { arity: 16 }
+                Filter (id) IS NOT NULL // { arity: 16 }
                   Get l0 // { arity: 16 }
-              ArrangeBy keys=[[#9]] // { arity: 13 }
+              ArrangeBy keys=[[creatorpersonid]] // { arity: 13 }
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
         Project (#0, #2..=#6, #8..=#15, #17, #18) // { arity: 16 }
-          Filter (#1 = "India") AND (#8 < 2012-11-09 00:00:00 UTC) AND (#0) IS NOT NULL AND (#4) IS NOT NULL // { arity: 19 }
-            Join on=(#0 = #7 AND #4 = #16) type=delta // { arity: 19 }
+          Filter (name = "India") AND (creationdate < 2012-11-09 00:00:00 UTC) AND (id) IS NOT NULL AND (id) IS NOT NULL // { arity: 19 }
+            Join on=(id = partofcountryid AND id = locationcityid) type=delta // { arity: 19 }
               implementation
                 %0:country » %1:city[#3]KA » %2:person[#8]KAif
                 %1:city » %0:country[#0]KAef » %2:person[#8]KAif
                 %2:person » %1:city[#0]KA » %0:country[#0]KAef
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[#0], [#3]] // { arity: 4 }
+              ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
                 ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[#8]] // { arity: 11 }
+              ArrangeBy keys=[[locationcityid]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
 
 Used Indexes:
@@ -2211,7 +2211,7 @@ EOF
 # \set country2 '\'Taiwan\''
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH PersonPairCandidates AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH PersonPairCandidates AS (
     SELECT Person1.id AS Person1Id
          , Person2.id AS Person2Id
          , City1.id AS cityId
@@ -2270,10 +2270,10 @@ SELECT score_ranks.Person1Id AS "person1.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, id asc nulls_last, person2id asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #1, #3, #4) // { arity: 4 }
-        TopK group_by=[#2] order_by=[#4 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=1 // { arity: 5 }
+        TopK group_by=[id] order_by=[#4 desc nulls_first, id asc nulls_last, person2id asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
@@ -2287,20 +2287,20 @@ Explained Query:
     With
       cte l9 =
         Project (#0..=#3, #6) // { arity: 5 }
-          Join on=(#2 = #4 AND #3 = #5) type=differential // { arity: 7 }
+          Join on=(id = #4 AND person2id = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l1[#2, #3]KK
-            ArrangeBy keys=[[#2, #3]] // { arity: 4 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 4 }
               Get l1 // { arity: 4 }
             ArrangeBy keys=[[#0, #1]] // { arity: 3 }
               Reduce group_by=[#1, #2] aggregates=[sum((case when #3 then case when #0 then 1 else 4 end else 0 end + case when #4 then case when #0 then 1 else 10 end else 0 end))] // { arity: 3 }
                 Project (#2..=#5, #8) // { arity: 5 }
-                  Join on=(#0 = #6 AND #1 = #7) type=differential // { arity: 9 }
+                  Join on=(id = id AND person2id = person2id) type=differential // { arity: 9 }
                     implementation
                       %0:l6[#0, #1]KK » %1[#0, #1]KK
-                    ArrangeBy keys=[[#0, #1]] // { arity: 6 }
+                    ArrangeBy keys=[[id, person2id]] // { arity: 6 }
                       Get l6 // { arity: 6 }
-                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                    ArrangeBy keys=[[id, person2id]] // { arity: 3 }
                       Union // { arity: 3 }
                         Map (true) // { arity: 3 }
                           Get l8 // { arity: 2 }
@@ -2311,32 +2311,32 @@ Explained Query:
                             Get l7 // { arity: 2 }
       cte l8 =
         Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+          Join on=(id = personid AND person2id = creatorpersonid) type=differential // { arity: 4 }
             implementation
               %0:l7[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
               Get l7 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Distinct group_by=[#1, #0] // { arity: 2 }
+            ArrangeBy keys=[[personid, creatorpersonid]] // { arity: 2 }
+              Distinct group_by=[personid, creatorpersonid] // { arity: 2 }
                 Project (#9, #14) // { arity: 2 }
-                  Join on=(#1 = #15) type=differential // { arity: 16 }
+                  Join on=(messageid = messageid) type=differential // { arity: 16 }
                     implementation
                       %0:l4[#1]KA » %1:person_likes_message[#2]KA
                     Get l4 // { arity: 13 }
-                    ArrangeBy keys=[[#2]] // { arity: 3 }
+                    ArrangeBy keys=[[messageid]] // { arity: 3 }
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l7 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[id, person2id] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l6 // { arity: 6 }
       cte l6 =
         Project (#0..=#4, #7) // { arity: 6 }
-          Join on=(#0 = #5 AND #1 = #6) type=differential // { arity: 8 }
+          Join on=(id = id AND person2id = person2id) type=differential // { arity: 8 }
             implementation
               %0:l2[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 5 }
               Get l2 // { arity: 5 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 3 }
               Union // { arity: 3 }
                 Map (true) // { arity: 3 }
                   Get l5 // { arity: 2 }
@@ -2347,30 +2347,30 @@ Explained Query:
                     Get l3 // { arity: 2 }
       cte l5 =
         Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+          Join on=(id = creatorpersonid AND person2id = creatorpersonid) type=differential // { arity: 4 }
             implementation
               %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
               Get l3 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-              Distinct group_by=[#1, #0] // { arity: 2 }
+            ArrangeBy keys=[[creatorpersonid, creatorpersonid]] // { arity: 2 }
+              Distinct group_by=[creatorpersonid, creatorpersonid] // { arity: 2 }
                 Project (#9, #22) // { arity: 2 }
-                  Filter (#1) IS NOT NULL // { arity: 26 }
-                    Join on=(#1 = #25) type=differential // { arity: 26 }
+                  Filter (messageid) IS NOT NULL // { arity: 26 }
+                    Join on=(messageid = parentmessageid) type=differential // { arity: 26 }
                       implementation
                         %0:l4[#1]KA » %1:message[#12]KA
                       Get l4 // { arity: 13 }
-                      ArrangeBy keys=[[#12]] // { arity: 13 }
+                      ArrangeBy keys=[[parentmessageid]] // { arity: 13 }
                         ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l4 =
-        ArrangeBy keys=[[#1]] // { arity: 13 }
+        ArrangeBy keys=[[messageid]] // { arity: 13 }
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
       cte l3 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[id, person2id] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l2 // { arity: 5 }
       cte l2 =
-        Map (case when #2 then #1 else #0 end, case when #2 then #0 else #1 end) // { arity: 5 }
+        Map (case when #2 then person2id else id end, case when #2 then id else person2id end) // { arity: 5 }
           Union // { arity: 3 }
             Project (#2..=#4) // { arity: 3 }
               Map (false) // { arity: 5 }
@@ -2380,24 +2380,24 @@ Explained Query:
                 Get l1 // { arity: 4 }
       cte l1 =
         Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (#1 = "Philippines") AND (#38 = "Taiwan") AND (#0) IS NOT NULL AND (#4) IS NOT NULL AND (#9) IS NOT NULL AND (#21) IS NOT NULL AND (#30) IS NOT NULL AND (#36) IS NOT NULL // { arity: 41 }
-            Join on=(#0 = #7 AND #4 = #16 AND #9 = #20 AND #21 = #23 AND #30 = #33 AND #36 = #37) type=differential // { arity: 41 }
+          Filter (name = "Philippines") AND (name = "Taiwan") AND (id) IS NOT NULL AND (id) IS NOT NULL AND (id) IS NOT NULL AND (person2id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 41 }
+            Join on=(id = partofcountryid AND id = locationcityid AND id = person1id AND person2id = id AND locationcityid = id AND partofcountryid = id) type=differential // { arity: 41 }
               implementation
                 %0:l0[#0]KAef » %1:city[#3]KAef » %2:person[#8]KAef » %3:person_knows_person[#1]KAef » %4:person[#1]KAef » %5:city[#0]KAef » %6:l0[#0]KAef
               Get l0 // { arity: 4 }
-              ArrangeBy keys=[[#3]] // { arity: 4 }
+              ArrangeBy keys=[[partofcountryid]] // { arity: 4 }
                 ReadIndex on=city city_partofcountryid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[#8]] // { arity: 11 }
+              ArrangeBy keys=[[locationcityid]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[differential join] // { arity: 11 }
-              ArrangeBy keys=[[#1]] // { arity: 3 }
+              ArrangeBy keys=[[person1id]] // { arity: 3 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[#1]] // { arity: 11 }
+              ArrangeBy keys=[[id]] // { arity: 11 }
                 ReadIndex on=person person_id=[differential join] // { arity: 11 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=city city_id=[differential join] // { arity: 4 }
               Get l0 // { arity: 4 }
       cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 4 }
+        ArrangeBy keys=[[id]] // { arity: 4 }
           ReadIndex on=country country_id=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -2423,7 +2423,7 @@ EOF
 # \set endDate '\'2012-11-10\''::timestamp
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   -- forums within the date range
   myForums AS (
       SELECT id FROM Forum f WHERE f.creationDate BETWEEN '2012-11-06'::TIMESTAMP AND '2012-11-10'::TIMESTAMP
@@ -2481,24 +2481,24 @@ Explained Query:
   Finish order_by=[#1 asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
-        Filter (#1 = 15393162796819) AND (#2 = #2) // { arity: 3 }
+        Filter (person2id = 15393162796819) AND (#2 = #2) // { arity: 3 }
           Get l3 // { arity: 3 }
     With Mutually Recursive
       cte l3 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (1450) // { arity: 3 }
-            Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-              Distinct group_by=[#0, #1] // { arity: 2 }
+            Reduce group_by=[person2id] aggregates=[min(#1)] // { arity: 2 }
+              Distinct group_by=[person2id, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
                     Map ((#1 + #4)) // { arity: 6 }
-                      Join on=(#0 = #2) type=differential // { arity: 5 }
+                      Join on=(#0 = person1id) type=differential // { arity: 5 }
                         implementation
                           %0:l3[#0]K » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             Get l3 // { arity: 3 }
-                        ArrangeBy keys=[[#0]] // { arity: 3 }
+                        ArrangeBy keys=[[person1id]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
@@ -2506,81 +2506,81 @@ Explained Query:
                                   Get l2 // { arity: 4 }
                                 Project (#1, #2, #6) // { arity: 3 }
                                   Map (null) // { arity: 7 }
-                                    Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                                    Join on=(creationdate = creationdate AND person1id = person1id AND person2id = person2id) type=differential // { arity: 6 }
                                       implementation
                                         %0[#0..=#2]KKK » %1:person_knows_person[#0..=#2]KKK
-                                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                      ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                                         Union // { arity: 3 }
                                           Negate // { arity: 3 }
-                                            Distinct group_by=[#0..=#2] // { arity: 3 }
+                                            Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
                                               Project (#0..=#2) // { arity: 3 }
                                                 Get l2 // { arity: 4 }
-                                          Distinct group_by=[#0..=#2] // { arity: 3 }
+                                          Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
                                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                                      ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                                      ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                                         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   Constant // { arity: 2 }
                     - (1450, 0)
       cte l2 =
         Project (#0..=#2, #5) // { arity: 4 }
-          Join on=(#3 = least(#1, #2) AND #4 = greatest(#1, #2)) type=differential // { arity: 6 }
+          Join on=(#3 = least(person1id, person2id) AND #4 = greatest(person1id, person2id)) type=differential // { arity: 6 }
             implementation
               %1[#1, #0]UKK » %0:person_knows_person[greatest(#1, #2), least(#1, #2)]KK
-            ArrangeBy keys=[[greatest(#1, #2), least(#1, #2)]] // { arity: 3 }
+            ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-              Reduce group_by=[least(#0, #1), greatest(#0, #1)] aggregates=[sum(case when (#2) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Reduce group_by=[least(person1id, person2id), greatest(person1id, person2id)] aggregates=[sum(case when (parentmessageid) IS NULL then 10 else 5 end)] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Join on=(eq(#3, #4, #5)) type=delta // { arity: 6 }
+                  Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 6 }
                     implementation
                       %0:l1 » %1[#0]UKA » %2[#0]UKA
                       %1 » %2[#0]UKA » %0:l1[#3]KA
                       %2 » %1[#0]UKA » %0:l1[#3]KA
-                    ArrangeBy keys=[[#3]] // { arity: 4 }
+                    ArrangeBy keys=[[containerforumid]] // { arity: 4 }
                       Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                    ArrangeBy keys=[[containerforumid]] // { arity: 1 }
+                      Distinct group_by=[containerforumid] // { arity: 1 }
                         Project (#3) // { arity: 1 }
-                          Filter (#3) IS NOT NULL // { arity: 4 }
+                          Filter (containerforumid) IS NOT NULL // { arity: 4 }
                             Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                    ArrangeBy keys=[[id]] // { arity: 1 }
+                      Distinct group_by=[id] // { arity: 1 }
                         Project (#1) // { arity: 1 }
-                          Filter (#0 <= 2012-11-10 00:00:00 UTC) AND (#0 >= 2012-11-06 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 4 }
+                          Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                             ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l1 =
         Project (#0, #1, #3, #4) // { arity: 4 }
-          Join on=(eq(#2, #5, #6)) type=delta // { arity: 7 }
+          Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 7 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:l0[#2]KA
               %2 » %1[#0]UKA » %0:l0[#2]KA
-            ArrangeBy keys=[[#2]] // { arity: 5 }
+            ArrangeBy keys=[[containerforumid]] // { arity: 5 }
               Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[containerforumid]] // { arity: 1 }
+              Distinct group_by=[containerforumid] // { arity: 1 }
                 Project (#2) // { arity: 1 }
-                  Filter (#2) IS NOT NULL // { arity: 5 }
+                  Filter (containerforumid) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#0 <= 2012-11-10 00:00:00 UTC) AND (#0 >= 2012-11-06 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 4 }
+                  Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                     ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l0 =
         Project (#1, #2, #13, #15, #17) // { arity: 5 }
-          Join on=(#1 = #12 AND #2 = #16 AND #4 = #18) type=delta // { arity: 19 }
+          Join on=(person1id = creatorpersonid AND person2id = creatorpersonid AND messageid = parentmessageid) type=delta // { arity: 19 }
             implementation
               %0:person_knows_person » %1:message[#9]KA » %2:message[#0, #2]KKA
               %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KKA
               %2:message » %1:message[#1]KA » %0:person_knows_person[#1, #2]KKA
-            ArrangeBy keys=[[#1], [#1, #2]] // { arity: 3 }
+            ArrangeBy keys=[[person1id], [person1id, person2id]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person1id_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-            ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+            ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+            ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 3 }
               Project (#9, #10, #12) // { arity: 3 }
-                Filter (#12) IS NOT NULL // { arity: 13 }
+                Filter (parentmessageid) IS NOT NULL // { arity: 13 }
                   ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2594,7 +2594,7 @@ EOF
 
 # original, w/crossjoins
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
   srcs (f bigint) AS (SELECT 1450::bigint),
   dsts (t bigint) AS (SELECT 15393162796819),
   myForums (id bigint) AS (
@@ -2718,14 +2718,14 @@ Explained Query:
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1 = #4) type=differential // { arity: 6 }
+                Join on=(person2id = person2id) type=differential // { arity: 6 }
                   implementation
                     %0:l17[#1]Kef » %1:l17[#1]Kef
-                  ArrangeBy keys=[[#1]] // { arity: 3 }
+                  ArrangeBy keys=[[person2id]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l17 // { arity: 4 }
-                  ArrangeBy keys=[[#1]] // { arity: 3 }
+                  ArrangeBy keys=[[person2id]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l17 // { arity: 4 }
@@ -2745,7 +2745,7 @@ Explained Query:
                     Get l16 // { arity: 6 }
   With Mutually Recursive
     cte l16 =
-      Distinct group_by=[#0..=#5] // { arity: 6 }
+      Distinct group_by=[#0, #1, person2id, #3, #4, #5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
@@ -2781,7 +2781,7 @@ Explained Query:
     cte l15 =
       Distinct // { arity: 0 }
         Project () // { arity: 0 }
-          Filter #1 AND (#0 = -1) // { arity: 2 }
+          Filter #1 AND (person2id = -1) // { arity: 2 }
             Get l7 // { arity: 2 }
     cte l14 =
       Project (#1) // { arity: 1 }
@@ -2798,26 +2798,26 @@ Explained Query:
     cte l13 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
-          Join on=(#0 = #2) type=differential // { arity: 4 }
+          Join on=(person2id = person2id) type=differential // { arity: 4 }
             implementation
               %0:l12[#0]Kef » %1:l12[#0]Kef
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
                   Get l12 // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[person2id]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
                   Get l12 // { arity: 5 }
     cte l12 =
-      TopK group_by=[#0..=#2] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+      TopK group_by=[#0, #1, person2id] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
-              Join on=(#0 = #5) type=differential // { arity: 7 }
+              Join on=(person1id = #5) type=differential // { arity: 7 }
                 implementation
                   %0:l3[#0]K » %1:l8[#2]K
-                ArrangeBy keys=[[#0]] // { arity: 3 }
+                ArrangeBy keys=[[person1id]] // { arity: 3 }
                   Get l3 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
@@ -2827,11 +2827,11 @@ Explained Query:
               Join on=(eq(#0, #6, #12) AND eq(#1, #7, #13) AND eq(#2, #8, #14) AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                 implementation
                   %1:l9[#0..=#5]UKKKKKK » %0:l16[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                   Get l16 // { arity: 6 }
-                ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                   Get l9 // { arity: 6 }
-                ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                   Union // { arity: 4 }
                     Map (true) // { arity: 4 }
                       Get l11 // { arity: 3 }
@@ -2840,30 +2840,30 @@ Explained Query:
                         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                           implementation
                             %1:l10[#0..=#2]UKKK » %0[#0..=#2]KKK
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
                                 Get l11 // { arity: 3 }
                               Get l10 // { arity: 3 }
-                          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                             Get l10 // { arity: 3 }
     cte l11 =
       Project (#0..=#2) // { arity: 3 }
         Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
           implementation
             %1[#0..=#2]UKKKA » %0:l10[#0..=#2]UKKK
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
             Get l10 // { arity: 3 }
-          ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-            Distinct group_by=[#0..=#2] // { arity: 3 }
+          ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+            Distinct group_by=[#0, #1, #2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Get l8 // { arity: 5 }
     cte l10 =
-      Distinct group_by=[#0..=#2] // { arity: 3 }
+      Distinct group_by=[#0, #1, #2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
           Get l9 // { arity: 6 }
     cte l9 =
-      Distinct group_by=[#0..=#5] // { arity: 6 }
+      Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
         Get l16 // { arity: 6 }
     cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -2871,9 +2871,9 @@ Explained Query:
           Filter (#4 = false) // { arity: 6 }
             Get l16 // { arity: 6 }
     cte l7 =
-      Distinct group_by=[#0, #1] // { arity: 2 }
+      Distinct group_by=[person2id, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Distinct group_by=[#0, #1] // { arity: 2 }
+          Distinct group_by=[person2id, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#1, #0) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
@@ -2896,14 +2896,14 @@ Explained Query:
     cte l6 =
       Distinct // { arity: 0 }
         Project () // { arity: 0 }
-          Join on=(#0 = #1) type=differential // { arity: 2 }
+          Join on=(person2id = person2id) type=differential // { arity: 2 }
             implementation
               %0:l5[#0]Kf » %1:l5[#0]Kf
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[person2id]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter #1 // { arity: 2 }
                   Get l5 // { arity: 2 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[person2id]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
                   Get l5 // { arity: 2 }
@@ -2914,12 +2914,12 @@ Explained Query:
         Get l7 // { arity: 2 }
     cte l4 =
       Project (#1, #3) // { arity: 2 }
-        Join on=(#0 = #2) type=differential // { arity: 4 }
+        Join on=(#0 = person1id) type=differential // { arity: 4 }
           implementation
             %0:l7[#0]K » %1:l3[#0]K
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Get l7 // { arity: 2 }
-          ArrangeBy keys=[[#0]] // { arity: 2 }
+          ArrangeBy keys=[[person1id]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Get l3 // { arity: 3 }
     cte l3 =
@@ -2930,79 +2930,79 @@ Explained Query:
               Get l2 // { arity: 4 }
             Project (#1, #2, #6) // { arity: 3 }
               Map (null) // { arity: 7 }
-                Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
+                Join on=(creationdate = creationdate AND person1id = person1id AND person2id = person2id) type=differential // { arity: 6 }
                   implementation
                     %0[#0..=#2]KKK » %1:person_knows_person[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                  ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                     Union // { arity: 3 }
                       Negate // { arity: 3 }
-                        Distinct group_by=[#0..=#2] // { arity: 3 }
+                        Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
                           Project (#0..=#2) // { arity: 3 }
                             Get l2 // { arity: 4 }
-                      Distinct group_by=[#0..=#2] // { arity: 3 }
+                      Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
                         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                  ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
       Project (#0..=#2, #5) // { arity: 4 }
-        Join on=(#3 = least(#1, #2) AND #4 = greatest(#1, #2)) type=differential // { arity: 6 }
+        Join on=(#3 = least(person1id, person2id) AND #4 = greatest(person1id, person2id)) type=differential // { arity: 6 }
           implementation
             %1[#1, #0]UKK » %0:person_knows_person[greatest(#1, #2), least(#1, #2)]KK
-          ArrangeBy keys=[[greatest(#1, #2), least(#1, #2)]] // { arity: 3 }
+          ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 3 }
             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(#0, #1), greatest(#0, #1)] aggregates=[sum(case when (#2) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Reduce group_by=[least(person1id, person2id), greatest(person1id, person2id)] aggregates=[sum(case when (parentmessageid) IS NULL then 10 else 5 end)] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Join on=(eq(#3, #4, #5)) type=delta // { arity: 6 }
+                Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 6 }
                   implementation
                     %0:l1 » %1[#0]UKA » %2[#0]UKA
                     %1 » %2[#0]UKA » %0:l1[#3]KA
                     %2 » %1[#0]UKA » %0:l1[#3]KA
-                  ArrangeBy keys=[[#3]] // { arity: 4 }
+                  ArrangeBy keys=[[containerforumid]] // { arity: 4 }
                     Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                  ArrangeBy keys=[[containerforumid]] // { arity: 1 }
+                    Distinct group_by=[containerforumid] // { arity: 1 }
                       Project (#3) // { arity: 1 }
-                        Filter (#3) IS NOT NULL // { arity: 4 }
+                        Filter (containerforumid) IS NOT NULL // { arity: 4 }
                           Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                  ArrangeBy keys=[[id]] // { arity: 1 }
+                    Distinct group_by=[id] // { arity: 1 }
                       Project (#1) // { arity: 1 }
-                        Filter (#0 <= 2012-11-10 00:00:00 UTC) AND (#0 >= 2012-11-06 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 4 }
+                        Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                           ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l1 =
       Project (#0, #1, #3, #4) // { arity: 4 }
-        Join on=(eq(#2, #5, #6)) type=delta // { arity: 7 }
+        Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 7 }
           implementation
             %0:l0 » %1[#0]UKA » %2[#0]UKA
             %1 » %2[#0]UKA » %0:l0[#2]KA
             %2 » %1[#0]UKA » %0:l0[#2]KA
-          ArrangeBy keys=[[#2]] // { arity: 5 }
+          ArrangeBy keys=[[containerforumid]] // { arity: 5 }
             Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+          ArrangeBy keys=[[containerforumid]] // { arity: 1 }
+            Distinct group_by=[containerforumid] // { arity: 1 }
               Project (#2) // { arity: 1 }
-                Filter (#2) IS NOT NULL // { arity: 5 }
+                Filter (containerforumid) IS NOT NULL // { arity: 5 }
                   Get l0 // { arity: 5 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+          ArrangeBy keys=[[id]] // { arity: 1 }
+            Distinct group_by=[id] // { arity: 1 }
               Project (#1) // { arity: 1 }
-                Filter (#0 <= 2012-11-10 00:00:00 UTC) AND (#0 >= 2012-11-06 00:00:00 UTC) AND (#1) IS NOT NULL // { arity: 4 }
+                Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                   ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l0 =
       Project (#1, #2, #13, #15, #17) // { arity: 5 }
-        Join on=(#1 = #12 AND #2 = #16 AND #4 = #18) type=delta // { arity: 19 }
+        Join on=(person1id = creatorpersonid AND person2id = creatorpersonid AND messageid = parentmessageid) type=delta // { arity: 19 }
           implementation
             %0:person_knows_person » %1:message[#9]KA » %2:message[#0, #2]KKA
             %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KKA
             %2:message » %1:message[#1]KA » %0:person_knows_person[#1, #2]KKA
-          ArrangeBy keys=[[#1], [#1, #2]] // { arity: 3 }
+          ArrangeBy keys=[[person1id], [person1id, person2id]] // { arity: 3 }
             ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person1id_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-          ArrangeBy keys=[[#1], [#9]] // { arity: 13 }
+          ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
             ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-          ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+          ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 3 }
             Project (#9, #10, #12) // { arity: 3 }
-              Filter (#12) IS NOT NULL // { arity: 13 }
+              Filter (parentmessageid) IS NOT NULL // { arity: 13 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -3027,7 +3027,7 @@ EOF
 
 # TODO(mgree) predicate push down anomaly on Tag.name
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   subgraphA AS (
     SELECT DISTINCT Person.id AS PersonId, Message.MessageId AS MessageId
     FROM Person
@@ -3089,117 +3089,117 @@ ORDER BY personA.cm + personB.cm DESC, PersonId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#6 desc nulls_first, #0 asc nulls_last] limit=20 output=[#0, #1, #4]
+  Finish order_by=[#6 desc nulls_first, id asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
       Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
         Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
           Map ((#1 + #4)) // { arity: 7 }
-            Join on=(#0 = #3) type=differential // { arity: 6 }
+            Join on=(id = id) type=differential // { arity: 6 }
               implementation
                 %0[#0]UKAif » %1[#0]UKAiif
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
+              ArrangeBy keys=[[id]] // { arity: 3 }
+                Reduce group_by=[id] aggregates=[count(distinct messageid), count(distinct person2id)] // { arity: 3 }
                   Union // { arity: 3 }
                     Get l5 // { arity: 3 }
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
+                          Distinct group_by=[id, messageid] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l5 // { arity: 3 }
                         Get l3 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[count(distinct #1), count(distinct #2)] // { arity: 3 }
+              ArrangeBy keys=[[id]] // { arity: 3 }
+                Reduce group_by=[id] aggregates=[count(distinct messageid), count(distinct person2id)] // { arity: 3 }
                   Union // { arity: 3 }
                     Get l7 // { arity: 3 }
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
+                          Distinct group_by=[id, messageid] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
     With
       cte l7 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(#0 = #3 AND #4 = #5) type=differential // { arity: 6 }
+          Join on=(id = person1id AND person2id = id) type=differential // { arity: 6 }
             implementation
               %0:l6[#0]K » %1:l4[#1]KA » %2[#0]UKA
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[id]] // { arity: 2 }
               Get l6 // { arity: 2 }
             Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l6 // { arity: 2 }
       cte l6 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 4 }
+          Join on=(id = creatorpersonid AND messageid = messageid) type=differential // { arity: 4 }
             implementation
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Distinct group_by=[#1, #0] // { arity: 2 }
+            ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
+              Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0))) // { arity: 13 }
+                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[messageid]] // { arity: 1 }
+              Distinct group_by=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2) IS NOT NULL // { arity: 8 }
-                    Join on=(#2 = #3) type=differential // { arity: 8 }
+                  Filter (tagid) IS NOT NULL // { arity: 8 }
+                    Join on=(tagid = id) type=differential // { arity: 8 }
                       implementation
                         %1:tag[#0]KAe » %0:l1[#2]KAe
                       Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0]] // { arity: 5 }
+                      ArrangeBy keys=[[id]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(#0 = #3 AND #4 = #5) type=differential // { arity: 6 }
+          Join on=(id = person1id AND person2id = id) type=differential // { arity: 6 }
             implementation
               %0:l3[#0]K » %1:l4[#1]KA » %2[#0]UKA
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[id]] // { arity: 2 }
               Get l3 // { arity: 2 }
             Get l4 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l4 =
-        ArrangeBy keys=[[#1]] // { arity: 3 }
+        ArrangeBy keys=[[person1id]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
       cte l3 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(#0 = #1 AND #2 = #3) type=differential // { arity: 4 }
+          Join on=(id = creatorpersonid AND messageid = messageid) type=differential // { arity: 4 }
             implementation
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
-              Distinct group_by=[#1, #0] // { arity: 2 }
+            ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
+              Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0))) // { arity: 13 }
+                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[messageid]] // { arity: 1 }
+              Distinct group_by=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#2) IS NOT NULL // { arity: 8 }
-                    Join on=(#2 = #3) type=differential // { arity: 8 }
+                  Filter (tagid) IS NOT NULL // { arity: 8 }
+                    Join on=(tagid = id) type=differential // { arity: 8 }
                       implementation
                         %1:tag[#0]KAe » %0:l1[#2]KAe
                       Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[#0]] // { arity: 5 }
+                      ArrangeBy keys=[[id]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l2 =
-        ArrangeBy keys=[[#1]] // { arity: 4 }
+        ArrangeBy keys=[[name]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
       cte l1 =
-        ArrangeBy keys=[[#2]] // { arity: 3 }
+        ArrangeBy keys=[[tagid]] // { arity: 3 }
           ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
       cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct group_by=[#0] // { arity: 1 }
+        ArrangeBy keys=[[id]] // { arity: 1 }
+          Distinct group_by=[id] // { arity: 1 }
             Project (#1) // { arity: 1 }
-              Filter (#1) IS NOT NULL // { arity: 11 }
+              Filter (id) IS NOT NULL // { arity: 11 }
                 ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
 
 Used Indexes:
@@ -3219,7 +3219,7 @@ EOF
 # \set delta '12'
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MyMessage as (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MyMessage as (
     SELECT *
     FROM Message
 -- (tag)<-[:HAS_TAG]-(message)
@@ -3255,75 +3255,75 @@ ORDER BY messageCount DESC, Message1.CreatorPersonId ASC
 LIMIT 10
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] limit=10 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(distinct #1)] // { arity: 2 }
+      Reduce group_by=[creatorpersonid] aggregates=[count(distinct messageid)] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #3 AND #2 = #4) type=differential // { arity: 5 }
+          Join on=(creatorpersonid = creatorpersonid AND containerforumid = containerforumid) type=differential // { arity: 5 }
             implementation
               %0:l2[#0, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+            ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                    Join on=(creatorpersonid = personid AND containerforumid = forumid) type=differential // { arity: 4 }
                       implementation
                         %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 2 }
                         Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Distinct group_by=[#1, #0] // { arity: 2 }
+                      ArrangeBy keys=[[personid, forumid]] // { arity: 2 }
+                        Distinct group_by=[personid, forumid] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[creatorpersonid, containerforumid] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
         Project (#1, #4, #6) // { arity: 3 }
-          Filter (#2 != #6) AND (#5 != #7) AND ((#0 + 12:00:00) < #3) // { arity: 15 }
-            Join on=(eq(#2, #10, #13) AND #4 = #8 AND #5 = #14 AND #7 = #11) type=differential // { arity: 15 }
+          Filter (containerforumid != containerforumid) AND (creatorpersonid != creatorpersonid) AND ((creationdate + 12:00:00) < creationdate) // { arity: 15 }
+            Join on=(eq(containerforumid, forumid, forumid) AND messageid = parentmessageid AND creatorpersonid = personid AND creatorpersonid = personid) type=differential // { arity: 15 }
               implementation
                 %3:l1[#1]KA » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
-              ArrangeBy keys=[[#2]] // { arity: 3 }
+              ArrangeBy keys=[[containerforumid]] // { arity: 3 }
                 Project (#0, #2, #3) // { arity: 3 }
-                  Filter (#3) IS NOT NULL // { arity: 5 }
+                  Filter (containerforumid) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
-              ArrangeBy keys=[[#2]] // { arity: 4 }
+              ArrangeBy keys=[[creatorpersonid]] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
                   Get l0 // { arity: 5 }
-              ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+              ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 2 }
                 Project (#2, #4) // { arity: 2 }
-                  Filter (#4) IS NOT NULL // { arity: 5 }
+                  Filter (parentmessageid) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[#1]] // { arity: 3 }
+        ArrangeBy keys=[[forumid]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0, #1, #9, #10, #12) // { arity: 5 }
-          Join on=(#1 = #13) type=differential // { arity: 14 }
+          Join on=(messageid = messageid) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
-            ArrangeBy keys=[[#1]] // { arity: 13 }
+            ArrangeBy keys=[[messageid]] // { arity: 13 }
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[messageid]] // { arity: 1 }
+              Distinct group_by=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Join on=(#2 = #3) type=differential // { arity: 4 }
+                  Join on=(tagid = id) type=differential // { arity: 4 }
                     implementation
                       %1[#0]UKA » %0:message_hastag_tag[#2]KA
-                    ArrangeBy keys=[[#2]] // { arity: 3 }
+                    ArrangeBy keys=[[tagid]] // { arity: 3 }
                       ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                    ArrangeBy keys=[[id]] // { arity: 1 }
+                      Distinct group_by=[id] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Filter (#0) IS NOT NULL // { arity: 5 }
+                          Filter (id) IS NOT NULL // { arity: 5 }
                             ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
 
 Used Indexes:
@@ -3341,7 +3341,7 @@ EOF
 # \set tag '\'Fyodor_Dostoyevsky\''
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
 PersonWithInterest AS (
 SELECT pt.PersonId AS PersonId
 FROM Person_hasInterest_Tag pt, Tag t
@@ -3368,53 +3368,53 @@ ORDER BY mutualFriendCount DESC, k1.InterestedId ASC, k2.InterestedId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[#2 desc nulls_first, personid asc nulls_last, personid asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[#0, #1] aggregates=[count(*)] // { arity: 3 }
+      Reduce group_by=[personid, personid] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+          Join on=(personid = personid AND personid = personid) type=differential // { arity: 4 }
             implementation
               %0:l1[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[personid, personid]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[personid, personid]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(#0 = #2 AND #1 = #3) type=differential // { arity: 4 }
+                    Join on=(personid = person2id AND personid = person1id) type=differential // { arity: 4 }
                       implementation
                         %0:l2[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+                      ArrangeBy keys=[[personid, personid]] // { arity: 2 }
                         Get l2 // { arity: 2 }
-                      ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                        Distinct group_by=[#1, #0] // { arity: 2 }
+                      ArrangeBy keys=[[person2id, person1id]] // { arity: 2 }
+                        Distinct group_by=[person2id, person1id] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
     With
       cte l2 =
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct group_by=[personid, personid] // { arity: 2 }
           Get l1 // { arity: 2 }
       cte l1 =
         Project (#0, #2) // { arity: 2 }
-          Filter (#0 != #2) // { arity: 4 }
-            Join on=(#1 = #3) type=differential // { arity: 4 }
+          Filter (personid != personid) // { arity: 4 }
+            Join on=(person2id = person2id) type=differential // { arity: 4 }
               implementation
                 %0:l0[#1]K » %1:l0[#1]K
               Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }
       cte l0 =
-        ArrangeBy keys=[[#1]] // { arity: 2 }
+        ArrangeBy keys=[[person2id]] // { arity: 2 }
           Project (#1, #10) // { arity: 2 }
-            Filter (#2) IS NOT NULL // { arity: 11 }
-              Join on=(#1 = #9 AND #2 = #3) type=differential // { arity: 11 }
+            Filter (tagid) IS NOT NULL // { arity: 11 }
+              Join on=(personid = person1id AND tagid = id) type=differential // { arity: 11 }
                 implementation
                   %1:tag[#0]KAe » %0:person_hasinterest_tag[#2]KAe » %2:person_knows_person[#1]KAe
-                ArrangeBy keys=[[#2]] // { arity: 3 }
+                ArrangeBy keys=[[tagid]] // { arity: 3 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[differential join] // { arity: 3 }
-                ArrangeBy keys=[[#0]] // { arity: 5 }
+                ArrangeBy keys=[[id]] // { arity: 5 }
                   ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-                ArrangeBy keys=[[#1]] // { arity: 3 }
+                ArrangeBy keys=[[person1id]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -3464,7 +3464,7 @@ statement ok
 CREATE INDEX PathQ19_src ON PathQ19 (src);
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH
   srcs AS (SELECT id FROM Person WHERE locationcityid = 655::bigint),
   dsts AS (SELECT id FROM Person WHERE locationcityid = 1138::bigint),
   completed_paths AS (
@@ -3513,40 +3513,40 @@ Explained Query:
     With
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(eq(#1, #3, #4)) type=delta // { arity: 5 }
+          Join on=(eq(id, id, id)) type=delta // { arity: 5 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:l0[#1]KA
               %2 » %1[#0]UKA » %0:l0[#1]KA
-            ArrangeBy keys=[[#1]] // { arity: 3 }
+            ArrangeBy keys=[[id]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#1) IS NOT NULL // { arity: 3 }
+                  Filter (id) IS NOT NULL // { arity: 3 }
                     Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[id]] // { arity: 1 }
+              Distinct group_by=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (#1) IS NOT NULL // { arity: 12 }
+                  Filter (id) IS NOT NULL // { arity: 12 }
                     ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
   With Mutually Recursive
     cte l0 =
-      Reduce group_by=[#0, #1] aggregates=[min(#2)] // { arity: 3 }
-        Distinct group_by=[#0..=#2] // { arity: 3 }
+      Reduce group_by=[id, id] aggregates=[min(#2)] // { arity: 3 }
+        Distinct group_by=[id, id, #2] // { arity: 3 }
           Union // { arity: 3 }
             Project (#1, #1, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
             Project (#0, #4, #6) // { arity: 3 }
-              Map ((#2 + bigint_to_double(#5))) // { arity: 7 }
-                Join on=(#1 = #3) type=differential // { arity: 6 }
+              Map ((#2 + bigint_to_double(w))) // { arity: 7 }
+                Join on=(#1 = src) type=differential // { arity: 6 }
                   implementation
                     %1:pathq19[#0]KA » %0:l0[#1]K
                   ArrangeBy keys=[[#1]] // { arity: 3 }
                     Filter (#1) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
-                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                  ArrangeBy keys=[[src]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -3557,7 +3557,7 @@ EOF
 
 # q19 (frank's version)
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
   -- Source and destination identifiers, which do not evolve recursively.
   srcs (f bigint) AS (SELECT id FROM Person WHERE locationcityid = 655::bigint),
   dsts (t bigint) AS (SELECT id FROM Person WHERE locationcityid = 1138::bigint),
@@ -3640,27 +3640,27 @@ Explained Query:
         Project (#2) // { arity: 1 }
           Get l4 // { arity: 3 }
     cte l4 =
-      Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+      Reduce group_by=[id, id] aggregates=[min((#1 + #3))] // { arity: 3 }
         Project (#0, #2, #3, #5) // { arity: 4 }
-          Join on=(#1 = #4) type=differential // { arity: 6 }
+          Join on=(id = id) type=differential // { arity: 6 }
             implementation
               %0:l1[#1]K » %1:l3[#1]K
-            ArrangeBy keys=[[#1]] // { arity: 3 }
-              Filter (#1) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[id]] // { arity: 3 }
+              Filter (id) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#1]] // { arity: 3 }
-              Filter (#1) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[id]] // { arity: 3 }
+              Filter (id) IS NOT NULL // { arity: 3 }
                 Get l3 // { arity: 3 }
     cte l3 =
-      TopK group_by=[#0, #1] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+      TopK group_by=[id, id] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1, #1, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6))) // { arity: 8 }
-                Join on=(#1 = #4) type=differential // { arity: 7 }
+              Map ((#2 + bigint_to_double(w))) // { arity: 8 }
+                Join on=(#1 = src) type=differential // { arity: 7 }
                   implementation
                     %2:pathq19[#0]KA » %0:l3[#1]K » %1[×]
                   ArrangeBy keys=[[#1]] // { arity: 3 }
@@ -3677,7 +3677,7 @@ Explained Query:
                                 Get l2 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                  ArrangeBy keys=[[src]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
     cte l2 =
       Union // { arity: 1 }
@@ -3691,15 +3691,15 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l6 // { arity: 1 }
     cte l1 =
-      TopK group_by=[#0, #1] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+      TopK group_by=[id, id] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1, #1, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(#6))) // { arity: 8 }
-                Join on=(#1 = #4) type=differential // { arity: 7 }
+              Map ((#2 + bigint_to_double(w))) // { arity: 8 }
+                Join on=(#1 = src) type=differential // { arity: 7 }
                   implementation
                     %2:pathq19[#0]KA » %0:l1[#1]K » %1[×]
                   ArrangeBy keys=[[#1]] // { arity: 3 }
@@ -3716,7 +3716,7 @@ Explained Query:
                                 Get l0 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                  ArrangeBy keys=[[src]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
     cte l0 =
       Union // { arity: 1 }
@@ -3738,7 +3738,7 @@ EOF
 
 # original query, w/cross joins
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
   srcs (f bigint) AS (SELECT id FROM Person WHERE locationcityid = 655::bigint),
   dsts (t bigint) AS (SELECT id FROM Person WHERE locationcityid = 1138::bigint),
   shorts (dir bool, gsrc bigint, dst bigint, w double precision, dead bool, iter bigint) AS (
@@ -3790,7 +3790,7 @@ EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
 SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#2]
+  Finish order_by=[id asc nulls_last, id asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
@@ -3807,16 +3807,16 @@ Explained Query:
                     Get l10 // { arity: 3 }
       With
         cte l10 =
-          Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+          Reduce group_by=[id, id] aggregates=[min((#1 + #3))] // { arity: 3 }
             Project (#0, #2, #3, #5) // { arity: 4 }
-              Join on=(#1 = #4) type=differential // { arity: 6 }
+              Join on=(id = id) type=differential // { arity: 6 }
                 implementation
                   %0:l9[#1]Kef » %1:l9[#1]Kef
-                ArrangeBy keys=[[#1]] // { arity: 3 }
+                ArrangeBy keys=[[id]] // { arity: 3 }
                   Project (#1..=#3) // { arity: 3 }
                     Filter (#0 = false) // { arity: 4 }
                       Get l9 // { arity: 4 }
-                ArrangeBy keys=[[#1]] // { arity: 3 }
+                ArrangeBy keys=[[id]] // { arity: 3 }
                   Project (#1..=#3) // { arity: 3 }
                     Filter (#0 = true) // { arity: 4 }
                       Get l9 // { arity: 4 }
@@ -3827,7 +3827,7 @@ Explained Query:
                 %1[#0]UK » %0:l8[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (#2) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (id) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l8 // { arity: 6 }
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Filter (#0) IS NOT NULL // { arity: 1 }
@@ -3836,7 +3836,7 @@ Explained Query:
                       Get l8 // { arity: 6 }
     With Mutually Recursive
       cte l8 =
-        Distinct group_by=[#0..=#5] // { arity: 6 }
+        Distinct group_by=[#0, id, id, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Map (0) // { arity: 6 }
               Union // { arity: 5 }
@@ -3870,7 +3870,7 @@ Explained Query:
                           Constant // { arity: 0 }
                             - ()
       cte l7 =
-        ArrangeBy keys=[[#8]] // { arity: 11 }
+        ArrangeBy keys=[[locationcityid]] // { arity: 11 }
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
       cte l6 =
         Project (#1) // { arity: 1 }
@@ -3887,27 +3887,27 @@ Explained Query:
       cte l5 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
-            Join on=(#0 = #2) type=differential // { arity: 4 }
+            Join on=(dst = dst) type=differential // { arity: 4 }
               implementation
                 %0:l4[#0]Kef » %1:l4[#0]Kef
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (#2) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = false) AND (dst) IS NOT NULL // { arity: 5 }
                     Get l4 // { arity: 5 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (#2) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = true) AND (dst) IS NOT NULL // { arity: 5 }
                     Get l4 // { arity: 5 }
       cte l4 =
-        TopK group_by=[#0..=#2] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct group_by=[#0..=#4] // { arity: 5 }
+        TopK group_by=[#0, #1, dst] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Distinct group_by=[#0, #1, dst, #3, #4] // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1, #7, #8) // { arity: 5 }
-                Map ((#6 + bigint_to_double(#2)), false) // { arity: 9 }
-                  Join on=(#0 = #5) type=differential // { arity: 7 }
+                Map ((#6 + bigint_to_double(w)), false) // { arity: 9 }
+                  Join on=(src = #5) type=differential // { arity: 7 }
                     implementation
                       %0:pathq19[#0]KA » %1:l0[#2]K
-                    ArrangeBy keys=[[#0]] // { arity: 3 }
+                    ArrangeBy keys=[[src]] // { arity: 3 }
                       ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#2]] // { arity: 4 }
                       Project (#0..=#3) // { arity: 4 }
@@ -3918,11 +3918,11 @@ Explained Query:
                   Join on=(eq(#0, #6, #12) AND eq(#1, #7, #13) AND eq(#2, #8, #14) AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                     implementation
                       %1:l1[#0..=#5]UKKKKKK » %0:l8[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                    ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                       Get l8 // { arity: 6 }
-                    ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                    ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                       Get l1 // { arity: 6 }
-                    ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                    ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                       Union // { arity: 4 }
                         Map (true) // { arity: 4 }
                           Get l3 // { arity: 3 }
@@ -3931,32 +3931,32 @@ Explained Query:
                             Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                               implementation
                                 %1:l2[#0..=#2]UKKK » %0[#0..=#2]KKK
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                                 Union // { arity: 3 }
                                   Negate // { arity: 3 }
                                     Get l3 // { arity: 3 }
                                   Get l2 // { arity: 3 }
-                              ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                              ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                                 Get l2 // { arity: 3 }
       cte l3 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
               %1[#0..=#2]UKKKA » %0:l2[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
                 Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct group_by=[#0..=#2] // { arity: 3 }
+            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+              Distinct group_by=[#0, #1, #2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
       cte l2 =
-        Distinct group_by=[#0..=#2] // { arity: 3 }
+        Distinct group_by=[#0, #1, #2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l1 // { arity: 6 }
       cte l1 =
-        Distinct group_by=[#0..=#5] // { arity: 6 }
+        Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
           Get l8 // { arity: 6 }
       cte l0 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -3990,7 +3990,7 @@ statement ok
 CREATE INDEX PathQ20_src ON PathQ20 (src);
 
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
   WITH MUTUALLY RECURSIVE
     paths (src bigint, dst bigint, w bigint) AS (
       SELECT 10995116285979::bigint AS src, 10995116285979::bigint AS dst, 0 AS w
@@ -4024,7 +4024,7 @@ EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[dst asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4050,39 +4050,39 @@ Explained Query:
             Get l1 // { arity: 2 }
         cte l1 =
           Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = #2) type=differential // { arity: 3 }
+            Join on=(dst = personid) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Project (#1, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[personid]] // { arity: 1 }
+                Distinct group_by=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5 = "Balkh_Airlines") AND (#2) IS NOT NULL // { arity: 8 }
-                      Join on=(#2 = #4) type=differential // { arity: 8 }
+                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
+                      Join on=(companyid = id) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2]] // { arity: 4 }
+                        ArrangeBy keys=[[companyid]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 4 }
+                        ArrangeBy keys=[[id]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
-            Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-              Distinct group_by=[#0, #1] // { arity: 2 }
+            Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
+              Distinct group_by=[dst, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
-                    Map ((#1 + integer_to_bigint(#4))) // { arity: 6 }
-                      Join on=(#0 = #2) type=differential // { arity: 5 }
+                    Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
+                      Join on=(#0 = src) type=differential // { arity: 5 }
                         implementation
                           %1:pathq20[#0]KA » %0:l0[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
-                        ArrangeBy keys=[[#0]] // { arity: 3 }
+                        ArrangeBy keys=[[src]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
                     - (10995116285979, 0)
@@ -4096,7 +4096,7 @@ EOF
 
 # without the unused src
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
   WITH MUTUALLY RECURSIVE
     paths (dst bigint, w bigint) AS (
       SELECT 10995116285979::bigint AS dst, 0 AS w
@@ -4130,7 +4130,7 @@ EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[dst asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4156,35 +4156,35 @@ Explained Query:
             Get l1 // { arity: 2 }
         cte l1 =
           Project (#0, #1) // { arity: 2 }
-            Join on=(#0 = #2) type=differential // { arity: 3 }
+            Join on=(dst = personid) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Get l0 // { arity: 2 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[personid]] // { arity: 1 }
+                Distinct group_by=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5 = "Balkh_Airlines") AND (#2) IS NOT NULL // { arity: 8 }
-                      Join on=(#2 = #4) type=differential // { arity: 8 }
+                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
+                      Join on=(companyid = id) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2]] // { arity: 4 }
+                        ArrangeBy keys=[[companyid]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 4 }
+                        ArrangeBy keys=[[id]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
-          Distinct group_by=[#0, #1] // { arity: 2 }
+        Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
+          Distinct group_by=[dst, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#3, #5) // { arity: 2 }
-                Map ((#1 + integer_to_bigint(#4))) // { arity: 6 }
-                  Join on=(#0 = #2) type=differential // { arity: 5 }
+                Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
+                  Join on=(#0 = src) type=differential // { arity: 5 }
                     implementation
                       %1:pathq20[#0]KA » %0:l0[#0]K
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[#0]] // { arity: 3 }
+                    ArrangeBy keys=[[src]] // { arity: 3 }
                       ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
               Constant // { arity: 2 }
                 - (10995116285979, 0)
@@ -4198,7 +4198,7 @@ EOF
 
 # tracking hops
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
   WITH MUTUALLY RECURSIVE
     paths (src bigint, dst bigint, w bigint, hops bigint) AS (
       SELECT 10995116285979::bigint AS src, 10995116285979::bigint AS dst, 0 AS w, 0 AS hops
@@ -4237,7 +4237,7 @@ EXPLAIN WITH(arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w, hops FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[dst asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
@@ -4263,40 +4263,40 @@ Explained Query:
             Get l1 // { arity: 3 }
         cte l1 =
           Project (#0..=#2) // { arity: 3 }
-            Join on=(#0 = #3) type=differential // { arity: 4 }
+            Join on=(dst = personid) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKA » %0:l0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 3 }
+              ArrangeBy keys=[[dst]] // { arity: 3 }
                 Project (#1..=#3) // { arity: 3 }
                   Get l0 // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+              ArrangeBy keys=[[personid]] // { arity: 1 }
+                Distinct group_by=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (#5 = "Balkh_Airlines") AND (#2) IS NOT NULL // { arity: 8 }
-                      Join on=(#2 = #4) type=differential // { arity: 8 }
+                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
+                      Join on=(companyid = id) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[#2]] // { arity: 4 }
+                        ArrangeBy keys=[[companyid]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[#0]] // { arity: 4 }
+                        ArrangeBy keys=[[id]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#3, #0..=#2) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
-            Reduce group_by=[#0, #2] aggregates=[min(#1)] // { arity: 3 }
-              Reduce group_by=[#0, #2] aggregates=[min(#1)] // { arity: 3 }
-                Distinct group_by=[#0..=#2] // { arity: 3 }
+            Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
+              Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
+                Distinct group_by=[dst, #1, #2] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#4, #6, #7) // { arity: 3 }
-                      Map ((#1 + integer_to_bigint(#5)), (#2 + 1)) // { arity: 8 }
-                        Join on=(#0 = #3) type=differential // { arity: 6 }
+                      Map ((#1 + integer_to_bigint(w)), (#2 + 1)) // { arity: 8 }
+                        Join on=(#0 = src) type=differential // { arity: 6 }
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0]] // { arity: 3 }
                             Project (#1..=#3) // { arity: 3 }
                               Get l0 // { arity: 4 }
-                          ArrangeBy keys=[[#0]] // { arity: 3 }
+                          ArrangeBy keys=[[src]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
                       - (10995116285979, 0, 0)
@@ -4310,7 +4310,7 @@ EOF
 
 # original query, w/extra crossjoins
 query T multiline
-EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
+EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
   srcs(f bigint) AS (SELECT 10995116285979::bigint),
   dsts(t bigint) AS (
       SELECT personid
@@ -4386,7 +4386,7 @@ EXPLAIN WITH(arity, join_impls) WITH MUTUALLY RECURSIVE
 SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[personid asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4404,16 +4404,16 @@ Explained Query:
       With
         cte l13 =
           Project (#1, #2) // { arity: 2 }
-            Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
+            Reduce group_by=[personid, personid] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(#1 = #4) type=differential // { arity: 6 }
+                Join on=(personid = personid) type=differential // { arity: 6 }
                   implementation
                     %0:l12[#1]Kef » %1:l12[#1]Kef
-                  ArrangeBy keys=[[#1]] // { arity: 3 }
+                  ArrangeBy keys=[[personid]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l12 // { arity: 4 }
-                  ArrangeBy keys=[[#1]] // { arity: 3 }
+                  ArrangeBy keys=[[personid]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l12 // { arity: 4 }
@@ -4433,11 +4433,11 @@ Explained Query:
                       Get l11 // { arity: 6 }
     With Mutually Recursive
       cte l11 =
-        Distinct group_by=[#0..=#5] // { arity: 6 }
+        Distinct group_by=[#0, personid, personid, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
-                Distinct group_by=[#0..=#2] // { arity: 3 }
+                Distinct group_by=[#0, personid, personid] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
@@ -4477,12 +4477,12 @@ Explained Query:
       cte l10 =
         Distinct // { arity: 0 }
           Project () // { arity: 0 }
-            Join on=(#0 = #1) type=differential // { arity: 2 }
+            Join on=(dst = personid) type=differential // { arity: 2 }
               implementation
                 %0:l2[#0]UK » %1:l0[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 1 }
+              ArrangeBy keys=[[dst]] // { arity: 1 }
                 Get l2 // { arity: 1 }
-              ArrangeBy keys=[[#0]] // { arity: 1 }
+              ArrangeBy keys=[[personid]] // { arity: 1 }
                 Get l0 // { arity: 1 }
       cte l9 =
         Project (#1) // { arity: 1 }
@@ -4499,26 +4499,26 @@ Explained Query:
       cte l8 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
-            Join on=(#0 = #2) type=differential // { arity: 4 }
+            Join on=(dst = dst) type=differential // { arity: 4 }
               implementation
                 %0:l7[#0]Kef » %1:l7[#0]Kef
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
                     Get l7 // { arity: 5 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
+              ArrangeBy keys=[[dst]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
                     Get l7 // { arity: 5 }
       cte l7 =
-        TopK group_by=[#0..=#2] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+        TopK group_by=[#0, #1, dst] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(#2)), false) // { arity: 9 }
-                Join on=(#0 = #5) type=differential // { arity: 7 }
+              Map ((#6 + integer_to_bigint(w)), false) // { arity: 9 }
+                Join on=(src = #5) type=differential // { arity: 7 }
                   implementation
                     %0:pathq20[#0]KA » %1:l3[#2]K
-                  ArrangeBy keys=[[#0]] // { arity: 3 }
+                  ArrangeBy keys=[[src]] // { arity: 3 }
                     ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
@@ -4528,11 +4528,11 @@ Explained Query:
                 Join on=(eq(#0, #6, #12) AND eq(#1, #7, #13) AND eq(#2, #8, #14) AND #3 = #9 AND #4 = #10 AND #5 = #11) type=differential // { arity: 16 }
                   implementation
                     %1:l4[#0..=#5]UKKKKKK » %0:l11[#0..=#5]KKKKKK » %2[#0..=#2]KKK
-                  ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                  ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                     Get l11 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#5]] // { arity: 6 }
+                  ArrangeBy keys=[[#0, #1, #2, #3, #4, #5]] // { arity: 6 }
                     Get l4 // { arity: 6 }
-                  ArrangeBy keys=[[#0..=#2]] // { arity: 4 }
+                  ArrangeBy keys=[[#0, #1, #2]] // { arity: 4 }
                     Union // { arity: 4 }
                       Map (true) // { arity: 4 }
                         Get l6 // { arity: 3 }
@@ -4541,30 +4541,30 @@ Explained Query:
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
                             implementation
                               %1:l5[#0..=#2]UKKK » %0[#0..=#2]KKK
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                               Union // { arity: 3 }
                                 Negate // { arity: 3 }
                                   Get l6 // { arity: 3 }
                                 Get l5 // { arity: 3 }
-                            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+                            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
                               Get l5 // { arity: 3 }
       cte l6 =
         Project (#0..=#2) // { arity: 3 }
           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) type=differential // { arity: 6 }
             implementation
               %1[#0..=#2]UKKKA » %0:l5[#0..=#2]UKKK
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
+            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Get l5 // { arity: 3 }
-            ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-              Distinct group_by=[#0..=#2] // { arity: 3 }
+            ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
+              Distinct group_by=[#0, #1, #2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Get l3 // { arity: 5 }
       cte l5 =
-        Distinct group_by=[#0..=#2] // { arity: 3 }
+        Distinct group_by=[#0, #1, #2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l4 // { arity: 6 }
       cte l4 =
-        Distinct group_by=[#0..=#5] // { arity: 6 }
+        Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
           Get l11 // { arity: 6 }
       cte l3 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -4572,25 +4572,25 @@ Explained Query:
             Filter (#4 = false) // { arity: 6 }
               Get l11 // { arity: 6 }
       cte l2 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[dst] // { arity: 1 }
           Union // { arity: 1 }
             Project (#2) // { arity: 1 }
-              Join on=(#0 = #1) type=differential // { arity: 4 }
+              Join on=(#0 = src) type=differential // { arity: 4 }
                 implementation
                   %1:pathq20[#0]KA » %0:l1[#0]K » %2[×]
                 Get l1 // { arity: 1 }
-                ArrangeBy keys=[[#0]] // { arity: 3 }
+                ArrangeBy keys=[[src]] // { arity: 3 }
                   ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                 ArrangeBy keys=[[]] // { arity: 0 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
                       Distinct // { arity: 0 }
                         Project () // { arity: 0 }
-                          Join on=(#0 = #1) type=differential // { arity: 2 }
+                          Join on=(#0 = personid) type=differential // { arity: 2 }
                             implementation
                               %0:l1[#0]K » %1:l0[#0]K
                             Get l1 // { arity: 1 }
-                            ArrangeBy keys=[[#0]] // { arity: 1 }
+                            ArrangeBy keys=[[personid]] // { arity: 1 }
                               Get l0 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
@@ -4601,13 +4601,13 @@ Explained Query:
           Get l2 // { arity: 1 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (#5 = "Balkh_Airlines") AND (#2) IS NOT NULL // { arity: 8 }
-            Join on=(#2 = #4) type=differential // { arity: 8 }
+          Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
+            Join on=(companyid = id) type=differential // { arity: 8 }
               implementation
                 %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-              ArrangeBy keys=[[#2]] // { arity: 4 }
+              ArrangeBy keys=[[companyid]] // { arity: 4 }
                 ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[id]] // { arity: 4 }
                 ReadIndex on=company company_id=[differential join] // { arity: 4 }
 
 Used Indexes:

--- a/test/sqllogictest/tpch.slt
+++ b/test/sqllogictest/tpch.slt
@@ -18,23 +18,23 @@ CREATE TABLE nation (
     n_name       char(25) NOT NULL,
     n_regionkey  integer NOT NULL,
     n_comment    varchar(152)
-)
+);
 
 statement ok
-CREATE INDEX pk_nation_nationkey ON nation (n_nationkey ASC)
+CREATE INDEX pk_nation_nationkey ON nation (n_nationkey ASC);
 
 statement ok
-CREATE INDEX fk_nation_regionkey ON nation (n_regionkey ASC)
+CREATE INDEX fk_nation_regionkey ON nation (n_regionkey ASC);
 
 statement ok
 CREATE TABLE region  (
     r_regionkey  integer,
     r_name       char(25) NOT NULL,
     r_comment    varchar(152)
-)
+);
 
 statement ok
-CREATE INDEX pk_region_regionkey ON region (r_regionkey ASC)
+CREATE INDEX pk_region_regionkey ON region (r_regionkey ASC);
 
 statement ok
 CREATE TABLE part (
@@ -47,10 +47,10 @@ CREATE TABLE part (
     p_container   char(10) NOT NULL,
     p_retailprice decimal(15, 2) NOT NULL,
     p_comment     varchar(23) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_part_partkey ON part (p_partkey ASC)
+CREATE INDEX pk_part_partkey ON part (p_partkey ASC);
 
 statement ok
 CREATE TABLE supplier (
@@ -61,13 +61,13 @@ CREATE TABLE supplier (
     s_phone       char(15) NOT NULL,
     s_acctbal     decimal(15, 2) NOT NULL,
     s_comment     varchar(101) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_supplier_suppkey ON supplier (s_suppkey ASC)
+CREATE INDEX pk_supplier_suppkey ON supplier (s_suppkey ASC);
 
 statement ok
-CREATE INDEX fk_supplier_nationkey ON supplier (s_nationkey ASC)
+CREATE INDEX fk_supplier_nationkey ON supplier (s_nationkey ASC);
 
 statement ok
 CREATE TABLE partsupp (
@@ -76,16 +76,16 @@ CREATE TABLE partsupp (
     ps_availqty    integer NOT NULL,
     ps_supplycost  decimal(15, 2) NOT NULL,
     ps_comment     varchar(199) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_partsupp_partkey_suppkey ON partsupp (ps_partkey ASC, ps_suppkey ASC)
+CREATE INDEX pk_partsupp_partkey_suppkey ON partsupp (ps_partkey ASC, ps_suppkey ASC);
 
 statement ok
-CREATE INDEX fk_partsupp_partkey ON partsupp (ps_partkey ASC)
+CREATE INDEX fk_partsupp_partkey ON partsupp (ps_partkey ASC);
 
 statement ok
-CREATE INDEX fk_partsupp_suppkey ON partsupp (ps_suppkey ASC)
+CREATE INDEX fk_partsupp_suppkey ON partsupp (ps_suppkey ASC);
 
 statement ok
 CREATE TABLE customer (
@@ -97,13 +97,13 @@ CREATE TABLE customer (
     c_acctbal     decimal(15, 2) NOT NULL,
     c_mktsegment  char(10) NOT NULL,
     c_comment     varchar(117) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_customer_custkey ON customer (c_custkey ASC)
+CREATE INDEX pk_customer_custkey ON customer (c_custkey ASC);
 
 statement ok
-CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC)
+CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC);
 
 statement ok
 CREATE TABLE orders (
@@ -116,13 +116,13 @@ CREATE TABLE orders (
     o_clerk          char(15) NOT NULL,
     o_shippriority   integer NOT NULL,
     o_comment        varchar(79) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_orders_orderkey ON orders (o_orderkey ASC)
+CREATE INDEX pk_orders_orderkey ON orders (o_orderkey ASC);
 
 statement ok
-CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC)
+CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
 
 statement ok
 CREATE TABLE lineitem (
@@ -142,28 +142,29 @@ CREATE TABLE lineitem (
     l_shipinstruct   char(25) NOT NULL,
     l_shipmode       char(10) NOT NULL,
     l_comment        varchar(44) NOT NULL
-)
+);
 
 statement ok
-CREATE INDEX pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey ASC, l_linenumber ASC)
+CREATE INDEX pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey ASC, l_linenumber ASC);
 
 statement ok
-CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC)
+CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
 
 statement ok
-CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC)
+CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC);
 
 statement ok
-CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC)
+CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
 
 statement ok
-CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC)
+CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
 
 
 
 query T multiline
 -- Query 01
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
 	l_returnflag,
 	l_linestatus,
 	sum(l_quantity) AS sum_qty,
@@ -183,15 +184,15 @@ GROUP BY
 	l_linestatus
 ORDER BY
 	l_returnflag,
-	l_linestatus
+	l_linestatus;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last] output=[#0..=#9]
+  Finish order_by=[l_returnflag asc nulls_last, l_linestatus asc nulls_last] output=[#0..=#9]
     Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
       Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
-        Reduce group_by=[#4, #5] aggregates=[sum(#0), sum(#1), sum((#1 * (1 - #2))), sum(((#1 * (1 - #2)) * (1 + #3))), count(*), sum(#2)] // { arity: 8 }
+        Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)] // { arity: 8 }
           Project (#4..=#9) // { arity: 6 }
-            Filter (date_to_timestamp(#10) <= 1998-10-02 00:00:00) // { arity: 16 }
+            Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -202,7 +203,8 @@ EOF
 
 query T multiline
 -- Query 02
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     s_acctbal,
     s_name,
     n_name,
@@ -235,30 +237,30 @@ WHERE
                     AND r_name = 'EUROPE'
             )
 ORDER BY
-    s_acctbal DESC, n_name, s_name, p_partkey
+    s_acctbal DESC, n_name, s_name, p_partkey;
 ----
 Explained Query:
-  Finish order_by=[#0 desc nulls_first, #2 asc nulls_last, #1 asc nulls_last, #3 asc nulls_last] output=[#0..=#7]
+  Finish order_by=[s_acctbal desc nulls_first, n_name asc nulls_last, s_name asc nulls_last, p_partkey asc nulls_last] output=[#0..=#7]
     Return // { arity: 8 }
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-        Join on=(#0 = #9 AND #7 = #10) type=differential // { arity: 11 }
+        Join on=(p_partkey = p_partkey AND ps_supplycost = #10) type=differential // { arity: 11 }
           implementation
             %1[#0, #1]UKK » %0:l4[#0, #7]KK
-          ArrangeBy keys=[[#0, #7]] // { arity: 9 }
+          ArrangeBy keys=[[p_partkey, ps_supplycost]] // { arity: 9 }
             Get l4 // { arity: 9 }
-          ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-            Reduce group_by=[#0] aggregates=[min(#1)] // { arity: 2 }
+          ArrangeBy keys=[[p_partkey, #1]] // { arity: 2 }
+            Reduce group_by=[p_partkey] aggregates=[min(ps_supplycost)] // { arity: 2 }
               Project (#0, #4) // { arity: 2 }
-                Filter (#18 = "EUROPE") AND (#2) IS NOT NULL AND (#9) IS NOT NULL AND (#15) IS NOT NULL // { arity: 20 }
-                  Join on=(#0 = #1 AND #2 = #6 AND #9 = #13 AND #15 = #17) type=delta // { arity: 20 }
+                Filter (r_name = "EUROPE") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 20 }
+                  Join on=(p_partkey = ps_partkey AND ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 20 }
                     implementation
                       %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                       %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                    ArrangeBy keys=[[p_partkey]] // { arity: 1 }
+                      Distinct group_by=[p_partkey] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l4 // { arity: 9 }
                     Get l1 // { arity: 5 }
@@ -268,31 +270,31 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (#5 = 15) AND (#26 = "EUROPE") AND (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#23) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4)) // { arity: 28 }
-            Join on=(#0 = #16 AND #9 = #17 AND #12 = #21 AND #23 = #25) type=delta // { arity: 28 }
+          Filter (p_size = 15) AND (r_name = "EUROPE") AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND like["%BRASS"](varchar_to_text(p_type)) // { arity: 28 }
+            Join on=(p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 28 }
               implementation
                 %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                 %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
                 %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                 %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
                 %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              ArrangeBy keys=[[#0]] // { arity: 9 }
+              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
               Get l0 // { arity: 7 }
               Get l1 // { arity: 5 }
               Get l2 // { arity: 4 }
               Get l3 // { arity: 3 }
       cte l3 =
-        ArrangeBy keys=[[#0]] // { arity: 3 }
+        ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
           ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
       cte l2 =
-        ArrangeBy keys=[[#0], [#2]] // { arity: 4 }
+        ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
           ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
       cte l1 =
-        ArrangeBy keys=[[#0], [#1]] // { arity: 5 }
+        ArrangeBy keys=[[ps_partkey], [ps_suppkey]] // { arity: 5 }
           ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
       cte l0 =
-        ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+        ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
           ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
@@ -310,7 +312,8 @@ EOF
 
 query T multiline
 -- Query 03
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     l_orderkey,
     sum(l_extendedprice * (1 - l_discount)) AS revenue,
     o_orderdate,
@@ -331,24 +334,24 @@ GROUP BY
     o_shippriority
 ORDER BY
     revenue DESC,
-    o_orderdate
+    o_orderdate;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #2 asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#1 desc nulls_first, o_orderdate asc nulls_last] output=[#0..=#3]
     Project (#0, #3, #1, #2) // { arity: 4 }
-      Reduce group_by=[#0..=#2] aggregates=[sum((#3 * (1 - #4)))] // { arity: 4 }
+      Reduce group_by=[o_orderkey, o_orderdate, o_shippriority] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
-          Filter (#6 = "BUILDING") AND (#12 < 1995-03-15) AND (#27 > 1995-03-15) AND (#0) IS NOT NULL AND (#8) IS NOT NULL // { arity: 33 }
-            Join on=(#0 = #9 AND #8 = #17) type=delta // { arity: 33 }
+          Filter (c_mktsegment = "BUILDING") AND (o_orderdate < 1995-03-15) AND (l_shipdate > 1995-03-15) AND (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
+            Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
               implementation
                 %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
                 %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
                 %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
-              ArrangeBy keys=[[#0]] // { arity: 8 }
+              ArrangeBy keys=[[c_custkey]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
+              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[#0]] // { arity: 16 }
+              ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -362,7 +365,8 @@ EOF
 
 query T multiline
 -- Query 04
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     o_orderpriority,
     count(*) AS order_count
 FROM
@@ -382,29 +386,29 @@ WHERE
 GROUP BY
     o_orderpriority
 ORDER BY
-    o_orderpriority
+    o_orderpriority;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] output=[#0, #1]
-    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+  Finish order_by=[o_orderpriority asc nulls_last] output=[#0, #1]
+    Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
       Project (#5) // { arity: 1 }
-        Filter (#4 >= 1993-07-01) AND (date_to_timestamp(#4) < 1993-10-01 00:00:00) // { arity: 11 }
-          Join on=(eq(#0, #9, #10)) type=delta // { arity: 11 }
+        Filter (o_orderdate >= 1993-07-01) AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 11 }
+          Join on=(eq(o_orderkey, o_orderkey, l_orderkey)) type=delta // { arity: 11 }
             implementation
               %0:orders » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:orders[#0]KAiif
               %2 » %1[#0]UKA » %0:orders[#0]KAiif
-            ArrangeBy keys=[[#0]] // { arity: 9 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
+              Distinct group_by=[o_orderkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#4 >= 1993-07-01) AND (#0) IS NOT NULL AND (date_to_timestamp(#4) < 1993-10-01 00:00:00) // { arity: 9 }
+                  Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
                     ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
+              Distinct group_by=[l_orderkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#11 < #12) // { arity: 16 }
+                  Filter (l_commitdate < l_receiptdate) // { arity: 16 }
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -416,7 +420,8 @@ EOF
 
 query T multiline
 -- Query 05
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     n_name,
     sum(l_extendedprice * (1 - l_discount)) AS revenue
 FROM
@@ -439,29 +444,29 @@ WHERE
 GROUP BY
     n_name
 ORDER BY
-    revenue DESC
+    revenue DESC;
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
-    Reduce group_by=[#2] aggregates=[sum((#0 * (1 - #1)))] // { arity: 2 }
+    Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
       Project (#22, #23, #36) // { arity: 3 }
-        Filter (#40 = "ASIA") AND (#12 < 1995-01-01) AND (#12 >= 1994-01-01) AND (#0) IS NOT NULL AND (#3) IS NOT NULL AND (#8) IS NOT NULL AND (#37) IS NOT NULL // { arity: 42 }
-          Join on=(#0 = #9 AND eq(#3, #34, #35) AND #8 = #17 AND #19 = #33 AND #37 = #39) type=differential // { arity: 42 }
+        Filter (r_name = "ASIA") AND (o_orderdate < 1995-01-01) AND (o_orderdate >= 1994-01-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 42 }
+          Join on=(c_custkey = o_custkey AND eq(c_nationkey, s_nationkey, n_nationkey) AND o_orderkey = l_orderkey AND l_suppkey = s_suppkey AND n_regionkey = r_regionkey) type=differential // { arity: 42 }
             implementation
               %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKeiif
-            ArrangeBy keys=[[#3]] // { arity: 8 }
+            ArrangeBy keys=[[c_nationkey]] // { arity: 8 }
               ReadIndex on=customer fk_customer_nationkey=[differential join] // { arity: 8 }
-            ArrangeBy keys=[[#1]] // { arity: 9 }
+            ArrangeBy keys=[[o_custkey]] // { arity: 9 }
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-            ArrangeBy keys=[[#0]] // { arity: 16 }
+            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[s_suppkey, s_nationkey]] // { arity: 2 }
               Project (#0, #3) // { arity: 2 }
-                Filter (#0) IS NOT NULL // { arity: 7 }
+                Filter (s_suppkey) IS NOT NULL // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
-            ArrangeBy keys=[[#2]] // { arity: 4 }
+            ArrangeBy keys=[[n_regionkey]] // { arity: 4 }
               ReadIndex on=nation fk_nation_regionkey=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 3 }
+            ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
               ReadIndex on=region pk_region_regionkey=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -477,7 +482,8 @@ EOF
 
 query T multiline
 -- Query 06
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     sum(l_extendedprice * l_discount) AS revenue
 FROM
     lineitem
@@ -485,7 +491,7 @@ WHERE
     l_quantity < 24
     AND l_shipdate >= DATE '1994-01-01'
     AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
-    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
 ----
 Explained Query:
   Return // { arity: 1 }
@@ -500,9 +506,9 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((#0 * #1))] // { arity: 1 }
+      Reduce aggregates=[sum((l_extendedprice * l_discount))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (#4 < 24) AND (#6 <= 0.07) AND (#6 >= 0.05) AND (#10 >= 1994-01-01) AND (date_to_timestamp(#10) < 1995-01-01 00:00:00) // { arity: 16 }
+          Filter (l_quantity < 24) AND (l_discount <= 0.07) AND (l_discount >= 0.05) AND (l_shipdate >= 1994-01-01) AND (date_to_timestamp(l_shipdate) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -513,7 +519,8 @@ EOF
 
 query T multiline
 -- Query 07
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     supp_nation,
     cust_nation,
     l_year,
@@ -551,16 +558,16 @@ GROUP BY
 ORDER BY
     supp_nation,
     cust_nation,
-    l_year
+    l_year;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
+  Finish order_by=[n_name asc nulls_last, n_name asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[#3, #4, extract_year_d(#2)] aggregates=[sum((#0 * (1 - #1)))] // { arity: 4 }
+      Reduce group_by=[n_name, n_name, extract_year_d(l_shipdate)] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
         Project (#12, #13, #17, #41, #45) // { arity: 5 }
-          Filter (#17 <= 1996-12-31) AND (#17 >= 1995-01-01) AND (#0) IS NOT NULL AND (#3) IS NOT NULL AND (#7) IS NOT NULL AND (#24) IS NOT NULL AND (#35) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
-            Map ((#41 = "FRANCE"), (#41 = "GERMANY"), (#45 = "FRANCE"), (#45 = "GERMANY")) // { arity: 52 }
-              Join on=(#0 = #9 AND #3 = #40 AND #7 = #23 AND #24 = #32 AND #35 = #44) type=delta // { arity: 48 }
+          Filter (l_shipdate <= 1996-12-31) AND (l_shipdate >= 1995-01-01) AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+            Map ((n_name = "FRANCE"), (n_name = "GERMANY"), (n_name = "FRANCE"), (n_name = "GERMANY")) // { arity: 52 }
+              Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey) type=delta // { arity: 48 }
                 implementation
                   %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                   %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
@@ -568,19 +575,19 @@ Explained Query:
                   %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                   %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                   %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
-                ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+                ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-                ArrangeBy keys=[[#0], [#2]] // { arity: 16 }
+                ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-                ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
+                ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-                ArrangeBy keys=[[#0], [#3]] // { arity: 8 }
+                ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
                   ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
                 Get l0 // { arity: 4 }
                 Get l0 // { arity: 4 }
     With
       cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 4 }
+        ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
           ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -599,7 +606,8 @@ EOF
 
 query T multiline
 -- Query 08
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     o_year,
     sum(case
         when nation = 'BRAZIL' then volume
@@ -635,16 +643,16 @@ FROM
 GROUP BY
     o_year
 ORDER BY
-    o_year
+    o_year;
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
     Project (#0, #3) // { arity: 2 }
       Map ((#1 / #2)) // { arity: 4 }
-        Reduce group_by=[extract_year_d(#2)] aggregates=[sum(case when (#3 = "BRAZIL") then (#0 * (1 - #1)) else 0 end), sum((#0 * (1 - #1)))] // { arity: 3 }
+        Reduce group_by=[extract_year_d(o_orderdate)] aggregates=[sum(case when (n_name = "BRAZIL") then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 3 }
           Project (#21, #22, #36, #54) // { arity: 4 }
-            Filter (#58 = "AMERICA") AND (#36 <= 1996-12-31) AND (#36 >= 1995-01-01) AND (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#16) IS NOT NULL AND (#33) IS NOT NULL AND (#44) IS NOT NULL AND (#51) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4)) // { arity: 60 }
-              Join on=(#0 = #17 AND #9 = #18 AND #12 = #53 AND #16 = #32 AND #33 = #41 AND #44 = #49 AND #51 = #57) type=delta // { arity: 60 }
+            Filter (r_name = "AMERICA") AND (o_orderdate <= 1996-12-31) AND (o_orderdate >= 1995-01-01) AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(p_type)) // { arity: 60 }
+              Join on=(p_partkey = l_partkey AND s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 60 }
                 implementation
                   %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
                   %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -654,21 +662,21 @@ Explained Query:
                   %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
                   %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
                   %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
-                ArrangeBy keys=[[#0]] // { arity: 9 }
+                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-                ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+                ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-                ArrangeBy keys=[[#0], [#1], [#2]] // { arity: 16 }
+                ArrangeBy keys=[[l_orderkey], [l_partkey], [l_suppkey]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-                ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
+                ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-                ArrangeBy keys=[[#0], [#3]] // { arity: 8 }
+                ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
                   ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
-                ArrangeBy keys=[[#0], [#2]] // { arity: 4 }
+                ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
                   ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-                ArrangeBy keys=[[#0]] // { arity: 4 }
+                ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
                   ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
-                ArrangeBy keys=[[#0]] // { arity: 3 }
+                ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
                   ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -691,7 +699,8 @@ EOF
 
 query T multiline
 -- Query 09
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     nation,
     o_year,
     sum(amount) AS sum_profit
@@ -722,14 +731,14 @@ GROUP BY
     o_year
 ORDER BY
     nation,
-    o_year DESC
+    o_year DESC;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
-    Reduce group_by=[#5, extract_year_d(#4)] aggregates=[sum(((#1 * (1 - #2)) - (#3 * #0)))] // { arity: 3 }
+  Finish order_by=[n_name asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
+    Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
       Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-        Filter (#0) IS NOT NULL AND (#9) IS NOT NULL AND (#12) IS NOT NULL AND (#16) IS NOT NULL AND like["%green%"](varchar_to_text(#1)) // { arity: 50 }
-          Join on=(eq(#0, #17, #32) AND eq(#9, #18, #33) AND #12 = #46 AND #16 = #37) type=delta // { arity: 50 }
+        Filter (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND like["%green%"](varchar_to_text(p_name)) // { arity: 50 }
+          Join on=(eq(p_partkey, l_partkey, ps_partkey) AND eq(s_suppkey, l_suppkey, ps_suppkey) AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 50 }
             implementation
               %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
               %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
@@ -737,17 +746,17 @@ Explained Query:
               %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
               %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
               %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
-            ArrangeBy keys=[[#0]] // { arity: 9 }
+            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[#0], [#1], [#1, #2], [#2]] // { arity: 16 }
+            ArrangeBy keys=[[l_orderkey], [l_partkey], [l_partkey, l_suppkey], [l_suppkey]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] fk_lineitem_partsuppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 5 }
+            ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 5 }
               ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[delta join lookup] // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 9 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[#0]] // { arity: 4 }
+            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -767,7 +776,8 @@ EOF
 
 query T multiline
 -- Query 10
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     c_custkey,
     c_name,
     sum(l_extendedprice * (1 - l_discount)) AS revenue,
@@ -798,27 +808,27 @@ GROUP BY
     c_address,
     c_comment
 ORDER BY
-    revenue DESC
+    revenue DESC;
 ----
 Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#7]
     Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
-      Reduce group_by=[#0, #1, #4, #3, #8, #2, #5] aggregates=[sum((#6 * (1 - #7)))] // { arity: 8 }
+      Reduce group_by=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 8 }
         Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
-          Filter (#25 = "R") AND (#12 < 1994-01-01) AND (#12 >= 1993-10-01) AND (#0) IS NOT NULL AND (#3) IS NOT NULL AND (#8) IS NOT NULL AND (date_to_timestamp(#12) < 1994-01-01 00:00:00) // { arity: 37 }
-            Join on=(#0 = #9 AND #3 = #33 AND #8 = #17) type=delta // { arity: 37 }
+          Filter (l_returnflag = "R") AND (o_orderdate < 1994-01-01) AND (o_orderdate >= 1993-10-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1994-01-01 00:00:00) // { arity: 37 }
+            Join on=(c_custkey = o_custkey AND c_nationkey = n_nationkey AND o_orderkey = l_orderkey) type=delta // { arity: 37 }
               implementation
                 %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
                 %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
                 %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
                 %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
-              ArrangeBy keys=[[#0], [#3]] // { arity: 8 }
+              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
+              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[#0]] // { arity: 16 }
+              ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -834,7 +844,8 @@ EOF
 
 query T multiline
 -- Query 11
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     ps_partkey,
     sum(ps_supplycost * ps_availqty) AS value
 FROM
@@ -860,7 +871,7 @@ GROUP BY
                 AND n_name = 'GERMANY'
         )
 ORDER BY
-    value DESC
+    value DESC;
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
@@ -871,26 +882,26 @@ Explained Query:
             implementation
               %1[×]UA » %0[×]
             ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce group_by=[#0] aggregates=[sum((#2 * integer_to_numeric(#1)))] // { arity: 2 }
+              Reduce group_by=[ps_partkey] aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 2 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum((#1 * integer_to_numeric(#0)))] // { arity: 1 }
+              Reduce aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 1 }
                 Project (#1, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
     With
       cte l0 =
         Project (#0, #2, #3) // { arity: 3 }
-          Filter (#13 = "GERMANY") AND (#1) IS NOT NULL AND (#8) IS NOT NULL // { arity: 16 }
-            Join on=(#1 = #5 AND #8 = #12) type=delta // { arity: 16 }
+          Filter (n_name = "GERMANY") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL // { arity: 16 }
+            Join on=(ps_suppkey = s_suppkey AND s_nationkey = n_nationkey) type=delta // { arity: 16 }
               implementation
                 %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
                 %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
                 %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
-              ArrangeBy keys=[[#1]] // { arity: 5 }
+              ArrangeBy keys=[[ps_suppkey]] // { arity: 5 }
                 ReadIndex on=partsupp fk_partsupp_suppkey=[delta join 1st input (full scan)] // { arity: 5 }
-              ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -904,7 +915,8 @@ EOF
 
 query T multiline
 -- Query 12
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     l_shipmode,
     sum(case
         when o_orderpriority = '1-URGENT'
@@ -931,19 +943,19 @@ WHERE
 GROUP BY
     l_shipmode
 ORDER BY
-    l_shipmode
+    l_shipmode;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
-    Reduce group_by=[#1] aggregates=[sum(case when ((#0 = "2-HIGH") OR (#0 = "1-URGENT")) then 1 else 0 end), sum(case when ((#0 != "2-HIGH") AND (#0 != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
+  Finish order_by=[l_shipmode asc nulls_last] output=[#0..=#2]
+    Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
       Project (#5, #23) // { arity: 2 }
-        Filter (#21 >= 1994-01-01) AND (#0) IS NOT NULL AND (#19 < #20) AND (#20 < #21) AND (date_to_timestamp(#21) < 1995-01-01 00:00:00) AND ((#23 = "MAIL") OR (#23 = "SHIP")) // { arity: 25 }
-          Join on=(#0 = #9) type=differential // { arity: 25 }
+        Filter (l_receiptdate >= 1994-01-01) AND (o_orderkey) IS NOT NULL AND (l_shipdate < l_commitdate) AND (l_commitdate < l_receiptdate) AND (date_to_timestamp(l_receiptdate) < 1995-01-01 00:00:00) AND ((l_shipmode = "MAIL") OR (l_shipmode = "SHIP")) // { arity: 25 }
+          Join on=(o_orderkey = l_orderkey) type=differential // { arity: 25 }
             implementation
               %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
-            ArrangeBy keys=[[#0]] // { arity: 9 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
-            ArrangeBy keys=[[#0]] // { arity: 16 }
+            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -955,7 +967,8 @@ EOF
 
 query T multiline
 -- Query 13
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     c_count,
     count(*) AS custdist
 FROM
@@ -974,42 +987,42 @@ GROUP BY
     c_count
 ORDER BY
     custdist DESC,
-    c_count DESC
+    c_count DESC;
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first, #0 desc nulls_first] output=[#0, #1]
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[#0] aggregates=[count(#1)] // { arity: 2 }
+          Reduce group_by=[c_custkey] aggregates=[count(o_orderkey)] // { arity: 2 }
             Union // { arity: 2 }
               Project (#0, #8) // { arity: 2 }
                 Get l0 // { arity: 9 }
               Project (#0, #16) // { arity: 2 }
                 Map (null) // { arity: 17 }
-                  Join on=(#0 = #8 AND #1 = #9 AND #2 = #10 AND #3 = #11 AND #4 = #12 AND #5 = #13 AND #6 = #14 AND #7 = #15) type=differential // { arity: 16 }
+                  Join on=(c_custkey = c_custkey AND c_name = c_name AND c_address = c_address AND c_nationkey = c_nationkey AND c_phone = c_phone AND c_acctbal = c_acctbal AND c_mktsegment = c_mktsegment AND c_comment = c_comment) type=differential // { arity: 16 }
                     implementation
                       %0[#0..=#7]KKKKKKKK » %1:customer[#0..=#7]KKKKKKKK
-                    ArrangeBy keys=[[#0..=#7]] // { arity: 8 }
+                    ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
-                          Distinct group_by=[#0..=#7] // { arity: 8 }
+                          Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                             Project (#0..=#7) // { arity: 8 }
                               Get l0 // { arity: 9 }
-                        Distinct group_by=[#0..=#7] // { arity: 8 }
+                        Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                           ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
-                    ArrangeBy keys=[[#0..=#7]] // { arity: 8 }
+                    ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                       ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
     With
       cte l0 =
         Project (#0..=#8) // { arity: 9 }
-          Filter (#0) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16))) // { arity: 17 }
-            Join on=(#0 = #9) type=differential // { arity: 17 }
+          Filter (c_custkey) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(o_comment))) // { arity: 17 }
+            Join on=(c_custkey = o_custkey) type=differential // { arity: 17 }
               implementation
                 %1:orders[#1]KAf » %0:customer[#0]KAf
-              ArrangeBy keys=[[#0]] // { arity: 8 }
+              ArrangeBy keys=[[c_custkey]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
-              ArrangeBy keys=[[#1]] // { arity: 9 }
+              ArrangeBy keys=[[o_custkey]] // { arity: 9 }
                 ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1021,7 +1034,8 @@ EOF
 
 query T multiline
 -- Query 14
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     100.00 * sum(case
         when p_type like 'PROMO%'
             then l_extendedprice * (1 - l_discount)
@@ -1033,7 +1047,7 @@ FROM
 WHERE
     l_partkey = p_partkey
     AND l_shipdate >= DATE '1995-09-01'
-    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
 ----
 Explained Query:
   Return // { arity: 1 }
@@ -1050,15 +1064,15 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2)) then (#0 * (1 - #1)) else 0 end), sum((#0 * (1 - #1)))] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(p_type)) then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (#10 >= 1995-09-01) AND (#1) IS NOT NULL AND (date_to_timestamp(#10) < 1995-10-01 00:00:00) // { arity: 25 }
-            Join on=(#1 = #16) type=differential // { arity: 25 }
+          Filter (l_shipdate >= 1995-09-01) AND (l_partkey) IS NOT NULL AND (date_to_timestamp(l_shipdate) < 1995-10-01 00:00:00) // { arity: 25 }
+            Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
-              ArrangeBy keys=[[#1]] // { arity: 16 }
+              ArrangeBy keys=[[l_partkey]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-              ArrangeBy keys=[[#0]] // { arity: 9 }
+              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1083,7 +1097,8 @@ create view revenue (supplier_no, total_revenue) as
 
 query T multiline
 -- Query 15
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     s_suppkey,
     s_name,
     s_address,
@@ -1101,19 +1116,19 @@ WHERE
             revenue
     )
 ORDER BY
-    s_suppkey
+    s_suppkey;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] output=[#0..=#4]
+  Finish order_by=[s_suppkey asc nulls_last] output=[#0..=#4]
     Return // { arity: 5 }
       Project (#0..=#2, #4, #8) // { arity: 5 }
-        Filter (#0) IS NOT NULL // { arity: 10 }
-          Join on=(#0 = #7 AND #8 = #9) type=differential // { arity: 10 }
+        Filter (s_suppkey) IS NOT NULL // { arity: 10 }
+          Join on=(s_suppkey = l_suppkey AND #8 = #9) type=differential // { arity: 10 }
             implementation
               %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UK
-            ArrangeBy keys=[[#0]] // { arity: 7 }
+            ArrangeBy keys=[[s_suppkey]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[#0]] // { arity: 2 }
+            ArrangeBy keys=[[l_suppkey]] // { arity: 2 }
               Get l0 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Reduce aggregates=[max(#0)] // { arity: 1 }
@@ -1121,9 +1136,9 @@ Explained Query:
                   Get l0 // { arity: 2 }
     With
       cte l0 =
-        Reduce group_by=[#0] aggregates=[sum((#1 * (1 - #2)))] // { arity: 2 }
+        Reduce group_by=[l_suppkey] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
           Project (#2, #5, #6) // { arity: 3 }
-            Filter (#10 >= 1996-01-01) AND (date_to_timestamp(#10) < 1996-04-01 00:00:00) // { arity: 16 }
+            Filter (l_shipdate >= 1996-01-01) AND (date_to_timestamp(l_shipdate) < 1996-04-01 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -1138,7 +1153,8 @@ drop view revenue
 
 query T multiline
 -- Query 16
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     p_brand,
     p_type,
     p_size,
@@ -1167,24 +1183,24 @@ ORDER BY
     supplier_cnt DESC,
     p_brand,
     p_type,
-    p_size
+    p_size;
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, #0 asc nulls_last, #1 asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, p_brand asc nulls_last, p_type asc nulls_last, p_size asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[#1..=#3] aggregates=[count(distinct #0)] // { arity: 4 }
+      Reduce group_by=[p_brand, p_type, p_size] aggregates=[count(distinct ps_suppkey)] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#0 = #4) type=differential // { arity: 5 }
+          Join on=(ps_suppkey = ps_suppkey) type=differential // { arity: 5 }
             implementation
               %0:l0[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 4 }
+            ArrangeBy keys=[[ps_suppkey]] // { arity: 4 }
               Get l0 // { arity: 4 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct group_by=[ps_suppkey] // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Filter ((#1) IS NULL OR (#0 = #1)) // { arity: 2 }
+                      Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
                           implementation
                             %1:supplier[×]lf » %0:l1[×]lf
@@ -1192,23 +1208,23 @@ Explained Query:
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
-                              Filter like["%Customer%Complaints%"](varchar_to_text(#6)) // { arity: 7 }
+                              Filter like["%Customer%Complaints%"](varchar_to_text(s_comment)) // { arity: 7 }
                                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
                 Get l1 // { arity: 1 }
     With
       cte l1 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[ps_suppkey] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 4 }
       cte l0 =
         Project (#1, #8..=#10) // { arity: 4 }
-          Filter (#8 != "Brand#45") AND (#0) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9))) AND ((#10 = 3) OR (#10 = 9) OR (#10 = 14) OR (#10 = 19) OR (#10 = 23) OR (#10 = 36) OR (#10 = 45) OR (#10 = 49)) // { arity: 14 }
-            Join on=(#0 = #5) type=differential // { arity: 14 }
+          Filter (p_brand != "Brand#45") AND (ps_partkey) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(p_type))) AND ((p_size = 3) OR (p_size = 9) OR (p_size = 14) OR (p_size = 19) OR (p_size = 23) OR (p_size = 36) OR (p_size = 45) OR (p_size = 49)) // { arity: 14 }
+            Join on=(ps_partkey = p_partkey) type=differential // { arity: 14 }
               implementation
                 %1:part[#0]KAef » %0:partsupp[#0]KAef
-              ArrangeBy keys=[[#0]] // { arity: 5 }
+              ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
                 ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-              ArrangeBy keys=[[#0]] // { arity: 9 }
+              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1221,7 +1237,8 @@ EOF
 
 query T multiline
 -- Query 17
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
   sum(l_extendedprice) / 7.0 AS avg_yearly
 FROM
   lineitem,
@@ -1237,7 +1254,7 @@ WHERE
       lineitem
     WHERE
       l_partkey = p_partkey
-  )
+  );
 ----
 Explained Query:
   Return // { arity: 1 }
@@ -1254,36 +1271,36 @@ Explained Query:
                 - ()
   With
     cte l2 =
-      Reduce aggregates=[sum(#0)] // { arity: 1 }
+      Reduce aggregates=[sum(l_extendedprice)] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (#1 < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(#0 = #3) type=differential // { arity: 6 }
+          Filter (l_quantity < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+            Join on=(l_partkey = l_partkey) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
-              ArrangeBy keys=[[#0]] // { arity: 3 }
+              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[#0]] // { arity: 3 }
-                Reduce group_by=[#0] aggregates=[sum(#1), count(*)] // { arity: 3 }
+              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+                Reduce group_by=[l_partkey] aggregates=[sum(l_quantity), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(#0 = #2) type=differential // { arity: 17 }
+                    Join on=(l_partkey = l_partkey) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[l_partkey]] // { arity: 1 }
+                        Distinct group_by=[l_partkey] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1, #4, #5) // { arity: 3 }
-        Filter (#19 = "Brand#23") AND (#22 = "MED BOX") AND (#1) IS NOT NULL // { arity: 25 }
-          Join on=(#1 = #16) type=differential // { arity: 25 }
+        Filter (p_brand = "Brand#23") AND (p_container = "MED BOX") AND (l_partkey) IS NOT NULL // { arity: 25 }
+          Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
-            ArrangeBy keys=[[#0]] // { arity: 9 }
+            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[#1]] // { arity: 16 }
+      ArrangeBy keys=[[l_partkey]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -1295,7 +1312,8 @@ EOF
 
 query T multiline
 -- Query 18
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     c_name,
     c_custkey,
     o_orderkey,
@@ -1326,46 +1344,46 @@ GROUP BY
     o_totalprice
 ORDER BY
     o_totalprice DESC,
-    o_orderdate
+    o_orderdate;
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, #3 asc nulls_last] output=[#0..=#5]
+  Finish order_by=[o_totalprice desc nulls_first, o_orderdate asc nulls_last] output=[#0..=#5]
     Return // { arity: 6 }
-      Reduce group_by=[#1, #0, #2, #4, #3] aggregates=[sum(#5)] // { arity: 6 }
+      Reduce group_by=[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] aggregates=[sum(l_quantity)] // { arity: 6 }
         Project (#0..=#5) // { arity: 6 }
           Filter (#7 > 300) // { arity: 8 }
-            Join on=(#2 = #6) type=differential // { arity: 8 }
+            Join on=(o_orderkey = o_orderkey) type=differential // { arity: 8 }
               implementation
                 %1[#0]UKAif » %0:l1[#2]Kif
-              ArrangeBy keys=[[#2]] // { arity: 6 }
+              ArrangeBy keys=[[o_orderkey]] // { arity: 6 }
                 Get l1 // { arity: 6 }
-              ArrangeBy keys=[[#0]] // { arity: 2 }
-                Reduce group_by=[#0] aggregates=[sum(#1)] // { arity: 2 }
+              ArrangeBy keys=[[o_orderkey]] // { arity: 2 }
+                Reduce group_by=[o_orderkey] aggregates=[sum(l_quantity)] // { arity: 2 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(#0 = #1) type=differential // { arity: 17 }
+                    Join on=(o_orderkey = l_orderkey) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#0]KA
-                      ArrangeBy keys=[[#0]] // { arity: 1 }
-                        Distinct group_by=[#0] // { arity: 1 }
+                      ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
+                        Distinct group_by=[o_orderkey] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l1 // { arity: 6 }
                       Get l0 // { arity: 16 }
     With
       cte l1 =
         Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-          Filter (#0) IS NOT NULL AND (#8) IS NOT NULL // { arity: 33 }
-            Join on=(#0 = #9 AND #8 = #17) type=delta // { arity: 33 }
+          Filter (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
+            Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
               implementation
                 %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
                 %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
                 %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-              ArrangeBy keys=[[#0]] // { arity: 8 }
+              ArrangeBy keys=[[c_custkey]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[#0], [#1]] // { arity: 9 }
+              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
               Get l0 // { arity: 16 }
       cte l0 =
-        ArrangeBy keys=[[#0]] // { arity: 16 }
+        ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -1379,7 +1397,8 @@ EOF
 
 query T multiline
 -- Query 19
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     sum(l_extendedprice* (1 - l_discount)) AS revenue
 FROM
     lineitem,
@@ -1413,7 +1432,7 @@ WHERE
         AND p_size BETWEEN CAST (1 AS smallint) AND CAST (15 AS smallint)
         AND l_shipmode IN ('AIR', 'AIR REG')
         AND l_shipinstruct = 'DELIVER IN PERSON'
-    )
+    );
 ----
 Explained Query:
   Return // { arity: 1 }
@@ -1428,16 +1447,16 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((#0 * (1 - #1)))] // { arity: 1 }
+      Reduce aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (#13 = "DELIVER IN PERSON") AND (#21 >= 1) AND (#1) IS NOT NULL AND ((#14 = "AIR") OR (#14 = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
-            Map ((#4 <= 20), (#4 >= 10), (#4 <= 30), (#4 >= 20), (#4 <= 11), (#4 >= 1), (#19 = "Brand#12"), (#21 <= 5), ((#22 = "SM BOX") OR (#22 = "SM PKG") OR (#22 = "SM CASE") OR (#22 = "SM PACK")), (#19 = "Brand#23"), (#21 <= 10), ((#22 = "MED BAG") OR (#22 = "MED BOX") OR (#22 = "MED PKG") OR (#22 = "MED PACK")), (#19 = "Brand#34"), (#21 <= 15), ((#22 = "LG BOX") OR (#22 = "LG PKG") OR (#22 = "LG CASE") OR (#22 = "LG PACK"))) // { arity: 40 }
-              Join on=(#1 = #16) type=differential // { arity: 25 }
+          Filter (l_shipinstruct = "DELIVER IN PERSON") AND (p_size >= 1) AND (l_partkey) IS NOT NULL AND ((l_shipmode = "AIR") OR (l_shipmode = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+            Map ((l_quantity <= 20), (l_quantity >= 10), (l_quantity <= 30), (l_quantity >= 20), (l_quantity <= 11), (l_quantity >= 1), (p_brand = "Brand#12"), (p_size <= 5), ((p_container = "SM BOX") OR (p_container = "SM PKG") OR (p_container = "SM CASE") OR (p_container = "SM PACK")), (p_brand = "Brand#23"), (p_size <= 10), ((p_container = "MED BAG") OR (p_container = "MED BOX") OR (p_container = "MED PKG") OR (p_container = "MED PACK")), (p_brand = "Brand#34"), (p_size <= 15), ((p_container = "LG BOX") OR (p_container = "LG PKG") OR (p_container = "LG CASE") OR (p_container = "LG PACK"))) // { arity: 40 }
+              Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
                 implementation
                   %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
-                ArrangeBy keys=[[#1]] // { arity: 16 }
+                ArrangeBy keys=[[l_partkey]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-                ArrangeBy keys=[[#0]] // { arity: 9 }
+                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1449,7 +1468,8 @@ EOF
 
 query T multiline
 -- Query 20
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     s_name,
     s_address
 FROM
@@ -1485,69 +1505,69 @@ WHERE
     AND s_nationkey = n_nationkey
     AND n_name = 'CANADA'
 ORDER BY
-    s_name
+    s_name;
 ----
 Explained Query:
-  Finish order_by=[#0 asc nulls_last] output=[#0, #1]
+  Finish order_by=[s_name asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(#0 = #3) type=differential // { arity: 4 }
+        Join on=(s_suppkey = s_suppkey) type=differential // { arity: 4 }
           implementation
             %1[#0]UKA » %0:l0[#0]K
-          ArrangeBy keys=[[#0]] // { arity: 3 }
+          ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
             Get l0 // { arity: 3 }
-          ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+          ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
+            Distinct group_by=[s_suppkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (integer_to_numeric(#2) > #5) // { arity: 6 }
-                  Join on=(#0 = #4 AND #1 = #3) type=differential // { arity: 6 }
+                Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
+                  Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
                     implementation
                       %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                    ArrangeBy keys=[[#0, #1]] // { arity: 3 }
+                    ArrangeBy keys=[[s_suppkey, ps_partkey]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
-                        Filter (#0 = #2) // { arity: 4 }
+                        Filter (s_suppkey = ps_suppkey) // { arity: 4 }
                           Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[#1, #0]] // { arity: 3 }
+                    ArrangeBy keys=[[ps_suppkey, ps_partkey]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Map ((0.5 * #2)) // { arity: 4 }
-                          Reduce group_by=[#0, #1] aggregates=[sum(#2)] // { arity: 3 }
+                          Reduce group_by=[ps_partkey, ps_suppkey] aggregates=[sum(l_quantity)] // { arity: 3 }
                             Project (#0, #1, #6) // { arity: 3 }
-                              Filter (#12 >= 1995-01-01) AND (date_to_timestamp(#12) < 1996-01-01 00:00:00) // { arity: 18 }
-                                Join on=(#0 = #3 AND #1 = #4) type=differential // { arity: 18 }
+                              Filter (l_shipdate >= 1995-01-01) AND (date_to_timestamp(l_shipdate) < 1996-01-01 00:00:00) // { arity: 18 }
+                                Join on=(ps_partkey = l_partkey AND ps_suppkey = l_suppkey) type=differential // { arity: 18 }
                                   implementation
                                     %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                  ArrangeBy keys=[[#0, #1]] // { arity: 2 }
-                                    Distinct group_by=[#0, #1] // { arity: 2 }
+                                  ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
+                                    Distinct group_by=[ps_partkey, ps_suppkey] // { arity: 2 }
                                       Project (#1, #2) // { arity: 2 }
                                         Get l1 // { arity: 4 }
-                                  ArrangeBy keys=[[#1, #2]] // { arity: 16 }
+                                  ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
                                     ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
     With
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(#1 = #6) type=differential // { arity: 7 }
+          Join on=(ps_partkey = p_partkey) type=differential // { arity: 7 }
             implementation
               %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
             ArrangeBy keys=[[]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+              Distinct group_by=[s_suppkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 5 }
+            ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+            ArrangeBy keys=[[p_partkey]] // { arity: 1 }
+              Distinct group_by=[p_partkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (#0) IS NOT NULL AND like["forest%"](varchar_to_text(#1)) // { arity: 9 }
+                  Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
       cte l0 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (#8 = "CANADA") AND (#3) IS NOT NULL // { arity: 11 }
-            Join on=(#3 = #7) type=differential // { arity: 11 }
+          Filter (n_name = "CANADA") AND (s_nationkey) IS NOT NULL // { arity: 11 }
+            Join on=(s_nationkey = n_nationkey) type=differential // { arity: 11 }
               implementation
                 %1:nation[#0]KAef » %0:supplier[#3]KAef
-              ArrangeBy keys=[[#3]] // { arity: 7 }
+              ArrangeBy keys=[[s_nationkey]] // { arity: 7 }
                 ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -1562,7 +1582,8 @@ EOF
 
 query T multiline
 -- Query 21
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     s_name,
     count(*) AS numwait
 FROM
@@ -1600,74 +1621,74 @@ GROUP BY
     s_name
 ORDER BY
     numwait DESC,
-    s_name
+    s_name;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, #0 asc nulls_last] output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, s_name asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[s_name] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
+          Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
             implementation
               %0:l2[#2, #0]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[#2, #0]] // { arity: 3 }
+            ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[#0, #1]] // { arity: 2 }
+            ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Distinct group_by=[#0, #1] // { arity: 2 }
+                  Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
-                      Filter (#1 != #4) AND (#14 > #13) // { arity: 18 }
-                        Join on=(#0 = #2) type=differential // { arity: 18 }
+                      Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
+                        Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
                           implementation
                             %1:l1[#0]KAf » %0:l3[#0]Kf
-                          ArrangeBy keys=[[#0]] // { arity: 2 }
+                          ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct group_by=[#1, #0] // { arity: 2 }
+        Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(#0 = #4 AND #2 = #3) type=differential // { arity: 5 }
+          Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:l0[#0, #2]KK
-            ArrangeBy keys=[[#0, #2]] // { arity: 3 }
+            ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-              Distinct group_by=[#0, #1] // { arity: 2 }
+            ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
+              Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
-                  Filter (#1 != #4) // { arity: 18 }
-                    Join on=(#0 = #2) type=differential // { arity: 18 }
+                  Filter (s_suppkey != l_suppkey) // { arity: 18 }
+                    Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
                       implementation
                         %1:l1[#0]KA » %0[#0]K
-                      ArrangeBy keys=[[#0]] // { arity: 2 }
-                        Distinct group_by=[#1, #0] // { arity: 2 }
+                      ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                        Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
                           Project (#0, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                       Get l1 // { arity: 16 }
       cte l1 =
-        ArrangeBy keys=[[#0]] // { arity: 16 }
+        ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
       cte l0 =
         Project (#0, #1, #7) // { arity: 3 }
-          Filter (#25 = "F") AND (#33 = "SAUDI ARABIA") AND (#0) IS NOT NULL AND (#3) IS NOT NULL AND (#7) IS NOT NULL AND (#19 > #18) // { arity: 36 }
-            Join on=(#0 = #9 AND #3 = #32 AND #7 = #23) type=delta // { arity: 36 }
+          Filter (o_orderstatus = "F") AND (n_name = "SAUDI ARABIA") AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (l_receiptdate > l_commitdate) // { arity: 36 }
+            Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 36 }
               implementation
                 %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
                 %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
                 %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
                 %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              ArrangeBy keys=[[#0], [#3]] // { arity: 7 }
+              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-              ArrangeBy keys=[[#0], [#2]] // { arity: 16 }
+              ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[#0]] // { arity: 9 }
+              ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[#0]] // { arity: 4 }
+              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -1683,7 +1704,8 @@ EOF
 
 query T multiline
 -- Query 22
-EXPLAIN WITH(arity, join_impls) SELECT
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+SELECT
     cntrycode,
     count(*) AS numcust,
     sum(c_acctbal) AS totacctbal
@@ -1729,41 +1751,41 @@ FROM
 GROUP BY
     cntrycode
 ORDER BY
-    cntrycode
+    cntrycode;
 ----
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[substr(char_to_text(#0), 1, 2)] aggregates=[count(*), sum(#1)] // { arity: 3 }
+      Reduce group_by=[substr(char_to_text(c_phone), 1, 2)] aggregates=[count(*), sum(c_acctbal)] // { arity: 3 }
         Project (#1, #2) // { arity: 2 }
-          Join on=(#0 = #3) type=differential // { arity: 4 }
+          Join on=(c_custkey = c_custkey) type=differential // { arity: 4 }
             implementation
               %0:l1[#0]K » %1[#0]K
-            ArrangeBy keys=[[#0]] // { arity: 3 }
+            ArrangeBy keys=[[c_custkey]] // { arity: 3 }
               Get l1 // { arity: 3 }
-            ArrangeBy keys=[[#0]] // { arity: 1 }
+            ArrangeBy keys=[[c_custkey]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Filter (#0) IS NOT NULL // { arity: 2 }
-                      Join on=(#0 = #1) type=differential // { arity: 2 }
+                    Filter (c_custkey) IS NOT NULL // { arity: 2 }
+                      Join on=(c_custkey = o_custkey) type=differential // { arity: 2 }
                         implementation
                           %0:l2[#0]UKA » %1[#0]UKA
-                        ArrangeBy keys=[[#0]] // { arity: 1 }
+                        ArrangeBy keys=[[c_custkey]] // { arity: 1 }
                           Get l2 // { arity: 1 }
-                        ArrangeBy keys=[[#0]] // { arity: 1 }
-                          Distinct group_by=[#0] // { arity: 1 }
+                        ArrangeBy keys=[[o_custkey]] // { arity: 1 }
+                          Distinct group_by=[o_custkey] // { arity: 1 }
                             Project (#1) // { arity: 1 }
                               ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct group_by=[c_custkey] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 3 }
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (#2 > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+          Filter (c_acctbal > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]UA » %0:l0[×]ef
@@ -1772,12 +1794,12 @@ Explained Query:
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(#0), count(*)] // { arity: 2 }
+                Reduce aggregates=[sum(c_acctbal), count(*)] // { arity: 2 }
                   Project (#5) // { arity: 1 }
-                    Filter (#5 > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Filter (c_acctbal > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                       Get l0 // { arity: 9 }
       cte l0 =
-        Map (substr(char_to_text(#4), 1, 2)) // { arity: 9 }
+        Map (substr(char_to_text(c_phone), 1, 2)) // { arity: 9 }
           ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:
@@ -1828,7 +1850,7 @@ WHERE
     AND s_nationkey = n_nationkey
     AND n_name = 'CANADA'
 ORDER BY
-    s_name
+    s_name;
 ----
 Finish order_by=[#0 asc nulls_last] output=[#0, #1]
   Project (#1, #2)


### PR DESCRIPTION
Add a `humanized` option to the `ExplainConfig`. For optimizer stages that produce an `MirRelationExpr`, one can now use

```sql
EXPLAIN WITH(humanized) ...
````

to get a more readable text output where column references are represented by their inferred (but possibly ambiguous) column name strings. For example, here is the humanized plan for TPC-H query #18851 

```text
Explained Query:
  Finish order_by=[l_returnflag asc nulls_last, l_linestatus asc nulls_last] output=[#0..=#9]
    Project (#0..=#5, #9..=#11, #6)
      Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8))
        Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)]
          Project (#4..=#9)
            Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00)
              ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***]

Used Indexes:
  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
```

### Motivation

  * This PR adds a feature that has not yet been specified.

We don't have an issue for that, but various people that frequently look at plans (most lately @teskje and @umanwizard) have asked for that.

### Tips for reviewer

Marked as draft as part of the changes here have been factored out in as separate PR: #21796.

This is opened as a WIP for preview. Please look at changes in `tpch.slt` and `ldbc.slt`. If we want to merge this I will split out a prefix of the contents from this PR (which adds a new `ColumnNames` attribute) into a separate PR.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
