### PR TITLE
adapter: optimize startup views in parallel

### DIFF
--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -52,7 +52,7 @@ impl DataflowBuilder<'_> {
                 match self.catalog.get_entry(&id).item() {
                     // Unmaterialized view. Search its dependencies.
                     CatalogItem::View(view) => {
-                        todo.extend(view.optimized_expr.0.depends_on());
+                        todo.extend(view.optimized_expr().depends_on());
                     }
                     CatalogItem::Source(_)
                     | CatalogItem::Table(_)

--- a/src/adapter/src/coord/sequencer/inner/create_view.rs
+++ b/src/adapter/src/coord/sequencer/inner/create_view.rs
@@ -378,7 +378,10 @@ impl Coordinator {
                 item: CatalogItem::View(View {
                     create_sql: create_sql.clone(),
                     raw_expr,
-                    desc: RelationDesc::new(optimized_expr.typ(), column_names.clone()),
+                    desc: Arc::new(OnceLock::from(RelationDesc::new(
+                        optimized_expr.typ(),
+                        column_names.clone(),
+                    ))),
                     optimized_expr: Arc::new(OnceLock::from(optimized_expr)),
                     conn_id: if temporary {
                         Some(session.conn_id().clone())

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -18,7 +18,7 @@ use chrono::{DateTime, Utc};
 use futures::Future;
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
-use mz_catalog::memory::objects::{CatalogItem, MaterializedView, View};
+use mz_catalog::memory::objects::{CatalogItem, MaterializedView};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::CollectionPlan;
 use mz_ore::collections::CollectionExt;
@@ -446,7 +446,8 @@ impl Coordinator {
                     CatalogItem::Index(index) => {
                         ids.push(index.on);
                     }
-                    CatalogItem::View(View { optimized_expr, .. }) => {
+                    CatalogItem::View(view) => {
+                        let optimized_expr = view.optimized_expr();
                         // If the definition contains a temporal function, the timeline must
                         // be timestamp dependent.
                         if optimized_expr.contains_temporal() {

--- a/src/ore/src/serde.rs
+++ b/src/ore/src/serde.rs
@@ -15,6 +15,8 @@
 
 //! Serde utilities.
 
+use std::sync::{Arc, OnceLock};
+
 /// Used to serialize fields of Maps whose key type is not a native string. Annotate the field with
 /// `#[serde(serialize_with = mz_ore::serde::map_key_to_string)]`.
 pub fn map_key_to_string<'a, I, K, V, S>(map: I, serializer: S) -> Result<S::Ok, S::Error>
@@ -31,4 +33,14 @@ where
         s.serialize_entry(&key.to_string(), value)?;
     }
     s.end()
+}
+
+/// Used to serialize `Arc<OnceLock<T>>`. Panics if the oncelock is not populated. Annotate the
+/// field with `#[serde(serialize_with = mz_ore::serde::arc_oncelock_must_exist)]`.
+pub fn arc_oncelock_must_exist<S, T>(t: &Arc<OnceLock<T>>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+    T: serde::Serialize,
+{
+    t.get().expect("must exist").serialize(serializer)
 }

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -159,7 +159,6 @@ pub struct RelationType {
     ///
     /// A collection can contain multiple sets of keys, although it is common to
     /// have either zero or one sets of key indices.
-    #[serde(default)]
     pub keys: Vec<Vec<usize>>,
 }
 


### PR DESCRIPTION
Change catalog opening to optimize views in background threads. This allows the
various open work to proceed in parallel to optimization, which can take many
seconds in debug.

The actual method this is accomplished is unpleasantly ugly. It is done by
accumulating JoinHandles during open and join'ing them before open returns. The
code assumes (and I verified) that nothing depends on the optimized view exprs
during open, so it's safe to join at the end of that function. There's no code
guarantee this remains the case, and race conditions could easily make this
appear to work until it blows up somewhere. Plumbing the JoinHandle up from
parse_item also feels overly hacky.

One alternative was to do just-in-time optimizing during first use. But because
the optimization can return an error, this is not a great approach because most
of the code paths that need the optimized expression don't return errors. Also
it'd be very weird to return an error after successfully creating an object if
using it would always produce an error.

On my machine, debug envd startup went from 9.4s to 3.2s. This should speed up
tests and our local dev cycle for essentially zero production performance cost
(and will speed up envd boot by just a bit there too).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
