### PR TITLE
feature-benchmark: Retry performance regressions up to 10 times

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -260,7 +260,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--max-retries",
         metavar="N",
         type=int,
-        default=5,
+        default=10,
         help="Retry any potential performance regressions up to N times.",
     )
 


### PR DESCRIPTION
For some reason, false positives sometimes repeat more than 5 times in a row, so additional retries are needed to weed them out.

### Motivation

The Release Qualification test failed with a false positive.