### PR TITLE
adatper: Add consistency check for object dependencies

### DIFF
--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 //! Internal consistency checks that validate invariants of [`CatalogState`].
-//! 
+//!
 //! Note: the implementation of consistency checks should favor simplicity over performance, to
 //! make it as easy as possible to understand what a given check is doing.
 

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -8,6 +8,9 @@
 // by the Apache License, Version 2.0.
 
 //! Internal consistency checks that validate invariants of [`CatalogState`].
+//! 
+//! Note: the implementation of consistency checks should favor simplicity over performance, to
+//! make it as easy as possible to understand what a given check is doing.
 
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_repr::role_id::RoleId;
@@ -28,6 +31,8 @@ pub struct CatalogInconsistencies {
     roles: Vec<RoleInconsistency>,
     /// Inconsistencies found with comments, if any.
     comments: Vec<CommentInconsistency>,
+    /// Inconsistencies found with object dependencies, if any.
+    object_dependencies: Vec<ObjectDependencyInconsistency>,
 }
 
 impl CatalogInconsistencies {
@@ -49,6 +54,9 @@ impl CatalogState {
         }
         if let Err(comments) = self.check_comments() {
             inconsistencies.comments = comments;
+        }
+        if let Err(dependencies) = self.check_object_dependencies() {
+            inconsistencies.object_dependencies = dependencies;
         }
 
         if inconsistencies.is_empty() {
@@ -282,6 +290,61 @@ impl CatalogState {
             Err(comment_inconsistencies)
         }
     }
+
+    /// # Invariants:
+    ///
+    /// * All of the objects in the "uses" collection of a CatalogEntry, should contain said
+    ///   CatalogEntry in their own "used_by" collection.
+    /// * All of the objects in the "used_by" collection of a CatalogEntry, should contain said
+    ///   CatalogEntry in their own "uses" collection.
+    ///
+    fn check_object_dependencies(&self) -> Result<(), Vec<ObjectDependencyInconsistency>> {
+        let mut dependency_inconsistencies = vec![];
+
+        for (id, entry) in &self.entry_by_id {
+            for used_id in &entry.uses().0 {
+                let Some(used_entry) = self.entry_by_id.get(used_id) else {
+                    dependency_inconsistencies.push(ObjectDependencyInconsistency::MissingUses {
+                        object_a: *id,
+                        object_b: *used_id,
+                    });
+                    continue;
+                };
+                if !used_entry.used_by.contains(id) {
+                    dependency_inconsistencies.push(
+                        ObjectDependencyInconsistency::InconsistentUsedBy {
+                            object_a: *id,
+                            object_b: *used_id,
+                        },
+                    );
+                }
+            }
+
+            for used_by in entry.used_by() {
+                let Some(used_by_entry) = self.entry_by_id.get(used_by) else {
+                    dependency_inconsistencies.push(ObjectDependencyInconsistency::MissingUsedBy {
+                        object_a: *id,
+                        object_b: *used_by,
+                    });
+                    continue;
+                };
+                if !used_by_entry.uses().0.contains(id) {
+                    dependency_inconsistencies.push(
+                        ObjectDependencyInconsistency::InconsistentUses {
+                            object_a: *id,
+                            object_b: *used_by,
+                        },
+                    );
+                }
+            }
+        }
+
+        if dependency_inconsistencies.is_empty() {
+            Ok(())
+        } else {
+            Err(dependency_inconsistencies)
+        }
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -317,4 +380,28 @@ enum CommentInconsistency {
     Dangling(CommentObjectId),
     /// A comment with a column position was found on a non-relation.
     NonRelation(CommentObjectId, usize),
+}
+
+#[derive(Debug, Serialize)]
+enum ObjectDependencyInconsistency {
+    /// Object A uses Object B, but Object B does not exist.
+    MissingUses {
+        object_a: GlobalId,
+        object_b: GlobalId,
+    },
+    /// Object A is used by Object B, but Object B does not exist.
+    MissingUsedBy {
+        object_a: GlobalId,
+        object_b: GlobalId,
+    },
+    /// Object A uses Object B, but Object B does not record that it is used by Object A.
+    InconsistentUsedBy {
+        object_a: GlobalId,
+        object_b: GlobalId,
+    },
+    /// Object B is used by Object A, but Object B does not record that is uses Object A.
+    InconsistentUses {
+        object_a: GlobalId,
+        object_b: GlobalId,
+    },
 }


### PR DESCRIPTION
This PR adds a catalog consistency check that makes sure the `used_by` and `uses` collections on `CatalogItem`s are correct.

### Motivation

The bug fixed by #21185 could have been detected by this consistency check

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a