### PR TITLE
doc: add inherited tables to PG source known limitations

### DIFF
--- a/doc/user/content/sql/create-source/postgres.md
+++ b/doc/user/content/sql/create-source/postgres.md
@@ -174,6 +174,31 @@ Instead, remove all rows from a table using an unqualified `DELETE`.
 DELETE FROM t;
 ```
 
+##### Inherited tables
+
+When using [PostgreSQL table
+inheritance](https://www.postgresql.org/docs/current/tutorial-inheritance.html),
+PostgreSQL serves data from `SELECT`s as if the inheriting tables' data is also
+present in the inherited table. However, both PostgreSQL's logical replication
+and `COPY` only present data written to the tables themselves, i.e. the
+inheriting data is _not_ treated as part of the inherited table.
+
+PostgreSQL sources use logical replication and `COPY` to ingest table data, so
+inheriting tables' data will only be ingested as part of the inheriting table,
+i.e. in Materialize, the data will not be returned when serving `SELECT`s from
+the inherited table.
+
+You can mimic PostgreSQL's `SELECT` behavior with inherited tables by creating a
+materialized view that `UNION`s data from the inherited and inheriting tables,
+though there are many caveats:
+
+-   Materialized views are maintained in arrangements, which moves the tables'
+    data from being stored in relatively low-cost storage into being stored in
+    memory.
+-   If new tables inherit from the table, data from the inheriting tables will
+    not be available in the view. You will need to add the inheriting tables via
+    `ADD SUBSOURCE` and create a new view that unions the new table.
+
 ## Examples
 
 {{< warning >}}


### PR DESCRIPTION
We ran into this issue with a customer and it's best described as a known limitation. @petrosagg pinging you just in case you have a take on how this ought to be described

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
