### PR TITLE
storage/kafka: snapshot topic on initialization

### DIFF
--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -456,7 +456,11 @@ impl SourceRender for KafkaSourceConnection {
                         if config.responsible_for(pid) {
                             reader.ensure_partition(pid);
                             if let Entry::Vacant(entry) = reader.partition_capabilities.entry(pid) {
-                                let part_min_ts = Partitioned::with_partition(pid, MzOffset::from(0));
+                                let start_offset = match reader.start_offsets.get(&pid) {
+                                    Some(&offset) => offset.try_into().unwrap(),
+                                    None => 0u64,
+                                };
+                                let part_min_ts = Partitioned::with_partition(pid, MzOffset::from(start_offset));
                                 let upper_offset = MzOffset::from(u64::try_from(upper).expect("invalid negative offset"));
                                 let part_upper_ts = Partitioned::with_partition(pid, upper_offset);
                                 entry.insert(PartitionCapability {

--- a/test/testdrive/kafka-correctness.td
+++ b/test/testdrive/kafka-correctness.td
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ set keyschema={
+    "type": "record",
+    "name": "Key",
+    "fields": [
+        {"name": "key", "type": "string"}
+    ]
+  }
+
+$ set schema={
+        "type" : "record",
+        "name" : "test",
+        "fields" : [
+            {"name":"f1", "type":"string"},
+            {"name":"f2", "type":"long"}
+        ]
+    }
+
+# Create a topic that is large enough to fill librdkafka's buffer, which will force some yielding to
+# happen. Each message is at least 128 bytes long so writing 1M of them produces at least 128MB of
+# data. Each of these million records sets the key="1" to the current iteration index.
+$ set count=1000000
+$ kafka-create-topic topic=correctness-data
+$ kafka-ingest format=avro topic=correctness-data key-format=avro key-schema=${keyschema} schema=${schema} repeat=${count} start-iteration=1
+{"key": "1"} {"f1": "some value that is 128 bytes loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong", "f2": ${kafka-ingest.iteration} }
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}')
+
+> CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+    URL '${testdrive.schema-registry-url}'
+  );
+
+# Now create an UPSERT source and immediately after that a sink. The goal here is for the sink to
+# get an AS_OF timestamp immediately, before the source has had the chance to produce data and
+# compact. This means that the sink will observe all the state changes.
+> CREATE SOURCE correctness_data
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-correctness-data-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE UPSERT
+
+> CREATE SINK correctness_sink FROM correctness_data
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-correctness-sink-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE DEBEZIUM
+
+# If we upheld correctness property 2 then the sink should produce exactly *one* record. The record
+# should be the accumulation of the snapshot
+$ kafka-verify-data format=avro sink=materialize.public.correctness_sink sort-messages=true
+{"before": null, "after": {"row": {"key": "1", "f1": "some value that is 128 bytes loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong", "f2": ${count} }}}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Our current Kafka source implementation starts reading the topic from the beginning, reporting the offsets of messages and making progress statements as it goes. This works fine if the Kafka topic has never been compacted but can produce impossible states if it has. In other words, the current implementation produces correctness violations. Here is a concrete example:

Suppose a key/value topic contained the following messages:

```
offset 0: {key: A, value: 1}
offset 1: {key: B, value: 2}
offset 2: {key: A, value: 3}
```

Then, suppose that kafka runs key-based compaction on it, which keeps the latest version of each key for the prefix of messages that get compacted. In this case let's assume that the entirety of the topic gets compacted. This will result in the following messages:

```
offset 1: {key: B, value: 2}
offset 2: {key: A, value: 3}
```

Finally, suppose that a user creates a Materialize upsert source pointed to that topic. There is a possibility that we reclock offsets 1 and 2 two separate timestamps. If that happens then it is possible for the user to perform a `SELECT * FROM source` and receive a result that only contains key `B`. This is a correctness violation because key `B` never existed on its own in the original data source.

In order to fix this problem our source implementation must emit the compacted prefix of a topic at a single timestamp, so that users never observe in-between states that might be nonsensical. Unfortunately Kafka does not expose the cursor (i.e frontier) of its compaction. For this reason we make the maximally pessimistic assumption that on initialization the whole topic is compacted and we emit all its data at a single timestamp[1]. After that point the source switches to streaming mode and emits fine grained progress updates as new messages come in.

The effect for the users is that Kafka sources will now initially appear empty and atomically switch to containing the entirety of the topic as we observed it at the time of initialization.


[1] In reality the data keeps being emitted at the offsets that we see in the topic, however we make sure that the progress output that drives reclocking jumps from the minimum frontier to the high watermark of each partition in one step, so this entire range gets reclocked to a single timestamp. In a future PR that will address the "source appears empty" part, which will require computing an storing an initial `since` frontier for each source, will make it such that the updates themselves are advanced by that initial since frontier and not rely on reclocking.


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
