### PR TITLE
[persist] Don't assume old parts are totally consolidated

### DIFF
--- a/src/persist-client/src/internal/paths.rs
+++ b/src/persist-client/src/internal/paths.rs
@@ -124,6 +124,17 @@ impl PartialBatchKey {
         PartialBatchKey(format!("{}/{}", version, part_id))
     }
 
+    pub fn split(&self) -> (WriterKey, PartId) {
+        let (writer_key, part_id) = self
+            .0
+            .split_once('/')
+            .expect("partial batch key should contain a /");
+
+        let writer_key = WriterKey::from_str(writer_key).expect("correctly formatted writer key");
+        let part_id = PartId::from_str(part_id).expect("correctly formatted part id");
+        (writer_key, part_id)
+    }
+
     pub fn complete(&self, shard_id: &ShardId) -> BlobKey {
         BlobKey(format!("{}/{}", shard_id, self))
     }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -25,17 +25,23 @@ use futures_util::stream::FuturesUnordered;
 use futures_util::TryStreamExt;
 use mz_persist::location::Blob;
 use mz_persist_types::Codec64;
+use semver::Version;
 use timely::progress::Timestamp;
 use tokio::task::JoinHandle;
 use tracing::{debug_span, Instrument};
 
 use crate::fetch::{fetch_batch_part, Cursor, EncodedPart, FetchBatchFilter, LeasedBatchPart};
 use crate::internal::metrics::{BatchPartReadMetrics, ReadMetrics, ShardMetrics};
-use crate::internal::paths::PartialBatchKey;
+use crate::internal::paths::{PartialBatchKey, WriterKey};
 use crate::internal::state::HollowBatchPart;
 use crate::metrics::Metrics;
 use crate::read::SubscriptionLeaseReturner;
 use crate::ShardId;
+
+/// Versions prior to this had bugs in consolidation, or used a different sort. However,
+/// we can assume that consolidated parts at this version or higher were consolidated
+/// according to the current definition.
+pub const MINIMUM_CONSOLIDATED_VERSION: Version = Version::new(0, 67, 0);
 
 type Tuple<T, D> = ((Vec<u8>, Vec<u8>), T, D);
 type TupleRef<'a, T, D> = (&'a [u8], &'a [u8], T, D);
@@ -72,6 +78,15 @@ pub(crate) enum FetchData<T: Timestamp + Codec64> {
 }
 
 impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
+    fn maybe_unconsolidated(&self) -> bool {
+        let min_version = WriterKey::for_version(&MINIMUM_CONSOLIDATED_VERSION);
+        match self {
+            FetchData::Unleased { part_key, .. } => part_key.split().0 >= min_version,
+            FetchData::Leased { part, .. } => part.key.split().0 >= min_version,
+            FetchData::AlreadyFetched => false,
+        }
+    }
+
     fn take(&mut self) -> Self {
         mem::replace(self, FetchData::AlreadyFetched)
     }
@@ -134,6 +149,7 @@ pub(crate) enum ConsolidationPart<T: Timestamp + Codec64, D> {
     },
     Prefetched {
         handle: JoinHandle<anyhow::Result<EncodedPart<T>>>,
+        maybe_unconsolidated: bool,
     },
     Encoded {
         part: EncodedPart<T>,
@@ -146,9 +162,13 @@ pub(crate) enum ConsolidationPart<T: Timestamp + Codec64, D> {
 }
 
 impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> ConsolidationPart<T, D> {
-    pub(crate) fn from_encoded(part: EncodedPart<T>, filter: &'a FetchBatchFilter<T>) -> Self {
+    pub(crate) fn from_encoded(
+        part: EncodedPart<T>,
+        filter: &'a FetchBatchFilter<T>,
+        maybe_unconsolidated: bool,
+    ) -> Self {
         let mut cursor = Cursor::default();
-        if part.maybe_unconsolidated() {
+        if part.maybe_unconsolidated() || maybe_unconsolidated {
             Self::from_iter(ConsolidationPartIter::encoded(&part, &mut cursor, filter))
         } else {
             ConsolidationPart::Encoded { part, cursor }
@@ -359,13 +379,22 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                 match part {
                     ConsolidationPart::Queued { data } => {
                         self.metrics.compaction.parts_waited.inc();
+                        let maybe_unconsolidated = data.maybe_unconsolidated();
                         *part = ConsolidationPart::from_encoded(
                             data.take().fetch().await?,
                             &self.filter,
+                            maybe_unconsolidated,
                         );
                     }
-                    ConsolidationPart::Prefetched { handle } => {
-                        *part = ConsolidationPart::from_encoded(handle.await??, &self.filter);
+                    ConsolidationPart::Prefetched {
+                        handle,
+                        maybe_unconsolidated,
+                    } => {
+                        *part = ConsolidationPart::from_encoded(
+                            handle.await??,
+                            &self.filter,
+                            *maybe_unconsolidated,
+                        );
                     }
                     ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
                 }
@@ -431,12 +460,16 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                     };
                     self.metrics.compaction.parts_prefetched.inc();
 
+                    let maybe_unconsolidated = data.maybe_unconsolidated();
                     let span = debug_span!("compaction::prefetch");
                     let handle = mz_ore::task::spawn(
                         || "persist::compaction::prefetch",
                         data.fetch().instrument(span),
                     );
-                    *c_part = ConsolidationPart::Prefetched { handle };
+                    *c_part = ConsolidationPart::Prefetched {
+                        handle,
+                        maybe_unconsolidated,
+                    };
                 }
             }
         }
@@ -786,7 +819,9 @@ mod tests {
                 let parts: Vec<_> = run
                     .into_iter()
                     .map(|encoded_size_bytes| HollowBatchPart {
-                        key: PartialBatchKey("".into()),
+                        key: PartialBatchKey(
+                            "n0000000/p00000000-0000-0000-0000-000000000000".into(),
+                        ),
                         encoded_size_bytes,
                         key_lower: vec![],
                         stats: None,


### PR DESCRIPTION
### Motivation

Support for #21615.

In particular, this is necessary if we want to assume that the output of the `Consolidator` is indeed consolidated.

### Tips for reviewer

To my knowledge the last important bug was fixed in df46c7464df110fe6cdd97564becb000c0d08933, and 0.67.0 is the first release that includes it.

I think this means it's safe to assert on ordering in the consolidator now, but I'll run all the upgrade tests to make sure.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
