### PR TITLE
webhooks: Update CORS policy

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -33,7 +33,7 @@ use futures::future::{FutureExt, Shared, TryFutureExt};
 use headers::authorization::{Authorization, Basic, Bearer};
 use headers::{HeaderMapExt, HeaderName};
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
-use http::{Request, StatusCode};
+use http::{Request, StatusCode, Method};
 use hyper_openssl::MaybeHttpsStream;
 use mz_adapter::{AdapterError, AdapterNotice, Client, SessionClient};
 use mz_frontegg_auth::{Authentication as FronteggAuthentication, Error as FronteggError};
@@ -164,6 +164,12 @@ impl HttpServer {
                 routing::post(webhook::handle_webhook),
             )
             .with_state(adapter_client)
+            .layer(
+                CorsLayer::new()
+                    .allow_methods(Method::POST)
+                    .allow_origin(AllowOrigin::mirror_request())
+                    .allow_headers(Any)
+            )
             .layer(
                 ServiceBuilder::new()
                     .layer(HandleErrorLayer::new(handle_load_error))

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -33,7 +33,7 @@ use futures::future::{FutureExt, Shared, TryFutureExt};
 use headers::authorization::{Authorization, Basic, Bearer};
 use headers::{HeaderMapExt, HeaderName};
 use http::header::{AUTHORIZATION, CONTENT_TYPE};
-use http::{Request, StatusCode, Method};
+use http::{Method, Request, StatusCode};
 use hyper_openssl::MaybeHttpsStream;
 use mz_adapter::{AdapterError, AdapterNotice, Client, SessionClient};
 use mz_frontegg_auth::{Authentication as FronteggAuthentication, Error as FronteggError};
@@ -168,7 +168,7 @@ impl HttpServer {
                 CorsLayer::new()
                     .allow_methods(Method::POST)
                     .allow_origin(AllowOrigin::mirror_request())
-                    .allow_headers(Any)
+                    .allow_headers(Any),
             )
             .layer(
                 ServiceBuilder::new()


### PR DESCRIPTION
This PR updates the CORS policy for the webhook endpoint to explicitly support all origins by mirroring the origin in the request, and limiting to just POST requests.

Note: I chatted with Matt Arthur about this and he signed off on it.

### Motivation

@bobbyiliev was working on a tool that can take a sample JSON blob and send faked data with that same schema. But he was encountering CORS issues related to localhost. This change to the CORS policy should be more permissive and allow a tool like Bobby's to work without issue.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Relaxes the CORS policy for the webhook API.
