### PR TITLE
doc/user: Fix Quickstart Numbering

### DIFF
--- a/doc/user/content/get-started/quickstart.md
+++ b/doc/user/content/get-started/quickstart.md
@@ -159,9 +159,9 @@ interactive.
    created in the previous step also make joins more interactive (as in other
    databases)!
 
-[//]: # "NOTE(morsapaes) This query is borderline unpredictable since we're
-relying on a load generator, but _mostly_ returns some results. The experience
-won't be great when it doesn't."
+    [//]: # "NOTE(morsapaes) This query is borderline unpredictable since we're
+    relying on a load generator, but _mostly_ returns some results. The experience
+    won't be great when it doesn't."
 
 1. Create a view that detects when a user wins an auction as a bidder, and then
 is identified as a seller for an item at a higher price.


### PR DESCRIPTION
I just noticed a small issue related to numbering in the quickstart:

![image](https://github.com/MaterializeInc/materialize/assets/11527560/67a06baa-4ab9-4eef-998a-d57ffcafa6bc)

caused by an unindented comment.

Fixed:
![image](https://github.com/MaterializeInc/materialize/assets/11527560/7ab5c8a8-41bc-4548-878e-a5cd49f8fa43)
