### PR TITLE
ci: Fix order of SLT files

### DIFF
--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -77,7 +77,7 @@ tests_with_views=(
      test/sqllogictest/sqlite/test/random/aggregates/slt_good_129.test \
 )
 
-readarray -d '' tests < <(find test/sqllogictest/sqlite/test -type f -print0)
+readarray -d '' tests < <(find test/sqllogictest/sqlite/test -type f -print0 | sort -z)
 # Exclude tests_with_views from tests
 for f in "${tests_with_views[@]}"; do
     tests=("${tests[@]/$f}")


### PR DESCRIPTION
find does not guarantee the order, thus we could end up not covering all SLT files in the 10 parallel SLT runs

This is in contrast to bash globbing (*.slt), which is guaranteed to be in order, so does not require any additional sorting