### PR TITLE
test: Fix flakey explain timestamp test

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1301,20 +1301,9 @@ fn test_explain_timestamp_json() {
 // 2. Acquires read holds for all objects within the same time domain
 // 3. Errors during a write-only transaction
 // 4. Errors when an object outside the chosen time domain is referenced
-#[ignore] // TODO: Fix 21078.
 #[mz_ore::test]
 fn test_github_18950() {
-    // Set the timestamp to zero for deterministic initial timestamps.
-    let nowfn = Arc::new(Mutex::new(NOW_ZERO.clone()));
-    let now = {
-        let nowfn = Arc::clone(&nowfn);
-        NowFn::from(move || (nowfn.lock().unwrap())())
-    };
-
-    let config = util::Config::default()
-        .workers(2)
-        .with_now(now)
-        .unsafe_mode();
+    let config = util::Config::default().workers(2).unsafe_mode();
 
     let server = util::start_server(config).unwrap();
 
@@ -1343,7 +1332,7 @@ fn test_github_18950() {
     client_reads.batch_execute("BEGIN").unwrap();
     let mut query_timestamp = None;
 
-    for i in 1..5 {
+    for _ in 1..5 {
         let row = client_reads
             .query_one("EXPLAIN TIMESTAMP AS JSON FOR SELECT * FROM t1;", &[])
             .unwrap();
@@ -1369,8 +1358,6 @@ fn test_github_18950() {
         // Ensure `t1`'s read frontier remains <= the query timestamp
         assert!(*explain_t1_read_frontier <= query_timestamp.unwrap());
 
-        // Increase now by 2s each iteration
-        *nowfn.lock().unwrap() = NowFn::from(move || 2000 * i);
         // Inserting tends to cause sources to compact, so this should ideally
         // strengthen the assertion above that `t1`'s read frontier should
         // not advance during the txn

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1301,8 +1301,10 @@ fn test_explain_timestamp_json() {
 // 2. Acquires read holds for all objects within the same time domain
 // 3. Errors during a write-only transaction
 // 4. Errors when an object outside the chosen time domain is referenced
+//
+// GitHub issue # 18950
 #[mz_ore::test]
-fn test_github_18950() {
+fn test_transactional_explain_timestamps() {
     let config = util::Config::default().workers(2).unsafe_mode();
 
     let server = util::start_server(config).unwrap();


### PR DESCRIPTION
The test_github_18950 test was flakey and occasionally timing out. The issue was (probably) due to the usage of deterministic timestamp.

  1. The deterministic timestamp prevents the system clock from advancing.
  2. The timestamp oracle advances far enough past the system clock that it stops and waits for the system clock to advance.
  3. The test tries to execute an INSERT which blocks until the timestamp will advance.
  4. The test is now deadlocked.

This commit removes deterministic timestamps from the test since they were unnecessary.

Fixes #21078

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
