### PR TITLE
docs/comments: Add basic docs for COMMENT ON

### DIFF
--- a/doc/user/content/sql/comment-on.md
+++ b/doc/user/content/sql/comment-on.md
@@ -1,6 +1,6 @@
 ---
 title: "COMMENT ON"
-description: "`COMMENT ON ...` add or update the comment of an object."
+description: "`COMMENT ON ...` adds or updates the comment of an object."
 menu:
   main:
     parent: 'commands'
@@ -8,7 +8,7 @@ menu:
 
 {{< private-preview />}}
 
-`COMMENT ON ...` add or update the comment of an object.
+`COMMENT ON ...` adds or updates the comment of an object.
 
 ## Syntax
 
@@ -20,14 +20,14 @@ menu:
 comment associated with it, so successive calls of `COMMENT ON` to a single object will overwrite
 the previous comment.
 
-To read the comments on an object you need to query the [mz_internal.mz_comments](/sql/system-catalog/mz_internal/#mz_comments)
+To read the comment on an object you need to query the [mz_internal.mz_comments](/sql/system-catalog/mz_internal/#mz_comments)
 catalog table.
 
 ## Privileges
 
 To comment on an object, the current role must be the owner of that object. Roles themselves do not
-have owners, so to comment on a Role you must have the `CREATEROLE` privilege. For more information
-on ownership and privileges, see [Role-based access control](/manage/access-control/rbac).
+have owners, so to comment on a role object you must have the `CREATEROLE` privilege. For more
+information on ownership and privileges, see [Role-based access control](/manage/access-control/rbac).
 
 ## Examples
 

--- a/doc/user/content/sql/comment-on.md
+++ b/doc/user/content/sql/comment-on.md
@@ -1,0 +1,47 @@
+---
+title: "COMMENT ON"
+description: "`COMMENT ON ...` add or update the comment of an object."
+menu:
+  main:
+    parent: 'commands'
+---
+
+{{< private-preview />}}
+
+`COMMENT ON ...` add or update the comment of an object.
+
+## Syntax
+
+{{< diagram "comment-on.svg" >}}
+
+## Details
+
+`COMMENT ON` stores a comment about an object in the database. Each object can only have one
+comment associated with it, so successive calls of `COMMENT ON` to a single object will overwrite
+the previous comment.
+
+To read the comments on an object you need to query the [mz_internal.mz_comments](/sql/system-catalog/mz_internal/#mz_comments)
+catalog table.
+
+## Privileges
+
+To comment on an object, the current role must be the owner of that object. Roles themselves do not
+have owners, so to comment on a Role you must have the `CREATEROLE` privilege. For more information
+on ownership and privileges, see [Role-based access control](/manage/access-control/rbac).
+
+## Examples
+
+```sql
+--- Add comments.
+COMMENT ON TABLE foo IS 'this table is important';
+COMMENT ON COLUMN foo.x IS 'holds all of the important data';
+
+--- Update a comment.
+COMMENT ON TABLE foo IS 'holds non-important data';
+
+--- Remove a comment.
+COMMENT ON TABLE foo IS NULL;
+
+--- Read comments.
+SELECT * FROM mz_internal.mz_comments;
+```

--- a/doc/user/layouts/partials/sql-grammar/comment-on.svg
+++ b/doc/user/layouts/partials/sql-grammar/comment-on.svg
@@ -9,54 +9,54 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="39" y="21">COMMENT ON</text>
-   <rect x="191" y="3" width="66" height="32" rx="10"/>
+   <rect x="191" y="3" width="84" height="32" rx="10"/>
    <rect x="189"
          y="1"
-         width="66"
+         width="84"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="21">TABLE</text>
-   <rect x="191" y="47" width="82" height="32" rx="10"/>
+   <text class="terminal" x="199" y="21">CLUSTER</text>
+   <rect x="191" y="47" width="148" height="32" rx="10"/>
    <rect x="189"
          y="45"
+         width="148"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="65">CLUSTER REPLICA</text>
+   <rect x="191" y="91" width="82" height="32" rx="10"/>
+   <rect x="189"
+         y="89"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="65">COLUMN</text>
-   <rect x="191" y="91" width="58" height="32" rx="10"/>
-   <rect x="189"
-         y="89"
-         width="58"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="109">VIEW</text>
-   <rect x="191" y="135" width="166" height="32" rx="10"/>
+   <text class="terminal" x="199" y="109">COLUMN</text>
+   <rect x="191" y="135" width="116" height="32" rx="10"/>
    <rect x="189"
          y="133"
-         width="166"
+         width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="153">MATERIALIZED VIEW</text>
-   <rect x="191" y="179" width="78" height="32" rx="10"/>
+   <text class="terminal" x="199" y="153">CONNECTION</text>
+   <rect x="191" y="179" width="98" height="32" rx="10"/>
    <rect x="189"
          y="177"
-         width="78"
+         width="98"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="197">SOURCE</text>
-   <rect x="191" y="223" width="52" height="32" rx="10"/>
+   <text class="terminal" x="199" y="197">DATABASE</text>
+   <rect x="191" y="223" width="94" height="32" rx="10"/>
    <rect x="189"
          y="221"
-         width="52"
+         width="94"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="241">SINK</text>
+   <text class="terminal" x="199" y="241">FUNCTION</text>
    <rect x="191" y="267" width="62" height="32" rx="10"/>
    <rect x="189"
          y="265"
@@ -65,30 +65,30 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="199" y="285">INDEX</text>
-   <rect x="191" y="311" width="94" height="32" rx="10"/>
+   <rect x="191" y="311" width="166" height="32" rx="10"/>
    <rect x="189"
          y="309"
-         width="94"
+         width="166"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="329">FUNCTION</text>
-   <rect x="191" y="355" width="116" height="32" rx="10"/>
+   <text class="terminal" x="199" y="329">MATERIALIZED VIEW</text>
+   <rect x="191" y="355" width="56" height="32" rx="10"/>
    <rect x="189"
          y="353"
-         width="116"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="373">CONNECTION</text>
-   <rect x="191" y="399" width="56" height="32" rx="10"/>
-   <rect x="189"
-         y="397"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="417">TYPE</text>
+   <text class="terminal" x="199" y="373">ROLE</text>
+   <rect x="191" y="399" width="82" height="32" rx="10"/>
+   <rect x="189"
+         y="397"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="417">SCHEMA</text>
    <rect x="191" y="443" width="76" height="32" rx="10"/>
    <rect x="189"
          y="441"
@@ -97,46 +97,46 @@
          class="terminal"
          rx="10"/>
    <text class="terminal" x="199" y="461">SECRET</text>
-   <rect x="191" y="487" width="56" height="32" rx="10"/>
+   <rect x="191" y="487" width="52" height="32" rx="10"/>
    <rect x="189"
          y="485"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="505">SINK</text>
+   <rect x="191" y="531" width="78" height="32" rx="10"/>
+   <rect x="189"
+         y="529"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="549">SOURCE</text>
+   <rect x="191" y="575" width="66" height="32" rx="10"/>
+   <rect x="189"
+         y="573"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="593">TABLE</text>
+   <rect x="191" y="619" width="56" height="32" rx="10"/>
+   <rect x="189"
+         y="617"
          width="56"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="505">ROLE</text>
-   <rect x="191" y="531" width="98" height="32" rx="10"/>
-   <rect x="189"
-         y="529"
-         width="98"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="549">DATABASE</text>
-   <rect x="191" y="575" width="82" height="32" rx="10"/>
-   <rect x="189"
-         y="573"
-         width="82"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="593">SCHEMA</text>
-   <rect x="191" y="619" width="84" height="32" rx="10"/>
-   <rect x="189"
-         y="617"
-         width="84"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="199" y="637">CLUSTER</text>
-   <rect x="191" y="663" width="148" height="32" rx="10"/>
+   <text class="terminal" x="199" y="637">TYPE</text>
+   <rect x="191" y="663" width="58" height="32" rx="10"/>
    <rect x="189"
          y="661"
-         width="148"
+         width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="199" y="681">CLUSTER REPLICA</text>
+   <text class="terminal" x="199" y="681">VIEW</text>
    <rect x="397" y="3" width="104" height="32"/>
    <rect x="395" y="1" width="104" height="32" class="nonterminal"/>
    <text class="nonterminal" x="405" y="21">object_name</text>
@@ -160,7 +160,7 @@
          rx="10"/>
    <text class="terminal" x="435" y="791">NULL</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m120 0 h10 m20 0 h10 m66 0 h10 m0 0 h100 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m58 0 h10 m0 0 h108 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m78 0 h10 m0 0 h88 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m52 0 h10 m0 0 h114 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m62 0 h10 m0 0 h104 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m94 0 h10 m0 0 h72 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m116 0 h10 m0 0 h50 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m76 0 h10 m0 0 h90 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m98 0 h10 m0 0 h68 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m84 0 h10 m0 0 h82 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m148 0 h10 m0 0 h18 m20 -660 h10 m104 0 h10 m0 0 h10 m32 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 726 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h44 m23 -44 h-3"/>
+         d="m17 17 h2 m0 0 h10 m120 0 h10 m20 0 h10 m84 0 h10 m0 0 h82 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m148 0 h10 m0 0 h18 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m116 0 h10 m0 0 h50 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m98 0 h10 m0 0 h68 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m94 0 h10 m0 0 h72 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m62 0 h10 m0 0 h104 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m76 0 h10 m0 0 h90 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m52 0 h10 m0 0 h114 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m78 0 h10 m0 0 h88 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m66 0 h10 m0 0 h100 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m58 0 h10 m0 0 h108 m20 -660 h10 m104 0 h10 m0 0 h10 m32 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 726 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h44 m23 -44 h-3"/>
    <polygon points="565 743 573 739 573 747"/>
    <polygon points="565 743 557 739 557 747"/>
 </svg>

--- a/doc/user/layouts/partials/sql-grammar/comment-on.svg
+++ b/doc/user/layouts/partials/sql-grammar/comment-on.svg
@@ -1,0 +1,166 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="575" height="807">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="120" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="120"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">COMMENT ON</text>
+   <rect x="191" y="3" width="66" height="32" rx="10"/>
+   <rect x="189"
+         y="1"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="21">TABLE</text>
+   <rect x="191" y="47" width="82" height="32" rx="10"/>
+   <rect x="189"
+         y="45"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="65">COLUMN</text>
+   <rect x="191" y="91" width="58" height="32" rx="10"/>
+   <rect x="189"
+         y="89"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="109">VIEW</text>
+   <rect x="191" y="135" width="166" height="32" rx="10"/>
+   <rect x="189"
+         y="133"
+         width="166"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="153">MATERIALIZED VIEW</text>
+   <rect x="191" y="179" width="78" height="32" rx="10"/>
+   <rect x="189"
+         y="177"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="197">SOURCE</text>
+   <rect x="191" y="223" width="52" height="32" rx="10"/>
+   <rect x="189"
+         y="221"
+         width="52"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="241">SINK</text>
+   <rect x="191" y="267" width="62" height="32" rx="10"/>
+   <rect x="189"
+         y="265"
+         width="62"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="285">INDEX</text>
+   <rect x="191" y="311" width="94" height="32" rx="10"/>
+   <rect x="189"
+         y="309"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="329">FUNCTION</text>
+   <rect x="191" y="355" width="116" height="32" rx="10"/>
+   <rect x="189"
+         y="353"
+         width="116"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="373">CONNECTION</text>
+   <rect x="191" y="399" width="56" height="32" rx="10"/>
+   <rect x="189"
+         y="397"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="417">TYPE</text>
+   <rect x="191" y="443" width="76" height="32" rx="10"/>
+   <rect x="189"
+         y="441"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="461">SECRET</text>
+   <rect x="191" y="487" width="56" height="32" rx="10"/>
+   <rect x="189"
+         y="485"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="505">ROLE</text>
+   <rect x="191" y="531" width="98" height="32" rx="10"/>
+   <rect x="189"
+         y="529"
+         width="98"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="549">DATABASE</text>
+   <rect x="191" y="575" width="82" height="32" rx="10"/>
+   <rect x="189"
+         y="573"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="593">SCHEMA</text>
+   <rect x="191" y="619" width="84" height="32" rx="10"/>
+   <rect x="189"
+         y="617"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="637">CLUSTER</text>
+   <rect x="191" y="663" width="148" height="32" rx="10"/>
+   <rect x="189"
+         y="661"
+         width="148"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="681">CLUSTER REPLICA</text>
+   <rect x="397" y="3" width="104" height="32"/>
+   <rect x="395" y="1" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="405" y="21">object_name</text>
+   <rect x="521" y="3" width="32" height="32" rx="10"/>
+   <rect x="519"
+         y="1"
+         width="32"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="529" y="21">IS</text>
+   <rect x="427" y="729" width="100" height="32"/>
+   <rect x="425" y="727" width="100" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="435" y="747">string_literal</text>
+   <rect x="427" y="773" width="56" height="32" rx="10"/>
+   <rect x="425"
+         y="771"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="435" y="791">NULL</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m120 0 h10 m20 0 h10 m66 0 h10 m0 0 h100 m-206 0 h20 m186 0 h20 m-226 0 q10 0 10 10 m206 0 q0 -10 10 -10 m-216 10 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m58 0 h10 m0 0 h108 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m166 0 h10 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m78 0 h10 m0 0 h88 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m52 0 h10 m0 0 h114 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m62 0 h10 m0 0 h104 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m94 0 h10 m0 0 h72 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m116 0 h10 m0 0 h50 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m76 0 h10 m0 0 h90 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m56 0 h10 m0 0 h110 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m98 0 h10 m0 0 h68 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m82 0 h10 m0 0 h84 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m84 0 h10 m0 0 h82 m-196 -10 v20 m206 0 v-20 m-206 20 v24 m206 0 v-24 m-206 24 q0 10 10 10 m186 0 q10 0 10 -10 m-196 10 h10 m148 0 h10 m0 0 h18 m20 -660 h10 m104 0 h10 m0 0 h10 m32 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-190 726 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m100 0 h10 m-140 0 h20 m120 0 h20 m-160 0 q10 0 10 10 m140 0 q0 -10 10 -10 m-150 10 v24 m140 0 v-24 m-140 24 q0 10 10 10 m120 0 q10 0 10 -10 m-130 10 h10 m56 0 h10 m0 0 h44 m23 -44 h-3"/>
+   <polygon points="565 743 573 739 573 747"/>
+   <polygon points="565 743 557 739 557 747"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -49,8 +49,9 @@ col_option ::=
   'DEFAULT' expr
 comment_on ::=
   'COMMENT ON' (
-    'TABLE' | 'COLUMN' | 'VIEW' | 'MATERIALIZED VIEW' | 'SOURCE' | 'SINK' | 'INDEX' | 'FUNCTION' |
-    'CONNECTION' | 'TYPE' | 'SECRET' | 'ROLE' | 'DATABASE' | 'SCHEMA' | 'CLUSTER' | 'CLUSTER REPLICA'
+    'CLUSTER' | 'CLUSTER REPLICA' | 'COLUMN' | 'CONNECTION' | 'DATABASE' | 'FUNCTION' |
+    'INDEX' | 'MATERIALIZED VIEW' | 'ROLE' | 'SCHEMA' | 'SECRET' | 'SINK' | 'SOURCE' |
+    'TABLE' | 'TYPE' | 'VIEW'
   ) object_name 'IS' ( string_literal | 'NULL' )
 commit ::=
   'COMMIT'

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -47,6 +47,11 @@ close ::=
 col_option ::=
   'NOT' 'NULL' |
   'DEFAULT' expr
+comment_on ::=
+  'COMMENT ON' (
+    'TABLE' | 'COLUMN' | 'VIEW' | 'MATERIALIZED VIEW' | 'SOURCE' | 'SINK' | 'INDEX' | 'FUNCTION' |
+    'CONNECTION' | 'TYPE' | 'SECRET' | 'ROLE' | 'DATABASE' | 'SCHEMA' | 'CLUSTER' | 'CLUSTER REPLICA'
+  ) object_name 'IS' ( string_literal | 'NULL' )
 commit ::=
   'COMMIT'
 copy_to ::=


### PR DESCRIPTION
# [Preview Docs](https://preview.materialize.com/materialize/21756/sql/comment-on/)

This PR adds basic documentation for the `COMMENT ON` sql command.

### Motivation

Adds documentation for `COMMENT ON`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds documentation for the `COMMENT ON` feature that is currently in private preview.
