### PR TITLE
Add redacted_sql column to mz_prepared_statement_history

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -32,6 +32,7 @@ use mz_sql::catalog::{EnvironmentId, SessionCatalog};
 use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::user::{User, SUPPORT_USER};
 use mz_sql::session::vars::VarInput;
+use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use mz_transform::Optimizer;
 use prometheus::Histogram;
@@ -464,7 +465,8 @@ impl SessionClient {
         let params = vec![];
         let result_formats = vec![mz_pgrepr::Format::Text; desc.arity()];
         let now = self.now();
-        let logging = self.session().mint_logging(sql, now);
+        let redacted_sql = stmt.to_ast_string_redacted();
+        let logging = self.session().mint_logging(sql, redacted_sql, now);
         self.session().set_portal(
             name,
             desc,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -14,6 +14,7 @@ use mz_ore::now::EpochMillis;
 use mz_repr::{GlobalId, ScalarType};
 use mz_sql::names::{Aug, ResolvedIds};
 use mz_sql::plan::{Params, StatementDesc};
+use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{Raw, Statement};
 
 use crate::catalog::Catalog;
@@ -73,7 +74,8 @@ impl Coordinator {
         let desc = describe(catalog, stmt.clone(), &param_types, session)?;
         let params = params.datums.into_iter().zip(params.types).collect();
         let result_formats = vec![mz_pgrepr::Format::Text; desc.arity()];
-        let logging = session.mint_logging(sql, now);
+        let redacted_sql = stmt.to_ast_string_redacted();
+        let logging = session.mint_logging(sql, redacted_sql, now);
         session.set_portal(
             name,
             desc,

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -72,6 +72,7 @@ pub struct StatementEndedExecutionRecord {
 pub struct StatementPreparedRecord {
     pub id: Uuid,
     pub sql: String,
+    pub redacted_sql: String,
     pub name: String,
     pub session_id: Uuid,
     pub prepared_at: EpochMillis,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -326,14 +326,16 @@ ORDER BY mseh.began_at;",
         // appear to give us any way to do that. Instead, let's just check
         // that none of these statements took longer than 5s wall-clock time.
         assert!(r.finished_at - r.began_at <= chrono::Duration::seconds(5));
-        let expected_redacted = mz_sql::parse::parse(&r.sql)
-            .unwrap()
-            .into_element()
-            .ast
-            .to_ast_string_redacted();
-        assert_eq!(r.redacted_sql, expected_redacted);
-        for constant in constants {
-            assert!(!r.redacted_sql.contains(constant));
+        if !r.sql.is_empty() {
+            let expected_redacted = mz_sql::parse::parse(&r.sql)
+                .unwrap()
+                .into_element()
+                .ast
+                .to_ast_string_redacted();
+            assert_eq!(r.redacted_sql, expected_redacted);
+            for constant in constants {
+                assert!(!r.redacted_sql.contains(constant));
+            }
         }
     }
 }

--- a/src/sql-parser/src/ast/defs/value.rs
+++ b/src/sql-parser/src/ast/defs/value.rs
@@ -62,6 +62,23 @@ pub enum Value {
 
 impl AstDisplay for Value {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        if f.redacted() {
+            // When adding branches to this match statement, think about whether it is OK for us to collect
+            // the value as part of our telemetry. Check the data management policy to be sure!
+            match self {
+                Value::Number(_) | Value::String(_) | Value::HexString(_) => {
+                    f.write_str("<REDACTED>");
+                    return;
+                }
+                Value::Interval(_) => {
+                    f.write_str("INTERVAL <REDACTED>");
+                    return;
+                }
+                Value::Boolean(_) | Value::Null => {
+                    // These are fine to log, so just fall through.
+                }
+            }
+        }
         match self {
             Value::Number(v) => f.write_str(v),
             Value::String(v) => {

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -66,6 +66,7 @@ pub static MZ_PREPARED_STATEMENT_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(||
         .with_column("session_id", ScalarType::Uuid.nullable(false))
         .with_column("name", ScalarType::String.nullable(false))
         .with_column("sql", ScalarType::String.nullable(false))
+        .with_column("redacted_sql", ScalarType::String.nullable(false))
         .with_column("prepared_at", ScalarType::TimestampTz.nullable(false))
 });
 


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature.

    redacted SQL in statement logging

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
