### PR TITLE
rbac: relax RBAC requirements for `EXPLAIN <query>`

### DIFF
--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -406,5 +406,3 @@ The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations and types in the explainee are contained in.
 - `USAGE` privileges on all types used in the explainee.
-- `SELECT` privileges on all relations in the explainee.
-  - NOTE: if any referenced relation is an index or a materialized view, then its owner must also have the necessary privileges to execute its definition.

--- a/doc/user/content/sql/explain-timestamp.md
+++ b/doc/user/content/sql/explain-timestamp.md
@@ -180,5 +180,3 @@ The privileges required to execute this statement are:
 
 - `USAGE` privileges on the schemas that all relations and types in the query are contained in.
 - `USAGE` privileges on all types used in the query.
-- `SELECT` privileges on all relations in the query.
-  - NOTE: if any referenced relation is an index or a materialized view, then its owner must also have the necessary privileges to execute its definition.

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -708,9 +708,15 @@ fn generate_rbac_requirements(
                     let schema_id: ObjectId = item.name().qualifiers.clone().into();
                     vec![(SystemObjectId::Object(schema_id), AclMode::USAGE, role_id)]
                 }
-                Explainee::Query { .. } => {
-                    generate_read_privileges(catalog, resolved_ids.0.iter().cloned(), role_id)
-                }
+                Explainee::Query { raw_plan, .. } => raw_plan
+                    .depends_on()
+                    .into_iter()
+                    .map(|id| {
+                        let item = catalog.get_item(&id);
+                        let schema_id: ObjectId = item.name().qualifiers.clone().into();
+                        (SystemObjectId::Object(schema_id), AclMode::USAGE, role_id)
+                    })
+                    .collect(),
             },
             item_usage: match explainee {
                 Explainee::MaterializedView(_) | Explainee::Index(_) => false,

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1702,25 +1702,23 @@ GRANT USAGE ON TYPE ty TO joe;
 ----
 COMPLETE 0
 
-simple conn=joe,user=joe
+simple multiline,conn=joe,user=joe
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE "materialize.public.t"
+Explained Query:
+  ReadStorage materialize.public.t
 
-simple conn=child,user=child
+EOF
+COMPLETE 1
+
+simple multiline,conn=child,user=child
 EXPLAIN SELECT a::ty FROM t;
 ----
-db error: ERROR: permission denied for TABLE "materialize.public.t"
+Explained Query:
+  ReadStorage materialize.public.t
 
-simple conn=mz_system,user=mz_system
-GRANT SELECT ON TABLE t TO joe;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE SELECT ON TABLE t FROM joe;
-----
-COMPLETE 0
+EOF
+COMPLETE 1
 
 simple conn=mz_system,user=mz_system
 REVOKE USAGE ON TYPE ty FROM joe;
@@ -1779,68 +1777,26 @@ GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
 
-simple conn=joe,user=joe
+simple multiline,conn=joe,user=joe
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW "materialize.public.v"
+Explained Query:
+  ReadStorage materialize.public.t
 
-simple conn=child,user=child
+EOF
+COMPLETE 1
+
+simple multiline,conn=child,user=child
 EXPLAIN SELECT * FROM v;
 ----
-db error: ERROR: permission denied for VIEW "materialize.public.v"
+Explained Query:
+  ReadStorage materialize.public.t
+
+EOF
+COMPLETE 1
 
 simple conn=mz_system,user=mz_system
-GRANT SELECT ON TABLE v TO joe;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-EXPLAIN SELECT * FROM v;
-----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
-
-simple conn=child,user=child
-EXPLAIN SELECT * FROM v;
-----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
-
-simple conn=mz_system,user=mz_system
-GRANT USAGE ON SCHEMA materialize.public TO view_owner;
-----
-COMPLETE 0
-
-simple conn=joe,user=joe
-EXPLAIN SELECT * FROM v;
-----
-db error: ERROR: permission denied for TABLE "materialize.public.t"
-
-simple conn=child,user=child
-EXPLAIN SELECT * FROM v;
-----
-db error: ERROR: permission denied for TABLE "materialize.public.t"
-
-simple conn=mz_system,user=mz_system
-GRANT SELECT ON TABLE t TO view_owner;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE SELECT ON TABLE t FROM view_owner;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE SELECT ON TABLE v FROM joe;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE USAGE ON SCHEMA materialize.public FROM joe;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-REVOKE CREATE, USAGE ON SCHEMA materialize.public FROM view_owner;
+REVOKE CREATE ON SCHEMA materialize.public FROM view_owner;
 ----
 COMPLETE 0
 
@@ -1951,12 +1907,12 @@ COMPLETE 0
 simple conn=joe,user=joe
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=child,user=child
 INSERT INTO t VALUES (1);
 ----
-db error: ERROR: permission denied for SCHEMA "materialize.public"
+db error: ERROR: permission denied for TABLE "materialize.public.t"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;


### PR DESCRIPTION
At the moment, executing `EXPLAIN <query>` statements requires read privileges to all items referenced in the query.

Since `EXPLAIN` is not evaluating a query (except for partially evaluating constant paths), we can relax the RBAC requirements to only require `USAGE` privilege on the schema of items contained in the query.

### Motivation

* This PR adds a known-desirable feature.

Closes #20478.

### Tips for reviewer

1. I did `--rewrite-tests` on tests containing RBAC expressions and got these changes. Looking at the other tests in `privilege_checks.slt`, I don't see any other passing tests, so I'm not sure if I should keep the rewritten items or delete them.
2. I think that this fixes the issue with `EXPLAIN <query>`, but not with `EXPLAIN <timestamp>`. I don't think that the latter will reveal more customer information (I would consider the progress timestamps metadata), so I would advocate for fixing this in the same PR as well.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
