### PR TITLE
also retry timeouts when talking to frontegg

### DIFF
--- a/misc/python/materialize/cloudtest/util/authentication.py
+++ b/misc/python/materialize/cloudtest/util/authentication.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, fields
 
 import requests
-from requests.exceptions import ConnectionError
+from requests.exceptions import ConnectionError, ReadTimeout
 
 from materialize.cloudtest.util.common import retry
 from materialize.cloudtest.util.jwt_key import fetch_jwt, make_jwt
@@ -56,7 +56,7 @@ def create_auth(
             refresh_fn,
         ),
         5,
-        [ConnectionError],
+        [ConnectionError, ReadTimeout],
     )
     return config
 


### PR DESCRIPTION
### Motivation

we're also seeing timeouts when making these api calls, not just connection errors

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user facing changes
