### PR TITLE
ci: adds vale as a prose linter for the docs

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -234,6 +234,14 @@ RUN if [ $ARCH_GCC = x86_64 ]; then \
     && rm hugo.tar.gz; \
     fi
 
+# Documentation dependency for linting prose.
+RUN if [ $ARCH_GCC = x86_64 ]; then \
+    curl -fsSL https://github.com/errata-ai/vale/releases/download/v2.28.3/vale_2.28.3_Linux_64-bit.tar.gz > vale.tar.gz \
+    && echo '3ad5305d56e19d97a061931f6c7c09709002e0ae527f36b2594017d5aa23de3c  vale.tar.gz' | sha256sum --check \
+    && tar -xzf vale.tar.gz -C /usr/local/bin vale \
+    && rm vale.tar.gz; \
+    fi
+
 # Install KinD and kubectl
 
 RUN curl -fsSL https://kind.sigs.k8s.io/dl/v0.14.0/kind-linux-$ARCH_GO > /usr/local/bin/kind \

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -20,5 +20,6 @@ ci_try hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --d
 echo "<!doctype html>" > ci/www/public/index.html
 ci_try htmltest -s ci/www/public -c doc/user/.htmltest.yml
 ci_try ci/test/lint-docs-catalog.sh
+ci_try vale doc/user/content/* --config doc/user/.vale.ini --ext=.md
 
 ci_status_report

--- a/doc/user/.vale.ini
+++ b/doc/user/.vale.ini
@@ -1,0 +1,12 @@
+# Vale configuration file.
+#
+# For more information, see https://errata-ai.gitbook.io/vale/getting-started/configuration.
+
+StylesPath = styles
+
+Vocab = Blog
+
+Packages = write-good
+
+[*.md]
+BasedOnStyles = Vale, write-good


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds [Vale](https://vale.sh/), a linter for prose, to our CI process.
The Vale configuration (`.vale.ini`) is not final. The idea is to test that the CI process works well, and that `vale` is doing its job.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
