### PR TITLE
zippy: Fix tests to work with unmanaged cluster

### DIFF
--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -40,6 +40,10 @@ class MzStart(Action):
                 print_statement=False,
             )
 
+        c.sql(
+            "ALTER CLUSTER default SET (MANAGED = false)", user="mz_system", port=6877
+        )
+
     def provides(self) -> list[Capability]:
         return [MzIsRunning()]
 


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/21698

Failed on release qualification run: https://buildkite.com/materialize/release-qualification/builds/319#018a9450-ffe5-49be-8acd-f3b0b5f7c154

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
