### PR TITLE
Correct string/number comparison in dataflow visualization

### DIFF
--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -412,36 +412,8 @@ async function getCreateView(dataflow_name) {
   return { name: create_table.rows[0][0], create: create_table.rows[0][1] };
 }
 
-function makeAddrStr(addrs, id, other) {
-  let addr = addrs[id].slice();
-  // The 0 source or target should not append itself to the address.
-  if (other !== 0) {
-    addr.push(other);
-  }
-  return addrStr(addr);
-}
-
 function addrStr(addr) {
   return addr.join(', ');
-}
-
-// dispNs displays ns nanoseconds in a human-readable string.
-function dispNs(ns) {
-  const timeTable = [
-    [60, 's'],
-    [60, 'm'],
-    [60, 'h'],
-  ];
-  const parts = [];
-  let v = ns / 1e9;
-  timeTable.forEach(([div, disp], idx) => {
-    const part = Math.floor(v % div);
-    if (part >= 1 || idx === 0) {
-      parts.unshift(`${part}${disp}`);
-    }
-    v = Math.floor(v / div);
-  });
-  return parts.join('');
 }
 
 function toggle_active(e) {

--- a/src/environmentd/src/http/static/js/hierarchical-memory.jsx
+++ b/src/environmentd/src/http/static/js/hierarchical-memory.jsx
@@ -261,8 +261,8 @@ function Dataflows(props) {
           let ids_seen = [];
           const edges = scope_channels.get(addr).map(([source, target, source_port, target_port, sent, batch_sent]) => {
             // if either `source` or `target` are zero, they signify a scope input or output, respectively.
-            let source1 = source != 0 ? addr_to_id[addr.concat(", ").concat(source)] : `input_${source_port}`;
-            let target1 = target != 0 ? addr_to_id[addr.concat(", ").concat(target)] : `output_${target_port}`;
+            let source1 = source != "0" ? addr_to_id[addr.concat(", ").concat(source)] : `input_${source_port}`;
+            let target1 = target != "0" ? addr_to_id[addr.concat(", ").concat(target)] : `output_${target_port}`;
             ids_seen.push(source1);
             ids_seen.push(target1);
             return sent == null ? `${source1} -> ${target1} [style="dashed"]` :

--- a/src/environmentd/src/http/static/js/memory.jsx
+++ b/src/environmentd/src/http/static/js/memory.jsx
@@ -611,7 +611,7 @@ async function getCreateView(dataflow_name) {
 function makeAddrStr(addrs, id, other) {
   let addr = addrs[id].slice();
   // The 0 source or target should not append itself to the address.
-  if (other !== 0) {
+  if (other !== "0") {
     addr.push(other);
   }
   return addrStr(addr);


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug: Fix dataflow graph rendering. With #21664 we changed how numbers are encoded, which moved the encoding of numbers from JSON numbers to strings. This broke some comparison in the memory visualizer.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
