### PR TITLE
Per replica notice

### DIFF
--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -20,7 +20,7 @@ datestyle                                   | `ISO, MDY`                | The di
 emit_timestamp_notice                       | `false`                   | Boolean flag indicating whether to send a `notice` specifying query timestamps.
 emit_trace_id_notice                        | `false`                   | Boolean flag indicating whether to send a `notice` specifying the trace ID, when available.
 enable_session_rbac_checks                  | `false`                   | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session.
-enable_per_replica_notice                   | `true`                    | Whether to print a notice when querying replica introspection relations.
+emit_introspection_query_notice             | `true`                    | Whether to print a notice when querying replica introspection relations.
 extra_float_digits                          | `3`                       | Boolean flag indicating whether to adjust the number of digits displayed for floating-point values.
 failpoints                                  |                           | Allows failpoints to be dynamically activated.
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -20,7 +20,7 @@ datestyle                                   | `ISO, MDY`                | The di
 emit_timestamp_notice                       | `false`                   | Boolean flag indicating whether to send a `notice` specifying query timestamps.
 emit_trace_id_notice                        | `false`                   | Boolean flag indicating whether to send a `notice` specifying the trace ID, when available.
 enable_session_rbac_checks                  | `false`                   | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session.
-enable_per_replica_notice                   | `true`                    | Whether to print a notice when querying per-replica introspection data
+enable_per_replica_notice                   | `true`                    | Whether to print a notice when querying replica introspection relations.
 extra_float_digits                          | `3`                       | Boolean flag indicating whether to adjust the number of digits displayed for floating-point values.
 failpoints                                  |                           | Allows failpoints to be dynamically activated.
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -20,6 +20,7 @@ datestyle                                   | `ISO, MDY`                | The di
 emit_timestamp_notice                       | `false`                   | Boolean flag indicating whether to send a `notice` specifying query timestamps.
 emit_trace_id_notice                        | `false`                   | Boolean flag indicating whether to send a `notice` specifying the trace ID, when available.
 enable_session_rbac_checks                  | `false`                   | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session.
+enable_per_replica_notice                   | `true`                    | Whether to print a notice when querying per-replica introspection data
 extra_float_digits                          | `3`                       | Boolean flag indicating whether to adjust the number of digits displayed for floating-point values.
 failpoints                                  |                           | Allows failpoints to be dynamically activated.
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.

--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -17,10 +17,10 @@ application_name                            |                           | The ap
 client_encoding                             | `UTF8`                    | The client's character set encoding. The only supported value is `UTF-8`.
 client_min_messages                         | `notice`                  | The message levels that are sent to the client. <br/><br/> Accepts values: `debug5`, `debug4`, `debug3`, `debug2`, `debug1`, `log`, `notice`, `warning`, `error`. Each level includes all the levels that follow it.
 datestyle                                   | `ISO, MDY`                | The display format for date and time values. The only supported value is `ISO, MDY`.
+emit_introspection_query_notice             | `true`                    | Whether to print a notice when querying replica introspection relations.
 emit_timestamp_notice                       | `false`                   | Boolean flag indicating whether to send a `notice` specifying query timestamps.
 emit_trace_id_notice                        | `false`                   | Boolean flag indicating whether to send a `notice` specifying the trace ID, when available.
 enable_session_rbac_checks                  | `false`                   | **Read-only.** Boolean flag indicating whether RBAC is enabled for the current session.
-emit_introspection_query_notice             | `true`                    | Whether to print a notice when querying replica introspection relations.
 extra_float_digits                          | `3`                       | Boolean flag indicating whether to adjust the number of digits displayed for floating-point values.
 failpoints                                  |                           | Allows failpoints to be dynamically activated.
 idle_in_transaction_session_timeout         | `120 seconds`             | The maximum allowed duration that a session can sit idle in a transaction before being terminated. If this value is specified without units, it is taken as milliseconds. A value of zero disables the timeout.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2747,7 +2747,7 @@ impl Coordinator {
             cluster,
             &depends_on,
             &mut target_replica,
-            session.vars(),
+            ctx.session().vars(),
         )?;
         ctx.session_mut().add_notices(notices);
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2157,7 +2157,10 @@ impl Coordinator {
         let in_immediate_multi_stmt_txn = session.transaction().is_in_multi_statement_transaction()
             && when == QueryWhen::Immediately;
 
-        check_no_invalid_log_reads(catalog, cluster, &source_ids, &mut target_replica)?;
+        let notices = check_log_reads(catalog, cluster, &source_ids, &mut target_replica)?;
+        if session.vars().enable_per_replica_notice() {
+            session.add_notices(notices);
+        }
 
         let validity = PlanValidity {
             transient_revision: catalog.transient_revision(),
@@ -2735,7 +2738,10 @@ impl Coordinator {
         // Determine the frontier of updates to subscribe *from*.
         // Updates greater or equal to this frontier will be produced.
         let depends_on = from.depends_on();
-        check_no_invalid_log_reads(self.catalog(), cluster, &depends_on, &mut target_replica)?;
+        let notices = check_log_reads(self.catalog(), cluster, &depends_on, &mut target_replica)?;
+        if ctx.session().vars().enable_per_replica_notice() {
+            ctx.session_mut().add_notices(notices);
+        }
         let id_bundle = self
             .index_oracle(cluster_id)
             .sufficient_collections(&depends_on);
@@ -5234,12 +5240,19 @@ impl Coordinator {
     }
 }
 
-fn check_no_invalid_log_reads(
+/// Checks whether we should emit diagnostic
+/// information associated with reading per-replica sources.
+///
+/// If an unrecoverable error is found (today: an
+/// untargeted read on a cluster with a non-1 number of replicas), return that.
+/// Otherwise, return a list of associated notices (today: we always emit exactly one notice if
+/// there are any per-replica log dependencies, and none otherwise.)
+fn check_log_reads(
     catalog: &Catalog,
     cluster: &Cluster,
     source_ids: &BTreeSet<GlobalId>,
     target_replica: &mut Option<ReplicaId>,
-) -> Result<(), AdapterError>
+) -> Result<impl IntoIterator<Item = AdapterNotice>, AdapterError>
 where
 {
     let log_names = source_ids
@@ -5249,7 +5262,7 @@ where
         .collect::<Vec<_>>();
 
     if log_names.is_empty() {
-        return Ok(());
+        return Ok(None);
     }
 
     // Reading from log sources on replicated clusters is only allowed if a
@@ -5272,7 +5285,7 @@ where
         return Err(AdapterError::IntrospectionDisabled { log_names });
     }
 
-    Ok(())
+    Ok(Some(AdapterNotice::PerReplicaLogRead { log_names }))
 }
 
 /// Return a [`SourceSinkClusterConfig`] based on the possibly altered

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5256,7 +5256,7 @@ impl Coordinator {
 /// cluster with a non-1 number of replicas), return that.  Otherwise,
 /// return a list of associated notices (today: we always emit exactly
 /// one notice if there are any per-replica log dependencies and if
-/// `enable_per_replica_notice` is set, and none otherwise.)
+/// `emit_introspection_query_notice` is set, and none otherwise.)
 fn check_log_reads(
     catalog: &Catalog,
     cluster: &Cluster,
@@ -5296,11 +5296,9 @@ where
         return Err(AdapterError::IntrospectionDisabled { log_names });
     }
 
-    Ok(if vars.enable_per_replica_notice() {
-        Some(AdapterNotice::PerReplicaLogRead { log_names })
-    } else {
-        None
-    })
+    Ok(vars
+        .emit_introspection_query_notice()
+        .then_some(AdapterNotice::PerReplicaLogRead { log_names }))
 }
 
 /// Return a [`SourceSinkClusterConfig`] based on the possibly altered

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -415,7 +415,7 @@ impl fmt::Display for AdapterNotice {
                 write!(f, "The dropped index {index_name} is being used by the following objects: {}. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!", separated(", ", dependant_objects))
             }
             AdapterNotice::PerReplicaLogRead { log_names } => {
-                write!(f, "Queried per-replica objects: {}. Unlike other objects in Materialize, these results depend on the current values of the `CLUSTER` and `REPLICA` session variables.", log_names.join(", "))
+                write!(f, "Queried introspection relations: {}. Unlike other objects in Materialize, results from querying these objects depend on the current values of the `cluster` and `cluster_replica` session variables.", log_names.join(", "))
             }
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -180,6 +180,7 @@ impl AdapterNotice {
             AdapterNotice::OptimizerNotice { .. } => Severity::Notice,
             AdapterNotice::WebhookSourceCreated { .. } => Severity::Notice,
             AdapterNotice::DroppedInUseIndex { .. } => Severity::Notice,
+            AdapterNotice::PerReplicaLogRead { .. } => Severity::Notice,
         }
     }
 

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -119,6 +119,9 @@ pub enum AdapterNotice {
         url: url::Url,
     },
     DroppedInUseIndex(DroppedInUseIndex),
+    PerReplicaLogRead {
+        log_names: Vec<String>,
+    },
 }
 
 impl AdapterNotice {
@@ -259,6 +262,7 @@ impl AdapterNotice {
             AdapterNotice::OptimizerNotice { .. } => SqlState::SUCCESSFUL_COMPLETION,
             AdapterNotice::DroppedInUseIndex { .. } => SqlState::WARNING,
             AdapterNotice::WebhookSourceCreated { .. } => SqlState::WARNING,
+            AdapterNotice::PerReplicaLogRead { .. } => SqlState::WARNING,
         }
     }
 }
@@ -409,6 +413,9 @@ impl fmt::Display for AdapterNotice {
                 dependant_objects,
             }) => {
                 write!(f, "The dropped index {index_name} is being used by the following objects: {}. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!", separated(", ", dependant_objects))
+            }
+            AdapterNotice::PerReplicaLogRead { log_names } => {
+                write!(f, "Queried per-replica objects: {}. Unlike other objects in Materialize, these results depend on the current values of the `CLUSTER` and `REPLICA` session variables.", log_names.join(", "))
             }
         }
     }

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2943,7 +2943,7 @@ fn test_auto_run_on_introspection_feature_enabled() {
     assert_introspection_notice(false);
 }
 
-const INTROSPECTION_NOTICE: &'static str = "results from querying these objects depend on the current values of the `cluster` and `cluster_replica` session variables";
+const INTROSPECTION_NOTICE: &str = "results from querying these objects depend on the current values of the `cluster` and `cluster_replica` session variables";
 
 #[mz_ore::test]
 fn test_auto_run_on_introspection_feature_disabled() {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1223,6 +1223,13 @@ pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
+pub const ENABLE_PER_REPLICA_NOTICE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_per_replica_notice"),
+    value: &true,
+    description: "Whether to print a notice when querying per-replica introspection sources.",
+    internal: false,
+};
+
 // TODO(mgree) change this to a SelectOption
 pub const ENABLE_SESSION_CARDINALITY_ESTIMATES: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_session_cardinality_estimates"),
@@ -1790,6 +1797,7 @@ impl SessionVars {
                 &STATEMENT_LOGGING_SAMPLE_RATE,
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
             )
+            .with_var(&ENABLE_PER_REPLICA_NOTICE)
     }
 
     fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
@@ -2066,7 +2074,7 @@ impl SessionVars {
         self.expect_value(&*CLUSTER).as_str()
     }
 
-    /// Returns the value of the `cluster_replica` configuration parameter.
+    /// Returns the value of te `cluster_replica` configuration parameter.
     pub fn cluster_replica(&self) -> Option<&str> {
         self.expect_value(&CLUSTER_REPLICA).as_deref()
     }
@@ -2205,6 +2213,11 @@ impl SessionVars {
 
     pub fn get_statement_logging_sample_rate(&self) -> Numeric {
         *self.expect_value(&STATEMENT_LOGGING_SAMPLE_RATE)
+    }
+
+    /// Returns the value of the `enable_per_replica_notice` configuration parameter.
+    pub fn enable_per_replica_notice(&self) -> bool {
+        *self.expect_value(&ENABLE_PER_REPLICA_NOTICE)
     }
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2074,7 +2074,7 @@ impl SessionVars {
         self.expect_value(&*CLUSTER).as_str()
     }
 
-    /// Returns the value of te `cluster_replica` configuration parameter.
+    /// Returns the value of the `cluster_replica` configuration parameter.
     pub fn cluster_replica(&self) -> Option<&str> {
         self.expect_value(&CLUSTER_REPLICA).as_deref()
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1223,8 +1223,8 @@ pub const ENABLE_SESSION_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
-pub const ENABLE_PER_REPLICA_NOTICE: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_per_replica_notice"),
+pub const EMIT_INTROSPECTION_QUERY_NOTICE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("emit_introspection_query_notice"),
     value: &true,
     description: "Whether to print a notice when querying per-replica introspection sources.",
     internal: false,
@@ -1797,7 +1797,7 @@ impl SessionVars {
                 &STATEMENT_LOGGING_SAMPLE_RATE,
                 ValueConstraint::Domain(&NumericInRange(0.0..=1.0)),
             )
-            .with_var(&ENABLE_PER_REPLICA_NOTICE)
+            .with_var(&EMIT_INTROSPECTION_QUERY_NOTICE)
     }
 
     fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
@@ -2215,9 +2215,9 @@ impl SessionVars {
         *self.expect_value(&STATEMENT_LOGGING_SAMPLE_RATE)
     }
 
-    /// Returns the value of the `enable_per_replica_notice` configuration parameter.
-    pub fn enable_per_replica_notice(&self) -> bool {
-        *self.expect_value(&ENABLE_PER_REPLICA_NOTICE)
+    /// Returns the value of the `emit_introspection_query_notice` configuration parameter.
+    pub fn emit_introspection_query_notice(&self) -> bool {
+        *self.expect_value(&EMIT_INTROSPECTION_QUERY_NOTICE)
     }
 }
 

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -25,6 +25,7 @@ cluster                             <VARIES>                "Sets the current cl
 cluster_replica                     ""                      "Sets a target cluster replica for SELECT queries (Materialize)."
 database                            materialize             "Sets the current database (CockroachDB)."
 DateStyle                           "ISO, MDY"              "Sets the display format for date and time values (PostgreSQL)."
+emit_introspection_query_notice     on                      "Whether to print a notice when querying per-replica introspection sources."
 emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
 enable_comment                      off                     "Enables the COMMENT ON feature for objects in the database (Materialize)."


### PR DESCRIPTION
I have observed lots of people (including myself and other Compute team members) getting confused by per-replica queries, which are a very unusual and niche concept in Materialize. I think this level of confusion justifies the additional noise in printing a notice every time such a query is issued.

For people who prefer not to have such noise, I have added a session variable `enable_per_replica_notice` that turns it off.

### Motivation

  * This PR adds a known-desirable feature.

    Fixes #21764 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds a notice when querying per-replica introspection data.
