### PR TITLE
rbac: allow `EXPLAIN` commands in `user_privilege_hack`

### DIFF
--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -248,21 +248,26 @@ pub fn user_privilege_hack(
         // **Special Cases**
         //
         // Generally we want to prevent the mz_support user from being able to
-        // access user objects. But there are a few special cases where we permit
-        // limited access, which are:
-        //   * SHOW CREATE ... commands, which are very useful for debugging, see
-        //     <https://github.com/MaterializeInc/materialize/issues/18027> for more
-        //     details.
+        // access user objects. But there are a few special cases where we
+        // permit limited access, which are are very useful for debugging. More
+        // specifically:
+        //   * SHOW CREATE ... commands. See
+        //     <https://github.com/MaterializeInc/materialize/issues/18027> for
+        //     more details.
+        //   * EXPLAIN PLAN ... and EXPLAIN TIMESTAMP ... and commands. See
+        //     <https://github.com/MaterializeInc/materialize/issues/20478> for
+        //     more details.
         //
-        Plan::ShowCreate(_) | Plan::ShowColumns(_) => {
+        Plan::ShowCreate(_)
+        | Plan::ShowColumns(_)
+        | Plan::ExplainPlan(_)
+        | Plan::ExplainTimestamp(_) => {
             return Ok(());
         }
 
         Plan::Subscribe(_)
         | Plan::Select(_)
         | Plan::CopyFrom(_)
-        | Plan::ExplainPlan(_)
-        | Plan::ExplainTimestamp(_)
         | Plan::ShowAllVariables
         | Plan::ShowVariable(_)
         | Plan::SetVariable(_)

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -1,0 +1,37 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests that assert the privileges that are assumed to be always granted to #
+# the mz_support user. This test can be rewritten to validate the output of the
+# `connection=mz_support` command once we have `SET ROLE` working.
+
+$ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
+
+> CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES WITH (size = '1');
+
+# The mz_support user can list database sources.
+$ postgres-execute connection=mz_support
+SHOW SOURCEs;
+
+# The mz_support user can execute `SHOW CREATE ...` commands.
+$ postgres-execute connection=mz_support
+SHOW CREATE SOURCE bids;
+
+# The mz_support user can execute `EXPLAIN PLAN ...` commands.
+$ postgres-execute connection=mz_support
+EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM bids b JOIN users u ON(b.buyer = u.id);
+
+# The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
+$ postgres-execute connection=mz_support
+EXPLAIN TIMESTAMP FOR SELECT * FROM bids b JOIN users u ON(b.buyer = u.id);
+
+# The mz_support user cannot execute `SELECT ...` commands.
+# We can uncomment this test once all regular commands are executed from `mz_support`
+# ! SELECT * FROM bids
+# contains:permission denied for SOURCE "materialize.public.bids"


### PR DESCRIPTION
Follow-up from #21760

### Motivation

Turns out that one bit was missing from #21760 in order to resolve #20478.

  * This PR adds a known-desirable feature.

This does in fact resolve #20478.

### Tips for reviewer

I had to change the definition of `user_privilege_hack` a bit.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
