### PR TITLE
[Cloudtest] Allow setting additional headers in cloudtest requests

### DIFF
--- a/misc/python/materialize/cloudtest/util/controller.py
+++ b/misc/python/materialize/cloudtest/util/controller.py
@@ -58,9 +58,17 @@ class ControllerDefinition:
         return self.endpoint.base_url
 
     def requests(
-        self, auth: AuthConfig | None, client_cert: tuple[str, str] | None = None
+        self,
+        auth: AuthConfig | None,
+        client_cert: tuple[str, str] | None = None,
+        additional_headers: dict[str, str] | None = None,
     ) -> WebRequests:
-        return WebRequests(auth, self.configured_base_url(), client_cert)
+        return WebRequests(
+            auth,
+            self.configured_base_url(),
+            client_cert=client_cert,
+            additional_headers=additional_headers,
+        )
 
 
 def wait_for_connectable(

--- a/misc/python/materialize/cloudtest/util/web_request.py
+++ b/misc/python/materialize/cloudtest/util/web_request.py
@@ -38,10 +38,12 @@ class WebRequests:
         auth: AuthConfig | None,
         base_url: str,
         client_cert: tuple[str, str] | None = None,
+        additional_headers: dict[str, str] | None = None,
     ):
         self.auth = auth
         self.base_url = base_url
         self.client_cert = client_cert
+        self.additional_headers = additional_headers
 
     def get(
         self,
@@ -176,7 +178,7 @@ class WebRequests:
         return response
 
     def _create_headers(self, auth: AuthConfig | None) -> dict[str, Any]:
-        headers = {}
+        headers = self.additional_headers.copy() if self.additional_headers else {}
         if auth:
             headers["Authorization"] = f"Bearer {auth.token}"
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Allows passing in headers for requests made via cloudtest 'controllers'. Necessary for setting new `X-MZ-Api-Version` header planned to be introduced in PR for https://github.com/MaterializeInc/cloud/issues/7429

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
