### PR TITLE
output consistency: fix value comparison (floating point, list)

### DIFF
--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -310,6 +310,9 @@ class ResultComparator:
         if value1 == value2:
             return True
 
+        if isinstance(value1, list) and isinstance(value2, list):
+            return self.is_list_equal(value1, value2)
+
         if isinstance(value1, Decimal) and isinstance(value2, Decimal):
             if value1.is_nan() and value2.is_nan():
                 return True
@@ -323,3 +326,13 @@ class ResultComparator:
                 return value1 == value2
 
         return False
+
+    def is_list_equal(self, list1: list[Any], list2: list[Any]) -> bool:
+        if len(list1) != len(list2):
+            return False
+
+        for value1, value2 in zip(list1, list2):
+            if not self.is_value_equal(value1, value2):
+                return False
+
+        return True

--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -311,9 +311,15 @@ class ResultComparator:
             return True
 
         if isinstance(value1, Decimal) and isinstance(value2, Decimal):
-            return value1.is_nan() and value2.is_nan()
+            if value1.is_nan() and value2.is_nan():
+                return True
+            else:
+                return value1 == value2
 
         if isinstance(value1, float) and isinstance(value2, float):
-            return math.isnan(value1) and math.isnan(value2)
+            if math.isnan(value1) and math.isnan(value2):
+                return True
+            else:
+                return value1 == value2
 
         return False


### PR DESCRIPTION
### Motivation

5f8f761e42f9e7e8cb4af06cab397d4d0ebd4454 fixes https://github.com/MaterializeInc/materialize/issues/21772, which requires a proper comparison of lists.
In addition, cb9083c7a216e60b5d0cccae19f263e08b588e32 fixes the comparison of floating point numbers, which was not performed. 
