### PR TITLE
coord: On Startup wait for table writes in caller

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3447,6 +3447,7 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "timely",
  "tokio",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -71,6 +71,7 @@ serde = "1.0.152"
 serde_json = "1.0.89"
 serde_plain = "1.0.1"
 smallvec = { version = "1.10.0", features = ["union"] }
+static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -205,8 +205,15 @@ impl Client {
         let StartupResponse {
             role_id,
             set_vars,
+            write_notify,
             catalog,
         } = response;
+
+        // Before we do ANYTHING, we need to wait for our BuiltinTable writes to complete. We wait
+        // for the writes here, as opposed to during the Startup command, because we don't want to
+        // block the coordinator on a Builtin Table write.
+        write_notify.await;
+
         client.session().initialize_role_metadata(role_id);
         for (name, val) in set_vars {
             client

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -20,6 +20,7 @@ use std::sync::Arc;
 use anyhow::Context;
 use derivative::Derivative;
 use enum_kinds::EnumKind;
+use futures::future::BoxFuture;
 use mz_ore::collections::CollectionExt;
 use mz_ore::soft_assert;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -179,12 +180,16 @@ pub struct Response<T> {
 pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send>>;
 
 /// The response to [`Client::startup`](crate::Client::startup).
-#[derive(Debug)]
+#[derive(Derivative)]
+#[derivative(Debug)]
 pub struct StartupResponse {
     /// RoleId for the user.
     pub role_id: RoleId,
     /// Vec of (name, VarInput::Flat) tuples of session variables that should be set.
     pub set_vars: Vec<(String, String)>,
+    /// A future that completes when all necessary Builtin Table writes have completed.
+    #[derivative(Debug = "ignore")]
+    pub write_notify: BoxFuture<'static, ()>,
     pub catalog: Arc<Catalog>,
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -132,7 +132,7 @@ use crate::catalog::{
 use crate::client::{Client, ConnectionId, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
 use crate::config::SystemParameterSyncConfig;
-use crate::coord::appends::{Deferred, PendingWriteTxn};
+use crate::coord::appends::{Deferred, GroupCommitPermit, PendingWriteTxn};
 use crate::coord::dataflows::dataflow_import_id_bundle;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::peek::PendingPeek;
@@ -196,7 +196,7 @@ pub enum Message<T = mz_repr::Timestamp> {
     SinkConnectionReady(SinkConnectionReady),
     WriteLockGrant(tokio::sync::OwnedMutexGuard<()>),
     /// Initiates a group commit.
-    GroupCommitInitiate(Span),
+    GroupCommitInitiate(Span, Option<GroupCommitPermit>),
     /// Makes a group commit visible to all clients.
     GroupCommitApply(
         /// Timestamp of the writes in the group commit.
@@ -205,6 +205,10 @@ pub enum Message<T = mz_repr::Timestamp> {
         Vec<CompletedClientTransmitter>,
         /// Optional lock if the group commit contained writes to user tables.
         Option<OwnedMutexGuard<()>>,
+        /// Operations waiting on this group commit to finish.
+        Vec<oneshot::Sender<()>>,
+        /// Permit which limits how many group commits we run at once.
+        Option<GroupCommitPermit>,
     ),
     AdvanceTimelines,
     ClusterEvent(ClusterEvent),
@@ -914,6 +918,8 @@ pub struct Coordinator {
 
     /// Channel to manage internal commands from the coordinator to itself.
     internal_cmd_tx: mpsc::UnboundedSender<Message>,
+    /// Notification that triggers a group commit.
+    group_commit_tx: appends::GroupCommitNotifier,
 
     /// Channel for strict serializable reads ready to commit.
     strict_serializable_reads_tx: mpsc::UnboundedSender<PendingReadTxn>,
@@ -1814,6 +1820,7 @@ impl Coordinator {
         mut internal_cmd_rx: mpsc::UnboundedReceiver<Message>,
         mut strict_serializable_reads_rx: mpsc::UnboundedReceiver<PendingReadTxn>,
         mut cmd_rx: mpsc::UnboundedReceiver<Command>,
+        group_commit_rx: appends::GroupCommitWaiter,
     ) {
         // Watcher that listens for and reports cluster service status changes.
         let mut cluster_events = self.controller.events_stream();
@@ -1895,6 +1902,12 @@ impl Coordinator {
                 () = self.controller.ready() => {
                     Message::ControllerReady
                 }
+                // See [`appends::GroupCommitWaiter`] for notes on why this is cancel safe.
+                permit = group_commit_rx.ready() => {
+                    let span = info_span!(parent: None, "group_commit_notify");
+                    span.follows_from(Span::current());
+                    Message::GroupCommitInitiate(span, Some(permit))
+                },
                 // `recv()` on `UnboundedReceiver` is cancellation safe:
                 // https://docs.rs/tokio/1.8.0/tokio/sync/mpsc/struct.UnboundedReceiver.html#cancel-safety
                 m = cmd_rx.recv() => match m {
@@ -1915,7 +1928,7 @@ impl Coordinator {
                 _ = self.advance_timelines_interval.tick() => {
                     let span = info_span!(parent: None, "advance_timelines_interval");
                     span.follows_from(Span::current());
-                    Message::GroupCommitInitiate(span)
+                    Message::GroupCommitInitiate(span, None)
                 },
 
                 // Process the idle metric at the lowest priority to sample queue non-idle time.
@@ -2034,6 +2047,7 @@ pub async fn serve(
 
     let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
     let (internal_cmd_tx, internal_cmd_rx) = mpsc::unbounded_channel();
+    let (group_commit_tx, group_commit_rx) = appends::notifier();
     let (strict_serializable_reads_tx, strict_serializable_reads_rx) = mpsc::unbounded_channel();
 
     // Validate and process availability zones.
@@ -2131,6 +2145,7 @@ pub async fn serve(
                 ),
                 catalog: Arc::new(catalog),
                 internal_cmd_tx,
+                group_commit_tx,
                 strict_serializable_reads_tx,
                 global_timelines: timestamp_oracles,
                 transient_id_counter: 1,
@@ -2179,7 +2194,12 @@ pub async fn serve(
                 .send(bootstrap)
                 .expect("bootstrap_rx is not dropped until it receives this message");
             if ok {
-                handle.block_on(coord.serve(internal_cmd_rx, strict_serializable_reads_rx, cmd_rx));
+                handle.block_on(coord.serve(
+                    internal_cmd_rx,
+                    strict_serializable_reads_rx,
+                    cmd_rx,
+                    group_commit_rx,
+                ));
             }
         })
         .expect("failed to create coordinator thread");

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1703,7 +1703,8 @@ impl Coordinator {
         }
 
         debug!("coordinator init: sending builtin table updates");
-        self.send_builtin_table_updates(builtin_table_updates).await;
+        self.send_builtin_table_updates_blocking(builtin_table_updates)
+            .await;
 
         // Signal to the storage controller that it is now free to reconcile its
         // state with what it has learned from the adapter.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -206,6 +206,11 @@ pub enum Message<T = mz_repr::Timestamp> {
         /// Optional lock if the group commit contained writes to user tables.
         Option<OwnedMutexGuard<()>>,
         /// Operations waiting on this group commit to finish.
+        ///
+        /// Note: this differs from the [`CompletedClientTransmitter`]s above because those are
+        /// used to send a response to a request, which indicates the Coordinator has finished all
+        /// of it's work, but these represent auxiliary work that still needs to be done, e.g.
+        /// waiting for a write to Persist to complete.
         Vec<oneshot::Sender<()>>,
         /// Permit which limits how many group commits we run at once.
         Option<GroupCommitPermit>,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -779,7 +779,7 @@ impl Coordinator {
         self.cancel_pending_peeks(conn.conn_id());
         self.end_session_for_statement_logging(conn.uuid());
         let update = self.catalog().state().pack_session_update(&conn, -1);
-        self.buffer_builtin_table_updates(vec![update]);
+        self.send_builtin_table_updates(vec![update]).await;
     }
 
     fn handle_append_webhook(

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -781,7 +781,7 @@ impl Coordinator {
 
         // Queue the builtin table update, we don't need to wait for it to complete.
         let update = self.catalog().state().pack_session_update(&conn, -1);
-        let _ = self.send_builtin_table_updates_notify(vec![update]);
+        self.send_builtin_table_updates_notify(vec![update]);
     }
 
     fn handle_append_webhook(

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -778,8 +778,10 @@ impl Coordinator {
             .dec();
         self.cancel_pending_peeks(conn.conn_id());
         self.end_session_for_statement_logging(conn.uuid());
+
+        // Queue the builtin table update, we don't need to wait for it to complete.
         let update = self.catalog().state().pack_session_update(&conn, -1);
-        self.send_builtin_table_updates(vec![update]).await;
+        let _ = self.send_builtin_table_updates_notify(vec![update]);
     }
 
     fn handle_append_webhook(

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -267,7 +267,7 @@ impl Coordinator {
 
                 // Note: Do NOT await the notify here, we pass this back to whatever requested the
                 // startup to prevent blocking the Coordinator on a builtin table update.
-                let notify = self.submit_builtin_table_updates(vec![update]);
+                let notify = self.send_builtin_table_updates_notify(vec![update]);
 
                 let resp = Ok(StartupResponse {
                     role_id,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -369,7 +369,8 @@ impl Coordinator {
         // No error returns are allowed after this point. Enforce this at compile time
         // by using this odd structure so we don't accidentally add a stray `?`.
         let _: () = async {
-            self.send_builtin_table_updates(builtin_table_updates).await;
+            self.send_builtin_table_updates_blocking(builtin_table_updates)
+                .await;
 
             if !timeline_associations.is_empty() {
                 for (timeline, (should_be_empty, id_bundle)) in timeline_associations {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -62,9 +62,11 @@ impl Coordinator {
             Message::WriteLockGrant(write_lock_guard) => {
                 self.message_write_lock_grant(write_lock_guard).await;
             }
-            Message::GroupCommitInitiate(span) => self.try_group_commit().instrument(span).await,
-            Message::GroupCommitApply(timestamp, responses, write_lock_guard) => {
-                self.group_commit_apply(timestamp, responses, write_lock_guard)
+            Message::GroupCommitInitiate(span, permit) => {
+                self.try_group_commit(permit).instrument(span).await
+            }
+            Message::GroupCommitApply(timestamp, responses, write_lock_guard, notifies, permit) => {
+                self.group_commit_apply(timestamp, responses, write_lock_guard, notifies, permit)
                     .await;
             }
             Message::AdvanceTimelines => {
@@ -600,7 +602,10 @@ impl Coordinator {
                             .await;
                     }
                 }
-                Deferred::GroupCommit => self.group_commit_initiate(Some(write_lock_guard)).await,
+                Deferred::GroupCommit => {
+                    self.group_commit_initiate(Some(write_lock_guard), None)
+                        .await
+                }
             }
         }
         // N.B. if no deferred plans, write lock is released by drop

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -218,7 +218,7 @@ impl Coordinator {
             .catalog()
             .state()
             .pack_subscribe_update(id, &active_subscribe, 1);
-        self.send_builtin_table_updates(vec![update]).await;
+        self.send_builtin_table_updates_blocking(vec![update]).await;
 
         let session_type = metrics::session_type_label_value(&active_subscribe.user);
         self.metrics
@@ -236,7 +236,7 @@ impl Coordinator {
                 .catalog()
                 .state()
                 .pack_subscribe_update(id, &active_subscribe, -1);
-            self.send_builtin_table_updates(vec![update]).await;
+            self.send_builtin_table_updates_blocking(vec![update]).await;
 
             let session_type = metrics::session_type_label_value(&active_subscribe.user);
             self.metrics

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2735,13 +2735,7 @@ fn test_timelines_persist_after_failed_transaction() {
 // we have no way to disconnect sessions using SLT.
 #[mz_ore::test]
 fn test_mz_sessions() {
-    // Set the timestamp to zero for deterministic initial timestamps.
-    let now = Arc::new(Mutex::new(0));
-    let now_fn = {
-        let now = Arc::clone(&now);
-        NowFn::from(move || *now.lock().unwrap())
-    };
-    let config = util::Config::default().with_now(now_fn).unsafe_mode();
+    let config = util::Config::default();
     let server = util::start_server(config).unwrap();
 
     let mut foo_client = server
@@ -2773,20 +2767,19 @@ fn test_mz_sessions() {
 
     // Concurrent session appears in mz_sessions and is removed from mz_sessions.
     {
-        *now.lock().expect("lock poisoned") += 1_000;
-        let _bar_client = server
+        let mut bar_client = server
             .pg_config()
             .user("bar")
             .connect(postgres::NoTls)
             .unwrap();
         assert_eq!(
-            foo_client
+            bar_client
                 .query_one("SELECT count(*) FROM mz_internal.mz_sessions", &[])
                 .unwrap()
                 .get::<_, i64>(0),
             2,
         );
-        let bar_session_row = foo_client
+        let bar_session_row = bar_client
             .query_one(
                 &format!("SELECT role_id FROM mz_internal.mz_sessions WHERE id <> {foo_conn_id}"),
                 &[],
@@ -2794,13 +2787,12 @@ fn test_mz_sessions() {
             .unwrap();
         let bar_role_id = bar_session_row.get::<_, String>("role_id");
         assert_eq!(
-            foo_client
+            bar_client
                 .query_one("SELECT name FROM mz_roles WHERE id = $1", &[&bar_role_id])
                 .unwrap()
                 .get::<_, String>(0),
             "bar",
         );
-        *now.lock().expect("lock poisoned") += 1_000;
     }
 
     assert_eq!(
@@ -2821,14 +2813,13 @@ fn test_mz_sessions() {
     // Concurrent session, with the same name as active session,
     // appears in mz_sessions and is removed from mz_sessions.
     {
-        *now.lock().expect("lock poisoned") += 1_000;
-        let _other_foo_client = server
+        let mut other_foo_client = server
             .pg_config()
             .user("foo")
             .connect(postgres::NoTls)
             .unwrap();
         assert_eq!(
-            foo_client
+            other_foo_client
                 .query_one("SELECT count(*) FROM mz_internal.mz_sessions", &[])
                 .unwrap()
                 .get::<_, i64>(0),
@@ -2844,7 +2835,6 @@ fn test_mz_sessions() {
         let other_foo_role_id = other_foo_session_row.get::<_, String>("role_id");
         assert_ne!(foo_conn_id, other_foo_conn_id);
         assert_eq!(foo_role_id, other_foo_role_id);
-        *now.lock().expect("lock poisoned") += 1_000;
     }
 
     assert_eq!(

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2795,6 +2795,9 @@ fn test_mz_sessions() {
         );
     }
 
+    // Wait for the previous session to get cleaned up.
+    std::thread::sleep(Duration::from_secs(3));
+
     assert_eq!(
         foo_client
             .query_one("SELECT count(*) FROM mz_internal.mz_sessions", &[])
@@ -2836,6 +2839,9 @@ fn test_mz_sessions() {
         assert_ne!(foo_conn_id, other_foo_conn_id);
         assert_eq!(foo_role_id, other_foo_role_id);
     }
+
+    // Wait for the previous session to get cleaned up.
+    std::thread::sleep(Duration::from_secs(3));
 
     assert_eq!(
         foo_client

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -12,6 +12,7 @@ import re
 import time
 from copy import copy
 from datetime import datetime
+from statistics import quantiles
 from textwrap import dedent
 from threading import Thread
 
@@ -85,6 +86,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "test-replica-metrics",
         "test-compute-controller-metrics",
         "test-metrics-retention-across-restart",
+        "test-concurrent-connections",
     ]:
         with c.test_case(name):
             c.workflow(name)
@@ -2381,3 +2383,45 @@ def workflow_test_metrics_retention_across_restart(c: Composition) -> None:
     table_since2, index_since2 = collect_sinces()
     validate_since(table_since2, "table_since2")
     validate_since(index_since2, "index_since2")
+
+
+def workflow_test_concurrent_connections(c: Composition) -> None:
+    """
+    Run many concurrent connections, measure their p50 and p99 latency, make
+    sure #21782 does not regress.
+    """
+    num_conns = 2000
+    runtimes: list[float] = [float("inf")] * num_conns
+
+    def worker(c: Composition, i: int) -> None:
+        start_time = time.time()
+        c.sql("SELECT 1")
+        end_time = time.time()
+        runtimes[i] = end_time - start_time
+
+    c.down(destroy_volumes=True)
+    c.up("materialized")
+
+    c.sql(
+        f"ALTER SYSTEM SET max_connections = {num_conns + 4};",
+        port=6877,
+        user="mz_system",
+    )
+
+    threads = []
+    for i in range(num_conns):
+        thread = Thread(name=f"worker_{i}", target=worker, args=(c, i))
+        threads.append(thread)
+
+    for thread in threads:
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    p = quantiles(runtimes, n=100)
+    print(
+        f"min: {min(runtimes):.2f}s, p50: {p[49]:.2f}s, p99: {p[98]:.2f}s, max: {max(runtimes):.2f}s"
+    )
+    assert p[49] < 1.0, f"p50 is {p[49]:.2f}s, should be less than 1.0s"
+    assert p[98] < 1.5, f"p99 is {p[98]:.2f}s, should be less than 1.5s"


### PR DESCRIPTION
This PR improves environmentd's ability to handle many concurrent connection requests at once. During startup we write to the `mz_sessions` builtin table, this PR moves waiting for that write from the Coordinator into the caller, e.g. the pgwire connection task. 

It also adds a new mechanism which attempts to be more performant in grouping commits by handing out a permit for a commit, and while the permit is outstanding, low priority group commits are not allowed to run. It also no longer blocks Termination on updating the `mz_sessions` builtin table. The reason being, when terminating many connections we could hang the coordinator for >30 seconds while we processed all of the builtin table writes.

### Motivation

Helps improve: #21782

With this change +  we have the following latencies when opening concurrent connections:

num requests | p50      | p90     | p99
-------------|----------|---------|------- 
32           |   34ms   | 371ms   | 495ms
64           |   25ms   | 285ms   | 367ms
128          |   31ms   | 189ms   | 331ms
256          |   66ms   | 565ms   | 660ms
512          |  4044ms  | 4828ms  | 4977ms
1024         |  9114ms  | 9880ms  | 10038ms
2048         |  20031ms | 20784ms | 20931ms
4096         |  21550ms | 22269ms | 22424ms
8192         |  23174ms | 24440ms | 24571ms

Something is still happening when we reach 512 connections, but this is about a 10x improvement over the current state of the world.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improves Materialize's ability to handle many concurrent connection requests.
