### PR TITLE
catalog: Add durable catalog trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,6 +3570,7 @@ dependencies = [
 name = "mz-catalog"
 version = "0.0.0"
 dependencies = [
+ "async-trait",
  "futures",
  "itertools",
  "mz-audit-log",
@@ -3586,6 +3587,7 @@ dependencies = [
  "mz-storage-client",
  "mz-storage-types",
  "once_cell",
+ "postgres-openssl",
  "proptest",
  "proptest-derive",
  "serde",

--- a/doc/developer/design/20230806_durable_catalog_state.md
+++ b/doc/developer/design/20230806_durable_catalog_state.md
@@ -103,21 +103,6 @@ pub trait DurableCatalogState {
     /// it will fail to open in read only mode.
     fn open_read_only(&mut self) -> Result<(), Error>;
 
-    /// Returns the timestamp at which the storage layer booted.
-    ///
-    /// This is the timestamp that will have been used to write any data during
-    /// migrations. It is exposed so that higher layers performing their own
-    /// migrations can write data at the same timestamp, if desired.
-    ///
-    /// The boot timestamp is guaranteed to never go backwards, even in the face
-    /// of backwards time jumps across restarts. Every time the catalog is opened,
-    /// this value is guaranteed to increase.
-    ///
-    /// NB: This is only ever used during startup to ensure that the timestamp for
-    /// all migrations are the same. There's probably a better way to handle this
-    /// than storing it in the catalog indefinitely.
-    fn boot_ts(&self) -> mz_repr::Timestamp;
-
     /// Returns the epoch of the current durable catalog state. The epoch acts as
     /// a fencing token to prevent split brain issues across two
     /// [`DurableCatalogState`]s. When a new [`DurableCatalogState`] opens the

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -10324,7 +10324,7 @@ mod tests {
                     migration_metadata
                         .migrated_system_object_mappings
                         .values()
-                        .map(|mapping| mapping.object_name.clone())
+                        .map(|mapping| mapping.description.object_name.clone())
                         .collect::<BTreeSet<_>>(),
                     test_case
                         .expected_migrated_system_object_mappings

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3622,7 +3622,7 @@ impl Catalog {
             if !storage.is_read_only() {
                 // IMPORTANT: we durably record the new timestamp before using it.
                 storage
-                    .persist_timestamp(&Timeline::EpochMilliseconds, boot_ts)
+                    .set_timestamp(&Timeline::EpochMilliseconds, boot_ts)
                     .await?;
             }
 
@@ -5322,7 +5322,7 @@ impl Catalog {
     ) -> Result<(), Error> {
         self.storage()
             .await
-            .persist_timestamp(timeline, timestamp)
+            .set_timestamp(timeline, timestamp)
             .await
             .err_into()
     }

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -32,7 +32,7 @@ use crate::config::SystemParameterSyncConfig;
 #[derive(Debug)]
 pub struct Config<'a> {
     /// The connection to the stash.
-    pub storage: mz_catalog::Connection,
+    pub storage: Box<dyn mz_catalog::DurableCatalogState>,
     /// Whether to enable unsafe mode.
     pub unsafe_mode: bool,
     /// Whether the build is a local dev build.

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -512,7 +512,7 @@ impl PlanValidity {
 /// Configures a coordinator.
 pub struct Config {
     pub dataflow_client: mz_controller::Controller,
-    pub storage: mz_catalog::Connection,
+    pub storage: Box<dyn mz_catalog::DurableCatalogState>,
     pub unsafe_mode: bool,
     pub all_features: bool,
     pub build_info: &'static BuildInfo,

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+async-trait = "0.1.68"
 futures = "0.3.25"
 itertools = "0.10.5"
 once_cell = "1.16.0"
@@ -25,6 +26,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
+postgres-openssl = { version = "0.5.0" }
 serde = "1.0.152"
 serde_json = "1.0.89"
 tracing = "0.1.37"

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -180,7 +180,7 @@ pub struct BootstrapArgs {
 #[async_trait]
 pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// Reports if the catalog state has been initialized.
-    async fn is_initialized(&self) -> Result<bool, Error>;
+    async fn is_initialized(&mut self) -> Result<bool, Error>;
 
     // TODO(jkosh44) add and implement open methods to be implementation agnostic.
     /*   /// Checks to see if opening the catalog would be
@@ -286,8 +286,9 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
         self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
 
-    /// Dumps the entire catalog contents in human readable JSON.
-    async fn dump(&self) -> Result<String, Error>;
+    // TODO(jkosh44) Implement this for the catalog debug tool.
+    /*    /// Dumps the entire catalog contents in human readable JSON.
+    async fn dump(&self) -> Result<String, Error>;*/
 }
 
 /// A read-write API for the durable catalog state.
@@ -348,7 +349,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     ) -> Result<(), Error>;
 
     /// Persist new global timestamp for a timeline.
-    async fn persist_timestamp(
+    async fn set_timestamp(
         &mut self,
         timeline: &Timeline,
         timestamp: mz_repr::Timestamp,

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -198,9 +198,6 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// it will fail to open in read only mode.
     async fn open_read_only(&mut self) -> Result<(), Error>;*/
 
-    /// Returns true if the catalog is opened in read only mode, false otherwise.
-    fn is_read_only(&self) -> bool;
-
     /// Returns the epoch of the current durable catalog state. The epoch acts as
     /// a fencing token to prevent split brain issues across two
     /// [`DurableCatalogState`]s. When a new [`DurableCatalogState`] opens the
@@ -300,6 +297,9 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /*/// Opens the catalog in a writeable mode. Initializes the
     /// catalog, if it is uninitialized, and executes migrations.
     async fn open(&mut self) -> Result<(), Error>;*/
+
+    /// Returns true if the catalog is opened in read only mode, false otherwise.
+    fn is_read_only(&self) -> bool;
 
     /// Creates a new durable catalog state transaction.
     async fn transaction(&mut self) -> Result<Transaction, Error>;

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -82,7 +82,7 @@
 use async_trait::async_trait;
 use std::collections::BTreeMap;
 use std::fmt;
-use std::fmt::Formatter;
+use std::fmt::{Debug, Formatter};
 use std::num::NonZeroI64;
 use std::time::Duration;
 
@@ -178,7 +178,7 @@ pub struct BootstrapArgs {
 
 /// A read only API for the durable catalog state.
 #[async_trait]
-pub trait ReadOnlyDurableCatalogState {
+pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// Reports if the catalog state has been initialized.
     async fn is_initialized(&self) -> Result<bool, Error>;
 
@@ -197,6 +197,9 @@ pub trait ReadOnlyDurableCatalogState {
     /// If the catalog is uninitialized or requires a migrations, then
     /// it will fail to open in read only mode.
     async fn open_read_only(&mut self) -> Result<(), Error>;*/
+
+    /// Returns true if the catalog is opened in read only mode, false otherwise.
+    fn is_read_only(&self) -> bool;
 
     /// Returns the epoch of the current durable catalog state. The epoch acts as
     /// a fencing token to prevent split brain issues across two

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -215,6 +215,8 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     fn epoch(&mut self) -> Option<NonZeroI64>;
 
     /// Returns the version of Materialize that last wrote to the catalog.
+    ///
+    /// If the catalog is uninitialized this will return None.
     async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error>;
 
     /// Get all clusters.

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -234,10 +234,11 @@ pub trait ReadOnlyDurableCatalogState {
     /// Returns (index-name, global-id).
     async fn get_introspection_source_indexes(
         &mut self,
+        cluster_id: ClusterId,
     ) -> Result<BTreeMap<String, GlobalId>, Error>;
 
     /// Get all roles.
-    async fn get_roles(&mut self) -> Result<Vec<Schema>, Error>;
+    async fn get_roles(&mut self) -> Result<Vec<Role>, Error>;
 
     /// Get all default privileges.
     async fn get_default_privileges(
@@ -267,7 +268,7 @@ pub trait ReadOnlyDurableCatalogState {
     ) -> Result<Option<mz_repr::Timestamp>, Error>;
 
     /// Get all audit log events.
-    async fn get_audit_log(&mut self) -> Result<Vec<VersionedEvent>, Error>;
+    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, Error>;
 
     /// Get the next ID of `id_type`, without allocating it.
     async fn get_next_id(&mut self, id_type: &str) -> Result<u64, Error>;
@@ -295,7 +296,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     async fn open(&mut self) -> Result<(), Error>;*/
 
     /// Creates a new durable catalog state transaction.
-    async fn transaction(&mut self) -> Transaction;
+    async fn transaction(&mut self) -> Result<Transaction, Error>;
 
     /// Commits a durable catalog state transaction.
     async fn commit_transaction(&mut self, txn_batch: TransactionBatch) -> Result<(), Error>;
@@ -320,7 +321,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     ) -> Result<Vec<VersionedStorageUsage>, Error>;
 
     /// Persist system items.
-    fn set_system_items(&mut self, mappings: Vec<SystemObjectMapping>) -> Result<(), Error>;
+    async fn set_system_items(&mut self, mappings: Vec<SystemObjectMapping>) -> Result<(), Error>;
 
     /// Persist introspection source indexes.
     ///

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -312,6 +312,19 @@ pub struct Item {
     pub privileges: Vec<MzAclItem>,
 }
 
+#[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
+pub struct SystemObjectDescription {
+    pub schema_name: String,
+    pub object_type: CatalogItemType,
+    pub object_name: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct SystemObjectUniqueIdentifier {
+    pub id: GlobalId,
+    pub fingerprint: String,
+}
+
 /// Functions can share the same name as any other catalog item type
 /// within a given schema.
 /// For example, a function can have the same name as a type, e.g.
@@ -321,11 +334,8 @@ pub struct Item {
 /// to be unique.
 #[derive(Debug, Clone)]
 pub struct SystemObjectMapping {
-    pub schema_name: String,
-    pub object_type: CatalogItemType,
-    pub object_name: String,
-    pub id: GlobalId,
-    pub fingerprint: String,
+    pub description: SystemObjectDescription,
+    pub unique_identifier: SystemObjectUniqueIdentifier,
 }
 
 // Structs used internally to represent on disk-state.

--- a/src/catalog/src/stash.rs
+++ b/src/catalog/src/stash.rs
@@ -193,11 +193,11 @@ impl Connection {
         Ok(conn)
     }
 
-    pub async fn set_connect_timeout(&mut self, connect_timeout: Duration) {
+    async fn set_connect_timeout(&mut self, connect_timeout: Duration) {
         self.stash.set_connect_timeout(connect_timeout).await;
     }
 
-    pub fn is_read_only(&self) -> bool {
+    fn is_read_only(&self) -> bool {
         self.stash.is_readonly()
     }
 
@@ -226,17 +226,17 @@ impl Connection {
             .map_err(|e| e.into())
     }
 
-    pub async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error> {
+    async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error> {
         self.get_setting("catalog_content_version").await
     }
 
-    pub async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), Error> {
+    async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), Error> {
         self.set_setting("catalog_content_version", new_version)
             .await
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_databases(&mut self) -> Result<Vec<Database>, Error> {
+    async fn load_databases(&mut self) -> Result<Vec<Database>, Error> {
         let entries = DATABASES_COLLECTION.peek_one(&mut self.stash).await?;
         let databases = entries
             .into_iter()
@@ -253,7 +253,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_schemas(&mut self) -> Result<Vec<Schema>, Error> {
+    async fn load_schemas(&mut self) -> Result<Vec<Schema>, Error> {
         let entries = SCHEMAS_COLLECTION.peek_one(&mut self.stash).await?;
         let schemas = entries
             .into_iter()
@@ -271,7 +271,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_roles(&mut self) -> Result<Vec<Role>, Error> {
+    async fn load_roles(&mut self) -> Result<Vec<Role>, Error> {
         let entries = ROLES_COLLECTION.peek_one(&mut self.stash).await?;
         let roles = entries
             .into_iter()
@@ -288,7 +288,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_clusters(&mut self) -> Result<Vec<Cluster>, Error> {
+    async fn load_clusters(&mut self) -> Result<Vec<Cluster>, Error> {
         let entries = CLUSTER_COLLECTION.peek_one(&mut self.stash).await?;
         let clusters = entries
             .into_iter()
@@ -307,7 +307,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, Error> {
+    async fn load_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, Error> {
         let entries = CLUSTER_REPLICA_COLLECTION.peek_one(&mut self.stash).await?;
         let replicas = entries
             .into_iter()
@@ -327,7 +327,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_audit_log(&mut self) -> Result<impl Iterator<Item = VersionedEvent>, Error> {
+    async fn load_audit_log(&mut self) -> Result<impl Iterator<Item = VersionedEvent>, Error> {
         let entries = AUDIT_LOG_COLLECTION.peek_one(&mut self.stash).await?;
         let logs: Vec<_> = entries
             .into_keys()
@@ -341,7 +341,7 @@ impl Connection {
     /// Loads storage usage events and permanently deletes from the stash those
     /// that happened more than the retention period ago from boot_ts.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn fetch_and_prune_storage_usage(
+    async fn fetch_and_prune_storage_usage(
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
@@ -383,7 +383,7 @@ impl Connection {
 
     /// Load the persisted mapping of system object to global ID. Key is (schema-name, object-name).
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_system_gids(
+    async fn load_system_gids(
         &mut self,
     ) -> Result<BTreeMap<(String, CatalogItemType, String), (GlobalId, String)>, Error> {
         let entries = SYSTEM_GID_MAPPING_COLLECTION
@@ -404,7 +404,7 @@ impl Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_introspection_source_index_gids(
+    async fn load_introspection_source_index_gids(
         &mut self,
         cluster_id: ClusterId,
     ) -> Result<BTreeMap<String, GlobalId>, Error> {
@@ -433,7 +433,7 @@ impl Connection {
 
     /// Load the persisted default privileges.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_default_privileges(
+    async fn load_default_privileges(
         &mut self,
     ) -> Result<Vec<(DefaultPrivilegeObject, DefaultPrivilegeAclItem)>, Error> {
         Ok(DEFAULT_PRIVILEGES_COLLECTION
@@ -457,7 +457,7 @@ impl Connection {
 
     /// Load the persisted system privileges.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_system_privileges(&mut self) -> Result<Vec<MzAclItem>, Error> {
+    async fn load_system_privileges(&mut self) -> Result<Vec<MzAclItem>, Error> {
         Ok(SYSTEM_PRIVILEGES_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -475,7 +475,7 @@ impl Connection {
 
     /// Load the persisted server configurations.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_system_configuration(&mut self) -> Result<BTreeMap<String, String>, Error> {
+    async fn load_system_configuration(&mut self) -> Result<BTreeMap<String, String>, Error> {
         SYSTEM_CONFIGURATION_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -486,7 +486,7 @@ impl Connection {
 
     /// Load all comments.
     #[tracing::instrument(level = "info", skip_all)]
-    pub async fn load_comments(
+    async fn load_comments(
         &mut self,
     ) -> Result<Vec<(CommentObjectId, Option<usize>, String)>, Error> {
         let comments = COMMENTS_COLLECTION
@@ -503,7 +503,7 @@ impl Connection {
     /// Persist mapping from system objects to global IDs and fingerprints.
     ///
     /// Panics if provided id is not a system id.
-    pub async fn set_system_object_mapping(
+    async fn set_system_object_mapping(
         &mut self,
         mappings: Vec<SystemObjectMapping>,
     ) -> Result<(), Error> {
@@ -539,7 +539,7 @@ impl Connection {
     }
 
     /// Panics if provided id is not a system id
-    pub async fn set_introspection_source_index_gids(
+    async fn set_introspection_source_index_gids(
         &mut self,
         mappings: Vec<(ClusterId, &str, GlobalId)>,
     ) -> Result<(), Error> {
@@ -572,7 +572,7 @@ impl Connection {
 
     /// Set the configuration of a replica.
     /// This accepts only one item, as we currently use this only for the default cluster
-    pub async fn set_replica_config(
+    async fn set_replica_config(
         &mut self,
         replica_id: ReplicaId,
         cluster_id: ClusterId,
@@ -594,43 +594,43 @@ impl Connection {
         Ok(())
     }
 
-    pub async fn allocate_system_ids(&mut self, amount: u64) -> Result<Vec<GlobalId>, Error> {
+    async fn allocate_system_ids(&mut self, amount: u64) -> Result<Vec<GlobalId>, Error> {
         let id = self.allocate_id("system", amount).await?;
 
         Ok(id.into_iter().map(GlobalId::System).collect())
     }
 
-    pub async fn allocate_user_id(&mut self) -> Result<GlobalId, Error> {
+    async fn allocate_user_id(&mut self) -> Result<GlobalId, Error> {
         let id = self.allocate_id("user", 1).await?;
         let id = id.into_element();
         Ok(GlobalId::User(id))
     }
 
-    pub async fn allocate_system_cluster_id(&mut self) -> Result<ClusterId, Error> {
+    async fn allocate_system_cluster_id(&mut self) -> Result<ClusterId, Error> {
         let id = self.allocate_id(SYSTEM_CLUSTER_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ClusterId::System(id))
     }
 
-    pub async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, Error> {
+    async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, Error> {
         let id = self.allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ClusterId::User(id))
     }
 
-    pub async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, Error> {
+    async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, Error> {
         let id = self.allocate_id(USER_REPLICA_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ReplicaId::User(id))
     }
 
     /// Get the next system replica id without allocating it.
-    pub async fn get_next_system_replica_id(&mut self) -> Result<u64, Error> {
+    async fn get_next_system_replica_id(&mut self) -> Result<u64, Error> {
         self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await
     }
 
     /// Get the next user replica id without allocating it.
-    pub async fn get_next_user_replica_id(&mut self) -> Result<u64, Error> {
+    async fn get_next_user_replica_id(&mut self) -> Result<u64, Error> {
         self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
 
@@ -673,7 +673,7 @@ impl Connection {
     /// Gets a global timestamp for a timeline that has been persisted to disk.
     ///
     /// Returns `None` if no persisted timestamp for the specified timeline exists.
-    pub async fn try_get_persisted_timestamp(
+    async fn try_get_persisted_timestamp(
         &mut self,
         timeline: &Timeline,
     ) -> Result<Option<mz_repr::Timestamp>, Error> {
@@ -690,7 +690,7 @@ impl Connection {
     }
 
     /// Get all global timestamps that has been persisted to disk.
-    pub async fn get_all_persisted_timestamps(
+    async fn get_all_persisted_timestamps(
         &mut self,
     ) -> Result<BTreeMap<Timeline, mz_repr::Timestamp>, Error> {
         let entries = TIMESTAMP_COLLECTION.peek_one(&mut self.stash).await?;
@@ -707,7 +707,7 @@ impl Connection {
 
     /// Persist new global timestamp for a timeline to disk.
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn persist_timestamp(
+    async fn persist_timestamp(
         &mut self,
         timeline: &Timeline,
         timestamp: mz_repr::Timestamp,
@@ -726,7 +726,7 @@ impl Connection {
         Ok(())
     }
 
-    pub async fn persist_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), Error> {
+    async fn persist_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), Error> {
         CONFIG_COLLECTION
             .upsert_key(
                 &mut self.stash,
@@ -745,7 +745,7 @@ impl Connection {
 
     /// Creates a new [`Transaction`].
     #[tracing::instrument(name = "storage::transaction", level = "debug", skip_all)]
-    pub async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
+    async fn transaction<'a>(&'a mut self) -> Result<Transaction<'a>, Error> {
         let (
             databases,
             schemas,
@@ -818,11 +818,11 @@ impl Connection {
     }
 
     /// Confirms that this [`Connection`] is connected as the stash leader.
-    pub async fn confirm_leadership(&mut self) -> Result<(), Error> {
+    async fn confirm_leadership(&mut self) -> Result<(), Error> {
         Ok(self.stash.confirm_leadership().await?)
     }
 
-    pub(crate) async fn commit(&mut self, txn_batch: TransactionBatch) -> Result<(), Error> {
+    async fn commit(&mut self, txn_batch: TransactionBatch) -> Result<(), Error> {
         async fn add_batch<'tx, K, V>(
             tx: &'tx mz_stash::Transaction<'tx>,
             batches: &mut Vec<AppendBatch>,
@@ -957,6 +957,10 @@ impl Connection {
 impl ReadOnlyDurableCatalogState for Connection {
     async fn is_initialized(&self) -> Result<bool, Error> {
         Connection::is_initialized(self).await
+    }
+
+    fn is_read_only(&self) -> bool {
+        Connection::is_read_only(self)
     }
 
     fn is_read_only(&self) -> bool {

--- a/src/catalog/src/transaction.rs
+++ b/src/catalog/src/transaction.rs
@@ -807,14 +807,14 @@ impl<'a> Transaction<'a> {
     ) -> Result<(), Error> {
         let n = self.system_gid_mapping.update(|_k, v| {
             if let Some(mapping) = mappings.get(&GlobalId::System(v.id)) {
-                let id = if let GlobalId::System(id) = mapping.id {
+                let id = if let GlobalId::System(id) = mapping.unique_identifier.id {
                     id
                 } else {
                     panic!("non-system id provided")
                 };
                 Some(GidMappingValue {
                     id,
-                    fingerprint: mapping.fingerprint.clone(),
+                    fingerprint: mapping.unique_identifier.fingerprint.clone(),
                 })
             } else {
                 None

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -493,7 +493,7 @@ impl Listeners {
         let segment_client = config.segment_api_key.map(mz_segment::Client::new);
         let (adapter_handle, adapter_client) = mz_adapter::serve(mz_adapter::Config {
             dataflow_client: controller,
-            storage: adapter_storage,
+            storage: Box::new(adapter_storage),
             unsafe_mode: config.unsafe_mode,
             all_features: config.all_features,
             build_info: &BUILD_INFO,

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -482,7 +482,7 @@ impl Usage {
         let secrets_reader = Arc::new(InMemorySecretsController::new());
 
         let (_catalog, _, _, last_catalog_version) = Catalog::open(Config {
-            storage,
+            storage: Box::new(storage),
             unsafe_mode: true,
             all_features: false,
             build_info: &BUILD_INFO,


### PR DESCRIPTION
This commit adds a trait for durable catalog functionality and
implements it with the existing stash infrastructure. All struct fields
that used to use `mz_catalog::Connection` has been updated to use
`Box<dyn mz_catalog::DurableCatalogState>` and all method calls have
been updated to use the trait methods.

The catalog initialization and opening process has not been updated and
is still specific to the stash. A later commit will update this
process.

This commit is mostly code movement and doesn't have any significant
logic changes.

Works towards resolving #20953

### Motivation
This PR refactors existing code.

### Tips for reviewer
I've tried to break the changes up into individual commits for easier reviewing. When I merge the PR I'll squash them all into a single commit.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
