### PR TITLE
ci: Disable parallel execution of Platform Checks in CI

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -401,6 +401,7 @@ steps:
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
@@ -412,6 +413,7 @@ steps:
 
   - id: checks-parallel-restart-clusterd-compute
     label: "Checks parallel + restart compute clusterd"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
@@ -423,6 +425,7 @@ steps:
 
   - id: checks-parallel-restart-entire-mz
     label: "Checks parallel + restart of the entire Mz"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
@@ -445,6 +448,7 @@ steps:
 
   - id: checks-parallel-kill-clusterd-storage
     label: "Checks parallel + kill storage clusterd"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
@@ -456,6 +460,7 @@ steps:
 
   - id: checks-parallel-restart-redpanda
     label: "Checks parallel + restart Redpanda & Debezium"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64

--- a/misc/python/materialize/checks/owners.py
+++ b/misc/python/materialize/checks/owners.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
-from materialize.checks.executors import Executor, MzcomposeExecutorParallel
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
@@ -116,10 +116,7 @@ class Owners(Check):
 
     def _can_run(self, e: Executor) -> bool:
         # Object owner changes weren't persisted in some cases earlier than 0.63.0.
-        # ALTER SET OWNER hangs in parallel mode - #21317
-        return self.base_version >= MzVersion.parse("0.63.0-dev") and not isinstance(
-            e, MzcomposeExecutorParallel
-        )
+        return self.base_version >= MzVersion.parse("0.63.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/privileges.py
+++ b/misc/python/materialize/checks/privileges.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
-from materialize.checks.executors import Executor, MzcomposeExecutorParallel
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
@@ -123,10 +123,7 @@ class Privileges(Check):
 
     def _can_run(self, e: Executor) -> bool:
         # Privilege changes weren't persisted in some cases earlier than 0.63.0.
-        # GRANT ALL PRIVILEGES hangs in parallel mode - #21317
-        return self.base_version >= MzVersion.parse("0.63.0-dev") and not isinstance(
-            e, MzcomposeExecutorParallel
-        )
+        return self.base_version >= MzVersion.parse("0.63.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/statement_logging.py
+++ b/misc/python/materialize/checks/statement_logging.py
@@ -10,11 +10,12 @@ from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.util import MzVersion
 
 
 class StatementLogging(Check):
-    def _can_run(self) -> bool:
+    def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion(0, 69, 0)
 
     def initialize(self) -> Testdrive:


### PR DESCRIPTION
Currently it hangs in multiple ways so disabling the running of individual Checks in a Parallel context was not effective.

So, remove the individual _can_run() methods added earlier and just skip the CI steps in Buildkite.

Relates to: #21317

### Motivation

Nightly CI kept failing.