### PR TITLE
pycheck: Run npx with --yes

### DIFF
--- a/bin/pycheck
+++ b/bin/pycheck
@@ -18,7 +18,7 @@ cd "$(dirname "$0")/.."
 . misc/shlib/shlib.bash
 
 pyright_version=$(sh ci/builder/pyright-version.sh)
-typecheck_cmd="npx pyright@$pyright_version"
+typecheck_cmd="npx --yes pyright@$pyright_version"
 
 python_folders=(ci misc/python)
 


### PR DESCRIPTION
Explicitly pass --yes to npx so that it does not block waiting for confirmation under certain curcumstances, such as when running `bin/ci-builder run stable bin/lint` locally.

### Motivation

If there is a terminal available and bin/ci-builder is used to run bin/lint, npx will block waiting for confirmation to install pyright.