### PR TITLE
adapter: add more LaunchDarkly contexts

### DIFF
--- a/src/adapter/src/config/mod.rs
+++ b/src/adapter/src/config/mod.rs
@@ -9,6 +9,7 @@
 
 use std::collections::BTreeMap;
 
+use mz_build_info::BuildInfo;
 use mz_ore::metric;
 use mz_ore::metrics::{MetricsRegistry, UIntGauge};
 use mz_ore::now::NowFn;
@@ -30,6 +31,8 @@ pub use sync::system_parameter_sync;
 pub struct SystemParameterSyncConfig {
     /// The environment ID that should identify connected clients.
     env_id: EnvironmentId,
+    /// Build info for the environment running this.
+    build_info: &'static BuildInfo,
     /// Parameter sync metrics.
     metrics: Metrics,
     /// Function to return the current time.
@@ -46,6 +49,7 @@ impl SystemParameterSyncConfig {
     /// Construct a new [SystemParameterFrontend] instance.
     pub fn new(
         env_id: EnvironmentId,
+        build_info: &'static BuildInfo,
         registry: &MetricsRegistry,
         now_fn: NowFn,
         ld_sdk_key: String,
@@ -53,6 +57,7 @@ impl SystemParameterSyncConfig {
     ) -> Self {
         Self {
             env_id,
+            build_info,
             metrics: Metrics::register_into(registry),
             now_fn,
             ld_sdk_key,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -504,6 +504,7 @@ impl Listeners {
         let system_parameter_sync_config = if let Some(ld_sdk_key) = config.launchdarkly_sdk_key {
             Some(SystemParameterSyncConfig::new(
                 config.environment_id.clone(),
+                &BUILD_INFO,
                 &config.metrics_registry,
                 config.now.clone(),
                 ld_sdk_key,


### PR DESCRIPTION
Change the `ld_ctx` contstructor function as follows:

- Build a multi-context LaunchDarkly context consisting of the old `environment` context and two new context types.
- Add an `organization` context identified by the Frontegg ID.
- Add a `build` context identified by the `BUILD_INFO` version and exposing `BuildInfo` attributes.

### Motivation

  * This PR adds a known-desirable feature.

- The console already uses the `organization` context type (since we want to unify our LD projects it would be good to align the context types).
- The `build` context type was requested by @umanwizard who wants to target by version.

### Tips for reviewer

Let's workshop if the above is sufficient for our needs. I will then extend the integration test to test the new context types.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
