### PR TITLE
transform: add `ColumnNames` attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5528,13 +5528,12 @@ dependencies = [
  "mz-ore",
  "mz-persist-client",
  "mz-repr",
- "num-derive",
  "num-traits",
  "ordered-float",
+ "paste",
  "proc-macro2",
  "serde_json",
  "tracing",
- "typemap_rev",
  "workspace-hack",
 ]
 
@@ -5651,17 +5650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "num-derive"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876a53fff98e03a936a674b29568b0e605f06b29372c2489ff4de23f1949743d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.107",
 ]
 
 [[package]]
@@ -8563,12 +8551,6 @@ dependencies = [
  "quote",
  "syn 1.0.107",
 ]
-
-[[package]]
-name = "typemap_rev"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74b08b0c1257381af16a5c3605254d529d3e7e109f3c62befc5d168968192998"
 
 [[package]]
 name = "typenum"

--- a/src/expr-parser/src/catalog.rs
+++ b/src/expr-parser/src/catalog.rs
@@ -19,7 +19,7 @@ use mz_repr::{GlobalId, RelationType, ScalarType};
 /// later.
 #[derive(Debug, Default)]
 pub struct TestCatalog {
-    objects: BTreeMap<String, (GlobalId, RelationType)>,
+    objects: BTreeMap<String, (GlobalId, Vec<String>, RelationType)>,
     names: BTreeMap<GlobalId, String>,
 }
 
@@ -35,6 +35,7 @@ impl<'a> TestCatalog {
     pub fn insert(
         &mut self,
         name: &str,
+        cols: Vec<String>,
         typ: RelationType,
         transient: bool,
     ) -> Result<GlobalId, String> {
@@ -46,12 +47,12 @@ impl<'a> TestCatalog {
         } else {
             GlobalId::User(u64::cast_from(self.objects.len()))
         };
-        self.objects.insert(name.to_string(), (id, typ));
+        self.objects.insert(name.to_string(), (id, cols, typ));
         self.names.insert(id, name.to_string());
         Ok(id)
     }
 
-    pub fn get(&'a self, name: &str) -> Option<&'a (GlobalId, RelationType)> {
+    pub fn get(&'a self, name: &str) -> Option<&'a (GlobalId, Vec<String>, RelationType)> {
         self.objects.get(name)
     }
 
@@ -63,7 +64,7 @@ impl<'a> TestCatalog {
     /// Clears all transient objects from the catalog.
     pub fn remove_transient_objects(&mut self) {
         self.objects
-            .retain(|_, (id, _)| !matches!(id, GlobalId::Transient(_)));
+            .retain(|_, (id, _, _)| !matches!(id, GlobalId::Transient(_)));
         self.names
             .retain(|k, _| !matches!(k, GlobalId::Transient(_)));
     }
@@ -82,8 +83,9 @@ impl ExprHumanizer for TestCatalog {
         DummyHumanizer.humanize_scalar_type(ty)
     }
 
-    fn column_names_for_id(&self, _id: GlobalId) -> Option<Vec<String>> {
-        None
+    fn column_names_for_id(&self, id: GlobalId) -> Option<Vec<String>> {
+        let src_name = self.get_source_name(&id)?;
+        self.objects.get(src_name).map(|(_, cols, _)| cols.clone())
     }
 
     fn id_exists(&self, id: GlobalId) -> bool {

--- a/src/expr-parser/src/command.rs
+++ b/src/expr-parser/src/command.rs
@@ -17,7 +17,7 @@ pub fn handle_define(catalog: &mut TestCatalog, input: &str) -> String {
     // Parse the relation, returning early on parse error.
     let result = match try_parse_def(catalog, input) {
         Ok(def) => match def {
-            Def::Source { name, typ } => match catalog.insert(&name, typ, true) {
+            Def::Source { name, cols, typ } => match catalog.insert(&name, cols, typ, true) {
                 Ok(id) => format!("Source defined as {id}"),
                 Err(err) => err,
             },

--- a/src/expr-parser/tests/test_mir_parser/simple_trees.spec
+++ b/src/expr-parser/tests/test_mir_parser/simple_trees.spec
@@ -13,17 +13,17 @@
 # Define t0 source
 define
 DefSource name=t0 keys=[[#0]]
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 

--- a/src/expr-parser/tests/test_mir_parser/with_ctes.spec
+++ b/src/expr-parser/tests/test_mir_parser/with_ctes.spec
@@ -13,8 +13,8 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 

--- a/src/transform/Cargo.toml
+++ b/src/transform/Cargo.toml
@@ -15,10 +15,9 @@ mz-ore = { path = "../ore" }
 mz-persist-client = { path = "../persist-client" }
 mz-repr = { path = "../repr", features = ["tracing_"] }
 num-traits = "0.2"
-num-derive = "0.3"
 ordered-float = { version = "3.4.0", features = ["serde"] }
+paste = "1.0.11"
 tracing = "0.1.37"
-typemap_rev = "0.3.0"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/transform/src/attribute/arity.rs
+++ b/src/transform/src/attribute/arity.rs
@@ -12,7 +12,7 @@
 use mz_expr::MirRelationExpr;
 
 use crate::attribute::subtree_size::SubtreeSize;
-use crate::attribute::{Attribute, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder};
 
 /// Compute the column types of each subtree of a [MirRelationExpr] from the
 /// bottom-up.
@@ -40,11 +40,11 @@ impl Attribute for Arity {
         self.results.push(subtree_arity);
     }
 
-    fn add_dependencies(builder: &mut RequiredAttributes)
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {
-        builder.require::<SubtreeSize>();
+        builder.require(SubtreeSize::default());
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/cardinality.rs
+++ b/src/transform/src/attribute/cardinality.rs
@@ -23,7 +23,7 @@ use ordered_float::OrderedFloat;
 
 use crate::attribute::subtree_size::SubtreeSize;
 use crate::attribute::unique_keys::UniqueKeys;
-use crate::attribute::{Attribute, DerivedAttributes, Env, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder, Env};
 use crate::symbolic::SymbolicExpression;
 
 use super::Arity;
@@ -501,13 +501,13 @@ impl Attribute for Cardinality {
         self.env.handle_tasks(&self.results);
     }
 
-    fn add_dependencies(builder: &mut RequiredAttributes)
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {
-        builder.require::<SubtreeSize>();
-        builder.require::<Arity>();
-        builder.require::<UniqueKeys>();
+        builder.require(SubtreeSize::default());
+        builder.require(Arity::default());
+        builder.require(UniqueKeys::default());
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/column_names.rs
+++ b/src/transform/src/attribute/column_names.rs
@@ -1,0 +1,267 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Definition and helper structs for the [`ColumnNames`] attribute.
+
+use std::ops::Range;
+
+use mz_expr::{Id, MirRelationExpr, MirScalarExpr};
+use mz_repr::explain::ExprHumanizer;
+
+use crate::attribute::subtree_size::SubtreeSize;
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder, Env};
+
+/// Compute the column types of each subtree of a [MirRelationExpr] from the
+/// bottom-up.
+#[allow(missing_debug_implementations)]
+pub struct ColumnNames<'c> {
+    humanizer: &'c dyn ExprHumanizer,
+    /// Environment of computed values for this attribute
+    env: Env<Self>,
+    /// A vector of results for all nodes in the visited tree in
+    /// post-visit order. An empty string denotes a missing value.
+    pub results: Vec<Vec<String>>,
+}
+
+impl<'c> ColumnNames<'c> {
+    /// Construct a new attribute instance.
+    pub fn new(humanizer: &'c dyn ExprHumanizer) -> Self {
+        Self {
+            humanizer,
+            env: Env::empty(),
+            results: Default::default(),
+        }
+    }
+
+    fn infer<'a, I>(&self, expr: &MirRelationExpr, mut input_results: I) -> Vec<String>
+    where
+        I: Iterator<Item = &'a Vec<String>>,
+    {
+        use MirRelationExpr::*;
+
+        match expr {
+            Constant { rows: _, typ } => {
+                // Fallback to an anonymous schema for constants.
+                ColumnNames::anonymous(0..typ.arity()).collect()
+            }
+            Get {
+                id: Id::Global(id),
+                typ,
+                access_strategy: _,
+            } => {
+                if let Some(column_names) = self.humanizer.column_names_for_id(*id) {
+                    column_names
+                } else {
+                    // Possible as some ExprHumanizer impls still return None.
+                    ColumnNames::anonymous(0..typ.arity()).collect()
+                }
+            }
+            Get {
+                id: Id::Local(id),
+                typ,
+                access_strategy: _,
+            } => {
+                if let Some(column_names) = self.env.get(id) {
+                    column_names.clone()
+                } else {
+                    // Possible because we infer LetRec bindings in order. This
+                    // can be improved by introducing a fixpoint loop in the
+                    // Env<A>::schedule_tasks LetRec handling block.
+                    ColumnNames::anonymous(0..typ.arity()).collect()
+                }
+            }
+            Let {
+                id: _,
+                value: _,
+                body: _,
+            } => {
+                // Return the column names of the `body`.
+                input_results.last().unwrap().clone()
+            }
+            LetRec {
+                ids: _,
+                values: _,
+                limits: _,
+                body: _,
+            } => {
+                // Return the column names of the `body`.
+                input_results.last().unwrap().clone()
+            }
+            Project { input: _, outputs } => {
+                // Permute the column names of the input.
+                let input_column_names = input_results.next().unwrap();
+                let mut column_names = vec![];
+                for col in outputs {
+                    column_names.push(input_column_names[*col].clone());
+                }
+                column_names
+            }
+            Map { input: _, scalars } => {
+                // Extend the column names of the input with anonymous columns.
+                let mut column_names = input_results.next().unwrap().clone();
+                ColumnNames::extend_with_scalars(&mut column_names, scalars);
+                column_names
+            }
+            FlatMap {
+                input: _,
+                func,
+                exprs: _,
+            } => {
+                // Extend the column names of the input with anonymous columns.
+                let mut column_names = input_results.next().unwrap().clone();
+                let func_output_start = column_names.len();
+                let func_output_end = column_names.len() + func.output_arity();
+                column_names.extend(ColumnNames::anonymous(func_output_start..func_output_end));
+                column_names
+            }
+            Filter {
+                input: _,
+                predicates: _,
+            } => {
+                // Return the column names of the `input`.
+                input_results.next().unwrap().clone()
+            }
+            Join {
+                inputs: _,
+                equivalences: _,
+                implementation: _,
+            } => {
+                let mut column_names = vec![];
+                for input_column_names in input_results {
+                    column_names.extend(input_column_names.iter().cloned());
+                }
+                column_names
+            }
+            Reduce {
+                input: _,
+                group_key,
+                aggregates,
+                monotonic: _,
+                expected_group_size: _,
+            } => {
+                // We clone and extend the input vector and then remove the part
+                // associated with the input at the end.
+                let mut column_names = input_results.next().unwrap().clone();
+                let input_arity = column_names.len();
+
+                // Infer the group key part.
+                ColumnNames::extend_with_scalars(&mut column_names, group_key);
+                // Infer the aggregates part.
+                let aggs_start = group_key.len();
+                let aggs_end = group_key.len() + aggregates.len();
+                column_names.extend(ColumnNames::anonymous(aggs_start..aggs_end));
+                // Remove the prefix associated with the input
+                column_names.drain(0..input_arity);
+
+                column_names
+            }
+            TopK {
+                input: _,
+                group_key: _,
+                order_key: _,
+                limit: _,
+                offset: _,
+                monotonic: _,
+                expected_group_size: _,
+            } => {
+                // Return the column names of the `input`.
+                input_results.next().unwrap().clone()
+            }
+            Negate { input: _ } => {
+                // Return the column names of the `input`.
+                input_results.next().unwrap().clone()
+            }
+            Threshold { input: _ } => {
+                // Return the column names of the `input`.
+                input_results.next().unwrap().clone()
+            }
+            Union { base: _, inputs: _ } => {
+                // Use the first non-empty column across all inputs.
+                let mut column_names = vec![];
+
+                let base_results = input_results.next().unwrap();
+                let inputs_results = input_results.collect::<Vec<_>>();
+
+                for (i, mut column_name) in base_results.iter().cloned().enumerate() {
+                    for input_results in inputs_results.iter() {
+                        if column_name.is_empty() && !input_results[i].is_empty() {
+                            column_name = input_results[i].clone();
+                            break;
+                        }
+                    }
+                    column_names.push(column_name);
+                }
+
+                column_names
+            }
+            ArrangeBy { input: _, keys: _ } => {
+                // Return the column names of the `input`.
+                input_results.next().unwrap().clone()
+            }
+        }
+    }
+
+    /// fallback schema consisting of ordinal column names: #0, #1, ...
+    fn anonymous(range: Range<usize>) -> impl Iterator<Item = String> {
+        range.map(|_| String::new())
+    }
+
+    /// fallback schema consisting of ordinal column names: #0, #1, ...
+    fn extend_with_scalars(column_names: &mut Vec<String>, scalars: &Vec<MirScalarExpr>) {
+        for scalar in scalars {
+            column_names.push(match scalar {
+                MirScalarExpr::Column(c) => column_names[*c].clone(),
+                _ => String::new(),
+            });
+        }
+    }
+}
+
+impl<'a> Attribute for ColumnNames<'a> {
+    type Value = Vec<String>;
+
+    fn derive(&mut self, expr: &MirRelationExpr, deps: &DerivedAttributes) {
+        let n = self.results.len();
+        let mut offsets = Vec::new();
+        let mut offset = 1;
+        for _ in 0..expr.num_inputs() {
+            offsets.push(n - offset);
+            offset += &deps.get_results::<SubtreeSize>()[n - offset];
+        }
+        let input_schemas = offsets.into_iter().rev().map(|o| &self.results[o]);
+        self.results.push(self.infer(expr, input_schemas));
+    }
+
+    fn schedule_env_tasks(&mut self, expr: &MirRelationExpr) {
+        self.env.schedule_tasks(expr);
+    }
+
+    fn handle_env_tasks(&mut self) {
+        self.env.handle_tasks(&self.results);
+    }
+
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
+    where
+        Self: Sized,
+    {
+        builder.require(SubtreeSize::default());
+    }
+
+    fn get_results(&self) -> &Vec<Self::Value> {
+        &self.results
+    }
+
+    fn get_results_mut(&mut self) -> &mut Vec<Self::Value> {
+        &mut self.results
+    }
+
+    fn take(self) -> Vec<Self::Value> {
+        self.results
+    }
+}

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -10,7 +10,6 @@
 //! Derived attributes framework and definitions.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::marker::PhantomData;
 
 use mz_expr::explain::ExplainContext;
 use mz_expr::visit::{Visit, Visitor};
@@ -18,21 +17,20 @@ use mz_expr::{LocalId, MirRelationExpr};
 use mz_ore::stack::RecursionLimitError;
 use mz_ore::str::{bracketed, separated};
 use mz_repr::explain::{AnnotatedPlan, Attributes, ExplainConfig};
-use num_traits::FromPrimitive;
-use typemap_rev::{TypeMap, TypeMapKey};
+
+mod arity;
+pub mod cardinality;
+mod non_negative;
+mod relation_type;
+mod subtree_size;
+mod unique_keys;
 
 // Attributes should have shortened paths when exported.
-mod arity;
 pub use arity::Arity;
-pub mod cardinality;
 pub use cardinality::Cardinality;
-mod non_negative;
 pub use non_negative::NonNegative;
-mod relation_type;
 pub use relation_type::RelationType;
-mod subtree_size;
 pub use subtree_size::SubtreeSize;
-mod unique_keys;
 pub use unique_keys::UniqueKeys;
 
 /// A common interface to be implemented by all derived attributes.
@@ -66,14 +64,6 @@ pub trait Attribute: 'static + Default + Send + Sync {
 
     /// Consume self and return the attributes for each subexpression.
     fn take(self) -> Vec<Self::Value>;
-}
-
-#[allow(missing_debug_implementations)]
-/// Converts an Attribute into a Key that can be looked up in [DerivedAttributes]
-struct AsKey<A: Attribute>(PhantomData<A>);
-
-impl<A: Attribute + 'static> TypeMapKey for AsKey<A> {
-    type Value = A;
 }
 
 /// A map that keeps the computed `A` values for all `LocalId`
@@ -229,23 +219,27 @@ impl EnvTask {
 #[derive(Default)]
 /// Builds an [DerivedAttributes]
 pub struct RequiredAttributes {
-    attributes: TypeMap,
+    attributes: Box<AttributeStore>,
 }
 
 impl RequiredAttributes {
     /// Add an attribute that [DerivedAttributes] should derive
-    pub fn require<A: Attribute>(&mut self) {
-        if !self.attributes.contains_key::<AsKey<A>>() {
+    pub fn require<A>(&mut self)
+    where
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
+    {
+        if !self.attributes.attribute_is_enabled() {
             A::add_dependencies(self);
-            self.attributes.insert::<AsKey<A>>(A::default());
+            self.attributes.push_attribute(A::default());
         }
     }
 
     /// Consume `self`, producing an [DerivedAttributes]
     pub fn finish(self) -> DerivedAttributes {
         DerivedAttributes {
-            attributes: Box::new(self.attributes),
-            to_be_derived: Box::new(TypeMap::default()),
+            store: self.attributes,
+            buffer: Box::new(AttributeStore::default()),
         }
     }
 }
@@ -256,10 +250,12 @@ impl RequiredAttributes {
 /// Can be constructed either manually from an [RequiredAttributes] or directly
 /// from an [ExplainConfig].
 pub struct DerivedAttributes {
-    attributes: Box<TypeMap>,
-    /// Holds attributes that have not yet been derived for a given
-    /// subexpression.
-    to_be_derived: Box<TypeMap>,
+    /// Holds the attributes derived for all subexpressions so far.
+    store: Box<AttributeStore>,
+    /// A buffer to be used for the next subexpresion. For every subexpressions
+    /// we swap the `store` and `buffer` state and then process items from
+    /// `buffer` one by one, moving them back to `store`.
+    buffer: Box<AttributeStore>,
 }
 
 impl From<&ExplainConfig> for DerivedAttributes {
@@ -289,26 +285,35 @@ impl From<&ExplainConfig> for DerivedAttributes {
 
 impl DerivedAttributes {
     /// Get a reference to the attributes derived so far.
-    pub fn get_results<A: Attribute>(&self) -> &Vec<A::Value> {
-        self.attributes.get::<AsKey<A>>().unwrap().get_results()
+    pub fn get_results<A>(&self) -> &Vec<A::Value>
+    where
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
+    {
+        self.store.get_attribute().unwrap().get_results()
     }
 
     /// Get a mutable reference to the attributes derived so far.
     ///
     /// Calling this and modifying the result risks messing up subsequent
     /// derivations.
-    pub fn get_results_mut<A: Attribute>(&mut self) -> &mut Vec<A::Value> {
-        self.attributes
-            .get_mut::<AsKey<A>>()
-            .unwrap()
-            .get_results_mut()
+    pub fn get_results_mut<A>(&mut self) -> &mut Vec<A::Value>
+    where
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
+    {
+        self.store.get_mut_attribute().unwrap().get_results_mut()
     }
 
     /// Extract the vector of attributes derived so far
     ///
     /// After this call, no further attributes of this type will be derived.
-    pub fn remove_results<A: Attribute>(&mut self) -> Vec<A::Value> {
-        self.attributes.remove::<AsKey<A>>().unwrap().take()
+    pub fn remove_results<A>(&mut self) -> Vec<A::Value>
+    where
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
+    {
+        self.store.take_attribute().unwrap().take()
     }
 
     /// Call when the most recently exited node of the [MirRelationExpr]
@@ -316,125 +321,145 @@ impl DerivedAttributes {
     ///
     /// For each attribute, removes the last value derived.
     pub fn trim(&mut self) {
-        for i in 0..TOTAL_ATTRIBUTES {
-            match FromPrimitive::from_usize(i) {
-                Some(AttributeId::SubtreeSize) => self.trim_attr::<AsKey<SubtreeSize>>(),
-                Some(AttributeId::NonNegative) => self.trim_attr::<AsKey<NonNegative>>(),
-                Some(AttributeId::RelationType) => self.trim_attr::<AsKey<RelationType>>(),
-                Some(AttributeId::Arity) => self.trim_attr::<AsKey<Arity>>(),
-                Some(AttributeId::UniqueKeys) => self.trim_attr::<AsKey<UniqueKeys>>(),
-                Some(AttributeId::Cardinality) => self.trim_attr::<AsKey<Cardinality>>(),
-                None => {}
-            }
-        }
+        self.trim_attr::<SubtreeSize>();
+        self.trim_attr::<NonNegative>();
+        self.trim_attr::<RelationType>();
+        self.trim_attr::<Arity>();
+        self.trim_attr::<UniqueKeys>();
+        self.trim_attr::<Cardinality>();
     }
 }
 
 impl Visitor<MirRelationExpr> for DerivedAttributes {
     /// Does derivation work required upon entering a subexpression.
     fn pre_visit(&mut self, expr: &MirRelationExpr) {
-        for i in 0..TOTAL_ATTRIBUTES {
-            match FromPrimitive::from_usize(i) {
-                Some(AttributeId::SubtreeSize) => {
-                    self.pre_visit_attr::<AsKey<SubtreeSize>>(expr);
-                }
-                Some(AttributeId::NonNegative) => {
-                    self.pre_visit_attr::<AsKey<NonNegative>>(expr);
-                }
-                Some(AttributeId::RelationType) => {
-                    self.pre_visit_attr::<AsKey<RelationType>>(expr);
-                }
-                Some(AttributeId::Arity) => {
-                    self.pre_visit_attr::<AsKey<Arity>>(expr);
-                }
-                Some(AttributeId::UniqueKeys) => {
-                    self.pre_visit_attr::<AsKey<UniqueKeys>>(expr);
-                }
-                Some(AttributeId::Cardinality) => {
-                    self.pre_visit_attr::<AsKey<Cardinality>>(expr);
-                }
-                None => {}
-            }
-        }
+        // The `pre_visit` methods must be called in dependency order!
+        self.pre_visit::<SubtreeSize>(expr);
+        self.pre_visit::<NonNegative>(expr);
+        self.pre_visit::<RelationType>(expr);
+        self.pre_visit::<Arity>(expr);
+        self.pre_visit::<UniqueKeys>(expr);
+        self.pre_visit::<Cardinality>(expr);
     }
 
     /// Does derivation work required upon exiting a subexpression.
     fn post_visit(&mut self, expr: &MirRelationExpr) {
-        std::mem::swap(&mut self.attributes, &mut self.to_be_derived);
-        for i in 0..TOTAL_ATTRIBUTES {
-            match FromPrimitive::from_usize(i) {
-                Some(AttributeId::SubtreeSize) => {
-                    self.post_visit_attr::<AsKey<SubtreeSize>>(expr);
-                }
-                Some(AttributeId::NonNegative) => {
-                    self.post_visit_attr::<AsKey<NonNegative>>(expr);
-                }
-                Some(AttributeId::RelationType) => {
-                    self.post_visit_attr::<AsKey<RelationType>>(expr);
-                }
-                Some(AttributeId::Arity) => {
-                    self.post_visit_attr::<AsKey<Arity>>(expr);
-                }
-                Some(AttributeId::UniqueKeys) => {
-                    self.post_visit_attr::<AsKey<UniqueKeys>>(expr);
-                }
-                Some(AttributeId::Cardinality) => {
-                    self.post_visit_attr::<AsKey<Cardinality>>(expr);
-                }
-                None => {}
-            }
-        }
+        std::mem::swap(&mut self.store, &mut self.buffer);
+        // The `post_visit` methods must be called in dependency order!
+        self.post_visit::<SubtreeSize>(expr);
+        self.post_visit::<NonNegative>(expr);
+        self.post_visit::<RelationType>(expr);
+        self.post_visit::<Arity>(expr);
+        self.post_visit::<UniqueKeys>(expr);
+        self.post_visit::<Cardinality>(expr);
     }
 }
 
 impl DerivedAttributes {
-    fn pre_visit_attr<T: TypeMapKey>(&mut self, expr: &MirRelationExpr)
+    fn pre_visit<A>(&mut self, expr: &MirRelationExpr)
     where
-        T::Value: Attribute,
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
     {
-        if let Some(attr) = self.attributes.get_mut::<T>() {
+        if let Some(attr) = self.store.get_mut_attribute() {
             attr.schedule_env_tasks(expr)
         }
     }
 
-    fn post_visit_attr<T: TypeMapKey>(&mut self, expr: &MirRelationExpr)
+    fn post_visit<A>(&mut self, expr: &MirRelationExpr)
     where
-        T::Value: Attribute,
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
     {
-        if let Some(mut attr) = self.to_be_derived.remove::<T>() {
+        if let Some(mut attr) = self.buffer.take_attribute() {
             attr.derive(expr, self);
             attr.handle_env_tasks();
-            self.attributes.insert::<T>(attr);
+            self.store.push_attribute(attr);
         }
     }
 
-    fn trim_attr<T: TypeMapKey>(&mut self)
+    fn trim_attr<A>(&mut self)
     where
-        T::Value: Attribute,
+        A: Attribute,
+        AttributeStore: AttributeContainer<A>,
     {
-        self.attributes.get_mut::<T>().iter_mut().for_each(|a| {
+        if let Some(a) = self.store.get_mut_attribute() {
             a.get_results_mut().pop();
-        });
+        };
     }
 }
 
-/// A topological sort of extant attributes.
-///
-/// The attribute assigned value 0 depends on no other attributes.
-/// We expect the attributes to be assigned numbers in the range
-/// 0..TOTAL_ATTRIBUTES with no gaps in between.
-#[derive(FromPrimitive)]
-enum AttributeId {
-    SubtreeSize = 0,
-    NonNegative = 1,
-    Arity = 2,
-    RelationType = 3,
-    UniqueKeys = 4,
-    Cardinality = 5,
+/// An API for manipulating the of type `A` an enclosing store.
+pub trait AttributeContainer<A: Attribute> {
+    /// Push the attribute to the store.
+    fn push_attribute(&mut self, value: A);
+
+    /// Take the attribute from the store, leaving its slot empty.
+    fn take_attribute(&mut self) -> Option<A>;
+
+    /// Check if the attribute is enabled.
+    fn attribute_is_enabled(&self) -> bool;
+
+    /// Get an immutable reference to the attribute.
+    fn get_attribute(&self) -> Option<&A>;
+
+    /// Get a mutable reference to the attribute.
+    fn get_mut_attribute(&mut self) -> Option<&mut A>;
 }
 
-/// Should always be equal to the number of attributes
-const TOTAL_ATTRIBUTES: usize = 6;
+/// A store of attribute derivation algorithms.
+///
+/// Values of `Some(attribute)` in the individual fields represent attributes
+/// that should be derived.
+///
+/// The definition order of the fields must respect dependencies (the first
+/// attribute cannot have dependencies, the second can only depend on the first,
+/// and so forth).
+#[allow(missing_debug_implementations)]
+#[derive(Default)]
+pub struct AttributeStore {
+    subtree_size: Option<SubtreeSize>,
+    non_negative: Option<NonNegative>,
+    arity: Option<Arity>,
+    relation_type: Option<RelationType>,
+    unique_keys: Option<UniqueKeys>,
+    cardinality: Option<Cardinality>,
+}
+
+macro_rules! attribute_store_container_for {
+    ($field:expr) => {
+        paste::paste! {
+            impl AttributeContainer<[<$field:camel>]> for AttributeStore {
+                fn push_attribute(&mut self, value: [<$field:camel>]) {
+                    self.$field = Some(value);
+                }
+
+                fn take_attribute(&mut self) -> Option<[<$field:camel>]> {
+                    std::mem::take(&mut self.$field)
+                }
+
+                fn attribute_is_enabled(&self) -> bool {
+                    self.$field.is_some()
+                }
+
+                fn get_attribute(&self) -> Option<&[<$field:camel>]> {
+                    self.$field.as_ref()
+                }
+
+                fn get_mut_attribute(&mut self) -> Option<&mut [<$field:camel>]> {
+                    self.$field.as_mut()
+                }
+            }
+        }
+    };
+}
+
+attribute_store_container_for!(subtree_size);
+attribute_store_container_for!(non_negative);
+attribute_store_container_for!(arity);
+attribute_store_container_for!(relation_type);
+attribute_store_container_for!(unique_keys);
+attribute_store_container_for!(cardinality);
 
 /// Produce an [`AnnotatedPlan`] wrapping the given [`MirRelationExpr`] along
 /// with [`Attributes`] derived from the given context configuration.

--- a/src/transform/src/attribute/non_negative.rs
+++ b/src/transform/src/attribute/non_negative.rs
@@ -12,7 +12,7 @@
 use mz_expr::{Id, MirRelationExpr};
 
 use crate::attribute::subtree_size::SubtreeSize;
-use crate::attribute::{Attribute, DerivedAttributes, Env, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder, Env};
 
 /// Traverses a [`MirRelationExpr`] tree and figures out whether for subtree
 /// the sum of all diffs up to a specific time for any record can be a
@@ -135,11 +135,11 @@ impl Attribute for NonNegative {
         self.env.handle_tasks(&self.results);
     }
 
-    fn add_dependencies(builder: &mut RequiredAttributes)
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {
-        builder.require::<SubtreeSize>();
+        builder.require(SubtreeSize::default());
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/relation_type.rs
+++ b/src/transform/src/attribute/relation_type.rs
@@ -13,7 +13,7 @@ use mz_expr::MirRelationExpr;
 use mz_repr::ColumnType;
 
 use crate::attribute::subtree_size::SubtreeSize;
-use crate::attribute::{Attribute, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder};
 
 /// Compute the column types of each subtree of a [MirRelationExpr] from the
 /// bottom-up.
@@ -49,11 +49,11 @@ impl Attribute for RelationType {
         }
     }
 
-    fn add_dependencies(builder: &mut RequiredAttributes)
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {
-        builder.require::<SubtreeSize>();
+        builder.require(SubtreeSize::default());
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/attribute/subtree_size.rs
+++ b/src/transform/src/attribute/subtree_size.rs
@@ -11,7 +11,7 @@
 
 use mz_expr::MirRelationExpr;
 
-use crate::attribute::{Attribute, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder};
 
 /// Compute the number of MirRelationExpr in each subtree in a bottom-up manner.
 #[derive(Default)]
@@ -104,7 +104,7 @@ impl Attribute for SubtreeSize {
         }
     }
 
-    fn add_dependencies(_builder: &mut RequiredAttributes)
+    fn add_dependencies(_builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {

--- a/src/transform/src/attribute/unique_keys.rs
+++ b/src/transform/src/attribute/unique_keys.rs
@@ -13,7 +13,7 @@ use mz_expr::MirRelationExpr;
 
 use crate::attribute::arity::Arity;
 use crate::attribute::subtree_size::SubtreeSize;
-use crate::attribute::{Attribute, DerivedAttributes, RequiredAttributes};
+use crate::attribute::{Attribute, DerivedAttributes, DerivedAttributesBuilder};
 
 /// Compute the unique keys of each subtree of a [MirRelationExpr] from the
 /// bottom-up.
@@ -49,12 +49,12 @@ impl Attribute for UniqueKeys {
         self.results.push(subtree_keys);
     }
 
-    fn add_dependencies(builder: &mut RequiredAttributes)
+    fn add_dependencies(builder: &mut DerivedAttributesBuilder)
     where
         Self: Sized,
     {
-        builder.require::<Arity>();
-        builder.require::<SubtreeSize>();
+        builder.require(Arity::default());
+        builder.require(SubtreeSize::default());
     }
 
     fn get_results(&self) -> &Vec<Self::Value> {

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -28,7 +28,7 @@ use mz_ore::cast::{CastFrom, CastLossy, TryCastFrom};
 use mz_ore::stack::{CheckedRecursion, RecursionGuard};
 
 use crate::attribute::cardinality::{FactorizerVariable, SymExp};
-use crate::attribute::{Cardinality, RequiredAttributes};
+use crate::attribute::{Cardinality, DerivedAttributesBuilder};
 use crate::join_implementation::index_map::IndexMap;
 use crate::predicate_pushdown::PredicatePushdown;
 use crate::{StatisticsOracle, TransformCtx, TransformError};
@@ -169,8 +169,8 @@ impl JoinImplementation {
             // Symbolic terms in the cardinality estimate
             let mut symbolics = std::collections::BTreeSet::new();
             for input in inputs.iter() {
-                let mut builder = RequiredAttributes::default();
-                builder.require::<Cardinality>();
+                let mut builder = DerivedAttributesBuilder::default();
+                builder.require(Cardinality::default());
                 let mut attributes = builder.finish();
 
                 input.visit(&mut attributes)?;

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -135,9 +135,6 @@ use crate::dataflow::DataflowMetainfo;
 pub use dataflow::optimize_dataflow;
 use mz_ore::soft_assert;
 
-#[macro_use]
-extern crate num_derive;
-
 /// Compute the conjunction of a variadic number of expressions.
 #[macro_export]
 macro_rules! all {

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -45,7 +45,7 @@ impl crate::Transform for ThresholdElision {
 }
 
 struct ThresholdElisionAction {
-    deriver: DerivedAttributes,
+    deriver: DerivedAttributes<'static>,
 }
 
 impl Default for ThresholdElisionAction {

--- a/src/transform/src/threshold_elision.rs
+++ b/src/transform/src/threshold_elision.rs
@@ -18,7 +18,7 @@
 use mz_expr::visit::{Visit, Visitor, VisitorMut};
 use mz_expr::MirRelationExpr;
 
-use crate::attribute::{DerivedAttributes, NonNegative, RequiredAttributes, SubtreeSize};
+use crate::attribute::{DerivedAttributes, DerivedAttributesBuilder, NonNegative, SubtreeSize};
 use crate::TransformCtx;
 
 /// Remove Threshold operators that have no effect.
@@ -50,9 +50,9 @@ struct ThresholdElisionAction {
 
 impl Default for ThresholdElisionAction {
     fn default() -> Self {
-        let mut builder = RequiredAttributes::default();
-        builder.require::<NonNegative>();
-        builder.require::<SubtreeSize>();
+        let mut builder = DerivedAttributesBuilder::default();
+        builder.require(NonNegative::default());
+        builder.require(SubtreeSize::default());
         Self {
             deriver: builder.finish(),
         }

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -13,8 +13,8 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 

--- a/src/transform/tests/test_transforms/arity.spec
+++ b/src/transform/tests/test_transforms/arity.spec
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0
+  - c0: bigint
+  - c1: bigint
+----
+Source defined as t0
+
+# Constant
+explain with=arity
+Constant // { types: "(bigint, bigint)" }
+  - (1, 2)
+  - (1, 3)
+----
+Constant // { arity: 2 }
+  - (1, 2)
+  - (1, 3)
+
+# Global Get
+explain with=arity
+Get t0
+----
+Get t0 // { arity: 2 }
+
+# Local Get in a Let block
+explain with=arity
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+----
+Return // { arity: 2 }
+  Get l0 // { arity: 2 }
+With
+  cte l0 =
+    Get t0 // { arity: 2 }
+
+# Local Get in a LetRec block
+explain with=arity
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint, bigint)" }
+    Get t0
+----
+Return // { arity: 2 }
+  Get l0 // { arity: 2 }
+With Mutually Recursive
+  cte l0 =
+    Get t0 // { arity: 2 }
+
+# Project
+explain with=arity
+Project (#1, #0, #1)
+  Get t0
+----
+Project (#1, #0, #1) // { arity: 3 }
+  Get t0 // { arity: 2 }
+
+# Map
+explain with=arity
+Map (#1, #0 + #1, #0)
+  Get t0
+----
+Map (#1, (#0 + #1), #0) // { arity: 5 }
+  Get t0 // { arity: 2 }
+
+# FlatMap
+explain with=arity
+FlatMap generate_series(#0, #1, 1)
+  Get t0
+----
+FlatMap generate_series(#0, #1, 1) // { arity: 3 }
+  Get t0 // { arity: 2 }
+
+# Filter
+explain with=arity
+Filter (#0 > #1 + 42)
+  Get t0
+----
+Filter (#0 > (#1 + 42)) // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# Reduce
+explain with=arity
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)]
+  Get t0
+----
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)] // { arity: 3 }
+  Get t0 // { arity: 2 }
+
+# TopK
+explain with=arity
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
+  Get t0
+----
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3 // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# Negate
+explain with=arity
+Negate
+  Get t0
+----
+Negate // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# Threshold
+explain with=arity
+Threshold
+  Get t0
+----
+Threshold // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# ArrangeBy
+explain with=arity
+ArrangeBy keys=[[#1], [#0, #1]]
+  Get t0
+----
+ArrangeBy keys=[[#1], [#0, #1]] // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# Union (anonymous last)
+explain with=arity
+Union
+  Get t0
+  Constant <empty> // { types: "(bigint, bigint)" }
+----
+Union // { arity: 2 }
+  Get t0 // { arity: 2 }
+  Constant <empty> // { arity: 2 }
+
+# Union (anonymous first)
+explain with=arity
+Union
+  Constant <empty> // { types: "(bigint, bigint)" }
+  Get t0
+----
+Union // { arity: 2 }
+  Constant <empty> // { arity: 2 }
+  Get t0 // { arity: 2 }
+
+# Join
+explain with=arity
+Join on=(#1 = #2)
+  Get t0
+  Get t0
+----
+Join on=(#1 = #2) // { arity: 4 }
+  Get t0 // { arity: 2 }
+  Get t0 // { arity: 2 }

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -13,33 +13,33 @@
 # Define t0 source
 define
 DefSource name=t0 keys=[[#0]]
-  - bigint
-  - bigint?
+  - c0: bigint
+  - c1: bigint?
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 
 # Define t2 source
 define
 DefSource name=t2
-  - bigint?
-  - bigint?
+  - c0: bigint?
+  - c1: bigint?
 ----
 Source defined as t2
 
 # Define t3 source
 define
 DefSource name=t3
-  - bigint?
-  - bigint?
+  - c0: bigint?
+  - c1: bigint?
 ----
 Source defined as t3
 

--- a/src/transform/tests/test_transforms/column_names.spec
+++ b/src/transform/tests/test_transforms/column_names.spec
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0
+  - c0: bigint
+  - c1: bigint
+----
+Source defined as t0
+
+# Constant
+explain with=column_names
+Constant // { types: "(bigint, bigint)" }
+  - (1, 2)
+  - (1, 3)
+----
+Constant // { column_names: "(#0, #1)" }
+  - (1, 2)
+  - (1, 3)
+
+# Global Get
+explain with=column_names
+Get t0
+----
+Get t0 // { column_names: "(c0, c1)" }
+
+# Local Get in a Let block
+explain with=column_names
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+----
+Return // { column_names: "(c0, c1)" }
+  Get l0 // { column_names: "(c0, c1)" }
+With
+  cte l0 =
+    Get t0 // { column_names: "(c0, c1)" }
+
+# Local Get in a LetRec block
+explain with=column_names
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint, bigint)" }
+    Get t0
+----
+Return // { column_names: "(c0, c1)" }
+  Get l0 // { column_names: "(c0, c1)" }
+With Mutually Recursive
+  cte l0 =
+    Get t0 // { column_names: "(c0, c1)" }
+
+# Project
+explain with=column_names
+Project (#1, #0, #1)
+  Get t0
+----
+Project (#1, #0, #1) // { column_names: "(c1, c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Map
+explain with=column_names
+Map (#1, #0 + #1, #0)
+  Get t0
+----
+Map (#1, (#0 + #1), #0) // { column_names: "(c0, c1, c1, #3, c0)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# FlatMap
+explain with=column_names
+FlatMap generate_series(#0, #1, 1)
+  Get t0
+----
+FlatMap generate_series(#0, #1, 1) // { column_names: "(c0, c1, #2)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Filter
+explain with=column_names
+Filter (#0 > #1 + 42)
+  Get t0
+----
+Filter (#0 > (#1 + 42)) // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Reduce
+explain with=column_names
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)]
+  Get t0
+----
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)] // { column_names: "(c0, #1, #2)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# TopK
+explain with=column_names
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
+  Get t0
+----
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3 // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Negate
+explain with=column_names
+Negate
+  Get t0
+----
+Negate // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Threshold
+explain with=column_names
+Threshold
+  Get t0
+----
+Threshold // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# ArrangeBy
+explain with=column_names
+ArrangeBy keys=[[#1], [#0, #1]]
+  Get t0
+----
+ArrangeBy keys=[[#1], [#0, #1]] // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Union (anonymous last)
+explain with=column_names
+Union
+  Get t0
+  Constant <empty> // { types: "(bigint, bigint)" }
+----
+Union // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+  Constant <empty> // { column_names: "(#0, #1)" }
+
+# Union (anonymous first)
+explain with=column_names
+Union
+  Constant <empty> // { types: "(bigint, bigint)" }
+  Get t0
+----
+Union // { column_names: "(c0, c1)" }
+  Constant <empty> // { column_names: "(#0, #1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+
+# Join
+explain with=column_names
+Join on=(#1 = #2)
+  Get t0
+  Get t0
+----
+Join on=(#1 = #2) // { column_names: "(c0, c1, c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }
+  Get t0 // { column_names: "(c0, c1)" }

--- a/src/transform/tests/test_transforms/literal_lifting.spec
+++ b/src/transform/tests/test_transforms/literal_lifting.spec
@@ -13,33 +13,33 @@
 # Define t0 source
 define
 DefSource name=t0 keys=[[#0]]
-  - bigint
-  - bigint?
+  - c0: bigint
+  - c1: bigint?
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 
 # Define t2 source
 define
 DefSource name=t2
-  - bigint?
-  - bigint?
+  - c0: bigint?
+  - c1: bigint?
 ----
 Source defined as t2
 
 # Define t3 source
 define
 DefSource name=t3
-  - bigint?
-  - bigint?
+  - c0: bigint?
+  - c1: bigint?
 ----
 Source defined as t3
 

--- a/src/transform/tests/test_transforms/non_null_requirements.spec
+++ b/src/transform/tests/test_transforms/non_null_requirements.spec
@@ -13,8 +13,8 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 

--- a/src/transform/tests/test_transforms/normalize_lets.spec
+++ b/src/transform/tests/test_transforms/normalize_lets.spec
@@ -13,8 +13,8 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 

--- a/src/transform/tests/test_transforms/predicate_pushdown.spec
+++ b/src/transform/tests/test_transforms/predicate_pushdown.spec
@@ -13,17 +13,17 @@
 # Define t0 source
 define
 DefSource name=t0 keys=[[#0]]
-  - bigint
-  - bigint?
+  - c0: bigint
+  - c1: bigint?
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/projection_lifting.spec
+++ b/src/transform/tests/test_transforms/projection_lifting.spec
@@ -13,17 +13,17 @@
 # Define t0 source
 define
 DefSource name=t0 keys=[[#0]]
-  - bigint
-  - bigint?
+  - c0: bigint
+  - c1: bigint?
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/projection_pushdown.spec
+++ b/src/transform/tests/test_transforms/projection_pushdown.spec
@@ -13,18 +13,18 @@
 # Define x source
 define
 DefSource name=x
-  - bigint
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
+  - c3: bigint
 ----
 Source defined as t0
 
 # Define y source
 define
 DefSource name=y
-  - bigint
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
+  - c3: bigint
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/redundant_join.spec
+++ b/src/transform/tests/test_transforms/redundant_join.spec
@@ -13,16 +13,16 @@
 # Define x source
 define
 DefSource name=x
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 
 # Define y source
 define
 DefSource name=y keys=[[#0]]
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -13,8 +13,8 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
+  - c0: bigint
+  - c1: bigint
 ----
 Source defined as t0
 

--- a/src/transform/tests/test_transforms/semijoin_idempotence.spec
+++ b/src/transform/tests/test_transforms/semijoin_idempotence.spec
@@ -13,17 +13,17 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint
-  - text?
+  - c0: bigint
+  - c1: bigint
+  - c2: text?
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1 keys=[[#0]]
-  - bigint
-  - text?
+  - c0: bigint
+  - c1: text?
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -27,18 +27,18 @@
 # Define t0 source
 define
 DefSource name=t0
-  - bigint
-  - bigint?
-  - text
+  - c0: bigint
+  - c1: bigint?
+  - c2: text
 ----
 Source defined as t0
 
 # Define t1 source
 define
 DefSource name=t1
-  - text
-  - bigint
-  - boolean
+  - c0: text
+  - c1: bigint
+  - c2: boolean
 ----
 Source defined as t1
 

--- a/src/transform/tests/test_transforms/types.spec
+++ b/src/transform/tests/test_transforms/types.spec
@@ -1,0 +1,165 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Source definitions
+# ------------------
+
+# Define t0 source
+define
+DefSource name=t0
+  - c0: bigint
+  - c1: smallint
+----
+Source defined as t0
+
+# Constant
+explain with=types
+Constant // { types: "(bigint, smallint)" }
+  - (1, 2)
+  - (1, 3)
+----
+Constant // { types: "(Int64, Int16)" }
+  - (1, 2)
+  - (1, 3)
+
+# Global Get
+explain with=types
+Get t0
+----
+Get t0 // { types: "(Int64, Int16)" }
+
+# Local Get in a Let block
+explain with=types
+Return
+  Get l0
+With
+  cte l0 =
+    Get t0
+----
+Return // { types: "(Int64, Int16)" }
+  Get l0 // { types: "(Int64, Int16)" }
+With
+  cte l0 =
+    Get t0 // { types: "(Int64, Int16)" }
+
+# Local Get in a LetRec block
+explain with=types
+Return
+  Get l0
+With Mutually Recursive
+  cte l0 = // { types: "(bigint, bigint)" }
+    Get t0
+----
+Return // { types: "(Int64, Int64)" }
+  Get l0 // { types: "(Int64, Int64)" }
+With Mutually Recursive
+  cte l0 =
+    Get t0 // { types: "(Int64, Int16)" }
+
+# Project
+explain with=types
+Project (#1, #0, #1)
+  Get t0
+----
+Project (#1, #0, #1) // { types: "(Int16, Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Map
+explain with=types
+Map (#1, #0 + #1, #0)
+  Get t0
+----
+Map (#1, (#0 + #1), #0) // { types: "(Int64, Int16, Int16, Int64, Int64)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# FlatMap
+explain with=types
+FlatMap generate_series(#0, #1, 1)
+  Get t0
+----
+FlatMap generate_series(#0, #1, 1) // { types: "(Int64, Int16, Int64)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Filter
+explain with=types
+Filter (#0 > #1 + 42)
+  Get t0
+----
+Filter (#0 > (#1 + 42)) // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Reduce
+explain with=types
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)]
+  Get t0
+----
+Reduce group_by=[#0] aggregates=[min(#1), max(#1)] // { types: "(Int64, Int16, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# TopK
+explain with=types
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3
+  Get t0
+----
+TopK order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=3 // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Negate
+explain with=types
+Negate
+  Get t0
+----
+Negate // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Threshold
+explain with=types
+Threshold
+  Get t0
+----
+Threshold // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# ArrangeBy
+explain with=types
+ArrangeBy keys=[[#1], [#0, #1]]
+  Get t0
+----
+ArrangeBy keys=[[#1], [#0, #1]] // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Union (anonymous last)
+explain with=types
+Union
+  Get t0
+  Constant <empty> // { types: "(bigint, smallint)" }
+----
+Union // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+  Constant <empty> // { types: "(Int64, Int16)" }
+
+# Union (anonymous first)
+explain with=types
+Union
+  Constant <empty> // { types: "(bigint, smallint)" }
+  Get t0
+----
+Union // { types: "(Int64, Int16)" }
+  Constant <empty> // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+
+# Join
+explain with=types
+Join on=(#1 = #2)
+  Get t0
+  Get t0
+----
+Join on=(#1 = #2) // { types: "(Int64, Int16, Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }
+  Get t0 // { types: "(Int64, Int16)" }


### PR DESCRIPTION
Add a `ColumnNames` attribute and expose it in `EXPLAIN` outputs through the `column_names` option.

### Motivation

  * This PR adds a feature that has not yet been specified.

We don't have an issue for that, but multiple people have expressed interest in having an `EXPLAIN` plan that prints humanized column names. This PR is the first step towards that.

### Tips for reviewer

See commit messages for details (specifically the message of the third commit for motivation and background of the refactoring).

The first four commits do some refactoring to the testing and attribute derivation frameworks required that is needed in order to implement the `ColumnNames` inference logic. More specifically, we need a way to create `Attribute` implementations with parameters (until now the structs implementing `Attribute` were all nullary). This is achieved by the third and fourth commits which:

- Introduce a struct-based `DerivedAttributes` container.
- Pass context to the attribute constructors.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
