### PR TITLE
Allow the `canary environment` mzcompose workflow to run against the Materialize Production Sandbox

### DIFF
--- a/misc/python/materialize/mzcompose/services/dbt.py
+++ b/misc/python/materialize/mzcompose/services/dbt.py
@@ -14,14 +14,12 @@ from materialize.mzcompose.service import (
 
 
 class Dbt(Service):
-    def __init__(self, name: str = "dbt") -> None:
+    def __init__(self, name: str = "dbt", environment: list[str] = []) -> None:
         super().__init__(
             name=name,
             config={
                 "mzbuild": "dbt-materialize",
-                "environment": [
-                    "TMPDIR=/share/tmp",
-                ],
+                "environment": environment + ["TMPDIR=/share/tmp"],
                 "volumes": [
                     ".:/workdir",
                     "secrets:/secrets",

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -120,8 +120,18 @@ impl ErrorLocation {
         let mut snippet = String::new();
         writeln!(&mut snippet, "     |").unwrap();
         for (i, l) in contents.lines().enumerate() {
+            let l_lc = l.to_lowercase();
             if i >= line {
                 break;
+            } else if l_lc.contains("postgres-") || l_lc.contains("secret") || l_lc.contains("url")
+            {
+                writeln!(
+                    &mut snippet,
+                    "{:4} | {} ... [rest of line truncated for security]",
+                    i + 1,
+                    l.get(0..20).unwrap()
+                )
+                .unwrap();
             } else if i + 2 >= line {
                 writeln!(&mut snippet, "{:4} | {}", i + 1, l).unwrap();
             }

--- a/test/canary-environment/README.md
+++ b/test/canary-environment/README.md
@@ -1,0 +1,92 @@
+# Introduction
+
+The canary environment workflow creates various database objects against the Materialize Production Sandbox
+
+The goals of this framework are:
+- create long-lived database objects in Materialize Production Sandbox whose operation will then be monitored
+  periodically going forward.
+
+- dog-food the use of dbt against Materialize
+
+Objects that are supported by dbt are created using dbt. Objects that are outside of the scope of dbt
+are created using testdrive.
+
+# Workload
+
+## TPC-H Generator (`models/tpc-h`)
+
+A set of two materialized views based on TPC-H queries are defined to run against a `GENERATOR TPCH` source.
+
+The TPC-H queries to materialize were chosen as to include both outer joins and aggregations.
+
+## Postgres source (`models/pg-cdc`)
+
+The postgres source is an RDS instance running in AWS that is replicating two tables.
+
+In order to continously emit updates, pg_cron jobs that update the tables are set up to run with a 1-second interval.
+
+## Kafka sources (`models/loadgen`)
+
+A Kafka broker running on the Confluent cloud is used to ingest topics that are being
+fed by a `loadgen` that is running independently.
+
+# Setup
+
+## Environment variables
+
+Authentication and host information is being passed into mzcompose and dbt using environment variables:
+
+```
+export MATERIALIZE_PROD_SANDBOX_HOSTNAME=...us-east-1.aws.materialize.cloud
+export MATERIALIZE_PROD_SANDBOX_USERNAME=...@materialize.com
+export MATERIALIZE_PROD_SANDBOX_PASSWORD=mzp_...
+
+export MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME=...eu-west-1.rds.amazonaws.com
+export MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD=...
+
+export CONFLUENT_CLOUD_FIELDENG_KAFKA_BROKER=...confluent.cloud:9092
+export CONFLUENT_CLOUD_FIELDENG_CSR_URL=https://...aws.confluent.cloud
+export CONFLUENT_CLOUD_FIELDENG_CSR_USERNAME=...
+export CONFLUENT_CLOUD_FIELDENG_CSR_PASSWORD=...
+export CONFLUENT_CLOUD_FIELDENG_KAFKA_USERNAME=...
+export CONFLUENT_CLOUD_FIELDENG_KAFKA_PASSWORD=...
+```
+
+## Clusters
+
+Two clusters have been created in the sanbox environment: `qa_canary_environment_storage`
+and `qa_canary_environment_compute` and all database objects are created in them. The use
+of the `default` cluster is strongly discouraged.
+
+# Creating the objects
+
+To create or re-create the database objects:
+
+1. Make sure the required environment variables are set
+
+2. Run
+
+```
+./mzcompose run create
+```
+
+# Validating the workloads
+
+the `dbt test` functionality is used to validate the correct operation of the database objects
+that are being created. Most of the logic that performs the tests is in `tests/`
+
+Among the things that are being checked is:
+- whether sources and materialized views emit records on SUBSCRIBE
+- the state of the sources as reported by mz_source_status table
+- that all replicas are ready
+- that all sources are running
+- that all compute frontiers are advancing
+
+To run the validation procedure:
+
+1. Make sure the required environment variables are set correctly
+2. Run:
+
+```
+./mzcompose run test
+```

--- a/test/canary-environment/macros/create_loadgen_source.sql
+++ b/test/canary-environment/macros/create_loadgen_source.sql
@@ -9,6 +9,7 @@
 
 {% macro create_loadgen_source(name) %}
 CREATE SOURCE IF NOT EXISTS "{{ name.schema }}"."{{ name.table }}"
+IN CLUSTER qa_canary_environment_storage
 FROM KAFKA CONNECTION kafka_connection (TOPIC 'datagen_demo_snowflakeschema_{{ name.table }}')
 KEY FORMAT BYTES
 VALUE FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection

--- a/test/canary-environment/models/loadgen/customer.sql
+++ b/test/canary-environment/models/loadgen/customer.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/product.sql
+++ b/test/canary-environment/models/loadgen/product.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/product_category.sql
+++ b/test/canary-environment/models/loadgen/product_category.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/region.sql
+++ b/test/canary-environment/models/loadgen/region.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/sales.sql
+++ b/test/canary-environment/models/loadgen/sales.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/sales_product_product_category.sql
+++ b/test/canary-environment/models/loadgen/sales_product_product_category.sql
@@ -6,12 +6,11 @@
 -- As of the Change Date specified in that file, in accordance with
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
-
 -- depends_on: {{ ref('sales') }}
 -- depends_on: {{ ref('product') }}
 -- depends_on: {{ ref('product_category') }}
 
-{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+{{ config(materialized='materializedview', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
 
 SELECT
     count(*) AS count_star,

--- a/test/canary-environment/models/loadgen/store.sql
+++ b/test/canary-environment/models/loadgen/store.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/loadgen/supplier.sql
+++ b/test/canary-environment/models/loadgen/supplier.sql
@@ -7,6 +7,6 @@
 -- the Business Source License, use of this software will be governed
 -- by the Apache License, Version 2.0.
 
-{{ config(materialized='source', indexes=[{'default': True}]) }}
+{{ config(materialized='source', indexes=[{'default': True, 'cluster': 'qa_canary_environment_compute'}]) }}
 
 {{ create_loadgen_source(this) }}

--- a/test/canary-environment/models/pg_cdc/pg_cdc.sql
+++ b/test/canary-environment/models/pg_cdc/pg_cdc.sql
@@ -10,6 +10,7 @@
 {{ config(materialized='source') }}
 
 CREATE SOURCE {{ this }}
+IN CLUSTER qa_canary_environment_storage
 FROM POSTGRES
 CONNECTION pg (PUBLICATION 'mz_source')
 FOR TABLES (people, relationships)

--- a/test/canary-environment/models/pg_cdc/wmr.sql
+++ b/test/canary-environment/models/pg_cdc/wmr.sql
@@ -12,7 +12,7 @@
 -- to ensure the result updates frequently
 
 -- depends_on: {{ ref('pg_cdc') }}
-{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+{{ config(materialized='materializedview', cluster="qa_canary_environment_compute", indexes=[{'default': True}]) }}
 
 WITH MUTUALLY RECURSIVE
     symm (a int, b int) AS (
@@ -28,7 +28,7 @@ WITH MUTUALLY RECURSIVE
         WHERE symm.b = reach.a
     ),
     reach(a int, b int, degree int) AS (
-        SELECT a , b , min(degree) FROM candidates group by a, b HAVING a != b
+        SELECT a, b, min(degree) FROM candidates group by a, b HAVING a != b
     )
 SELECT DISTINCT a_people.name AS a_name, b_people.name AS b_name, degree
 FROM reach

--- a/test/canary-environment/models/tpch/tpch.sql
+++ b/test/canary-environment/models/tpch/tpch.sql
@@ -10,6 +10,7 @@
 {{ config(materialized='source') }}
 
 CREATE SOURCE {{ this }}
+  IN CLUSTER qa_canary_environment_storage
   FROM LOAD GENERATOR
   TPCH (SCALE FACTOR 1, TICK INTERVAL '0.1s')
   FOR ALL TABLES

--- a/test/canary-environment/models/tpch/tpch_q01.sql
+++ b/test/canary-environment/models/tpch/tpch_q01.sql
@@ -10,7 +10,7 @@
 -- TPC-H Query #Q18, chosen for the workload for its GROUP BY clause
 
 -- depends_on: {{ ref('tpch') }}
-{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+{{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
 SELECT
     l_returnflag,

--- a/test/canary-environment/models/tpch/tpch_q18.sql
+++ b/test/canary-environment/models/tpch/tpch_q18.sql
@@ -12,7 +12,7 @@
 -- to ensure the result updates frequently
 
 -- depends_on: {{ ref('tpch') }}
-{{ config(materialized='materializedview', indexes=[{'default': True}]) }}
+{{ config(materialized='materializedview', cluster='qa_canary_environment_compute', indexes=[{'default': True}]) }}
 
 SELECT
     c_name,

--- a/test/canary-environment/mzcompose.py
+++ b/test/canary-environment/mzcompose.py
@@ -9,17 +9,31 @@
 
 import os
 from textwrap import dedent
+from urllib.parse import quote
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.dbt import Dbt
-from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.testdrive import Testdrive
 
-# The FieldEng cluster in the Confluent Cloud is used to provide Kafka services
-KAFKA_BOOTSTRAP_SERVER = "pkc-n00kk.us-east-1.aws.confluent.cloud:9092"
-SCHEMA_REGISTRY_ENDPOINT = "https://psrc-e0919.us-east-2.aws.confluent.cloud"
 # The actual values are stored as Pulumi secrets in the i2 repository
+MATERIALIZE_PROD_SANDBOX_HOSTNAME = os.environ["MATERIALIZE_PROD_SANDBOX_HOSTNAME"]
+MATERIALIZE_PROD_SANDBOX_USERNAME = os.environ["MATERIALIZE_PROD_SANDBOX_USERNAME"]
+MATERIALIZE_PROD_SANDBOX_APP_PASSWORD = os.environ[
+    "MATERIALIZE_PROD_SANDBOX_APP_PASSWORD"
+]
+
+MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME = os.environ[
+    "MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME"
+]
+MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD = os.environ[
+    "MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD"
+]
+
+CONFLUENT_CLOUD_FIELDENG_KAFKA_BROKER = os.environ[
+    "CONFLUENT_CLOUD_FIELDENG_KAFKA_BROKER"
+]
+CONFLUENT_CLOUD_FIELDENG_CSR_URL = os.environ["CONFLUENT_CLOUD_FIELDENG_CSR_URL"]
+
 CONFLUENT_CLOUD_FIELDENG_CSR_USERNAME = os.environ[
     "CONFLUENT_CLOUD_FIELDENG_CSR_USERNAME"
 ]
@@ -33,25 +47,44 @@ CONFLUENT_CLOUD_FIELDENG_KAFKA_PASSWORD = os.environ[
     "CONFLUENT_CLOUD_FIELDENG_KAFKA_PASSWORD"
 ]
 
-SERVICES = [Materialized(), Dbt(), Testdrive(no_reset=True), Postgres()]
+
+SERVICES = [
+    Dbt(
+        environment=[
+            "MATERIALIZE_PROD_SANDBOX_HOSTNAME",
+            "MATERIALIZE_PROD_SANDBOX_USERNAME",
+            "MATERIALIZE_PROD_SANDBOX_APP_PASSWORD",
+        ]
+    ),
+    Testdrive(no_reset=True),
+]
 
 POSTGRES_RANGE = 1024
 POSTGRES_RANGE_FUNCTION = "FLOOR(RANDOM() * (SELECT MAX(id) FROM people))"
 
 
-def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.up("materialized", "postgres")
+def workflow_create(c: Composition, parser: WorkflowArgumentParser) -> None:
     c.up("dbt", persistent=True)
     c.up("testdrive", persistent=True)
 
-    c.testdrive(
-        input=dedent(
-            f"""
+    materialize_url = f"postgres://{quote(MATERIALIZE_PROD_SANDBOX_USERNAME)}:{quote(MATERIALIZE_PROD_SANDBOX_APP_PASSWORD)}@{quote(MATERIALIZE_PROD_SANDBOX_HOSTNAME)}:6875"
+
+    with c.override(
+        Testdrive(
+            default_timeout="1200s",
+            materialize_url=materialize_url,
+            no_reset=True,  # Required so that admin port 6877 is not used
+        )
+    ):
+        c.testdrive(
+            input=dedent(
+                f"""
+            > SET DATABASE=qa_canary_environment
             > CREATE SECRET IF NOT EXISTS kafka_username AS '{CONFLUENT_CLOUD_FIELDENG_KAFKA_USERNAME}'
             > CREATE SECRET IF NOT EXISTS kafka_password AS '{CONFLUENT_CLOUD_FIELDENG_KAFKA_PASSWORD}'
 
             > CREATE CONNECTION IF NOT EXISTS kafka_connection TO KAFKA (
-              BROKER '{KAFKA_BOOTSTRAP_SERVER}',
+              BROKER '{CONFLUENT_CLOUD_FIELDENG_KAFKA_BROKER}',
               SASL MECHANISMS = 'PLAIN',
               SASL USERNAME = SECRET kafka_username,
               SASL PASSWORD = SECRET kafka_password
@@ -61,19 +94,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             > CREATE SECRET IF NOT EXISTS csr_password AS '{CONFLUENT_CLOUD_FIELDENG_CSR_PASSWORD}'
 
             > CREATE CONNECTION IF NOT EXISTS csr_connection TO CONFLUENT SCHEMA REGISTRY (
-              URL '{SCHEMA_REGISTRY_ENDPOINT}',
+              URL '{CONFLUENT_CLOUD_FIELDENG_CSR_URL}',
               USERNAME = SECRET csr_username,
               PASSWORD = SECRET csr_password
               )
         """
+            )
         )
-    )
 
-    c.testdrive(
-        input=dedent(
-            f"""
-            $ postgres-execute connection=postgres://postgres:postgres@postgres
-            ALTER USER postgres WITH replication;
+        c.testdrive(
+            input=dedent(
+                f"""
+            > SET DATABASE=qa_canary_environment
+            $ postgres-execute connection=postgres://postgres:{MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD}@{MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME}
+            -- ALTER USER postgres WITH replication;
 
             DROP SCHEMA IF EXISTS public CASCADE;
             CREATE SCHEMA public;
@@ -101,24 +135,25 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
             SELECT cron.schedule('delete-relationships', '1 seconds', 'DELETE FROM relationships WHERE a = {POSTGRES_RANGE_FUNCTION} AND b = {POSTGRES_RANGE_FUNCTION}');
 
-            > CREATE SECRET IF NOT EXISTS pgpass AS 'postgres'
+            > CREATE SECRET IF NOT EXISTS pg_password AS '{MATERIALIZE_PROD_SANDBOX_RDS_PASSWORD}'
 
             > CREATE CONNECTION IF NOT EXISTS pg TO POSTGRES (
-              HOST postgres,
+              HOST '{MATERIALIZE_PROD_SANDBOX_RDS_HOSTNAME}',
               DATABASE postgres,
               USER postgres,
-              PASSWORD SECRET pgpass
+              PASSWORD SECRET pg_password,
+              SSL MODE 'require'
               )
             """
+            )
         )
-    )
 
     c.exec("dbt", "dbt", "run", "--threads", "8", workdir="/workdir")
-    workflow_test(c, parser)
 
 
 def workflow_test(c: Composition, parser: WorkflowArgumentParser) -> None:
-    c.exec("dbt", "dbt", "test", "--threads", "8", workdir="/workdir")
+    c.up("dbt", persistent=True)
+    c.exec("dbt", "dbt", "test", workdir="/workdir")
 
 
 def workflow_clean(c: Composition, parser: WorkflowArgumentParser) -> None:

--- a/test/canary-environment/profiles.yml
+++ b/test/canary-environment/profiles.yml
@@ -10,6 +10,17 @@
 canary_environment:
   outputs:
 
+    prod:
+      type: materialize
+      threads: 1
+      host: "{{ env_var('MATERIALIZE_PROD_SANDBOX_HOSTNAME') }}"
+      port: 6875
+      user: "{{ env_var('MATERIALIZE_PROD_SANDBOX_USERNAME') }}"
+      password: "{{env_var('MATERIALIZE_PROD_SANDBOX_APP_PASSWORD')}}"
+      dbname: qa_canary_environment
+      schema: public
+      autocommit: True
+
     dev:
       type: materialize
       threads: 1
@@ -21,4 +32,4 @@ canary_environment:
       schema: public
       autocommit: True
 
-  target: dev
+  target: prod

--- a/test/canary-environment/tests/all_sources_running.sql
+++ b/test/canary-environment/tests/all_sources_running.sql
@@ -9,7 +9,12 @@
 
 select *
 from mz_internal.mz_source_statuses
-where not (
+join mz_sources using (id)
+join mz_schemas on (schema_id = mz_schemas.id)
+join mz_databases on (database_id = mz_databases.id)
+where mz_databases.name = 'qa_canary_environment'
+and not (
   status = 'running' or
-  (type = 'progress' and status = 'created')
+  (mz_sources.type = 'progress' and status = 'created') or
+  (mz_sources.type = 'subsource' and status = 'starting')
 )


### PR DESCRIPTION
### Motivation

Our canary environments that were used to determine if a release is good enough to go were largely empty/idle and were therefore not a good canary for anything.

With this mzcompose workflow, one can create a complete set of sources/generators/materialized views and then validate that they are running properly and have not stalled for some reason. See `README.md` for more information.

### Tips for reviewer

Reviewing commit-by-commit may work best.