### PR TITLE
adapter: Apply write ts in bootstrapping

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1644,7 +1644,7 @@ impl Coordinator {
         // Advance all tables to the current timestamp
         debug!("coordinator init: advancing all tables to current timestamp");
         let WriteTimestamp {
-            timestamp: _,
+            timestamp: write_ts,
             advance_to,
         } = self.get_local_write_ts().await;
         let appends = entries
@@ -1659,6 +1659,7 @@ impl Coordinator {
             .await
             .expect("One-shot shouldn't be dropped during bootstrap")
             .unwrap_or_terminate("cannot fail to append");
+        self.apply_local_write(write_ts).await;
 
         // Add builtin table updates the clear the contents of all system tables
         debug!("coordinator init: resetting system tables");


### PR DESCRIPTION
Previously, the Coordinator would do the following during bootstrap:

  1. Get a write timestamp from the timestamp oracle, ws1.
  2. Advance all tables to ws1.
  3. Get a read timestamp from the timestamp oracle, rs1.
  4. Read a snapshot of all system tables at rs1.
  5. Get a write timestamp from the timestamp oracle, ws2.
  6. Write retractions for all system tables at ws2.
  7. Apply ws2 with the timestamp oracle.

This commit adds a step after step (2) but before step (3) to apply ws1 with the timestamp oracle. This guarantees that rs1 >= ws1, which was not previously true. There shouldn't be any existing issues from this since the table advancements are all empty writes, but it's still a better practice to always apply write timestamps after using them.

### Motivation
This PR fixes a previously unreported bug.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
