### PR TITLE
persist: split out a maelstrom-persist-base mzimage

### DIFF
--- a/src/persist-cli/ci-base/Dockerfile
+++ b/src/persist-cli/ci-base/Dockerfile
@@ -1,0 +1,25 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This is a separate mzimage from maelstrom-persist so that we don't have to
+# re-install the apt things or maelstrom every time we get a CI builder with a
+# cold cache.
+
+MZFROM ubuntu-base
+
+RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    bzip2 \
+    curl \
+    git \
+    gnuplot \
+    openjdk-11-jre
+
+RUN mkdir -p /usr/local/share/java \
+    && curl -fsSL https://github.com/jepsen-io/maelstrom/releases/download/v0.2.1/maelstrom.tar.bz2 \
+        | tar -xj --strip-components=2 -C /usr/local/share/java maelstrom/lib/maelstrom.jar

--- a/src/persist-cli/ci-base/mzbuild.yml
+++ b/src/persist-cli/ci-base/mzbuild.yml
@@ -7,8 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM maelstrom-persist-base
-
-COPY persistcli /usr/local/bin/persistcli
-
-ENTRYPOINT ["java", "-Djava.awt.headless=true", "-jar", "/usr/local/share/java/maelstrom.jar", "test", "-w", "txn-list-append", "--bin=/usr/local/bin/persistcli"]
+name: maelstrom-persist-base


### PR DESCRIPTION
And then MZFROM it in maelstrom-persist. This way we don't have to re-install the apt things or maelstrom every time we get a CI builder with a cold cache.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
