### PR TITLE
ci: Disable parallel execution of Platform Checks in CI (part 2)

### DIFF
--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -437,6 +437,7 @@ steps:
 
   - id: checks-parallel-restart-environmentd-clusterd-storage
     label: "Checks parallel + restart of environmentd & storage clusterd"
+    skip: "Affected by #21317"
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64


### PR DESCRIPTION
One Buildkite step was missing the `skip` directive.


### Motivation

One of the steps that were meant to be skipped continued to run in Nightly.