### PR TITLE
storage: merge `Controller` with `StorageControllerState`

### DIFF
--- a/src/storage-controller/src/command_wals.rs
+++ b/src/storage-controller/src/command_wals.rs
@@ -55,7 +55,7 @@ where
     {
         SHARD_FINALIZATION
             .insert_without_overwrite(
-                &mut self.state.stash,
+                &mut self.stash,
                 entries.into_iter().map(|key| (key.into_proto(), ())),
             )
             .await
@@ -75,7 +75,7 @@ where
             .map(|s| RustType::into_proto(&s))
             .collect();
         SHARD_FINALIZATION
-            .delete_keys(&mut self.state.stash, proto_shards)
+            .delete_keys(&mut self.stash, proto_shards)
             .await
             .expect("must be able to write to stash")
     }
@@ -110,7 +110,6 @@ where
 
         // Get stash metadata.
         let (metadata, shard_finalization) = self
-            .state
             .stash
             .with_transaction(move |tx| {
                 Box::pin(async move {
@@ -178,7 +177,7 @@ where
                 .map(|id| RustType::into_proto(&id))
                 .collect();
             super::METADATA_COLLECTION
-                .delete_keys(&mut self.state.stash, proto_ids_to_drop)
+                .delete_keys(&mut self.stash, proto_ids_to_drop)
                 .await
                 .expect("stash operation must succeed");
         }


### PR DESCRIPTION
### Motivation

I can't remember how or why the controller evolved to have its state in a separate struct but it doesn't make a lot of sense so I merged them.

The PR is purely code movement so no need to look at the diff too closely

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
