### PR TITLE
adapter: rename RescaleNumeric and CastTimestampToTimestamp functions + More tests

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -126,7 +126,8 @@ message ProtoUnaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType return_ty = 1;
         repeated ProtoMirScalarExpr cast_exprs = 2;
     }
-    reserved 5, 6, 15, 104, 111, 115;
+    reserved 5, 6, 15, 104, 111, 115, 212;
+    // max field number
     oneof kind {
         google.protobuf.Empty not = 1;
         google.protobuf.Empty is_null = 2;
@@ -344,7 +345,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty exp_numeric = 209;
         google.protobuf.Empty sleep = 210;
         google.protobuf.Empty panic = 211;
-        mz_repr.adt.numeric.ProtoNumericMaxScale rescale_numeric = 212;
+        mz_repr.adt.numeric.ProtoNumericMaxScale adjust_numeric_scale = 314;
         google.protobuf.Empty pg_column_size = 213;
         google.protobuf.Empty mz_row_size = 214;
         google.protobuf.Empty mz_type_name = 215;

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -126,8 +126,8 @@ message ProtoUnaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType return_ty = 1;
         repeated ProtoMirScalarExpr cast_exprs = 2;
     }
-    reserved 5, 6, 15, 104, 111, 115, 212;
-    // max field number
+    reserved 5, 6, 15, 104, 111, 115, 212, 306;
+    // next field number 316
     oneof kind {
         google.protobuf.Empty not = 1;
         google.protobuf.Empty is_null = 2;
@@ -241,7 +241,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty cast_interval_to_time = 109;
         google.protobuf.Empty cast_timestamp_to_date = 110;
         mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions cast_timestamp_to_timestamp_tz = 311;
-        mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions cast_timestamp_to_timestamp = 306;
+        mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions adjust_timestamp_precision = 315;
         google.protobuf.Empty cast_timestamp_to_string = 112;
         google.protobuf.Empty cast_timestamp_to_time = 113;
         google.protobuf.Empty cast_timestamp_tz_to_date = 114;

--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -126,8 +126,8 @@ message ProtoUnaryFunc {
         mz_repr.relation_and_scalar.ProtoScalarType return_ty = 1;
         repeated ProtoMirScalarExpr cast_exprs = 2;
     }
-    reserved 5, 6, 15, 104, 111, 115, 212, 306;
-    // next field number 316
+    reserved 5, 6, 15, 104, 111, 115, 212, 306, 313;
+    // next field number 317
     oneof kind {
         google.protobuf.Empty not = 1;
         google.protobuf.Empty is_null = 2;
@@ -246,7 +246,7 @@ message ProtoUnaryFunc {
         google.protobuf.Empty cast_timestamp_to_time = 113;
         google.protobuf.Empty cast_timestamp_tz_to_date = 114;
         mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions cast_timestamp_tz_to_timestamp = 312;
-        mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions cast_timestamp_tz_to_timestamp_tz = 313;
+        mz_repr.adt.timestamp.ProtoFromToTimestampPrecisions adjust_timestamp_tz_precision = 316;
         google.protobuf.Empty cast_timestamp_tz_to_string = 116;
         google.protobuf.Empty cast_timestamp_tz_to_time = 117;
         google.protobuf.Empty cast_pg_legacy_char_to_string = 118;

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4586,7 +4586,7 @@ derive_unary!(
     ExpNumeric,
     Sleep,
     Panic,
-    RescaleNumeric,
+    AdjustNumericScale,
     PgColumnSize,
     MzRowSize,
     MzTypeName,
@@ -5000,7 +5000,7 @@ impl Arbitrary for UnaryFunc {
             ExpNumeric::arbitrary().prop_map_into().boxed(),
             Sleep::arbitrary().prop_map_into().boxed(),
             Panic::arbitrary().prop_map_into().boxed(),
-            RescaleNumeric::arbitrary().prop_map_into().boxed(),
+            AdjustNumericScale::arbitrary().prop_map_into().boxed(),
             PgColumnSize::arbitrary().prop_map_into().boxed(),
             MzRowSize::arbitrary().prop_map_into().boxed(),
             MzTypeName::arbitrary().prop_map_into().boxed(),
@@ -5375,7 +5375,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::ExpNumeric(_) => ExpNumeric(()),
             UnaryFunc::Sleep(_) => Sleep(()),
             UnaryFunc::Panic(_) => Panic(()),
-            UnaryFunc::RescaleNumeric(func) => RescaleNumeric(func.0.into_proto()),
+            UnaryFunc::AdjustNumericScale(func) => AdjustNumericScale(func.0.into_proto()),
             UnaryFunc::PgColumnSize(_) => PgColumnSize(()),
             UnaryFunc::MzRowSize(_) => MzRowSize(()),
             UnaryFunc::MzTypeName(_) => MzTypeName(()),
@@ -5834,8 +5834,8 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 ExpNumeric(()) => Ok(impls::ExpNumeric.into()),
                 Sleep(()) => Ok(impls::Sleep.into()),
                 Panic(()) => Ok(impls::Panic.into()),
-                RescaleNumeric(max_scale) => {
-                    Ok(impls::RescaleNumeric(max_scale.into_rust()?).into())
+                AdjustNumericScale(max_scale) => {
+                    Ok(impls::AdjustNumericScale(max_scale.into_rust()?).into())
                 }
                 PgColumnSize(()) => Ok(impls::PgColumnSize.into()),
                 MzRowSize(()) => Ok(impls::MzRowSize.into()),

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4476,7 +4476,7 @@ derive_unary!(
     CastIntervalToString,
     CastIntervalToTime,
     CastTimestampToDate,
-    CastTimestampToTimestamp,
+    AdjustTimestampPrecision,
     CastTimestampToTimestampTz,
     CastTimestampToString,
     CastTimestampToTime,
@@ -5226,12 +5226,12 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::CastIntervalToString(_) => CastIntervalToString(()),
             UnaryFunc::CastIntervalToTime(_) => CastIntervalToTime(()),
             UnaryFunc::CastTimestampToDate(_) => CastTimestampToDate(()),
-            UnaryFunc::CastTimestampToTimestamp(func) => {
-                CastTimestampToTimestamp(mz_repr::adt::timestamp::ProtoFromToTimestampPrecisions {
+            UnaryFunc::AdjustTimestampPrecision(func) => Kind::AdjustTimestampPrecision(
+                mz_repr::adt::timestamp::ProtoFromToTimestampPrecisions {
                     from: func.from.map(|p| p.into_proto()),
                     to: func.to.map(|p| p.into_proto()),
-                })
-            }
+                },
+            ),
             UnaryFunc::CastTimestampToTimestampTz(func) => CastTimestampToTimestampTz(
                 mz_repr::adt::timestamp::ProtoFromToTimestampPrecisions {
                     from: func.from.map(|p| p.into_proto()),
@@ -5650,7 +5650,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                 CastIntervalToString(()) => Ok(impls::CastIntervalToString.into()),
                 CastIntervalToTime(()) => Ok(impls::CastIntervalToTime.into()),
                 CastTimestampToDate(()) => Ok(impls::CastTimestampToDate.into()),
-                CastTimestampToTimestamp(precisions) => Ok(impls::CastTimestampToTimestamp {
+                AdjustTimestampPrecision(precisions) => Ok(impls::AdjustTimestampPrecision {
                     from: precisions.from.into_rust()?,
                     to: precisions.to.into_rust()?,
                 }

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -4482,7 +4482,7 @@ derive_unary!(
     CastTimestampToTime,
     CastTimestampTzToDate,
     CastTimestampTzToTimestamp,
-    CastTimestampTzToTimestampTz,
+    AdjustTimestampTzPrecision,
     CastTimestampTzToString,
     CastTimestampTzToTime,
     CastPgLegacyCharToString,
@@ -5241,7 +5241,7 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
             UnaryFunc::CastTimestampToString(_) => CastTimestampToString(()),
             UnaryFunc::CastTimestampToTime(_) => CastTimestampToTime(()),
             UnaryFunc::CastTimestampTzToDate(_) => CastTimestampTzToDate(()),
-            UnaryFunc::CastTimestampTzToTimestampTz(func) => CastTimestampTzToTimestampTz(
+            UnaryFunc::AdjustTimestampTzPrecision(func) => Kind::AdjustTimestampTzPrecision(
                 mz_repr::adt::timestamp::ProtoFromToTimestampPrecisions {
                     from: func.from.map(|p| p.into_proto()),
                     to: func.to.map(|p| p.into_proto()),
@@ -5668,13 +5668,11 @@ impl RustType<ProtoUnaryFunc> for UnaryFunc {
                     to: precisions.to.into_rust()?,
                 }
                 .into()),
-                CastTimestampTzToTimestampTz(precisions) => {
-                    Ok(impls::CastTimestampTzToTimestampTz {
-                        from: precisions.from.into_rust()?,
-                        to: precisions.to.into_rust()?,
-                    }
-                    .into())
+                AdjustTimestampTzPrecision(precisions) => Ok(impls::AdjustTimestampTzPrecision {
+                    from: precisions.from.into_rust()?,
+                    to: precisions.to.into_rust()?,
                 }
+                .into()),
                 CastTimestampTzToString(()) => Ok(impls::CastTimestampTzToString.into()),
                 CastTimestampTzToTime(()) => Ok(impls::CastTimestampTzToTime.into()),
                 CastPgLegacyCharToString(()) => Ok(impls::CastPgLegacyCharToString.into()),

--- a/src/expr/src/scalar/func/impls/numeric.rs
+++ b/src/expr/src/scalar/func/impls/numeric.rs
@@ -302,9 +302,9 @@ sqlfunc!(
 #[derive(
     Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
 )]
-pub struct RescaleNumeric(pub NumericMaxScale);
+pub struct AdjustNumericScale(pub NumericMaxScale);
 
-impl<'a> EagerUnaryFunc<'a> for RescaleNumeric {
+impl<'a> EagerUnaryFunc<'a> for AdjustNumericScale {
     type Input = Numeric;
     type Output = Result<Numeric, EvalError>;
 
@@ -323,8 +323,8 @@ impl<'a> EagerUnaryFunc<'a> for RescaleNumeric {
     }
 }
 
-impl fmt::Display for RescaleNumeric {
+impl fmt::Display for AdjustNumericScale {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("rescale_numeric")
+        f.write_str("adjust_numeric_scale")
     }
 }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -143,6 +143,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
+        mz_ore::soft_assert!(self.to != self.from);
+
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         let from_p = self.from.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         // If it's getting cast to a higher precision, it should preserve uniqueness but not otherwise.
@@ -239,6 +241,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
+        mz_ore::soft_assert!(self.to != self.from);
+
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         let from_p = self.from.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         // If it's getting cast to a higher precision, it should preserve uniqueness but not otherwise.

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -217,12 +217,12 @@ impl fmt::Display for CastTimestampTzToTimestamp {
 #[derive(
     Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
 )]
-pub struct CastTimestampTzToTimestampTz {
+pub struct AdjustTimestampTzPrecision {
     pub from: Option<TimestampPrecision>,
     pub to: Option<TimestampPrecision>,
 }
 
-impl<'a> EagerUnaryFunc<'a> for CastTimestampTzToTimestampTz {
+impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
     type Input = CheckedTimestamp<DateTime<Utc>>;
     type Output = Result<CheckedTimestamp<DateTime<Utc>>, EvalError>;
 
@@ -254,9 +254,9 @@ impl<'a> EagerUnaryFunc<'a> for CastTimestampTzToTimestampTz {
     }
 }
 
-impl fmt::Display for CastTimestampTzToTimestampTz {
+impl fmt::Display for AdjustTimestampTzPrecision {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("timestamp_with_time_zone_to_timestamp_with_time_zone")
+        f.write_str("adjust_timestamp_with_time_zone_precision")
     }
 }
 

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -134,10 +134,9 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
         &self,
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
-        // If the from and to precisions are same, then this is effectively a no-op.
-        // Adding a soft_assert to flag such instances.
-        mz_ore::soft_assert!(self.to != self.from);
-
+        if self.to == self.from {
+            return Ok(a);
+        }
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
     }
@@ -238,9 +237,9 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
         &self,
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
-        // If the from and to precisions are same, then this is effectively a no-op.
-        // Adding a soft_assert to flag such instances.
-        mz_ore::soft_assert!(self.to != self.from);
+        if self.to == self.from {
+            return Ok(a);
+        }
 
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -134,6 +134,10 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
         &self,
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
+        // If the from and to precisions are same, then this is effectively a no-op.
+        // Adding a soft_assert to flag such instances.
+        mz_ore::soft_assert!(self.to != self.from);
+
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
     }
@@ -143,6 +147,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
+        // If the from and to precisions are same, then this is effectively a no-op.
+        // Adding a soft_assert to flag such instances.
         mz_ore::soft_assert!(self.to != self.from);
 
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
@@ -232,6 +238,10 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
         &self,
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
+        // If the from and to precisions are same, then this is effectively a no-op.
+        // Adding a soft_assert to flag such instances.
+        mz_ore::soft_assert!(self.to != self.from);
+
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
     }
@@ -241,6 +251,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
+        // If the from and to precisions are same, then this is effectively a no-op.
+        // Adding a soft_assert to flag such instances.
         mz_ore::soft_assert!(self.to != self.from);
 
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -121,12 +121,12 @@ impl fmt::Display for CastTimestampToTimestampTz {
 #[derive(
     Arbitrary, Ord, PartialOrd, Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, MzReflect,
 )]
-pub struct CastTimestampToTimestamp {
+pub struct AdjustTimestampPrecision {
     pub from: Option<TimestampPrecision>,
     pub to: Option<TimestampPrecision>,
 }
 
-impl<'a> EagerUnaryFunc<'a> for CastTimestampToTimestamp {
+impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
     type Input = CheckedTimestamp<NaiveDateTime>;
     type Output = Result<CheckedTimestamp<NaiveDateTime>, EvalError>;
 
@@ -158,9 +158,9 @@ impl<'a> EagerUnaryFunc<'a> for CastTimestampToTimestamp {
     }
 }
 
-impl fmt::Display for CastTimestampToTimestamp {
+impl fmt::Display for AdjustTimestampPrecision {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("timestamp_to_timestamp")
+        f.write_str("adjust_timestamp_precision")
     }
 }
 

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -134,9 +134,10 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
         &self,
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
-        if self.to == self.from {
-            return Ok(a);
-        }
+        // This should never have been called if precisions are same.
+        // Adding a soft_assert to flag if there are such instances.
+        mz_ore::soft_assert!(self.to != self.from);
+
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
     }
@@ -146,10 +147,6 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
-        // If the from and to precisions are same, then this is effectively a no-op.
-        // Adding a soft_assert to flag such instances.
-        mz_ore::soft_assert!(self.to != self.from);
-
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         let from_p = self.from.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         // If it's getting cast to a higher precision, it should preserve uniqueness but not otherwise.
@@ -237,9 +234,9 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
         &self,
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
-        if self.to == self.from {
-            return Ok(a);
-        }
+        // This should never have been called if precisions are same.
+        // Adding a soft_assert to flag if there are such instances.
+        mz_ore::soft_assert!(self.to != self.from);
 
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
@@ -250,10 +247,6 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
     }
 
     fn preserves_uniqueness(&self) -> bool {
-        // If the from and to precisions are same, then this is effectively a no-op.
-        // Adding a soft_assert to flag such instances.
-        mz_ore::soft_assert!(self.to != self.from);
-
         let to_p = self.to.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         let from_p = self.from.map(|p| p.into_u8()).unwrap_or(MAX_PRECISION);
         // If it's getting cast to a higher precision, it should preserve uniqueness but not otherwise.

--- a/src/repr/src/adt/timestamp.rs
+++ b/src/repr/src/adt/timestamp.rs
@@ -1086,6 +1086,24 @@ mod test {
         assert_eq!(date1, date2);
     }
 
+    #[mz_ore::test]
+    fn test_equality_with_different_precisions() {
+        let date1 =
+            CheckedTimestamp::try_from(NaiveDateTime::from_timestamp_opt(0, 123500000).unwrap())
+                .unwrap();
+        let date1 = date1
+            .round_to_precision(Some(TimestampPrecision(5)))
+            .unwrap();
+
+        let date2 =
+            CheckedTimestamp::try_from(NaiveDateTime::from_timestamp_opt(0, 123456789).unwrap())
+                .unwrap();
+        let date2 = date2
+            .round_to_precision(Some(TimestampPrecision(4)))
+            .unwrap();
+        assert_eq!(date1, date2);
+    }
+
     proptest! {
         #[mz_ore::test]
         #[cfg_attr(miri, ignore)] // slow

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -374,7 +374,7 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
         (Timestamp, Timestamp) => Assignment: CastTemplate::new(|_ecx, _ccx, from_type, to_type| {
             let from = from_type.unwrap_timestamp_precision();
             let to = to_type.unwrap_timestamp_precision();
-            Some(move |e: HirScalarExpr| e.call_unary(CastTimestampToTimestamp(func::CastTimestampToTimestamp{from, to})))
+            Some(move |e: HirScalarExpr| e.call_unary(AdjustTimestampPrecision(func::AdjustTimestampPrecision{from, to})))
         }),
         (Timestamp, Time) => Assignment: CastTimestampToTime(func::CastTimestampToTime),
         (Timestamp, String) => Assignment: CastTimestampToString(func::CastTimestampToString),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -389,7 +389,7 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
         (TimestampTz, TimestampTz) => Assignment: CastTemplate::new(|_ecx, _ccx, from_type, to_type| {
             let from = from_type.unwrap_timestamp_precision();
             let to = to_type.unwrap_timestamp_precision();
-            Some(move |e: HirScalarExpr| e.call_unary(CastTimestampTzToTimestampTz(func::CastTimestampTzToTimestampTz{from, to})))
+            Some(move |e: HirScalarExpr| e.call_unary(AdjustTimestampTzPrecision(func::AdjustTimestampTzPrecision{from, to})))
         }),
         (TimestampTz, Time) => Assignment: CastTimestampTzToTime(func::CastTimestampTzToTime),
         (TimestampTz, String) => Assignment: CastTimestampTzToString(func::CastTimestampTzToString),

--- a/src/sql/src/plan/typeconv.rs
+++ b/src/sql/src/plan/typeconv.rs
@@ -675,7 +675,7 @@ static VALID_CASTS: Lazy<BTreeMap<(ScalarBaseType, ScalarBaseType), CastImpl>> =
             let scale = to_type.unwrap_numeric_max_scale();
             Some(move |e: HirScalarExpr| match scale {
                 None => e,
-                Some(scale) => e.call_unary(UnaryFunc::RescaleNumeric(func::RescaleNumeric(scale))),
+                Some(scale) => e.call_unary(UnaryFunc::AdjustNumericScale(func::AdjustNumericScale(scale))),
             })
         }),
         (Numeric, Float32) => Implicit: CastNumericToFloat32(func::CastNumericToFloat32),

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1582,3 +1582,34 @@ SELECT timestamptz(10000000000000000000) '95143-12-31 23:59:59.123456789+06';
 
 query error number too large to fit in target type
 SELECT timestamp(9223372036854775808) '95143-12-31 23:59:59.123456789+06';
+
+# checking we are not converting between the same precision again
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT '95143-12-31 23:59:59.123456789+06'::timestamptz(3)::timestamptz(3);
+----
+Map (text_to_timestamp_with_time_zone("95143-12-31 23:59:59.123456789+06"))
+  Constant
+    - ()
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT timestamp(3) '95143-12-31 23:59:59.123456789+06'::timestamp(3);
+----
+Map (text_to_timestamp("95143-12-31 23:59:59.123456789+06"))
+  Constant
+    - ()
+
+EOF
+
+query T multiline
+EXPLAIN RAW PLAN FOR
+SELECT timestamp(3) '95143-12-31 23:59:59.123456789+06'::timestamp(6);
+----
+Map (adjust_timestamp_precision(text_to_timestamp("95143-12-31 23:59:59.123456789+06")))
+  Constant
+    - ()
+
+EOF

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1557,6 +1557,11 @@ SELECT timestamp '95143-12-31 17:59:59.123456789+00' = timestamp(6) '95143-12-31
 ----
 true
 
+query B
+SELECT timestamp(5) '95143-12-31 17:59:59.1235+00' = timestamp(4) '95143-12-31 17:59:59.123456789+00';
+----
+true
+
 query error Expected literal unsigned integer
 SELECT timestamp(-1) '95143-12-31 23:59:59.123456789+06';
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Fast-follow to https://github.com/MaterializeInc/materialize/pull/21570 to rename 
* `CastTimestampTzToTimestampTz` to `AdjustTimestampTzPrecision`
* `CastTimestampToTimestamp` to `AdjustTimestampPrecision`
* `RescaleNumeric` to `AdjustNumericScale`

### Motivation
Addressing follow ups from https://github.com/MaterializeInc/materialize/pull/21570#pullrequestreview-1633496526

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
