### PR TITLE
[persist] Dynamic lease timeouts

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -159,6 +159,7 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
             multiplier: config.persist_next_listen_batch_retryer_multiplier(),
             clamp: config.persist_next_listen_batch_retryer_clamp(),
         }),
+        reader_lease_duration: Some(config.persist_reader_lease_duration()),
         stats_audit_percent: Some(config.persist_stats_audit_percent()),
         stats_collection_enabled: Some(config.persist_stats_collection_enabled()),
         stats_filter_enabled: Some(config.persist_stats_filter_enabled()),

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -30,6 +30,7 @@ message ProtoPersistParameters {
     optional uint64 blob_cache_mem_limit_bytes = 14;
     mz_proto.ProtoDuration consensus_connection_pool_ttl = 15;
     mz_proto.ProtoDuration consensus_connection_pool_ttl_stagger = 16;
+    mz_proto.ProtoDuration reader_lease_duration = 20;
     optional uint64 stats_budget_bytes = 17;
     optional ProtoUntrimmableColumns stats_untrimmable_columns = 18;
     map<string, bool> feature_flags = 19;

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -899,7 +899,7 @@ where
             reader_id
         );
         isolated_runtime.spawn_named(|| name, async move {
-            let sleep_duration = machine.applier.cfg.reader_lease_duration / 2;
+            let sleep_duration = machine.applier.cfg.dynamic.reader_lease_duration() / 2;
             loop {
                 let before_sleep = Instant::now();
                 tokio::time::sleep(sleep_duration).await;
@@ -1692,7 +1692,7 @@ pub mod datadriven {
             .register_leased_reader(
                 &reader_id,
                 "tests",
-                datadriven.client.cfg.reader_lease_duration,
+                datadriven.client.cfg.dynamic.reader_lease_duration(),
                 (datadriven.client.cfg.now)(),
             )
             .await;

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -433,7 +433,7 @@ impl PersistClient {
             .register_leased_reader(
                 &reader_id,
                 &diagnostics.handle_purpose,
-                self.cfg.reader_lease_duration,
+                self.cfg.dynamic.reader_lease_duration(),
                 heartbeat_ts,
             )
             .await;
@@ -1972,7 +1972,10 @@ mod tests {
         // Verify that the ReadHandle and WriteHandle background heartbeat tasks
         // shut down cleanly after the handle is expired.
         let mut cache = new_test_client_cache();
-        cache.cfg.reader_lease_duration = Duration::from_millis(1);
+        cache
+            .cfg
+            .dynamic
+            .set_reader_lease_duration(Duration::from_millis(1));
         cache.cfg.writer_lease_duration = Duration::from_millis(1);
         let (_write, mut read) = cache
             .open(PersistLocation::new_in_mem())

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -603,6 +603,14 @@ const PERSIST_CONSENSUS_CONNECTION_POOL_TTL: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connection_pool_ttl`].
+const PERSIST_READER_LEASE_DURATION: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_reader_lease_duration"),
+    value: &PersistConfig::DEFAULT_READ_LEASE_DURATION,
+    description: "The time after which we'll clean up stale read leases",
+    internal: true,
+};
+
 /// Controls [`mz_persist_client::cfg::DynamicConfig::consensus_connection_pool_ttl_stagger`].
 const PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("persist_consensus_connection_pool_ttl_stagger"),
@@ -2316,6 +2324,7 @@ impl SystemVars {
             .with_var(&PERSIST_COMPACTION_MINIMUM_TIMEOUT)
             .with_var(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL)
             .with_var(&PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER)
+            .with_var(&PERSIST_READER_LEASE_DURATION)
             .with_var(&CRDB_CONNECT_TIMEOUT)
             .with_var(&CRDB_TCP_USER_TIMEOUT)
             .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
@@ -2813,6 +2822,10 @@ impl SystemVars {
     /// Returns the `persist_next_listen_batch_retryer_clamp` configuration parameter.
     pub fn persist_next_listen_batch_retryer_clamp(&self) -> Duration {
         *self.expect_value(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+    }
+
+    pub fn persist_reader_lease_duration(&self) -> Duration {
+        *self.expect_value(&PERSIST_READER_LEASE_DURATION)
     }
 
     /// Returns the `persist_compaction_minimum_timeout` configuration parameter.
@@ -4627,6 +4640,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_COMPACTION_MINIMUM_TIMEOUT.name()
         || name == PERSIST_CONSENSUS_CONNECTION_POOL_TTL.name()
         || name == PERSIST_CONSENSUS_CONNECTION_POOL_TTL_STAGGER.name()
+        || name == PERSIST_READER_LEASE_DURATION.name()
         || name == CRDB_CONNECT_TIMEOUT.name()
         || name == CRDB_TCP_USER_TIMEOUT.name()
         || name == PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -634,8 +634,10 @@ mod tests {
     static PERSIST_READER_LEASE_TIMEOUT_MS: Duration = Duration::from_secs(60 * 15);
 
     static PERSIST_CACHE: Lazy<Arc<PersistClientCache>> = Lazy::new(|| {
-        let mut persistcfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-        persistcfg.reader_lease_duration = PERSIST_READER_LEASE_TIMEOUT_MS;
+        let persistcfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
+        persistcfg
+            .dynamic
+            .set_reader_lease_duration(PERSIST_READER_LEASE_TIMEOUT_MS);
         Arc::new(PersistClientCache::new(
             persistcfg,
             &MetricsRegistry::new(),

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -200,7 +200,9 @@ where
             let decode_metrics = DecodeMetrics::register_with(&metrics_registry);
 
             let mut persistcfg = PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone());
-            persistcfg.reader_lease_duration = std::time::Duration::from_secs(60 * 15);
+            persistcfg
+                .dynamic
+                .set_reader_lease_duration(Duration::from_secs(60 * 15));
             persistcfg.now = SYSTEM_TIME.clone();
 
             let persist_location = mz_persist_client::PersistLocation {


### PR DESCRIPTION
### Motivation

This is a long-time known-useful knob which has recently become more urgent.

Closes #21821

### Tips for reviewer

I have not yet tested that all the wiring is set up correctly; will comment when that's done.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
