### PR TITLE
catalog: Omit storage collections from migrations

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4701,8 +4701,13 @@ impl Catalog {
 
             // Push drop commands.
             match entry.item() {
-                CatalogItem::Table(_) | CatalogItem::Source(_) => {
-                    migration_metadata.previous_source_ids.push(id)
+                CatalogItem::Table(_) => migration_metadata.previous_source_ids.push(id),
+                CatalogItem::Source(source) => {
+                    if matches!(source.data_source, DataSourceDesc::Introspection(_)) {
+                        panic!("Cannot migrate storage managed collection: {entry:?}");
+                    } else {
+                        migration_metadata.previous_source_ids.push(id);
+                    }
                 }
                 CatalogItem::Sink(_) => migration_metadata.previous_sink_ids.push(id),
                 CatalogItem::MaterializedView(_) => {


### PR DESCRIPTION
The builtin object migration framework relies on being able to repopulate all system objects with data from the stash. However, storage managed collections cannot be re-populated with data from the stash. Therefore, storage managed collections cannot be properly migrated via the builtin migration framework.

This commit removes storage managed collections from the builtin migration framework to prevent anyone from accidentally migrating a storage managed collection.

Part of #21817

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
