### PR TITLE
dbt Test Cluster

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 * Support cancelling outstanding queries when pressing Ctrl+C.
 
+* Allow `cluster` configuration for `dbt test`.
+
 ## 1.5.1 - 2023-07-24
 
 * Enable the `indexes` config for `table` materializations.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -51,10 +51,11 @@
   {% set fail_calc = config.get('fail_calc') %}
   {% set warn_if = config.get('warn_if') %}
   {% set error_if = config.get('error_if') %}
+  {% set cluster = config.get('cluster') %}
 
   {% call statement('main', fetch_result=True) -%}
 
-    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit)}}
+    {{ cluster_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster)}}
 
   {%- endcall %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -55,7 +55,7 @@
 
   {% call statement('main', fetch_result=True) -%}
 
-    {{ cluster_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster)}}
+    {{ get_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster)}}
 
   {%- endcall %}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
@@ -1,0 +1,9 @@
+{% macro cluster_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster) -%}
+    {% if cluster %}
+        {% call statement(auto_begin=True) %}
+            set cluster = {{ cluster }}
+        {% endcall %}
+    {% endif %}
+
+  {{ adapter.dispatch('get_test_sql', 'dbt')(main_sql, fail_calc, warn_if, error_if, limit) }}
+{%- endmacro %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
@@ -1,3 +1,18 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Licensed under the Apache License, Version 2.0 (the "License");
+-- you may not use this file except in compliance with the License.
+-- You may obtain a copy of the License in the LICENSE file at the
+-- root of this repository, or online at
+--
+--     http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS,
+-- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+-- See the License for the specific language governing permissions and
+-- limitations under the License.
+
 {% macro cluster_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster) -%}
     {% if cluster %}
         {% call statement(auto_begin=True) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/tests/helpers.sql
@@ -13,7 +13,7 @@
 -- See the License for the specific language governing permissions and
 -- limitations under the License.
 
-{% macro cluster_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster) -%}
+{% macro get_test_sql(main_sql, fail_calc, warn_if, error_if, limit, cluster) -%}
     {% if cluster %}
         {% call statement(auto_begin=True) %}
             set cluster = {{ cluster }}

--- a/misc/dbt-materialize/tests/adapter/test_data_tests.py
+++ b/misc/dbt-materialize/tests/adapter/test_data_tests.py
@@ -77,7 +77,6 @@ class TestDataTestCluster:
 
     def test_store_failures_cluster(self, project):
         project.run_sql("CREATE CLUSTER not_default_test REPLICAS (r1 (SIZE '1'))")
-        project.run_sql("CREATE SCHEMA etl_failure")
 
         # run models
         results = run_dbt(["run"])


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes #20763.

Allow users to specify the cluster that is used for testing. This is configured in the `dbt_project.yml`
```
tests:
  example:
    +store_failures: true
    +schema: 'etl_failure'
    +cluster: 'dbt_test' # Set here
```
If `cluster` is set, the SELECT statements will be prefaced with `SET CLUSTER`. If `store_failures` is set, the clusters will also be created within the given cluster.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
