### PR TITLE
scalability-test: Allow running with --find

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ perf.data*
 **/*.profdata
 **/*.debug
 scratch
+*.swp
 
 # This is un-orthodox, but adding it to the repo would "tie" it to each user's
 # local version of nixpkgs. This way, we can all use the flake and have a

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -13,9 +13,13 @@ import subprocess
 import pandas as pd
 from matplotlib import pyplot as plt  # type: ignore
 
+from materialize import MZ_ROOT
+
+RESULTS_DIR = MZ_ROOT / "test" / "scalability" / "results"
+
 
 def plotit(csv_file_name: str) -> None:
-    targets = next(os.walk("results"))[1]
+    targets = next(os.walk(RESULTS_DIR))[1]
     legend = []
     plt.rcParams["figure.figsize"] = (16, 10)
     fig, (summary_subplot, details_subplot) = plt.subplots(2, 1)
@@ -34,10 +38,10 @@ def plotit(csv_file_name: str) -> None:
 
         legend.append(f"{target} - {target_comment}")
 
-        df = pd.read_csv(f"results/{target}/{csv_file_name}.csv")
+        df = pd.read_csv(RESULTS_DIR / target / f"{csv_file_name}.csv")
         summary_subplot.scatter(df["concurrency"], df["tps"], label="tps")
 
-        df_details = pd.read_csv(f"results/{target}/{csv_file_name}_details.csv")
+        df_details = pd.read_csv(RESULTS_DIR / target / f"{csv_file_name}_details.csv")
         details_subplot.scatter(
             df_details["concurrency"] + i, df_details["wallclock"], alpha=0.25
         )

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -20,6 +20,7 @@ import pandas as pd
 from jupyter_core.command import main as jupyter_core_command_main
 from psycopg import Cursor
 
+from materialize import MZ_ROOT
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
@@ -36,6 +37,7 @@ from materialize.scalability.workload import Workload, WorkloadSelfTest
 from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
 
+RESULTS_DIR = MZ_ROOT / "test" / "scalability" / "results"
 SERVICES = [Materialized(image="materialize/materialized:latest"), Postgres()]
 
 
@@ -186,11 +188,11 @@ def run_workload(
         df_details = pd.concat([df_details, df_detail])
 
         endpoint_name = endpoint.name()
-        pathlib.Path(f"results/{endpoint_name}").mkdir(parents=True, exist_ok=True)
+        pathlib.Path(RESULTS_DIR / endpoint_name).mkdir(parents=True, exist_ok=True)
 
-        df_totals.to_csv(f"results/{endpoint_name}/{type(workload).__name__}.csv")
+        df_totals.to_csv(RESULTS_DIR / endpoint_name / f"{type(workload).__name__}.csv")
         df_details.to_csv(
-            f"results/{endpoint_name}/{type(workload).__name__}_details.csv"
+            RESULTS_DIR / endpoint_name / f"{type(workload).__name__}_details.csv"
         )
 
 
@@ -311,7 +313,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     workload_names = [workload.__name__ for workload in workloads]
     df_workloads = pd.DataFrame(data={"workload": workload_names})
-    df_workloads.to_csv("results/workloads.csv")
+    df_workloads.to_csv(RESULTS_DIR / "workloads.csv")
 
     for workload in workloads:
         assert issubclass(workload, Workload), f"{workload} is not a Workload"


### PR DESCRIPTION
Tried with `bin/mzcompose --find scalability run default --workload SelectOneWorkload --max-concurrency 2048 --count 1`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
