### PR TITLE
Enable co-locating compute and storage objects

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3816,17 +3816,24 @@ impl Catalog {
             );
         }
         let cluster = self.resolve_cluster(session.vars().cluster())?;
-        // Disallow queries on storage clusters. There's no technical reason for
-        // this restriction, just a philosophical one: we want all crashes in
-        // a storage cluster to be the result of sources and sinks, not user
-        // queries.
-        if cluster.bound_objects.iter().any(|id| {
-            matches!(
-                self.get_entry(id).item_type(),
-                CatalogItemType::Source | CatalogItemType::Sink
-            )
-        }) {
-            coord_bail!("cannot execute queries on cluster containing sources or sinks");
+
+        if !self
+            .for_session(session)
+            .system_vars()
+            .enable_unified_clusters()
+        {
+            // Disallow queries on storage clusters. There's no technical reason for
+            // this restriction, just a philosophical one: we want all crashes in
+            // a storage cluster to be the result of sources and sinks, not user
+            // queries.
+            if cluster.bound_objects.iter().any(|id| {
+                matches!(
+                    self.get_entry(id).item_type(),
+                    CatalogItemType::Source | CatalogItemType::Sink
+                )
+            }) {
+                coord_bail!("cannot execute queries on cluster containing sources or sinks");
+            }
         }
         Ok(cluster)
     }

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -20,8 +20,8 @@ use mz_controller::clusters::{
 use mz_controller_types::{ClusterId, ReplicaId, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS};
 use mz_ore::cast::CastFrom;
 use mz_repr::role_id::RoleId;
-use mz_sql::catalog::{CatalogCluster, CatalogItem, CatalogItemType, ObjectType};
-use mz_sql::names::ObjectId;
+use mz_sql::catalog::{CatalogCluster, CatalogItem, CatalogItemType, ObjectType, SessionCatalog};
+use mz_sql::names::{ObjectId, QualifiedItemName};
 use mz_sql::plan::{
     AlterClusterPlan, AlterClusterRenamePlan, AlterClusterReplicaRenamePlan, AlterOptionParameter,
     ComputeReplicaIntrospectionConfig, CreateClusterManagedPlan, CreateClusterPlan,
@@ -999,16 +999,40 @@ impl Coordinator {
         }
     }
 
-    /// Returns whether the given cluster exclusively maintains items
-    /// that were formerly maintained on `computed`.
-    pub(crate) fn is_compute_cluster(&self, id: ClusterId) -> bool {
-        let cluster = self.catalog().get_cluster(id);
-        cluster.bound_objects().iter().all(|id| {
-            matches!(
-                self.catalog().get_entry(id).item_type(),
-                CatalogItemType::Index | CatalogItemType::MaterializedView
-            )
-        })
+    /// Determine whether we can create a compute item in the specified cluster.
+    ///
+    /// Returns `Ok` if the item can be created, and an error otherwise.
+    pub(crate) fn ensure_cluster_can_host_compute_item(
+        &self,
+        name: &QualifiedItemName,
+        cluster_id: ClusterId,
+    ) -> Result<(), AdapterError> {
+        let is_system_schema_specifier = self
+            .catalog()
+            .state()
+            .is_system_schema_specifier(&name.qualifiers.schema_spec);
+
+        let enable_unified_clusters = self
+            .catalog()
+            .for_system_session()
+            .system_vars()
+            .enable_unified_clusters();
+
+        let cluster = self.catalog().get_cluster(cluster_id);
+        let is_compute_cluster = cluster.bound_objects().is_empty()
+            || cluster.bound_objects().iter().any(|id| {
+                matches!(
+                    self.catalog().get_entry(id).item_type(),
+                    CatalogItemType::Index | CatalogItemType::MaterializedView
+                )
+            });
+
+        if !is_system_schema_specifier && !enable_unified_clusters && !is_compute_cluster {
+            let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
+            Err(AdapterError::BadItemInStorageCluster { cluster_name })
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -964,15 +964,7 @@ impl Coordinator {
             ambiguous_columns,
         } = plan;
 
-        if !self
-            .catalog()
-            .state()
-            .is_system_schema_specifier(&name.qualifiers.schema_spec)
-            && !self.is_compute_cluster(cluster_id)
-        {
-            let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
-            return Err(AdapterError::BadItemInStorageCluster { cluster_name });
-        }
+        self.ensure_cluster_can_host_compute_item(&name, cluster_id)?;
 
         // Validate any references in the materialized view's expression. We do
         // this on the unoptimized plan to better reflect what the user typed.
@@ -1122,15 +1114,7 @@ impl Coordinator {
         // An index must be created on a specific cluster.
         let cluster_id = index.cluster_id;
 
-        if !self
-            .catalog()
-            .state()
-            .is_system_schema_specifier(&name.qualifiers.schema_spec)
-            && !self.is_compute_cluster(cluster_id)
-        {
-            let cluster_name = self.catalog().get_cluster(cluster_id).name.clone();
-            return Err(AdapterError::BadItemInStorageCluster { cluster_name });
-        }
+        self.ensure_cluster_can_host_compute_item(&name, cluster_id)?;
 
         let empty_key = index.keys.is_empty();
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1696,6 +1696,10 @@ feature_flags!(
         enable_role_vars,
         "setting default session variables for a role"
     ),
+    (
+        enable_unified_clusters,
+        "unified compute and storage cluster"
+    ),
 );
 
 /// Represents the input to a variable.

--- a/test/sqllogictest/unified_cluster.slt
+++ b/test/sqllogictest/unified_cluster.slt
@@ -1,0 +1,97 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Basic tests of colocating compute and storage objects
+
+mode cockroach
+
+# Start from a pristine state
+reset-server
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unified_clusters = on;
+----
+COMPLETE 0
+
+statement ok
+CREATE CLUSTER c SIZE '1', REPLICATION FACTOR 2;
+
+statement error db error: ERROR: cannot create source in cluster with more than one replica
+CREATE SOURCE ldgen IN CLUSTER c FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s');
+
+statement ok
+ALTER CLUSTER c SET (REPLICATION FACTOR 1)
+
+statement ok
+CREATE SOURCE ldgen IN CLUSTER c FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s');
+
+statement error db error: ERROR: cannot create more than one replica of a cluster containing sources or sinks
+ALTER CLUSTER c SET (REPLICATION FACTOR 2)
+
+statement ok
+CREATE TABLE t(a int);
+
+statement ok
+CREATE INDEX t_idx IN CLUSTER c ON t(a);
+
+statement ok
+SET CLUSTER = c;
+
+query TT
+SELECT s.name, c.name FROM mz_sources s JOIN mz_clusters c ON s.cluster_id = c.id
+----
+ldgen   c
+
+statement ok
+INSERT INTO t VALUES (1);
+
+query T
+SELECT * FROM t;
+----
+1
+
+statement ok
+ALTER CLUSTER c SET (REPLICATION FACTOR 0);
+
+statement error db error: ERROR: cannot create more than one replica of a cluster containing sources or sinks
+ALTER CLUSTER c SET (SIZE '2', REPLICATION FACTOR 2);
+
+statement ok
+ALTER CLUSTER c SET (REPLICATION FACTOR 1);
+
+statement ok
+INSERT INTO t VALUES (2);
+
+query T
+SELECT * FROM t;
+----
+1
+2
+
+statement ok
+DROP CLUSTER c CASCADE;
+
+# First create a compute item, then a storage item
+
+statement ok
+CREATE CLUSTER c SIZE '1';
+
+statement ok
+CREATE MATERIALIZED VIEW mv IN CLUSTER c AS SELECT 1;
+
+statement ok
+CREATE SOURCE ldgen IN CLUSTER c FROM LOAD GENERATOR COUNTER (TICK INTERVAL '1s');
+
+statement ok
+SET CLUSTER = c;
+
+query T
+SELECT * FROM mv;
+----
+1


### PR DESCRIPTION
### Motivation

Get us closer to cluster unification by allowing to co-locate compute and storage objects. This PR only moves the check behind a feature flag, which, if enabled, allows co-locating the objects.

It does not unify the protocol, controller and Timely runtimes.

### Tips for reviewer

This is not intended to declare cluster unification done, but could enable us to experiment what we'd get out of cluster unification, minus introspection data.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
