### PR TITLE
Better output bin/lint etc. in CI

### DIFF
--- a/bin/fmt
+++ b/bin/fmt
@@ -23,4 +23,4 @@ if [[ ! "${MZDEV_NO_PYTHON:-}" ]]; then
   bin/pyfmt
 fi
 
-try_finish
+try_status_report

--- a/bin/lint
+++ b/bin/lint
@@ -106,4 +106,4 @@ try bin/gen-completion check
 try bin/gen-lints
 try git diff --compact-summary --exit-code
 
-try_finish
+try_status_report

--- a/bin/pre-push
+++ b/bin/pre-push
@@ -13,13 +13,11 @@
 
 set -euo pipefail
 
-SHLIB_NOT_IN_CI=1
-
 . misc/shlib/shlib.bash
 
-ci_try bin/lint
-ci_try cargo fmt -- --check
-ci_try cargo clippy --all-targets -- -D warnings
-ci_try bin/doc --no-deps
+try bin/lint
+try cargo fmt -- --check
+try cargo clippy --all-targets -- -D warnings
+try bin/doc --no-deps
 
-ci_status_report
+try_status_report

--- a/bin/pycheck
+++ b/bin/pycheck
@@ -37,4 +37,4 @@ if [[ ! "${MZDEV_NO_PYTHON_DOCTEST:-}" ]]; then
   try bin/pyactivate -m pytest -qq --doctest-modules misc/python
 fi
 
-try_finish
+try_status_report

--- a/bin/pyfmt
+++ b/bin/pyfmt
@@ -20,4 +20,4 @@ cd "$(dirname "$0")/.."
 try bin/pyactivate -m black . "$@"
 try bin/pyactivate -m ruff --fix --extend-exclude=misc/dbt-materialize .
 try bin/pyactivate -m ruff --target-version=py38 --fix misc/dbt-materialize
-try_finish
+try_status_report

--- a/ci/test/lint-deps.sh
+++ b/ci/test/lint-deps.sh
@@ -76,9 +76,9 @@ for target in "${targets[@]}"; do
         deps > "$resources/$target-default"
         deps --no-default-features > "$resources/$target-no-default-features"
     else
-        ci_try diff "$resources/$target-default" <(deps)
-        ci_try diff "$resources/$target-no-default-features" <(deps --no-default-features)
+        try diff "$resources/$target-default" <(deps)
+        try diff "$resources/$target-no-default-features" <(deps --no-default-features)
     fi
 done
 
-ci_status_report
+try_status_report

--- a/ci/test/lint-docs-catalog.sh
+++ b/ci/test/lint-docs-catalog.sh
@@ -42,10 +42,10 @@ fi
 for catalog_file in "${catalog_files[@]}"; do
     slt="$slt_directory/$(basename "$catalog_file" .md).slt"
     if $rewrite; then
-        ci_try bin/pyactivate ci/test/lint-docs-catalog.py "$catalog_file" > "$slt"
+        try bin/pyactivate ci/test/lint-docs-catalog.py "$catalog_file" > "$slt"
     else
-        ci_try diff "$slt" <(bin/pyactivate ci/test/lint-docs-catalog.py "$catalog_file")
+        try diff "$slt" <(bin/pyactivate ci/test/lint-docs-catalog.py "$catalog_file")
     fi
 done
 
-ci_status_report
+try_status_report

--- a/ci/test/lint-docs.sh
+++ b/ci/test/lint-docs.sh
@@ -16,9 +16,9 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 
 git clean -ffdX ci/www/public
-ci_try hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destination ../../ci/www/public/docs
+try hugo --gc --baseURL https://ci.materialize.com/docs --source doc/user --destination ../../ci/www/public/docs
 echo "<!doctype html>" > ci/www/public/index.html
-ci_try htmltest -s ci/www/public -c doc/user/.htmltest.yml
-ci_try ci/test/lint-docs-catalog.sh
+try htmltest -s ci/www/public -c doc/user/.htmltest.yml
+try ci/test/lint-docs-catalog.sh
 
-ci_status_report
+try_status_report

--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -16,17 +16,17 @@ set -euo pipefail
 . misc/shlib/shlib.bash
 . misc/buildkite/git.bash
 
-ci_try bin/lint
-ci_try cargo --locked fmt -- --check
-ci_try cargo --locked deny check licenses bans sources
-ci_try cargo hakari generate --diff
-ci_try cargo hakari manage-deps --dry-run
-ci_try cargo deplint Cargo.lock ci/test/lint-deps.toml
+try bin/lint
+try cargo --locked fmt -- --check
+try cargo --locked deny check licenses bans sources
+try cargo hakari generate --diff
+try cargo hakari manage-deps --dry-run
+try cargo deplint Cargo.lock ci/test/lint-deps.toml
 
 # Smoke out failures in generating the license metadata page, even though we
 # don't care about its output in the test pipeline, so that we don't only
 # discover the failures after a merge to main.
-ci_try cargo --locked about generate ci/deploy/licenses.hbs > /dev/null
+try cargo --locked about generate ci/deploy/licenses.hbs > /dev/null
 
 
 if [[ "${BUILDKITE_PULL_REQUEST:-true}" != "false" ]]; then
@@ -35,7 +35,7 @@ if [[ "${BUILDKITE_PULL_REQUEST:-true}" != "false" ]]; then
   ci_collapsed_heading "Lint protobuf"
   # exceptions can be defined in src/buf.yaml
   COMMON_ANCESTOR="$(get_common_ancestor_commit_of_pr_and_target)"
-  ci_try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src"
+  try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src"
 fi
 
-ci_status_report
+try_status_report

--- a/ci/test/lint-slow.sh
+++ b/ci/test/lint-slow.sh
@@ -15,11 +15,11 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-ci_try cargo clippy --all-targets -- -D warnings
+try cargo clippy --all-targets -- -D warnings
 
-ci_try bin/doc
-ci_try bin/doc --document-private-items
+try bin/doc
+try bin/doc --document-private-items
 
-ci_try bin/xcompile cargo test --locked --doc
+try bin/xcompile cargo test --locked --doc
 
-ci_status_report
+try_status_report

--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -70,15 +70,23 @@ git_files() {
 # try COMMAND [ARGS...]
 #
 # Runs COMMAND with the specified ARGS without aborting the script if the
-# command fails. See also try_last_failed and try_finish.
+# command fails. See also try_last_failed and try_status_report.
 try() {
-    try_last_failed=false
-    if ! run "$@"; then
-        try_failed=true
+    ci_collapsed_heading "$@"
+
+    # Try the command.
+    if "$@"; then
+        try_last_failed=false
+        ((++ci_try_passed))
+    else
         try_last_failed=true
+        # The command failed. Tell Buildkite to uncollapse this log section, so
+        # that the errors are immediately visible.
+        in_ci && ci_uncollapse_current_section
     fi
+    ((++ci_try_total))
 }
-try_failed=false
+try_last_failed=false
 
 # try_last_failed
 #
@@ -87,15 +95,16 @@ try_last_failed() {
     $try_last_failed
 }
 
-# try_finish
+# try_status_report
 #
 # Exits the script with a code that reflects whether all commands executed with
 # `try` were successful.
-try_finish() {
-    if $try_failed; then
+try_status_report() {
+    ci_uncollapsed_heading "Status report"
+    echo "$ci_try_passed/$ci_try_total commands passed"
+    if ((ci_try_passed != ci_try_total)); then
         exit 1
     fi
-    exit 0
 }
 
 ci_unimportant_heading() {
@@ -111,33 +120,13 @@ ci_uncollapsed_heading() {
 }
 
 ci_uncollapse_current_section() {
-    echo "^^^ +++" >&2
+    if in_ci; then
+        echo "^^^ +++" >&2
+    fi
 }
 
 ci_try_passed=0
 ci_try_total=0
-
-ci_try() {
-    ci_collapsed_heading "$@"
-
-    # Try the command.
-    if "$@"; then
-        ((++ci_try_passed))
-    else
-        # The command failed. Tell Buildkite to uncollapse this log section, so
-        # that the errors are immediately visible.
-        [[ "${SHLIB_NOT_IN_CI-}" ]] || ci_uncollapse_current_section
-    fi
-    ((++ci_try_total))
-}
-
-ci_status_report() {
-    ci_uncollapsed_heading "Status report"
-    echo "$ci_try_passed/$ci_try_total commands passed"
-    if ((ci_try_passed != ci_try_total)); then
-        exit 1
-    fi
-}
 
 # read_list PREFIX
 #
@@ -210,4 +199,12 @@ arch_go() {
 # Prints the provided text in red.
 red() {
     echo -ne "\e[31m$*\e[0m"
+}
+
+# in_ci
+#
+# Returns 1 if in CI and 0 otherwise
+in_ci() {
+    [ -z "${BUILDKITE-}" ] && return 1
+    return 0
 }

--- a/test/lang/js/test.sh
+++ b/test/lang/js/test.sh
@@ -21,7 +21,7 @@ cd test/lang/js
 
 yarn install --frozen-lockfile
 
-ci_try yarn run fmt-check
-ci_try yarn test
+try yarn run fmt-check
+try yarn test
 
-ci_status_report
+try_status_report


### PR DESCRIPTION
### Motivation

I've missed the actual error in lints in CI several times. This PR improves the rendering of such errors to minimize this kind of confusion!

![image](https://github.com/MaterializeInc/materialize/assets/582946/41121c1f-c6b8-4cb5-8bed-86b784551a68)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
