### PR TITLE
storage: manage sink connections when rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5537,6 +5537,7 @@ dependencies = [
  "differential-dataflow",
  "http",
  "itertools",
+ "maplit",
  "mz-ccsr",
  "mz-cluster-client",
  "mz-kafka-util",

--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -787,6 +787,13 @@ once one record matches, the following must all match.  There are permitted to b
 topic after the matching is complete.  Note that if the topic is not required to have `partial-search`
 elements in it but there will be an attempt to read up to this number with a blocking read.
 
+#### `kafka-verify-topic [sink=... | topic=...] [await-value-schema=false] [await-key-schema=false]`
+
+Verifies that the broker contains the appropriate topic.
+
+`await-value-schema` and `await-key-schema` optionally check that the Confluent
+Schema Registry also contains the appropriate subjects before continuing.
+
 #### `kafka-verify-commit consumer-group-id=... topic=... partition=...
 
 Verifies that the provided offset (the input data) matches the committed offset

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -57,6 +57,7 @@ class CreateDebeziumSource(Action):
     def __init__(self, capabilities: Capabilities) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
+        cluster_name = random.choice(["storage", "default"])
         debezium_source_name = f"debezium_source_{postgres_table.name}"
         this_debezium_source = DebeziumSourceExists(name=debezium_source_name)
 
@@ -72,6 +73,7 @@ class CreateDebeziumSource(Action):
             self.debezium_source = this_debezium_source
             self.postgres_table = postgres_table
             self.debezium_source.postgres_table = self.postgres_table
+            self.cluster_name = cluster_name
         elif len(existing_debezium_sources) == 1:
             self.new_debezium_source = False
 
@@ -120,7 +122,7 @@ class CreateDebeziumSource(Action):
                     > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');
 
                     > CREATE SOURCE {self.debezium_source.name}
-                      IN CLUSTER storaged
+                      IN CLUSTER {self.cluster_name}
                       FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.{self.postgres_table.name}')
                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                       ENVELOPE DEBEZIUM

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -41,7 +41,12 @@ class MzStart(Action):
             )
 
         c.sql(
-            "ALTER CLUSTER default SET (MANAGED = false)", user="mz_system", port=6877
+            """
+            ALTER CLUSTER default SET (MANAGED = false);
+            ALTER SYSTEM SET enable_unified_clusters = true;
+            """,
+            user="mz_system",
+            port=6877,
         )
 
     def provides(self) -> list[Capability]:

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -30,6 +30,7 @@ class CreatePostgresCdcTable(Action):
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
         postgres_pg_cdc_name = f"postgres_{postgres_table.name}"
         this_postgres_cdc_table = PostgresCdcTableExists(name=postgres_pg_cdc_name)
+        cluster_name = random.choice(["storage", "default"])
 
         existing_postgres_cdc_tables = [
             s
@@ -42,6 +43,7 @@ class CreatePostgresCdcTable(Action):
 
             self.postgres_cdc_table = this_postgres_cdc_table
             self.postgres_cdc_table.postgres_table = postgres_table
+            self.cluster_name = cluster_name
         elif len(existing_postgres_cdc_tables) == 1:
             self.new_postgres_cdc_table = False
 
@@ -73,7 +75,7 @@ class CreatePostgresCdcTable(Action):
                       );
 
                     > CREATE SOURCE {name}_source
-                      IN CLUSTER storaged
+                      IN CLUSTER {self.cluster_name}
                       FROM POSTGRES CONNECTION {name}_connection (PUBLICATION '{name}_publication')
                       FOR TABLES ({self.postgres_cdc_table.postgres_table.name} AS {name})
                     """

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -102,6 +102,8 @@ class CreateSink(Action):
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.sink.name}_csr_conn
                   ENVELOPE DEBEZIUM;
 
+                $ kafka-verify-topic sink=materialize.public.{self.sink.name} await-value-schema=true
+
                 # Ingest the sink again in order to be able to validate its contents
 
                 > CREATE SOURCE {self.sink.name}_source

--- a/misc/python/materialize/zippy/sink_capabilities.py
+++ b/misc/python/materialize/zippy/sink_capabilities.py
@@ -23,8 +23,15 @@ class SinkExists(Capability):
         return "sink_{}"
 
     def __init__(
-        self, name: str, source_view: ViewExists, dest_view: ViewExists
+        self,
+        name: str,
+        source_view: ViewExists,
+        dest_view: ViewExists,
+        cluster_name_out: str,
+        cluster_name_in: str,
     ) -> None:
         self.name = name
         self.source_view = source_view
         self.dest_view = dest_view
+        self.cluster_name_out = cluster_name_out
+        self.cluster_name_in = cluster_name_in

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -40,6 +40,7 @@ class CreateSourceParameterized(ActionFactory):
                     source=SourceExists(
                         name=new_source_name,
                         topic=random.choice(capabilities.get(TopicExists)),
+                        cluster_name=random.choice(["storage", "default"]),
                     ),
                 )
             ]
@@ -64,7 +65,7 @@ class CreateSource(Action):
                   TO KAFKA (BROKER '${{testdrive.kafka-addr}}');
 
                 > CREATE SOURCE {self.source.name}
-                  IN CLUSTER storaged
+                  IN CLUSTER {self.source.cluster_name}
                   FROM KAFKA CONNECTION {self.source.name}_kafka_conn
                   (TOPIC 'testdrive-{self.source.topic.name}-${{testdrive.seed}}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION {self.source.name}_csr_conn

--- a/misc/python/materialize/zippy/source_capabilities.py
+++ b/misc/python/materialize/zippy/source_capabilities.py
@@ -19,9 +19,10 @@ class SourceExists(Capability):
     def format_str(cls) -> str:
         return "source_{}"
 
-    def __init__(self, name: str, topic: TopicExists) -> None:
+    def __init__(self, name: str, topic: TopicExists, cluster_name: str) -> None:
         self.name = name
         self.topic = topic
+        self.cluster_name = cluster_name
 
     def get_watermarks(self) -> Watermarks:
         return self.topic.watermarks

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3609,7 +3609,7 @@ impl Catalog {
             }) => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
                 from: sink.from,
-                connection: StorageSinkConnectionState::Pending(sink.connection_builder),
+                connection: sink.connection_builder,
                 envelope: sink.envelope,
                 with_snapshot,
                 resolved_ids,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -995,11 +995,6 @@ impl Catalog {
             .cluster_replica_dependents(cluster_id, replica_id, &mut seen)
     }
 
-    pub(crate) fn item_dependents(&self, item_id: GlobalId) -> Vec<ObjectId> {
-        let mut seen = BTreeSet::new();
-        self.state.item_dependents(item_id, &mut seen)
-    }
-
     /// Gets GlobalIds of temporary items to be created, checks for name collisions
     /// within a connection id.
     fn temporary_ids(
@@ -3609,7 +3604,7 @@ impl Catalog {
             }) => CatalogItem::Sink(Sink {
                 create_sql: sink.create_sql,
                 from: sink.from,
-                connection: sink.connection_builder,
+                connection: sink.connection,
                 envelope: sink.envelope,
                 with_snapshot,
                 resolved_ids,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -760,7 +760,7 @@ impl CatalogState {
         owner_id: RoleId,
         privileges: PrivilegeMap,
     ) {
-        if !id.is_system() && !item.is_placeholder() {
+        if !id.is_system() {
             info!(
                 "create {} {} ({})",
                 item.typ(),
@@ -825,14 +825,12 @@ impl CatalogState {
     #[tracing::instrument(level = "trace", skip(self))]
     pub(super) fn drop_item(&mut self, id: GlobalId) {
         let metadata = self.entry_by_id.remove(&id).expect("catalog out of sync");
-        if !metadata.item().is_placeholder() {
-            info!(
-                "drop {} {} ({})",
-                metadata.item_type(),
-                self.resolve_full_name(metadata.name(), metadata.conn_id()),
-                id
-            );
-        }
+        info!(
+            "drop {} {} ({})",
+            metadata.item_type(),
+            self.resolve_full_name(metadata.name(), metadata.conn_id()),
+            id
+        );
         for u in &metadata.uses().0 {
             if let Some(dep_metadata) = self.entry_by_id.get_mut(u) {
                 dep_metadata.used_by.retain(|u| *u != metadata.id())

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1600,7 +1600,7 @@ impl Coordinator {
                         .prepare_export(id, sink.from)
                         .unwrap_or_terminate("cannot fail to prepare export");
 
-                    self.create_storage_export(create_export_token, sink, sink.connection.clone())
+                    self.create_storage_export(create_export_token, sink)
                         .await
                         .unwrap_or_terminate("cannot fail to create exports");
                 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1594,13 +1594,7 @@ impl Coordinator {
                 }
                 CatalogItem::Sink(sink) => {
                     let id = entry.id();
-                    let create_export_token = self
-                        .controller
-                        .storage
-                        .prepare_export(id, sink.from)
-                        .unwrap_or_terminate("cannot fail to prepare export");
-
-                    self.create_storage_export(create_export_token, sink)
+                    self.create_storage_export(id, sink)
                         .await
                         .unwrap_or_terminate("cannot fail to create exports");
                 }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -90,11 +90,10 @@ use mz_expr::{MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr, RowSetFi
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::metrics::{MetricsFutureExt, MetricsRegistry};
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_ore::retry::Retry;
 use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
-use mz_ore::{soft_assert_or_log, stack, task};
+use mz_ore::{soft_assert_or_log, stack};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
 use mz_repr::role_id::RoleId;
@@ -113,7 +112,6 @@ use mz_storage_client::controller::{
 };
 use mz_storage_types::connections::inline::{IntoInlineConnection, ReferencedConnection};
 use mz_storage_types::connections::ConnectionContext;
-use mz_storage_types::controller::StorageError;
 use mz_storage_types::sinks::StorageSinkConnection;
 use mz_storage_types::sources::Timeline;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -127,7 +125,7 @@ use uuid::Uuid;
 
 use crate::catalog::{
     self, AwsPrincipalContext, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog, CatalogItem,
-    ClusterReplicaSizeMap, DataSourceDesc, Source, StorageSinkConnectionState,
+    ClusterReplicaSizeMap, DataSourceDesc, Source,
 };
 use crate::client::{Client, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
@@ -1611,17 +1609,8 @@ impl Coordinator {
                     }
                 }
                 CatalogItem::Sink(sink) => {
-                    // Re-create the sink.
-                    let builder = match &sink.connection {
-                        StorageSinkConnectionState::Pending(builder) => builder.clone(),
-                        StorageSinkConnectionState::Ready(_) => {
-                            panic!("sink already initialized during catalog boot")
-                        }
-                    };
                     // Now we're ready to create the sink connection. Arrange to notify the
                     // main coordinator thread when the future completes.
-                    let internal_cmd_tx = self.internal_cmd_tx.clone();
-                    let connection_context = self.connection_context.clone();
                     let id = entry.id();
                     let oid = entry.oid();
 
@@ -1631,44 +1620,19 @@ impl Coordinator {
                         .prepare_export(id, sink.from)
                         .unwrap_or_terminate("cannot fail to prepare export");
 
-                    let referenced_builder = builder.clone();
-                    let builder = builder.into_inline_connection(self.catalog().state());
-
-                    task::spawn(
-                        || format!("sink_connection_ready:{}", sink.from),
-                        async move {
-                            let conn_result = Retry::default()
-                                .max_tries(usize::MAX)
-                                .clamp_backoff(Duration::from_secs(60 * 10))
-                                .retry_async(|_| async {
-                                    let referenced_builder = referenced_builder.clone();
-                                    let builder = builder.clone();
-                                    let connection_context = connection_context.clone();
-                                    mz_storage_client::sink::build_sink_connection(
-                                        builder,
-                                        referenced_builder,
-                                        connection_context,
-                                    )
-                                    .await
-                                })
-                                .await
-                                .map_err(StorageError::Generic)
-                                .map_err(AdapterError::from);
-                            // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
-                            let result = internal_cmd_tx.send(Message::SinkConnectionReady(
-                                SinkConnectionReady {
-                                    ctx: None,
-                                    id,
-                                    oid,
-                                    create_export_token,
-                                    result: conn_result,
-                                },
-                            ));
-                            if let Err(e) = result {
-                                warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                            }
+                    // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
+                    let result = self.internal_cmd_tx.send(Message::SinkConnectionReady(
+                        SinkConnectionReady {
+                            ctx: None,
+                            id,
+                            oid,
+                            create_export_token,
+                            result: Ok(sink.connection.clone()),
                         },
-                    );
+                    ));
+                    if let Err(e) = result {
+                        warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+                    }
                 }
                 CatalogItem::Connection(catalog_connection) => {
                     if let mz_storage_types::connections::Connection::AwsPrivatelink(conn) =

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -34,7 +34,7 @@ use mz_sql::session::vars::{
     MAX_OBJECTS_PER_SCHEMA, MAX_POSTGRES_CONNECTIONS, MAX_REPLICAS_PER_CLUSTER, MAX_ROLES,
     MAX_SCHEMAS_PER_DATABASE, MAX_SECRETS, MAX_SINKS, MAX_SOURCES, MAX_TABLES,
 };
-use mz_storage_client::controller::{CreateExportToken, ExportDescription, ReadPolicy};
+use mz_storage_client::controller::{ExportDescription, ReadPolicy};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
 use mz_storage_types::sinks::SinkAsOf;
@@ -816,7 +816,7 @@ impl Coordinator {
 
     pub(crate) async fn create_storage_export(
         &mut self,
-        create_export_token: CreateExportToken,
+        id: GlobalId,
         sink: &Sink,
     ) -> Result<(), AdapterError> {
         // Validate `sink.from` is in fact a storage collection
@@ -871,7 +871,7 @@ impl Coordinator {
             .controller
             .storage
             .create_exports(vec![(
-                create_export_token,
+                id,
                 ExportDescription {
                     sink: storage_sink_desc,
                     instance_id: sink.cluster_id,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -35,9 +35,9 @@ use mz_sql::session::vars::{
     MAX_SCHEMAS_PER_DATABASE, MAX_SECRETS, MAX_SINKS, MAX_SOURCES, MAX_TABLES,
 };
 use mz_storage_client::controller::{CreateExportToken, ExportDescription, ReadPolicy};
-use mz_storage_types::connections::inline::{IntoInlineConnection, ReferencedConnection};
+use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
-use mz_storage_types::sinks::{SinkAsOf, StorageSinkConnection};
+use mz_storage_types::sinks::SinkAsOf;
 use mz_storage_types::sources::{GenericSourceConnection, Timeline};
 use serde_json::json;
 use timely::progress::Antichain;
@@ -818,10 +818,7 @@ impl Coordinator {
         &mut self,
         create_export_token: CreateExportToken,
         sink: &Sink,
-        connection: StorageSinkConnection<ReferencedConnection>,
     ) -> Result<(), AdapterError> {
-        let connection = connection.into_inline_connection(self.catalog().state());
-
         // Validate `sink.from` is in fact a storage collection
         self.controller.storage.collection(sink.from)?;
 
@@ -860,7 +857,10 @@ impl Coordinator {
                 ))
                 .expect("indexes can only be built on items with descs")
                 .into_owned(),
-            connection,
+            connection: sink
+                .connection
+                .clone()
+                .into_inline_connection(self.catalog().state()),
             envelope: Some(sink.envelope),
             as_of,
             status_id,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -861,7 +861,7 @@ impl Coordinator {
                 .connection
                 .clone()
                 .into_inline_connection(self.catalog().state()),
-            envelope: Some(sink.envelope),
+            envelope: sink.envelope,
             as_of,
             status_id,
             from_storage_metadata: (),

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -44,8 +44,7 @@ use timely::progress::Antichain;
 use tracing::{event, warn, Level};
 
 use crate::catalog::{
-    CatalogItem, CatalogState, DataSourceDesc, Op, Sink, StorageSinkConnectionState,
-    TransactionResult, SYSTEM_CONN_ID,
+    CatalogItem, CatalogState, DataSourceDesc, Op, Sink, TransactionResult, SYSTEM_CONN_ID,
 };
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::{TimelineContext, TimelineState};
@@ -166,12 +165,9 @@ impl Coordinator {
                                 }
                             }
                         }
-                        CatalogItem::Sink(catalog::Sink { connection, .. }) => match connection {
-                            StorageSinkConnectionState::Ready(_) => {
-                                storage_sinks_to_drop.push(*id);
-                            }
-                            StorageSinkConnectionState::Pending(_) => (),
-                        },
+                        CatalogItem::Sink(catalog::Sink { .. }) => {
+                            storage_sinks_to_drop.push(*id);
+                        }
                         CatalogItem::Index(catalog::Index { cluster_id, .. }) => {
                             indexes_to_drop.push((*cluster_id, *id));
                         }
@@ -897,12 +893,8 @@ impl Coordinator {
         let name = entry.name().clone();
         let owner_id = entry.owner_id().clone();
         let sink = match entry.item() {
-            CatalogItem::Sink(sink) => sink,
+            CatalogItem::Sink(sink) => sink.clone(),
             _ => unreachable!(),
-        };
-        let sink = catalog::Sink {
-            connection: StorageSinkConnectionState::Ready(connection.clone()),
-            ..sink.clone()
         };
 
         // We always need to drop the already existing item: either because we fail to create it or we're replacing it.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -814,7 +814,7 @@ impl Coordinator {
             .set_limit(webhook_request_limit);
     }
 
-    async fn create_storage_export(
+    pub(crate) async fn create_storage_export(
         &mut self,
         create_export_token: CreateExportToken,
         sink: &Sink,
@@ -878,60 +878,6 @@ impl Coordinator {
                 },
             )])
             .await?)
-    }
-
-    pub(crate) async fn handle_sink_connection_ready(
-        &mut self,
-        id: GlobalId,
-        oid: u32,
-        connection: StorageSinkConnection<ReferencedConnection>,
-        create_export_token: CreateExportToken,
-        session: Option<&Session>,
-    ) -> Result<(), AdapterError> {
-        // Update catalog entry with sink connection.
-        let entry = self.catalog().get_entry(&id);
-        let name = entry.name().clone();
-        let owner_id = entry.owner_id().clone();
-        let sink = match entry.item() {
-            CatalogItem::Sink(sink) => sink.clone(),
-            _ => unreachable!(),
-        };
-
-        // We always need to drop the already existing item: either because we fail to create it or we're replacing it.
-        let mut ops = vec![catalog::Op::DropObject(ObjectId::Item(id))];
-
-        // Speculatively create the storage export before confirming in the catalog.  We chose this order of operations
-        // for the following reasons:
-        // - We want to avoid ever putting into the catalog a sink in `StorageSinkConnectionState::Ready`
-        //   if we're not able to actually create the sink for some reason
-        // - Dropping the sink will either succeed (or panic) so it's easier to reason about rolling that change back
-        //   than it is rolling back a catalog change.
-        match self
-            .create_storage_export(create_export_token, &sink, connection)
-            .await
-        {
-            Ok(()) => {
-                ops.push(catalog::Op::CreateItem {
-                    id,
-                    oid,
-                    name,
-                    item: CatalogItem::Sink(sink.clone()),
-                    owner_id,
-                });
-                match self.catalog_transact(session, ops).await {
-                    Ok(()) => (),
-                    catalog_err @ Err(_) => {
-                        let () = self.drop_storage_sinks(vec![id]);
-                        catalog_err?
-                    }
-                }
-            }
-            storage_err @ Err(_) => match self.catalog_transact(session, ops).await {
-                Ok(()) => storage_err?,
-                catalog_err @ Err(_) => catalog_err?,
-            },
-        };
-        Ok(())
     }
 
     /// Validate all resource limits in a catalog transaction and return an error if that limit is

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -26,12 +26,11 @@ use mz_storage_types::controller::CollectionMetadata;
 use rand::{rngs, Rng, SeedableRng};
 use tracing::{event, warn, Instrument, Level};
 
-use crate::command::{Command, ExecuteResponse};
+use crate::command::Command;
 use crate::coord::appends::Deferred;
 use crate::coord::{
     Coordinator, CreateConnectionValidationReady, Message, PeekStage, PeekStageFinish,
     PendingReadTxn, PlanValidity, PurifiedStatementReady, RealTimeRecencyContext,
-    SinkConnectionReady,
 };
 use crate::session::Session;
 use crate::util::{ComputeSinkId, ResultExt};
@@ -57,7 +56,6 @@ impl Coordinator {
             Message::CreateConnectionValidationReady(ready) => {
                 self.message_create_connection_validation_ready(ready).await
             }
-            Message::SinkConnectionReady(ready) => self.message_sink_connection_ready(ready).await,
             Message::WriteLockGrant(write_lock_guard) => {
                 self.message_write_lock_grant(write_lock_guard).await;
             }
@@ -463,79 +461,6 @@ impl Coordinator {
             )
             .await;
         ctx.retire(result);
-    }
-
-    #[tracing::instrument(level = "debug", skip(self, ctx))]
-    async fn message_sink_connection_ready(
-        &mut self,
-        SinkConnectionReady {
-            ctx,
-            id,
-            oid,
-            create_export_token,
-            result,
-        }: SinkConnectionReady,
-    ) {
-        match result {
-            Ok(connection) => {
-                // NOTE: we must not fail from here on out. We have a
-                // connection, which means there is external state (like
-                // a Kafka topic) that's been created on our behalf. If
-                // we fail now, we'll leak that external state.
-                if self.catalog().try_get_entry(&id).is_some() {
-                    // TODO(benesch): this `expect` here is possibly scary, but
-                    // no better solution presents itself. Possibly sinks should
-                    // have an error bit, and an error here would set the error
-                    // bit on the sink.
-                    self.handle_sink_connection_ready(
-                        id,
-                        oid,
-                        connection,
-                        create_export_token,
-                        ctx.as_ref().map(|ctx| ctx.session()),
-                    )
-                    .await
-                    // XXX(chae): I really don't like this -- especially as we're now doing cross
-                    // process calls to start a sink.
-                    .expect("sinks should be validated by sequence_create_sink");
-                } else {
-                    // Another session dropped the sink while we were
-                    // creating the connection. Report to the client that
-                    // we created the sink, because from their
-                    // perspective we did, as there is state (e.g. a
-                    // Kafka topic) they need to clean up.
-                }
-                if let Some(ctx) = ctx {
-                    ctx.retire(Ok(ExecuteResponse::CreatedSink));
-                }
-            }
-            Err(e) => {
-                // Drop the placeholder sink if still present.
-                if self.catalog().try_get_entry(&id).is_some() {
-                    let ops = self
-                        .catalog()
-                        .item_dependents(id)
-                        .into_iter()
-                        .map(catalog::Op::DropObject)
-                        .collect();
-                    self.catalog_transact(ctx.as_ref().map(|ctx| ctx.session()), ops)
-                        .await
-                        .expect("deleting placeholder sink cannot fail");
-                } else {
-                    // Another session may have dropped the placeholder sink while we were
-                    // attempting to create the connection, in which case we don't need to do
-                    // anything.
-                }
-                // Drop the placeholder sink in the storage controller
-                let () = self
-                    .controller
-                    .storage
-                    .cancel_prepare_export(create_export_token);
-                if let Some(ctx) = ctx {
-                    ctx.retire(Err(e));
-                }
-            }
-        }
     }
 
     #[tracing::instrument(level = "debug", skip_all)]

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -781,13 +781,11 @@ impl Coordinator {
             ctx
         );
 
-        self.create_storage_export(
-            create_export_token,
-            &catalog_sink,
-            catalog_sink.connection.clone(),
-        )
-        .await
-        .unwrap_or_terminate("cannot fail to create exports");
+        self.create_storage_export(create_export_token, &catalog_sink)
+            .await
+            .unwrap_or_terminate("cannot fail to create exports");
+
+        ctx.retire(Ok(ExecuteResponse::CreatedSink))
     }
 
     /// Validates that a view definition does not contain any expressions that may lead to

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -75,7 +75,6 @@ use mz_storage_client::controller::{
 };
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
-use mz_storage_types::sinks::StorageSinkConnection;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::optimizer_notices::OptimizerNotice;
 use mz_transform::{EmptyStatisticsOracle, Optimizer, StatisticsOracle};
@@ -106,7 +105,7 @@ use crate::coord::{
     peek, Coordinator, CreateConnectionValidationReady, ExecuteContext, Message, PeekStage,
     PeekStageFinish, PeekStageOptimize, PeekStageTimestamp, PeekStageValidate, PendingRead,
     PendingReadTxn, PendingTxn, PendingTxnResponse, PlanValidity, RealTimeRecencyContext,
-    SinkConnectionReady, TargetCluster,
+    TargetCluster,
 };
 use crate::error::AdapterError;
 use crate::explain::explain_dataflow;
@@ -717,20 +716,10 @@ impl Coordinator {
             ctx
         );
 
-        // Knowing that we're only handling kafka sinks here helps us simplify.
-        let StorageSinkConnection::Kafka(connection_builder) = sink.connection_builder.clone();
-
-        // Then try to create a placeholder catalog item with an unknown
-        // connection. If that fails, we're done, though if the client specified
-        // `if_not_exists` we'll tell the client we succeeded.
-        //
-        // This placeholder catalog item reserves the name while we create
-        // the sink connection, which could take an arbitrarily long time.
-
         let catalog_sink = catalog::Sink {
             create_sql: sink.create_sql,
             from: sink.from,
-            connection: StorageSinkConnection::Kafka(connection_builder),
+            connection: sink.connection,
             envelope: sink.envelope,
             with_snapshot,
             resolved_ids,
@@ -792,19 +781,13 @@ impl Coordinator {
             ctx
         );
 
-        // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
-        let result = self
-            .internal_cmd_tx
-            .send(Message::SinkConnectionReady(SinkConnectionReady {
-                ctx: Some(ctx),
-                id,
-                oid,
-                create_export_token,
-                result: Ok(sink.connection_builder),
-            }));
-        if let Err(e) = result {
-            warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-        }
+        self.create_storage_export(
+            create_export_token,
+            &catalog_sink,
+            catalog_sink.connection.clone(),
+        )
+        .await
+        .unwrap_or_terminate("cannot fail to create exports");
     }
 
     /// Validates that a view definition does not contain any expressions that may lead to

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -75,7 +75,7 @@ use mz_storage_client::controller::{
 };
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use mz_storage_types::controller::StorageError;
-use mz_storage_types::sinks::StorageSinkConnectionBuilder;
+use mz_storage_types::sinks::StorageSinkConnection;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::optimizer_notices::OptimizerNotice;
 use mz_transform::{EmptyStatisticsOracle, Optimizer, StatisticsOracle};
@@ -87,7 +87,7 @@ use tracing_core::callsite::rebuild_interest_cache;
 
 use crate::catalog::{
     self, Catalog, CatalogItem, CatalogState, Cluster, ConnCatalog, Connection, DataSourceDesc,
-    StorageSinkConnectionState, UpdatePrivilegeVariant,
+    UpdatePrivilegeVariant,
 };
 use crate::command::{ExecuteResponse, Response};
 use crate::coord::appends::{Deferred, DeferredPlan, PendingWriteTxn};
@@ -718,8 +718,7 @@ impl Coordinator {
         );
 
         // Knowing that we're only handling kafka sinks here helps us simplify.
-        let StorageSinkConnectionBuilder::Kafka(connection_builder) =
-            sink.connection_builder.clone();
+        let StorageSinkConnection::Kafka(connection_builder) = sink.connection_builder.clone();
 
         // Then try to create a placeholder catalog item with an unknown
         // connection. If that fails, we're done, though if the client specified
@@ -731,9 +730,7 @@ impl Coordinator {
         let catalog_sink = catalog::Sink {
             create_sql: sink.create_sql,
             from: sink.from,
-            connection: StorageSinkConnectionState::Pending(StorageSinkConnectionBuilder::Kafka(
-                connection_builder,
-            )),
+            connection: StorageSinkConnection::Kafka(connection_builder),
             envelope: sink.envelope,
             with_snapshot,
             resolved_ids,
@@ -795,39 +792,19 @@ impl Coordinator {
             ctx
         );
 
-        let referenced_builder = sink.connection_builder.clone();
-
-        // Now we're ready to create the sink connection. Arrange to notify the
-        // main coordinator thread when the future completes.
-        let connection_builder = sink
-            .connection_builder
-            .into_inline_connection(self.catalog().state());
-
-        let internal_cmd_tx = self.internal_cmd_tx.clone();
-        let connection_context = self.connection_context.clone();
-        task::spawn(
-            || format!("sink_connection_ready:{}", sink.from),
-            async move {
-                // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
-                let result =
-                    internal_cmd_tx.send(Message::SinkConnectionReady(SinkConnectionReady {
-                        ctx: Some(ctx),
-                        id,
-                        oid,
-                        create_export_token,
-                        result: mz_storage_client::sink::build_sink_connection(
-                            connection_builder,
-                            referenced_builder,
-                            connection_context,
-                        )
-                        .await
-                        .map_err(Into::into),
-                    }));
-                if let Err(e) = result {
-                    warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                }
-            },
-        );
+        // It is not an error for sink connections to become ready after `internal_cmd_rx` is dropped.
+        let result = self
+            .internal_cmd_tx
+            .send(Message::SinkConnectionReady(SinkConnectionReady {
+                ctx: Some(ctx),
+                id,
+                oid,
+                create_export_token,
+                result: Ok(sink.connection_builder),
+            }));
+        if let Err(e) = result {
+            warn!("internal_cmd_rx dropped before we could send: {:?}", e);
+        }
     }
 
     /// Validates that a view definition does not contain any expressions that may lead to

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -774,14 +774,7 @@ impl Coordinator {
 
         self.maybe_create_linked_cluster(id).await;
 
-        let create_export_token = return_if_err!(
-            self.controller
-                .storage
-                .prepare_export(id, catalog_sink.from),
-            ctx
-        );
-
-        self.create_storage_export(create_export_token, &catalog_sink)
+        self.create_storage_export(id, &catalog_sink)
             .await
             .unwrap_or_terminate("cannot fail to create exports");
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -332,6 +332,7 @@ impl ShouldHalt for StorageError {
             | StorageError::Generic(_)
             | StorageError::DataflowError(_)
             | StorageError::InvalidAlterSource { .. }
+            | StorageError::IncompatibleSinkDescriptions { .. }
             | StorageError::ShuttingDown(_) => false,
             StorageError::IOError(e) => e.is_unrecoverable(),
         }

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -50,7 +50,7 @@ use mz_sql::rbac;
 use mz_sql::session::vars::OwnedVarInput;
 use mz_storage_client::controller::IntrospectionType;
 use mz_storage_types::connections::inline::ReferencedConnection;
-use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection, StorageSinkConnectionBuilder};
+use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
 use mz_storage_types::sources::{
     IngestionDescription, SourceConnection, SourceDesc, SourceEnvelope, SourceExport, Timeline,
 };
@@ -633,7 +633,7 @@ pub struct Sink {
     // TODO(benesch): this field duplicates information that could be derived
     // from the connection ID. Too hard to fix at the moment.
     #[serde(skip)]
-    pub connection: StorageSinkConnectionState,
+    pub connection: StorageSinkConnection<ReferencedConnection>,
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
     pub resolved_ids: ResolvedIds,
@@ -642,10 +642,7 @@ pub struct Sink {
 
 impl Sink {
     pub fn sink_type(&self) -> &str {
-        match &self.connection {
-            StorageSinkConnectionState::Pending(pending) => pending.name(),
-            StorageSinkConnectionState::Ready(ready) => ready.name(),
-        }
+        self.connection.name()
     }
 
     /// Envelope of the sink.
@@ -657,16 +654,13 @@ impl Sink {
     }
 
     pub fn connection_id(&self) -> Option<GlobalId> {
-        match &self.connection {
-            StorageSinkConnectionState::Pending(pending) => pending.connection_id(),
-            StorageSinkConnectionState::Ready(ready) => ready.connection_id(),
-        }
+        self.connection.connection_id()
     }
 }
 
 #[derive(Debug, Clone, Serialize)]
 pub enum StorageSinkConnectionState {
-    Pending(StorageSinkConnectionBuilder<ReferencedConnection>),
+    Pending(StorageSinkConnection<ReferencedConnection>),
     Ready(StorageSinkConnection<ReferencedConnection>),
 }
 
@@ -819,27 +813,6 @@ impl CatalogItem {
             CatalogItem::MaterializedView(mview) => &mview.resolved_ids,
             CatalogItem::Secret(_) => &*EMPTY,
             CatalogItem::Connection(connection) => &connection.resolved_ids,
-        }
-    }
-
-    /// Indicates whether this item is a placeholder for a future item
-    /// or if it's actually a real item.
-    pub fn is_placeholder(&self) -> bool {
-        match self {
-            CatalogItem::Func(_)
-            | CatalogItem::Index(_)
-            | CatalogItem::Source(_)
-            | CatalogItem::Log(_)
-            | CatalogItem::Table(_)
-            | CatalogItem::Type(_)
-            | CatalogItem::View(_)
-            | CatalogItem::MaterializedView(_)
-            | CatalogItem::Secret(_)
-            | CatalogItem::Connection(_) => false,
-            CatalogItem::Sink(s) => match s.connection {
-                StorageSinkConnectionState::Pending(_) => true,
-                StorageSinkConnectionState::Ready(_) => false,
-            },
         }
     }
 

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -118,6 +118,9 @@ pub enum MzKafkaError {
     /// SSL authentication required
     #[error("SSL authentication required")]
     SSLAuthenticationRequired,
+    /// Unknown topic or partition
+    #[error("Unknown topic or partition")]
+    UnknownTopicOrPartition,
     /// An internal kafka error
     #[error("Internal kafka error: {0}")]
     Internal(String),
@@ -170,6 +173,8 @@ impl FromStr for MzKafkaError {
             .unwrap_or_default()
         {
             Ok(Self::AllBrokersDown)
+        } else if s.contains("Unknown topic or partition") || s.contains("Unknown partition") {
+            Ok(Self::UnknownTopicOrPartition)
         } else {
             Err(())
         }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -46,7 +46,7 @@ use mz_sql_parser::ast::{
     TransactionIsolationLevel, TransactionMode, WithOptionValue,
 };
 use mz_storage_types::connections::inline::ReferencedConnection;
-use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnectionBuilder};
+use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
 use mz_storage_types::sources::{SourceDesc, Timeline};
 use serde::{Deserialize, Serialize};
 
@@ -1337,7 +1337,7 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connection_builder: StorageSinkConnectionBuilder<ReferencedConnection>,
+    pub connection_builder: StorageSinkConnection<ReferencedConnection>,
     pub envelope: SinkEnvelope,
 }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1337,7 +1337,7 @@ pub struct Secret {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    pub connection_builder: StorageSinkConnection<ReferencedConnection>,
+    pub connection: StorageSinkConnection<ReferencedConnection>,
     pub envelope: SinkEnvelope,
 }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2334,7 +2334,7 @@ pub fn plan_create_sink(
         sink: Sink {
             create_sql,
             from: from.id(),
-            connection_builder,
+            connection: connection_builder,
             envelope,
         },
         with_snapshot,

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -47,8 +47,8 @@ use mz_storage_types::connections::{
     KafkaSecurity, KafkaTlsConfig, SaslConfig, SshTunnel, StringOrSecret, TlsIdentity, Tunnel,
 };
 use mz_storage_types::sinks::{
-    KafkaConsistencyConfig, KafkaSinkConnectionBuilder, KafkaSinkConnectionRetention,
-    KafkaSinkFormat, SinkEnvelope, StorageSinkConnectionBuilder,
+    KafkaConsistencyConfig, KafkaSinkAvroFormatState, KafkaSinkConnection,
+    KafkaSinkConnectionRetention, KafkaSinkFormat, SinkEnvelope, StorageSinkConnection,
 };
 use mz_storage_types::sources::encoding::{
     included_column_desc, AvroEncoding, ColumnSpec, CsvEncoding, DataEncoding, DataEncodingInner,
@@ -2468,7 +2468,7 @@ fn kafka_sink_builder(
     value_desc: RelationDesc,
     envelope: SinkEnvelope,
     sink_from: GlobalId,
-) -> Result<StorageSinkConnectionBuilder<ReferencedConnection>, PlanError> {
+) -> Result<StorageSinkConnection<ReferencedConnection>, PlanError> {
     let item = scx.get_item_by_resolved_name(&connection)?;
     // Get Kafka connection
     let mut connection = match item.connection()? {
@@ -2596,11 +2596,11 @@ fn kafka_sink_builder(
                 .key_writer_schema()
                 .map(|key_schema| key_schema.to_string());
 
-            KafkaSinkFormat::Avro {
+            KafkaSinkFormat::Avro(KafkaSinkAvroFormatState::UnpublishedMaybe {
                 key_schema,
                 value_schema,
                 csr_connection,
-            }
+            })
         }
         Some(Format::Json) => KafkaSinkFormat::Json,
         Some(format) => bail_unsupported!(format!("sink format {:?}", format)),
@@ -2640,22 +2640,20 @@ fn kafka_sink_builder(
         bytes: retention_bytes,
     };
 
-    Ok(StorageSinkConnectionBuilder::Kafka(
-        KafkaSinkConnectionBuilder {
-            connection_id,
-            connection,
-            format,
-            topic_name,
-            consistency_config,
-            partition_count,
-            replication_factor,
-            fuel: 10000,
-            relation_key_indices,
-            key_desc_and_indices,
-            value_desc,
-            retention,
-        },
-    ))
+    Ok(StorageSinkConnection::Kafka(KafkaSinkConnection {
+        connection_id,
+        connection,
+        format,
+        topic: topic_name,
+        consistency_config,
+        partition_count,
+        replication_factor,
+        fuel: 10000,
+        relation_key_indices,
+        key_desc_and_indices,
+        value_desc,
+        retention,
+    }))
 }
 
 pub fn describe_create_index(

--- a/src/sql/src/pure/error.rs
+++ b/src/sql/src/pure/error.rs
@@ -203,3 +203,49 @@ impl LoadGeneratorSourcePurificationError {
         }
     }
 }
+
+/// Logical errors detectable during purification for a KAFKA SOURCE.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum KafkaSinkPurificationError {
+    #[error("{0} is not a KAFKA CONNECTION")]
+    NotKafkaConnection(FullItemName),
+    #[error("admin client errored")]
+    AdminClientError(String),
+    #[error("zero brokers discovered in metadata request")]
+    ZeroBrokers,
+}
+
+impl KafkaSinkPurificationError {
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            Self::AdminClientError(e) => Some(e.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
+}
+
+/// Logical errors detectable during purification for a KAFKA SOURCE.
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum CsrPurificationError {
+    #[error("{0} is not a CONFLUENT SCHEMA REGISTRY CONNECTION")]
+    NotCsrConnection(FullItemName),
+    #[error("client errored")]
+    ClientError(String),
+}
+
+impl CsrPurificationError {
+    pub fn detail(&self) -> Option<String> {
+        match self {
+            Self::ClientError(e) => Some(e.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn hint(&self) -> Option<String> {
+        None
+    }
+}

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -15,6 +15,7 @@ differential-dataflow = "0.12.0"
 http = "0.2.8"
 itertools = { version = "0.10.5" }
 once_cell = "1.16.0"
+maplit = "1.0.2"
 mz-ccsr = { path = "../ccsr" }
 mz-cluster-client = { path = "../cluster-client" }
 mz-kafka-util = { path = "../kafka-util" }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -172,23 +172,6 @@ pub struct ExportDescription<T = mz_repr::Timestamp> {
     pub instance_id: StorageInstanceId,
 }
 
-/// Opaque token to ensure `prepare_export` is called before `create_exports`.  This token proves
-/// that compaction is being held back on `from_id` at least until `id` is created.  It should be
-/// held while the AS OF is determined.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CreateExportToken<T = mz_repr::Timestamp> {
-    pub id: GlobalId,
-    pub from_id: GlobalId,
-    pub acquired_since: Antichain<T>,
-}
-
-impl CreateExportToken {
-    /// Returns the ID of the export with which the token is associated.
-    pub fn id(&self) -> GlobalId {
-        self.id
-    }
-}
-
 /// A cursor over a snapshot, allowing us to read just part of a snapshot in its
 /// consolidated form.
 pub struct SnapshotCursor<T: Codec64 + Timestamp + Lattice> {
@@ -334,21 +317,8 @@ pub trait StorageController: Debug + Send {
     /// Create the sinks described by the `ExportDescription`.
     async fn create_exports(
         &mut self,
-        exports: Vec<(
-            CreateExportToken<Self::Timestamp>,
-            ExportDescription<Self::Timestamp>,
-        )>,
+        exports: Vec<(GlobalId, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError>;
-
-    /// Notify the storage controller to prepare for an export to be created
-    fn prepare_export(
-        &mut self,
-        id: GlobalId,
-        from_id: GlobalId,
-    ) -> Result<CreateExportToken<Self::Timestamp>, StorageError>;
-
-    /// Cancel the pending export
-    fn cancel_prepare_export(&mut self, token: CreateExportToken<Self::Timestamp>);
 
     /// Drops the read capability for the sources and allows their resources to be reclaimed.
     fn drop_sources(&mut self, identifiers: Vec<GlobalId>) -> Result<(), StorageError>;

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -8,19 +8,47 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
-use mz_kafka_util::client::{MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT};
+use maplit::btreemap;
+use mz_kafka_util::client::{
+    BrokerRewritingClientContext, MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
+};
 use mz_ore::collections::CollectionExt;
+use mz_ore::retry::Retry;
+use mz_ore::task;
+use mz_repr::{GlobalId, Timestamp};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sinks::{
     KafkaConsistencyConfig, KafkaSinkAvroFormatState, KafkaSinkConnection,
     KafkaSinkConnectionRetention, KafkaSinkFormat,
 };
 use rdkafka::admin::{AdminClient, AdminOptions, NewTopic, ResourceSpecifier, TopicReplication};
-use rdkafka::ClientContext;
-use tracing::warn;
+use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
+use rdkafka::error::KafkaError;
+use rdkafka::{ClientContext, Message, Offset, TopicPartitionList};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, warn};
+
+/// Formatter for Kafka group.id setting
+pub struct SinkGroupId;
+
+impl SinkGroupId {
+    pub fn new(sink_id: GlobalId) -> String {
+        format!("materialize-bootstrap-sink-{sink_id}")
+    }
+}
+
+/// Formatter for the progress topic's key's
+pub struct ProgressKey;
+
+impl ProgressKey {
+    pub fn new(sink_id: GlobalId) -> String {
+        format!("mz-sink-{sink_id}")
+    }
+}
 
 struct TopicConfigs {
     partition_count: i32,
@@ -208,20 +236,69 @@ async fn publish_kafka_schemas(
 
 /// Ensures that the Kafka sink's data and consistency collateral exist.
 ///
-/// Note that this function guarantees that the topics exist, even in the face
-/// of the user having previously deleted one or both of the topics. If a user
-/// does delete a sink's topics, we no longer make any guarantees about the
-/// sink's consistency.
+/// # Errors
+/// - If the [`KafkaSinkConnection`]'s consistency collateral exists and
+///   contains data for this sink, but the sink's data topic does not exist.
 pub async fn build_kafka(
+    sink_id: mz_repr::GlobalId,
     connection: &mut KafkaSinkConnection,
     connection_cx: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
-    // Create Kafka topic.
     let client: AdminClient<_> = connection
         .connection
         .create_with_context(connection_cx, MzClientContext::default(), &BTreeMap::new())
         .await
         .context("creating admin client failed")?;
+
+    // Check for existence of progress topic; if it exists and contains data for
+    // this sink, we expect the data topic to exist, as well. Note that we don't
+    // expect the converse to be true because we don't want to prevent users
+    // from creating topics before setting up their sinks.
+    let meta = client
+        .inner()
+        .fetch_metadata(None, Duration::from_secs(10))?;
+
+    // Check if the broker's metadata already contains the progress topic.
+    let progress_topic = match &connection.consistency_config {
+        KafkaConsistencyConfig::Progress { topic } => {
+            meta.topics().iter().find(|t| t.name() == topic)
+        }
+    };
+
+    // If the consistency topic exists, check to see if it contains this sink's
+    // data.
+    if let Some(progress_topic) = progress_topic {
+        let progress_client: BaseConsumer<_> = connection
+            .connection
+            .create_with_context(
+                connection_cx,
+                MzClientContext::default(),
+                &btreemap! {
+                    "group.id" => SinkGroupId::new(sink_id),
+                    "isolation.level" => "read_committed".into(),
+                    "enable.auto.commit" => "false".into(),
+                    "auto.offset.reset" => "earliest".into(),
+                    "enable.partition.eof" => "true".into(),
+                },
+            )
+            .await?;
+
+        let latest_ts = determine_latest_progress_record(
+            format!("build_kafka_{}", sink_id),
+            progress_topic.name().to_string(),
+            ProgressKey::new(sink_id),
+            Arc::new(progress_client),
+        )
+        .await?;
+
+        // If we have progress data, we should have the topic listed in the
+        // broker's metadata. If we don't, error.
+        if latest_ts.is_some() && !meta.topics().iter().any(|t| t.name() == connection.topic) {
+            bail!("sink progress data exists, but sink data topic is missing");
+        }
+    }
+
+    // Create Kafka topic.
     ensure_kafka_topic(
         &client,
         &connection.topic,
@@ -273,4 +350,190 @@ pub async fn build_kafka(
     };
 
     Ok(())
+}
+
+#[derive(Serialize, Deserialize)]
+/// This struct is emitted as part of a transactional produce, and captures the information we
+/// need to resume the Kafka sink at the correct place in the sunk collection. (Currently, all
+/// we need is the timestamp... this is a record to make it easier to add more metadata in the
+/// future if needed.) It's encoded as JSON to make it easier to introspect while debugging, and
+/// because we expect it to remain small.
+///
+/// Unlike the old consistency topic, this is not intended to be a user-facing feature; it's there
+/// purely so the sink can maintain its transactional guarantees. Any future user-facing consistency
+/// information should be added elsewhere instead of overloading this record.
+pub struct ProgressRecord {
+    pub timestamp: Timestamp,
+}
+
+/// Determines the latest progress record from the specified topic for the given
+/// key (e.g. akin to a sink's GlobalId).
+pub async fn determine_latest_progress_record(
+    name: String,
+    progress_topic: String,
+    progress_key: String,
+    progress_client: Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>,
+) -> Result<Option<Timestamp>, anyhow::Error> {
+    // Polls a message from a Kafka Source.  Blocking so should always be called on background
+    // thread.
+    fn get_next_message<C>(
+        consumer: &BaseConsumer<C>,
+        timeout: Duration,
+    ) -> Result<Option<(Vec<u8>, Vec<u8>, i64)>, anyhow::Error>
+    where
+        C: ConsumerContext,
+    {
+        if let Some(result) = consumer.poll(timeout) {
+            match result {
+                Ok(message) => match message.payload() {
+                    Some(p) => Ok(Some((
+                        message.key().unwrap_or(&[]).to_vec(),
+                        p.to_vec(),
+                        message.offset(),
+                    ))),
+                    None => bail!("unexpected null payload"),
+                },
+                Err(KafkaError::PartitionEOF(_)) => Ok(None),
+                Err(err) => bail!("Failed to process message {}", err),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    // Retrieves the latest committed timestamp from the progress topic.  Blocking so should
+    // always be called on background thread
+    fn get_latest_ts<C>(
+        progress_topic: &str,
+        progress_key: &str,
+        progress_client: &BaseConsumer<C>,
+        timeout: Duration,
+    ) -> Result<Option<Timestamp>, anyhow::Error>
+    where
+        C: ConsumerContext,
+    {
+        // ensure the progress topic has exactly one partition
+        let partitions = mz_kafka_util::client::get_partitions(
+            progress_client.client(),
+            progress_topic,
+            timeout,
+        )
+        .with_context(|| {
+            format!(
+                "Unable to fetch metadata about progress topic {}",
+                progress_topic
+            )
+        })?;
+
+        if partitions.len() != 1 {
+            bail!(
+                    "Progress topic {} should contain a single partition, but instead contains {} partitions",
+                    progress_topic, partitions.len(),
+                );
+        }
+
+        let partition = partitions.into_element();
+
+        // We scan from the beginning and see if we can find a progress record. We have
+        // to do it like this because Kafka Control Batches mess with offsets. We
+        // therefore cannot simply take the last offset from the back and expect a
+        // progress message there. With a transactional producer, the OffsetTail(1) will
+        // not point to an progress message but a control message. With aborted
+        // transactions, there might even be a lot of garbage at the end of the
+        // topic or in between.
+
+        let mut tps = TopicPartitionList::new();
+        tps.add_partition(progress_topic, partition);
+        tps.set_partition_offset(progress_topic, partition, Offset::Beginning)?;
+
+        progress_client.assign(&tps).with_context(|| {
+            format!(
+                "Error seeking in progress topic {}:{}",
+                progress_topic, partition
+            )
+        })?;
+
+        let (lo, hi) = progress_client
+            .fetch_watermarks(progress_topic, 0, timeout)
+            .map_err(|e| {
+                anyhow!(
+                    "Failed to fetch metadata while reading from progress topic: {}",
+                    e
+                )
+            })?;
+
+        // Empty topic.  Return early to avoid unnecessary call to kafka below.
+        if hi == 0 {
+            return Ok(None);
+        }
+
+        let mut latest_ts = None;
+        let mut latest_offset = None;
+
+        let progress_key_bytes = progress_key.as_bytes();
+        while let Some((key, message, offset)) = get_next_message(progress_client, timeout)? {
+            debug_assert!(offset >= latest_offset.unwrap_or(0));
+            latest_offset = Some(offset);
+
+            let timestamp_opt = if &key == progress_key_bytes {
+                let progress: ProgressRecord = serde_json::from_slice(&message)?;
+                Some(progress.timestamp)
+            } else {
+                None
+            };
+
+            if let Some(ts) = timestamp_opt {
+                if ts >= latest_ts.unwrap_or_else(timely::progress::Timestamp::minimum) {
+                    latest_ts = Some(ts);
+                }
+            }
+
+            // If the next possible offset for the client is past the high watermark, we've seen
+            // everything we expect to see.
+            let position = progress_client
+                .position()?
+                .find_partition(progress_topic, partition)
+                .ok_or_else(|| anyhow!("No progress info for known partition"))?
+                .offset();
+            if let Offset::Offset(i) = position {
+                if i >= hi {
+                    break;
+                }
+            }
+        }
+
+        // Topic not empty but we couldn't read any messages.  We don't expect this to happen but we
+        // have no reason to rely on kafka not inserting any internal messages at the beginning.
+        if latest_offset.is_none() {
+            debug!(
+                "unable to read any messages from non-empty topic {}:{}, lo/hi: {}/{}",
+                progress_topic, partition, lo, hi
+            );
+        }
+        Ok(latest_ts)
+    }
+
+    // Only actually used for retriable errors.
+    Retry::default()
+        .max_tries(3)
+        .clamp_backoff(Duration::from_secs(60 * 10))
+        .retry_async(|_| async {
+            let progress_topic = progress_topic.clone();
+            let progress_key = progress_key.clone();
+            let progress_client = Arc::clone(&progress_client);
+            task::spawn_blocking(
+                || format!("get_latest_ts:{name}"),
+                move || {
+                    get_latest_ts(
+                        &progress_topic,
+                        &progress_key,
+                        &progress_client,
+                        DEFAULT_FETCH_METADATA_TIMEOUT,
+                    )
+                },
+            )
+            .await
+            .unwrap_or_else(|e| bail!(e))
+        })
+        .await
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -116,9 +116,9 @@ use mz_storage_client::client::{
     TimestamplessUpdate,
 };
 use mz_storage_client::controller::{
-    CollectionDescription, CollectionState, CreateExportToken, DataSource, DataSourceOther,
-    ExportDescription, ExportState, IntrospectionType, MonotonicAppender, ReadPolicy,
-    SnapshotCursor, StorageController,
+    CollectionDescription, CollectionState, DataSource, DataSourceOther, ExportDescription,
+    ExportState, IntrospectionType, MonotonicAppender, ReadPolicy, SnapshotCursor,
+    StorageController,
 };
 use mz_storage_client::healthcheck::{
     self, MZ_PREPARED_STATEMENT_HISTORY_DESC, MZ_SESSION_HISTORY_DESC,
@@ -934,66 +934,14 @@ where
             .ok_or(StorageError::IdentifierMissing(id))
     }
 
-    fn prepare_export(
-        &mut self,
-        id: GlobalId,
-        from_id: GlobalId,
-    ) -> Result<CreateExportToken<T>, StorageError> {
-        if let Ok(_export) = self.export(id) {
-            return Err(StorageError::SourceIdReused(id));
-        }
-
-        let dependency_since = self.determine_collection_since_joins(&[from_id])?;
-        self.install_read_capabilities(id, &[from_id], dependency_since.clone())?;
-
-        info!(
-            sink_id = id.to_string(),
-            from_id = from_id.to_string(),
-            acquired_since = ?dependency_since,
-            "prepare_export: sink acquired read holds"
-        );
-
-        Ok(CreateExportToken {
-            id,
-            from_id,
-            acquired_since: dependency_since,
-        })
-    }
-
-    fn cancel_prepare_export(
-        &mut self,
-        CreateExportToken {
-            id,
-            from_id,
-            acquired_since,
-        }: CreateExportToken<T>,
-    ) {
-        info!(
-            sink_id = id.to_string(),
-            from_id = from_id.to_string(),
-            acquired_since = ?acquired_since,
-            "cancel_prepare_export: sink releasing read holds",
-        );
-        self.remove_read_capabilities(acquired_since, &[from_id]);
-    }
-
     async fn create_exports(
         &mut self,
-        exports: Vec<(
-            CreateExportToken<Self::Timestamp>,
-            ExportDescription<Self::Timestamp>,
-        )>,
+        exports: Vec<(GlobalId, ExportDescription<Self::Timestamp>)>,
     ) -> Result<(), StorageError> {
         // Validate first, to avoid corrupting state.
-        let mut dedup_hashmap = BTreeMap::<&_, &_>::new();
-        for (export, desc) in exports.iter() {
-            let CreateExportToken {
-                id,
-                from_id,
-                acquired_since: _,
-            } = export;
-
-            if dedup_hashmap.insert(id, desc).is_some() {
+        let mut dedup = BTreeMap::new();
+        for (id, desc) in exports.iter() {
+            if dedup.insert(id, desc).is_some() {
                 return Err(StorageError::SinkIdReused(*id));
             }
             if let Ok(export) = self.export(*id) {
@@ -1001,21 +949,20 @@ where
                     return Err(StorageError::SinkIdReused(*id));
                 }
             }
-            if desc.sink.from != *from_id {
-                return Err(StorageError::InvalidUsage(format!(
-                    "sink {id} was prepared using from_id {from_id}, \
-                    but is now presented with from_id {}",
-                    desc.sink.from
-                )));
-            }
         }
 
-        for (export, description) in exports {
-            let CreateExportToken {
-                id,
-                from_id,
-                acquired_since,
-            } = export;
+        for (id, description) in exports {
+            let from_id = description.sink.from;
+
+            let dependency_since = self.determine_collection_since_joins(&[from_id])?;
+            self.install_read_capabilities(id, &[from_id], dependency_since.clone())?;
+
+            info!(
+                sink_id = id.to_string(),
+                from_id = from_id.to_string(),
+                acquired_since = ?dependency_since,
+                "prepare_export: sink acquired read holds"
+            );
 
             // It's worth adding a quick note on write frontiers here.
             //
@@ -1064,12 +1011,13 @@ where
             let mut durable_export_data = DurableExportMetadata::from_proto(value)
                 .map_err(|e| StorageError::IOError(e.into()))?;
 
-            durable_export_data.initial_as_of.downgrade(&acquired_since);
+            durable_export_data
+                .initial_as_of
+                .downgrade(&dependency_since);
 
             info!(
                 sink_id = id.to_string(),
                 from_id = from_id.to_string(),
-                acquired_since = ?acquired_since,
                 initial_as_of = ?durable_export_data.initial_as_of,
                 "create_exports: creating sink"
             );
@@ -1078,7 +1026,7 @@ where
                 id,
                 ExportState::new(
                     description.clone(),
-                    acquired_since,
+                    dependency_since,
                     read_policy,
                     storage_dependencies,
                 ),
@@ -1133,7 +1081,7 @@ where
     }
 
     fn drop_sources_unvalidated(&mut self, identifiers: Vec<GlobalId>) {
-        // We don't explicitly call `remove_read_capabilities`! Downgrading the
+        // We don't explicitly remove read capabilities! Downgrading the
         // frontier of the source to `[]` (the empty Antichain), will propagate
         // to the storage dependencies.
         let policies = identifiers
@@ -1158,8 +1106,9 @@ where
                 continue;
             }
 
-            // We don't explicitly call `remove_read_capabilities`! Downgrading the frontier of the
-            // sink to `[]` (the empty Antichain), will propagate to the storage dependencies.
+            // We don't explicitly remove read capabilities! Downgrading the
+            // frontier of the sink to `[]` (the empty Antichain), will
+            // propagate to the storage dependencies.
 
             // Remove sink by removing its write frontier and arranging for deprovisioning.
             self.update_write_frontiers(&[(id, Antichain::new())]);
@@ -2011,32 +1960,6 @@ where
         self.update_read_capabilities(&mut storage_read_updates);
 
         Ok(())
-    }
-
-    /// Removes read holds that were previously acquired via
-    /// `install_read_capabilities`.
-    ///
-    /// ## Panics
-    ///
-    /// This panics if there are no read capabilities at `capability` for all
-    /// depended-upon collections.
-    fn remove_read_capabilities(
-        &mut self,
-        capability: Antichain<T>,
-        storage_dependencies: &[GlobalId],
-    ) {
-        let mut changes = ChangeBatch::new();
-        for time in capability.iter() {
-            changes.update(time.clone(), -1);
-        }
-
-        // Remove holds for all dependencies, which we previously acquired.
-        let mut storage_read_updates = storage_dependencies
-            .iter()
-            .map(|id| (*id, changes.clone()))
-            .collect();
-
-        self.update_read_capabilities(&mut storage_read_updates);
     }
 
     /// Opens a write and critical since handles for the given `shard`.

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -157,6 +157,9 @@ pub enum StorageError {
     ResourceExhausted(&'static str),
     /// The specified component is shutting down.
     ShuttingDown(&'static str),
+    /// Response if we try to change a sink's description to a state
+    /// incompatible with its current state.
+    IncompatibleSinkDescriptions { id: GlobalId },
     /// A generic error that happens during operations of the storage controller.
     // TODO(aljoscha): Get rid of this!
     Generic(anyhow::Error),
@@ -180,6 +183,7 @@ impl Error for StorageError {
             Self::InvalidUsage(_) => None,
             Self::ResourceExhausted(_) => None,
             Self::ShuttingDown(_) => None,
+            Self::IncompatibleSinkDescriptions { .. } => None,
             Self::Generic(err) => err.source(),
         }
     }
@@ -243,6 +247,15 @@ impl fmt::Display for StorageError {
             Self::InvalidUsage(err) => write!(f, "invalid usage: {}", err),
             Self::ResourceExhausted(rsc) => write!(f, "{rsc} is exhausted"),
             Self::ShuttingDown(cmp) => write!(f, "{cmp} is shutting down"),
+            Self::IncompatibleSinkDescriptions { id } => {
+                // n.b. this error is only used in assertions currently, so
+                // doesn't need to contain more detail until we support `ALTER
+                // SINK`.
+                write!(
+                    f,
+                    "{id} cannot be have its description changed in the requested way"
+                )
+            }
             Self::Generic(err) => std::fmt::Display::fmt(err, f),
         }
     }

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -37,15 +37,12 @@ message ProtoSinkEnvelope {
 }
 
 message ProtoStorageSinkConnection {
-    oneof kind {
-        ProtoKafkaSinkConnection kafka = 1;
-    }
-}
+    reserved 1;
+    reserved "kafka";
 
-message ProtoKafkaSinkProgressConnection {
-    string topic = 1;
-    // int32 schema_id = 2;
-    reserved 2;
+    oneof kind {
+        ProtoKafkaSinkConnectionV2 kafka_v2 = 2;
+    }
 }
 
 message ProtoSinkAsOf {
@@ -53,7 +50,47 @@ message ProtoSinkAsOf {
     bool strict = 2;
 }
 
-message ProtoKafkaSinkConnection {
+message ProtoKafkaSinkFormat {
+    message ProtoKafkaSinkAvroFormatState {
+        message ProtoUnpublishedMaybe {
+            optional string key_schema = 1;
+            string value_schema = 2;
+            mz_storage_types.connections.ProtoCsrConnection csr_connection = 3;
+        }
+        message ProtoPublished {
+            optional int32 key_schema_id = 1;
+            int32 value_schema_id = 2;
+        }
+        oneof kind {
+            ProtoUnpublishedMaybe unpublished_maybe = 1;
+            ProtoPublished published = 2;
+        }
+    }
+
+    reserved 1;
+
+    oneof kind {
+        google.protobuf.Empty json = 2;
+        ProtoKafkaSinkAvroFormatState avro = 3;
+    }
+}
+
+message ProtoKafkaConsistencyConfig {
+    message ProtoKafkaConsistencyConfigProgress {
+        string topic = 1;
+    }
+
+    oneof kind {
+        ProtoKafkaConsistencyConfigProgress progress = 1;
+    }
+}
+
+message ProtoKafkaSinkConnectionRetention {
+    optional int64 duration = 1;
+    optional int64 bytes = 2;
+}
+
+message ProtoKafkaSinkConnectionV2 {
     message ProtoKeyDescAndIndices {
         mz_repr.relation_and_scalar.ProtoRelationDesc desc = 1;
         repeated uint64 indices = 2;
@@ -63,22 +100,18 @@ message ProtoKafkaSinkConnection {
         repeated uint64 relation_key_indices = 1;
     }
 
-    reserved 3, 9, 10;
-
-    mz_repr.global_id.ProtoGlobalId connection_id = 13;
-    mz_storage_types.connections.ProtoKafkaConnection connection = 1;
-    string topic = 2;
+    mz_repr.global_id.ProtoGlobalId connection_id = 1;
+    mz_storage_types.connections.ProtoKafkaConnection connection = 2;
+    string topic = 3;
     optional ProtoKeyDescAndIndices key_desc_and_indices = 4;
     optional ProtoRelationKeyIndicesVec relation_key_indices = 5;
     mz_repr.relation_and_scalar.ProtoRelationDesc value_desc = 6;
-    optional ProtoPublishedSchemaInfo published_schema_info = 7;
-    ProtoKafkaSinkProgressConnection progress = 8;
-    uint64 fuel = 11;
-}
-
-message ProtoPublishedSchemaInfo {
-    optional int32 key_schema_id = 1;
-    int32 value_schema_id = 2;
+    uint64 fuel = 7;
+    ProtoKafkaSinkConnectionRetention retention = 8;
+    int32 replication_factor = 9;
+    ProtoKafkaConsistencyConfig consistency_config = 10;
+    ProtoKafkaSinkFormat format = 11;
+    int32 partition_count = 12;
 }
 
 message ProtoPersistSinkConnection {

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -38,7 +38,7 @@ pub struct StorageSinkDesc<S: StorageSinkDescFillState, T = mz_repr::Timestamp> 
     pub from: GlobalId,
     pub from_desc: RelationDesc,
     pub connection: StorageSinkConnection,
-    pub envelope: Option<SinkEnvelope>,
+    pub envelope: SinkEnvelope,
     pub as_of: SinkAsOf<T>,
     pub status_id: Option<<S as StorageSinkDescFillState>::StatusId>,
     pub from_storage_metadata: <S as StorageSinkDescFillState>::StorageMetadata,
@@ -72,7 +72,7 @@ impl Arbitrary for StorageSinkDesc<MetadataFilled, mz_repr::Timestamp> {
             any::<GlobalId>(),
             any::<RelationDesc>(),
             any::<StorageSinkConnection>(),
-            any::<Option<SinkEnvelope>>(),
+            any::<SinkEnvelope>(),
             any::<SinkAsOf<mz_repr::Timestamp>>(),
             any::<Option<ShardId>>(),
             any::<CollectionMetadata>(),
@@ -108,7 +108,7 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
             connection: Some(self.connection.into_proto()),
             from: Some(self.from.into_proto()),
             from_desc: Some(self.from_desc.into_proto()),
-            envelope: self.envelope.into_proto(),
+            envelope: Some(self.envelope.into_proto()),
             as_of: Some(self.as_of.into_proto()),
             status_id: self.status_id.into_proto(),
             from_storage_metadata: Some(self.from_storage_metadata.into_proto()),
@@ -124,7 +124,9 @@ impl RustType<ProtoStorageSinkDesc> for StorageSinkDesc<MetadataFilled, mz_repr:
             connection: proto
                 .connection
                 .into_rust_if_some("ProtoStorageSinkDesc::connection")?,
-            envelope: proto.envelope.into_rust()?,
+            envelope: proto
+                .envelope
+                .into_rust_if_some("ProtoStorageSinkDesc::envelope")?,
             as_of: proto
                 .as_of
                 .into_rust_if_some("ProtoStorageSinkDesc::as_of")?,

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -11,6 +11,7 @@
 
 use std::fmt::Debug;
 
+use mz_ore::cast::CastFrom;
 use mz_persist_client::ShardId;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
@@ -235,7 +236,7 @@ impl RustType<proto::SinkAsOf> for SinkAsOf<mz_repr::Timestamp> {
     }
 }
 
-#[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum StorageSinkConnection<C: ConnectionAccess = InlinedConnection> {
     Kafka(KafkaSinkConnection<C>),
 }
@@ -250,6 +251,29 @@ impl<R: ConnectionResolver> IntoInlineConnection<StorageSinkConnection, R>
     }
 }
 
+impl RustType<ProtoStorageSinkConnection> for StorageSinkConnection {
+    fn into_proto(&self) -> ProtoStorageSinkConnection {
+        use proto_storage_sink_connection::Kind::*;
+
+        ProtoStorageSinkConnection {
+            kind: Some(match self {
+                Self::Kafka(conn) => KafkaV2(conn.into_proto()),
+            }),
+        }
+    }
+    fn from_proto(proto: ProtoStorageSinkConnection) -> Result<Self, TryFromProtoError> {
+        use proto_storage_sink_connection::Kind::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoKafkaConsistencyConfig::kind"))?;
+
+        Ok(match kind {
+            KafkaV2(proto) => Self::Kafka(proto.into_rust()?),
+        })
+    }
+}
+
 impl<C: ConnectionAccess> StorageSinkConnection<C> {
     /// returns an option to not constrain ourselves in the future
     pub fn connection_id(&self) -> Option<GlobalId> {
@@ -261,105 +285,25 @@ impl<C: ConnectionAccess> StorageSinkConnection<C> {
 
     /// Returns the name of the sink connection.
     pub fn name(&self) -> &'static str {
+        use StorageSinkConnection::*;
         match self {
-            StorageSinkConnection::Kafka(_) => "kafka",
+            Kafka(_) => "kafka",
         }
     }
 }
 
-impl RustType<ProtoStorageSinkConnection> for StorageSinkConnection {
-    fn into_proto(&self) -> ProtoStorageSinkConnection {
-        use proto_storage_sink_connection::Kind;
-        ProtoStorageSinkConnection {
-            kind: Some(match self {
-                StorageSinkConnection::Kafka(kafka) => Kind::Kafka(kafka.into_proto()),
-            }),
-        }
-    }
-
-    fn from_proto(proto: ProtoStorageSinkConnection) -> Result<Self, TryFromProtoError> {
-        use proto_storage_sink_connection::Kind;
-        let kind = proto
-            .kind
-            .ok_or_else(|| TryFromProtoError::missing_field("ProtoStorageSinkConnection::kind"))?;
-        Ok(match kind {
-            Kind::Kafka(kafka) => StorageSinkConnection::Kafka(kafka.into_rust()?),
-        })
-    }
-}
-
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkProgressConnection {
-    pub topic: String,
-}
-
-impl RustType<ProtoKafkaSinkProgressConnection> for KafkaSinkProgressConnection {
-    fn into_proto(&self) -> ProtoKafkaSinkProgressConnection {
-        ProtoKafkaSinkProgressConnection {
-            topic: self.topic.clone(),
-        }
-    }
-
-    fn from_proto(proto: ProtoKafkaSinkProgressConnection) -> Result<Self, TryFromProtoError> {
-        Ok(KafkaSinkProgressConnection { topic: proto.topic })
-    }
-}
-
-#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConnection<C: ConnectionAccess = InlinedConnection> {
-    pub connection: KafkaConnection<C>,
-    pub connection_id: GlobalId,
-    pub topic: String,
-    pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
-    pub relation_key_indices: Option<Vec<usize>>,
-    pub value_desc: RelationDesc,
-    pub published_schema_info: Option<PublishedSchemaInfo>,
-    pub progress: KafkaSinkProgressConnection,
-    // Maximum number of records the sink will attempt to send each time it is
-    // invoked
-    pub fuel: usize,
-}
-
-impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnection, R>
-    for KafkaSinkConnection<ReferencedConnection>
+impl RustType<proto_kafka_sink_connection_v2::ProtoKeyDescAndIndices>
+    for (RelationDesc, Vec<usize>)
 {
-    fn into_inline_connection(self, r: R) -> KafkaSinkConnection {
-        let KafkaSinkConnection {
-            connection,
-            connection_id,
-            topic,
-            key_desc_and_indices,
-            relation_key_indices,
-            value_desc,
-            published_schema_info,
-            progress,
-            fuel,
-        } = self;
-
-        KafkaSinkConnection {
-            connection: connection.into_inline_connection(r),
-            connection_id,
-            topic,
-            key_desc_and_indices,
-            relation_key_indices,
-            value_desc,
-            published_schema_info,
-            progress,
-            fuel,
-        }
-    }
-}
-
-impl RustType<proto_kafka_sink_connection::ProtoKeyDescAndIndices> for (RelationDesc, Vec<usize>) {
-    fn into_proto(&self) -> proto_kafka_sink_connection::ProtoKeyDescAndIndices {
-        proto_kafka_sink_connection::ProtoKeyDescAndIndices {
+    fn into_proto(&self) -> proto_kafka_sink_connection_v2::ProtoKeyDescAndIndices {
+        proto_kafka_sink_connection_v2::ProtoKeyDescAndIndices {
             desc: Some(self.0.into_proto()),
             indices: self.1.into_proto(),
         }
     }
 
     fn from_proto(
-        proto: proto_kafka_sink_connection::ProtoKeyDescAndIndices,
+        proto: proto_kafka_sink_connection_v2::ProtoKeyDescAndIndices,
     ) -> Result<Self, TryFromProtoError> {
         Ok((
             proto
@@ -370,123 +314,53 @@ impl RustType<proto_kafka_sink_connection::ProtoKeyDescAndIndices> for (Relation
     }
 }
 
-impl RustType<proto_kafka_sink_connection::ProtoRelationKeyIndicesVec> for Vec<usize> {
-    fn into_proto(&self) -> proto_kafka_sink_connection::ProtoRelationKeyIndicesVec {
-        proto_kafka_sink_connection::ProtoRelationKeyIndicesVec {
+impl RustType<proto_kafka_sink_connection_v2::ProtoRelationKeyIndicesVec> for Vec<usize> {
+    fn into_proto(&self) -> proto_kafka_sink_connection_v2::ProtoRelationKeyIndicesVec {
+        proto_kafka_sink_connection_v2::ProtoRelationKeyIndicesVec {
             relation_key_indices: self.into_proto(),
         }
     }
 
     fn from_proto(
-        proto: proto_kafka_sink_connection::ProtoRelationKeyIndicesVec,
+        proto: proto_kafka_sink_connection_v2::ProtoRelationKeyIndicesVec,
     ) -> Result<Self, TryFromProtoError> {
         proto.relation_key_indices.into_rust()
     }
 }
 
-impl RustType<ProtoKafkaSinkConnection> for KafkaSinkConnection {
-    fn into_proto(&self) -> ProtoKafkaSinkConnection {
-        ProtoKafkaSinkConnection {
-            connection: Some(self.connection.into_proto()),
-            connection_id: Some(self.connection_id.into_proto()),
-            topic: self.topic.clone(),
-            key_desc_and_indices: self.key_desc_and_indices.into_proto(),
-            relation_key_indices: self.relation_key_indices.into_proto(),
-            value_desc: Some(self.value_desc.into_proto()),
-            published_schema_info: self.published_schema_info.into_proto(),
-            progress: Some(self.progress.into_proto()),
-            fuel: self.fuel.into_proto(),
-        }
-    }
-
-    fn from_proto(proto: ProtoKafkaSinkConnection) -> Result<Self, TryFromProtoError> {
-        Ok(KafkaSinkConnection {
-            connection: proto
-                .connection
-                .into_rust_if_some("ProtoKafkaSinkConnection::connection")?,
-            connection_id: proto
-                .connection_id
-                .into_rust_if_some("ProtoKafkaSinkConnection::connection_id")?,
-            topic: proto.topic,
-            key_desc_and_indices: proto.key_desc_and_indices.into_rust()?,
-            relation_key_indices: proto.relation_key_indices.into_rust()?,
-            value_desc: proto
-                .value_desc
-                .into_rust_if_some("ProtoKafkaSinkConnection::addrs")?,
-            published_schema_info: proto.published_schema_info.into_rust()?,
-            progress: proto
-                .progress
-                .into_rust_if_some("ProtoKafkaSinkConnection::progress")?,
-            fuel: proto.fuel.into_rust()?,
-        })
-    }
-}
-
-/// TODO(JLDLaughlin): Documentation.
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct PublishedSchemaInfo {
-    pub key_schema_id: Option<i32>,
-    pub value_schema_id: i32,
-}
-
-impl RustType<ProtoPublishedSchemaInfo> for PublishedSchemaInfo {
-    fn into_proto(&self) -> ProtoPublishedSchemaInfo {
-        ProtoPublishedSchemaInfo {
-            key_schema_id: self.key_schema_id.clone(),
-            value_schema_id: self.value_schema_id,
-        }
-    }
-
-    fn from_proto(proto: ProtoPublishedSchemaInfo) -> Result<Self, TryFromProtoError> {
-        Ok(PublishedSchemaInfo {
-            key_schema_id: proto.key_schema_id,
-            value_schema_id: proto.value_schema_id,
-        })
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum StorageSinkConnectionBuilder<C: ConnectionAccess = InlinedConnection> {
-    Kafka(KafkaSinkConnectionBuilder<C>),
-}
-
-impl<R: ConnectionResolver> IntoInlineConnection<StorageSinkConnectionBuilder, R>
-    for StorageSinkConnectionBuilder<ReferencedConnection>
-{
-    fn into_inline_connection(self, r: R) -> StorageSinkConnectionBuilder {
-        match self {
-            Self::Kafka(conn) => {
-                StorageSinkConnectionBuilder::Kafka(conn.into_inline_connection(r))
-            }
-        }
-    }
-}
-
-impl<C: ConnectionAccess> StorageSinkConnectionBuilder<C> {
-    /// returns an option to not constrain ourselves in the future
-    pub fn connection_id(&self) -> Option<GlobalId> {
-        use StorageSinkConnectionBuilder::*;
-        match self {
-            Kafka(KafkaSinkConnectionBuilder { connection_id, .. }) => Some(*connection_id),
-        }
-    }
-
-    /// Returns the name of the sink connection.
-    pub fn name(&self) -> &'static str {
-        use StorageSinkConnectionBuilder::*;
-        match self {
-            Kafka(_) => "kafka",
-        }
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum KafkaConsistencyConfig {
     Progress { topic: String },
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct KafkaSinkConnectionBuilder<C: ConnectionAccess = InlinedConnection> {
+impl RustType<ProtoKafkaConsistencyConfig> for KafkaConsistencyConfig {
+    fn into_proto(&self) -> ProtoKafkaConsistencyConfig {
+        use proto_kafka_consistency_config::Kind::*;
+        use proto_kafka_consistency_config::ProtoKafkaConsistencyConfigProgress;
+
+        ProtoKafkaConsistencyConfig {
+            kind: Some(match self {
+                Self::Progress { topic } => Progress(ProtoKafkaConsistencyConfigProgress {
+                    topic: topic.clone(),
+                }),
+            }),
+        }
+    }
+    fn from_proto(proto: ProtoKafkaConsistencyConfig) -> Result<Self, TryFromProtoError> {
+        use proto_kafka_consistency_config::Kind::*;
+
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoKafkaConsistencyConfig::kind"))?;
+
+        Ok(match kind {
+            Progress(proto) => Self::Progress { topic: proto.topic },
+        })
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KafkaSinkConnection<C: ConnectionAccess = InlinedConnection> {
     pub connection_id: GlobalId,
     pub connection: KafkaConnection<C>,
     pub format: KafkaSinkFormat<C>,
@@ -495,7 +369,7 @@ pub struct KafkaSinkConnectionBuilder<C: ConnectionAccess = InlinedConnection> {
     /// The user-specified key for the sink.
     pub key_desc_and_indices: Option<(RelationDesc, Vec<usize>)>,
     pub value_desc: RelationDesc,
-    pub topic_name: String,
+    pub topic: String,
     pub consistency_config: KafkaConsistencyConfig,
     pub partition_count: i32,
     pub replication_factor: i32,
@@ -503,32 +377,32 @@ pub struct KafkaSinkConnectionBuilder<C: ConnectionAccess = InlinedConnection> {
     pub retention: KafkaSinkConnectionRetention,
 }
 
-impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnectionBuilder, R>
-    for KafkaSinkConnectionBuilder<ReferencedConnection>
+impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnection, R>
+    for KafkaSinkConnection<ReferencedConnection>
 {
-    fn into_inline_connection(self, r: R) -> KafkaSinkConnectionBuilder {
-        let KafkaSinkConnectionBuilder {
+    fn into_inline_connection(self, r: R) -> KafkaSinkConnection {
+        let KafkaSinkConnection {
             connection_id,
             connection,
             format,
             relation_key_indices,
             key_desc_and_indices,
             value_desc,
-            topic_name,
+            topic,
             consistency_config,
             partition_count,
             replication_factor,
             fuel,
             retention,
         } = self;
-        KafkaSinkConnectionBuilder {
+        KafkaSinkConnection {
             connection_id,
             connection: connection.into_inline_connection(&r),
             format: format.into_inline_connection(r),
             relation_key_indices,
             key_desc_and_indices,
             value_desc,
-            topic_name,
+            topic,
             consistency_config,
             partition_count,
             replication_factor,
@@ -538,20 +412,186 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnectionBuilder, R>
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+impl RustType<ProtoKafkaSinkConnectionV2> for KafkaSinkConnection {
+    fn into_proto(&self) -> ProtoKafkaSinkConnectionV2 {
+        ProtoKafkaSinkConnectionV2 {
+            connection_id: Some(self.connection_id.into_proto()),
+            connection: Some(self.connection.into_proto()),
+            format: Some(self.format.into_proto()),
+            key_desc_and_indices: self.key_desc_and_indices.into_proto(),
+            relation_key_indices: self.relation_key_indices.into_proto(),
+            value_desc: Some(self.value_desc.into_proto()),
+            topic: self.topic.clone(),
+            consistency_config: Some(self.consistency_config.into_proto()),
+            partition_count: self.partition_count,
+            replication_factor: self.replication_factor,
+            fuel: u64::cast_from(self.fuel),
+            retention: Some(self.retention.into_proto()),
+        }
+    }
+
+    fn from_proto(proto: ProtoKafkaSinkConnectionV2) -> Result<Self, TryFromProtoError> {
+        Ok(KafkaSinkConnection {
+            connection_id: proto
+                .connection_id
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::connection_id")?,
+            connection: proto
+                .connection
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::connection")?,
+            format: proto
+                .format
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::format")?,
+            key_desc_and_indices: proto.key_desc_and_indices.into_rust()?,
+            relation_key_indices: proto.relation_key_indices.into_rust()?,
+            value_desc: proto
+                .value_desc
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::value_desc")?,
+            topic: proto.topic,
+            consistency_config: proto
+                .consistency_config
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::consistency_config")?,
+            partition_count: proto.partition_count,
+            replication_factor: proto.replication_factor,
+            fuel: proto.fuel.into_rust()?,
+            retention: proto
+                .retention
+                .into_rust_if_some("ProtoKafkaSinkConnectionV2::retention")?,
+        })
+    }
+}
+
+#[derive(Arbitrary, Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct KafkaSinkConnectionRetention {
     pub duration: Option<i64>,
     pub bytes: Option<i64>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub enum KafkaSinkFormat<C: ConnectionAccess = InlinedConnection> {
-    Avro {
+impl RustType<ProtoKafkaSinkConnectionRetention> for KafkaSinkConnectionRetention {
+    fn into_proto(&self) -> ProtoKafkaSinkConnectionRetention {
+        ProtoKafkaSinkConnectionRetention {
+            duration: self.duration,
+            bytes: self.bytes,
+        }
+    }
+
+    fn from_proto(proto: ProtoKafkaSinkConnectionRetention) -> Result<Self, TryFromProtoError> {
+        Ok(KafkaSinkConnectionRetention {
+            duration: proto.duration,
+            bytes: proto.bytes,
+        })
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum KafkaSinkAvroFormatState<C: ConnectionAccess = InlinedConnection> {
+    /// If we haven't yet communicated with the CSR, we don't yet know if we
+    /// have a schema and value ID. It's possible that this schema was already
+    /// published.
+    UnpublishedMaybe {
         key_schema: Option<String>,
         value_schema: String,
         csr_connection: CsrConnection<C>,
     },
+    /// After communicating with the CSR, the IDs we've been given for the
+    /// schemas.
+    Published {
+        key_schema_id: Option<i32>,
+        value_schema_id: i32,
+    },
+}
+
+impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkAvroFormatState, R>
+    for KafkaSinkAvroFormatState<ReferencedConnection>
+{
+    fn into_inline_connection(self, r: R) -> KafkaSinkAvroFormatState {
+        match self {
+            Self::UnpublishedMaybe {
+                key_schema,
+                value_schema,
+                csr_connection,
+            } => KafkaSinkAvroFormatState::UnpublishedMaybe {
+                key_schema,
+                value_schema,
+                csr_connection: csr_connection.into_inline_connection(r),
+            },
+            Self::Published {
+                key_schema_id,
+                value_schema_id,
+            } => KafkaSinkAvroFormatState::Published {
+                key_schema_id,
+                value_schema_id,
+            },
+        }
+    }
+}
+
+impl RustType<proto_kafka_sink_format::ProtoKafkaSinkAvroFormatState> for KafkaSinkAvroFormatState {
+    fn into_proto(&self) -> proto_kafka_sink_format::ProtoKafkaSinkAvroFormatState {
+        use proto_kafka_sink_format::proto_kafka_sink_avro_format_state::{
+            Kind, ProtoPublished, ProtoUnpublishedMaybe,
+        };
+        use proto_kafka_sink_format::ProtoKafkaSinkAvroFormatState;
+
+        ProtoKafkaSinkAvroFormatState {
+            kind: Some(match self {
+                KafkaSinkAvroFormatState::UnpublishedMaybe {
+                    key_schema,
+                    value_schema,
+                    csr_connection,
+                } => Kind::UnpublishedMaybe(ProtoUnpublishedMaybe {
+                    key_schema: key_schema.clone(),
+                    value_schema: value_schema.clone(),
+                    csr_connection: Some(csr_connection.into_proto()),
+                }),
+                KafkaSinkAvroFormatState::Published {
+                    key_schema_id,
+                    value_schema_id,
+                } => Kind::Published(ProtoPublished {
+                    key_schema_id: *key_schema_id,
+                    value_schema_id: *value_schema_id,
+                }),
+            }),
+        }
+    }
+
+    fn from_proto(
+        proto: proto_kafka_sink_format::ProtoKafkaSinkAvroFormatState,
+    ) -> Result<Self, TryFromProtoError> {
+        use proto_kafka_sink_format::proto_kafka_sink_avro_format_state::Kind;
+
+        let kind = proto.kind.ok_or_else(|| {
+            TryFromProtoError::missing_field("ProtoKafkaSinkAvroFormatState::kind")
+        })?;
+
+        Ok(match kind {
+            Kind::UnpublishedMaybe(proto) => Self::UnpublishedMaybe {
+                key_schema: proto.key_schema,
+                value_schema: proto.value_schema,
+                csr_connection: proto
+                    .csr_connection
+                    .into_rust_if_some("ProtoKafkaSinkAvroFormatState::csr_connection")?,
+            },
+            Kind::Published(proto) => Self::Published {
+                key_schema_id: proto.key_schema_id,
+                value_schema_id: proto.value_schema_id,
+            },
+        })
+    }
+}
+
+#[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub enum KafkaSinkFormat<C: ConnectionAccess = InlinedConnection> {
+    Avro(KafkaSinkAvroFormatState<C>),
     Json,
+}
+
+impl KafkaSinkFormat {
+    pub fn get_format_name(&self) -> &str {
+        match self {
+            Self::Avro(_) => "avro",
+            Self::Json => "json",
+        }
+    }
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkFormat, R>
@@ -559,16 +599,32 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkFormat, R>
 {
     fn into_inline_connection(self, r: R) -> KafkaSinkFormat {
         match self {
-            Self::Avro {
-                key_schema,
-                value_schema,
-                csr_connection,
-            } => KafkaSinkFormat::Avro {
-                key_schema,
-                value_schema,
-                csr_connection: csr_connection.into_inline_connection(r),
-            },
+            Self::Avro(avro) => KafkaSinkFormat::Avro(avro.into_inline_connection(r)),
             Self::Json => KafkaSinkFormat::Json,
         }
+    }
+}
+
+impl RustType<ProtoKafkaSinkFormat> for KafkaSinkFormat {
+    fn into_proto(&self) -> ProtoKafkaSinkFormat {
+        use proto_kafka_sink_format::Kind;
+        ProtoKafkaSinkFormat {
+            kind: Some(match self {
+                Self::Avro(avro) => Kind::Avro(avro.into_proto()),
+                Self::Json => Kind::Json(()),
+            }),
+        }
+    }
+
+    fn from_proto(proto: ProtoKafkaSinkFormat) -> Result<Self, TryFromProtoError> {
+        use proto_kafka_sink_format::Kind;
+        let kind = proto
+            .kind
+            .ok_or_else(|| TryFromProtoError::missing_field("ProtoKafkaSinkFormat::kind"))?;
+
+        Ok(match kind {
+            Kind::Avro(avro) => Self::Avro(avro.into_rust()?),
+            Kind::Json(()) => Self::Json,
+        })
     }
 }

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -61,14 +61,25 @@ postgres-protocol = { version = "0.6.5" }
 prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
-rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
+rdkafka = { version = "0.29.0", features = [
+    "cmake-build",
+    "ssl-vendored",
+    "libz-static",
+    "zstd",
+] }
 regex = { version = "1.7.0" }
-rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = ["snappy", "zstd", "lz4"] }
+rocksdb = { git = "https://github.com/MaterializeInc/rust-rocksdb", branch = "master", default-features = false, features = [
+    "snappy",
+    "zstd",
+    "lz4",
+] }
 seahash = "4"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"
-timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
+timely = { version = "0.12.0", default-features = false, features = [
+    "bincode",
+] }
 tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -154,7 +154,7 @@ where
     // * Upsert" does the same, except at the last step, it renders the diff pair in upsert format.
     //   (As part of doing so, it asserts that there are not multiple conflicting values at the same timestamp)
     let collection = match sink.envelope {
-        Some(SinkEnvelope::Debezium) => {
+        SinkEnvelope::Debezium => {
             // Allow access to `arrange_named` because we cannot access Mz's wrapper from here.
             // TODO(#17413): Revisit with cluster unification.
             #[allow(clippy::disallowed_methods)]
@@ -187,7 +187,7 @@ where
             });
             collection
         }
-        Some(SinkEnvelope::Upsert) => {
+        SinkEnvelope::Upsert => {
             // Allow access to `arrange_named` because we cannot access Mz's wrapper from here.
             // TODO(#17413): Revisit with cluster unification.
             #[allow(clippy::disallowed_methods)]
@@ -206,7 +206,6 @@ where
             });
             collection
         }
-        None => keyed.map(|(key, value)| (key, Some(value))),
     };
 
     collection

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -789,7 +789,7 @@ fn kafka<G>(
     collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     id: GlobalId,
     connection: KafkaSinkConnection,
-    envelope: Option<SinkEnvelope>,
+    envelope: SinkEnvelope,
     as_of: SinkAsOf,
     write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
     metrics: KafkaBaseMetrics,
@@ -813,7 +813,7 @@ where
         &name,
         connection.clone(),
         connection_context.clone(),
-        envelope.clone(),
+        envelope,
     );
 
     let (produce_health_stream, produce_token) = produce_to_kafka(
@@ -1142,7 +1142,7 @@ fn encode_stream<G>(
     name_prefix: &str,
     mut connection: KafkaSinkConnection,
     connection_context: ConnectionContext,
-    envelope: Option<SinkEnvelope>,
+    envelope: SinkEnvelope,
 ) -> (
     Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>,
     Stream<G, HealthStatusMessage>,
@@ -1209,7 +1209,7 @@ where
                 value_schema_id,
             }) => {
                 let options = AvroSchemaOptions {
-                    is_debezium: matches!(envelope, Some(SinkEnvelope::Debezium)),
+                    is_debezium: matches!(envelope, SinkEnvelope::Debezium),
                     ..Default::default()
                 };
 
@@ -1227,7 +1227,7 @@ where
             KafkaSinkFormat::Json => Box::new(JsonEncoder::new(
                 key_desc,
                 value_desc,
-                matches!(envelope, Some(SinkEnvelope::Debezium)),
+                matches!(envelope, SinkEnvelope::Debezium),
             )),
         };
 

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -38,8 +38,8 @@ use mz_storage_client::client::SinkStatisticsUpdate;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sinks::{
-    KafkaSinkConnection, MetadataFilled, PublishedSchemaInfo, SinkAsOf, SinkEnvelope,
-    StorageSinkDesc,
+    KafkaConsistencyConfig, KafkaSinkAvroFormatState, KafkaSinkConnection, KafkaSinkFormat,
+    MetadataFilled, SinkAsOf, SinkEnvelope, StorageSinkDesc,
 };
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use prometheus::core::AtomicU64;
@@ -52,7 +52,7 @@ use rdkafka::{Offset, TopicPartitionList};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pushers::TeeCore;
-use timely::dataflow::operators::{Enter, Leave, Map};
+use timely::dataflow::operators::Concat;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as _};
 use timely::PartialOrder;
@@ -439,10 +439,6 @@ impl KafkaSinkState {
             &healthchecker,
             #[allow(clippy::redundant_closure_call)]
             (|| async {
-                fail::fail_point!("kafka_sink_creation_error", |_| Err(anyhow::anyhow!(
-                    "synthetic error"
-                )));
-
                 connection
                     .connection
                     .create_with_context(
@@ -515,7 +511,9 @@ impl KafkaSinkState {
             pending_rows: BTreeMap::new(),
             ready_rows: VecDeque::new(),
             retry_manager,
-            progress_topic: connection.progress.topic,
+            progress_topic: match connection.consistency_config {
+                KafkaConsistencyConfig::Progress { topic } => topic,
+            },
             progress_key: format!("mz-sink-{sink_id}"),
             progress_client: Some(Arc::new(progress_client)),
             healthchecker,
@@ -962,7 +960,6 @@ struct EncodedRow {
     count: usize,
 }
 
-// TODO@jldlaughlin: What guarantees does this sink support? #1728
 fn kafka<G>(
     collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
     id: GlobalId,
@@ -983,49 +980,18 @@ where
 
     let shared_gate_ts = Rc::new(Cell::new(None));
 
-    let key_desc = connection
-        .key_desc_and_indices
-        .as_ref()
-        .map(|(desc, _indices)| desc.clone());
-    let value_desc = connection.value_desc.clone();
+    let (encoded_stream, encode_health_stream, encode_token) = encode_stream(
+        stream,
+        id,
+        as_of.clone(),
+        Rc::clone(&shared_gate_ts),
+        &name,
+        connection.clone(),
+        connection_context.clone(),
+        envelope.clone(),
+    );
 
-    let encoded_stream = match connection.published_schema_info {
-        Some(PublishedSchemaInfo {
-            key_schema_id,
-            value_schema_id,
-        }) => {
-            let options = AvroSchemaOptions {
-                is_debezium: matches!(envelope, Some(SinkEnvelope::Debezium)),
-                ..Default::default()
-            };
-            let schema_generator = AvroSchemaGenerator::new(key_desc, value_desc, options)
-                .expect("avro schema validated");
-            let encoder = AvroEncoder::new(schema_generator, key_schema_id, value_schema_id);
-            encode_stream(
-                stream,
-                as_of.clone(),
-                Rc::clone(&shared_gate_ts),
-                encoder,
-                &name,
-            )
-        }
-        None => {
-            let encoder = JsonEncoder::new(
-                key_desc,
-                value_desc,
-                matches!(envelope, Some(SinkEnvelope::Debezium)),
-            );
-            encode_stream(
-                stream,
-                as_of.clone(),
-                Rc::clone(&shared_gate_ts),
-                encoder,
-                &name,
-            )
-        }
-    };
-
-    produce_to_kafka(
+    let (produce_health_stream, produce_token) = produce_to_kafka(
         encoded_stream,
         id,
         name,
@@ -1036,6 +1002,11 @@ where
         metrics,
         sink_statistics,
         connection_context,
+    );
+
+    (
+        encode_health_stream.concat(&produce_health_stream),
+        Rc::new((encode_token, produce_token)),
     )
 }
 
@@ -1050,7 +1021,7 @@ where
 ///
 /// Updates that are not beyond the given [`SinkAsOf`] and/or the `gate_ts` in
 /// [`KafkaSinkConnection`] will be discarded without producing them.
-pub fn produce_to_kafka<G>(
+fn produce_to_kafka<G>(
     stream: Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>,
     id: GlobalId,
     name: String,
@@ -1079,8 +1050,11 @@ where
 
     let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    // The frontier of this output is never inspected, so we can just use a normal output,
-    // even if its frontier is connected to the input.
+    // The frontier of this output is never inspected, so we can just use a
+    // normal output, even if its frontier is connected to the input.
+    //
+    // n.b. each operator needs to have its own `HealthOutputHandle` and they
+    // cannot be shared between operators.
     let (health_output, health_stream) = builder.new_output();
 
     let button = builder.build(move |caps| async move {
@@ -1328,37 +1302,125 @@ where
 /// changed.
 fn encode_stream<G>(
     input_stream: &Stream<G, ((Option<Row>, Option<Row>), Timestamp, Diff)>,
+    sink_id: GlobalId,
     as_of: SinkAsOf,
     shared_gate_ts: Rc<Cell<Option<Timestamp>>>,
-    encoder: impl Encode + 'static,
     name_prefix: &str,
-) -> Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>
+    mut connection: KafkaSinkConnection,
+    connection_context: ConnectionContext,
+    envelope: Option<SinkEnvelope>,
+) -> (
+    Stream<G, ((Option<Vec<u8>>, Option<Vec<u8>>), Timestamp, Diff)>,
+    Stream<G, HealthStatusMessage>,
+    Rc<dyn Any>,
+)
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let name = format!("{}-{}_encode", name_prefix, encoder.get_format_name());
-    input_stream.scope().region_named(&name, |region| {
-        input_stream
-            .enter(region)
-            .flat_map(move |((key, value), time, diff)| {
-                let should_emit = if as_of.strict {
-                    as_of.frontier.less_than(&time)
-                } else {
-                    as_of.frontier.less_equal(&time)
-                };
-                let ts_gated = Some(time) <= shared_gate_ts.get();
+    let name = format!(
+        "{}-{}_encode",
+        name_prefix,
+        connection.format.get_format_name()
+    );
+    let worker_id = input_stream.scope().index();
+    let worker_count = input_stream.scope().peers();
+    let hashed_id = sink_id.hashed();
+    let is_active_worker = usize::cast_from(hashed_id) % worker_count == worker_id;
 
-                if !should_emit || ts_gated {
-                    // Skip stale data for already published timestamps
-                    None
-                } else {
+    let mut builder = AsyncOperatorBuilder::new(name.clone(), input_stream.scope());
+
+    let mut input = builder.new_input(input_stream, Exchange::new(move |_| hashed_id));
+    let (mut output, stream) = builder.new_output();
+
+    // The frontier of this output is never inspected, so we can just use a normal output,
+    // even if its frontier is connected to the input.
+    let (health_output, health_stream) = builder.new_output();
+
+    let button = builder.build(move |caps| async move {
+        let [output_cap, health_cap]: [_; 2] = caps.try_into().unwrap();
+        drop(output_cap);
+
+        if !is_active_worker {
+            return;
+        }
+
+        // Ensure that Kafka collateral exists. While this looks somewhat
+        // innocuous, this step is why this must be an async operator.
+        //
+        // Also note that where this lies in the rendering cycle means that we
+        // might create the collateral topics each time the sink is rendered,
+        // e.g. if the broker's admin deleted the progress and data topics. For
+        // more details, see `mz_storage_client::sink::build_kafka`.
+        let healthchecker = HealthOutputHandle {
+            health_cap,
+            handle: Mutex::new(health_output),
+        };
+
+        let _ = halt_on_err(
+            &healthchecker,
+            mz_storage_client::sink::build_kafka(&mut connection, &connection_context).await,
+        )
+        .await;
+
+        let key_desc = connection
+            .key_desc_and_indices
+            .as_ref()
+            .map(|(desc, _indices)| desc.clone());
+        let value_desc = connection.value_desc.clone();
+
+        let encoder: Box<dyn Encode> = match connection.format {
+            KafkaSinkFormat::Avro(KafkaSinkAvroFormatState::Published {
+                key_schema_id,
+                value_schema_id,
+            }) => {
+                let options = AvroSchemaOptions {
+                    is_debezium: matches!(envelope, Some(SinkEnvelope::Debezium)),
+                    ..Default::default()
+                };
+
+                let schema_generator = AvroSchemaGenerator::new(key_desc, value_desc, options)
+                    .expect("avro schema validated");
+                Box::new(AvroEncoder::new(
+                    schema_generator,
+                    key_schema_id,
+                    value_schema_id,
+                ))
+            }
+            KafkaSinkFormat::Avro(KafkaSinkAvroFormatState::UnpublishedMaybe { .. }) => {
+                unreachable!("must have communicated with CSR")
+            }
+            KafkaSinkFormat::Json => Box::new(JsonEncoder::new(
+                key_desc,
+                value_desc,
+                matches!(envelope, Some(SinkEnvelope::Debezium)),
+            )),
+        };
+
+        while let Some(event) = input.next_mut().await {
+            if let Event::Data(cap, rows) = event {
+                for ((key, value), time, diff) in rows.drain(..) {
+                    let should_emit = if as_of.strict {
+                        as_of.frontier.less_than(&time)
+                    } else {
+                        as_of.frontier.less_equal(&time)
+                    };
+                    let ts_gated = Some(time) <= shared_gate_ts.get();
+
+                    if !should_emit || ts_gated {
+                        // Skip stale data for already published timestamps
+                        continue;
+                    }
+
                     let key = key.map(|key| encoder.encode_key_unchecked(key));
                     let value = value.map(|value| encoder.encode_value_unchecked(value));
-                    Some(((key, value), time, diff))
+
+                    output.give(&cap, ((key, value), time, diff)).await;
                 }
-            })
-            .leave()
-    })
+            }
+        }
+    });
+
+    (stream, health_stream, Rc::new(button.press_on_drop()))
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -17,24 +17,22 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{anyhow, bail, Context};
+use anyhow::anyhow;
 use differential_dataflow::{Collection, Hashable};
 use futures::{StreamExt, TryFutureExt};
 use maplit::btreemap;
 use mz_interchange::avro::{AvroEncoder, AvroSchemaGenerator, AvroSchemaOptions};
 use mz_interchange::encode::Encode;
 use mz_interchange::json::JsonEncoder;
-use mz_kafka_util::client::{
-    BrokerRewritingClientContext, MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
-};
+use mz_kafka_util::client::{BrokerRewritingClientContext, MzClientContext};
 use mz_ore::cast::CastFrom;
-use mz_ore::collections::CollectionExt;
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
 use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::task;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_client::client::SinkStatisticsUpdate;
+use mz_storage_client::sink::ProgressRecord;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sinks::{
@@ -44,12 +42,10 @@ use mz_storage_types::sinks::{
 use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
 use prometheus::core::AtomicU64;
 use rdkafka::client::ClientContext;
-use rdkafka::consumer::{BaseConsumer, Consumer, ConsumerContext};
+use rdkafka::consumer::BaseConsumer;
 use rdkafka::error::{KafkaError, KafkaResult, RDKafkaError, RDKafkaErrorCode};
 use rdkafka::message::{Header, Message, OwnedHeaders, OwnedMessage, ToBytes};
 use rdkafka::producer::{BaseRecord, DeliveryResult, Producer, ProducerContext, ThreadedProducer};
-use rdkafka::{Offset, TopicPartitionList};
-use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::channels::pushers::TeeCore;
 use timely::dataflow::operators::Concat;
@@ -492,7 +488,7 @@ impl KafkaSinkState {
                     connection_context,
                     MzClientContext::default(),
                     &btreemap! {
-                        "group.id" => format!("materialize-bootstrap-sink-{sink_id}"),
+                        "group.id" => mz_storage_client::sink::SinkGroupId::new(sink_id),
                         "isolation.level" => "read_committed".into(),
                         "enable.auto.commit" => "false".into(),
                         "auto.offset.reset" => "earliest".into(),
@@ -514,7 +510,7 @@ impl KafkaSinkState {
             progress_topic: match connection.consistency_config {
                 KafkaConsistencyConfig::Progress { topic } => topic,
             },
-            progress_key: format!("mz-sink-{sink_id}"),
+            progress_key: mz_storage_client::sink::ProgressKey::new(sink_id),
             progress_client: Some(Arc::new(progress_client)),
             healthchecker,
             gate_ts,
@@ -596,177 +592,6 @@ impl KafkaSinkState {
             .retry_async(|_| self.producer.flush())
             .await
             .expect("Infinite retry cannot fail");
-    }
-
-    async fn determine_latest_progress_record(
-        &mut self,
-    ) -> Result<Option<Timestamp>, anyhow::Error> {
-        // Polls a message from a Kafka Source.  Blocking so should always be called on background
-        // thread.
-        fn get_next_message<C>(
-            consumer: &BaseConsumer<C>,
-            timeout: Duration,
-        ) -> Result<Option<(Vec<u8>, Vec<u8>, i64)>, anyhow::Error>
-        where
-            C: ConsumerContext,
-        {
-            if let Some(result) = consumer.poll(timeout) {
-                match result {
-                    Ok(message) => match message.payload() {
-                        Some(p) => Ok(Some((
-                            message.key().unwrap_or(&[]).to_vec(),
-                            p.to_vec(),
-                            message.offset(),
-                        ))),
-                        None => bail!("unexpected null payload"),
-                    },
-                    Err(KafkaError::PartitionEOF(_)) => Ok(None),
-                    Err(err) => bail!("Failed to process message {}", err),
-                }
-            } else {
-                Ok(None)
-            }
-        }
-
-        // Retrieves the latest committed timestamp from the progress topic.  Blocking so should
-        // always be called on background thread
-        fn get_latest_ts<C>(
-            progress_topic: &str,
-            progress_key: &str,
-            progress_client: &BaseConsumer<C>,
-            timeout: Duration,
-        ) -> Result<Option<Timestamp>, anyhow::Error>
-        where
-            C: ConsumerContext,
-        {
-            // ensure the progress topic has exactly one partition
-            let partitions = mz_kafka_util::client::get_partitions(
-                progress_client.client(),
-                progress_topic,
-                timeout,
-            )
-            .with_context(|| {
-                format!(
-                    "Unable to fetch metadata about progress topic {}",
-                    progress_topic
-                )
-            })?;
-
-            if partitions.len() != 1 {
-                bail!(
-                    "Progress topic {} should contain a single partition, but instead contains {} partitions",
-                    progress_topic, partitions.len(),
-                );
-            }
-
-            let partition = partitions.into_element();
-
-            // We scan from the beginning and see if we can find a progress record. We have
-            // to do it like this because Kafka Control Batches mess with offsets. We
-            // therefore cannot simply take the last offset from the back and expect a
-            // progress message there. With a transactional producer, the OffsetTail(1) will
-            // not point to an progress message but a control message. With aborted
-            // transactions, there might even be a lot of garbage at the end of the
-            // topic or in between.
-
-            let mut tps = TopicPartitionList::new();
-            tps.add_partition(progress_topic, partition);
-            tps.set_partition_offset(progress_topic, partition, Offset::Beginning)?;
-
-            progress_client.assign(&tps).with_context(|| {
-                format!(
-                    "Error seeking in progress topic {}:{}",
-                    progress_topic, partition
-                )
-            })?;
-
-            let (lo, hi) = progress_client
-                .fetch_watermarks(progress_topic, 0, timeout)
-                .map_err(|e| {
-                    anyhow!(
-                        "Failed to fetch metadata while reading from progress topic: {}",
-                        e
-                    )
-                })?;
-
-            // Empty topic.  Return early to avoid unnecessary call to kafka below.
-            if hi == 0 {
-                return Ok(None);
-            }
-
-            let mut latest_ts = None;
-            let mut latest_offset = None;
-
-            let progress_key_bytes = progress_key.as_bytes();
-            while let Some((key, message, offset)) = get_next_message(progress_client, timeout)? {
-                debug_assert!(offset >= latest_offset.unwrap_or(0));
-                latest_offset = Some(offset);
-
-                let timestamp_opt = if &key == progress_key_bytes {
-                    let progress: ProgressRecord = serde_json::from_slice(&message)?;
-                    Some(progress.timestamp)
-                } else {
-                    None
-                };
-
-                if let Some(ts) = timestamp_opt {
-                    if ts >= latest_ts.unwrap_or_else(timely::progress::Timestamp::minimum) {
-                        latest_ts = Some(ts);
-                    }
-                }
-
-                // If the next possible offset for the client is past the high watermark, we've seen
-                // everything we expect to see.
-                let position = progress_client
-                    .position()?
-                    .find_partition(progress_topic, partition)
-                    .ok_or_else(|| anyhow!("No progress info for known partition"))?
-                    .offset();
-                if let Offset::Offset(i) = position {
-                    if i >= hi {
-                        break;
-                    }
-                }
-            }
-
-            // Topic not empty but we couldn't read any messages.  We don't expect this to happen but we
-            // have no reason to rely on kafka not inserting any internal messages at the beginning.
-            if latest_offset.is_none() {
-                debug!(
-                    "unable to read any messages from non-empty topic {}:{}, lo/hi: {}/{}",
-                    progress_topic, partition, lo, hi
-                );
-            }
-            Ok(latest_ts)
-        }
-
-        let progress_client = self
-            .progress_client
-            .take()
-            .expect("Claiming just-created progress client");
-        // Only actually used for retriable errors.
-        Retry::default()
-            .max_tries(3)
-            .clamp_backoff(Duration::from_secs(60 * 10))
-            .retry_async(|_| async {
-                let progress_topic = self.progress_topic.clone();
-                let progress_key = self.progress_key.clone();
-                let progress_client = Arc::clone(&progress_client);
-                task::spawn_blocking(
-                    || format!("get_latest_ts:{}", self.name),
-                    move || {
-                        get_latest_ts(
-                            &progress_topic,
-                            &progress_key,
-                            &progress_client,
-                            DEFAULT_FETCH_METADATA_TIMEOUT,
-                        )
-                    },
-                )
-                .await
-                .unwrap_or_else(|e| bail!(e))
-            })
-            .await
     }
 
     async fn send_progress_record(&self, transaction_id: Timestamp) {
@@ -1087,7 +912,16 @@ where
         )
         .await;
 
-        let latest_ts = s.determine_latest_progress_record().await;
+        let latest_ts = mz_storage_client::sink::determine_latest_progress_record(
+            s.name.clone(),
+            s.progress_topic.clone(),
+            s.progress_key.clone(),
+            s.progress_client
+                .take()
+                .expect("Claiming just-created progress client"),
+        )
+        .await;
+
         let latest_ts = s.halt_on_err(latest_ts).await;
         info!(
             "{}: initial as_of: {:?}, latest progress record: {:?}",
@@ -1358,7 +1192,8 @@ where
 
         let _ = halt_on_err(
             &healthchecker,
-            mz_storage_client::sink::build_kafka(&mut connection, &connection_context).await,
+            mz_storage_client::sink::build_kafka(sink_id, &mut connection, &connection_context)
+                .await,
         )
         .await;
 
@@ -1421,18 +1256,4 @@ where
     });
 
     (stream, health_stream, Rc::new(button.press_on_drop()))
-}
-
-#[derive(Serialize, Deserialize)]
-/// This struct is emitted as part of a transactional produce, and captures the information we
-/// need to resume the Kafka sink at the correct place in the sunk collection. (Currently, all
-/// we need is the timestamp... this is a record to make it easier to add more metadata in the
-/// future if needed.) It's encoded as JSON to make it easier to introspect while debugging, and
-/// because we expect it to remain small.
-///
-/// Unlike the old consistency topic, this is not intended to be a user-facing feature; it's there
-/// purely so the sink can maintain its transactional guarantees. Any future user-facing consistency
-/// information should be added elsewhere instead of overloading this record.
-struct ProgressRecord {
-    timestamp: Timestamp,
 }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -435,6 +435,10 @@ impl KafkaSinkState {
             &healthchecker,
             #[allow(clippy::redundant_closure_call)]
             (|| async {
+                fail::fail_point!("kafka_sink_creation_error", |_| Err(anyhow::anyhow!(
+                    "synthetic error"
+                )));
+
                 connection
                     .connection
                     .create_with_context(

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1101,13 +1101,15 @@ impl<'w, A: Allocate> Worker<'w, A> {
                         } else if let Some(existing) = self.storage_state.exports.get(&export.id) {
                             stale_exports.remove(&export.id);
                             // If we've been asked to create an export that is
-                            // already installed, the descriptions must match
-                            // exactly.
-                            assert_eq!(
-                                *existing, export.description,
-                                "New export with same ID {:?}",
-                                export.id,
-                            );
+                            // already installed, the descriptions must be
+                            // compatible.
+                            //
+                            // TODO(ALTER CONNECTION): we will need to update
+                            // the stored connection description if it's
+                            // changed.
+                            existing
+                                .alter_compatible(export.id, &export.description)
+                                .expect("reconciled sinks must have compatible descriptions");
                             false
                         } else {
                             true

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -569,6 +569,7 @@ impl Run for PosCommand {
                     "kafka-ingest" => kafka::run_ingest(builtin, state).await,
                     "kafka-verify-data" => kafka::run_verify_data(builtin, state).await,
                     "kafka-verify-commit" => kafka::run_verify_commit(builtin, state).await,
+                    "kafka-verify-topic" => kafka::run_verify_topic(builtin, state).await,
                     "mysql-connect" => mysql::run_connect(builtin, state).await,
                     "mysql-execute" => mysql::run_execute(builtin, state).await,
                     "nop" => nop::run_nop(),

--- a/src/testdrive/src/action/kafka.rs
+++ b/src/testdrive/src/action/kafka.rs
@@ -13,6 +13,7 @@ mod delete_topic;
 mod ingest;
 mod verify_commit;
 mod verify_data;
+mod verify_topic;
 
 pub use add_partitions::run_add_partitions;
 pub use create_topic::run_create_topic;
@@ -20,3 +21,4 @@ pub use delete_topic::run_delete_topic;
 pub use ingest::run_ingest;
 pub use verify_commit::run_verify_commit;
 pub use verify_data::run_verify_data;
+pub use verify_topic::run_verify_topic;

--- a/src/testdrive/src/action/kafka/verify_topic.rs
+++ b/src/testdrive/src/action/kafka/verify_topic.rs
@@ -1,0 +1,126 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::str;
+use std::time::Duration;
+
+use anyhow::{bail, Context};
+use mz_ore::retry::Retry;
+use rdkafka::admin::AdminClient;
+
+use crate::action::{ControlFlow, State};
+use crate::parser::BuiltinCommand;
+
+enum Topic {
+    FromSink(String),
+    Named(String),
+}
+
+async fn get_topic(
+    sink: &str,
+    topic_field: &str,
+    state: &mut State,
+) -> Result<String, anyhow::Error> {
+    let query = format!(
+        "SELECT {} FROM mz_sinks JOIN mz_kafka_sinks \
+        ON mz_sinks.id = mz_kafka_sinks.id \
+        JOIN mz_schemas s ON s.id = mz_sinks.schema_id \
+        LEFT JOIN mz_databases d ON d.id = s.database_id \
+        WHERE d.name = $1 \
+        AND s.name = $2 \
+        AND mz_sinks.name = $3",
+        topic_field
+    );
+    let sink_fields: Vec<&str> = sink.split('.').collect();
+    let result = state
+        .pgclient
+        .query_one(
+            query.as_str(),
+            &[&sink_fields[0], &sink_fields[1], &sink_fields[2]],
+        )
+        .await
+        .context("retrieving topic name")?
+        .get(topic_field);
+    Ok(result)
+}
+
+pub async fn run_verify_topic(
+    mut cmd: BuiltinCommand,
+    state: &mut State,
+) -> Result<ControlFlow, anyhow::Error> {
+    let source = match (cmd.args.opt_string("sink"), cmd.args.opt_string("topic")) {
+        (Some(sink), None) => Topic::FromSink(sink),
+        (None, Some(topic)) => Topic::Named(topic),
+        (Some(_), Some(_)) => {
+            bail!("Can't provide both `source` and `topic` to kafka-verify-topic")
+        }
+        (None, None) => bail!("kafka-verify-topic expects either `source` or `topic`"),
+    };
+
+    let topic: String = match &source {
+        Topic::FromSink(sink) => get_topic(sink, "topic", state).await?,
+        Topic::Named(name) => name.clone(),
+    };
+
+    let await_value_schema = cmd.args.opt_bool("await-value-schema")?.unwrap_or(false);
+    let await_key_schema = cmd.args.opt_bool("await-key-schema")?.unwrap_or(false);
+
+    cmd.args.done()?;
+
+    println!("Verifying Kafka topic {}", topic);
+
+    let mut config = state.kafka_config.clone();
+    config.set("enable.auto.offset.store", "false");
+
+    let client: AdminClient<_> = config.create().context("creating kafka consumer")?;
+
+    println!("waiting to create Kafka topic...");
+
+    Retry::default()
+        .max_duration(state.default_timeout)
+        .retry_async(|_state| async {
+            let meta = client
+                .inner()
+                .fetch_metadata(None, Duration::from_secs(1))?;
+
+            meta.topics()
+                .iter()
+                .find(|t| t.name() == topic)
+                .ok_or(anyhow::anyhow!("topic not found"))
+                .map(|_| ())
+        })
+        .await?;
+
+    let mut await_schemas = vec![];
+    if await_value_schema {
+        await_schemas.push(format!("{topic}-value"));
+    }
+    if await_key_schema {
+        await_schemas.push(format!("{topic}-key"));
+    }
+
+    for schema_subject in await_schemas {
+        println!("waiting for schema subject {}...", schema_subject);
+        Retry::default()
+            .max_duration(state.default_timeout)
+            .retry_async(|_state| async {
+                state
+                    .ccsr_client
+                    .list_subjects()
+                    .await?
+                    .iter()
+                    .find(|subject| subject == &&schema_subject)
+                    .ok_or(anyhow::anyhow!("schema not found"))
+                    .map(|_| ())
+            })
+            .await?;
+    }
+
+    Ok(ControlFlow::Continue)
+}

--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -44,6 +44,8 @@ def populate(mz: MaterializeApplication, seed: int) -> None:
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE DEBEZIUM;
 
+            $ kafka-verify-topic sink=materialize.public.sink{i} await-value-schema=true
+
             > CREATE SOURCE sink{i}_check
               IN CLUSTER storage_shared_fate
               FROM KAFKA CONNECTION kafka (TOPIC 'testdrive-storage-shared-fate-sink{i}-${{testdrive.seed}}')

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -1132,6 +1132,8 @@ $ kafka-ingest format=avro topic=sink-input key-format=avro key-schema=${{keysch
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+$ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true await-key-schema=true
+
 # Wait until all the records have been emited from the sink, as observed by the sink1_check source
 
 > CREATE SOURCE sink1_check

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -112,7 +112,8 @@ $ kafka-verify-data format=avro sink=materialize.public.snk sort-messages=true
   INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION no_basic_auth_conn
   ENVELOPE DEBEZIUM
-contains:error publishing kafka schemas for sink: unable to publish value schema to registry in kafka sink: server error 401: Unauthorized
+contains:CONFLUENT SCHEMA REGISTRY validation: client errored
+detail:server error 401: Unauthorized
 
 > CREATE CONNECTION csr_without_ssl
   FOR CONFLUENT SCHEMA REGISTRY

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -499,6 +499,7 @@ class KafkaSinks(Generator):
                        INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-{i}')
                        FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                        ENVELOPE DEBEZIUM;
+                     $ kafka-verify-topic sink=materialize.public.s{i}
                      """
                 )
             )
@@ -544,6 +545,7 @@ class KafkaSinksSameSource(Generator):
                        INTO KAFKA CONNECTION kafka_conn (TOPIC 'kafka-sink-same-source-{i}')
                        FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                        ENVELOPE DEBEZIUM
+                     $ kafka-verify-topic sink=materialize.public.s{i}
                      """
                 )
             )

--- a/test/persistence/kafka-sources/wide-data-before.td
+++ b/test/persistence/kafka-sources/wide-data-before.td
@@ -59,6 +59,8 @@ $ kafka-ingest format=avro topic=wide-data-ten key-format=avro key-schema=${keys
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE UPSERT;
 
+$ kafka-verify-topic sink=materialize.public.wide_data_sink await-value-schema=true await-key-schema=true
+
 > CREATE SOURCE wide_data_source
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-wide-data-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -349,6 +349,8 @@ def workflow_bound_size_mz_status_history(c: Composition) -> None:
               INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
               ENVELOPE DEBEZIUM
+
+            $ kafka-verify-topic sink=materialize.public.kafka_sink
             """
         ),
     )

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from textwrap import dedent
 from typing import Protocol
 
+from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.kafka import Kafka
@@ -22,6 +23,11 @@ from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
+
+
+def schema() -> str:
+    return dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+
 
 SERVICES = [
     Redpanda(),
@@ -207,15 +213,6 @@ class KafkaDisruption:
                   FROM mz_internal.mz_source_statuses
                   WHERE name = 'source1'
                 stalled true
-
-                # Sinks generally halt after receiving an error, which means that they may alternate
-                # between `stalled` and `starting`. Instead of relying on the current status, we
-                # check that there is a stalled status with the expected error.
-                > SELECT bool_or(error ~* '{error}'), bool_or(details->'namespaced'->>'kafka' ~* '{error}')
-                  FROM mz_internal.mz_sink_status_history
-                  JOIN mz_sinks ON mz_sinks.id = sink_id
-                  WHERE name = 'sink1' and status = 'stalled'
-                true true
                 """
             )
         )
@@ -234,7 +231,103 @@ class KafkaDisruption:
                   FROM mz_internal.mz_source_statuses
                   WHERE name = 'source1'
                 running <null>
+                """
+            )
+        )
 
+
+@dataclass
+class KafkaSinkDisruption:
+    name: str
+    breakage: Callable
+    expected_error: str
+    fixage: Callable | None
+
+    def run_test(self, c: Composition) -> None:
+        print(f"+++ Running Kafka sink disruption scenario {self.name}")
+        seed = random.randint(0, 256**4)
+
+        c.down(destroy_volumes=True, sanity_restart_mz=False)
+        c.up("testdrive", persistent=True)
+        c.up("redpanda", "materialized", "clusterd")
+
+        with c.override(
+            Testdrive(
+                no_reset=True,
+                seed=seed,
+                entrypoint_extra=["--initial-backoff=1s", "--backoff-factor=0"],
+            )
+        ):
+            self.populate(c)
+            self.breakage(c, seed)
+            self.assert_error(c, self.expected_error)
+
+            if self.fixage:
+                self.fixage(c, seed)
+                self.assert_recovery(c)
+
+    def populate(self, c: Composition) -> None:
+        # Create a source and a sink
+        c.testdrive(
+            schema()
+            + dedent(
+                """
+                # We specify the progress topic explicitly so we can delete it in a test later,
+                # and confirm that the sink stalls. (Deleting the output topic is not enough if
+                # we're not actively publishing new messages to the sink.)
+                > CREATE CONNECTION kafka_conn
+                  TO KAFKA (
+                    BROKER '${testdrive.kafka-addr}',
+                    PROGRESS TOPIC 'testdrive-progress-topic-${testdrive.seed}'
+                  );
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
+                  URL '${testdrive.schema-registry-url}'
+                  );
+
+                $ kafka-create-topic topic=source-topic
+
+                $ kafka-ingest topic=source-topic format=avro schema=${schema}
+                {"f1": "A"}
+
+                > CREATE SOURCE source1
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-source-topic-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE NONE
+                # WITH ( REMOTE 'clusterd:2100' ) https://github.com/MaterializeInc/materialize/issues/16582
+
+                > CREATE SINK sink1 FROM source1
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-topic-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+                # WITH ( REMOTE 'clusterd:2100' ) https://github.com/MaterializeInc/materialize/issues/16582
+
+                $ kafka-verify-data format=avro sink=materialize.public.sink1 sort-messages=true
+                {"before": null, "after": {"row":{"f1": "A"}}}
+                """
+            )
+        )
+
+    def assert_error(self, c: Composition, error: str) -> None:
+        c.testdrive(
+            dedent(
+                f"""
+                # Sinks generally halt after receiving an error, which means that they may alternate
+                # between `stalled` and `starting`. Instead of relying on the current status, we
+                # check that there is a stalled status with the expected error.
+                > SELECT bool_or(error ~* '{error}'), bool_or(details->'namespaced'->>'kafka' ~* '{error}')
+                  FROM mz_internal.mz_sink_status_history
+                  JOIN mz_sinks ON mz_sinks.id = sink_id
+                  WHERE name = 'sink1' and status = 'stalled'
+                true true
+                """
+            )
+        )
+
+    def assert_recovery(self, c: Composition) -> None:
+        c.testdrive(
+            dedent(
+                """
                 > SELECT status, error
                   FROM mz_internal.mz_sink_statuses
                   WHERE name = 'sink1'
@@ -346,9 +439,29 @@ class PgDisruption:
 
 
 disruptions: list[Disruption] = [
+    KafkaSinkDisruption(
+        name="delete-sink-topic-delete-progress-fix",
+        breakage=lambda c, seed: delete_sink_topic(c, seed),
+        expected_error="sink progress data exists, but sink data topic is missing",
+        # If we delete the progress topic, we will re-create the sink as if it is new.
+        fixage=lambda c, seed: c.exec(
+            "redpanda", "rpk", "topic", "delete", f"testdrive-progress-topic-{seed}"
+        ),
+    ),
+    KafkaSinkDisruption(
+        name="delete-sink-topic-recreate-topic-fix",
+        breakage=lambda c, seed: delete_sink_topic(c, seed),
+        expected_error="sink progress data exists, but sink data topic is missing",
+        # If we recreate the sink topic, the sink will work but will likely be inconsistent.
+        fixage=lambda c, seed: c.exec(
+            "redpanda", "rpk", "topic", "create", f"testdrive-sink-topic-{seed}"
+        ),
+    ),
     KafkaDisruption(
-        name="delete-topic",
-        breakage=lambda c, seed: redpanda_topics(c, "delete", seed),
+        name="delete-source-topic",
+        breakage=lambda c, seed: c.exec(
+            "redpanda", "rpk", "topic", "delete", f"testdrive-source-topic-{seed}"
+        ),
         expected_error="UnknownTopicOrPartition|topic",
         fixage=None
         # Re-creating the topic does not restart the source
@@ -422,9 +535,22 @@ def workflow_default(c: Composition) -> None:
         disruption.run_test(c)
 
 
-def redpanda_topics(c: Composition, action: str, seed: int) -> None:
-    for topic in ["source", "sink", "progress"]:
-        c.exec("redpanda", "rpk", "topic", action, f"testdrive-{topic}-topic-{seed}")
+def delete_sink_topic(c: Composition, seed: int) -> None:
+    c.exec("redpanda", "rpk", "topic", "delete", f"testdrive-sink-topic-{seed}")
+
+    # Write new data to source otherwise nothing will encounter the missing topic
+    c.testdrive(
+        schema()
+        + dedent(
+            """
+            $ kafka-ingest topic=source-topic format=avro schema=${schema}
+            {"f1": "B"}
+
+            > SELECT COUNT(*) FROM source1;
+            2
+            """
+        )
+    )
 
 
 def alter_pg_table(c: Composition) -> None:

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -103,6 +103,8 @@ class KafkaTransactionLogGreaterThan1:
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM
+
+                $ kafka-verify-topic sink=materialize.public.kafka_sink
                 """
             ),
         )
@@ -191,6 +193,8 @@ class KafkaDisruption:
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM
                 # WITH ( REMOTE 'clusterd:2100' ) https://github.com/MaterializeInc/materialize/issues/16582
+
+                $ kafka-verify-topic sink=materialize.public.sink1
                 """
             )
         )

--- a/test/testdrive/kafka-sink-errors.td
+++ b/test/testdrive/kafka-sink-errors.td
@@ -51,7 +51,8 @@ contains:REPLICATION FACTOR for sink topics must be a positive integer or -1 for
   INTO KAFKA CONNECTION kafka_conn (ACKS = foo, TOPIC 'testdrive-kafka-sink-errors-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
-contains:Invalid value for configuration property "request.required.acks" acks foo
+contains:KAFKA sink validation: admin client errored
+detail:Invalid value for configuration property "request.required.acks" acks foo
 
 # Ensure that a sink whose topic fails to create does not result in an
 # orphaned linked cluster. See #17061.

--- a/test/testdrive/materialized-views.td
+++ b/test/testdrive/materialized-views.td
@@ -63,6 +63,8 @@ $ kafka-ingest format=avro topic=materialized-views schema=${materialized-views}
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE DEBEZIUM
 
+$ kafka-verify-topic sink=materialize.public.sink1 await-value-schema=true
+
 > CREATE SOURCE sink1_check
   FROM KAFKA CONNECTION kafka_conn (
     TOPIC 'testdrive-materialized-views-sink-${testdrive.seed}'

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -166,7 +166,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sql(
             """
-            CREATE CLUSTER storaged REPLICAS (r2 (
+            CREATE CLUSTER storage REPLICAS (r2 (
                 STORAGECTL ADDRESSES ['storaged:2100'],
                 STORAGE ADDRESSES ['storaged:2103'],
                 COMPUTECTL ADDRESSES ['storaged:2101'],


### PR DESCRIPTION
Establish Kafka broker connections + topics when rendering sinks, rather than during sequencing.

@MaterializeInc/testing I could use some help developing tests for this. Namely, I think we could use a test that:
1. Sets up a sink, produces data, etc.
2. Reboots MZ but leaves the worker running the sink.
3. Verifies that the cluster that was running the sink did not panic. This is currently the case on `main` because we fail to reconcile the running cluster's sinks with the catalog.

Closes #17210
Closes #20019
Closes #20020

### Motivation

 This PR adds a known-desirable feature. #20919

### Tips for reviewer

The methods that need the most review are:

- `build_kafka` in `src/storage-client/src/sink.rs`, which now sets up the collateral topics in the Kafka broker during rendering (whereas previously these were done during sequencing).
- `encode_stream` in `src/storage/src/sink/kafka.rs`, which now holds `build_kafka`.

The following commits need review:

- `storage/sink: error if progress data present, but data topic missing`
- `storage: allow reconciling runnings sinks w/ differing as ofs`, which looks a little goofy but will make more sense in the context of `ALTER CONNECTION`, which I have a sketch PR currentlu open for #21239

I was also unsure of the most handsome way to handle the evolution of the `KafkaSinkConnection` proto. It's really an evolution of the `KafkaSinkConnectionBuilder`, but is different enough that the number of reserved fields was obnoxious, so wanted to start afresh. Appending `V2` feels not quite right, but wasn't sure if there's a better approach.

The remainder of the code is either uninteresting code movement, deleting unused code paths, or somewhat straightforward work that doesn't require close scrutiny (e.g. purification).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
