### PR TITLE
sql: Execute entire transaction on single cluster

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5423,6 +5423,9 @@ impl Catalog {
                 Ok(self.resolve_builtin_cluster(&MZ_INTROSPECTION_CLUSTER))
             }
             TargetCluster::Active => self.active_cluster(session),
+            TargetCluster::Transaction(cluster_id) => self
+                .try_get_cluster(cluster_id)
+                .ok_or(AdapterError::ConcurrentClusterDrop),
         }
     }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -443,6 +443,8 @@ pub enum TargetCluster {
     Introspection,
     /// The current user's active cluster.
     Active,
+    /// The cluster selected at the start of a transaction.
+    Transaction(ClusterId),
 }
 
 /// A struct to hold information about the validity of plans and if they should be abandoned after

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -134,6 +134,11 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
         | Plan::SideEffectingFunc(_) => return TargetCluster::Active,
     };
 
+    // Use transaction cluster if we're mid-transaction
+    if let Some(cluster_id) = session.transaction().cluster() {
+        return TargetCluster::Transaction(cluster_id);
+    }
+
     // Bail if the user has disabled it via the SessionVar.
     if !session.vars().auto_route_introspection_queries() {
         return TargetCluster::Active;

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1770,6 +1770,9 @@ impl Coordinator {
         if &name == TRANSACTION_ISOLATION_VAR_NAME {
             self.validate_set_isolation_level(session)?;
         }
+        if &name == CLUSTER_VAR_NAME {
+            self.validate_set_cluster(session)?;
+        }
 
         let vars = session.vars_mut();
         let values = match plan.value {
@@ -1830,6 +1833,9 @@ impl Coordinator {
         if &name == TRANSACTION_ISOLATION_VAR_NAME {
             self.validate_set_isolation_level(session)?;
         }
+        if &name == CLUSTER_VAR_NAME {
+            self.validate_set_cluster(session)?;
+        }
         session
             .vars_mut()
             .reset(Some(self.catalog().system_config()), &name, false)?;
@@ -1873,6 +1879,14 @@ impl Coordinator {
         }
     }
 
+    fn validate_set_cluster(&self, session: &Session) -> Result<(), AdapterError> {
+        if session.transaction().contains_ops() {
+            Err(AdapterError::InvalidSetCluster)
+        } else {
+            Ok(())
+        }
+    }
+
     pub(super) fn sequence_end_transaction(
         &mut self,
         mut ctx: ExecuteContext,
@@ -1911,7 +1925,7 @@ impl Coordinator {
                 });
                 return;
             }
-            Ok((Some(TransactionOps::Peeks(determination)), _))
+            Ok((Some(TransactionOps::Peeks { determination, .. }), _))
                 if ctx.session().vars().transaction_isolation()
                     == &IsolationLevel::StrictSerializable =>
             {
@@ -2562,11 +2576,17 @@ impl Coordinator {
         // depend on whether or not reads have occurred in the txn.
         let mut transaction_determination = determination.clone();
         if when.is_transactional() {
-            session.add_transaction_ops(TransactionOps::Peeks(transaction_determination))?;
+            session.add_transaction_ops(TransactionOps::Peeks {
+                determination: transaction_determination,
+                cluster_id,
+            })?;
         } else if matches!(session.transaction(), &TransactionStatus::InTransaction(_)) {
             // If the query uses AS OF, then ignore the timestamp.
             transaction_determination.timestamp_context = TimestampContext::NoTimestamp;
-            session.add_transaction_ops(TransactionOps::Peeks(transaction_determination))?;
+            session.add_transaction_ops(TransactionOps::Peeks {
+                determination: transaction_determination,
+                cluster_id,
+            })?;
         };
 
         Ok(determination)

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -19,6 +19,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use mz_build_info::{BuildInfo, DUMMY_BUILD_INFO};
+use mz_controller_types::ClusterId;
 use mz_ore::now::EpochMillis;
 use mz_pgrepr::Format;
 use mz_repr::role_id::RoleId;
@@ -224,7 +225,7 @@ impl<T: TimestampManipulation> Session<T> {
             // - Currently in `READ ONLY`
             // - Already performed a query
             let read_write_prohibited = match txn.ops {
-                TransactionOps::Peeks(_) | TransactionOps::Subscribe => {
+                TransactionOps::Peeks { .. } | TransactionOps::Subscribe => {
                     txn.access == Some(TransactionAccessMode::ReadOnly)
                 }
                 TransactionOps::None
@@ -424,7 +425,7 @@ impl<T: TimestampManipulation> Session<T> {
     /// anomalies will occur if cleared.
     pub fn take_transaction_timestamp_context(&mut self) -> Option<TimestampContext<T>> {
         if let Some(Transaction { ops, .. }) = self.transaction.inner_mut() {
-            if let TransactionOps::Peeks(_) = ops {
+            if let TransactionOps::Peeks { .. } = ops {
                 let ops = std::mem::take(ops);
                 Some(
                     ops.timestamp_determination()
@@ -447,7 +448,7 @@ impl<T: TimestampManipulation> Session<T> {
         match self.transaction.inner() {
             Some(Transaction {
                 pcx: _,
-                ops: TransactionOps::Peeks(determination),
+                ops: TransactionOps::Peeks { determination, .. },
                 write_lock_guard: _,
                 access: _,
                 id: _,
@@ -462,10 +463,13 @@ impl<T: TimestampManipulation> Session<T> {
             self.transaction.inner(),
             Some(Transaction {
                 pcx: _,
-                ops: TransactionOps::Peeks(TimestampDetermination {
-                    timestamp_context: TimestampContext::TimelineTimestamp(_, _),
+                ops: TransactionOps::Peeks {
+                    determination: TimestampDetermination {
+                        timestamp_context: TimestampContext::TimelineTimestamp(_, _),
+                        ..
+                    },
                     ..
-                }),
+                },
                 write_lock_guard: _,
                 access: _,
                 id: _,
@@ -953,6 +957,17 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
         }
     }
 
+    /// The cluster of the transaction, if one exists.
+    pub fn cluster(&self) -> Option<ClusterId> {
+        match self {
+            TransactionStatus::Default => None,
+            TransactionStatus::Started(txn)
+            | TransactionStatus::InTransaction(txn)
+            | TransactionStatus::InTransactionImplicit(txn)
+            | TransactionStatus::Failed(txn) => txn.cluster(),
+        }
+    }
+
     /// Reports whether any operations have been executed as part of this transaction
     pub fn contains_ops(&self) -> bool {
         match self.inner() {
@@ -978,8 +993,15 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
                         }
                         *ops = add_ops;
                     }
-                    TransactionOps::Peeks(determination) => match add_ops {
-                        TransactionOps::Peeks(add_timestamp_determination) => {
+                    TransactionOps::Peeks {
+                        determination,
+                        cluster_id,
+                    } => match add_ops {
+                        TransactionOps::Peeks {
+                            determination: add_timestamp_determination,
+                            cluster_id: add_cluster_id,
+                        } => {
+                            assert_eq!(*cluster_id, add_cluster_id);
                             match (
                                 &determination.timestamp_context,
                                 &add_timestamp_determination.timestamp_context,
@@ -1029,7 +1051,7 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
                         }
                         // Iff peeks do not have a timestamp (i.e. they are
                         // constant), we can permit them.
-                        TransactionOps::Peeks(determination)
+                        TransactionOps::Peeks { determination, .. }
                             if !determination.timestamp_context.contains_timestamp() => {}
                         _ => {
                             return Err(AdapterError::WriteOnlyTransaction);
@@ -1084,12 +1106,27 @@ impl<T> Transaction<T> {
     /// The timeline of the transaction, if one exists.
     fn timeline(&self) -> Option<Timeline> {
         match &self.ops {
-            TransactionOps::Peeks(TimestampDetermination {
-                timestamp_context: TimestampContext::TimelineTimestamp(timeline, _),
+            TransactionOps::Peeks {
+                determination:
+                    TimestampDetermination {
+                        timestamp_context: TimestampContext::TimelineTimestamp(timeline, _),
+                        ..
+                    },
                 ..
-            }) => Some(timeline.clone()),
-            TransactionOps::Peeks(_)
+            } => Some(timeline.clone()),
+            TransactionOps::Peeks { .. }
             | TransactionOps::None
+            | TransactionOps::Subscribe
+            | TransactionOps::Writes(_)
+            | TransactionOps::SingleStatement { .. } => None,
+        }
+    }
+
+    /// The cluster of the transaction, if one exists.
+    pub fn cluster(&self) -> Option<ClusterId> {
+        match &self.ops {
+            TransactionOps::Peeks { cluster_id, .. } => Some(cluster_id.clone()),
+            TransactionOps::None
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_)
             | TransactionOps::SingleStatement { .. } => None,
@@ -1156,7 +1193,12 @@ pub enum TransactionOps<T> {
     /// is has a timestamp, it must only do other peeks. However, if it doesn't
     /// have a timestamp (i.e. the values are constants), the transaction can still
     /// perform writes.
-    Peeks(TimestampDetermination<T>),
+    Peeks {
+        /// The timestamp and timestamp related metadata for the peek.
+        determination: TimestampDetermination<T>,
+        /// The cluster used to execute peeks.
+        cluster_id: ClusterId,
+    },
     /// This transaction has done a `SUBSCRIBE` and must do nothing else.
     Subscribe,
     /// This transaction has had a write (`INSERT`, `UPDATE`, `DELETE`) and must
@@ -1174,7 +1216,7 @@ pub enum TransactionOps<T> {
 impl<T> TransactionOps<T> {
     fn timestamp_determination(self) -> Option<TimestampDetermination<T>> {
         match self {
-            TransactionOps::Peeks(determination) => Some(determination),
+            TransactionOps::Peeks { determination, .. } => Some(determination),
             TransactionOps::None
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_)

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -38,11 +38,3 @@ begin;
 query II
 select * from t1
 ----
-
-# Additionally, verify that changing cluster mid transaction causes the indexes
-# to be unavailable.
-statement ok
-set cluster = c
-
-query error Transactions can only reference objects in the same timedomain.
-select * from t1

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -39,4 +39,3 @@ DETAIL: The following relations in the query are outside the transaction's time 
 "materialize.public.i2"
 Only the following relations are available:
 "materialize.public.i1"
-"materialize.public.t1"

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -39,3 +39,4 @@ DETAIL: The following relations in the query are outside the transaction's time 
 "materialize.public.i2"
 Only the following relations are available:
 "materialize.public.i1"
+"materialize.public.t1"

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -799,3 +799,102 @@ simple
 SHOW SOURCES
 ----
 COMPLETE 0
+
+# Test that the cluster cannot change mid-transaction.
+
+statement ok
+DROP TABLE t CASCADE
+
+statement ok
+CREATE TABLE t (a INT)
+
+statement ok
+CREATE CLUSTER c REPLICAS (r1 (SIZE '1'))
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM t
+
+statement error SET cluster cannot be called in an active transaction
+SET CLUSTER TO c
+
+statement ok
+ROLLBACK
+
+# Test that the cluster is selected at the start of a transaction and doesn't change.
+
+## Auto-routing selects mz_introspection at the start of transaction.
+
+statement ok
+BEGIN
+
+statement ok
+SHOW VIEWS
+
+query T multiline
+EXPLAIN SELECT *, generate_series(1, 100) FROM mz_views
+----
+Explained Query:
+  CrossJoin type=differential
+    ArrangeBy keys=[[]]
+      ReadIndex on=mz_views mz_show_views_ind=[*** full scan ***]
+    ArrangeBy keys=[[]]
+      Constant
+        total_rows (diffs absed): 100
+        first_rows:
+          - (1)
+          - (2)
+          - (3)
+          - (4)
+          - (5)
+          - (6)
+          - (7)
+          - (8)
+          - (9)
+          - (10)
+          - (11)
+          - (12)
+          - (13)
+          - (14)
+          - (15)
+          - (16)
+          - (17)
+          - (18)
+          - (19)
+          - (20)
+
+Used Indexes:
+  - mz_internal.mz_show_views_ind (*** full scan ***)
+
+EOF
+
+statement ok
+COMMIT
+
+## Auto-routing doesn't select mz_introspection in the middle of a transaction.
+
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM t, mz_views
+
+query T multiline
+EXPLAIN SHOW VIEWS
+----
+            Optimized Plan
+---------------------------------------
+ Explained Query:                     +
+   Project (#3)                       +
+     Filter (#2 = "u3")               +
+       ReadStorage mz_catalog.mz_views+
+                                      +
+ Source mz_catalog.mz_views           +
+   filter=((#2 = "u3"))               +
+
+EOF
+
+statement ok
+COMMIT

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -875,6 +875,14 @@ COMMIT
 
 ## Auto-routing doesn't select mz_introspection in the middle of a transaction.
 
+# Since mz_views uses custom types, the postgres client will look it up in the catalog on
+# first use. If the first use happens to be in a transaction, then we can get unexpected time
+# domain errors. This is an annoying hack to load the information in the postgres client before
+# we start any transactions.
+statement ok
+SELECT * FROM mz_views LIMIT 0
+----
+
 statement ok
 BEGIN
 
@@ -884,15 +892,13 @@ SELECT * FROM t, mz_views
 query T multiline
 EXPLAIN SHOW VIEWS
 ----
-            Optimized Plan
----------------------------------------
- Explained Query:                     +
-   Project (#3)                       +
-     Filter (#2 = "u3")               +
-       ReadStorage mz_catalog.mz_views+
-                                      +
- Source mz_catalog.mz_views           +
-   filter=((#2 = "u3"))               +
+Explained Query:
+  Project (#3)
+    Filter (#2 = "u3")
+      ReadStorage mz_catalog.mz_views
+
+Source mz_catalog.mz_views
+  filter=((#2 = "u3"))
 
 EOF
 


### PR DESCRIPTION
This commit updates the transaction logic so the entire transaction is executed on a single cluster. Users cannot change clusters mid-transaction and auto-routing is disabled mid-transaction.

The first query in a transaction determines the time domain of the transaction. The timedomain only contains indexes on the active cluster of the first query. Switching clusters will almost always lead to timedomain errors. Additionally, some serving layer work will be moved to clusters in the future. Switching cluster mid-transactions will complicate that work.

Including multiple cluster indexes in a single transaction's timedomain has negative use-case isolation implications because we need to take read holds on all indexes.

Resolves #21839

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Restrict transactions to execute on a single cluster
