### PR TITLE
update to tokio 1.32 (and add ids to task names)

### DIFF
--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -73,7 +73,7 @@ serde_plain = "1.0.1"
 smallvec = { version = "1.10.0", features = ["union"] }
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["rt", "time"] }
+tokio = { version = "1.32.0", features = ["rt", "time"] }
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = "0.1.11"
 tracing = "0.1.37"

--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -21,7 +21,7 @@ hyper = { version = "0.14.23", features = ["server"] }
 once_cell = "1.16.0"
 mz-ore = { path = "../ore", features = ["async"] }
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.32.0", features = ["macros"] }
 tracing = "0.1.37"
 
 [build-dependencies]

--- a/src/cloud-api/Cargo.toml
+++ b/src/cloud-api/Cargo.toml
@@ -15,7 +15,7 @@ once_cell = "1.16.0"
 serde = { version = "1.0.130", features = ["derive"] }
 url = "2.2.2"
 thiserror = "1.0.37"
-tokio = "1.27.0"
+tokio = "1.32.0"
 mz-frontegg-client = { path = "../frontegg-client" }
 mz-frontegg-auth = { path = "../frontegg-auth" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/cluster-client/Cargo.toml
+++ b/src/cluster-client/Cargo.toml
@@ -25,7 +25,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tracing = "0.1.37"

--- a/src/cluster/Cargo.toml
+++ b/src/cluster/Cargo.toml
@@ -32,7 +32,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "net"] }
+tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/clusterd/Cargo.toml
+++ b/src/clusterd/Cargo.toml
@@ -31,7 +31,7 @@ mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 once_cell = { version = "1.16.0" }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/compute-client/Cargo.toml
+++ b/src/compute-client/Cargo.toml
@@ -42,7 +42,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tracing = "0.1.37"

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -38,7 +38,7 @@ scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "net"] }
+tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "net"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde", "v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/controller/Cargo.toml
+++ b/src/controller/Cargo.toml
@@ -31,7 +31,7 @@ regex = "1.7.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-stream = "0.1.11"
 tracing = "0.1.37"
 uuid = { version = "1.2.2" }

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -81,7 +81,7 @@ socket2 = "0.4.7"
 sysctl = "0.5.4"
 tempfile = "3.2.0"
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["sync"] }
+tokio = { version = "1.32.0", features = ["sync"] }
 tokio-openssl = "0.6.3"
 tokio-postgres = { version = "0.7.8" }
 tokio-stream = { version = "0.1.11", features = ["net"] }

--- a/src/frontegg-auth/Cargo.toml
+++ b/src/frontegg-auth/Cargo.toml
@@ -18,7 +18,7 @@ reqwest-retry = "0.2.2"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.32.0", features = ["macros"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
@@ -26,7 +26,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 [dev-dependencies]
 axum = "0.6.20"
 mz-ore = { path = "../ore", features = ["network", "test"] }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/frontegg-client/Cargo.toml
+++ b/src/frontegg-client/Cargo.toml
@@ -14,7 +14,7 @@ reqwest = { version = "0.11.13", features = ["json"] }
 serde = { version = "1.0.152", features = ["derive"] }
 once_cell = "1.16.0"
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.32.0", features = ["macros"] }
 serde_json = "1.0.89"
 uuid = { version = "1.2.2", features = ["serde"] }
 url = "2.3.1"

--- a/src/http-util/Cargo.toml
+++ b/src/http-util/Cargo.toml
@@ -18,7 +18,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["metrics", "tr
 prometheus = { version = "0.13.3", default-features = false }
 serde = "1.0.152"
 serde_json = { version = "1.0.89" }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["balance", "buffer", "filter", "limit", "retry", "timeout", "util"] }
 tower-http = { version = "0.4.2", features = ["auth", "cors", "map-response-body", "trace", "util"] }
 tracing = "0.1.37"

--- a/src/interchange/Cargo.toml
+++ b/src/interchange/Cargo.toml
@@ -30,14 +30,14 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 prost-reflect = "0.11.4"
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.32.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
-tokio = { version = "1.24.2", features = ["macros"] }
+tokio = { version = "1.32.0", features = ["macros"] }
 
 [build-dependencies]
 prost-build = "0.11.2"

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -20,7 +20,7 @@ rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", features = ["macros", "sync"] }
+tokio = { version = "1.32.0", features = ["macros", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/mz/Cargo.toml
+++ b/src/mz/Cargo.toml
@@ -31,7 +31,7 @@ serde-aux = "4.1.2"
 serde_json = "1.0.89"
 tabled = "0.10.0"
 time = "0.3.17"
-tokio = { version = "1.24.2", features = ["full"] }
+tokio = { version = "1.32.0", features = ["full"] }
 toml = "0.5.9"
 toml_edit = { version = "0.19.7", features = ["serde"] }
 thiserror = "1.0.37"

--- a/src/orchestrator-process/Cargo.toml
+++ b/src/orchestrator-process/Cargo.toml
@@ -27,7 +27,7 @@ serde_json = "1.0.89"
 scopeguard = "1.1.0"
 sha1 = "0.10.5"
 sysinfo = "0.27.2"
-tokio = { version = "1.24.2", features = [ "fs", "process", "time" ] }
+tokio = { version = "1.32.0", features = [ "fs", "process", "time" ] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -33,7 +33,7 @@ smallvec = { version = "1.10.0", optional = true }
 stacker = { version = "0.1.15", optional = true }
 sentry = { version = "0.29.1", optional = true, features = ["debug-images"] }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
-tokio = { version = "1.24.2", features = ["io-util", "net", "rt-multi-thread", "sync", "time"], optional = true }
+tokio = { version = "1.32.0", features = ["io-util", "net", "rt-multi-thread", "sync", "time"], optional = true }
 tokio-openssl = { version = "0.6.3", optional = true }
 # TODO(guswynn): determine, when, if ever, we can remove `tracing-log`
 # The `tracing-log` feature here is load-bearing: While our busiest-logging dependency (`rdkafka`) is now hooked-up
@@ -66,7 +66,7 @@ anyhow = { version = "1.0.66" }
 scopeguard = "1.1.0"
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }
 tokio-test = "0.4.2"
 
 [features]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -71,7 +71,7 @@ tokio-test = "0.4.2"
 
 [features]
 default = ["workspace-hack"]
-async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio"]
+async = ["async-trait", "futures", "openssl", "tokio-openssl", "tokio", "tracing"]
 bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 tracing_ = [

--- a/src/ore/src/task.rs
+++ b/src/ore/src/task.rs
@@ -118,7 +118,7 @@ where
 {
     #[allow(clippy::disallowed_methods)]
     task::Builder::new()
-        .name(nc().as_ref())
+        .name(&format!("{}:{}", Handle::current().id(), nc().as_ref()))
         .spawn(future)
         .expect("task spawning cannot fail")
 }
@@ -163,7 +163,7 @@ where
     Output: Send + 'static,
 {
     task::Builder::new()
-        .name(nc().as_ref())
+        .name(&format!("{}:{}", Handle::current().id(), nc().as_ref()))
         .spawn_blocking(function)
         .expect("task spawning cannot fail")
 }

--- a/src/persist-cli/Cargo.toml
+++ b/src/persist-cli/Cargo.toml
@@ -35,7 +35,7 @@ prometheus = { version = "0.13.3", default-features = false }
 serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.32.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 uuid = { version = "1.2.2", features = ["v4"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/persist-client/Cargo.toml
+++ b/src/persist-client/Cargo.toml
@@ -52,7 +52,7 @@ serde = { version = "1.0.152", features = ["derive", "rc"] }
 serde_json = "1.0.89"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.32.0", default-features = false, features = ["macros", "sync", "rt", "rt-multi-thread", "time"] }
 tokio-metrics = "0.3.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -18,7 +18,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 futures = "0.3.25"
-tokio = { version = "1.24.2", default-features = false, features = ["rt", "rt-multi-thread"] }
+tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -48,7 +48,7 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = { version = "0.8.5", features = ["small_rng"] }
 serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
+tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/pgwire/Cargo.toml
+++ b/src/pgwire/Cargo.toml
@@ -24,7 +24,7 @@ mz-repr = { path = "../repr" }
 mz-sql = { path = "../sql" }
 openssl = { version = "0.10.48", features = ["vendored"] }
 postgres = { version = "0.19.5" }
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-stream = "0.1.11"
 tokio-openssl = "0.6.3"
 tokio-util = { version = "0.7.4", features = ["codec"] }

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -27,7 +27,7 @@ prost = { version = "0.11.3", features = [
 ], optional = true }
 serde = { version = "1.0.152", features = ["derive"], optional = true }
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync"] }
+tokio = { version = "1.32.0", features = ["fs", "rt", "sync"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/prof/Cargo.toml
+++ b/src/prof/Cargo.toml
@@ -27,7 +27,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 tempfile = "3.2.0"
 tikv-jemalloc-ctl = { version = "0.5.0", features = ["use_std"], optional = true }
 tracing = "0.1.37"
-tokio = { version = "1.24.2", features = ["time"] }
+tokio = { version = "1.32.0", features = ["time"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [build-dependencies]

--- a/src/rocksdb/Cargo.toml
+++ b/src/rocksdb/Cargo.toml
@@ -20,7 +20,7 @@ prometheus = { version = "0.13.3", default-features = false }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"]}
 proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
-tokio = { version = "1.24.2", features = ["macros", "sync", "rt"] }
+tokio = { version = "1.32.0", features = ["macros", "sync", "rt"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 thiserror = "1.0.37"

--- a/src/s3-datagen/Cargo.toml
+++ b/src/s3-datagen/Cargo.toml
@@ -16,7 +16,7 @@ futures = "0.3.25"
 indicatif = "0.17.2"
 mz-aws-s3-util = { path = "../aws-s3-util" }
 mz-ore = { path = "../ore", features = ["cli"] }
-tokio = { version = "1.24.2", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
+tokio = { version = "1.32.0", features = ["macros", "net", "rt", "rt-multi-thread", "time"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/secrets/Cargo.toml
+++ b/src/secrets/Cargo.toml
@@ -15,7 +15,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 mz-ore = { path = "../ore" }
-tokio = { version = "1.24.2", features = ["macros", "rt"] }
+tokio = { version = "1.32.0", features = ["macros", "rt"] }
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/segment/Cargo.toml
+++ b/src/segment/Cargo.toml
@@ -10,7 +10,7 @@ publish = false
 mz-ore = { path = "../ore", features = ["async"], default-features = false }
 segment = { version = "0.2.1", features = ["native-tls-vendored"], default-features = false }
 serde_json = "1.0.89"
-tokio = { version = "1.24.2", features = ["sync"] }
+tokio = { version = "1.32.0", features = ["sync"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }

--- a/src/service/Cargo.toml
+++ b/src/service/Cargo.toml
@@ -32,7 +32,7 @@ semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 sysinfo = "0.27.2"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-stream = "0.1.11"
 tonic = "0.9.2"
 tower = "0.4.13"

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -61,7 +61,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 static_assertions = "1.1"
 thiserror = "1.0.37"
-tokio = { version = "1.24.2", features = ["fs"] }
+tokio = { version = "1.32.0", features = ["fs"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src/sqllogictest/Cargo.toml
+++ b/src/sqllogictest/Cargo.toml
@@ -42,7 +42,7 @@ serde_json = "1.0.89"
 tempfile = "3.2.0"
 time = "0.3.17"
 tracing = "0.1.37"
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-uuid-1", "with-serde_json-1"] }
 tower-http = { version = "0.4.2", features = ["cors"] }
 uuid = "1.2.2"

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -18,7 +18,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
-tokio = "1.24.2"
+tokio = "1.32.0"
 tracing = "0.1.37"
 zeroize = { version = "1.5.7", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -21,7 +21,7 @@ mz-storage-controller = { path = "../storage-controller" }
 once_cell = "1.16.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde_json = "1.0.89"
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-postgres = { version = "0.7.8", features = [ "with-serde_json-1" ] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -33,7 +33,7 @@ serde = "1.0.152"
 serde_json = "1.0.89"
 static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false }
-tokio = "1.24.2"
+tokio = "1.32.0"
 tokio-postgres = { version = "0.7.8", features = ["with-serde_json-1"] }
 tracing = "0.1.37"
 uuid = "1.2.2"
@@ -45,7 +45,7 @@ criterion = { version = "0.4.0", features = ["async_tokio"] }
 mz-postgres-util = { path = "../postgres-util" }
 once_cell = "1.16.0"
 similar-asserts = "1.4"
-tokio = { version = "1.24.2", features = ["rt", "time"] }
+tokio = { version = "1.32.0", features = ["rt", "time"] }
 
 [build-dependencies]
 anyhow = "1.0.66"

--- a/src/storage-client/Cargo.toml
+++ b/src/storage-client/Cargo.toml
@@ -40,7 +40,7 @@ static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = [
     "bincode",
 ] }
-tokio = { version = "1.24.2", features = [
+tokio = { version = "1.32.0", features = [
     "fs",
     "rt",
     "sync",

--- a/src/storage/Cargo.toml
+++ b/src/storage/Cargo.toml
@@ -69,7 +69,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 sha2 = "0.10.6"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
-tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util"] }
+tokio = { version = "1.32.0", features = ["fs", "rt", "sync", "test-util"] }
 tokio-postgres = { version = "0.7.8", features = ["serde"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["io"] }
@@ -95,7 +95,7 @@ mz-orchestrator-tracing = { path = "../orchestrator-tracing" }
 itertools = "0.10.5"
 num_cpus = "1.14.0"
 tempfile = "3.2.0"
-tokio = { version = "1.24.2", features = ["test-util"] }
+tokio = { version = "1.32.0", features = ["test-util"] }
 
 [package.metadata.cargo-udeps.ignore]
 # only used on linux

--- a/src/test-macro/Cargo.toml
+++ b/src/test-macro/Cargo.toml
@@ -14,7 +14,7 @@ syn = {version = "1.0", features = ["extra-traits", "full"]}
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [dev-dependencies]
-tokio = {version = "1.24.2", default-features = false, features = ["rt-multi-thread", "macros"]}
+tokio = {version = "1.32.0", default-features = false, features = ["rt-multi-thread", "macros"]}
 
 [features]
 default = ["workspace-hack"]

--- a/src/testdrive/Cargo.toml
+++ b/src/testdrive/Cargo.toml
@@ -62,7 +62,7 @@ tiberius = { version = "0.11.3", default-features = false }
 time = "0.3.17"
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tokio = { version = "1.24.2", features = ["process"] }
+tokio = { version = "1.32.0", features = ["process"] }
 tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-stream = "0.1.11"
 tokio-util = { version = "0.7.4", features = ["compat"] }

--- a/src/timely-util/Cargo.toml
+++ b/src/timely-util/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 mz-ore = { path = "../ore", features = ["tracing_", "test"] }
 polonius-the-crab = "0.3.1"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
-tokio = { version = "1.24.2", features = ["macros", "rt-multi-thread", "time"] }
+tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread", "time"] }
 num-traits = "0.2"
 ahash = { version = "0.8.0", default_features = false }
 


### PR DESCRIPTION
This pr upgrades tokio to 1.32 (this required some other dep bumps, but didn't cause any duplicate dependencies. Also also pre-pends task names with the tokio runtime id: https://docs.rs/tokio/1.32.0/tokio/runtime/struct.Handle.html#method.id (this wasnt available until a few version past 

### Motivation


  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
