### PR TITLE
Unencrypted HTTP and SQL listeners for balancer connections

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -225,6 +225,30 @@ pub struct Args {
         default_value = "127.0.0.1:6879"
     )]
     internal_persist_pubsub_listen_addr: SocketAddr,
+    /// The address on which to listen for SQL connections from the balancers.
+    ///
+    /// Connections to this address are not subject to encryption.
+    /// Care should be taken to not expose this address to the public internet
+    /// or other unauthorized parties.
+    #[clap(
+        long,
+        value_name = "HOST:PORT",
+        env = "BALANCER_SQL_LISTEN_ADDR",
+        default_value = "127.0.0.1:6880"
+    )]
+    balancer_sql_listen_addr: SocketAddr,
+    /// The address on which to listen for trusted HTTP connections.
+    ///
+    /// Connections to this address are not subject to encryption.
+    /// Care should be taken to not expose this address to the public internet
+    /// or other unauthorized parties.
+    #[clap(
+        long,
+        value_name = "HOST:PORT",
+        env = "BALANCER_HTTP_LISTEN_ADDR",
+        default_value = "127.0.0.1:6881"
+    )]
+    balancer_http_listen_addr: SocketAddr,
     /// Enable cross-origin resource sharing (CORS) for HTTP requests from the
     /// specified origin.
     ///
@@ -895,6 +919,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         let listeners = Listeners::bind(ListenersConfig {
             sql_listen_addr: args.sql_listen_addr,
             http_listen_addr: args.http_listen_addr,
+            balancer_sql_listen_addr: args.balancer_sql_listen_addr,
+            balancer_http_listen_addr: args.balancer_http_listen_addr,
             internal_sql_listen_addr: args.internal_sql_listen_addr,
             internal_http_listen_addr: args.internal_http_listen_addr,
         })

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -228,6 +228,11 @@ pub struct ListenersConfig {
     pub sql_listen_addr: SocketAddr,
     /// The IP address and port to listen for HTTP connections on.
     pub http_listen_addr: SocketAddr,
+    /// The IP address and port to listen on for pgwire connections from the cloud
+    /// balancer pods.
+    pub balancer_sql_listen_addr: SocketAddr,
+    /// The IP address and port to listen for HTTP connections from the cloud balancer pods.
+    pub balancer_http_listen_addr: SocketAddr,
     /// The IP address and port to listen for pgwire connections from the cloud
     /// system on.
     pub internal_sql_listen_addr: SocketAddr,
@@ -240,6 +245,8 @@ pub struct Listeners {
     // Drop order matters for these fields.
     sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
+    balancer_sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
+    balancer_http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     internal_sql: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
     internal_http: (ListenerHandle, Pin<Box<dyn ConnectionStream>>),
 }
@@ -260,17 +267,23 @@ impl Listeners {
         ListenersConfig {
             sql_listen_addr,
             http_listen_addr,
+            balancer_sql_listen_addr,
+            balancer_http_listen_addr,
             internal_sql_listen_addr,
             internal_http_listen_addr,
         }: ListenersConfig,
     ) -> Result<Listeners, anyhow::Error> {
         let sql = mz_ore::server::listen(sql_listen_addr).await?;
         let http = mz_ore::server::listen(http_listen_addr).await?;
+        let balancer_sql = mz_ore::server::listen(balancer_sql_listen_addr).await?;
+        let balancer_http = mz_ore::server::listen(balancer_http_listen_addr).await?;
         let internal_sql = mz_ore::server::listen(internal_sql_listen_addr).await?;
         let internal_http = mz_ore::server::listen(internal_http_listen_addr).await?;
         Ok(Listeners {
             sql,
             http,
+            balancer_sql,
+            balancer_http,
             internal_sql,
             internal_http,
         })
@@ -282,6 +295,8 @@ impl Listeners {
         Listeners::bind(ListenersConfig {
             sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            balancer_sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+            balancer_http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             internal_sql_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
             internal_http_listen_addr: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
         })
@@ -296,6 +311,8 @@ impl Listeners {
         let Listeners {
             sql: (sql_listener, sql_conns),
             http: (http_listener, http_conns),
+            balancer_sql: (balancer_sql_listener, balancer_sql_conns),
+            balancer_http: (balancer_http_listener, balancer_http_conns),
             internal_sql: (internal_sql_listener, internal_sql_conns),
             internal_http: (internal_http_listener, internal_http_conns),
         } = self;
@@ -528,7 +545,7 @@ impl Listeners {
                 }),
                 adapter_client: adapter_client.clone(),
                 frontegg: None,
-                metrics,
+                metrics: metrics.clone(),
                 internal: true,
                 active_connection_count: Arc::clone(&active_connection_count),
             });
@@ -542,6 +559,23 @@ impl Listeners {
                 tls: http_tls,
                 frontegg: config.frontegg.clone(),
                 adapter_client: adapter_client.clone(),
+                allowed_origin: config.cors_allowed_origin.clone(),
+                active_connection_count: Arc::clone(&active_connection_count),
+                concurrent_webhook_req_count: config
+                    .concurrent_webhook_req_count
+                    .unwrap_or(http::WEBHOOK_CONCURRENCY_LIMIT),
+                metrics: http_metrics.clone(),
+            });
+            mz_ore::server::serve(http_conns, http_server)
+        });
+
+        // Launch HTTP server exposed to balancers
+        task::spawn(|| "balancer_http_server", {
+            let balancer_http_server = HttpServer::new(HttpConfig {
+                // TODO(Alex): implement self-signed TLS for all internal connections
+                tls: None,
+                frontegg: config.frontegg.clone(),
+                adapter_client: adapter_client.clone(),
                 allowed_origin: config.cors_allowed_origin,
                 active_connection_count: Arc::clone(&active_connection_count),
                 concurrent_webhook_req_count: config
@@ -549,7 +583,20 @@ impl Listeners {
                     .unwrap_or(http::WEBHOOK_CONCURRENCY_LIMIT),
                 metrics: http_metrics,
             });
-            mz_ore::server::serve(http_conns, http_server)
+            mz_ore::server::serve(balancer_http_conns, balancer_http_server)
+        });
+
+        // Launch SQL server exposed to balancers
+        task::spawn(|| "balancer_sql_server", {
+            let balancer_sql_server = mz_pgwire::Server::new(mz_pgwire::Config {
+                tls: None,
+                adapter_client: adapter_client.clone(),
+                frontegg: config.frontegg.clone(),
+                metrics,
+                internal: false,
+                active_connection_count: Arc::clone(&active_connection_count),
+            });
+            mz_ore::server::serve(balancer_sql_conns, balancer_sql_server)
         });
 
         // Start telemetry reporting loop.
@@ -578,6 +625,8 @@ impl Listeners {
         Ok(Server {
             sql_listener,
             http_listener,
+            balancer_sql_listener,
+            balancer_http_listener,
             internal_sql_listener,
             internal_http_listener,
             _adapter_handle: adapter_handle,
@@ -606,6 +655,8 @@ pub struct Server {
     // Drop order matters for these fields.
     sql_listener: ListenerHandle,
     http_listener: ListenerHandle,
+    balancer_sql_listener: ListenerHandle,
+    balancer_http_listener: ListenerHandle,
     internal_sql_listener: ListenerHandle,
     internal_http_listener: ListenerHandle,
     _adapter_handle: mz_adapter::Handle,
@@ -618,6 +669,14 @@ impl Server {
 
     pub fn http_local_addr(&self) -> SocketAddr {
         self.http_listener.local_addr()
+    }
+
+    pub fn balancer_sql_local_addr(&self) -> SocketAddr {
+        self.balancer_sql_listener.local_addr()
+    }
+
+    pub fn balancer_http_local_addr(&self) -> SocketAddr {
+        self.balancer_http_listener.local_addr()
     }
 
     pub fn internal_sql_local_addr(&self) -> SocketAddr {


### PR DESCRIPTION
Adds new unencrypted HTTP and SQL listeners for connections from the balancer pods.

### Motivation


  * This PR adds a known-desirable feature.
Part of https://github.com/MaterializeInc/cloud/issues/7522

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
