### PR TITLE
Add metrics for optimization notices

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1252,6 +1252,10 @@ impl Coordinator {
         }
         for dropped_in_use_index in dropped_in_use_indexes {
             session.add_notice(AdapterNotice::DroppedInUseIndex(dropped_in_use_index));
+            self.metrics
+                .optimization_notices
+                .with_label_values(&["DroppedInUseIndex"])
+                .inc_by(1);
         }
         Ok(ExecuteResponse::DroppedObject(object_type))
     }
@@ -5224,6 +5228,10 @@ impl Coordinator {
                 let (notice, hint) = optimizer_notice.to_string(&humanizer);
                 session.add_notice(AdapterNotice::OptimizerNotice { notice, hint });
             }
+            self.metrics
+                .optimization_notices
+                .with_label_values(&[optimizer_notice.metric_label()])
+                .inc_by(1);
         }
     }
 }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -32,6 +32,7 @@ pub struct Metrics {
     pub statement_logging_unsampled_bytes: IntCounterVec,
     pub statement_logging_actual_bytes: IntCounterVec,
     pub slow_message_handling: HistogramVec,
+    pub optimization_notices: IntCounterVec,
 }
 
 impl Metrics {
@@ -113,6 +114,11 @@ impl Metrics {
                     defined by the LaunchDarkly variable 'coord_slow_message_reporting_threshold'",
                 var_labels: ["message_kind"],
                 buckets: histogram_seconds_buckets(0.128, 32.0),
+            )),
+            optimization_notices: registry.register(metric!(
+                name: "mz_optimization_notices",
+                help: "Number of optimization notices per notice type.",
+                var_labels: ["notice_type"],
             )),
         }
     }

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -349,7 +349,7 @@ impl fmt::Display for AdapterNotice {
                 index_name,
                 dependant_objects,
             }) => {
-                write!(f, "The dropped index {index_name} is being used by the following objects: {}. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!", separated(", ", dependant_objects))
+                write!(f, "The dropped index {index_name} is being used by the following objects: {}. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!", separated(", ", dependant_objects))
             }
         }
     }

--- a/src/transform/src/optimizer_notices.rs
+++ b/src/transform/src/optimizer_notices.rs
@@ -98,6 +98,17 @@ impl OptimizerNotice {
             OptimizerNotice::IndexKeyEmpty => true,
         }
     }
+
+    /// A notice name, which will be applied as the label on the metric that is counting notices
+    /// labelled by notice type.
+    pub fn metric_label(&self) -> &str {
+        match self {
+            OptimizerNotice::IndexTooWideForLiteralConstraints(..) => {
+                "IndexTooWideForLiteralConstraints"
+            }
+            OptimizerNotice::IndexKeyEmpty => "IndexKeyEmpty",
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/test/pgtest-mz/notice.pt
+++ b/test/pgtest-mz/notice.pt
@@ -55,7 +55,7 @@ CommandComplete {"tag":"CREATE INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"DROP INDEX"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv1. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv1. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!"}]}
 CommandComplete {"tag":"DROP INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"DROP MATERIALIZED VIEW"}
@@ -72,14 +72,14 @@ CommandComplete {"tag":"CREATE INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"CREATE MATERIALIZED VIEW"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv2. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.mv2. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!"}]}
 CommandComplete {"tag":"DROP INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"CREATE INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"CREATE INDEX"}
 ReadyForQuery {"status":"I"}
-NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.v1_idx_a. The index will be dropped from the catalog, but it will continue to be maintained and take up resources!"}]}
+NoticeResponse {"fields":[{"typ":"S","value":"NOTICE"},{"typ":"C","value":"01000"},{"typ":"M","value":"The dropped index materialize.public.t_idx_a is being used by the following objects: materialize.public.v1_idx_a. The index is now dropped from the catalog, but it will continue to be maintained and take up resources until all dependent objects are dropped, altered, or Materialize is restarted!"}]}
 CommandComplete {"tag":"DROP INDEX"}
 ReadyForQuery {"status":"I"}
 CommandComplete {"tag":"DROP INDEX"}


### PR DESCRIPTION
This adds metrics for the notices that we have about indexes: 
- Index too wide for a literal constraint.
- Index with an empty key.
- Dropping an in-use index.

This will make it easier to prioritize follow-up work, e.g., adding other similar notices, and surfacing these notices properly in built-in tables and the Web Console.

I also sneaked in a notice message change discussed [here](https://github.com/MaterializeInc/materialize/pull/21706#discussion_r1332998749).

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
