### PR TITLE
Update MZ CLI to use new Region API version 1 semantics

### DIFF
--- a/src/cloud-api/src/client.rs
+++ b/src/cloud-api/src/client.rs
@@ -17,10 +17,11 @@
 //! Frontegg client is used to request and manage the access token.
 use std::sync::Arc;
 
-use reqwest::{Method, RequestBuilder, StatusCode, Url};
+use reqwest::{header::HeaderMap, Method, RequestBuilder, StatusCode, Url};
 use serde::de::DeserializeOwned;
 use serde::Deserialize;
 
+use crate::config::API_VERSION_HEADER;
 use crate::error::{ApiError, Error};
 
 use self::cloud_provider::CloudProvider;
@@ -57,7 +58,7 @@ impl Client {
         P: IntoIterator,
         P::Item: AsRef<str>,
     {
-        self.build_request(method, path, self.endpoint.clone())
+        self.build_request(method, path, self.endpoint.clone(), None)
             .await
     }
 
@@ -65,18 +66,31 @@ impl Client {
     /// The function requires a [CloudProvider] as parameter
     /// since it contains the api url (Region API url)
     /// to interact with the region.
+    /// Specify an api_version corresponding to the request/response
+    /// schema your code will handle. Refer to the Region API docs
+    /// for schema information.
     async fn build_region_request<P>(
         &self,
         method: Method,
         path: P,
         cloud_provider: &CloudProvider,
+        api_version: Option<u16>,
     ) -> Result<RequestBuilder, Error>
     where
         P: IntoIterator,
         P::Item: AsRef<str>,
     {
-        self.build_request(method, path, cloud_provider.url.clone())
-            .await
+        self.build_request(
+            method,
+            path,
+            cloud_provider.url.clone(),
+            api_version.and_then(|api_ver| {
+                let mut headers = HeaderMap::with_capacity(1);
+                headers.insert(API_VERSION_HEADER, api_ver.into());
+                Some(headers)
+            }),
+        )
+        .await
     }
 
     /// Builds a request towards the `Client`'s endpoint
@@ -85,6 +99,7 @@ impl Client {
         method: Method,
         path: P,
         mut domain: Url,
+        headers: Option<HeaderMap>,
     ) -> Result<RequestBuilder, Error>
     where
         P: IntoIterator,
@@ -96,7 +111,10 @@ impl Client {
             .clear()
             .extend(path);
 
-        let req = self.inner.request(method, domain);
+        let mut req = self.inner.request(method, domain);
+        if let Some(header_map) = headers {
+            req = req.headers(header_map);
+        }
         let token = self.auth_client.auth().await?;
 
         Ok(req.bearer_auth(token))

--- a/src/cloud-api/src/config.rs
+++ b/src/cloud-api/src/config.rs
@@ -27,6 +27,9 @@ use crate::client::Client;
 pub static DEFAULT_ENDPOINT: Lazy<Url> =
     Lazy::new(|| "https://api.cloud.materialize.com".parse().unwrap());
 
+/// The header used by the Region API to specify which API version this client supports
+pub static API_VERSION_HEADER: &str = "X-Materialize-Api-Version";
+
 /// Configures the required parameters of a [`Client`].
 pub struct ClientConfig {
     /// The authorization client to get the authorization token.

--- a/src/mz/CHANGELOG.md
+++ b/src/mz/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 All notable changes to the `mz` CLI will be documented in this file.
 
-
 ## [0.2.1] - 2023-09-07
 
 This version only implements changes in the release process.

--- a/src/mz/README.md
+++ b/src/mz/README.md
@@ -134,7 +134,7 @@ Field             | Type   | Description
 `app-password`    | string | *Secret.* The app password to use for this profile.
 `region`          | string | The default region to use for this profile.
 `vault`           | string | The vault to use for this profile. See [Global parameters](#global-parameters) above.
-`api-endpoint`    | string | *Internal use only.* The Materialize API endpoint to use.
+`cloud-endpoint`  | string | *Internal use only.* The Materialize API endpoint to use.
 `admin-endpoint`  | string | *Internal use only.* The Materialize administration endpoint to use.
 
 

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use crate::{context::RegionContext, error::Error};
 
-use mz_cloud_api::client::cloud_provider::CloudProvider;
+use mz_cloud_api::client::{cloud_provider::CloudProvider, region::RegionState};
 use mz_ore::retry::Retry;
 use serde::{Deserialize, Serialize};
 use tabled::Tabled;
@@ -50,24 +50,36 @@ pub async fn enable(cx: RegionContext, version: Option<String>) -> Result<(), Er
         .max_duration(Duration::from_secs(720))
         .clamp_backoff(Duration::from_secs(1))
         .retry_async(|_| async {
-            let region_info = cx.get_region().await?.region_info;
+            let region = cx.get_region().await?;
 
-            match region_info {
-                Some(region_info) => {
+            match region.region_state {
+                RegionState::EnablementPending => {
                     loading_spinner.set_message("Waiting for the region to be ready...");
-                    if region_info.resolvable {
-                        if cx
-                            .sql_client()
-                            .is_ready(&region_info, cx.admin_client().claims().await?.email)?
-                        {
-                            return Ok(());
-                        }
-                        Err(Error::NotPgReadyError)
-                    } else {
-                        Err(Error::NotResolvableRegion)
-                    }
+                    Err(Error::NotReadyRegion)
                 }
-                None => Err(Error::NotReadyRegion),
+                RegionState::DeletionPending => Err(Error::CommandExecutionError(
+                    "This region is pending deletion!".to_string(),
+                )),
+                RegionState::SoftDeleted => Err(Error::CommandExecutionError(
+                    "This region has been marked soft-deleted!".to_string(),
+                )),
+                RegionState::Enabled => match region.region_info {
+                    Some(region_info) => {
+                        loading_spinner.set_message("Waiting for the region to be resolvable...");
+                        if region_info.resolvable {
+                            if cx
+                                .sql_client()
+                                .is_ready(&region_info, cx.admin_client().claims().await?.email)?
+                            {
+                                return Ok(());
+                            }
+                            Err(Error::NotPgReadyError)
+                        } else {
+                            Err(Error::NotResolvableRegion)
+                        }
+                    }
+                    None => Err(Error::NotReadyRegion),
+                },
             }
         })
         .await


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: A follow-on to https://github.com/MaterializeInc/cloud/issues/7429 to update the `mz` cli to use the new Region API response semantics introduced with api version `1`.

 
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]



    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

I tested the `mz region list`, `mz region enable`, and `mz region disable` commands against staging. Let me know if there are other tests to include. I wasn't able to test using the `e2e` test which looks like it's currently disabled.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
