### PR TITLE
ci: require backward compatibility for all protobufs

### DIFF
--- a/ci/test/lint-fast.sh
+++ b/ci/test/lint-fast.sh
@@ -33,7 +33,6 @@ if [[ "${BUILDKITE_PULL_REQUEST:-true}" != "false" ]]; then
   fetch_pr_target_branch
 
   ci_collapsed_heading "Lint protobuf"
-  # exceptions can be defined in src/buf.yaml
   COMMON_ANCESTOR="$(get_common_ancestor_commit_of_pr_and_target)"
   ci_try buf breaking src --against ".git#ref=$COMMON_ANCESTOR,subdir=src"
 fi

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -11,17 +11,6 @@ version: v1
 breaking:
   use:
     - WIRE
-  ignore:
-    # does currently not require backward-compatibility
-    - cluster-client
-    # does currently not require backward-compatibility
-    - compute-client
-    # does currently not require backward-compatibility
-    - storage-client
-    # does not currently require backward-compatibility
-    - stash
-    # still under active development
-    - persist-types
 lint:
   use:
     - DEFAULT


### PR DESCRIPTION
We recently had an incident caused by introducing a backward incompatible change to a protobuf definition. So far we've been differentiating between ptotobufs that are persisted from protobufs that don't. We've been liberally introducing backwards incompatible changes to the ones that are not persisted and been careful with the ones that are.

Unfortunately due to a combination of human error and a misconfiguration of the backward compatibility checker we shipped backward incompatible change.

This PR makes it so backward compatibility is required for all protobuf definitions for two reasons:

1. It will start a culture shift of everyone getting into the habit of making backward compatible changes.
2. It will make it much harder for the CI check to fail as there will be no exceptions.

There is the possibility that we truly want to ship a backward incompatible change between for non-persisted protobufs in the future (e.g for the controller <-> clusterd protocol) and we might need to relax this policy. If and when this happens we can reconsider our tool configuration and hopefully by that point some muscle memory will have already been infused to the team.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
