### PR TITLE
persist: run the heartbeat_read task on two tokio runtimes

### DIFF
--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1983,14 +1983,16 @@ mod tests {
             .expect("client construction failed")
             .expect_open::<(), (), u64, i64>(ShardId::new())
             .await;
-        let read_heartbeat_task = read
-            .heartbeat_task
+        let read_heartbeat_tasks = read
+            .heartbeat_tasks
             .take()
             .expect("handle should have heartbeat task");
         read.expire().await;
-        let () = read_heartbeat_task
-            .await
-            .expect("task should shutdown cleanly");
+        for read_heartbeat_task in read_heartbeat_tasks {
+            let () = read_heartbeat_task
+                .await
+                .expect("task should shutdown cleanly");
+        }
     }
 
     /// Regression test for 16743, where the nightly tests found that calling


### PR DESCRIPTION
In response to a production incident, this runs the heartbeat task on both the in-context tokio runtime and persist's isolated runtime. We think we were seeing tasks (including this one) get stuck indefinitely in tokio while waiting for a runtime worker. This could happen if some other task in that runtime never yields. It's possible that one of the two runtimes is healthy while the other isn't (this was inconclusive in the incident debugging), and the heartbeat task is fairly lightweight, so run a copy in each in case that helps.

The real fix here is to find the misbehaving task and fix it. Remove this duplication when that happens.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
