### PR TITLE
dbt-materialize: fix bug in `persist_docs` for materialized views

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -4,9 +4,7 @@
 
 * Support the [`ASSERT NOT NULL` option](https://materialize.com/docs/sql/create-materialized-view/#non-null-assertions)
   for `materialized_view` materializations via the `not_null` column-level
-  constraint. It's important to note that other constraint types are not
-  supported, and that `not_null` constraints can only be defined at the
-  column-level (not model-level).
+  constraint.
 
   ```yaml
     - name: model_with_constraints
@@ -21,6 +19,20 @@
       - name: col_without_constraints
         data_type: int
   ```
+
+  It's important to note that other constraint types are not
+  supported, and that `not_null` constraints can only be defined at the
+  column-level (not model-level).
+
+* Work around a bug in [`--persist-docs`](https://docs.getdbt.com/reference/resource-configs/persist_docs)
+  that prevented comments from being persisted for `materialized_view`
+  materializations. See [#21878]
+  (https://github.com/MaterializeInc/materialize/pull/21878) for details.
+
+  The `--persist-docs` flag requires [Materialize >=0.68.0](https://materialize.com/docs/releases/v0.68/).
+  Previous versions **do not** have support for the `COMMENT ON` syntax, which
+  is required to persist resource descriptions as column and relation comments
+  in Materialize.
 
 * Load seeds into tables rather than materialized views.
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -59,7 +59,7 @@
       {% set ns.m_constraints = True %}
     {%- endif %}
 
-    {% if ns.c_constraints or ns.m_constraints %}
+    {% if ns.c_constraints %}
       with
         {{ get_table_columns_and_constraints() }}
     {%- endif %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/adapters.sql
@@ -131,6 +131,15 @@
     {%- endif %};
 {%- endmacro %}
 
+{% macro materialize__alter_relation_comment(relation, comment) -%}
+  {% set escaped_comment = postgres_escape_comment(comment) %}
+  {% if relation.type == 'materializedview' -%}
+    {% set relation_type = "materialized view" %}
+  {%- else -%}
+    {%- set relation_type = relation.type -%}
+  {%- endif -%}
+  comment on {{ relation_type }} {{ relation }} is {{ escaped_comment }};
+{% endmacro %}
 
 -- In the dbt-adapter we extend the Relation class to include sinks and indexes
 {% macro materialize__list_relations_without_caching(schema_relation) %}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -30,18 +30,20 @@
                  --in mz_objects to correctly report subsources.
                  when o.type = 'source' then so.type
                  else o.type end as table_type,
-            '' as table_comment,
+            coalesce(obj_desc.comment, '') as table_comment,
             c.name as column_name,
             c.position as column_index,
             c.type as column_type,
-            '' as column_comment,
+            coalesce(col_desc.comment, '') as column_comment,
             r.name as table_owner
         from mz_objects o
-        left join mz_sources so on o.id = so.id
-        join mz_roles r on o.owner_id = r.id
         join mz_schemas s on o.schema_id = s.id
         join mz_databases d on s.database_id = d.id and d.name = '{{ database }}'
         join mz_columns c on c.id = o.id
+        join mz_roles r on o.owner_id = r.id
+        left join mz_sources so on o.id = so.id
+        left outer join mz_internal.mz_comments obj_desc on (o.id = obj_desc.id and obj_desc.object_sub_id is null)
+        left outer join mz_internal.mz_comments col_desc on (o.id = col_desc.id and col_desc.object_sub_id = c.position)
         where s.name in (
             {%- for schema in schemas -%}
                 '{{ schema }}' {%- if not loop.last %}, {% endif -%}

--- a/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/catalog.sql
@@ -30,11 +30,11 @@
                  --in mz_objects to correctly report subsources.
                  when o.type = 'source' then so.type
                  else o.type end as table_type,
-            coalesce(obj_desc.comment, '') as table_comment,
+            obj_desc.comment as table_comment,
             c.name as column_name,
             c.position as column_index,
             c.type as column_type,
-            coalesce(col_desc.comment, '') as column_comment,
+            col_desc.comment as column_comment,
             r.name as table_owner
         from mz_objects o
         join mz_schemas s on o.schema_id = s.id

--- a/misc/dbt-materialize/tests/adapter/test_persist_docs.py
+++ b/misc/dbt-materialize/tests/adapter/test_persist_docs.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 from dbt.tests.adapter.persist_docs.test_persist_docs import (
     BasePersistDocs,
     BasePersistDocsColumnMissing,
@@ -21,17 +20,14 @@ from dbt.tests.adapter.persist_docs.test_persist_docs import (
 )
 
 
-@pytest.mark.skip(reason="Materialize does not support COMMENT")
 class TestPersistDocsMaterialize(BasePersistDocs):
     pass
 
 
-@pytest.mark.skip(reason="Materialize does not support COMMENT")
 class TestPersistDocsColumnMissingMaterialize(BasePersistDocsColumnMissing):
     pass
 
 
-@pytest.mark.skip(reason="Materialize does not support COMMENT")
 class TestPersistDocsCommentOnQuotedColumnMaterialize(
     BasePersistDocsCommentOnQuotedColumn
 ):


### PR DESCRIPTION
In `dbt-postgres`, the [macro that backs object-level `persist_docs`](https://github.com/dbt-labs/dbt-core/blob/d91265411061463b42d6f4d6d94e094a42a96d2b/plugins/postgres/dbt/include/postgres/macros/adapters.sql#L195) uses `{{ relation.type }}` to derive the object type in the `COMMENT ON` statement. This breaks for materialized views in both adapters (which use a slightly different materialization type):

```bash
15:35:01  Database Error in model funds_movement (models/marts/funds_movement.sql)
15:35:01    Expected one of TABLE or VIEW or COLUMN or MATERIALIZED or SOURCE or SINK or INDEX or FUNCTION or CONNECTION or TYPE or SECRET or ROLE or DATABASE or SCHEMA or CLUSTER, found identifier "materializedview"
15:35:01    LINE 5:   comment on materializedview "marta"."public"."funds_moveme...
15:35:01                         ^
15:35:01    compiled Code at target/run/mz_get_started/models/marts/funds_movement.sql
15:35:01
15:35:01  Done. PASS=3 WARN=0 ERROR=2 SKIP=0 TOTAL=5
```

Blocking #21401.