### PR TITLE
adapter: Add more timedomain comments and tests

### DIFF
--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -979,6 +979,12 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
     /// Adds operations to the current transaction. An error is produced if
     /// they cannot be merged (i.e., a timestamp-dependent read cannot be
     /// merged to an insert).
+    ///
+    /// # Panics
+    /// If the operations are compatible but the operation metadata doesn't match.
+    /// Such as reads at different timestamps, reads on different timelines, reads
+    /// on different clusters, etc. It's up to the caller to make sure these are
+    /// aligned.
     pub fn add_ops(&mut self, add_ops: TransactionOps<T>) -> Result<(), AdapterError> {
         match self {
             TransactionStatus::Started(Transaction { ops, access, .. })

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -849,6 +849,50 @@ SET CLUSTER TO c
 statement ok
 ROLLBACK
 
+statement ok
+BEGIN
+
+statement ok
+SELECT * FROM t
+
+statement error SET cluster cannot be called in an active transaction
+SET LOCAL CLUSTER TO c
+
+statement ok
+ROLLBACK
+
+# Test that the cluster can change at the start of a transaction.
+
+statement ok
+BEGIN
+
+statement ok
+SET CLUSTER TO c
+
+statement ok
+SELECT * FROM t
+
+statement ok
+COMMIT
+
+statement ok
+SET CLUSTER TO default
+
+statement ok
+BEGIN
+
+statement ok
+SET LOCAL CLUSTER TO c
+
+statement ok
+SELECT * FROM t
+
+statement ok
+COMMIT
+
+statement ok
+SET CLUSTER TO default
+
 # Test that the cluster is selected at the start of a transaction and doesn't change.
 
 ## Auto-routing selects mz_introspection at the start of transaction.


### PR DESCRIPTION
This commit adds some followup tests and comments to 3f225c6e2c8befc1ca68c08556f4bf8b889fe464

Resolves #21839

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
