### PR TITLE
comments: Fix uniqueness bug

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -147,7 +147,7 @@ The `mz_comments` table stores optional comments (descriptions) for objects in t
 | -------------- |-------------| --------                                                                                     |
 | `id`           | [`text`]    | The ID of the object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).           |
 | `object_type`  | [`text`]    | The type of object the comment is associated with.                                           |
-| `sub_id`       | [`uint8`]   | For a comment on a column of a relation, this is the column number. For all other object types this column is `NULL`. |
+| `object_sub_id`| [`uint8`]   | For a comment on a column of a relation, this is the column number. For all other object types this column is `NULL`. |
 | `comment`      | [`text`]    | The comment itself.                                                                          |
 
 ### `mz_compute_dependencies`

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2249,7 +2249,7 @@ pub static MZ_COMMENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
-        .with_column("sub_id", ScalarType::UInt64.nullable(true))
+        .with_column("object_sub_id", ScalarType::UInt64.nullable(true))
         .with_column("comment", ScalarType::String.nullable(false)),
     is_retained_metrics_object: false,
 });

--- a/src/catalog/src/transaction.rs
+++ b/src/catalog/src/transaction.rs
@@ -201,9 +201,7 @@ impl<'a> Transaction<'a> {
             items: TableTransaction::new(items, |a: &ItemValue, b| {
                 a.schema_id == b.schema_id && a.name == b.name
             })?,
-            comments: TableTransaction::new(comments, |a: &CommentValue, b| {
-                a.comment == b.comment
-            })?,
+            comments: TableTransaction::new(comments, |_a, _b| false)?,
             roles: TableTransaction::new(roles, |a: &RoleValue, b| a.name == b.name)?,
             clusters: TableTransaction::new(clusters, |a: &ClusterValue, b| a.name == b.name)?,
             cluster_replicas: TableTransaction::new(

--- a/test/legacy-upgrade/check-from-v0.68.0-comment.td
+++ b/test/legacy-upgrade/check-from-v0.68.0-comment.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT object_type, sub_id, comment FROM mz_internal.mz_comments;
+> SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 "table" "<null>" "foo"
 "table" "1" "load_bearing"
 "view" "<null>" "subset_of_comment_table"

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -95,7 +95,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  id  text
 2  object_type  text
-3  sub_id  uint8
+3  object_sub_id  uint8
 4  comment  text
 
 query ITT

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -57,12 +57,19 @@ u1  table  2  load_bearing
 u2  table  1  utc_timestamp
 
 statement ok
+COMMENT ON TABLE b IS 'foo_table';
+
+statement ok
 DROP TABLE a;
 
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
+u2  table  NULL foo_table
 u2  table  1  utc_timestamp
+
+statement ok
+COMMENT ON TABLE b IS NULL
 
 statement ok
 COMMENT ON COLUMN b.ts IS NULL


### PR DESCRIPTION
When @morsapaes was trying out `COMMENT ON` she found a couple bugs, this PR fixes those bugs.

### Motivation

* This PR fixes a recognized bug.

Fixes #21875

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
