### PR TITLE
sql [2/2]: Variable defaults for Roles

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4329,6 +4329,7 @@ impl Catalog {
                     id,
                     name,
                     attributes,
+                    vars,
                 } => {
                     state.ensure_not_reserved_role(&id)?;
                     if let Some(builtin_update) = state.pack_role_update(id, -1) {
@@ -4336,6 +4337,7 @@ impl Catalog {
                     }
                     let existing_role = state.get_role_mut(&id);
                     existing_role.attributes = attributes;
+                    existing_role.vars = vars;
                     tx.update_role(id, existing_role.clone().into())?;
                     if let Some(builtin_update) = state.pack_role_update(id, 1) {
                         builtin_table_updates.push(builtin_update);
@@ -6784,6 +6786,7 @@ pub enum Op {
         id: RoleId,
         name: String,
         attributes: RoleAttributes,
+        vars: RoleVars,
     },
     CreateDatabase {
         name: String,
@@ -7579,12 +7582,16 @@ impl mz_sql::catalog::CatalogRole for Role {
         self.id
     }
 
-    fn is_inherit(&self) -> bool {
-        self.attributes.inherit
-    }
-
     fn membership(&self) -> &BTreeMap<RoleId, RoleId> {
         &self.membership.map
+    }
+
+    fn attributes(&self) -> &RoleAttributes {
+        &self.attributes
+    }
+
+    fn vars(&self) -> &BTreeMap<String, OwnedVarInput> {
+        &self.vars.map
     }
 }
 

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -31,7 +31,6 @@ use mz_sql::ast::{Raw, Statement};
 use mz_sql::catalog::{EnvironmentId, SessionCatalog};
 use mz_sql::session::hint::ApplicationNameHint;
 use mz_sql::session::user::{User, SUPPORT_USER};
-use mz_sql::session::vars::VarInput;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::parser::{ParserStatementError, StatementParseResult};
 use mz_transform::Optimizer;
@@ -204,8 +203,9 @@ impl Client {
 
         let StartupResponse {
             role_id,
-            set_vars,
             write_notify,
+            session_vars,
+            role_vars,
             catalog,
         } = response;
 
@@ -215,12 +215,18 @@ impl Client {
         write_notify.await;
 
         client.session().initialize_role_metadata(role_id);
-        for (name, val) in set_vars {
-            client
-                .session()
-                .vars_mut()
-                .set(None, &name, VarInput::Flat(&val), false)
+        let vars_mut = client.session().vars_mut();
+        for (name, val) in session_vars {
+            vars_mut
+                .set(None, &name, val.borrow(), false)
                 .expect("constrained to be valid");
+        }
+        for (name, val) in role_vars {
+            if let Err(err) = vars_mut.set_role_default(&name, val.borrow()) {
+                // Note: erroring here is unexpected, but we don't want to panic if somehow our
+                // assumptions are wrong.
+                tracing::error!("failed to set peristed role default, {err:?}");
+            }
         }
         client
             .session()

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -35,7 +35,7 @@ use mz_sql::plan::{
     ExecuteTimeout, Plan, PlanKind, WebhookHeaders, WebhookValidation, WebhookValidationSecret,
 };
 use mz_sql::session::user::User;
-use mz_sql::session::vars::Var;
+use mz_sql::session::vars::{OwnedVarInput, Var};
 use mz_sql_parser::ast::{AlterObjectRenameStatement, AlterOwnerStatement, DropObjectsStatement};
 use mz_storage_client::controller::MonotonicAppender;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -185,11 +185,13 @@ pub type RowsFuture = Pin<Box<dyn Future<Output = PeekResponseUnary> + Send>>;
 pub struct StartupResponse {
     /// RoleId for the user.
     pub role_id: RoleId,
-    /// Vec of (name, VarInput::Flat) tuples of session variables that should be set.
-    pub set_vars: Vec<(String, String)>,
     /// A future that completes when all necessary Builtin Table writes have completed.
     #[derivative(Debug = "ignore")]
     pub write_notify: BoxFuture<'static, ()>,
+    /// Vec of (name, VarInput::Flat) tuples of session variables that should be set.
+    pub session_vars: Vec<(String, OwnedVarInput)>,
+    /// Vec of (name, VarInput::Flat) tuples of Role default variables that should be set.
+    pub role_vars: Vec<(String, OwnedVarInput)>,
     pub catalog: Arc<Catalog>,
 }
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -228,7 +228,7 @@ impl Coordinator {
         // Early return if successful, otherwise cleanup any possible state.
         match self.handle_startup_inner(&user, &conn_id).await {
             Ok(role_id) => {
-                let mut set_vars = Vec::new();
+                let mut session_vars = Vec::new();
                 if !set_setting_keys
                     .iter()
                     .any(|k| k == STATEMENT_LOGGING_SAMPLE_RATE.name())
@@ -238,11 +238,17 @@ impl Coordinator {
                         .state()
                         .system_config()
                         .statement_logging_default_sample_rate();
-                    set_vars.push((
+                    session_vars.push((
                         STATEMENT_LOGGING_SAMPLE_RATE.name().to_string(),
-                        default.to_string(),
+                        OwnedVarInput::Flat(default.to_string()),
                     ));
                 }
+                let role_vars = self
+                    .catalog()
+                    .get_role(&role_id)
+                    .vars()
+                    .map(|(name, val)| (name.to_owned(), val.clone()))
+                    .collect();
 
                 let session_type = metrics::session_type_label_value(&user);
                 self.metrics
@@ -271,8 +277,9 @@ impl Coordinator {
 
                 let resp = Ok(StartupResponse {
                     role_id,
-                    set_vars,
                     write_notify: notify,
+                    session_vars,
+                    role_vars,
                     catalog: self.owned_catalog(),
                 });
                 if tx.send(resp).is_err() {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -361,7 +361,7 @@ impl Coordinator {
                 ctx.retire(result);
             }
             Plan::AlterRole(plan) => {
-                let result = self.sequence_alter_role(ctx.session(), plan).await;
+                let result = self.sequence_alter_role(ctx.session_mut(), plan).await;
                 if result.is_ok() {
                     self.maybe_send_rbac_notice(ctx.session());
                 }

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2161,29 +2161,45 @@ impl_display!(AlterConnectionStatement);
 pub struct AlterRoleStatement<T: AstInfo> {
     /// The specified role.
     pub name: T::RoleName,
-    /// Any options that were attached, in the order they were presented.
-    pub options: Vec<RoleAttribute>,
-    /// A variable that we want to provide a default value for this role.
-    pub variable: Option<SetRoleVar>,
+    /// Alterations we're making to the role.
+    pub option: AlterRoleOption,
 }
 
 impl<T: AstInfo> AstDisplay for AlterRoleStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("ALTER ROLE ");
         f.write_node(&self.name);
-
-        for option in &self.options {
-            f.write_str(" ");
-            option.fmt(f)
-        }
-
-        if let Some(variable) = &self.variable {
-            f.write_str(" ");
-            f.write_node(variable);
-        }
+        f.write_node(&self.option);
     }
 }
 impl_display_t!(AlterRoleStatement);
+
+/// `ALTER ROLE ... [ WITH | SET ] ...`
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum AlterRoleOption {
+    /// Any options that were attached, in the order they were presented.
+    Attributes(Vec<RoleAttribute>),
+    /// A variable that we want to provide a default value for this role.
+    Variable(SetRoleVar),
+}
+
+impl AstDisplay for AlterRoleOption {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            AlterRoleOption::Attributes(attrs) => {
+                for attr in attrs {
+                    f.write_str(" ");
+                    attr.fmt(f)
+                }
+            }
+            AlterRoleOption::Variable(var) => {
+                f.write_str(" ");
+                f.write_node(var);
+            }
+        }
+    }
+}
+impl_display!(AlterRoleOption);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct DiscardStatement {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -4737,34 +4737,28 @@ impl<'a> Parser<'a> {
     fn parse_alter_role(&mut self) -> Result<Statement<Raw>, ParserError> {
         let name = self.parse_identifier()?;
 
-        let (options, variable) = match self.parse_one_of_keywords(&[SET, RESET, WITH]) {
+        let option = match self.parse_one_of_keywords(&[SET, RESET, WITH]) {
             Some(SET) => {
                 let name = self.parse_identifier()?;
                 self.expect_keyword_or_token(TO, &Token::Eq)?;
                 let value = self.parse_set_variable_to()?;
                 let var = SetRoleVar::Set { name, value };
-
-                (vec![], Some(var))
+                AlterRoleOption::Variable(var)
             }
             Some(RESET) => {
                 let name = self.parse_identifier()?;
                 let var = SetRoleVar::Reset { name };
-
-                (vec![], Some(var))
+                AlterRoleOption::Variable(var)
             }
             Some(WITH) | None => {
                 let _ = self.parse_keyword(WITH);
-                let options = self.parse_role_attributes();
-                (options, None)
+                let attrs = self.parse_role_attributes();
+                AlterRoleOption::Attributes(attrs)
             }
             Some(k) => unreachable!("unmatched keyword: {k}"),
         };
 
-        Ok(Statement::AlterRole(AlterRoleStatement {
-            name,
-            options,
-            variable,
-        }))
+        Ok(Statement::AlterRole(AlterRoleStatement { name, option }))
     }
 
     fn parse_alter_default_privileges(&mut self) -> Result<Statement<Raw>, ParserError> {

--- a/src/sql-parser/tests/testdata/alter
+++ b/src/sql-parser/tests/testdata/alter
@@ -18,21 +18,21 @@ ALTER ROLE arjun
 ----
 ALTER ROLE arjun
 =>
-AlterRole(AlterRoleStatement { name: Ident("arjun"), options: [], variable: None })
+AlterRole(AlterRoleStatement { name: Ident("arjun"), option: Attributes([]) })
 
 parse-statement
 ALTER ROLE frank SUPERUSER
 ----
 ALTER ROLE frank SUPERUSER
 =>
-AlterRole(AlterRoleStatement { name: Ident("frank"), options: [SuperUser], variable: None })
+AlterRole(AlterRoleStatement { name: Ident("frank"), option: Attributes([SuperUser]) })
 
 parse-statement
 ALTER ROLE other_usr LOGIN NOSUPERUSER SUPERUSER NOLOGIN INHERIT NOINHERIT CREATECLUSTER NOCREATECLUSTER CREATEDB NOCREATEDB CREATEROLE NOCREATEROLE
 ----
 ALTER ROLE other_usr LOGIN NOSUPERUSER SUPERUSER NOLOGIN INHERIT NOINHERIT CREATECLUSTER NOCREATECLUSTER CREATEDB NOCREATEDB CREATEROLE NOCREATEROLE
 =>
-AlterRole(AlterRoleStatement { name: Ident("other_usr"), options: [Login, NoSuperUser, SuperUser, NoLogin, Inherit, NoInherit, CreateCluster, NoCreateCluster, CreateDB, NoCreateDB, CreateRole, NoCreateRole], variable: None })
+AlterRole(AlterRoleStatement { name: Ident("other_usr"), option: Attributes([Login, NoSuperUser, SuperUser, NoLogin, Inherit, NoInherit, CreateCluster, NoCreateCluster, CreateDB, NoCreateDB, CreateRole, NoCreateRole]) })
 
 parse-statement
 ALTER ROLE bad.qualification
@@ -46,7 +46,7 @@ ALTER ROLE usr WITH LOGIN
 ----
 ALTER ROLE usr LOGIN
 =>
-AlterRole(AlterRoleStatement { name: Ident("usr"), options: [Login], variable: None })
+AlterRole(AlterRoleStatement { name: Ident("usr"), option: Attributes([Login]) })
 
 parse-statement
 ALTER ROLE usr WITH badopt
@@ -60,11 +60,11 @@ ALTER ROLE parker SET cluster TO my_cluster
 ----
 ALTER ROLE parker SET cluster = my_cluster
 =>
-AlterRole(AlterRoleStatement { name: Ident("parker"), options: [], variable: Some(Set { name: Ident("cluster"), value: Values([Ident(Ident("my_cluster"))]) }) })
+AlterRole(AlterRoleStatement { name: Ident("parker"), option: Variable(Set { name: Ident("cluster"), value: Values([Ident(Ident("my_cluster"))]) }) })
 
 parse-statement
 ALTER ROLE parker RESET cluster
 ----
 ALTER ROLE parker RESET cluster
 =>
-AlterRole(AlterRoleStatement { name: Ident("parker"), options: [], variable: Some(Reset { name: Ident("cluster") }) })
+AlterRole(AlterRoleStatement { name: Ident("parker"), option: Variable(Reset { name: Ident("cluster") }) })

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -435,6 +435,11 @@ impl RoleAttributes {
         self.inherit = true;
         self
     }
+
+    /// Returns whether or not the role has inheritence of privileges.
+    pub const fn is_inherit(&self) -> bool {
+        self.inherit
+    }
 }
 
 impl From<PlannedRoleAttributes> for RoleAttributes {
@@ -442,17 +447,6 @@ impl From<PlannedRoleAttributes> for RoleAttributes {
         let default_attributes = RoleAttributes::new();
         RoleAttributes {
             inherit: inherit.unwrap_or(default_attributes.inherit),
-            _private: (),
-        }
-    }
-}
-
-impl From<(&dyn CatalogRole, PlannedRoleAttributes)> for RoleAttributes {
-    fn from(
-        (role, PlannedRoleAttributes { inherit }): (&dyn CatalogRole, PlannedRoleAttributes),
-    ) -> RoleAttributes {
-        RoleAttributes {
-            inherit: inherit.unwrap_or_else(|| role.is_inherit()),
             _private: (),
         }
     }
@@ -539,14 +533,17 @@ pub trait CatalogRole {
     /// Returns a stable ID for the role.
     fn id(&self) -> RoleId;
 
-    /// Indicates whether the role has inheritance of privileges.
-    fn is_inherit(&self) -> bool;
-
     /// Returns all role IDs that this role is an immediate a member of, and the grantor of that
     /// membership.
     ///
     /// Key is the role that some role is a member of, value is the grantor role ID.
     fn membership(&self) -> &BTreeMap<RoleId, RoleId>;
+
+    /// Returns the attributes associated with this role.
+    fn attributes(&self) -> &RoleAttributes;
+
+    /// Returns all variables that this role has a default value stored for.
+    fn vars(&self) -> &BTreeMap<String, OwnedVarInput>;
 }
 
 /// A cluster in a [`SessionCatalog`].

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -94,7 +94,7 @@ pub use optimize::OptimizerConfig;
 pub use query::{ExprContext, QueryContext, QueryLifetime};
 pub use scope::Scope;
 pub use side_effecting_func::SideEffectingFunc;
-pub use statement::ddl::PlannedRoleAttributes;
+pub use statement::ddl::{PlannedAlterRoleOption, PlannedRoleVariable};
 pub use statement::{describe, plan, plan_copy_from, StatementContext, StatementDesc};
 
 /// Instructions for executing a SQL query.
@@ -978,7 +978,7 @@ pub struct AlterSystemResetAllPlan {}
 pub struct AlterRolePlan {
     pub id: RoleId,
     pub name: String,
-    pub attributes: PlannedRoleAttributes,
+    pub option: PlannedAlterRoleOption,
 }
 
 #[derive(Debug)]

--- a/test/legacy-upgrade/check-from-v0.71.0-role-var.td
+++ b/test/legacy-upgrade/check-from-v0.71.0-role-var.td
@@ -1,0 +1,11 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> SHOW application_name
+foo_bar_baz

--- a/test/legacy-upgrade/create-in-v0.71.0-role-var.td
+++ b/test/legacy-upgrade/create-in-v0.71.0-role-var.td
@@ -1,0 +1,15 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+
+$ postgres-execute connection=mz_system
+ALTER SYSTEM SET enable_role_vars = true;
+
+> ALTER ROLE materialize SET application_name TO foo_bar_baz;

--- a/test/sqllogictest/vars.slt
+++ b/test/sqllogictest/vars.slt
@@ -436,3 +436,213 @@ SELECT generate_series(1, 10)
 
 statement ok
 RESET max_query_result_size
+
+statement ok
+CREATE ROLE parker;
+
+statement error setting default session variables for a role is not supported
+ALTER ROLE parker SET cluster TO foo;
+
+# Enable Role variable defaults.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_role_vars TO true;
+----
+COMPLETE 0
+
+statement ok
+ALTER ROLE parker SET cluster TO foo;
+
+query T
+SHOW cluster;
+----
+default
+
+simple conn=parker_1,user=parker
+SHOW cluster;
+----
+foo
+COMPLETE 1
+
+simple conn=parker_1,user=parker
+ALTER ROLE parker RESET cluster;
+----
+COMPLETE 0
+
+# Altering the Role defaults does not take effect until you restart your session, this matches
+# Postgres.
+simple conn=parker_1,user=parker
+SHOW cluster;
+----
+foo
+COMPLETE 1
+
+# A new connection gets us a new session.
+simple conn=parker_2,user=parker
+SHOW cluster;
+----
+default
+COMPLETE 1
+
+# Roles can alter their own variables.
+simple conn=parker_2,user=parker
+ALTER ROLE parker SET cluster TO bar;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+bar
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+SET cluster TO session_var;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+session_var
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+RESET cluster;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+BEGIN;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+bar
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+SET cluster TO in_transaction;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+in_transaction
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+COMMIT;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+in_transaction
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+RESET cluster;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+bar
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+BEGIN;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SET LOCAL cluster TO local_transaction;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+local_transaction
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+ROLLBACK;
+----
+COMPLETE 0
+
+simple conn=parker_3,user=parker
+SHOW cluster;
+----
+bar
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+SHOW search_path;
+----
+public
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+ALTER ROLE parker SET search_path TO foo, bar, baz;
+----
+COMPLETE 0
+
+simple conn=parker_4,user=parker
+SHOW search_path;
+----
+foo, bar, baz
+COMPLETE 1
+
+simple conn=parker_3,user=parker
+ALTER ROLE parker SET search_path TO DEFAULT;
+----
+COMPLETE 0
+
+simple conn=parker_5,user=parker
+SHOW search_path;
+----
+public
+COMPLETE 1
+
+statement ok
+CREATE ROLE joe;
+
+# You can set variable values for yourself, but you need CREATEROLE privileges to set them for
+# other roles.
+simple conn=parker_3,user=parker
+ALTER ROLE joe SET cluster TO wont_work;
+----
+db error: ERROR: permission denied for SYSTEM
+
+statement ok
+ALTER ROLE joe SET cluster TO will_work
+
+simple conn=joe,user=joe
+SHOW cluster;
+----
+will_work
+COMPLETE 1
+
+# Should not be able to set a system variable.
+simple conn=parker_3,user=parker
+ALTER ROLE parker SET metrics_retention TO 10;
+----
+db error: ERROR: unrecognized configuration parameter "metrics_retention"
+
+# Should not be able to set a variable that does not exist.
+simple conn=parker_3,user=parker
+ALTER ROLE parker SET i_am_a_fake_variable TO 10;
+----
+db error: ERROR: unrecognized configuration parameter "i_am_a_fake_variable"
+
+# mz_system cannot set a system variable.
+simple conn=mz_system,user=mz_system
+ALTER ROLE parker SET metrics_retention TO 10;
+----
+db error: ERROR: unrecognized configuration parameter "metrics_retention"


### PR DESCRIPTION
_This PR is stacked on top of_ #21853 

This PR implements the planning and sequencing portions of setting default session variables for Roles. Specifically it allows you to do the following:

```
ALTER ROLE parker SET cluster TO adpater_compute;
```

The next time I connect to Materialize with the role `parker` the default value for the session variable `cluster` will be `adapter_compute`. In order to set a session variable default for a role you must have the `CREATEROLE` privilege, or you must be setting the value for yourself. These two behaviors match Postgres.

This feature is behind a LaunchDarkly flag `enable_role_vars`.

### Motivation

* This PR adds a known-desirable feature.

Fixes https://github.com/MaterializeInc/materialize/issues/15651

### Tips for reviewer

_Please skip commits 1 - 3, they are from_ #21853 

4. Planning and sequencing changes to support setting a Role default
5. Sqllogictests and upgrade tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds the ability to set session variable defaults for Roles.
