### PR TITLE
Implement /internal-console redirect route on envd internal http server

### DIFF
--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -537,6 +537,10 @@ pub struct Args {
     #[clap(long, env = "HTTP_HOST_NAME")]
     http_host_name: Option<String>,
 
+    /// URL of the Web Console to redirect to from the /internal-console endpoint on the InternalHTTPServer
+    #[clap(long, env = "INTERNAL_CONSOLE_REDIRECT_URL")]
+    internal_console_redirect_url: Option<String>,
+
     #[clap(long, env = "DEPLOY_GENERATION")]
     deploy_generation: Option<u64>,
 
@@ -943,6 +947,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 bootstrap_role: args.bootstrap_role,
                 deploy_generation: args.deploy_generation,
                 http_host_name: args.http_host_name,
+                internal_console_redirect_url: args.internal_console_redirect_url,
             })
             .await
     })?;

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -27,7 +27,7 @@ use axum::error_handling::HandleErrorLayer;
 use axum::extract::ws::{Message, WebSocket};
 use axum::extract::{DefaultBodyLimit, FromRequestParts, Query, State};
 use axum::middleware::{self, Next};
-use axum::response::{IntoResponse, Response};
+use axum::response::{IntoResponse, Redirect, Response};
 use axum::{routing, Extension, Json, Router};
 use futures::future::{FutureExt, Shared, TryFutureExt};
 use headers::authorization::{Authorization, Basic, Bearer};
@@ -225,6 +225,7 @@ pub struct InternalHttpConfig {
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
     pub promote_leader: oneshot::Sender<()>,
     pub ready_to_promote: oneshot::Receiver<()>,
+    pub internal_console_redirect_url: Option<String>,
 }
 
 pub struct InternalHttpServer {
@@ -350,6 +351,25 @@ pub async fn handle_leader_promote(
     )
 }
 
+/// This route allows User Impersonation by using Teleport to proxy requests to the Internal HTTP Server.
+/// Teleport is configured to handle the user auth and then set an auth cookie stored in the user's browser
+/// that is tied to the host being proxied (the InternalHTTPServer). This /internal-console route accepts
+/// that request and then redirects the user's browser to a Web Console URL, and the Console code can
+/// then make further requests to the InternalHTTPServer using the teleport auth cookie now in the user's browser
+async fn handle_internal_console_redirect(
+    internal_console_redirect_url: &Option<String>,
+) -> Response {
+    if let Some(redirect_url) = internal_console_redirect_url {
+        Redirect::temporary(redirect_url).into_response()
+    } else {
+        (
+            StatusCode::BAD_REQUEST,
+            "Redirect URL is not correctly configured".to_string(),
+        )
+            .into_response()
+    }
+}
+
 impl InternalHttpServer {
     pub fn new(
         InternalHttpConfig {
@@ -358,6 +378,7 @@ impl InternalHttpServer {
             active_connection_count,
             promote_leader,
             ready_to_promote,
+            internal_console_redirect_url,
         }: InternalHttpConfig,
     ) -> InternalHttpServer {
         let metrics = Metrics::register_into(&metrics_registry, "mz_internal_http");
@@ -407,6 +428,12 @@ impl InternalHttpServer {
             .route(
                 "/api/catalog/check",
                 routing::get(catalog::handle_catalog_check),
+            )
+            .route(
+                "/api/internal-console",
+                routing::get(|| async move {
+                    handle_internal_console_redirect(&internal_console_redirect_url).await
+                }),
             )
             .layer(Extension(AuthedUser(SYSTEM_USER.clone())))
             .layer(Extension(adapter_client_rx.shared()))

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -206,6 +206,8 @@ pub struct Config {
     pub deploy_generation: Option<u64>,
     /// Host name or URL for connecting to the HTTP server of this instance.
     pub http_host_name: Option<String>,
+    /// URL of the Web Console to redirect to from the /internal-console endpoint on the InternalHTTPServer
+    pub internal_console_redirect_url: Option<String>,
 
     // === Tracing options. ===
     /// The metrics registry to use.
@@ -336,6 +338,7 @@ impl Listeners {
                 active_connection_count: Arc::clone(&active_connection_count),
                 promote_leader: promote_leader_tx,
                 ready_to_promote: ready_to_promote_rx,
+                internal_console_redirect_url: config.internal_console_redirect_url,
             });
             mz_ore::server::serve(internal_http_conns, internal_http_server)
         });

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -146,6 +146,7 @@ pub struct Config {
     deploy_generation: Option<u64>,
     system_parameter_defaults: BTreeMap<String, String>,
     concurrent_webhook_req_count: Option<usize>,
+    internal_console_redirect_url: Option<String>,
 }
 
 impl Default for Config {
@@ -168,6 +169,7 @@ impl Default for Config {
             deploy_generation: None,
             system_parameter_defaults: BTreeMap::new(),
             concurrent_webhook_req_count: None,
+            internal_console_redirect_url: None,
         }
     }
 }
@@ -265,6 +267,14 @@ impl Config {
 
     pub fn with_concurrent_webhook_req_count(mut self, limit: usize) -> Self {
         self.concurrent_webhook_req_count = Some(limit);
+        self
+    }
+
+    pub fn with_internal_console_redirect_url(
+        mut self,
+        internal_console_redirect_url: Option<String>,
+    ) -> Self {
+        self.internal_console_redirect_url = internal_console_redirect_url;
         self
     }
 }
@@ -463,6 +473,7 @@ impl Listeners {
                     bootstrap_role: config.bootstrap_role,
                     deploy_generation: config.deploy_generation,
                     http_host_name: Some(host_name),
+                    internal_console_redirect_url: config.internal_console_redirect_url,
                 })
                 .await
         })?;

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1023,6 +1023,7 @@ impl<'a> RunnerInner<'a> {
             bootstrap_role: Some("materialize".into()),
             deploy_generation: None,
             http_host_name: Some(host_name),
+            internal_console_redirect_url: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

This is a task from: https://github.com/MaterializeInc/console/issues/370 based on the solution described here: https://github.com/MaterializeInc/console/blob/6253e701f6c17182e6def3917d2ca88f44d46226/doc/design/20230831_user_impersonation.md#solution-proposal

This was a prerequisite before the work to introduce a teleport app for each environmentd internal http server and test the auth+redirect functionality which I plan to tackle next week. I'll also update the environment-controller to pass this new `internal_console_redirect_url` arg to envd.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Wrote a quick test to validate this endpoint. It's a little tricky to test the full end-to-end flow until we have the teleport side of this configured.

I also ended up using a 307 redirect instead of a 302, mostly because `axum` provides a handy helper for it https://docs.rs/axum/latest/axum/response/struct.Redirect.html#method.temporary and they behave identically for all GET requests.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
