### PR TITLE
test-concurrent-connections: Bump p99 to 4.0s

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2424,4 +2424,4 @@ def workflow_test_concurrent_connections(c: Composition) -> None:
         f"min: {min(runtimes):.2f}s, p50: {p[49]:.2f}s, p99: {p[98]:.2f}s, max: {max(runtimes):.2f}s"
     )
     assert p[49] < 1.0, f"p50 is {p[49]:.2f}s, should be less than 1.0s"
-    assert p[98] < 1.5, f"p99 is {p[98]:.2f}s, should be less than 1.5s"
+    assert p[98] < 4.0, f"p99 is {p[98]:.2f}s, should be less than 4.0s"


### PR DESCRIPTION
As reported by ParkMyCar, currently flaky in CI (didn't see it locally): https://buildkite.com/materialize/tests/builds/64214#018ab96a-60e3-444f-9b3c-b62ec9dad929

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
