### PR TITLE
Bump cargo nextest timeout to 180 s

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,5 +1,5 @@
 [profile.default]
-slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "90s", terminate-after = 2 }
 
 [profile.default-miri]
 slow-timeout = { period = "1200s", terminate-after = 2 }


### PR DESCRIPTION
Some tests have become slower, worst offenders:
```
  TIMEOUT [ 120.012s]                           mz-stash tests::test_stash_postgres
     PASS [ 115.726s]              mz-environmentd::auth test_auth_admin
     PASS [ 112.010s]              mz-environmentd::auth test_auth_expiry
     PASS [  77.000s]                         mz-adapter catalog::tests::test_builtin_migration
     PASS [  69.085s]                         mz-adapter catalog::tests::test_smoketest_all_builtins
```
https://buildkite.com/materialize/tests/builds/64229#018ab99a-692c-4118-88ca-9e9a3e62989e

I'd appreciate devs getting the cargo tests faster, for now this is the workaround.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
