### PR TITLE
ensure MetricsFutureExt is Send/Sync

### DIFF
--- a/src/ore/src/metrics.rs
+++ b/src/ore/src/metrics.rs
@@ -517,7 +517,7 @@ pub struct WallTimeFuture<F, Metric> {
     /// [`Instant`] at which the [`Future`] was first polled.
     start: Option<Instant>,
     /// Optional filter that determines if we observe the wall time of this [`Future`].
-    filter: Option<Box<dyn FnMut(Duration) -> bool>>,
+    filter: Option<Box<dyn FnMut(Duration) -> bool + Send + Sync>>,
 }
 
 impl<F: Debug, M: Debug> fmt::Debug for WallTimeFuture<F, M> {
@@ -573,7 +573,10 @@ impl<F, M> WallTimeFuture<F, M> {
     ///
     /// This can be particularly useful if you have a high volume `Future` and you only want to
     /// record ones that take a long time to complete.
-    pub fn with_filter(mut self, filter: impl FnMut(Duration) -> bool + 'static) -> Self {
+    pub fn with_filter(
+        mut self,
+        filter: impl FnMut(Duration) -> bool + Send + Sync + 'static,
+    ) -> Self {
         self.filter = Some(Box::new(filter));
         self
     }
@@ -620,7 +623,7 @@ pub struct ExecTimeFuture<F, Metric> {
     /// Total [`Duration`] for which this [`Future`] has been executing.
     running_duration: Duration,
     /// Optional filter that determines if we observe the execution time of this [`Future`].
-    filter: Option<Box<dyn FnMut(Duration) -> bool>>,
+    filter: Option<Box<dyn FnMut(Duration) -> bool + Send + Sync>>,
 }
 
 impl<F: Debug, M: Debug> fmt::Debug for ExecTimeFuture<F, M> {
@@ -673,7 +676,10 @@ impl<F> ExecTimeFuture<F, UnspecifiedMetric> {
 
 impl<F, M> ExecTimeFuture<F, M> {
     /// Specifies a filter which much return `true` for the execution time to be recorded.
-    pub fn with_filter(mut self, filter: impl FnMut(Duration) -> bool + 'static) -> Self {
+    pub fn with_filter(
+        mut self,
+        filter: impl FnMut(Duration) -> bool + Send + Sync + 'static,
+    ) -> Self {
         self.filter = Some(Box::new(filter));
         self
     }


### PR DESCRIPTION
These are sometimes not usable in tokio tasks!

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
