### PR TITLE
Internal environmentd http interface accepts a user header

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -42,7 +42,10 @@ use mz_ore::cast::u64_to_usize;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::server::{ConnectionHandler, Server};
 use mz_ore::str::StrExt;
-use mz_sql::session::user::{ExternalUserMetadata, User, HTTP_DEFAULT_USER, SYSTEM_USER};
+use mz_sql::session::user::{
+    ExternalUserMetadata, User, HTTP_DEFAULT_USER, SUPPORT_USER, SUPPORT_USER_NAME, SYSTEM_USER,
+    SYSTEM_USER_NAME,
+};
 use mz_sql::session::vars::{ConnectionCounter, DropConnection, VarInput};
 use openssl::ssl::{Ssl, SslContext};
 use serde::{Deserialize, Serialize};
@@ -435,7 +438,7 @@ impl InternalHttpServer {
                     handle_internal_console_redirect(&internal_console_redirect_url).await
                 }),
             )
-            .layer(Extension(AuthedUser(SYSTEM_USER.clone())))
+            .layer(middleware::from_fn(internal_http_auth))
             .layer(Extension(adapter_client_rx.shared()))
             .layer(Extension(active_connection_count));
 
@@ -451,6 +454,25 @@ impl InternalHttpServer {
 
         InternalHttpServer { router }
     }
+}
+
+async fn internal_http_auth<B>(mut req: Request<B>, next: Next<B>) -> impl IntoResponse {
+    let user_name = req
+        .headers()
+        .get("x-materialize-user")
+        .map(|h| h.to_str())
+        .unwrap_or_else(|| Ok(SYSTEM_USER_NAME));
+    let user = match user_name {
+        Ok(SUPPORT_USER_NAME) => AuthedUser(SUPPORT_USER.clone()),
+        Ok(SYSTEM_USER_NAME) => AuthedUser(SYSTEM_USER.clone()),
+        _ => {
+            return Err(AuthError::MismatchedUser(format!(
+            "user specified in x-materialize-user must be {SUPPORT_USER_NAME} or {SYSTEM_USER_NAME}"
+        )));
+        }
+    };
+    req.extensions_mut().insert(user);
+    Ok(next.run(req).await)
 }
 
 #[async_trait]
@@ -592,7 +614,7 @@ enum AuthError {
     #[error("missing authorization header")]
     MissingHttpAuthentication,
     #[error("{0}")]
-    MismatchedUser(&'static str),
+    MismatchedUser(String),
     #[error("unexpected credentials")]
     UnexpectedCredentials,
 }
@@ -639,7 +661,7 @@ async fn http_auth<B>(
                 if let Some(user) = cert_user {
                     if basic.username() != user {
                         return Err(AuthError::MismatchedUser(
-                        "user in client certificate did not match user specified in authorization header",
+                        "user in client certificate did not match user specified in authorization header".to_string(),
                     ));
                     }
                 }


### PR DESCRIPTION
Currently the internal http interface always authorizes users as mz_system. This PR adds support for a custom header `x-materialize-user` that can be set to either mz_system or mz_support. If not specified, it falls back to mz_system.

This will be set by teleport so impersonated sessions have read only access the mz_support user.

### Motivation

  * This PR adds a known-desirable feature.
https://github.com/MaterializeInc/console/issues/846


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/console/blob/6253e701f6c17182e6def3917d2ca88f44d46226/doc/design/20230831_user_impersonation.md)
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - No user facing impact