### PR TITLE
platform checks: Test avro deserialization failures for UPSERT sources

### DIFF
--- a/doc/user/content/releases/v0.69.md
+++ b/doc/user/content/releases/v0.69.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.69"
 date: 2023-09-20
 released: true
-patch: 2
+patch: 5
 ---
 
 ## v0.69.0

--- a/misc/python/materialize/checks/error.py
+++ b/misc/python/materialize/checks/error.py
@@ -184,3 +184,201 @@ class DecodeError(Check):
                 """
             )
         )
+
+
+class DecodeErrorUpsertValue(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $ kafka-create-topic topic=decode-error-upsert-value
+
+                $ set schema={
+                  "type" : "record",
+                  "name" : "test",
+                  "fields" : [
+                    {"name":"f1", "type":"int"}
+                    ]
+                  }
+
+                $ kafka-ingest format=avro topic=decode-error-upsert-value key-format=bytes key-terminator=: schema=${schema}
+                key0: {"f1": 1}
+                key1: {"f1": 2}
+                key2: {"f1": 3}
+
+                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
+
+                > CREATE SOURCE decode_error_upsert_value
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-upsert-value-${testdrive.seed}')
+                  KEY FORMAT TEXT
+                  VALUE FORMAT AVRO USING SCHEMA '${schema}'
+                  ENVELOPE UPSERT
+
+                $ kafka-ingest topic=decode-error-upsert-value key-format=bytes key-terminator=: format=bytes
+                key1: garbage
+
+                ! SELECT * FROM decode_error_upsert_value
+                contains: avro deserialization error
+            """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(
+                dedent(
+                    """
+                    $ kafka-ingest topic=decode-error-upsert-value key-format=bytes key-terminator=: format=bytes
+                    key2: garbage2
+
+                    ! SELECT * FROM decode_error_upsert_value
+                    contains: avro deserialization error
+                    """
+                )
+            ),
+            Testdrive(
+                dedent(
+                    """
+                    # Ingest valid avro, but with an incompatible schema
+                    $ set schema-string={
+                       "type" : "record",
+                       "name" : "test",
+                       "fields" : [
+                        {"name":"f1", "type":"string"}
+                       ]
+                      }
+
+                    $ kafka-ingest topic=decode-error-upsert-value key-format=bytes key-terminator=: format=avro schema=${schema-string} confluent-wire-format=false
+                    key3: {"f1": "garbage3"}
+
+                    ! SELECT * FROM decode_error_upsert_value
+                    contains: avro deserialization error
+                    """,
+                )
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                # Retract all the garbage and confirm the source is now operational
+
+                $ kafka-ingest topic=decode-error-upsert-value key-format=bytes key-terminator=: format=bytes
+                key1:
+                key2:
+                key3:
+
+                > SELECT f1 FROM decode_error_upsert_value
+                1
+                """
+            )
+        )
+
+
+class DecodeErrorUpsertKey(Check):
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                $ kafka-create-topic topic=decode-error-upsert-key
+
+                $ set key-schema={
+                  "type" : "record",
+                  "name" : "test",
+                  "fields" : [
+                    {"name":"f1", "type":"int"}
+                    ]
+                  }
+
+                $ kafka-ingest topic=decode-error-upsert-key key-format=avro format=bytes key-schema=${key-schema}
+                {"f1": 1} value1
+                {"f1": 2} value2
+
+                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
+
+                > CREATE SOURCE decode_error_upsert_key
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-upsert-key-${testdrive.seed}')
+                  KEY FORMAT AVRO USING SCHEMA '${key-schema}'
+                  VALUE FORMAT BYTES
+                  ENVELOPE UPSERT
+
+                $ kafka-ingest topic=decode-error-upsert-key key-format=bytes key-terminator=: format=bytes
+                garbage1: value3
+
+                ! SELECT * FROM decode_error_upsert_key
+                contains: avro deserialization error
+            """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(
+                dedent(
+                    """
+                    # Retract existing garbage
+                    $ kafka-ingest topic=decode-error-upsert-key key-format=bytes format=bytes key-terminator=:
+                    garbage1:
+
+                    # And introduce a new one -- valid avro, but with an incompatible schema
+                    $ set key-schema-string={
+                       "type" : "record",
+                       "name" : "test",
+                       "fields" : [
+                        {"name":"f1", "type":"string"}
+                       ]
+                      }
+
+                    $ kafka-ingest topic=decode-error-upsert-key key-format=avro format=bytes key-schema=${key-schema-string} confluent-wire-format=false
+                    {"f1": "garbage2"} value4
+
+                    ! SELECT * FROM decode_error_upsert_key
+                    contains: avro deserialization error
+                    """
+                )
+            ),
+            Testdrive(
+                dedent(
+                    """
+                    # Retract existing garbage and introduce a new one
+                    $ kafka-ingest topic=decode-error-upsert-key key-format=bytes format=bytes key-terminator=:
+                    garbage3: value4
+
+                    $ set key-schema-string={
+                       "type" : "record",
+                       "name" : "test",
+                       "fields" : [
+                        {"name":"f1", "type":"string"}
+                       ]
+                      }
+
+                    $ kafka-ingest topic=decode-error-upsert-key key-format=avro format=bytes key-schema=${key-schema-string} confluent-wire-format=false
+                    {"f1": "garbage2"}
+
+                    ! SELECT * FROM decode_error_upsert_key
+                    contains: avro deserialization error
+                    """,
+                )
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                # Retract any remaining garbage
+                $ kafka-ingest topic=decode-error-upsert-key key-format=bytes format=bytes key-terminator=:
+                garbage3:
+
+                # Source should return to operational status
+                > SELECT f1 FROM decode_error_upsert_key
+                1
+                2
+                """
+            )
+        )


### PR DESCRIPTION
The following combinations are covered:
- garbage in both the key and the value of the kafka record
- non-avro garbage as well as valid avro that does not match schema
- introductions and retractions of garbage

### Motivation

This covers a hole in the testing that was exposed recently.
