### PR TITLE
output consistency: add new string functions

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -258,6 +258,22 @@ TEXT_OPERATION_TYPES.append(
 
 TEXT_OPERATION_TYPES.append(
     DbFunction(
+        "regexp_replace",
+        [TextOperationParam(), REGEX_PARAM, TextOperationParam()],
+        ArrayReturnTypeSpec(DataTypeCategory.TEXT),
+    )
+)
+
+TEXT_OPERATION_TYPES.append(
+    DbFunction(
+        "regexp_split_to_array",
+        [TextOperationParam(), REGEX_PARAM, REGEX_FLAG_PARAM],
+        ArrayReturnTypeSpec(DataTypeCategory.ARRAY),
+    )
+)
+
+TEXT_OPERATION_TYPES.append(
+    DbFunction(
         "repeat",
         [
             TextOperationParam(),


### PR DESCRIPTION
Adding two new functions introduced with [release 0.69.](https://materialize.com/docs/releases/v0.69/)
(The third function, `regexp_split_to_table`, produces an output of a type that is currently not supported. Therefore, I skip it here.)

Nightly build: https://buildkite.com/materialize/nightlies/builds/4291