### PR TITLE
dbt-materialize: Use managed clusters

### DIFF
--- a/misc/dbt-materialize/tests/adapter/test_clusters.py
+++ b/misc/dbt-materialize/tests/adapter/test_clusters.py
@@ -100,7 +100,7 @@ class TestModelCluster:
         results = run_dbt(["seed"])
         assert len(results) == 1
 
-        project.run_sql("CREATE CLUSTER not_default REPLICAS (r1 (SIZE '1'))")
+        project.run_sql("CREATE CLUSTER not_default SIZE = '1'")
         run_dbt(["run", "--exclude", "invalid_cluster", "default_cluster"])
 
         check_relations_equal(project.adapter, ["actual_clusters", "expected_clusters"])
@@ -118,7 +118,7 @@ class TestModelCluster:
         run_dbt(["run", "--models", "override_cluster"], expect_pass=True)
         run_dbt(["run", "--models", "default_cluster"], expect_pass=False)
 
-        project.run_sql("CREATE CLUSTER default REPLICAS (r1 (SIZE '1'))")
+        project.run_sql("CREATE CLUSTER default SIZE = '1'")
 
 
 class TestProjectConfigCluster:

--- a/misc/dbt-materialize/tests/adapter/test_data_tests.py
+++ b/misc/dbt-materialize/tests/adapter/test_data_tests.py
@@ -76,7 +76,7 @@ class TestDataTestCluster:
         }
 
     def test_store_failures_cluster(self, project):
-        project.run_sql("CREATE CLUSTER not_default_test REPLICAS (r1 (SIZE '1'))")
+        project.run_sql("CREATE CLUSTER not_default_test SIZE = '1'")
 
         # run models
         results = run_dbt(["run"])


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Fixes #21935

Use managed clusters for the infrastructure for testing

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
