### PR TITLE
storage: appropriately return when suspending + restarting sinks

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -711,6 +711,9 @@ impl<'w, A: Allocate> Worker<'w, A> {
                             sink_description,
                         ));
                     }
+
+                    // Continue with other commands.
+                    return;
                 }
 
                 if !self


### PR DESCRIPTION
We did not properly exit the control flow for `handle_internal_storage_command` when processing `SuspendAndRestart` commands for sinks--they always continued to the subsequent block, which would log an error (downgraded to a warning in #21938) that we had dropped something that was neither source nor sink.

To fix this, we just need to exit the control flow after the `CreateSinkDataflow` broadcast.

### Motivation

This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
