### PR TITLE
[persist] Wrap all postgres calls in a tokio task

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -22,7 +22,7 @@ use differential_dataflow::lattice::Lattice;
 use mz_ore::metrics::MetricsRegistry;
 use mz_persist::cfg::{BlobConfig, ConsensusConfig};
 use mz_persist::location::{
-    Blob, Consensus, ExternalError, VersionedData, BLOB_GET_LIVENESS_KEY,
+    Blob, Consensus, ExternalError, Tasked, VersionedData, BLOB_GET_LIVENESS_KEY,
     CONSENSUS_HEAD_LIVENESS_KEY,
 };
 use mz_persist_types::{Codec, Codec64};
@@ -159,6 +159,7 @@ impl PersistClientCache {
                     .await;
                 let consensus =
                     Arc::new(MetricsConsensus::new(consensus, Arc::clone(&self.metrics)));
+                let consensus = Arc::new(Tasked(consensus));
                 let task = consensus_rtt_latency_task(
                     Arc::clone(&consensus),
                     Arc::clone(&self.metrics),
@@ -261,7 +262,7 @@ async fn blob_rtt_latency_task(
 /// start.
 #[allow(clippy::unused_async)]
 async fn consensus_rtt_latency_task(
-    consensus: Arc<MetricsConsensus>,
+    consensus: Arc<Tasked<MetricsConsensus>>,
     metrics: Arc<Metrics>,
     measurement_interval: Duration,
 ) -> JoinHandle<()> {

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -638,7 +638,7 @@ mod tests {
     ///
     /// NOTE: This test is weird: if everything is good it will pass. If we
     /// break the assumption that we test this will time out and we will notice.
-    #[mz_ore::test(tokio::test)]
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_implicit_initial_as_of() {
         let (persist_clients, location) = new_test_client_cache_and_location();
@@ -707,7 +707,7 @@ mod tests {
     ///
     /// NOTE: This test is weird: if everything is good it will pass. If we
     /// break the assumption that we test this will time out and we will notice.
-    #[mz_ore::test(tokio::test)]
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_explicit_initial_as_of() {
         let (persist_clients, location) = new_test_client_cache_and_location();

--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -10,6 +10,7 @@
 //! Abstractions over files, cloud storage, etc used in persistence.
 
 use std::fmt;
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::anyhow;
@@ -17,6 +18,7 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::u64_to_usize;
+use mz_ore::task::JoinHandleExt;
 use mz_proto::RustType;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -320,6 +322,18 @@ pub enum CaSResult {
     ExpectationMismatch,
 }
 
+/// Wraps all calls to a backing store in a new tokio task. This adds extra overhead,
+/// but insulates the system from callers who fail to drive futures promptly to completion,
+/// which can cause timeouts or resource exhaustion in a store.
+#[derive(Debug)]
+pub struct Tasked<A>(pub Arc<A>);
+
+impl<A> Tasked<A> {
+    fn clone_backing(&self) -> Arc<A> {
+        Arc::clone(&self.0)
+    }
+}
+
 /// An abstraction for [VersionedData] held in a location in persistent storage
 /// where the data are conditionally updated by version.
 ///
@@ -370,6 +384,60 @@ pub trait Consensus: std::fmt::Debug {
     /// `seqno` is greater than the current sequence number, or if there is no
     /// data at this key.
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError>;
+}
+
+#[async_trait]
+impl<A: Consensus + Sync + Send + 'static> Consensus for Tasked<A> {
+    async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
+        let backing = self.clone_backing();
+        let key = key.to_owned();
+        mz_ore::task::spawn(
+            || "persist::task::head",
+            async move { backing.head(&key).await },
+        )
+        .wait_and_assert_finished()
+        .await
+    }
+
+    async fn compare_and_set(
+        &self,
+        key: &str,
+        expected: Option<SeqNo>,
+        new: VersionedData,
+    ) -> Result<CaSResult, ExternalError> {
+        let backing = self.clone_backing();
+        let key = key.to_owned();
+        mz_ore::task::spawn(|| "persist::task::cas", async move {
+            backing.compare_and_set(&key, expected, new).await
+        })
+        .wait_and_assert_finished()
+        .await
+    }
+
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
+        let backing = self.clone_backing();
+        let key = key.to_owned();
+        mz_ore::task::spawn(|| "persist::task::scan", async move {
+            backing.scan(&key, from, limit).await
+        })
+        .wait_and_assert_finished()
+        .await
+    }
+
+    async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {
+        let backing = self.clone_backing();
+        let key = key.to_owned();
+        mz_ore::task::spawn(|| "persist::task::truncate", async move {
+            backing.truncate(&key, seqno).await
+        })
+        .wait_and_assert_finished()
+        .await
+    }
 }
 
 /// Metadata about a particular blob stored by persist


### PR DESCRIPTION
### Motivation

As part of dealing with https://github.com/MaterializeInc/cloud/issues/7602, we discovered:
- many futures (presumably on timely threads) were not being promptly polled;
- some of those futures were holding connections from the pool we use to speak to CRDB;
- these connections appeared to be starving out other, more time-sensitive connnections to our backing store.

We now run every CRDB consensus I/O through a tokio task. This adds some overhead, but it appears to be small, and it pays for itself by making these calls shorter-lived and more reliable.

### Tips for reviewer

I'll get nightlies running on this. Let me know if you think it needs any other validation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
