### PR TITLE
Refactorings in preparation for window aggregations

### DIFF
--- a/src/sql/src/plan/explain/text.rs
+++ b/src/sql/src/plan/explain/text.rs
@@ -382,11 +382,11 @@ impl fmt::Display for HirScalarExpr {
                 // This is close to the SQL syntax, but we are adding some [] to make it easier to
                 // read.
                 write!(f, " over (")?;
-                if !expr.partition.is_empty() {
+                if !expr.partition_by.is_empty() {
                     write!(
                         f,
                         "partition by [{}] ",
-                        separated(", ", expr.partition.iter())
+                        separated(", ", expr.partition_by.iter())
                     )?;
                 }
                 write!(f, "order by [{}]", separated(", ", order_by.iter()))?;

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -231,7 +231,7 @@ pub enum HirScalarExpr {
 /// order.
 pub struct WindowExpr {
     pub func: WindowExprType,
-    pub partition: Vec<HirScalarExpr>,
+    pub partition_by: Vec<HirScalarExpr>,
     // ORDER BY is represented in a complicated way: `plan_function_order_by` gave us two things:
     // - the `ColumnOrder`s we have put in `func` above,
     // - the `HirScalarExpr`s we have put in the following `order_by` field.
@@ -245,7 +245,7 @@ impl WindowExpr {
     {
         #[allow(deprecated)]
         self.func.visit_expressions(f)?;
-        for expr in self.partition.iter() {
+        for expr in self.partition_by.iter() {
             f(expr)?;
         }
         for expr in self.order_by.iter() {
@@ -260,7 +260,7 @@ impl WindowExpr {
     {
         #[allow(deprecated)]
         self.func.visit_expressions_mut(f)?;
-        for expr in self.partition.iter_mut() {
+        for expr in self.partition_by.iter_mut() {
             f(expr)?;
         }
         for expr in self.order_by.iter_mut() {
@@ -276,7 +276,7 @@ impl VisitChildren<HirScalarExpr> for WindowExpr {
         F: FnMut(&HirScalarExpr),
     {
         self.func.visit_children(&mut f);
-        for expr in self.partition.iter() {
+        for expr in self.partition_by.iter() {
             f(expr);
         }
         for expr in self.order_by.iter() {
@@ -289,7 +289,7 @@ impl VisitChildren<HirScalarExpr> for WindowExpr {
         F: FnMut(&mut HirScalarExpr),
     {
         self.func.visit_mut_children(&mut f);
-        for expr in self.partition.iter_mut() {
+        for expr in self.partition_by.iter_mut() {
             f(expr);
         }
         for expr in self.order_by.iter_mut() {
@@ -303,7 +303,7 @@ impl VisitChildren<HirScalarExpr> for WindowExpr {
         E: From<RecursionLimitError>,
     {
         self.func.try_visit_children(&mut f)?;
-        for expr in self.partition.iter() {
+        for expr in self.partition_by.iter() {
             f(expr)?;
         }
         for expr in self.order_by.iter() {
@@ -318,7 +318,7 @@ impl VisitChildren<HirScalarExpr> for WindowExpr {
         E: From<RecursionLimitError>,
     {
         self.func.try_visit_mut_children(&mut f)?;
-        for expr in self.partition.iter_mut() {
+        for expr in self.partition_by.iter_mut() {
             f(expr)?;
         }
         for expr in self.order_by.iter_mut() {

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -40,7 +40,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter::repeat;
 
 use itertools::Itertools;
-use mz_expr::{AccessStrategy, AggregateFunc};
+use mz_expr::{AccessStrategy, AggregateFunc, MirScalarExpr};
 use mz_ore::collections::CollectionExt;
 use mz_ore::stack::maybe_grow;
 use mz_repr::*;
@@ -966,7 +966,7 @@ impl HirScalarExpr {
                     match expr.func {
                         WindowExprType::Scalar(scalar_window_expr) => {
                             let mir_aggr_func = scalar_window_expr.into_expr();
-                            Self::scalar_window_func_applied_to(
+                            Self::window_func_applied_to(
                                 id_gen,
                                 col_map,
                                 cte_map,
@@ -975,12 +975,55 @@ impl HirScalarExpr {
                                 partition_by,
                                 order_by,
                                 mir_aggr_func,
+                                |_id_gen,
+                                 _col_map,
+                                 _cte_map,
+                                 _get_inner,
+                                 _subquery_map,
+                                 order_by_mir,
+                                 original_row_record,
+                                 original_row_record_type| {
+                                    let agg_input = mz_expr::MirScalarExpr::CallVariadic {
+                                        func: mz_expr::VariadicFunc::ListCreate {
+                                            elem_type: original_row_record_type.clone(),
+                                        },
+                                        exprs: vec![original_row_record],
+                                    };
+                                    let mut agg_input = vec![agg_input];
+                                    agg_input.extend(order_by_mir.clone());
+                                    let agg_input = mz_expr::MirScalarExpr::CallVariadic {
+                                        func: mz_expr::VariadicFunc::RecordCreate {
+                                            field_names: (0..1)
+                                                .map(|_| ColumnName::from("?column?"))
+                                                .collect_vec(),
+                                        },
+                                        exprs: agg_input,
+                                    };
+                                    let list_type = ScalarType::List {
+                                        element_type: Box::new(original_row_record_type),
+                                        custom_id: None,
+                                    };
+                                    let agg_input_type = ScalarType::Record {
+                                        fields: std::iter::once(&list_type)
+                                            .map(|t| {
+                                                (
+                                                    ColumnName::from("?column?"),
+                                                    t.clone().nullable(false),
+                                                )
+                                            })
+                                            .collect_vec(),
+                                        custom_id: None,
+                                    }
+                                    .nullable(false);
+
+                                    Ok((agg_input, agg_input_type))
+                                },
                             )?
                         }
                         WindowExprType::Value(value_window_expr) => {
-                            let hir_encoded_args = value_window_expr.args.clone();
-                            let mir_aggr_func = value_window_expr.into_expr();
-                            Self::value_window_func_applied_to(
+                            let (hir_encoded_args, mir_aggr_func) = value_window_expr.into_expr();
+
+                            Self::window_func_applied_to(
                                 id_gen,
                                 col_map,
                                 cte_map,
@@ -989,7 +1032,78 @@ impl HirScalarExpr {
                                 partition_by,
                                 order_by,
                                 mir_aggr_func,
-                                hir_encoded_args,
+                                |id_gen,
+                                 col_map,
+                                 cte_map,
+                                 get_inner,
+                                 subquery_map,
+                                 order_by_mir,
+                                 original_row_record,
+                                 original_row_record_type| {
+                                    // Creates [((OriginalRow, EncodedArgs), OrderByExprs...)]
+
+                                    // Compute the encoded args for all rows
+                                    let mir_encoded_args = hir_encoded_args.applied_to(
+                                        id_gen,
+                                        col_map,
+                                        cte_map,
+                                        get_inner,
+                                        subquery_map,
+                                    )?;
+                                    let mir_encoded_args_type = mir_encoded_args
+                                        .typ(&get_inner.typ().column_types)
+                                        .scalar_type;
+
+                                    // Build a new record with the original row in a record in a list + the encoded args in a record
+                                    let fn_input_record_fields =
+                                        [original_row_record_type, mir_encoded_args_type]
+                                            .iter()
+                                            .map(|t| {
+                                                (
+                                                    ColumnName::from("?column?"),
+                                                    t.clone().nullable(false),
+                                                )
+                                            })
+                                            .collect_vec();
+                                    let fn_input_record = MirScalarExpr::CallVariadic {
+                                        func: mz_expr::VariadicFunc::RecordCreate {
+                                            field_names: fn_input_record_fields
+                                                .iter()
+                                                .map(|(n, _)| n.clone())
+                                                .collect_vec(),
+                                        },
+                                        exprs: vec![original_row_record, mir_encoded_args],
+                                    };
+                                    let fn_input_record_type = ScalarType::Record {
+                                        fields: fn_input_record_fields,
+                                        custom_id: None,
+                                    }
+                                    .nullable(false);
+
+                                    // Build a new record with the record above + the ORDER BY exprs
+                                    // This follows the standard encoding of ORDER BY exprs used by aggregate functions
+                                    let mut agg_input = vec![fn_input_record];
+                                    agg_input.extend(order_by_mir.clone());
+                                    let agg_input = MirScalarExpr::CallVariadic {
+                                        func: mz_expr::VariadicFunc::RecordCreate {
+                                            field_names: (0..2)
+                                                .map(|_| ColumnName::from("?column?"))
+                                                .collect_vec(),
+                                        },
+                                        exprs: agg_input,
+                                    };
+
+                                    let agg_input_type = ScalarType::Record {
+                                        fields: vec![(
+                                            ColumnName::from("?column?"),
+                                            fn_input_record_type.nullable(false),
+                                        )],
+                                        custom_id: None,
+                                    }
+                                    .nullable(false);
+
+                                    Ok((agg_input, agg_input_type))
+                                },
                             )?
                         }
                     }
@@ -998,7 +1112,7 @@ impl HirScalarExpr {
         })
     }
 
-    fn scalar_window_func_applied_to(
+    fn window_func_applied_to<F>(
         id_gen: &mut mz_ore::id_gen::IdGen,
         col_map: &ColumnMap,
         cte_map: &mut CteMap,
@@ -1007,159 +1121,24 @@ impl HirScalarExpr {
         partition_by: Vec<HirScalarExpr>,
         order_by: Vec<HirScalarExpr>,
         mir_aggr_func: AggregateFunc,
-    ) -> Result<mz_expr::MirScalarExpr, PlanError> {
+        lower_args: F,
+    ) -> Result<MirScalarExpr, PlanError>
+    where
+        F: FnOnce(
+            &mut mz_ore::id_gen::IdGen,
+            &ColumnMap,
+            &mut CteMap,
+            &mut mz_expr::MirRelationExpr,
+            &Option<&BTreeMap<HirScalarExpr, usize>>,
+            Vec<MirScalarExpr>,
+            MirScalarExpr,
+            ScalarType,
+        ) -> Result<(MirScalarExpr, ColumnType), PlanError>,
+    {
         *inner = inner
             .take_dangerous()
             .let_in_fallible(id_gen, |id_gen, mut get_inner| {
-                let order_by = order_by
-                    .into_iter()
-                    .map(|o| o.applied_to(id_gen, col_map, cte_map, &mut get_inner, subquery_map))
-                    .collect::<Result<Vec<_>, _>>()?;
-
-                // Record input arity here so that any group_keys that need to mutate get_inner
-                // don't add those columns to the aggregate input.
-                let input_arity = get_inner.typ().arity();
-                // The reduction that computes the window function must be keyed on the columns
-                // from the outer context, plus the expressions in the partition key. The current
-                // subquery will be 'executed' for every distinct row from the outer context so
-                // by putting the outer columns in the grouping key we isolate each re-execution.
-                let mut group_key = col_map
-                    .inner
-                    .iter()
-                    .map(|(_, outer_col)| *outer_col)
-                    .sorted()
-                    .collect_vec();
-                for p in partition_by {
-                    let key =
-                        p.applied_to(id_gen, col_map, cte_map, &mut get_inner, subquery_map)?;
-                    if let mz_expr::MirScalarExpr::Column(c) = key {
-                        group_key.push(c);
-                    } else {
-                        get_inner = get_inner.map_one(key);
-                        group_key.push(get_inner.arity() - 1);
-                    }
-                }
-
-                get_inner.let_in_fallible(id_gen, |_id_gen, get_inner| {
-                    let input_type = get_inner.typ();
-
-                    // Original columns of the relation
-                    let fields = input_type
-                        .column_types
-                        .iter()
-                        .take(input_arity)
-                        .map(|t| (ColumnName::from("?column?"), t.clone()))
-                        .collect_vec();
-
-                    // Original row made into a record
-                    let original_row_record = mz_expr::MirScalarExpr::CallVariadic {
-                        func: mz_expr::VariadicFunc::RecordCreate {
-                            field_names: fields.iter().map(|(name, _)| name.clone()).collect_vec(),
-                        },
-                        exprs: (0..input_arity)
-                            .map(|column| mz_expr::MirScalarExpr::Column(column))
-                            .collect_vec(),
-                    };
-                    let original_row_record_type = ScalarType::Record {
-                        fields,
-                        custom_id: None,
-                    };
-
-                    let agg_input = mz_expr::MirScalarExpr::CallVariadic {
-                        func: mz_expr::VariadicFunc::ListCreate {
-                            elem_type: original_row_record_type.clone(),
-                        },
-                        exprs: vec![original_row_record],
-                    };
-                    let mut agg_input = vec![agg_input];
-                    agg_input.extend(order_by.clone());
-                    let agg_input = mz_expr::MirScalarExpr::CallVariadic {
-                        func: mz_expr::VariadicFunc::RecordCreate {
-                            field_names: (0..1).map(|_| ColumnName::from("?column?")).collect_vec(),
-                        },
-                        exprs: agg_input,
-                    };
-                    let list_type = ScalarType::List {
-                        element_type: Box::new(original_row_record_type),
-                        custom_id: None,
-                    };
-                    let agg_input_type = ScalarType::Record {
-                        fields: std::iter::once(&list_type)
-                            .map(|t| (ColumnName::from("?column?"), t.clone().nullable(false)))
-                            .collect_vec(),
-                        custom_id: None,
-                    }
-                    .nullable(false);
-
-                    let aggregate = mz_expr::AggregateExpr {
-                        func: mir_aggr_func,
-                        expr: agg_input,
-                        distinct: false,
-                    };
-
-                    let mut reduce = get_inner
-                        .reduce(group_key.clone(), vec![aggregate.clone()], None)
-                        .flat_map(
-                            mz_expr::TableFunc::UnnestList {
-                                el_typ: aggregate
-                                    .func
-                                    .output_type(agg_input_type)
-                                    .scalar_type
-                                    .unwrap_list_element_type()
-                                    .clone(),
-                            },
-                            vec![mz_expr::MirScalarExpr::Column(group_key.len())],
-                        );
-                    let record_col = reduce.arity() - 1;
-
-                    // Unpack the record output by the window function
-                    for c in 0..input_arity {
-                        reduce =
-                            reduce
-                                .take_dangerous()
-                                .map_one(mz_expr::MirScalarExpr::CallUnary {
-                                    func: mz_expr::UnaryFunc::RecordGet(mz_expr::func::RecordGet(
-                                        c,
-                                    )),
-                                    expr: Box::new(mz_expr::MirScalarExpr::CallUnary {
-                                        func: mz_expr::UnaryFunc::RecordGet(
-                                            mz_expr::func::RecordGet(1),
-                                        ),
-                                        expr: Box::new(mz_expr::MirScalarExpr::Column(record_col)),
-                                    }),
-                                });
-                    }
-
-                    // Append the column with the result of the window function.
-                    reduce = reduce
-                        .take_dangerous()
-                        .map_one(mz_expr::MirScalarExpr::CallUnary {
-                            func: mz_expr::UnaryFunc::RecordGet(mz_expr::func::RecordGet(0)),
-                            expr: Box::new(mz_expr::MirScalarExpr::Column(record_col)),
-                        });
-
-                    let agg_col = record_col + 1 + input_arity;
-                    Ok::<_, PlanError>(reduce.project((record_col + 1..agg_col + 1).collect_vec()))
-                })
-            })?;
-        Ok(mz_expr::MirScalarExpr::Column(inner.arity() - 1))
-    }
-
-    fn value_window_func_applied_to(
-        id_gen: &mut mz_ore::id_gen::IdGen,
-        col_map: &ColumnMap,
-        cte_map: &mut CteMap,
-        inner: &mut mz_expr::MirRelationExpr,
-        subquery_map: &Option<&BTreeMap<HirScalarExpr, usize>>,
-        partition_by: Vec<HirScalarExpr>,
-        order_by: Vec<HirScalarExpr>,
-        mir_aggr_func: AggregateFunc,
-        hir_encoded_args: Box<HirScalarExpr>,
-    ) -> Result<mz_expr::MirScalarExpr, PlanError> {
-        *inner = inner
-            .take_dangerous()
-            .let_in_fallible(id_gen, |id_gen, mut get_inner| {
-                let order_by = order_by
+                let order_by_mir = order_by
                     .into_iter()
                     .map(|o| o.applied_to(id_gen, col_map, cte_map, &mut get_inner, subquery_map))
                     .collect::<Result<Vec<_>, _>>()?;
@@ -1213,57 +1192,16 @@ impl HirScalarExpr {
                         custom_id: None,
                     };
 
-                    // Compute the encoded args for all rows
-                    let mir_encoded_args = hir_encoded_args.applied_to(
+                    let (agg_input, agg_input_type) = lower_args(
                         id_gen,
                         col_map,
                         cte_map,
                         &mut get_inner,
                         subquery_map,
+                        order_by_mir,
+                        original_row_record,
+                        original_row_record_type,
                     )?;
-                    let mir_encoded_args_type = mir_encoded_args
-                        .typ(&get_inner.typ().column_types)
-                        .scalar_type;
-
-                    // Build a new record with the original row in a record in a list + the encoded args in a record
-                    let fn_input_record_fields = [original_row_record_type, mir_encoded_args_type]
-                        .iter()
-                        .map(|t| (ColumnName::from("?column?"), t.clone().nullable(false)))
-                        .collect_vec();
-                    let fn_input_record = mz_expr::MirScalarExpr::CallVariadic {
-                        func: mz_expr::VariadicFunc::RecordCreate {
-                            field_names: fn_input_record_fields
-                                .iter()
-                                .map(|(n, _)| n.clone())
-                                .collect_vec(),
-                        },
-                        exprs: vec![original_row_record, mir_encoded_args],
-                    };
-                    let fn_input_record_type = ScalarType::Record {
-                        fields: fn_input_record_fields,
-                        custom_id: None,
-                    }
-                    .nullable(false);
-
-                    // Build a new record with the record above + the ORDER BY exprs
-                    // This follows the standard encoding of ORDER BY exprs used by aggregate functions
-                    let mut agg_input = vec![fn_input_record];
-                    agg_input.extend(order_by.clone());
-                    let agg_input = mz_expr::MirScalarExpr::CallVariadic {
-                        func: mz_expr::VariadicFunc::RecordCreate {
-                            field_names: (0..2).map(|_| ColumnName::from("?column?")).collect_vec(),
-                        },
-                        exprs: agg_input,
-                    };
-
-                    let agg_input_type = ScalarType::Record {
-                        fields: vec![(
-                            ColumnName::from("?column?"),
-                            fn_input_record_type.nullable(false),
-                        )],
-                        custom_id: None,
-                    }
-                    .nullable(false);
 
                     let aggregate = mz_expr::AggregateExpr {
                         func: mir_aggr_func,
@@ -1272,7 +1210,6 @@ impl HirScalarExpr {
                     };
 
                     // Actually call reduce with the window function
-                    // The input is [((OriginalRow, EncodedArgs), OrderByExprs...)]
                     // The output of the aggregation function should be a list of tuples that has
                     // the result in the first position, and the original row in the second position
                     let mut reduce = get_inner

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -2943,7 +2943,7 @@ fn plan_table_function_internal(
                 func: ScalarWindowFunc::RowNumber,
                 order_by: vec![],
             }),
-            partition: vec![],
+            partition_by: vec![],
             order_by: vec![],
         })]);
         scope
@@ -4765,7 +4765,7 @@ fn plan_function<'a>(
                     func,
                     order_by: col_orders,
                 }),
-                partition,
+                partition_by: partition,
                 order_by,
             }));
         }
@@ -4796,7 +4796,7 @@ fn plan_function<'a>(
                     window_frame,
                     ignore_nulls: window_spec.ignore_nulls, // (RESPECT NULLS is the default)
                 }),
-                partition,
+                partition_by: partition,
                 order_by,
             }));
         }


### PR DESCRIPTION
This is just a refactoring PR with mostly straightforward changes, in preparation for the window aggregations (coming soon, maybe on ~~Tuesday~~ Wednesday). See the commit messages for details.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Reading it commit by commit is easier. Hiding whitespace also helps, as there is a lot of code movement.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
