### PR TITLE
Unconditionally enable WITH MUTUALLY RECURSIVE

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -59,7 +59,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_ld_rbac_checks": "true",
     "enable_rbac_checks": "true",
     "enable_monotonic_oneshot_selects": "true",
-    "enable_with_mutually_recursive": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",
     "enable_disk_cluster_replicas": "true",

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -943,7 +943,6 @@ fn test_cancel_long_running_query() {
 fn test_cancellation_cancels_dataflows(query: &str) {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
-    server.enable_feature_flags(&["enable_with_mutually_recursive"]);
 
     let mut client1 = server.connect(postgres::NoTls).unwrap();
     let mut client2 = server.connect(postgres::NoTls).unwrap();
@@ -1028,7 +1027,6 @@ fn test_cancel_insert_select() {
 fn test_closing_connection_cancels_dataflows(query: String) {
     let config = util::Config::default().unsafe_mode();
     let server = util::start_server(config).unwrap();
-    server.enable_feature_flags(&["enable_with_mutually_recursive"]);
 
     let mut cmd = Command::new("psql");
     let cmd = cmd

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -88,7 +88,7 @@ use crate::plan::{
     transform_ast, Params, PlanContext, QueryWhen, ShowCreatePlan, WebhookValidation,
     WebhookValidationSecret,
 };
-use crate::session::vars::{self, FeatureFlag};
+use crate::session::vars::FeatureFlag;
 
 #[derive(Debug)]
 pub struct PlannedQuery<E> {
@@ -1397,9 +1397,6 @@ pub fn plan_ctes(
             }
         }
         CteBlock::MutuallyRecursive(MutRecBlock { options: _, ctes }) => {
-            qcx.scx
-                .require_feature_flag(&vars::ENABLE_WITH_MUTUALLY_RECURSIVE)?;
-
             // Insert column types into `qcx.ctes` first for recursive bindings.
             for cte in ctes.iter() {
                 let cte_name = normalize::ident(cte.name.clone());

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1636,7 +1636,6 @@ feature_flags!(
         enable_disk_cluster_replicas,
         "`WITH (DISK)` for cluster replicas"
     ),
-    (enable_with_mutually_recursive, "WITH MUTUALLY RECURSIVE"),
     (
         enable_within_timestamp_order_by_in_subscribe,
         "`WITHIN TIMESTAMP ORDER BY ..`"

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1096,18 +1096,14 @@ impl<'a> RunnerInner<'a> {
     /// Set features that should be enabled regardless of whether reset-server was
     /// called. These features may be set conditionally depending on the run configuration.
     async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
-        // We turn on enable_monotonic_oneshot_selects and enable_with_mutually_recursive,
-        // as these two features have reached enough maturity to do so.
+        // We turn on enable_monotonic_oneshot_selects,
+        // as that feature has reached enough maturity to do so.
         // TODO(vmarcos): Remove this code when we retire these feature flags.
         self.system_client
             .execute(
                 "ALTER SYSTEM SET enable_monotonic_oneshot_selects = on",
                 &[],
             )
-            .await?;
-
-        self.system_client
-            .execute("ALTER SYSTEM SET enable_with_mutually_recursive = on", &[])
             .await?;
 
         // Dangerous functions are useful for tests so we enable it for all tests.

--- a/test/sql-feature-flags/mzcompose.py
+++ b/test/sql-feature-flags/mzcompose.py
@@ -226,35 +226,6 @@ class FeatureTestScenario:
         assert False, "query_item() must be overriden"
 
 
-class WithMutuallyRecursive(FeatureTestScenario):
-    @classmethod
-    def feature_name(cls) -> str:
-        return "enable_with_mutually_recursive"
-
-    @classmethod
-    def feature_error(cls) -> str:
-        return "WITH MUTUALLY RECURSIVE is not supported"
-
-    @classmethod
-    def create_item(cls, ordinal: int) -> str:
-        return dedent(
-            f"""
-            CREATE VIEW wmr_{ordinal:02d} AS WITH MUTUALLY RECURSIVE
-                foo (a int, b int) AS (SELECT 1, 2 UNION SELECT a, 7 FROM bar),
-                bar (a int) as (SELECT a FROM foo)
-            SELECT * FROM bar;
-            """
-        )
-
-    @classmethod
-    def drop_item(cls, ordinal: int) -> str:
-        return f"DROP VIEW wmr_{ordinal:02d}"
-
-    @classmethod
-    def query_item(cls, ordinal: int) -> str:
-        return f"SELECT * FROM wmr_{ordinal:02d}"
-
-
 def run_test(c: Composition, args: argparse.Namespace) -> None:
     c.up("redpanda", "materialized")
     c.up("testdrive", persistent=True)

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -199,11 +199,6 @@ EOF
 # regression test drawn from LDBC-BI query 15 for having a selectivity of 0
 # TODO(mgree): we could probably trim this down to be tighter, but the optimizer has been too clever for me
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive TO true;
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE Person_knows_Person (
     creationDate timestamp with time zone NOT NULL,
@@ -326,11 +321,6 @@ EOF
 
 # regression test drawn from LDBC-BI query 15 for having a selectivity of 0
 # TODO(mgree): we could probably trim this down to be tighter, but the optimizer has been too clever for me
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive TO true;
-----
-COMPLETE 0
 
 query T multiline
 EXPLAIN WITH MUTUALLY RECURSIVE

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -10,11 +10,6 @@
 # The underlying LDBC SNB BI benchmark is under the Apache 2.0 license
 # as well; see materialize/test/ldbc-bi/LICENSE.txt.
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_with_mutually_recursive TO true;
-----
-COMPLETE 0
-
 ######################################################################
 # TABLE DEFINITIONS
 ######################################################################


### PR DESCRIPTION

### Motivation



   * This PR refactors existing code.

WMR has been on for all production users for a while. This change simplifies the code and turns it on for `bin/environmentd` without needing extra flags.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None.
