### PR TITLE
[persist] Pool timeout and monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4844,6 +4844,7 @@ dependencies = [
  "deadpool-postgres",
  "mz-ore",
  "mz-tls-util",
+ "prometheus",
  "tokio",
  "tracing",
  "workspace-hack",

--- a/doc/developer/cloudtest.md
+++ b/doc/developer/cloudtest.md
@@ -136,7 +136,7 @@ cluster to become ready:
 
 See the examples in `test/clustertest/test_smoke.py`.
 
-The tests folow pytest conventions:
+The tests follow pytest conventions:
 
 ```python
 from materialize.cloudtest.app.materialize_application import MaterializeApplication

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -231,6 +231,13 @@ impl CastLossy<usize> for f64 {
     }
 }
 
+impl CastLossy<isize> for f64 {
+    #[allow(clippy::as_conversions)]
+    fn cast_lossy(from: isize) -> Self {
+        from as f64
+    }
+}
+
 impl CastLossy<f64> for usize {
     #[allow(clippy::as_conversions)]
     fn cast_lossy(from: f64) -> Self {

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -131,6 +131,8 @@ pub struct PersistConfig {
     /// The maximum size of the connection pool to Postgres/CRDB when performing
     /// consensus reads and writes.
     pub consensus_connection_pool_max_size: usize,
+    /// The maximum time to wait when attempting to obtain a connection from the pool.
+    pub consensus_connection_pool_max_wait: Option<Duration>,
     /// Length of time after a writer's last operation after which the writer
     /// may be expired.
     pub writer_lease_duration: Duration,
@@ -213,6 +215,7 @@ impl PersistConfig {
             compaction_queue_size: 20,
             compaction_yield_after_n_updates: 100_000,
             consensus_connection_pool_max_size: 50,
+            consensus_connection_pool_max_wait: Some(Duration::from_secs(60)),
             writer_lease_duration: 60 * Duration::from_secs(60),
             critical_downgrade_interval: Duration::from_secs(30),
             pubsub_connect_attempt_timeout: Duration::from_secs(5),
@@ -352,6 +355,10 @@ impl PersistConfig {
 impl PostgresClientKnobs for PersistConfig {
     fn connection_pool_max_size(&self) -> usize {
         self.consensus_connection_pool_max_size
+    }
+
+    fn connection_pool_max_wait(&self) -> Option<Duration> {
+        self.consensus_connection_pool_max_wait
     }
 
     fn connection_pool_ttl(&self) -> Duration {

--- a/src/persist/src/postgres.rs
+++ b/src/persist/src/postgres.rs
@@ -138,6 +138,11 @@ impl PostgresConsensusConfig {
             fn connection_pool_max_size(&self) -> usize {
                 2
             }
+
+            fn connection_pool_max_wait(&self) -> Option<Duration> {
+                None
+            }
+
             fn connection_pool_ttl(&self) -> Duration {
                 Duration::MAX
             }

--- a/src/postgres-client/Cargo.toml
+++ b/src/postgres-client/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = { version = "1.0.66", features = ["backtrace"] }
 deadpool-postgres = "0.10.3"
 mz-ore = { path = "../ore", default-features = false, features = ["metrics", "async", "bytes_"] }
 mz-tls-util = { path = "../tls-util" }
+prometheus = { version = "0.13.3", default-features = false}
 tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/postgres-client/src/metrics.rs
+++ b/src/postgres-client/src/metrics.rs
@@ -19,6 +19,7 @@ pub struct PostgresClientMetrics {
     pub(crate) connpool_size: UIntGauge,
     pub(crate) connpool_acquires: IntCounter,
     pub(crate) connpool_acquire_seconds: Counter,
+    pub(crate) connpool_available: prometheus::Gauge,
     pub(crate) connpool_connections_created: Counter,
     pub(crate) connpool_connection_errors: Counter,
     pub(crate) connpool_ttl_reconnections: Counter,
@@ -39,6 +40,10 @@ impl PostgresClientMetrics {
             connpool_acquire_seconds: registry.register(metric!(
                 name: format!("{}_postgres_connpool_acquire_seconds", prefix),
                 help: "time spent acquiring connections from pool",
+            )),
+            connpool_available: registry.register(metric!(
+                name: "mz_persist_postgres_connpool_available",
+                help: "available connections in the pool",
             )),
             connpool_connections_created: registry.register(metric!(
                 name: format!("{}_postgres_connpool_connections_created", prefix),


### PR DESCRIPTION
`PostgresConsensus` tweaks: add a timeout on retrieving a connection from the connection pool, and track the provided availability metric.

### Motivation

For the metric: this is one of the few metrics exposed by the pool, and is the one that most directly tracks whether the pool is heavily contended or not. Generally useful to know!

For the timeout: this came up in a team discussion; instead of blocking on a semaphore forever we'd rather defer to some higher-level retry loop.

### Tips for reviewer

The metrics are reported both before and after trying to acquire a connection. In the abstract I feel like this would be nice as a computed gauge, but I think that would require more restructuring of the code for minimal benefit.

The timeout is extracted to config but not made dynamic. I don't think the specific value seems very important... it needs to be high enough to not time out on anything approaching reasonable contention, and to not cause too high of a frequency of retries. I've picked a number that seems much higher than we'd expect any healthy cluster to show, but feel free to tell me to make it higher.

I think the basics are well-covered by existing tests, but I will push an additional unit test for the timeout behaviour.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
