### PR TITLE
stash: split test_stash into multiple tests

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7897,7 +7897,7 @@ mod tests {
     async fn test_catalog_revision() {
         let debug_stash_factory = DebugStashFactory::new().await;
         {
-            let stash = debug_stash_factory.open_debug().await;
+            let stash = debug_stash_factory.open().await;
             let mut catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -7919,7 +7919,7 @@ mod tests {
             assert_eq!(catalog.transient_revision(), 2);
         }
         {
-            let stash = debug_stash_factory.open_debug().await;
+            let stash = debug_stash_factory.open().await;
             let catalog = Catalog::open_debug_stash(stash, NOW_ZERO.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -8775,7 +8775,7 @@ mod tests {
         let debug_stash_factory = DebugStashFactory::new().await;
         let id = GlobalId::User(1);
         {
-            let stash = debug_stash_factory.open_debug().await;
+            let stash = debug_stash_factory.open().await;
             let mut catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -8806,7 +8806,7 @@ mod tests {
                 .expect("failed to transact");
         }
         {
-            let stash = debug_stash_factory.open_debug().await;
+            let stash = debug_stash_factory.open().await;
             let catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
                 .await
                 .expect("unable to open debug catalog");
@@ -8902,7 +8902,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn test_object_type() {
         let debug_stash_factory = DebugStashFactory::new().await;
-        let stash = debug_stash_factory.open_debug().await;
+        let stash = debug_stash_factory.open().await;
         let catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
             .await
             .expect("unable to open debug catalog");
@@ -8925,7 +8925,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn test_get_privileges() {
         let debug_stash_factory = DebugStashFactory::new().await;
-        let stash = debug_stash_factory.open_debug().await;
+        let stash = debug_stash_factory.open().await;
         let catalog = Catalog::open_debug_stash(stash, SYSTEM_TIME.clone())
             .await
             .expect("unable to open debug catalog");

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -323,6 +323,7 @@ impl Listeners {
 
         let (ready_to_promote_tx, ready_to_promote_rx) = oneshot::channel();
         let (promote_leader_tx, promote_leader_rx) = oneshot::channel();
+        let stash_schema = None;
 
         // Start the internal HTTP server.
         //
@@ -351,7 +352,11 @@ impl Listeners {
             let mut stash = match config
                 .controller
                 .postgres_factory
-                .open_savepoint(config.adapter_stash_url.clone(), tls.clone())
+                .open_savepoint(
+                    config.adapter_stash_url.clone(),
+                    stash_schema.clone(),
+                    tls.clone(),
+                )
                 .await
             {
                 Ok(stash) => stash,
@@ -416,7 +421,7 @@ impl Listeners {
         let stash = config
             .controller
             .postgres_factory
-            .open(config.adapter_stash_url.clone(), None, tls)
+            .open(config.adapter_stash_url.clone(), stash_schema, tls)
             .await?;
 
         // Load the adapter catalog from disk.

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -78,14 +78,13 @@ use std::convert::Infallible;
 use std::time::Duration;
 
 use crate::{
-    AppendBatch, Data, Stash, StashCollection, StashError, StashFactory, TableTransaction,
-    Timestamp, TypedCollection, INSERT_BATCH_SPLIT_SIZE,
+    AppendBatch, Data, DebugStashFactory, Stash, StashCollection, StashError, StashFactory,
+    TableTransaction, Timestamp, TypedCollection, INSERT_BATCH_SPLIT_SIZE,
 };
 use futures::Future;
 use mz_ore::assert_contains;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::task::spawn;
-use postgres_openssl::MakeTlsConnector;
 use timely::progress::Antichain;
 use tokio::sync::oneshot;
 use tokio_postgres::Config;
@@ -95,214 +94,17 @@ static C_SAVEPOINT: TypedCollection<i64, i64> = TypedCollection::new("c_savepoin
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-async fn test_stash_postgres() {
-    mz_ore::test::init_logging_default("debug");
-
+async fn test_stash_invalid_url() {
     let tls = mz_postgres_util::make_tls(&Config::new()).unwrap();
     let factory = StashFactory::new(&MetricsRegistry::new());
 
-    {
-        // Verify invalid URLs fail on connect.
-        assert!(factory
-            .open("host=invalid".into(), None, tls.clone(),)
-            .await
-            .unwrap_err()
-            .to_string()
-            .contains("stash error: postgres: error connecting to server"));
-    }
-
-    let connstr = std::env::var("COCKROACH_URL").expect("COCKROACH_URL must be set");
-    async fn connect(
-        factory: &StashFactory,
-        connstr: &str,
-        tls: MakeTlsConnector,
-        clear: bool,
-    ) -> Stash {
-        if clear {
-            Stash::clear(connstr, tls.clone()).await.unwrap();
-        }
-        factory.open(connstr.to_string(), None, tls).await.unwrap()
-    }
-    {
-        connect(&factory, &connstr, tls.clone(), true).await;
-        let stash =
-            test_stash(|| async { connect(&factory, &connstr, tls.clone(), false).await }).await;
-        stash.verify().await.unwrap();
-    }
-    {
-        connect(&factory, &connstr, tls.clone(), true).await;
-        let stash =
-            test_append(|| async { connect(&factory, &connstr, tls.clone(), false).await }).await;
-        stash.verify().await.unwrap();
-    }
-    // Test the fence.
-    {
-        let mut conn1 = connect(&factory, &connstr, tls.clone(), true).await;
-        // Don't clear the stash tables.
-        let mut conn2 = connect(&factory, &connstr, tls.clone(), false).await;
-        assert!(match collection::<String, String>(&mut conn1, "c").await {
-            Err(e) => e.is_unrecoverable(),
-            _ => panic!("expected error"),
-        });
-        let _: StashCollection<String, String> = collection(&mut conn2, "c").await.unwrap();
-    }
-    // Test failures after commit.
-    {
-        let mut stash = connect(&factory, &connstr, tls.clone(), true).await;
-        let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
-        let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        col.append_to_batch(&mut batch, &1, &2, 1);
-        append(&mut stash, vec![batch]).await.unwrap();
-        assert_eq!(
-            C1.peek_one(&mut stash).await.unwrap(),
-            BTreeMap::from([(1, 2)])
-        );
-        let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        col.append_to_batch(&mut batch, &1, &2, -1);
-
-        fail::cfg("stash_commit_pre", "return(commit failpoint)").unwrap();
-        fail::cfg("stash_commit_post", "return(commit failpoint)").unwrap();
-        // Because the commit error will either retry or discover it succeeded,
-        // it never returns an error. Thus, we need to re-enable the failpoint
-        // in another thread. Use both a pre and post commit error to test both
-        // commit success and fail paths. Use a channel to check that we haven't
-        // succeeded unexpectedly.
-        let (tx, mut rx) = oneshot::channel();
-        let handle = spawn(|| "stash_commit_enable", async {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            // Assert no success yet.
-            rx.try_recv().unwrap_err();
-            fail::cfg("stash_commit_post", "off").unwrap();
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            // Assert no success yet.
-            rx.try_recv().unwrap_err();
-            fail::cfg("stash_commit_pre", "off").unwrap();
-            rx.await.unwrap();
-        });
-        append(&mut stash, vec![batch.clone()]).await.unwrap();
-        assert_eq!(C1.peek_one(&mut stash).await.unwrap(), BTreeMap::new());
-        tx.send(()).unwrap();
-        handle.await.unwrap();
-    }
-
-    // Test batches with a large serialized size.
-    {
-        static S: TypedCollection<i64, String> = TypedCollection::new("s");
-        let mut stash = connect(&factory, &connstr, tls.clone(), true).await;
-        let _16mb = "0".repeat(1 << 24);
-        // A too large update will always fail.
-        assert_contains!(
-            S.upsert(&mut stash, vec![(1, _16mb)])
-                .await
-                .unwrap_err()
-                .to_string(),
-            "message size 16 MiB bigger than maximum allowed message size"
-        );
-        // An large but reasonable update will be split into batches.
-        let large = "0".repeat(INSERT_BATCH_SPLIT_SIZE);
-        S.upsert(&mut stash, vec![(1, large.clone()), (2, large)])
-            .await
-            .unwrap();
-        assert_eq!(S.iter(&mut stash).await.unwrap().len(), 2);
-    }
-    // Test batches with a large number of individual updates.
-    {
-        let mut stash = connect(&factory, &connstr, tls.clone(), true).await;
-        let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
-        let mut batch = make_batch(&col, &mut stash).await.unwrap();
-        for i in 0..500_000 {
-            col.append_to_batch(&mut batch, &i, &(i + 1), 1);
-        }
-        append(&mut stash, vec![batch]).await.unwrap();
-    }
-    // Test readonly.
-    {
-        Stash::clear(&connstr, tls.clone()).await.unwrap();
-        let mut stash_rw = factory
-            .open(connstr.to_string(), None, tls.clone())
-            .await
-            .unwrap();
-        let col_rw = collection::<i64, i64>(&mut stash_rw, "c1").await.unwrap();
-        let mut batch = make_batch(&col_rw, &mut stash_rw).await.unwrap();
-        col_rw.append_to_batch(&mut batch, &1, &2, 1);
-        append(&mut stash_rw, vec![batch]).await.unwrap();
-
-        // Now make a readonly stash. We should fail to create new collections,
-        // but be able to read existing collections.
-        let mut stash_ro = factory
-            .open_readonly(connstr.to_string(), None, tls.clone())
-            .await
-            .unwrap();
-        let res = collection::<i64, i64>(&mut stash_ro, "c2").await;
-        assert_contains!(
-            res.unwrap_err().to_string(),
-            "cannot execute INSERT in a read-only transaction"
-        );
-        assert_eq!(
-            C1.peek_one(&mut stash_ro).await.unwrap(),
-            BTreeMap::from([(1, 2)])
-        );
-
-        // The previous stash should still be the leader.
-        assert!(stash_rw.confirm_leadership().await.is_ok());
-        stash_rw.verify().await.unwrap();
-    }
-    // Test savepoint.
-    {
-        let mut stash_rw = factory
-            .open(connstr.to_string(), None, tls.clone())
-            .await
-            .unwrap();
-        // Data still present from previous test.
-
-        // Now make a savepoint stash. We should be allowed to create anything
-        // we want, but it shouldn't be viewable to other stashes.
-        let mut stash_sp = factory
-            .open_savepoint(connstr.to_string(), tls)
-            .await
-            .unwrap();
-        let c1_sp = collection::<i64, i64>(&mut stash_rw, "c1").await.unwrap();
-        let mut batch = make_batch(&c1_sp, &mut stash_sp).await.unwrap();
-        c1_sp.append_to_batch(&mut batch, &5, &6, 1);
-        append(&mut stash_sp, vec![batch]).await.unwrap();
-        assert_eq!(
-            C1.peek_one(&mut stash_sp).await.unwrap(),
-            BTreeMap::from([(1, 2), (5, 6)]),
-        );
-        // RW collection can't see the new row.
-        assert_eq!(
-            C1.peek_one(&mut stash_rw).await.unwrap(),
-            BTreeMap::from([(1, 2)])
-        );
-
-        // SP stash can create a new collection, append to it, peek it.
-        let c_savepoint = collection::<i64, i64>(&mut stash_sp, "c_savepoint")
-            .await
-            .unwrap();
-        let mut batch = make_batch(&c_savepoint, &mut stash_sp).await.unwrap();
-        c_savepoint.append_to_batch(&mut batch, &3, &4, 1);
-        append(&mut stash_sp, vec![batch]).await.unwrap();
-        assert_eq!(
-            C_SAVEPOINT.peek_one(&mut stash_sp).await.unwrap(),
-            BTreeMap::from([(3, 4)])
-        );
-        // But the RW collection can't see it.
-        assert_eq!(
-            BTreeSet::from_iter(stash_rw.collections().await.unwrap().into_values()),
-            BTreeSet::from(["c1".to_string()])
-        );
-
-        drop(stash_sp);
-
-        // The previous stash should still be the leader.
-        assert!(stash_rw.confirm_leadership().await.is_ok());
-        // Verify c1 didn't change.
-        assert_eq!(
-            C1.peek_one(&mut stash_rw).await.unwrap(),
-            BTreeMap::from([(1, 2)])
-        );
-        stash_rw.verify().await.unwrap();
-    }
+    // Verify invalid URLs fail on connect.
+    assert!(factory
+        .open("host=invalid".into(), None, tls)
+        .await
+        .unwrap_err()
+        .to_string()
+        .contains("stash error: postgres: error connecting to server"));
 }
 
 async fn test_append<F, O>(f: F) -> Stash
@@ -757,6 +559,202 @@ where
         .unwrap();
 
     stash
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_fail_after_commit() {
+    Stash::with_debug_stash(|mut stash| async move {
+        let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
+        let mut batch = make_batch(&col, &mut stash).await.unwrap();
+        col.append_to_batch(&mut batch, &1, &2, 1);
+        append(&mut stash, vec![batch]).await.unwrap();
+        assert_eq!(
+            C1.peek_one(&mut stash).await.unwrap(),
+            BTreeMap::from([(1, 2)])
+        );
+        let mut batch = make_batch(&col, &mut stash).await.unwrap();
+        col.append_to_batch(&mut batch, &1, &2, -1);
+
+        fail::cfg("stash_commit_pre", "return(commit failpoint)").unwrap();
+        fail::cfg("stash_commit_post", "return(commit failpoint)").unwrap();
+        // Because the commit error will either retry or discover it succeeded,
+        // it never returns an error. Thus, we need to re-enable the failpoint
+        // in another thread. Use both a pre and post commit error to test both
+        // commit success and fail paths. Use a channel to check that we haven't
+        // succeeded unexpectedly.
+        let (tx, mut rx) = oneshot::channel();
+        let handle = spawn(|| "stash_commit_enable", async {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Assert no success yet.
+            rx.try_recv().unwrap_err();
+            fail::cfg("stash_commit_post", "off").unwrap();
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            // Assert no success yet.
+            rx.try_recv().unwrap_err();
+            fail::cfg("stash_commit_pre", "off").unwrap();
+            rx.await.unwrap();
+        });
+        append(&mut stash, vec![batch.clone()]).await.unwrap();
+        assert_eq!(C1.peek_one(&mut stash).await.unwrap(), BTreeMap::new());
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+    })
+    .await
+    .expect("must succeed");
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_batch_large_serialized_size() {
+    Stash::with_debug_stash(|mut stash| async move {
+        static S: TypedCollection<i64, String> = TypedCollection::new("s");
+        let _16mb = "0".repeat(1 << 24);
+        // A too large update will always fail.
+        assert_contains!(
+            S.upsert(&mut stash, vec![(1, _16mb)])
+                .await
+                .unwrap_err()
+                .to_string(),
+            "message size 16 MiB bigger than maximum allowed message size"
+        );
+        // An large but reasonable update will be split into batches.
+        let large = "0".repeat(INSERT_BATCH_SPLIT_SIZE);
+        S.upsert(&mut stash, vec![(1, large.clone()), (2, large)])
+            .await
+            .unwrap();
+        assert_eq!(S.iter(&mut stash).await.unwrap().len(), 2);
+    })
+    .await
+    .expect("must succeed");
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_batch_large_number_updates() {
+    Stash::with_debug_stash(|mut stash| async move {
+        let col = collection::<i64, i64>(&mut stash, "c1").await.unwrap();
+        let mut batch = make_batch(&col, &mut stash).await.unwrap();
+        for i in 0..500_000 {
+            col.append_to_batch(&mut batch, &i, &(i + 1), 1);
+        }
+        append(&mut stash, vec![batch]).await.unwrap();
+    })
+    .await
+    .expect("must succeed");
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_readonly() {
+    let factory = DebugStashFactory::try_new().await.expect("must succeed");
+    let mut stash_rw = factory.open().await;
+    let col_rw = collection::<i64, i64>(&mut stash_rw, "c1").await.unwrap();
+    let mut batch = make_batch(&col_rw, &mut stash_rw).await.unwrap();
+    col_rw.append_to_batch(&mut batch, &1, &2, 1);
+    append(&mut stash_rw, vec![batch]).await.unwrap();
+
+    // Now make a readonly stash. We should fail to create new collections,
+    // but be able to read existing collections.
+    let mut stash_ro = factory.open_readonly().await;
+    let res = collection::<i64, i64>(&mut stash_ro, "c2").await;
+    assert_contains!(
+        res.unwrap_err().to_string(),
+        "cannot execute INSERT in a read-only transaction"
+    );
+    assert_eq!(
+        C1.peek_one(&mut stash_ro).await.unwrap(),
+        BTreeMap::from([(1, 2)])
+    );
+
+    // The previous stash should still be the leader.
+    assert!(stash_rw.confirm_leadership().await.is_ok());
+    stash_rw.verify().await.unwrap();
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_savepoint() {
+    let factory = DebugStashFactory::try_new().await.expect("must succeed");
+    let mut stash_rw = factory.open().await;
+    // Data still present from previous test.
+
+    // Now make a savepoint stash. We should be allowed to create anything
+    // we want, but it shouldn't be viewable to other stashes.
+    let mut stash_sp = factory.open_savepoint().await;
+    let c1 = collection::<i64, i64>(&mut stash_rw, "c1").await.unwrap();
+    let mut batch = make_batch(&c1, &mut stash_rw).await.unwrap();
+    c1.append_to_batch(&mut batch, &1, &2, 1);
+    append(&mut stash_rw, vec![batch]).await.unwrap();
+    let mut batch = make_batch(&c1, &mut stash_sp).await.unwrap();
+    c1.append_to_batch(&mut batch, &5, &6, 1);
+    append(&mut stash_sp, vec![batch]).await.unwrap();
+    assert_eq!(
+        C1.peek_one(&mut stash_sp).await.unwrap(),
+        BTreeMap::from([(1, 2), (5, 6)]),
+    );
+    // RW collection can't see the new row.
+    assert_eq!(
+        C1.peek_one(&mut stash_rw).await.unwrap(),
+        BTreeMap::from([(1, 2)])
+    );
+
+    // SP stash can create a new collection, append to it, peek it.
+    let c_savepoint = collection::<i64, i64>(&mut stash_sp, "c_savepoint")
+        .await
+        .unwrap();
+    let mut batch = make_batch(&c_savepoint, &mut stash_sp).await.unwrap();
+    c_savepoint.append_to_batch(&mut batch, &3, &4, 1);
+    append(&mut stash_sp, vec![batch]).await.unwrap();
+    assert_eq!(
+        C_SAVEPOINT.peek_one(&mut stash_sp).await.unwrap(),
+        BTreeMap::from([(3, 4)])
+    );
+    // But the RW collection can't see it.
+    assert_eq!(
+        BTreeSet::from_iter(stash_rw.collections().await.unwrap().into_values()),
+        BTreeSet::from(["c1".to_string()])
+    );
+
+    drop(stash_sp);
+
+    // The previous stash should still be the leader.
+    assert!(stash_rw.confirm_leadership().await.is_ok());
+    // Verify c1 didn't change.
+    assert_eq!(
+        C1.peek_one(&mut stash_rw).await.unwrap(),
+        BTreeMap::from([(1, 2)])
+    );
+    stash_rw.verify().await.unwrap();
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_fence() {
+    let factory = DebugStashFactory::try_new().await.expect("must succeed");
+    let mut conn1 = factory.open().await;
+    let mut conn2 = factory.open().await;
+    assert!(match collection::<String, String>(&mut conn1, "c").await {
+        Err(e) => e.is_unrecoverable(),
+        _ => panic!("expected error"),
+    });
+    let _: StashCollection<String, String> = collection(&mut conn2, "c").await.unwrap();
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_append() {
+    let factory = DebugStashFactory::try_new().await.expect("must succeed");
+    test_append(|| async { factory.open().await }).await;
+    factory.open().await.verify().await.unwrap();
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_stash_stash() {
+    let factory = DebugStashFactory::try_new().await.expect("must succeed");
+    test_stash(|| async { factory.open().await }).await;
+    factory.open().await.verify().await.unwrap();
 }
 
 async fn make_batch<K, V>(

--- a/src/stash/src/upgrade/v27_to_v28.rs
+++ b/src/stash/src/upgrade/v27_to_v28.rs
@@ -150,7 +150,7 @@ mod tests {
 
         // Connect to the Stash.
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         // Insert a database.
         let databases_v27: TypedCollection<objects_v27::DatabaseKey, objects_v27::DatabaseValue> =

--- a/src/stash/src/upgrade/v28_to_v29.rs
+++ b/src/stash/src/upgrade/v28_to_v29.rs
@@ -273,7 +273,7 @@ mod tests {
 
         // Connect to the Stash.
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         // Insert a database.
         let databases_v28: TypedCollection<objects_v28::DatabaseKey, objects_v28::DatabaseValue> =

--- a/src/stash/src/upgrade/v31_to_v32.rs
+++ b/src/stash/src/upgrade/v31_to_v32.rs
@@ -179,7 +179,7 @@ mod tests {
     async fn smoke_test() {
         // Connect to the Stash.
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         // Insert a cluster.
         let cluster_replica_v31: TypedCollection<

--- a/src/stash/src/upgrade/v32_to_v33.rs
+++ b/src/stash/src/upgrade/v32_to_v33.rs
@@ -63,7 +63,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test() {
         let factory: DebugStashFactory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         let roles_v32: TypedCollection<objects_v32::RoleKey, objects_v32::RoleValue> =
             TypedCollection::new("role");

--- a/src/stash/src/upgrade/v33_to_v34.rs
+++ b/src/stash/src/upgrade/v33_to_v34.rs
@@ -255,7 +255,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test() {
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         CLUSTER_REPLICA_COLLECTION
             .insert_without_overwrite(
@@ -381,7 +381,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn audit_log_migration() {
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         AUDIT_LOG_COLLECTION
             .insert_without_overwrite(

--- a/src/stash/src/upgrade/v35_to_v36.rs
+++ b/src/stash/src/upgrade/v35_to_v36.rs
@@ -90,7 +90,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test_existing_flags() {
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         SYSTEM_CONFIGURATION_COLLECTION
             .insert_without_overwrite(
@@ -150,7 +150,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test_empty_flags() {
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         SYSTEM_CONFIGURATION_COLLECTION
             .insert_without_overwrite(&mut stash, vec![])

--- a/src/stash/src/upgrade/v38_to_v39.rs
+++ b/src/stash/src/upgrade/v38_to_v39.rs
@@ -58,7 +58,7 @@ mod tests {
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test_role_vars_added() {
         let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open_debug().await;
+        let mut stash = factory.open().await;
 
         ROLES_COLLECTION
             .insert_without_overwrite(


### PR DESCRIPTION
These can now be run in parallel.

Improve DebugStashFactory to allow it to make all stash variants.

Additionally (and sadly missed missed until now): teach the Consolidator about schemas. It is fairly scary we have not done this until now, which is likely a result of passing schemas in URLs. Probably only tests ever needed this. Now that we use the DebugStashFactory for things which creates a random schema each time, it was required to get some tests to pass.

See #21891

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a