### PR TITLE
Add first cut at mz_compute_delays_average

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -773,6 +773,12 @@ Specifically, reductions can use more memory than we show here.
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_heap_capacity_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_heap_size_raw -->
 
+<!-- mz_internal.mz_compute_delays_average is undocumented because it's just just a prototype,
+     so we are highly likely to change it.
+     Currently, it reports the frontier delay of an export relative to the minimum
+     frontier across all its imports, averaged over the last ten seconds. -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_compute_delays_average -->
+
 ### `mz_compute_delays_histogram`
 
 The `mz_compute_delays_histogram` view describes a histogram of the wall-clock delay in nanoseconds between observations of import frontier advancements of a [dataflow] and the advancements of the corresponding export frontiers.

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1474,6 +1474,12 @@ pub const MZ_MESSAGE_BATCH_COUNTS_RECEIVED_RAW: BuiltinLog = BuiltinLog {
     variant: LogVariant::Timely(TimelyLog::BatchesReceived),
 };
 
+pub const MZ_COMPUTE_DELAYS_AVERAGE: BuiltinLog = BuiltinLog {
+    name: "mz_compute_delays_average",
+    schema: MZ_INTERNAL_SCHEMA,
+    variant: LogVariant::Compute(ComputeLog::FrontierDelayAvg),
+};
+
 pub const MZ_MESSAGE_BATCH_COUNTS_SENT_RAW: BuiltinLog = BuiltinLog {
     name: "mz_message_batch_counts_sent_raw",
     schema: MZ_INTERNAL_SCHEMA,
@@ -5078,6 +5084,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Log(&MZ_MESSAGE_COUNTS_RECEIVED_RAW),
         Builtin::Log(&MZ_MESSAGE_COUNTS_SENT_RAW),
         Builtin::Log(&MZ_MESSAGE_BATCH_COUNTS_RECEIVED_RAW),
+        Builtin::Log(&MZ_COMPUTE_DELAYS_AVERAGE),
         Builtin::Log(&MZ_MESSAGE_BATCH_COUNTS_SENT_RAW),
         Builtin::Log(&MZ_ACTIVE_PEEKS_PER_WORKER),
         Builtin::Log(&MZ_PEEK_DURATIONS_HISTOGRAM_RAW),

--- a/src/compute-client/src/logging.proto
+++ b/src/compute-client/src/logging.proto
@@ -56,6 +56,7 @@ message ProtoComputeLog {
         google.protobuf.Empty arrangement_heap_capacity = 9;
         google.protobuf.Empty arrangement_heap_allocations = 10;
         google.protobuf.Empty shutdown_duration = 11;
+        google.protobuf.Empty frontier_delay_avg = 12;
     }
 }
 message ProtoLogVariant {

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -229,6 +229,7 @@ pub enum ComputeLog {
     ArrangementHeapCapacity,
     ArrangementHeapAllocations,
     ShutdownDuration,
+    FrontierDelayAvg,
 }
 
 impl RustType<ProtoComputeLog> for ComputeLog {
@@ -246,6 +247,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
                 ComputeLog::ArrangementHeapCapacity => ArrangementHeapCapacity(()),
                 ComputeLog::ArrangementHeapAllocations => ArrangementHeapAllocations(()),
                 ComputeLog::ShutdownDuration => ShutdownDuration(()),
+                ComputeLog::FrontierDelayAvg => FrontierDelayAvg(()),
             }),
         }
     }
@@ -263,6 +265,7 @@ impl RustType<ProtoComputeLog> for ComputeLog {
             Some(ArrangementHeapCapacity(())) => Ok(ComputeLog::ArrangementHeapCapacity),
             Some(ArrangementHeapAllocations(())) => Ok(ComputeLog::ArrangementHeapAllocations),
             Some(ShutdownDuration(())) => Ok(ComputeLog::ShutdownDuration),
+            Some(FrontierDelayAvg(())) => Ok(ComputeLog::FrontierDelayAvg),
             None => Err(TryFromProtoError::missing_field("ProtoComputeLog::kind")),
         }
     }
@@ -433,6 +436,10 @@ impl LogVariant {
             LogVariant::Compute(ComputeLog::ShutdownDuration) => RelationDesc::empty()
                 .with_column("worker_id", ScalarType::UInt64.nullable(false))
                 .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
+
+            LogVariant::Compute(ComputeLog::FrontierDelayAvg) => RelationDesc::empty()
+                .with_column("export_id", ScalarType::String.nullable(false))
+                .with_column("avg_ns", ScalarType::UInt64.nullable(false)),
         }
     }
 
@@ -476,6 +483,7 @@ impl LogVariant {
             Compute(ComputeLog::PeekCurrent) => vec![],
             Compute(ComputeLog::PeekDuration) => vec![],
             Compute(ComputeLog::ShutdownDuration) => vec![],
+            Compute(ComputeLog::FrontierDelayAvg) => vec![],
         }
     }
 }

--- a/src/ore/src/collections.rs
+++ b/src/ore/src/collections.rs
@@ -21,8 +21,10 @@ use std::collections::BTreeMap;
 use std::fmt::{Debug, Display};
 
 mod hash;
+mod pop;
 
 pub use crate::collections::hash::{HashMap, HashSet};
+pub use crate::collections::pop::{PopBack, PopFront};
 
 /// Extension methods for collections.
 pub trait CollectionExt<T>: Sized

--- a/src/ore/src/collections/pop.rs
+++ b/src/ore/src/collections/pop.rs
@@ -31,7 +31,7 @@ pub trait PopFront {
 /// Helper methods for collections that support `back` and `pop_back`, or
 /// similar methods (e.g. `last` and `pop` for `Vec`).
 pub trait PopBack {
-    // The item contained by the collection.
+    /// The item contained by the collection.
     type Item;
     /// Call a supplied function on each element at the
     /// back of the collection in turn, removing it if the

--- a/src/ore/src/collections/pop.rs
+++ b/src/ore/src/collections/pop.rs
@@ -1,0 +1,79 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Additional helper methods for collections that support `front` and `pop_front` and/or
+//! `back` and `pop_back`.
+
+use std::collections::VecDeque;
+
+/// Helper methods for collections that support `front` and `pop_front`
+pub trait PopFront {
+    /// The item contained by the collection.
+    type Item;
+    /// Call a supplied function on each element at the
+    /// front of the collection in turn, removing it if the
+    /// function returns true, and stopping otherwise.
+    fn pop_front_while<F: FnMut(&Self::Item) -> bool>(&mut self, f: F);
+}
+
+/// Helper methods for collections that support `back` and `pop_back`, or
+/// similar methods (e.g. `last` and `pop` for `Vec`).
+pub trait PopBack {
+    // The item contained by the collection.
+    type Item;
+    /// Call a supplied function on each element at the
+    /// back of the collection in turn, removing it if the
+    /// function returns true, and stopping otherwise.
+    fn pop_back_while<F: FnMut(&Self::Item) -> bool>(&mut self, f: F);
+}
+
+impl<T> PopFront for VecDeque<T> {
+    type Item = T;
+    fn pop_front_while<F: FnMut(&T) -> bool>(&mut self, mut f: F) {
+        while let Some(item) = self.front() {
+            if f(item) {
+                self.pop_front();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl<T> PopBack for VecDeque<T> {
+    type Item = T;
+    fn pop_back_while<F: FnMut(&T) -> bool>(&mut self, mut f: F) {
+        while let Some(item) = self.back() {
+            if f(item) {
+                self.pop_back();
+            } else {
+                break;
+            }
+        }
+    }
+}
+
+impl<T> PopBack for Vec<T> {
+    type Item = T;
+    fn pop_back_while<F: FnMut(&T) -> bool>(&mut self, mut f: F) {
+        while let Some(item) = self.last() {
+            if f(item) {
+                self.pop();
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -598,6 +598,7 @@ mz_cluster_replica_sizes
 mz_cluster_replica_statuses
 mz_cluster_replica_utilization
 mz_comments
+mz_compute_delays_average
 mz_compute_delays_histogram
 mz_compute_delays_histogram_per_worker
 mz_compute_delays_histogram_raw

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -199,6 +199,8 @@ bar  mz_arrangement_records_raw  mz_arrangement_records_raw_u7_primary_idx  1  o
 bar  mz_arrangement_records_raw  mz_arrangement_records_raw_u7_primary_idx  2  worker_id  NULL  false
 bar  mz_arrangement_sharing_raw  mz_arrangement_sharing_raw_u7_primary_idx  1  operator_id  NULL  false
 bar  mz_arrangement_sharing_raw  mz_arrangement_sharing_raw_u7_primary_idx  2  worker_id  NULL  false
+bar  mz_compute_delays_average  mz_compute_delays_average_u7_primary_idx  1  export_id  NULL  false
+bar  mz_compute_delays_average  mz_compute_delays_average_u7_primary_idx  2  avg_ns  NULL  false
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  1  export_id  NULL  false
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  2  import_id  NULL  false
 bar  mz_compute_delays_histogram_raw  mz_compute_delays_histogram_raw_u7_primary_idx  3  worker_id  NULL  false
@@ -396,7 +398,7 @@ DROP CLUSTER foo, foo2, foo3, foo4 CASCADE
 query I
 SELECT COUNT(name) FROM mz_indexes WHERE cluster_id = 'u1';
 ----
-24
+25
 
 query I
 SELECT COUNT(name) FROM mz_indexes WHERE cluster_id <> 'u1' AND cluster_id NOT LIKE 's%';
@@ -409,7 +411,7 @@ CREATE CLUSTER test REPLICAS (foo (SIZE '1'));
 query I
 SELECT COUNT(name) FROM mz_indexes;
 ----
-123
+127
 
 statement ok
 DROP CLUSTER test CASCADE
@@ -417,7 +419,7 @@ DROP CLUSTER test CASCADE
 query T
 SELECT COUNT(name) FROM mz_indexes;
 ----
-99
+102
 
 simple conn=mz_system,user=mz_system
 ALTER CLUSTER default OWNER TO materialize

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -317,6 +317,10 @@ mz_comments
 BASE TABLE
 materialize
 mz_internal
+mz_compute_delays_average
+SOURCE
+materialize
+mz_internal
 mz_compute_delays_histogram
 VIEW
 materialize

--- a/test/testdrive/divergent-dataflow-cancellation.td
+++ b/test/testdrive/divergent-dataflow-cancellation.td
@@ -87,7 +87,7 @@ contains: canceling statement due to statement timeout
 > SELECT count(*)
   FROM mz_internal.mz_compute_frontiers_per_worker
   WHERE worker_id = 0
-24
+25
 
 > SELECT count(*) FROM mz_internal.mz_compute_import_frontiers_per_worker
 0

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -298,6 +298,7 @@ mz_cluster_replica_sizes_ind                                mz_cluster_replica_s
 mz_cluster_replica_statuses_ind                             mz_cluster_replica_statuses                  mz_introspection    {replica_id}
 mz_cluster_replicas_ind                                     mz_cluster_replicas                          mz_introspection    {id}
 mz_clusters_ind                                             mz_clusters                                  mz_introspection    {id}
+mz_compute_delays_average_s2_primary_idx                    mz_compute_delays_average                    mz_introspection    {export_id,avg_ns}
 mz_compute_delays_histogram_raw_s2_primary_idx              mz_compute_delays_histogram_raw              mz_introspection    {export_id,import_id,worker_id,delay_ns}
 mz_compute_exports_per_worker_s2_primary_idx                mz_compute_exports_per_worker                mz_introspection    {export_id,worker_id}
 mz_compute_frontiers_per_worker_s2_primary_idx              mz_compute_frontiers_per_worker              mz_introspection    {export_id,worker_id,time}

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -840,6 +840,7 @@ CREATE CLUSTER REPLICA default.replica SIZE = '2', INTROSPECTION DEBUGGING = tru
 "ArrangeByKey Compute(DataflowCurrent)"
 "ArrangeByKey Compute(FrontierCurrent)"
 "ArrangeByKey Compute(FrontierDelay)"
+"ArrangeByKey Compute(FrontierDelayAvg)"
 "ArrangeByKey Compute(ImportFrontierCurrent)"
 "ArrangeByKey Compute(PeekCurrent)"
 "ArrangeByKey Compute(PeekDuration)"


### PR DESCRIPTION
This metric computes the average for the last 10 seconds of what I'll call the "total frontier delay" of each dataflow; that is, how long after all the inputs became available at a given timestamp did the output become available at that timestamp?

The maximum value of this metric across the whole replica seems to correlate decently well with the "fullness" of the replica; that is, if it's at 50%, you can roughly process twice as much as you currently are without falling over.

I did a bit of playing around locally and this seems to be legit (or at least much more so than the current CPU time metric), but I'm avoiding documenting it for now in case we want to change it. The goal for now is just to get it into staging so we can play around with it more and gain confidence about whether it's useful.

### Tips for Reviewers

Note that we don't bother keeping around the state to retract when a dataflow is dropped, because everything will fall off after 10 seconds anyway.

### Motivation

  * This PR adds a known-desirable feature.

https://github.com/MaterializeInc/database-issues/issues/6524

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
