### PR TITLE
sql: correctly determine resolved ids for arrays

### DIFF
--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -864,6 +864,57 @@ pub enum CatalogType<T: TypeReference> {
     MzAclItem,
 }
 
+impl<T: TypeReference> CatalogType<T> {
+    /// Returns any referenced types.
+    pub fn references(&self) -> Vec<&T::Reference> {
+        match self {
+            CatalogType::Array { element_reference } => vec![element_reference],
+            CatalogType::List { element_reference } => vec![element_reference],
+            CatalogType::Map {
+                key_reference,
+                value_reference,
+            } => vec![key_reference, value_reference],
+            CatalogType::Range { element_reference } => vec![element_reference],
+            CatalogType::Record { fields } => {
+                fields.iter().map(|(_name, reference)| reference).collect()
+            }
+
+            CatalogType::AclItem
+            | CatalogType::Bool
+            | CatalogType::Bytes
+            | CatalogType::Char
+            | CatalogType::Date
+            | CatalogType::Float32
+            | CatalogType::Float64
+            | CatalogType::Int16
+            | CatalogType::Int2Vector
+            | CatalogType::Int32
+            | CatalogType::Int64
+            | CatalogType::Interval
+            | CatalogType::Jsonb
+            | CatalogType::MzAclItem
+            | CatalogType::MzTimestamp
+            | CatalogType::Numeric
+            | CatalogType::Oid
+            | CatalogType::PgLegacyChar
+            | CatalogType::PgLegacyName
+            | CatalogType::Pseudo
+            | CatalogType::RegClass
+            | CatalogType::RegProc
+            | CatalogType::RegType
+            | CatalogType::String
+            | CatalogType::Time
+            | CatalogType::Timestamp
+            | CatalogType::TimestampTz
+            | CatalogType::UInt16
+            | CatalogType::UInt32
+            | CatalogType::UInt64
+            | CatalogType::Uuid
+            | CatalogType::VarChar => Vec::new(),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 /// Mirrored from [PostgreSQL's `typcategory`][typcategory].
 ///

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1440,7 +1440,17 @@ impl<'a> NameResolver<'a> {
                         (full_name, item)
                     }
                 };
-                self.referenced_ids(item.id());
+
+                self.ids.insert(item.id());
+                self.ids.extend(
+                    item.type_details()
+                        .expect("references type")
+                        .typ
+                        .references()
+                        .iter()
+                        .cloned(),
+                );
+
                 Ok(ResolvedDataType::Named {
                     id: item.id(),
                     qualifiers: item.name().qualifiers.clone(),
@@ -1449,20 +1459,6 @@ impl<'a> NameResolver<'a> {
                     print_id: true,
                 })
             }
-        }
-    }
-
-    /// Adds leaf types referenced by `id`.
-    fn referenced_ids(&mut self, id: GlobalId) {
-        let item = self.catalog.get_item(&id);
-        let details = item.type_details().expect("must be a Type");
-        let refs = details.typ.references();
-        if refs.is_empty() {
-            self.ids.insert(id);
-            return;
-        }
-        for r in refs {
-            self.referenced_ids(*r);
         }
     }
 

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1399,6 +1399,7 @@ impl<'a> NameResolver<'a> {
                                     .quoted()
                             ),
                         };
+                        self.ids.insert(array_item.id());
                         Ok(ResolvedDataType::Named {
                             id: array_item.id(),
                             qualifiers: array_item.name().qualifiers.clone(),

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1440,7 +1440,7 @@ impl<'a> NameResolver<'a> {
                         (full_name, item)
                     }
                 };
-                self.ids.insert(item.id());
+                self.referenced_ids(item.id());
                 Ok(ResolvedDataType::Named {
                     id: item.id(),
                     qualifiers: item.name().qualifiers.clone(),
@@ -1449,6 +1449,20 @@ impl<'a> NameResolver<'a> {
                     print_id: true,
                 })
             }
+        }
+    }
+
+    /// Adds leaf types referenced by `id`.
+    fn referenced_ids(&mut self, id: GlobalId) {
+        let item = self.catalog.get_item(&id);
+        let details = item.type_details().expect("must be a Type");
+        let refs = details.typ.references();
+        if refs.is_empty() {
+            self.ids.insert(id);
+            return;
+        }
+        for r in refs {
+            self.referenced_ids(*r);
         }
     }
 

--- a/test/testdrive/github-21958.td
+++ b/test/testdrive/github-21958.td
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that table creation involving types that depend on other types correctly describe their
+# resolved_ids on restart. This is asserted by testdrive during its catalog verification step after
+#each DDL.
+
+> CREATE TYPE point AS (x integer, y integer);
+> CREATE TYPE custom_map AS MAP (KEY TYPE = text, VALUE TYPE = bool);
+> CREATE TABLE t (c1 point, c2 custom_map, c3 integer[], c4 map[text=>map[text=>map[text=>text]]]);


### PR DESCRIPTION
Explicitly described maps, arrays, and lists referenced their inner types in resolved_ids. However, on restart some types would have a named variant that was not obviously an array. For example, `int[]` would convert to `pg_catalog._int`, triggering the "named" type path instead of "array" type path. In the named path, there was no awareness of possible inner types, so the outer type would be added to resolved_ids, resulting in catalog consistency violations.

Teach the named type path to use referenced types when adding to resolved_ids so the code paths have the same results.

Fixes #21958

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a