### PR TITLE
explain: support `EXPLAIN CREATE MATERIALIZED VIEW`

### DIFF
--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -160,7 +160,7 @@ tests_without_views=(
     test/sqllogictest/timestamp.slt
     test/sqllogictest/timestamptz.slt
     test/sqllogictest/timezone.slt
-    test/sqllogictest/tpch.slt
+    test/sqllogictest/tpch_select.slt
     test/sqllogictest/transactions.slt
     test/sqllogictest/type-promotion.slt
     test/sqllogictest/typeof.slt

--- a/ci/test/slt-fast.sh
+++ b/ci/test/slt-fast.sh
@@ -161,6 +161,7 @@ tests_without_views=(
     test/sqllogictest/timestamptz.slt
     test/sqllogictest/timezone.slt
     test/sqllogictest/tpch_select.slt
+    test/sqllogictest/tpch_materialized_view.slt
     test/sqllogictest/transactions.slt
     test/sqllogictest/type-promotion.slt
     test/sqllogictest/typeof.slt

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6403,7 +6403,9 @@ impl Catalog {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
-                let optimized_expr = optimizer.optimize(view.expr)?;
+                let raw_expr = view.expr;
+                let decorrelated_expr = raw_expr.optimize_and_lower(&plan::OptimizerConfig {})?;
+                let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -6418,7 +6418,9 @@ impl Catalog {
             }) => {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
-                let optimized_expr = optimizer.optimize(materialized_view.expr)?;
+                let raw_expr = materialized_view.expr;
+                let decorrelated_expr = raw_expr.optimize_and_lower(&plan::OptimizerConfig {})?;
+                let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), materialized_view.column_names);
                 CatalogItem::MaterializedView(MaterializedView {
                     create_sql: materialized_view.create_sql,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -701,7 +701,10 @@ impl CatalogState {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
-                let optimized_expr = optimizer.optimize(view.expr)?;
+                let raw_expr = view.expr;
+                let decorrelated_expr =
+                    raw_expr.optimize_and_lower(&mz_sql::plan::OptimizerConfig {})?;
+                let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,

--- a/src/adapter/src/coord/introspection.rs
+++ b/src/adapter/src/coord/introspection.rs
@@ -22,7 +22,9 @@ use mz_expr::CollectionPlan;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{ErrorMessageObjectDescription, SessionCatalog};
 use mz_sql::names::{ResolvedIds, SystemObjectId};
-use mz_sql::plan::{ExplainPlanPlan, ExplainTimestampPlan, Explainee, Plan, SubscribeFrom};
+use mz_sql::plan::{
+    ExplainPlanPlan, ExplainTimestampPlan, Explainee, ExplaineeStatement, Plan, SubscribeFrom,
+};
 use mz_sql::rbac;
 use smallvec::SmallVec;
 
@@ -53,7 +55,7 @@ pub fn auto_run_on_introspection<'a, 's, 'p>(
             },
         ),
         Plan::ExplainPlan(ExplainPlanPlan {
-            explainee: Explainee::Query { raw_plan, .. },
+            explainee: Explainee::Statement(ExplaineeStatement::Query { raw_plan, .. }),
             ..
         }) => (
             raw_plan.depends_on(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3106,8 +3106,8 @@ impl Coordinator {
 
         let trace = optimizer_trace.drain_all(
             format,
-            config,
-            self.catalog().for_session(ctx.session()),
+            &config,
+            &self.catalog().for_session(ctx.session()),
             row_set_finishing,
             used_indexes,
             fast_path_plan,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -911,7 +911,9 @@ impl Coordinator {
         );
         let view_id = self.catalog_mut().allocate_user_id().await?;
         let view_oid = self.catalog_mut().allocate_oid()?;
-        let optimized_expr = self.view_optimizer.optimize(view.expr.clone())?;
+        let raw_expr = view.expr.clone();
+        let decorrelated_expr = raw_expr.optimize_and_lower(&plan::OptimizerConfig {})?;
+        let optimized_expr = self.view_optimizer.optimize(decorrelated_expr)?;
         let desc = RelationDesc::new(optimized_expr.typ(), view.column_names.clone());
         let view = catalog::View {
             create_sql: view.create_sql.clone(),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
+use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 use maplit::btreeset;
@@ -33,9 +34,13 @@ use mz_ore::vec::VecExt;
 use mz_ore::{soft_assert, task};
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
-use mz_repr::explain::{ExplainFormat, ExprHumanizer, UsedIndexes};
+use mz_repr::explain::{
+    ExplainFormat, ExprHumanizer, ExprHumanizerExt, TransientItem, UsedIndexes,
+};
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowArena, Timestamp};
+use mz_repr::{
+    ColumnName, Datum, Diff, GlobalId, RelationDesc, RelationType, Row, RowArena, Timestamp,
+};
 use mz_sql::ast::{ExplainStage, IndexOptionName};
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError,
@@ -2896,8 +2901,8 @@ impl Coordinator {
         target_cluster: TargetCluster,
     ) {
         let result = match plan.explainee {
-            Explainee::Query { .. } => {
-                let result = self.explain_query(&mut ctx, plan, target_cluster);
+            Explainee::Statement(_) => {
+                let result = self.explain_statement(&mut ctx, plan, target_cluster);
                 result.await
             }
             Explainee::MaterializedView(_) => {
@@ -3048,7 +3053,7 @@ impl Coordinator {
         Ok(Self::send_immediate_rows(rows))
     }
 
-    async fn explain_query(
+    async fn explain_statement(
         &mut self,
         ctx: &mut ExecuteContext,
         plan: plan::ExplainPlanPlan,
@@ -3061,56 +3066,74 @@ impl Coordinator {
             explainee,
         } = plan;
 
-        let Explainee::Query {
-            raw_plan,
-            row_set_finishing,
-            broken,
-        } = explainee
-        else {
+        let Explainee::Statement(stmt) = explainee else {
             // This is currently asserted in the `sequence_explain_plan` code that
             // calls this method.
             unreachable!()
         };
 
+        let broken = stmt.broken();
+        let row_set_finishing = stmt.row_set_finishing();
+
         // Create an OptimizerTrace instance to collect plans emitted when
         // executing the optimizer pipeline.
         let optimizer_trace = OptimizerTrace::new(broken, stage.path());
 
-        let pipeline_result = {
-            self.explain_query_optimizer_pipeline(
+        let pipeline_result = match stmt {
+            plan::ExplaineeStatement::Query {
                 raw_plan,
+                row_set_finishing,
                 broken,
-                target_cluster,
-                ctx.session_mut(),
-                &row_set_finishing,
-            )
-            .with_subscriber(&optimizer_trace)
-            .await
+            } => {
+                self.explain_query_optimizer_pipeline(
+                    raw_plan,
+                    broken,
+                    target_cluster,
+                    ctx.session_mut(),
+                    &row_set_finishing,
+                )
+                .with_subscriber(&optimizer_trace)
+                .await
+            }
+            plan::ExplaineeStatement::CreateMaterializedView {
+                name,
+                raw_plan,
+                column_names,
+                cluster_id,
+                broken,
+            } => {
+                self.explain_create_materialized_view_optimizer_pipeline(
+                    name,
+                    raw_plan,
+                    column_names,
+                    cluster_id,
+                    broken,
+                )
+                .with_subscriber(&optimizer_trace)
+                .await
+            }
         };
 
-        let (used_indexes, fast_path_plan, dataflow_metainfo) = match pipeline_result {
-            Ok((used_indexes, fast_path_plan, dataflow_metainfo)) => {
-                (used_indexes, fast_path_plan, dataflow_metainfo)
-            }
-            Err(err) => {
-                if broken {
-                    tracing::error!("error while handling EXPLAIN statement: {}", err);
-
-                    let used_indexes = UsedIndexes::default();
-                    let fast_path_plan: Option<FastPathPlan> = None;
-                    let dataflow_metainfo = DataflowMetainfo::default();
-
-                    (used_indexes, fast_path_plan, dataflow_metainfo)
-                } else {
-                    return Err(err);
+        let (used_indexes, fast_path_plan, dataflow_metainfo, transient_items) =
+            match pipeline_result {
+                Ok(pipeline_result) => pipeline_result,
+                Err(err) => {
+                    if broken {
+                        tracing::error!("error while handling EXPLAIN statement: {}", err);
+                        Default::default()
+                    } else {
+                        return Err(err);
+                    }
                 }
-            }
-        };
+            };
+
+        let session_catalog = self.catalog().for_session(ctx.session());
+        let expr_humanizer = ExprHumanizerExt::new(transient_items, &session_catalog);
 
         let trace = optimizer_trace.drain_all(
             format,
             &config,
-            &self.catalog().for_session(ctx.session()),
+            &expr_humanizer,
             row_set_finishing,
             used_indexes,
             fast_path_plan,
@@ -3125,10 +3148,9 @@ impl Coordinator {
                     .into_iter()
                     .map(|entry| {
                         // The trace would have to take over 584 years to overflow a u64.
-                        let span_duration =
-                            u64::try_from(entry.span_duration.as_nanos()).unwrap_or(u64::MAX);
+                        let span_duration = u64::try_from(entry.span_duration.as_nanos());
                         Row::pack_slice(&[
-                            Datum::from(span_duration),
+                            Datum::from(span_duration.unwrap_or(u64::MAX)),
                             Datum::from(entry.path.as_str()),
                             Datum::from(entry.plan.as_str()),
                         ])
@@ -3167,7 +3189,15 @@ impl Coordinator {
         target_cluster: TargetCluster,
         session: &mut Session,
         finishing: &Option<RowSetFinishing>,
-    ) -> Result<(UsedIndexes, Option<FastPathPlan>, DataflowMetainfo), AdapterError> {
+    ) -> Result<
+        (
+            UsedIndexes,
+            Option<FastPathPlan>,
+            DataflowMetainfo,
+            BTreeMap<GlobalId, TransientItem>,
+        ),
+        AdapterError,
+    > {
         use mz_repr::explain::trace_plan;
 
         if broken {
@@ -3196,7 +3226,7 @@ impl Coordinator {
         }
 
         let catalog = self.catalog();
-        let cluster_id = catalog.resolve_target_cluster(target_cluster, session)?.id;
+        let target_cluster_id = catalog.resolve_target_cluster(target_cluster, session)?.id;
         // Set parameter values for optimizing one-shot SELECT queries.
         let explainee_id = GlobalId::Explain;
         let is_oneshot = true;
@@ -3227,7 +3257,7 @@ impl Coordinator {
 
         let source_ids = decorrelated_plan.depends_on();
         let id_bundle = self
-            .index_oracle(cluster_id)
+            .index_oracle(target_cluster_id)
             .sufficient_collections(&source_ids);
 
         // Execute the `optimize/local` stage.
@@ -3242,7 +3272,7 @@ impl Coordinator {
         })?;
 
         let mut dataflow = DataflowDesc::new("explanation".to_string());
-        let mut builder = self.dataflow_builder(cluster_id);
+        let mut builder = self.dataflow_builder(target_cluster_id);
         builder.import_view_into_dataflow(&explainee_id, &optimized_plan, &mut dataflow)?;
 
         // Resolve all unmaterializable function calls except mz_now(), because we don't yet have a
@@ -3262,7 +3292,7 @@ impl Coordinator {
             .sequence_peek_timestamp(
                 session,
                 &QueryWhen::Immediately,
-                cluster_id,
+                target_cluster_id,
                 timeline_context,
                 &id_bundle,
                 &source_ids,
@@ -3280,7 +3310,7 @@ impl Coordinator {
         let dataflow_metainfo = catch_unwind(broken, "global", || {
             mz_transform::optimize_dataflow(
                 &mut dataflow,
-                &self.index_oracle(cluster_id),
+                &self.index_oracle(target_cluster_id),
                 stats.as_ref(),
             )
         })?;
@@ -3327,7 +3357,7 @@ impl Coordinator {
 
         // Execute the `optimize/finalize_dataflow` stage.
         let dataflow_plan = catch_unwind(broken, "finalize_dataflow", || {
-            self.finalize_dataflow(dataflow, cluster_id)
+            self.finalize_dataflow(dataflow, target_cluster_id)
         })?;
 
         // Trace the resulting plan for the top-level `optimize` path.
@@ -3335,7 +3365,171 @@ impl Coordinator {
 
         // Return objects that need to be passed to the `ExplainContext`
         // when rendering explanations for the various trace entries.
-        Ok((used_indexes, fast_path_plan, dataflow_metainfo))
+        Ok((
+            used_indexes,
+            fast_path_plan,
+            dataflow_metainfo,
+            BTreeMap::new(),
+        ))
+    }
+
+    #[tracing::instrument(target = "optimizer", level = "trace", name = "optimize", skip_all)]
+    async fn explain_create_materialized_view_optimizer_pipeline(
+        &mut self,
+        name: QualifiedItemName,
+        raw_plan: mz_sql::plan::HirRelationExpr,
+        column_names: Vec<ColumnName>,
+        target_cluster_id: ClusterId,
+        broken: bool,
+    ) -> Result<
+        (
+            UsedIndexes,
+            Option<FastPathPlan>,
+            DataflowMetainfo,
+            BTreeMap<GlobalId, TransientItem>,
+        ),
+        AdapterError,
+    > {
+        use mz_repr::explain::trace_plan;
+
+        if broken {
+            tracing::warn!("EXPLAIN ... BROKEN <query> is known to leak memory, use with caution");
+        }
+
+        // Initialize helper context
+        // -------------------------
+
+        /// Like [`mz_ore::panic::catch_unwind`], with an extra guard that must be true
+        /// in order to wrap the function call in a [`mz_ore::panic::catch_unwind`] call.
+        fn catch_unwind<R, E, F>(guard: bool, stage: &'static str, f: F) -> Result<R, AdapterError>
+        where
+            F: FnOnce() -> Result<R, E>,
+            E: Into<AdapterError>,
+        {
+            if guard {
+                let r: Result<Result<R, E>, _> = mz_ore::panic::catch_unwind(AssertUnwindSafe(f));
+                match r {
+                    Ok(result) => result.map_err(Into::into),
+                    Err(_) => {
+                        let msg = format!("panic at the `{}` optimization stage", stage);
+                        Err(AdapterError::Internal(msg))
+                    }
+                }
+            } else {
+                f().map_err(Into::into)
+            }
+        }
+
+        let full_name = self.catalog().resolve_full_name(&name, None);
+
+        // Initialize optimizer context
+        // ----------------------------
+
+        let compute_instance = self
+            .instance_snapshot(target_cluster_id)
+            .expect("compute instance does not exist");
+        let exported_sink_id = self.allocate_transient_id()?;
+        let internal_view_id = self.allocate_transient_id()?;
+        let debug_name = full_name.to_string();
+        let as_of = {
+            let id_bundle = self
+                .index_oracle(target_cluster_id)
+                .sufficient_collections(&raw_plan.depends_on());
+            self.least_valid_read(&id_bundle)
+        };
+
+        // Create a transient catalog item
+        // -------------------------------
+
+        let mut transient_items = BTreeMap::new();
+        transient_items.insert(exported_sink_id, {
+            TransientItem::new(
+                Some(full_name.to_string()),
+                Some(full_name.item.to_string()),
+                Some(column_names.iter().map(|c| c.to_string()).collect()),
+            )
+        });
+
+        // Execute the various stages of the optimization pipeline
+        // -------------------------------------------------------
+
+        // Trace the pipeline input under `optimize/raw`.
+        tracing::span!(target: "optimizer", Level::TRACE, "raw").in_scope(|| {
+            trace_plan(&raw_plan);
+        });
+
+        // Execute the `optimize/hir_to_mir` stage.
+        let decorrelated_plan = catch_unwind(broken, "hir_to_mir", || {
+            raw_plan.optimize_and_lower(&OptimizerConfig {})
+        })?;
+
+        // Execute the `optimize/local` stage.
+        let optimized_plan = catch_unwind(broken, "local", || {
+            tracing::span!(target: "optimizer", Level::TRACE, "local").in_scope(|| {
+                let optimized_plan = self.view_optimizer.optimize(decorrelated_plan);
+                if let Ok(ref optimized_plan) = optimized_plan {
+                    trace_plan(optimized_plan.as_inner());
+                }
+                optimized_plan.map_err(AdapterError::from)
+            })
+        })?;
+
+        // Execute the `optimize/global` stage.
+        let (mut df, df_metainfo) = catch_unwind(broken, "global", || {
+            let mut dataflow_builder =
+                DataflowBuilder::new(self.catalog().state(), compute_instance);
+            dataflow_builder.build_materialized_view(
+                exported_sink_id,
+                internal_view_id,
+                debug_name,
+                &optimized_plan,
+                &RelationDesc::new(optimized_plan.typ(), column_names),
+            )
+        })?;
+
+        // Collect the list of indexes used by the dataflow at this point
+        let used_indexes = UsedIndexes::new(
+            df
+                .index_imports
+                .iter()
+                .map(|(id, _index_import)| {
+                    (*id, df_metainfo.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
+                })
+                .collect(),
+        );
+
+        df.set_as_of(as_of);
+
+        // In the actual sequencing of `CREATE MATERIALIZED VIEW` statements,
+        // the following DataflowDescription manipulations happen in the
+        // `ship_dataflow` call. However, since we don't want to ship, we have
+        // temporary duplicated the code below. This will be resolved once we
+        // implement the proposal from #20569.
+
+        // If the only outputs of the dataflow are sinks, we might be able to
+        // turn off the computation early, if they all have non-trivial
+        // `up_to`s.
+        //
+        // TODO: This should always be the case here so we can demote
+        // the outer index to a soft assert.
+        if df.index_exports.is_empty() {
+            df.until = Antichain::from_elem(Timestamp::MIN);
+            for (_, sink) in &df.sink_exports {
+                df.until.join_assign(&sink.up_to);
+            }
+        }
+
+        // Execute the `optimize/finalize_dataflow` stage.
+        let df = catch_unwind(broken, "finalize_dataflow", || {
+            self.finalize_dataflow(df, target_cluster_id)
+        })?;
+
+        // Trace the resulting plan for the top-level `optimize` path.
+        trace_plan(&df);
+
+        // Return objects that need to be passed to the `ExplainContext`
+        // when rendering explanations for the various trace entries.
+        Ok((used_indexes, None, df_metainfo, transient_items))
     }
 
     pub fn sequence_explain_timestamp(

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3149,7 +3149,8 @@ pub enum Explainee<T: AstInfo> {
     View(T::ItemName),
     MaterializedView(T::ItemName),
     Index(T::ItemName),
-    Query(Query<T>, bool),
+    Query(Box<Query<T>>, bool),
+    CreateMaterializedView(Box<CreateMaterializedViewStatement<T>>, bool),
 }
 
 impl<T: AstInfo> AstDisplay for Explainee<T> {
@@ -3172,6 +3173,12 @@ impl<T: AstInfo> AstDisplay for Explainee<T> {
                     f.write_str("BROKEN ");
                 }
                 f.write_node(query);
+            }
+            Self::CreateMaterializedView(statement, broken) => {
+                if *broken {
+                    f.write_str("BROKEN ");
+                }
+                f.write_node(statement);
             }
         }
     }

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -139,3 +139,17 @@ EXPLAIN OPTIMIZER TRACE WITH(est_cost) AS TEXT FOR BROKEN SELECT 1 + 1
 ExplainPlan(ExplainPlanStatement { stage: Trace, config_flags: [Ident("est_cost")], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, true) })
 
 # TODO (#13299): Add negative tests for new explain API.
+
+parse-statement
+EXPLAIN WITH (humanized_exprs) CREATE MATERIALIZED VIEW mv AS SELECT 665
+----
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs) AS TEXT FOR CREATE MATERIALIZED VIEW mv AS SELECT 665
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [Ident("humanized_exprs")], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, false) })
+
+parse-statement
+EXPLAIN BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
+----
+EXPLAIN OPTIMIZED PLAN AS TEXT FOR BROKEN CREATE MATERIALIZED VIEW mv AS SELECT 665
+=>
+ExplainPlan(ExplainPlanStatement { stage: OptimizedPlan, config_flags: [], format: Text, explainee: CreateMaterializedView(CreateMaterializedViewStatement { if_exists: Error, name: UnresolvedItemName([Ident("mv")]), columns: [], in_cluster: None, query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Value(Number("665")), alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None } }, true) })

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1251,7 +1251,7 @@ pub struct Sink {
 #[derive(Clone, Debug)]
 pub struct View {
     pub create_sql: String,
-    pub expr: mz_expr::MirRelationExpr,
+    pub expr: HirRelationExpr,
     pub column_names: Vec<ColumnName>,
     pub temporary: bool,
 }

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1259,7 +1259,7 @@ pub struct View {
 #[derive(Clone, Debug)]
 pub struct MaterializedView {
     pub create_sql: String,
-    pub expr: mz_expr::MirRelationExpr,
+    pub expr: HirRelationExpr,
     pub column_names: Vec<ColumnName>,
     pub cluster_id: ClusterId,
 }

--- a/src/sql/src/plan/optimize.rs
+++ b/src/sql/src/plan/optimize.rs
@@ -10,19 +10,12 @@
 //! This module defines the API and logic for running optimization pipelines.
 
 use crate::plan::expr::HirRelationExpr;
-use crate::plan::{PlanError, StatementContext};
+use crate::plan::PlanError;
 
 /// Feature flags for the [`HirRelationExpr::optimize_and_lower()`] logic.
 #[derive(Debug)]
 pub struct OptimizerConfig {
     // TODO: add parameters driving the optimization pass here
-}
-
-/// Convert a reference to a [`StatementContext`] to an [`OptimizerConfig`].
-impl<'a> From<&StatementContext<'a>> for OptimizerConfig {
-    fn from(_scx: &StatementContext) -> Self {
-        OptimizerConfig {}
-    }
 }
 
 impl HirRelationExpr {

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2060,7 +2060,6 @@ pub fn plan_create_materialized_view(
     assert!(finishing.is_trivial(expr.arity()));
 
     expr.bind_parameters(params)?;
-    let expr = expr.optimize_and_lower(&scx.into())?;
 
     plan_utils::maybe_rename_columns(
         format!("materialized view {}", scx.catalog.resolve_full_name(&name)),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -1919,7 +1919,6 @@ pub fn plan_view(
     assert!(finishing.is_trivial(expr.arity()));
 
     expr.bind_parameters(params)?;
-    let relation_expr = expr.optimize_and_lower(&scx.into())?;
 
     let name = if temporary {
         scx.allocate_temporary_qualified_name(normalize::unresolved_item_name(name.to_owned())?)?
@@ -1940,7 +1939,7 @@ pub fn plan_view(
 
     let view = View {
         create_sql,
-        expr: relation_expr,
+        expr,
         column_names: names,
         temporary,
     };

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -21,7 +21,9 @@ use mz_pgcopy::{CopyCsvFormatParams, CopyFormatParams, CopyTextFormatParams};
 use mz_repr::adt::numeric::NumericMaxScale;
 use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::{RelationDesc, ScalarType};
-use mz_sql_parser::ast::{ExplainTimestampStatement, Expr, OrderByExpr, SubscribeOutput};
+use mz_sql_parser::ast::{
+    ExplainTimestampStatement, Expr, IfExistsBehavior, OrderByExpr, SubscribeOutput,
+};
 
 use crate::ast::display::AstDisplay;
 use crate::ast::{
@@ -35,7 +37,7 @@ use crate::names::{Aug, ResolvedItemName};
 use crate::normalize;
 use crate::plan::query::{plan_up_to, ExprContext, QueryLifetime};
 use crate::plan::scope::Scope;
-use crate::plan::statement::{StatementContext, StatementDesc};
+use crate::plan::statement::{ddl, StatementContext, StatementDesc};
 use crate::plan::with_options::TryFromValue;
 use crate::plan::{self, side_effecting_func, ExplainTimestampPlan};
 use crate::plan::{
@@ -232,7 +234,7 @@ pub fn describe_explain_plan(
                 describe_select(
                     scx,
                     SelectStatement {
-                        query: q,
+                        query: *q,
                         as_of: None,
                     },
                 )?
@@ -264,6 +266,8 @@ pub fn plan_explain_plan(
     }: ExplainPlanStatement<Aug>,
     params: &Params,
 ) -> Result<Plan, PlanError> {
+    use crate::plan::ExplaineeStatement;
+
     let format = match format {
         mz_sql_parser::ast::ExplainFormat::Text => ExplainFormat::Text,
         mz_sql_parser::ast::ExplainFormat::Json => ExplainFormat::Json,
@@ -317,7 +321,7 @@ pub fn plan_explain_plan(
                 desc,
                 finishing,
                 scope: _,
-            } = query::plan_root_query(scx, query, QueryLifetime::OneShot)?;
+            } = query::plan_root_query(scx, *query, QueryLifetime::OneShot)?;
             raw_plan.bind_parameters(params)?;
 
             let row_set_finishing = if finishing.is_trivial(desc.arity()) {
@@ -330,11 +334,39 @@ pub fn plan_explain_plan(
                 scx.require_feature_flag(&vars::ENABLE_EXPLAIN_BROKEN)?;
             }
 
-            crate::plan::Explainee::Query {
+            crate::plan::Explainee::Statement(ExplaineeStatement::Query {
                 raw_plan,
                 row_set_finishing,
                 broken,
-            }
+            })
+        }
+        Explainee::CreateMaterializedView(mut stmt, broken) => {
+            // If we don't force this parameter to Skip planning fails for names
+            // that already exist in the catalog.
+            stmt.if_exists = IfExistsBehavior::Skip;
+
+            let Plan::CreateMaterializedView(plan::CreateMaterializedViewPlan {
+                name,
+                materialized_view:
+                    plan::MaterializedView {
+                        expr: raw_plan,
+                        column_names,
+                        cluster_id,
+                        ..
+                    },
+                ..
+            }) = ddl::plan_create_materialized_view(scx, *stmt, params)?
+            else {
+                sql_bail!("expected CreateMaterializedViewPlan plan");
+            };
+
+            crate::plan::Explainee::Statement(ExplaineeStatement::CreateMaterializedView {
+                name,
+                raw_plan,
+                column_names,
+                cluster_id,
+                broken,
+            })
         }
     };
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -708,7 +708,7 @@ fn generate_rbac_requirements(
                     let schema_id: ObjectId = item.name().qualifiers.clone().into();
                     vec![(SystemObjectId::Object(schema_id), AclMode::USAGE, role_id)]
                 }
-                Explainee::Query { raw_plan, .. } => raw_plan
+                Explainee::Statement(stmt) => stmt
                     .depends_on()
                     .into_iter()
                     .map(|id| {
@@ -720,7 +720,7 @@ fn generate_rbac_requirements(
             },
             item_usage: match explainee {
                 Explainee::MaterializedView(_) | Explainee::Index(_) => false,
-                Explainee::Query { .. } => true,
+                Explainee::Statement(_) => true,
             },
             ..Default::default()
         },

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1124,6 +1124,11 @@ class UnionsNested(Generator):
 
 
 class CaseWhen(Generator):
+    # Originally this was working with 1000, but after moving lowering and
+    # decorrelation from the `plan_~` to the `sequence_~` method we had to
+    # reduce it a bit in order to avoid overflowing the stack.
+    COUNT = 950
+
     @classmethod
     def body(cls) -> None:
         print(

--- a/test/sqllogictest/tpch_materialized_view.slt
+++ b/test/sqllogictest/tpch_materialized_view.slt
@@ -1,0 +1,1891 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Plans for the TPC-H workload modeled as CREATE MATERIALIZED VIEW
+# statements.
+
+# PRIMARY KEY annotations (which are in the spec) are currently
+# removed from this slt, because we don't support them at the moment.
+# (Note that _in slts_ they are actually supported, but it's better
+# to match the plans of real runs more closely.)
+
+statement ok
+CREATE TABLE nation (
+    n_nationkey  integer,
+    n_name       char(25) NOT NULL,
+    n_regionkey  integer NOT NULL,
+    n_comment    varchar(152)
+);
+
+statement ok
+CREATE INDEX pk_nation_nationkey ON nation (n_nationkey ASC);
+
+statement ok
+CREATE INDEX fk_nation_regionkey ON nation (n_regionkey ASC);
+
+statement ok
+CREATE TABLE region  (
+    r_regionkey  integer,
+    r_name       char(25) NOT NULL,
+    r_comment    varchar(152)
+);
+
+statement ok
+CREATE INDEX pk_region_regionkey ON region (r_regionkey ASC);
+
+statement ok
+CREATE TABLE part (
+    p_partkey     integer,
+    p_name        varchar(55) NOT NULL,
+    p_mfgr        char(25) NOT NULL,
+    p_brand       char(10) NOT NULL,
+    p_type        varchar(25) NOT NULL,
+    p_size        integer NOT NULL,
+    p_container   char(10) NOT NULL,
+    p_retailprice decimal(15, 2) NOT NULL,
+    p_comment     varchar(23) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_part_partkey ON part (p_partkey ASC);
+
+statement ok
+CREATE TABLE supplier (
+    s_suppkey     integer,
+    s_name        char(25) NOT NULL,
+    s_address     varchar(40) NOT NULL,
+    s_nationkey   integer NOT NULL,
+    s_phone       char(15) NOT NULL,
+    s_acctbal     decimal(15, 2) NOT NULL,
+    s_comment     varchar(101) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_supplier_suppkey ON supplier (s_suppkey ASC);
+
+statement ok
+CREATE INDEX fk_supplier_nationkey ON supplier (s_nationkey ASC);
+
+statement ok
+CREATE TABLE partsupp (
+    ps_partkey     integer NOT NULL,
+    ps_suppkey     integer NOT NULL,
+    ps_availqty    integer NOT NULL,
+    ps_supplycost  decimal(15, 2) NOT NULL,
+    ps_comment     varchar(199) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_partsupp_partkey_suppkey ON partsupp (ps_partkey ASC, ps_suppkey ASC);
+
+statement ok
+CREATE INDEX fk_partsupp_partkey ON partsupp (ps_partkey ASC);
+
+statement ok
+CREATE INDEX fk_partsupp_suppkey ON partsupp (ps_suppkey ASC);
+
+statement ok
+CREATE TABLE customer (
+    c_custkey     integer,
+    c_name        varchar(25) NOT NULL,
+    c_address     varchar(40) NOT NULL,
+    c_nationkey   integer NOT NULL,
+    c_phone       char(15) NOT NULL,
+    c_acctbal     decimal(15, 2) NOT NULL,
+    c_mktsegment  char(10) NOT NULL,
+    c_comment     varchar(117) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_customer_custkey ON customer (c_custkey ASC);
+
+statement ok
+CREATE INDEX fk_customer_nationkey ON customer (c_nationkey ASC);
+
+statement ok
+CREATE TABLE orders (
+    o_orderkey       integer,
+    o_custkey        integer NOT NULL,
+    o_orderstatus    char(1) NOT NULL,
+    o_totalprice     decimal(15, 2) NOT NULL,
+    o_orderdate      DATE NOT NULL,
+    o_orderpriority  char(15) NOT NULL,
+    o_clerk          char(15) NOT NULL,
+    o_shippriority   integer NOT NULL,
+    o_comment        varchar(79) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_orders_orderkey ON orders (o_orderkey ASC);
+
+statement ok
+CREATE INDEX fk_orders_custkey ON orders (o_custkey ASC);
+
+statement ok
+CREATE TABLE lineitem (
+    l_orderkey       integer NOT NULL,
+    l_partkey        integer NOT NULL,
+    l_suppkey        integer NOT NULL,
+    l_linenumber     integer NOT NULL,
+    l_quantity       decimal(15, 2) NOT NULL,
+    l_extendedprice  decimal(15, 2) NOT NULL,
+    l_discount       decimal(15, 2) NOT NULL,
+    l_tax            decimal(15, 2) NOT NULL,
+    l_returnflag     char(1) NOT NULL,
+    l_linestatus     char(1) NOT NULL,
+    l_shipdate       date NOT NULL,
+    l_commitdate     date NOT NULL,
+    l_receiptdate    date NOT NULL,
+    l_shipinstruct   char(25) NOT NULL,
+    l_shipmode       char(10) NOT NULL,
+    l_comment        varchar(44) NOT NULL
+);
+
+statement ok
+CREATE INDEX pk_lineitem_orderkey_linenumber ON lineitem (l_orderkey ASC, l_linenumber ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_orderkey ON lineitem (l_orderkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_partkey ON lineitem (l_partkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_suppkey ON lineitem (l_suppkey ASC);
+
+statement ok
+CREATE INDEX fk_lineitem_partsuppkey ON lineitem (l_partkey ASC, l_suppkey ASC);
+
+
+
+query T multiline
+-- Query 01
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q01 AS
+SELECT
+	l_returnflag,
+	l_linestatus,
+	sum(l_quantity) AS sum_qty,
+	sum(l_extendedprice) AS sum_base_price,
+	sum(l_extendedprice * (1 - l_discount)) AS sum_disc_price,
+	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) AS sum_charge,
+	avg(l_quantity) AS avg_qty,
+	avg(l_extendedprice) AS avg_price,
+	avg(l_discount) AS avg_disc,
+	count(*) AS count_order
+FROM
+	lineitem
+WHERE
+	l_shipdate <= DATE '1998-12-01' - INTERVAL '60' day
+GROUP BY
+	l_returnflag,
+	l_linestatus
+ORDER BY
+	l_returnflag,
+	l_linestatus;
+----
+materialize.public.q01:
+  Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
+    Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
+      Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)] // { arity: 8 }
+        Project (#4..=#9) // { arity: 6 }
+          Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
+
+EOF
+
+
+query T multiline
+-- Query 02
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q02 AS
+SELECT
+    s_acctbal,
+    s_name,
+    n_name,
+    p_partkey,
+    p_mfgr,
+    s_address,
+    s_phone,
+    s_comment
+FROM
+    part, supplier, partsupp, nation, region
+WHERE
+    p_partkey = ps_partkey
+    AND s_suppkey = ps_suppkey
+    AND p_size = CAST (15 AS smallint)
+    AND p_type LIKE '%BRASS'
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'EUROPE'
+    AND ps_supplycost
+        = (
+                SELECT
+                    min(ps_supplycost)
+                FROM
+                    partsupp, supplier, nation, region
+                WHERE
+                    p_partkey = ps_partkey
+                    AND s_suppkey = ps_suppkey
+                    AND s_nationkey = n_nationkey
+                    AND n_regionkey = r_regionkey
+                    AND r_name = 'EUROPE'
+            )
+ORDER BY
+    s_acctbal DESC, n_name, s_name, p_partkey;
+----
+materialize.public.q02:
+  Return // { arity: 8 }
+    Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
+      Join on=(p_partkey = p_partkey AND ps_supplycost = #10) type=differential // { arity: 11 }
+        implementation
+          %1[#0, #1]UKK » %0:l4[#0, #7]KK
+        ArrangeBy keys=[[p_partkey, ps_supplycost]] // { arity: 9 }
+          Get l4 // { arity: 9 }
+        ArrangeBy keys=[[p_partkey, #1]] // { arity: 2 }
+          Reduce group_by=[p_partkey] aggregates=[min(ps_supplycost)] // { arity: 2 }
+            Project (#0, #4) // { arity: 2 }
+              Filter (r_name = "EUROPE") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 20 }
+                Join on=(p_partkey = ps_partkey AND ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 20 }
+                  implementation
+                    %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                    %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+                    %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
+                    %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                    %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
+                  ArrangeBy keys=[[p_partkey]] // { arity: 1 }
+                    Distinct group_by=[p_partkey] // { arity: 1 }
+                      Project (#0) // { arity: 1 }
+                        Get l4 // { arity: 9 }
+                  Get l1 // { arity: 5 }
+                  Get l0 // { arity: 7 }
+                  Get l2 // { arity: 4 }
+                  Get l3 // { arity: 3 }
+  With
+    cte l4 =
+      Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
+        Filter (p_size = 15) AND (r_name = "EUROPE") AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND like["%BRASS"](varchar_to_text(p_type)) // { arity: 28 }
+          Join on=(p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 28 }
+            implementation
+              %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
+              %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
+              %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+              %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
+            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+            Get l0 // { arity: 7 }
+            Get l1 // { arity: 5 }
+            Get l2 // { arity: 4 }
+            Get l3 // { arity: 3 }
+    cte l3 =
+      ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+        ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
+    cte l2 =
+      ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+    cte l1 =
+      ArrangeBy keys=[[ps_partkey], [ps_suppkey]] // { arity: 5 }
+        ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
+    cte l0 =
+      ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+        ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.fk_nation_regionkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.fk_partsupp_partkey (delta join lookup)
+  - materialize.public.fk_partsupp_suppkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 03
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q03 AS
+SELECT
+    l_orderkey,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    o_orderdate,
+    o_shippriority
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    c_mktsegment = 'BUILDING'
+    AND c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate < DATE '1995-03-15'
+    AND l_shipdate > DATE '1995-03-15'
+GROUP BY
+    l_orderkey,
+    o_orderdate,
+    o_shippriority
+ORDER BY
+    revenue DESC,
+    o_orderdate;
+----
+materialize.public.q03:
+  Project (#0, #3, #1, #2) // { arity: 4 }
+    Reduce group_by=[o_orderkey, o_orderdate, o_shippriority] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+      Project (#8, #12, #15, #22, #23) // { arity: 5 }
+        Filter (c_mktsegment = "BUILDING") AND (o_orderdate < 1995-03-15) AND (l_shipdate > 1995-03-15) AND (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
+          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+            implementation
+              %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
+              %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
+              %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
+            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 04
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q04 AS
+SELECT
+    o_orderpriority,
+    count(*) AS order_count
+FROM
+    orders
+WHERE
+    o_orderdate >= DATE '1993-07-01'
+    AND o_orderdate < DATE '1993-07-01' + INTERVAL '3' month
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem
+        WHERE
+            l_orderkey = o_orderkey
+            AND l_commitdate < l_receiptdate
+    )
+GROUP BY
+    o_orderpriority
+ORDER BY
+    o_orderpriority;
+----
+materialize.public.q04:
+  Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
+    Project (#5) // { arity: 1 }
+      Filter (o_orderdate >= 1993-07-01) AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 11 }
+        Join on=(eq(o_orderkey, o_orderkey, l_orderkey)) type=delta // { arity: 11 }
+          implementation
+            %0:orders » %1[#0]UKA » %2[#0]UKA
+            %1 » %2[#0]UKA » %0:orders[#0]KAiif
+            %2 » %1[#0]UKA » %0:orders[#0]KAiif
+          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
+          ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
+            Distinct group_by=[o_orderkey] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
+                  ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+          ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
+            Distinct group_by=[l_orderkey] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (l_commitdate < l_receiptdate) // { arity: 16 }
+                  ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_orders_orderkey (*** full scan ***, delta join 1st input (full scan))
+  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
+
+EOF
+
+
+query T multiline
+-- Query 05
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q05 AS
+SELECT
+    n_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue
+FROM
+    customer,
+    orders,
+    lineitem,
+    supplier,
+    nation,
+    region
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND l_suppkey = s_suppkey
+    AND c_nationkey = s_nationkey
+    AND s_nationkey = n_nationkey
+    AND n_regionkey = r_regionkey
+    AND r_name = 'ASIA'
+    AND o_orderdate >= DATE '1994-01-01'
+    AND o_orderdate < DATE '1995-01-01'
+GROUP BY
+    n_name
+ORDER BY
+    revenue DESC;
+----
+materialize.public.q05:
+  Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+    Project (#22, #23, #36) // { arity: 3 }
+      Filter (r_name = "ASIA") AND (o_orderdate < 1995-01-01) AND (o_orderdate >= 1994-01-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 42 }
+        Join on=(c_custkey = o_custkey AND eq(c_nationkey, s_nationkey, n_nationkey) AND o_orderkey = l_orderkey AND l_suppkey = s_suppkey AND n_regionkey = r_regionkey) type=differential // { arity: 42 }
+          implementation
+            %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKeiif
+          ArrangeBy keys=[[c_nationkey]] // { arity: 8 }
+            ReadIndex on=customer fk_customer_nationkey=[differential join] // { arity: 8 }
+          ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+            ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
+          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+          ArrangeBy keys=[[s_suppkey, s_nationkey]] // { arity: 2 }
+            Project (#0, #3) // { arity: 2 }
+              Filter (s_suppkey) IS NOT NULL // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+          ArrangeBy keys=[[n_regionkey]] // { arity: 4 }
+            ReadIndex on=nation fk_nation_regionkey=[differential join] // { arity: 4 }
+          ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+            ReadIndex on=region pk_region_regionkey=[differential join] // { arity: 3 }
+
+Used Indexes:
+  - materialize.public.fk_nation_regionkey (differential join)
+  - materialize.public.pk_region_regionkey (differential join)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
+  - materialize.public.fk_customer_nationkey (differential join)
+  - materialize.public.fk_orders_custkey (differential join)
+  - materialize.public.fk_lineitem_orderkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 06
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q06 AS
+SELECT
+    sum(l_extendedprice * l_discount) AS revenue
+FROM
+    lineitem
+WHERE
+    l_quantity < 24
+    AND l_shipdate >= DATE '1994-01-01'
+    AND l_shipdate < DATE '1994-01-01' + INTERVAL '1' year
+    AND l_discount BETWEEN 0.06 - 0.01 AND 0.07;
+----
+materialize.public.q06:
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
+  With
+    cte l0 =
+      Reduce aggregates=[sum((l_extendedprice * l_discount))] // { arity: 1 }
+        Project (#5, #6) // { arity: 2 }
+          Filter (l_quantity < 24) AND (l_discount <= 0.07) AND (l_discount >= 0.05) AND (l_shipdate >= 1994-01-01) AND (date_to_timestamp(l_shipdate) < 1995-01-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
+
+EOF
+
+
+query T multiline
+-- Query 07
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q07 AS
+SELECT
+    supp_nation,
+    cust_nation,
+    l_year,
+    sum(volume) AS revenue
+FROM
+    (
+        SELECT
+            n1.n_name AS supp_nation,
+            n2.n_name AS cust_nation,
+            extract(year FROM l_shipdate) AS l_year,
+            l_extendedprice * (1 - l_discount) AS volume
+        FROM
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2
+        WHERE
+            s_suppkey = l_suppkey
+            AND o_orderkey = l_orderkey
+            AND c_custkey = o_custkey
+            AND s_nationkey = n1.n_nationkey
+            AND c_nationkey = n2.n_nationkey
+            AND (
+                (n1.n_name = 'FRANCE' AND n2.n_name = 'GERMANY')
+                or (n1.n_name = 'GERMANY' AND n2.n_name = 'FRANCE')
+            )
+            AND l_shipdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+    ) AS shipping
+GROUP BY
+    supp_nation,
+    cust_nation,
+    l_year
+ORDER BY
+    supp_nation,
+    cust_nation,
+    l_year;
+----
+materialize.public.q07:
+  Return // { arity: 4 }
+    Reduce group_by=[n_name, n_name, extract_year_d(l_shipdate)] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+      Project (#12, #13, #17, #41, #45) // { arity: 5 }
+        Filter (l_shipdate <= 1996-12-31) AND (l_shipdate >= 1995-01-01) AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+          Map ((n_name = "FRANCE"), (n_name = "GERMANY"), (n_name = "FRANCE"), (n_name = "GERMANY")) // { arity: 52 }
+            Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey) type=delta // { arity: 48 }
+              implementation
+                %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                %2:orders » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef » %3:customer[#0]KA » %5:l0[#0]KAef
+                %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
+                %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
+                %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
+              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+              ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+                ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+                ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
+              Get l0 // { arity: 4 }
+              Get l0 // { arity: 4 }
+  With
+    cte l0 =
+      ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+        ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.fk_customer_nationkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 08
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q08 AS
+SELECT
+    o_year,
+    sum(case
+        when nation = 'BRAZIL' then volume
+        else 0
+    end) / sum(volume) AS mkt_share
+FROM
+    (
+        SELECT
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) AS volume,
+            n2.n_name AS nation
+        FROM
+            part,
+            supplier,
+            lineitem,
+            orders,
+            customer,
+            nation n1,
+            nation n2,
+            region
+        WHERE
+            p_partkey = l_partkey
+            AND s_suppkey = l_suppkey
+            AND l_orderkey = o_orderkey
+            AND o_custkey = c_custkey
+            AND c_nationkey = n1.n_nationkey
+            AND n1.n_regionkey = r_regionkey
+            AND r_name = 'AMERICA'
+            AND s_nationkey = n2.n_nationkey
+            AND o_orderdate BETWEEN DATE '1995-01-01' AND DATE '1996-12-31'
+            AND p_type = 'ECONOMY ANODIZED STEEL'
+    ) AS all_nations
+GROUP BY
+    o_year
+ORDER BY
+    o_year;
+----
+materialize.public.q08:
+  Project (#0, #3) // { arity: 2 }
+    Map ((#1 / #2)) // { arity: 4 }
+      Reduce group_by=[extract_year_d(o_orderdate)] aggregates=[sum(case when (n_name = "BRAZIL") then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 3 }
+        Project (#21, #22, #36, #54) // { arity: 4 }
+          Filter (r_name = "AMERICA") AND (o_orderdate <= 1996-12-31) AND (o_orderdate >= 1995-01-01) AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(p_type)) // { arity: 60 }
+            Join on=(p_partkey = l_partkey AND s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 60 }
+              implementation
+                %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                %2:lineitem » %0:part[#0]KAef » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                %3:orders » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                %4:customer » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
+                %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
+                %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
+                %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
+              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+                ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+              ArrangeBy keys=[[l_orderkey], [l_partkey], [l_suppkey]] // { arity: 16 }
+                ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+                ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+                ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
+              ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+                ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+                ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+              ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+                ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.fk_nation_regionkey (delta join lookup)
+  - materialize.public.pk_region_regionkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.pk_customer_custkey (delta join lookup)
+  - materialize.public.fk_customer_nationkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_partkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 09
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q09 AS
+SELECT
+    nation,
+    o_year,
+    sum(amount) AS sum_profit
+FROM
+    (
+        SELECT
+            n_name AS nation,
+            extract(year FROM o_orderdate) AS o_year,
+            l_extendedprice * (1 - l_discount) - ps_supplycost * l_quantity AS amount
+        FROM
+            part,
+            supplier,
+            lineitem,
+            partsupp,
+            orders,
+            nation
+        WHERE
+            s_suppkey = l_suppkey
+            AND ps_suppkey = l_suppkey
+            AND ps_partkey = l_partkey
+            AND p_partkey = l_partkey
+            AND o_orderkey = l_orderkey
+            AND s_nationkey = n_nationkey
+            AND p_name like '%green%'
+    ) AS profit
+GROUP BY
+    nation,
+    o_year
+ORDER BY
+    nation,
+    o_year DESC;
+----
+materialize.public.q09:
+  Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
+    Project (#20..=#22, #35, #41, #47) // { arity: 6 }
+      Filter (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND like["%green%"](varchar_to_text(p_name)) // { arity: 50 }
+        Join on=(eq(p_partkey, l_partkey, ps_partkey) AND eq(s_suppkey, l_suppkey, ps_suppkey) AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 50 }
+          implementation
+            %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+            %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
+            %2:lineitem » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+            %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
+            %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
+            %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
+          ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
+          ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+          ArrangeBy keys=[[l_orderkey], [l_partkey], [l_partkey, l_suppkey], [l_suppkey]] // { arity: 16 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] fk_lineitem_partsuppkey=[delta join lookup] // { arity: 16 }
+          ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 5 }
+            ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[delta join lookup] // { arity: 5 }
+          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
+          ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_part_partkey (delta join 1st input (full scan))
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.pk_partsupp_partkey_suppkey (delta join lookup)
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_partkey (delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+  - materialize.public.fk_lineitem_partsuppkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 10
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q10 AS
+SELECT
+    c_custkey,
+    c_name,
+    sum(l_extendedprice * (1 - l_discount)) AS revenue,
+    c_acctbal,
+    n_name,
+    c_address,
+    c_phone,
+    c_comment
+FROM
+    customer,
+    orders,
+    lineitem,
+    nation
+WHERE
+    c_custkey = o_custkey
+    AND l_orderkey = o_orderkey
+    AND o_orderdate >= DATE '1993-10-01'
+    AND o_orderdate < DATE '1994-01-01'
+    AND o_orderdate < DATE '1993-10-01' + INTERVAL '3' month
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+GROUP BY
+    c_custkey,
+    c_name,
+    c_acctbal,
+    c_phone,
+    n_name,
+    c_address,
+    c_comment
+ORDER BY
+    revenue DESC;
+----
+materialize.public.q10:
+  Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
+    Reduce group_by=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 8 }
+      Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
+        Filter (l_returnflag = "R") AND (o_orderdate < 1994-01-01) AND (o_orderdate >= 1993-10-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1994-01-01 00:00:00) // { arity: 37 }
+          Join on=(c_custkey = o_custkey AND c_nationkey = n_nationkey AND o_orderkey = l_orderkey) type=delta // { arity: 37 }
+            implementation
+              %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
+              %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
+              %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
+              %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
+            ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
+            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.fk_customer_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 11
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q11 AS
+SELECT
+    ps_partkey,
+    sum(ps_supplycost * ps_availqty) AS value
+FROM
+    partsupp,
+    supplier,
+    nation
+WHERE
+    ps_suppkey = s_suppkey
+    AND s_nationkey = n_nationkey
+    AND n_name = 'GERMANY'
+GROUP BY
+    ps_partkey having
+        sum(ps_supplycost * ps_availqty) > (
+            SELECT
+                sum(ps_supplycost * ps_availqty) * 0.0001
+            FROM
+                partsupp,
+                supplier,
+                nation
+            WHERE
+                ps_suppkey = s_suppkey
+                AND s_nationkey = n_nationkey
+                AND n_name = 'GERMANY'
+        )
+ORDER BY
+    value DESC;
+----
+materialize.public.q11:
+  Return // { arity: 2 }
+    Project (#0, #1) // { arity: 2 }
+      Filter (#1 > (#2 * 0.0001)) // { arity: 3 }
+        CrossJoin type=differential // { arity: 3 }
+          implementation
+            %1[×]UA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 2 }
+            Reduce group_by=[ps_partkey] aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 2 }
+              Get l0 // { arity: 3 }
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Reduce aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 1 }
+              Project (#1, #2) // { arity: 2 }
+                Get l0 // { arity: 3 }
+  With
+    cte l0 =
+      Project (#0, #2, #3) // { arity: 3 }
+        Filter (n_name = "GERMANY") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL // { arity: 16 }
+          Join on=(ps_suppkey = s_suppkey AND s_nationkey = n_nationkey) type=delta // { arity: 16 }
+            implementation
+              %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
+              %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
+              %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
+            ArrangeBy keys=[[ps_suppkey]] // { arity: 5 }
+              ReadIndex on=partsupp fk_partsupp_suppkey=[delta join 1st input (full scan)] // { arity: 5 }
+            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
+            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join lookup)
+  - materialize.public.fk_supplier_nationkey (delta join lookup)
+  - materialize.public.fk_partsupp_suppkey (delta join 1st input (full scan))
+
+EOF
+
+
+query T multiline
+-- Query 12
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q12 AS
+SELECT
+    l_shipmode,
+    sum(case
+        when o_orderpriority = '1-URGENT'
+            or o_orderpriority = '2-HIGH'
+            then 1
+        else 0
+    end) AS high_line_count,
+    sum(case
+        when o_orderpriority <> '1-URGENT'
+            AND o_orderpriority <> '2-HIGH'
+            then 1
+        else 0
+    end) AS low_line_count
+FROM
+    orders,
+    lineitem
+WHERE
+    o_orderkey = l_orderkey
+    AND l_shipmode IN ('MAIL', 'SHIP')
+    AND l_commitdate < l_receiptdate
+    AND l_shipdate < l_commitdate
+    AND l_receiptdate >= DATE '1994-01-01'
+    AND l_receiptdate < DATE '1994-01-01' + INTERVAL '1' year
+GROUP BY
+    l_shipmode
+ORDER BY
+    l_shipmode;
+----
+materialize.public.q12:
+  Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
+    Project (#5, #23) // { arity: 2 }
+      Filter (l_receiptdate >= 1994-01-01) AND (o_orderkey) IS NOT NULL AND (l_shipdate < l_commitdate) AND (l_commitdate < l_receiptdate) AND (date_to_timestamp(l_receiptdate) < 1995-01-01 00:00:00) AND ((l_shipmode = "MAIL") OR (l_shipmode = "SHIP")) // { arity: 25 }
+        Join on=(o_orderkey = l_orderkey) type=differential // { arity: 25 }
+          implementation
+            %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
+          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
+          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_orders_orderkey (differential join)
+  - materialize.public.fk_lineitem_orderkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 13
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q13 AS
+SELECT
+    c_count,
+    count(*) AS custdist
+FROM
+    (
+        SELECT
+            c_custkey,
+            count(o_orderkey) c_count -- workaround for no column aliases
+        FROM
+            customer LEFT OUTER JOIN orders ON
+                c_custkey = o_custkey
+                AND o_comment NOT LIKE '%special%requests%'
+        GROUP BY
+            c_custkey
+    ) AS c_orders -- (c_custkey, c_count) -- no column aliases yet
+GROUP BY
+    c_count
+ORDER BY
+    custdist DESC,
+    c_count DESC;
+----
+materialize.public.q13:
+  Return // { arity: 2 }
+    Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
+      Project (#1) // { arity: 1 }
+        Reduce group_by=[c_custkey] aggregates=[count(o_orderkey)] // { arity: 2 }
+          Union // { arity: 2 }
+            Project (#0, #8) // { arity: 2 }
+              Get l0 // { arity: 9 }
+            Project (#0, #16) // { arity: 2 }
+              Map (null) // { arity: 17 }
+                Join on=(c_custkey = c_custkey AND c_name = c_name AND c_address = c_address AND c_nationkey = c_nationkey AND c_phone = c_phone AND c_acctbal = c_acctbal AND c_mktsegment = c_mktsegment AND c_comment = c_comment) type=differential // { arity: 16 }
+                  implementation
+                    %0[#0..=#7]KKKKKKKK » %1:customer[#0..=#7]KKKKKKKK
+                  ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
+                    Union // { arity: 8 }
+                      Negate // { arity: 8 }
+                        Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                          Project (#0..=#7) // { arity: 8 }
+                            Get l0 // { arity: 9 }
+                      Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+                  ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
+                    ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+  With
+    cte l0 =
+      Project (#0..=#8) // { arity: 9 }
+        Filter (c_custkey) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(o_comment))) // { arity: 17 }
+          Join on=(c_custkey = o_custkey) type=differential // { arity: 17 }
+            implementation
+              %1:orders[#1]KAf » %0:customer[#0]KAf
+            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
+            ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+              ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
+
+Used Indexes:
+  - materialize.public.pk_customer_custkey (*** full scan ***, differential join)
+  - materialize.public.fk_orders_custkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 14
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q14 AS
+SELECT
+    100.00 * sum(case
+        when p_type like 'PROMO%'
+            then l_extendedprice * (1 - l_discount)
+        else 0
+    end) / sum(l_extendedprice * (1 - l_discount)) AS promo_revenue
+FROM
+    lineitem,
+    part
+WHERE
+    l_partkey = p_partkey
+    AND l_shipdate >= DATE '1995-09-01'
+    AND l_shipdate < DATE '1995-09-01' + INTERVAL '1' month;
+----
+materialize.public.q14:
+  Return // { arity: 1 }
+    Project (#2) // { arity: 1 }
+      Map (((100 * #0) / #1)) // { arity: 3 }
+        Union // { arity: 2 }
+          Get l0 // { arity: 2 }
+          Map (null, null) // { arity: 2 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l0 // { arity: 2 }
+              Constant // { arity: 0 }
+                - ()
+  With
+    cte l0 =
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(p_type)) then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+        Project (#5, #6, #20) // { arity: 3 }
+          Filter (l_shipdate >= 1995-09-01) AND (l_partkey) IS NOT NULL AND (date_to_timestamp(l_shipdate) < 1995-10-01 00:00:00) // { arity: 25 }
+            Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+              implementation
+                %0:lineitem[#1]KAiif » %1:part[#0]KAiif
+              ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+                ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+
+Used Indexes:
+  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.fk_lineitem_partkey (differential join)
+
+EOF
+
+
+statement ok
+create view revenue (supplier_no, total_revenue) as
+    SELECT
+        l_suppkey,
+        sum(l_extendedprice * (1 - l_discount))
+    FROM
+        lineitem
+    WHERE
+        l_shipdate >= DATE '1996-01-01'
+        AND l_shipdate < DATE '1996-01-01' + INTERVAL '3' month
+    GROUP BY
+        l_suppkey
+
+query T multiline
+-- Query 15
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q15 AS
+SELECT
+    s_suppkey,
+    s_name,
+    s_address,
+    s_phone,
+    total_revenue
+FROM
+    supplier,
+    revenue
+WHERE
+    s_suppkey = supplier_no
+    AND total_revenue = (
+        SELECT
+            max(total_revenue)
+        FROM
+            revenue
+    )
+ORDER BY
+    s_suppkey;
+----
+materialize.public.q15:
+  Return // { arity: 5 }
+    Project (#0..=#2, #4, #8) // { arity: 5 }
+      Filter (s_suppkey) IS NOT NULL // { arity: 10 }
+        Join on=(s_suppkey = l_suppkey AND #8 = #9) type=differential // { arity: 10 }
+          implementation
+            %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UK
+          ArrangeBy keys=[[s_suppkey]] // { arity: 7 }
+            ReadIndex on=supplier pk_supplier_suppkey=[differential join] // { arity: 7 }
+          ArrangeBy keys=[[l_suppkey]] // { arity: 2 }
+            Get l0 // { arity: 2 }
+          ArrangeBy keys=[[#0]] // { arity: 1 }
+            Reduce aggregates=[max(#0)] // { arity: 1 }
+              Project (#1) // { arity: 1 }
+                Get l0 // { arity: 2 }
+  With
+    cte l0 =
+      Reduce group_by=[l_suppkey] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+        Project (#2, #5, #6) // { arity: 3 }
+          Filter (l_shipdate >= 1996-01-01) AND (date_to_timestamp(l_shipdate) < 1996-04-01 00:00:00) // { arity: 16 }
+            ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_supplier_suppkey (differential join)
+  - materialize.public.pk_lineitem_orderkey_linenumber (*** full scan ***)
+
+EOF
+
+statement ok
+drop view revenue
+
+
+query T multiline
+-- Query 16
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q16 AS
+SELECT
+    p_brand,
+    p_type,
+    p_size,
+    count(DISTINCT ps_suppkey) AS supplier_cnt
+FROM
+    partsupp,
+    part
+WHERE
+    p_partkey = ps_partkey
+    AND p_brand <> 'Brand#45'
+    AND p_type NOT LIKE 'MEDIUM POLISHED%'
+    AND p_size IN (49, 14, 23, 45, 19, 3, 36, 9)
+    AND ps_suppkey NOT IN (
+        SELECT
+            s_suppkey
+        FROM
+            supplier
+        WHERE
+            s_comment like '%Customer%Complaints%'
+    )
+GROUP BY
+    p_brand,
+    p_type,
+    p_size
+ORDER BY
+    supplier_cnt DESC,
+    p_brand,
+    p_type,
+    p_size;
+----
+materialize.public.q16:
+  Return // { arity: 4 }
+    Reduce group_by=[p_brand, p_type, p_size] aggregates=[count(distinct ps_suppkey)] // { arity: 4 }
+      Project (#0..=#3) // { arity: 4 }
+        Join on=(ps_suppkey = ps_suppkey) type=differential // { arity: 5 }
+          implementation
+            %0:l0[#0]K » %1[#0]K
+          ArrangeBy keys=[[ps_suppkey]] // { arity: 4 }
+            Get l0 // { arity: 4 }
+          ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Distinct group_by=[ps_suppkey] // { arity: 1 }
+                  Project (#0) // { arity: 1 }
+                    Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
+                      CrossJoin type=differential // { arity: 2 }
+                        implementation
+                          %1:supplier[×]lf » %0:l1[×]lf
+                        ArrangeBy keys=[[]] // { arity: 1 }
+                          Get l1 // { arity: 1 }
+                        ArrangeBy keys=[[]] // { arity: 1 }
+                          Project (#0) // { arity: 1 }
+                            Filter like["%Customer%Complaints%"](varchar_to_text(s_comment)) // { arity: 7 }
+                              ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
+              Get l1 // { arity: 1 }
+  With
+    cte l1 =
+      Distinct group_by=[ps_suppkey] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l0 // { arity: 4 }
+    cte l0 =
+      Project (#1, #8..=#10) // { arity: 4 }
+        Filter (p_brand != "Brand#45") AND (ps_partkey) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(p_type))) AND ((p_size = 3) OR (p_size = 9) OR (p_size = 14) OR (p_size = 19) OR (p_size = 23) OR (p_size = 36) OR (p_size = 45) OR (p_size = 49)) // { arity: 14 }
+          Join on=(ps_partkey = p_partkey) type=differential // { arity: 14 }
+            implementation
+              %1:part[#0]KAef » %0:partsupp[#0]KAef
+            ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+              ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
+            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+
+Used Indexes:
+  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.pk_supplier_suppkey (*** full scan ***)
+  - materialize.public.fk_partsupp_partkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 17
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q17 AS
+SELECT
+  sum(l_extendedprice) / 7.0 AS avg_yearly
+FROM
+  lineitem,
+  part
+WHERE
+  p_partkey = l_partkey
+  AND p_brand = 'Brand#23'
+  AND p_container = 'MED BOX'
+  AND l_quantity < (
+    SELECT
+      0.2 * avg(l_quantity)
+    FROM
+      lineitem
+    WHERE
+      l_partkey = p_partkey
+  );
+----
+materialize.public.q17:
+  Return // { arity: 1 }
+    Project (#1) // { arity: 1 }
+      Map ((#0 / 7)) // { arity: 2 }
+        Union // { arity: 1 }
+          Get l2 // { arity: 1 }
+          Map (null) // { arity: 1 }
+            Union // { arity: 0 }
+              Negate // { arity: 0 }
+                Project () // { arity: 0 }
+                  Get l2 // { arity: 1 }
+              Constant // { arity: 0 }
+                - ()
+  With
+    cte l2 =
+      Reduce aggregates=[sum(l_extendedprice)] // { arity: 1 }
+        Project (#2) // { arity: 1 }
+          Filter (l_quantity < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+            Join on=(l_partkey = l_partkey) type=differential // { arity: 6 }
+              implementation
+                %1[#0]UKA » %0:l1[#0]K
+              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+                Get l1 // { arity: 3 }
+              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+                Reduce group_by=[l_partkey] aggregates=[sum(l_quantity), count(*)] // { arity: 3 }
+                  Project (#0, #5) // { arity: 2 }
+                    Join on=(l_partkey = l_partkey) type=differential // { arity: 17 }
+                      implementation
+                        %0[#0]UKA » %1:l0[#1]KA
+                      ArrangeBy keys=[[l_partkey]] // { arity: 1 }
+                        Distinct group_by=[l_partkey] // { arity: 1 }
+                          Project (#0) // { arity: 1 }
+                            Get l1 // { arity: 3 }
+                      Get l0 // { arity: 16 }
+    cte l1 =
+      Project (#1, #4, #5) // { arity: 3 }
+        Filter (p_brand = "Brand#23") AND (p_container = "MED BOX") AND (l_partkey) IS NOT NULL // { arity: 25 }
+          Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+            implementation
+              %1:part[#0]KAef » %0:l0[#1]KAef
+            Get l0 // { arity: 16 }
+            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+    cte l0 =
+      ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.fk_lineitem_partkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 18
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q18 AS
+SELECT
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice,
+    sum(l_quantity)
+FROM
+    customer,
+    orders,
+    lineitem
+WHERE
+    o_orderkey IN (
+        SELECT
+            l_orderkey
+        FROM
+            lineitem
+        GROUP BY
+            l_orderkey having
+                sum(l_quantity) > 300
+    )
+    AND c_custkey = o_custkey
+    AND o_orderkey = l_orderkey
+GROUP BY
+    c_name,
+    c_custkey,
+    o_orderkey,
+    o_orderdate,
+    o_totalprice
+ORDER BY
+    o_totalprice DESC,
+    o_orderdate;
+----
+materialize.public.q18:
+  Return // { arity: 6 }
+    Reduce group_by=[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] aggregates=[sum(l_quantity)] // { arity: 6 }
+      Project (#0..=#5) // { arity: 6 }
+        Filter (#7 > 300) // { arity: 8 }
+          Join on=(o_orderkey = o_orderkey) type=differential // { arity: 8 }
+            implementation
+              %1[#0]UKAif » %0:l1[#2]Kif
+            ArrangeBy keys=[[o_orderkey]] // { arity: 6 }
+              Get l1 // { arity: 6 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 2 }
+              Reduce group_by=[o_orderkey] aggregates=[sum(l_quantity)] // { arity: 2 }
+                Project (#0, #5) // { arity: 2 }
+                  Join on=(o_orderkey = l_orderkey) type=differential // { arity: 17 }
+                    implementation
+                      %0[#0]UKA » %1:l0[#0]KA
+                    ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
+                      Distinct group_by=[o_orderkey] // { arity: 1 }
+                        Project (#2) // { arity: 1 }
+                          Get l1 // { arity: 6 }
+                    Get l0 // { arity: 16 }
+  With
+    cte l1 =
+      Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
+        Filter (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
+          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+            implementation
+              %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
+              %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
+              %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
+            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+              ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
+            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
+            Get l0 // { arity: 16 }
+    cte l0 =
+      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
+
+Used Indexes:
+  - materialize.public.pk_customer_custkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_orders_custkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 19
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q19 AS
+SELECT
+    sum(l_extendedprice* (1 - l_discount)) AS revenue
+FROM
+    lineitem,
+    part
+WHERE
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#12'
+        AND p_container IN ('SM CASE', 'SM BOX', 'SM PACK', 'SM PKG')
+        AND l_quantity >= CAST (1 AS smallint) AND l_quantity <= CAST (1 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (5 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#23'
+        AND p_container IN ('MED BAG', 'MED BOX', 'MED PKG', 'MED PACK')
+        AND l_quantity >= CAST (10 AS smallint) AND l_quantity <= CAST (10 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (10 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    )
+    or
+    (
+        p_partkey = l_partkey
+        AND p_brand = 'Brand#34'
+        AND p_container IN ('LG CASE', 'LG BOX', 'LG PACK', 'LG PKG')
+        AND l_quantity >= CAST (20 AS smallint) AND l_quantity <= CAST (20 + 10 AS smallint)
+        AND p_size BETWEEN CAST (1 AS smallint) AND CAST (15 AS smallint)
+        AND l_shipmode IN ('AIR', 'AIR REG')
+        AND l_shipinstruct = 'DELIVER IN PERSON'
+    );
+----
+materialize.public.q19:
+  Return // { arity: 1 }
+    Union // { arity: 1 }
+      Get l0 // { arity: 1 }
+      Map (null) // { arity: 1 }
+        Union // { arity: 0 }
+          Negate // { arity: 0 }
+            Project () // { arity: 0 }
+              Get l0 // { arity: 1 }
+          Constant // { arity: 0 }
+            - ()
+  With
+    cte l0 =
+      Reduce aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 1 }
+        Project (#5, #6) // { arity: 2 }
+          Filter (l_shipinstruct = "DELIVER IN PERSON") AND (p_size >= 1) AND (l_partkey) IS NOT NULL AND ((l_shipmode = "AIR") OR (l_shipmode = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+            Map ((l_quantity <= 20), (l_quantity >= 10), (l_quantity <= 30), (l_quantity >= 20), (l_quantity <= 11), (l_quantity >= 1), (p_brand = "Brand#12"), (p_size <= 5), ((p_container = "SM BOX") OR (p_container = "SM PKG") OR (p_container = "SM CASE") OR (p_container = "SM PACK")), (p_brand = "Brand#23"), (p_size <= 10), ((p_container = "MED BAG") OR (p_container = "MED BOX") OR (p_container = "MED PKG") OR (p_container = "MED PACK")), (p_brand = "Brand#34"), (p_size <= 15), ((p_container = "LG BOX") OR (p_container = "LG PKG") OR (p_container = "LG CASE") OR (p_container = "LG PACK"))) // { arity: 40 }
+              Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+                implementation
+                  %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
+                ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+                  ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
+                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                  ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
+
+Used Indexes:
+  - materialize.public.pk_part_partkey (differential join)
+  - materialize.public.fk_lineitem_partkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 20
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q20 AS
+SELECT
+    s_name,
+    s_address
+FROM
+    supplier,
+    nation
+WHERE
+    s_suppkey IN (
+        SELECT
+            ps_suppkey
+        FROM
+            partsupp
+        WHERE
+            ps_partkey IN (
+                SELECT
+                    p_partkey
+                FROM
+                    part
+                WHERE
+                    p_name like 'forest%'
+            )
+            AND ps_availqty > (
+                SELECT
+                    0.5 * sum(l_quantity)
+                FROM
+                    lineitem
+                WHERE
+                    l_partkey = ps_partkey
+                    AND l_suppkey = ps_suppkey
+                    AND l_shipdate >= DATE '1995-01-01'
+                    AND l_shipdate < DATE '1995-01-01' + INTERVAL '1' year
+            )
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'CANADA'
+ORDER BY
+    s_name;
+----
+materialize.public.q20:
+  Return // { arity: 2 }
+    Project (#1, #2) // { arity: 2 }
+      Join on=(s_suppkey = s_suppkey) type=differential // { arity: 4 }
+        implementation
+          %1[#0]UKA » %0:l0[#0]K
+        ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
+          Get l0 // { arity: 3 }
+        ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
+          Distinct group_by=[s_suppkey] // { arity: 1 }
+            Project (#0) // { arity: 1 }
+              Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
+                Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
+                  implementation
+                    %1[#1, #0]UKK » %0:l1[#0, #1]KKf
+                  ArrangeBy keys=[[s_suppkey, ps_partkey]] // { arity: 3 }
+                    Project (#0, #1, #3) // { arity: 3 }
+                      Filter (s_suppkey = ps_suppkey) // { arity: 4 }
+                        Get l1 // { arity: 4 }
+                  ArrangeBy keys=[[ps_suppkey, ps_partkey]] // { arity: 3 }
+                    Project (#0, #1, #3) // { arity: 3 }
+                      Map ((0.5 * #2)) // { arity: 4 }
+                        Reduce group_by=[ps_partkey, ps_suppkey] aggregates=[sum(l_quantity)] // { arity: 3 }
+                          Project (#0, #1, #6) // { arity: 3 }
+                            Filter (l_shipdate >= 1995-01-01) AND (date_to_timestamp(l_shipdate) < 1996-01-01 00:00:00) // { arity: 18 }
+                              Join on=(ps_partkey = l_partkey AND ps_suppkey = l_suppkey) type=differential // { arity: 18 }
+                                implementation
+                                  %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
+                                ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
+                                  Distinct group_by=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                    Project (#1, #2) // { arity: 2 }
+                                      Get l1 // { arity: 4 }
+                                ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
+                                  ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
+  With
+    cte l1 =
+      Project (#0..=#3) // { arity: 4 }
+        Join on=(ps_partkey = p_partkey) type=differential // { arity: 7 }
+          implementation
+            %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
+          ArrangeBy keys=[[]] // { arity: 1 }
+            Distinct group_by=[s_suppkey] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Get l0 // { arity: 3 }
+          ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+            ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
+          ArrangeBy keys=[[p_partkey]] // { arity: 1 }
+            Distinct group_by=[p_partkey] // { arity: 1 }
+              Project (#0) // { arity: 1 }
+                Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
+                  ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
+    cte l0 =
+      Project (#0..=#2) // { arity: 3 }
+        Filter (n_name = "CANADA") AND (s_nationkey) IS NOT NULL // { arity: 11 }
+          Join on=(s_nationkey = n_nationkey) type=differential // { arity: 11 }
+            implementation
+              %1:nation[#0]KAef » %0:supplier[#3]KAef
+            ArrangeBy keys=[[s_nationkey]] // { arity: 7 }
+              ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
+            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (differential join)
+  - materialize.public.pk_part_partkey (*** full scan ***)
+  - materialize.public.fk_supplier_nationkey (differential join)
+  - materialize.public.fk_partsupp_partkey (differential join)
+  - materialize.public.fk_lineitem_partsuppkey (differential join)
+
+EOF
+
+
+query T multiline
+-- Query 21
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q21 AS
+SELECT
+    s_name,
+    count(*) AS numwait
+FROM
+    supplier,
+    lineitem l1,
+    orders,
+    nation
+WHERE
+    s_suppkey = l1.l_suppkey
+    AND o_orderkey = l1.l_orderkey
+    AND o_orderstatus = 'F'
+    AND l1.l_receiptdate > l1.l_commitdate
+    AND EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l2
+        WHERE
+            l2.l_orderkey = l1.l_orderkey
+            AND l2.l_suppkey <> l1.l_suppkey
+    )
+    AND not EXISTS (
+        SELECT
+            *
+        FROM
+            lineitem l3
+        WHERE
+            l3.l_orderkey = l1.l_orderkey
+            AND l3.l_suppkey <> l1.l_suppkey
+            AND l3.l_receiptdate > l3.l_commitdate
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'SAUDI ARABIA'
+GROUP BY
+    s_name
+ORDER BY
+    numwait DESC,
+    s_name;
+----
+materialize.public.q21:
+  Return // { arity: 2 }
+    Reduce group_by=[s_name] aggregates=[count(*)] // { arity: 2 }
+      Project (#1) // { arity: 1 }
+        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+          implementation
+            %0:l2[#2, #0]KK » %1[#0, #1]KK
+          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 3 }
+            Get l2 // { arity: 3 }
+          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
+            Union // { arity: 2 }
+              Negate // { arity: 2 }
+                Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                  Project (#0, #1) // { arity: 2 }
+                    Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
+                      Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                        implementation
+                          %1:l1[#0]KAf » %0:l3[#0]Kf
+                        ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                          Get l3 // { arity: 2 }
+                        Get l1 // { arity: 16 }
+              Get l3 // { arity: 2 }
+  With
+    cte l3 =
+      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+        Project (#0, #2) // { arity: 2 }
+          Get l2 // { arity: 3 }
+    cte l2 =
+      Project (#0..=#2) // { arity: 3 }
+        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+          implementation
+            %1[#1, #0]UKK » %0:l0[#0, #2]KK
+          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
+            Get l0 // { arity: 3 }
+          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
+            Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+              Project (#0, #1) // { arity: 2 }
+                Filter (s_suppkey != l_suppkey) // { arity: 18 }
+                  Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                    implementation
+                      %1:l1[#0]KA » %0[#0]K
+                    ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                        Project (#0, #2) // { arity: 2 }
+                          Get l0 // { arity: 3 }
+                    Get l1 // { arity: 16 }
+    cte l1 =
+      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+        ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
+    cte l0 =
+      Project (#0, #1, #7) // { arity: 3 }
+        Filter (o_orderstatus = "F") AND (n_name = "SAUDI ARABIA") AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (l_receiptdate > l_commitdate) // { arity: 36 }
+          Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 36 }
+            implementation
+              %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+              %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
+              %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
+            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
+            ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+              ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
+            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+              ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
+            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
+
+Used Indexes:
+  - materialize.public.pk_nation_nationkey (delta join lookup)
+  - materialize.public.pk_supplier_suppkey (delta join 1st input (full scan))
+  - materialize.public.fk_supplier_nationkey (delta join 1st input (full scan))
+  - materialize.public.pk_orders_orderkey (delta join lookup)
+  - materialize.public.fk_lineitem_orderkey (differential join, delta join lookup)
+  - materialize.public.fk_lineitem_suppkey (delta join lookup)
+
+EOF
+
+
+query T multiline
+-- Query 22
+EXPLAIN WITH(humanized_exprs, arity, join_impls)
+CREATE MATERIALIZED VIEW Q22 AS
+SELECT
+    cntrycode,
+    count(*) AS numcust,
+    sum(c_acctbal) AS totacctbal
+FROM
+    (
+        SELECT
+            substring(c_phone, 1, 2) AS cntrycode, c_acctbal
+        FROM
+            customer
+        WHERE
+            substring(c_phone, 1, 2)
+            IN ('13', '31', '23', '29', '30', '18', '17')
+            AND c_acctbal
+                > (
+                        SELECT
+                            avg(c_acctbal)
+                        FROM
+                            customer
+                        WHERE
+                            c_acctbal > 0.00
+                            AND substring(c_phone, 1, 2)
+                                IN (
+                                        '13',
+                                        '31',
+                                        '23',
+                                        '29',
+                                        '30',
+                                        '18',
+                                        '17'
+                                    )
+                    )
+            AND NOT
+                    EXISTS(
+                        SELECT
+                            *
+                        FROM
+                            orders
+                        WHERE
+                            o_custkey = c_custkey
+                    )
+    )
+        AS custsale
+GROUP BY
+    cntrycode
+ORDER BY
+    cntrycode;
+----
+materialize.public.q22:
+  Return // { arity: 3 }
+    Reduce group_by=[substr(char_to_text(c_phone), 1, 2)] aggregates=[count(*), sum(c_acctbal)] // { arity: 3 }
+      Project (#1, #2) // { arity: 2 }
+        Join on=(c_custkey = c_custkey) type=differential // { arity: 4 }
+          implementation
+            %0:l1[#0]K » %1[#0]K
+          ArrangeBy keys=[[c_custkey]] // { arity: 3 }
+            Get l1 // { arity: 3 }
+          ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+            Union // { arity: 1 }
+              Negate // { arity: 1 }
+                Project (#0) // { arity: 1 }
+                  Filter (c_custkey) IS NOT NULL // { arity: 2 }
+                    Join on=(c_custkey = o_custkey) type=differential // { arity: 2 }
+                      implementation
+                        %0:l2[#0]UKA » %1[#0]UKA
+                      ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+                        Get l2 // { arity: 1 }
+                      ArrangeBy keys=[[o_custkey]] // { arity: 1 }
+                        Distinct group_by=[o_custkey] // { arity: 1 }
+                          Project (#1) // { arity: 1 }
+                            ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
+              Get l2 // { arity: 1 }
+  With
+    cte l2 =
+      Distinct group_by=[c_custkey] // { arity: 1 }
+        Project (#0) // { arity: 1 }
+          Get l1 // { arity: 3 }
+    cte l1 =
+      Project (#0..=#2) // { arity: 3 }
+        Filter (c_acctbal > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+          CrossJoin type=differential // { arity: 5 }
+            implementation
+              %1[×]UA » %0:l0[×]ef
+            ArrangeBy keys=[[]] // { arity: 3 }
+              Project (#0, #4, #5) // { arity: 3 }
+                Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                  Get l0 // { arity: 9 }
+            ArrangeBy keys=[[]] // { arity: 2 }
+              Reduce aggregates=[sum(c_acctbal), count(*)] // { arity: 2 }
+                Project (#5) // { arity: 1 }
+                  Filter (c_acctbal > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Get l0 // { arity: 9 }
+    cte l0 =
+      Map (substr(char_to_text(c_phone), 1, 2)) // { arity: 9 }
+        ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
+
+Used Indexes:
+  - materialize.public.pk_customer_custkey (*** full scan ***)
+  - materialize.public.pk_orders_orderkey (*** full scan ***)
+
+EOF
+
+################################################################################
+# end of optimized plans - below here is a sampling of other plan info
+################################################################################
+
+query T multiline
+-- Query 20
+EXPLAIN RAW PLAN FOR
+CREATE MATERIALIZED VIEW Q20 AS
+SELECT
+    s_name,
+    s_address
+FROM
+    supplier,
+    nation
+WHERE
+    s_suppkey IN (
+        SELECT
+            ps_suppkey
+        FROM
+            partsupp
+        WHERE
+            ps_partkey IN (
+                SELECT
+                    p_partkey
+                FROM
+                    part
+                WHERE
+                    p_name like 'forest%'
+            )
+            AND ps_availqty > (
+                SELECT
+                    0.5 * sum(l_quantity)
+                FROM
+                    lineitem
+                WHERE
+                    l_partkey = ps_partkey
+                    AND l_suppkey = ps_suppkey
+                    AND l_shipdate >= DATE '1995-01-01'
+                    AND l_shipdate < DATE '1995-01-01' + INTERVAL '1' year
+            )
+    )
+    AND s_nationkey = n_nationkey
+    AND n_name = 'CANADA'
+ORDER BY
+    s_name;
+----
+TopK order_by=[#0 asc nulls_last]
+  Project (#1, #2)
+    Return
+      Filter ((select(Get l3) AND (#3 = #7)) AND (#8 = text_to_char("CANADA")))
+        CrossJoin
+          Get materialize.public.supplier
+          Get materialize.public.nation
+    With
+      cte l3 =
+        Reduce aggregates=[any((#^0 = #0))]
+          Project (#1)
+            Return
+              Filter (select(Get l1) AND (integer_to_numeric(#2) > select(Get l2)))
+                Get materialize.public.partsupp
+            With
+              cte l1 =
+                Reduce aggregates=[any((#^0 = #0))]
+                  Project (#0)
+                    Filter (varchar_to_text(#1) like "forest%")
+                      Get materialize.public.part
+              cte l2 =
+                Project (#1)
+                  Map ((0.5 * #0))
+                    Reduce aggregates=[sum(#4)]
+                      Filter ((((#1 = #^0) AND (#2 = #^1)) AND (#10 >= text_to_date("1995-01-01"))) AND (date_to_timestamp(#10) < (text_to_date("1995-01-01") + 1 year)))
+                        Get materialize.public.lineitem
+
+EOF

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+# Plans for the TPC-H workload modeled as plain old SELECT statements.
+
 # PRIMARY KEY annotations (which are in the spec) are currently
 # removed from this slt, because we don't support them at the moment.
 # (Note that _in slts_ they are actually supported, but it's better

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -23,13 +23,17 @@ SHOW SOURCEs;
 $ postgres-execute connection=mz_support
 SHOW CREATE SOURCE bids;
 
-# The mz_support user can execute `EXPLAIN PLAN ...` commands.
+# The mz_support user can execute `EXPLAIN PLAN ... FOR SELECT` commands.
 $ postgres-execute connection=mz_support
-EXPLAIN OPTIMIZED PLAN FOR SELECT * FROM bids b JOIN users u ON(b.buyer = u.id);
+EXPLAIN OPTIMIZED PLAN FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
+
+# The mz_support user can execute `EXPLAIN PLAN ... FOR CREATE MATERIALIZED VIEW` commands.
+$ postgres-execute connection=mz_support
+EXPLAIN OPTIMIZED PLAN FOR CREATE MATERIALIZED VIEW mv AS SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
 
 # The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
 $ postgres-execute connection=mz_support
-EXPLAIN TIMESTAMP FOR SELECT * FROM bids b JOIN users u ON(b.buyer = u.id);
+EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
 
 # The mz_support user cannot execute `SELECT ...` commands.
 # We can uncomment this test once all regular commands are executed from `mz_support`


### PR DESCRIPTION
Add support for

```sql
EXPLAIN CREATE MATERIALIZED VIEW $name AS $query
```

syntax.

### Motivation
  * This PR adds a known-desirable feature.

Part of #18089.

### Tips for reviewer

- See individual commit messages for details. 
- For test coverage I cloned `tpch.slt` and changed the workload to use `CREATE MATERIALIZED VIEW $qXX AS $query` instead of `$query`. Besides the different rendering and the disappearing `Finishing` lines, there were no other changes (you can diff the two `tpch_*.slt` files to see what changed).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
