### PR TITLE
cloudtests: allow configuring default timeout for requests

### DIFF
--- a/misc/python/materialize/cloudtest/util/environment.py
+++ b/misc/python/materialize/cloudtest/util/environment.py
@@ -30,9 +30,10 @@ class Environment:
         self.auth = auth
         self.env_kubectl = env_kubectl
         self.sys_kubectl = sys_kubectl
-        self.region_api_requests = WebRequests(self.auth, region_api_server_base_url)
+        self.region_api_requests = WebRequests(
+            self.auth, region_api_server_base_url, default_timeout_in_sec=45
+        )
         self.create_env_assignment_get_retries = 120
-        self.envd_waiting_region_api_timeout = 45
         self.envd_waiting_get_env_retries = 900
 
     def create_environment_assignment(
@@ -66,7 +67,6 @@ class Environment:
         def get_environment() -> Response:
             response = self.region_api_requests.get(
                 "/api/region",
-                self.envd_waiting_region_api_timeout,
             )
             region_info = response.json().get("regionInfo")
             assert region_info
@@ -92,7 +92,7 @@ class Environment:
                 # we have a 60 second timeout in the region api's load balancer
                 # for this call and a 5 minute timeout in the region api (which
                 # is relevant when running in kind)
-                timeout=305,
+                timeout_in_sec=305,
             )
 
         retry(delete_environment, 20, [requests.exceptions.HTTPError])

--- a/misc/python/materialize/cloudtest/util/web_request.py
+++ b/misc/python/materialize/cloudtest/util/web_request.py
@@ -39,16 +39,18 @@ class WebRequests:
         base_url: str,
         client_cert: tuple[str, str] | None = None,
         additional_headers: dict[str, str] | None = None,
+        default_timeout_in_sec: int = 15,
     ):
         self.auth = auth
         self.base_url = base_url
         self.client_cert = client_cert
         self.additional_headers = additional_headers
+        self.default_timeout_in_sec = default_timeout_in_sec
 
     def get(
         self,
         path: str,
-        timeout: int = 15,
+        timeout_in_sec: int | None = None,
     ) -> requests.Response:
         eprint(f"GET {self.base_url}{path}")
 
@@ -58,7 +60,7 @@ class WebRequests:
                 response = requests.get(
                     f"{self.base_url}{path}",
                     headers=headers,
-                    timeout=timeout,
+                    timeout=self._timeout_or_default(timeout_in_sec),
                     cert=self.client_cert,
                 )
                 response.raise_for_status()
@@ -79,7 +81,7 @@ class WebRequests:
         self,
         path: str,
         json: Any,
-        timeout: int = 15,
+        timeout_in_sec: int | None = None,
     ) -> requests.Response:
         eprint(f"POST {self.base_url}{path}")
 
@@ -90,7 +92,7 @@ class WebRequests:
                     f"{self.base_url}{path}",
                     headers=headers,
                     json=json,
-                    timeout=timeout,
+                    timeout=self._timeout_or_default(timeout_in_sec),
                     cert=self.client_cert,
                 )
                 response.raise_for_status()
@@ -111,7 +113,7 @@ class WebRequests:
         self,
         path: str,
         json: Any,
-        timeout: int = 15,
+        timeout_in_sec: int | None = None,
     ) -> requests.Response:
         eprint(f"PATCH {self.base_url}{path}")
 
@@ -122,7 +124,7 @@ class WebRequests:
                     f"{self.base_url}{path}",
                     headers=headers,
                     json=json,
-                    timeout=timeout,
+                    timeout=self._timeout_or_default(timeout_in_sec),
                     cert=self.client_cert,
                 )
                 response.raise_for_status()
@@ -143,7 +145,7 @@ class WebRequests:
         self,
         path: str,
         params: Any = None,
-        timeout: int = 15,
+        timeout_in_sec: int | None = None,
     ) -> requests.Response:
         eprint(f"DELETE {self.base_url}{path}")
 
@@ -153,7 +155,7 @@ class WebRequests:
                 response = requests.delete(
                     f"{self.base_url}{path}",
                     headers=headers,
-                    timeout=timeout,
+                    timeout=self._timeout_or_default(timeout_in_sec),
                     cert=self.client_cert,
                     **(
                         {
@@ -183,3 +185,6 @@ class WebRequests:
             headers["Authorization"] = f"Bearer {auth.token}"
 
         return headers
+
+    def _timeout_or_default(self, timeout_in_sec: int | None) -> int:
+        return timeout_in_sec or self.default_timeout_in_sec


### PR DESCRIPTION
Further configuration possibility to allow getting rid of override logic.
