### PR TITLE
testdrive: Support comments inside of queries

### DIFF
--- a/src/testdrive/src/parser.rs
+++ b/src/testdrive/src/parser.rs
@@ -527,7 +527,8 @@ impl<'a> Iterator for LineReader<'a> {
         if self.inner.is_empty() {
             return None;
         }
-        let mut fold_newlines = is_sigil(self.inner.chars().next());
+        let mut fold_newlines = is_non_sql_sigil(self.inner.chars().next());
+        let mut handle_newlines = is_sql_sigil(self.inner.chars().next());
         let mut line = String::new();
         let mut chars = self.inner.char_indices().fuse().peekable();
         while let Some((i, c)) = chars.next() {
@@ -535,13 +536,25 @@ impl<'a> Iterator for LineReader<'a> {
                 self.src_line += 1;
                 if fold_newlines && self.inner.get(i + 1..i + 3) == Some("  ") {
                     // Chomp the newline and one space. This ensures a SQL query
-                    // that is split over two lines does not become invalid.
+                    // that is split over two lines does not become invalid. For $ commands the
+                    // newline should not be removed so that the argument parser can handle the
+                    // arguments correctly.
                     chars.next();
                     self.pos_map.insert(self.pos + i, (self.src_line, 2));
                     continue;
+                } else if handle_newlines && self.inner.get(i + 1..i + 3) == Some("  ") {
+                    // Chomp the two spaces after newline. This ensures a SQL query
+                    // that is split over two lines does not become invalid, and keeping the
+                    // newline ensures that comments don't remove the following lines.
+                    line.push(c);
+                    chars.next();
+                    chars.next();
+                    self.pos_map.insert(self.pos + i + 1, (self.src_line, 2));
+                    continue;
                 } else if line.chars().all(char::is_whitespace) {
                     line.clear();
-                    fold_newlines = is_sigil(chars.peek().map(|c| c.1));
+                    fold_newlines = is_non_sql_sigil(chars.peek().map(|c| c.1));
+                    handle_newlines = is_sql_sigil(chars.peek().map(|c| c.1));
                     self.pos_map.insert(self.pos, (self.src_line, 1));
                     continue;
                 }
@@ -563,7 +576,15 @@ impl<'a> Iterator for LineReader<'a> {
 }
 
 fn is_sigil(c: Option<char>) -> bool {
-    matches!(c, Some('$') | Some('>') | Some('!') | Some('?'))
+    is_sql_sigil(c) || is_non_sql_sigil(c)
+}
+
+fn is_sql_sigil(c: Option<char>) -> bool {
+    matches!(c, Some('>') | Some('!') | Some('?'))
+}
+
+fn is_non_sql_sigil(c: Option<char>) -> bool {
+    matches!(c, Some('$'))
 }
 
 struct BuiltinReader<'a> {

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -246,7 +246,7 @@ materialize.public.byzantine_view "CREATE VIEW \"materialize\".\"public\".\"byza
 > SHOW CREATE VIEW oppositional_view
 name                                 create_sql
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-materialize.public.oppositional_view "CREATE VIEW \"materialize\".\"public\".\"oppositional_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\" WHERE \"b\" = '   an adversarial string   \"materialize\".\"public\".\"mz_data\"   '"
+materialize.public.oppositional_view "CREATE VIEW \"materialize\".\"public\".\"oppositional_view\" AS SELECT * FROM \"materialize\".\"public\".\"renamed_mz_view\" WHERE \"b\" = '\n  an adversarial string\n  \"materialize\".\"public\".\"mz_data\"\n  '"
 
 # 🔬 Name collisions
 

--- a/test/testdrive/testdrive.td
+++ b/test/testdrive/testdrive.td
@@ -200,3 +200,12 @@ COMMIT;
 
 > SELECT COUNT(*) FROM postgres_connect;
 2
+
+# Comments don't affect following lines
+> CREATE TABLE t (x int)
+
+> INSERT INTO t VALUES (0)
+
+> SELECT *
+  FROM t -- this is a comment
+  WHERE x = 1


### PR DESCRIPTION
As suggested by @umanwizard in https://materializeinc.slack.com/archives/C01LKF361MZ/p1695739768728589

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
