### PR TITLE
mz: use a specific config path for the tests

### DIFF
--- a/src/mz/tests/e2e.rs
+++ b/src/mz/tests/e2e.rs
@@ -85,24 +85,21 @@ mod tests {
     };
 
     use assert_cmd::{assert::Assert, Command};
-    use mz::{config_file::ConfigFile, ui::OptionalStr};
+    use mz::ui::OptionalStr;
     use mz_frontegg_auth::AppPassword;
     use serde::{Deserialize, Serialize};
     use tabled::{Style, Table, Tabled};
 
     fn get_config_path() -> PathBuf {
-        let config_file_path = ConfigFile::default_path().unwrap();
-        let config_dir = config_file_path
-            .parent()
-            .expect("Failed to get parent directory");
+        let config_file_path = dirs::cache_dir().unwrap();
+        let mut config_path_buf = config_file_path.to_path_buf();
+        config_path_buf.push("materialize");
 
-        if !config_dir.exists() {
-            fs::create_dir_all(config_dir).expect("Failed to create directory");
+        if !config_path_buf.exists() {
+            fs::create_dir_all(config_path_buf.clone()).expect("Failed to create directory");
         }
 
-        let mut config_path_buf = config_dir.to_path_buf();
         config_path_buf.push("mz_test_config.toml");
-
         config_path_buf
     }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

When running the `mz` test, it overwrites the user's configuration. This behavior is not desired. This PR modifies the test to use an alternative configuration file, `mz_test_config.toml`.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
