### PR TITLE
sqlsmith: Add new expected error

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -158,6 +158,7 @@ known_errors = [
     '" does not exist',  # role does not exist
     "csv_extract number of columns too large",
     "target replica failed or was dropped",  # expected on replica OoMs with #21587
+    "cannot materialize call to",  # create materialized view on some internal views
 ]
 
 


### PR DESCRIPTION
following enabling EXPLAIN CREATE MATERIALIZED VIEW

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
