### PR TITLE
Correct numbers in an `unwrap` justification comment

### DIFF
--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -305,11 +305,11 @@ impl NamespacedOrchestrator for NamespacedProcessOrchestrator {
                             // Justification for `unwrap`:
                             //
                             // `u64::try_cast_from(f: f64)`
-                            // will always succeed if 0 <= f <= 2^53.
+                            // will always succeed if 0 <= f < 2^64.
                             // Since the max value of `process.cpu_usage()` is
                             // 100.0 * num_of_cores, this will be true whenever there
-                            // are less than 2^53 / 10^9 logical cores, or about
-                            // 9 million.
+                            // are less than 2^64 / 10^9 logical cores, or about
+                            // 18 billion.
                             let cpu = u64::try_cast_from(
                                 (f64::from(process.cpu_usage()) * 10_000_000.0).trunc(),
                             )


### PR DESCRIPTION
The number is wrong, but the reasoning still holds!

### Motivation

  * This PR fixes a code comment.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A