### PR TITLE
adapter: remove get_timestamp_oracle_mut

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -666,7 +666,7 @@ impl Coordinator {
             if let TimestampContext::TimelineTimestamp(timeline, timestamp) =
                 read_txn.txn.timestamp_context()
             {
-                let timestamp_oracle = self.get_timestamp_oracle_mut(&timeline);
+                let timestamp_oracle = self.get_timestamp_oracle(&timeline);
                 let read_ts = timestamp_oracle.read_ts();
                 if timestamp <= read_ts {
                     ready_txns.push(read_txn);

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -353,17 +353,6 @@ impl Coordinator {
         to_datetime(self.now())
     }
 
-    pub(crate) fn get_timestamp_oracle_mut(
-        &mut self,
-        timeline: &Timeline,
-    ) -> &mut DurableTimestampOracle<Timestamp> {
-        &mut self
-            .global_timelines
-            .get_mut(timeline)
-            .expect("all timelines have a timestamp oracle")
-            .oracle
-    }
-
     pub(crate) fn get_timestamp_oracle(
         &self,
         timeline: &Timeline,


### PR DESCRIPTION
It was used in only one place, where an immutable reference is enough.

### Motivation

Cleaning up stuff that I noticed during my Distributed TimestampOracle work.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
