### PR TITLE
cloud-push: require specifying an explicit tag

### DIFF
--- a/bin/cloud-push
+++ b/bin/cloud-push
@@ -17,20 +17,22 @@ cd "$(dirname "$0")/.."
 
 . misc/shlib/shlib.bash
 
-if [[ $# -lt 1 ]]; then
-    die "usage: $0 DOCKER-HUB-USERNAME [arguments for mzimage]"
+if [[ $# -lt 2 ]]; then
+    die "usage: $0 DOCKER-HUB-USERNAME TAG [arguments for mzimage]"
 fi
 username=$1
+shift
+tag=$1
 shift
 
 for image in environmentd clusterd; do
     bin/mzimage acquire --arch=x86_64 "$image" "$@"
-    docker tag "$(bin/mzimage spec --arch=x86_64 "$image" "$@")" "$username/$image"
-    docker push "$username/$image"
+    docker tag "$(bin/mzimage spec --arch=x86_64 "$image" "$@")" "$username/$image:$tag"
+    docker push "$username/$image:$tag"
 done
 
 echo "Deploy this build to staging by running:"
 echo
 echo "    $ bin/mz profile init --endpoint=https://staging.cloud.materialize.com --profile=staging"
-echo "    $ bin/mz region enable --version $username:latest --region=aws/us-east-1 --profile=staging"
+echo "    $ bin/mz region enable --version $username:$tag --region=aws/us-east-1 --profile=staging"
 echo


### PR DESCRIPTION
### Motivation

I felt the need for uploading and switching between multiple custom images while messing around with custom builds in staging.

I don't know if anyone else uses this or if not specifying a tag is a requirement that, say, the cloud team has.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
