### PR TITLE
tests: Add platform-check for NULL DEFAULTS sinks

### DIFF
--- a/test/testdrive/kafka-avro-sinks-defaults.td
+++ b/test/testdrive/kafka-avro-sinks-defaults.td
@@ -147,6 +147,26 @@ contains: invalid NULL DEFAULTS: cannot use value as boolean
   KEY (c2) NOT ENFORCED
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   (
+    NULL DEFAULTS = ""
+  )
+  ENVELOPE UPSERT
+contains: Expected option value, found identifier ""
+
+! CREATE SINK bad_sink FROM v
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink1-${testdrive.seed}')
+  KEY (c2) NOT ENFORCED
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  (
+    NULL DEFAULTS = NULL
+  )
+  ENVELOPE UPSERT
+contains: invalid NULL DEFAULTS: cannot use value as boolean
+
+! CREATE SINK bad_sink FROM v
+  INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink1-${testdrive.seed}')
+  KEY (c2) NOT ENFORCED
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  (
     NULL DEFAULTS,
     NULL DEFAULTS = TRUE
   )


### PR DESCRIPTION
Also added 2 small parsing checks

Follow-up to https://github.com/MaterializeInc/materialize/pull/21842 which I missed

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
