### PR TITLE
[persist] Switch the error handling approach in Tasked

### DIFF
--- a/src/persist/src/location.rs
+++ b/src/persist/src/location.rs
@@ -18,7 +18,6 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use mz_ore::bytes::SegmentedBytes;
 use mz_ore::cast::u64_to_usize;
-use mz_ore::task::JoinHandleExt;
 use mz_proto::RustType;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -395,8 +394,7 @@ impl<A: Consensus + Sync + Send + 'static> Consensus for Tasked<A> {
             || "persist::task::head",
             async move { backing.head(&key).await },
         )
-        .wait_and_assert_finished()
-        .await
+        .await?
     }
 
     async fn compare_and_set(
@@ -410,8 +408,7 @@ impl<A: Consensus + Sync + Send + 'static> Consensus for Tasked<A> {
         mz_ore::task::spawn(|| "persist::task::cas", async move {
             backing.compare_and_set(&key, expected, new).await
         })
-        .wait_and_assert_finished()
-        .await
+        .await?
     }
 
     async fn scan(
@@ -425,8 +422,7 @@ impl<A: Consensus + Sync + Send + 'static> Consensus for Tasked<A> {
         mz_ore::task::spawn(|| "persist::task::scan", async move {
             backing.scan(&key, from, limit).await
         })
-        .wait_and_assert_finished()
-        .await
+        .await?
     }
 
     async fn truncate(&self, key: &str, seqno: SeqNo) -> Result<usize, ExternalError> {
@@ -435,8 +431,7 @@ impl<A: Consensus + Sync + Send + 'static> Consensus for Tasked<A> {
         mz_ore::task::spawn(|| "persist::task::truncate", async move {
             backing.truncate(&key, seqno).await
         })
-        .wait_and_assert_finished()
-        .await
+        .await?
     }
 }
 


### PR DESCRIPTION
The old one is causing errors in sqllogictest. It's possible this is because we're not yielding to the relevant runtime for a particular task? But anyways we're ambivalent about the error handling strategy here, so let's just raise things up.

### Motivation

Reported: https://github.com/MaterializeInc/materialize/issues/21991.

### Tips for reviewer

I still want to spend a bit of time understanding why the helper didn't work in this case... are we yielding to the wrong runtime?

I'll make sure to kick off some sqllogictest runs for this to help validate it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
