### PR TITLE
cloud-canary: Disable sanity restart

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -700,7 +700,12 @@ class Composition:
     def sanity_restart_mz(self) -> None:
         """Restart Materialized if it is part of the composition to find
         problems with persisted objects, functions as a sanity check."""
-        if "materialized" in self.compose["services"]:
+        # Exclude environmentd image, which is used in cloud-canary, and doesn't start up fully without clusterd images
+        if (
+            "materialized" in self.compose["services"]
+            and "materialize/environmentd"
+            not in self.compose["services"]["materialized"]["image"]
+        ):
             self.kill("materialized")
             # TODO(def-): Better way to detect when kill has finished
             time.sleep(3)


### PR DESCRIPTION
Fixes: #21998

@joacoc Is there an easy way to run cloud-canary locally? I always get `KeyError: 'NIGHTLY_CANARY_APP_PASSWORD'` and am not sure where to get the credentials. I'd like to verify that this actually fixes the issue.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
