### PR TITLE
test: (Hacky) fix for slow test cleanups

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1332,6 +1332,17 @@ impl DebugStashFactory {
                 tracing::error!("postgres stash connection error: {e}");
             }
         });
+        // Running tests in parallel has been causing some deadlock/starvation issue that we haven't
+        // been able to figure out. For some reason, uncommitted transactions are being left open
+        // which causes the schema cleanup in the Drop impl to block for an enormous amount of time
+        // (many minutes). Setting a small idle transaction timeout globally seems to resolve the
+        // issue somehow. This is a gross hack and we don't really understand what's going on, but
+        // for now it resolves issues in CI while we debug further.
+        client
+            .batch_execute(
+                "SET CLUSTER SETTING sql.defaults.idle_in_transaction_session_timeout TO '3s'",
+            )
+            .await?;
         client
             .batch_execute(&format!("CREATE SCHEMA {schema}"))
             .await?;
@@ -1359,25 +1370,6 @@ impl DebugStashFactory {
 
     async fn try_open_inner(&self, mode: TransactionMode) -> Result<Stash, StashError> {
         debug!("debug stash open: {mode:?}, {}", self.schema);
-
-        // Running tests in parallel has been causing some deadlock/starvation issue that we haven't
-        // been able to figure out. For some reason, uncommitted transactions are being left open
-        // which causes the schema cleanup in the Drop impl to block for an enormous amount of time
-        // (many minutes). Setting a small idle transaction timeout globally seems to resolve the
-        // issue somehow. This is a gross hack and we don't really understand what's going on, but
-        // for now it resolves issues in CI while we debug further.
-        let url = self.url.clone();
-        let tls = self.tls.clone();
-        let (client, connection) = tokio_postgres::connect(&url, tls).await?;
-        mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
-            let _ = connection.await;
-        });
-        client
-            .batch_execute(
-                "SET CLUSTER SETTING sql.defaults.idle_in_transaction_session_timeout TO '3s'",
-            )
-            .await?;
-
         self.stash_factory
             .open_inner(
                 mode,

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1340,7 +1340,7 @@ impl DebugStashFactory {
         // for now it resolves issues in CI while we debug further.
         client
             .batch_execute(
-                "SET CLUSTER SETTING sql.defaults.idle_in_transaction_session_timeout TO '3s'",
+                "SET CLUSTER SETTING sql.defaults.idle_in_transaction_session_timeout TO '1s'",
             )
             .await?;
         client


### PR DESCRIPTION
Running tests in parallel has been causing some deadlock/starvation
issue that we haven't been able to figure out. For some reason,
uncommitted transactions are being left open which causes the schema
cleanup in the Drop impl of DebugStashFactory to block for an enormous
amount of time (many minutes). Setting a small idle transaction timeout
globally seems to resolve the issue somehow. This is a gross hack and
we don't really understand what's going on, but for now it resolves
issues in CI while we debug further.

Works towards resolving #21891

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
