### PR TITLE
concurrent-connections: Bump test limits

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2410,8 +2410,8 @@ def workflow_test_concurrent_connections(c: Composition) -> None:
     sure #21782 does not regress.
     """
     num_conns = 2000
-    p50_limit = 2.0
-    p99_limit = 6.0
+    p50_limit = 10.0
+    p99_limit = 20.0
 
     runtimes: list[float] = [float("inf")] * num_conns
 


### PR DESCRIPTION
At this point the test feels pretty useless, I'm not sure if I should just disable it: https://buildkite.com/materialize/tests/builds/64642#018ad89f-eb60-4fd8-8179-b0f9900b25be

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
