### PR TITLE
doc/user: update v0.70 release note metadata

### DIFF
--- a/doc/user/content/releases/v0.69.md
+++ b/doc/user/content/releases/v0.69.md
@@ -2,7 +2,7 @@
 title: "Materialize v0.69"
 date: 2023-09-20
 released: true
-patch: 5
+patch: 6
 ---
 
 ## v0.69.0

--- a/doc/user/content/releases/v0.70.md
+++ b/doc/user/content/releases/v0.70.md
@@ -5,4 +5,16 @@ released: true
 patch: 2
 ---
 
-## v0.70.2
+## v0.70.0
+
+#### Sources and sinks
+
+* Automatically check if there are tables not currently configured to use `REPLICA IDENTITY FULL` in a publication used with a [PostgreSQL source](/sql/create-source/postgres/).
+
+* Support constraining the precision of the fractional seconds in timestamps. This allows users to construct Avro-formatted sinks that use the `timestamp-millis` logical type instead of the `timestamp-micros` logical type.
+
+#### Bug fixes and other improvements
+
+* Limit the amount of data that can be copied using `COPY FROM` to 1 GiB. Please [contact us](https://materialize.com/contact/) if you need this limit increased in your Materialize region.
+
+* Restrict transactions to execute on a single cluster, in order to improve use case isolation. The first query in a transaction now determines the time domain of the entire transaction {{% gh 21854 %}}.

--- a/doc/user/content/releases/v0.70.md
+++ b/doc/user/content/releases/v0.70.md
@@ -1,11 +1,8 @@
 ---
 title: "Materialize v0.70"
 date: 2023-09-27
-released: false
+released: true
+patch: 2
 ---
 
-## v0.70.0
-
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+## v0.70.2

--- a/doc/user/content/releases/v0.71.md
+++ b/doc/user/content/releases/v0.71.md
@@ -4,7 +4,7 @@ date: 2023-10-04
 released: false
 ---
 
-## v0.70.1
+## v0.71.0
 
 {{< warning >}}
 This version of Materialize is not yet released.

--- a/doc/user/content/releases/v0.71.md
+++ b/doc/user/content/releases/v0.71.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.71"
+date: 2023-10-04
+released: false
+---
+
+## v0.70.1
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
This commit updates release note metadata for v0.70, according to release upgrade procedures, and creates a placeholder for v0.71.

### Motivation

  * This PR update documentation according to release instructions. https://github.com/MaterializeInc/cloud/issues/7581

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note): N/A
