### PR TITLE
parallel-workload: Use unified clusters

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -74,6 +74,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # Advance coverage on some Persist internals changes
     "persist_streaming_compaction_enabled": "true",
     "persist_streaming_snapshot_and_fetch_enabled": "true",
+    "enable_unified_clusters": "true",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -113,7 +113,23 @@ body false text
 headers false map
 
 # Make sure that webhook_cluster only contains sources.
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unified_clusters = false
+----
+COMPLETE 0
+
 statement error cannot create this kind of item in a cluster that contains sources or sinks
+CREATE MATERIALIZED VIEW mat_view_text IN CLUSTER webhook_cluster AS (
+    SELECT body FROM webhook_text_include_headers
+);
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unified_clusters = true
+----
+COMPLETE 0
+
+statement ok
 CREATE MATERIALIZED VIEW mat_view_text IN CLUSTER webhook_cluster AS (
     SELECT body FROM webhook_text_include_headers
 );
@@ -368,7 +384,21 @@ CREATE CLUSTER compute_cluster REPLICAS (r1 (SIZE '1'));
 statement ok
 CREATE MATERIALIZED VIEW mv1 IN CLUSTER compute_cluster AS SELECT name FROM mz_objects;
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unified_clusters = false
+----
+COMPLETE 0
+
 statement error cannot create source in cluster containing indexes or materialized views
+CREATE SOURCE webhook_on_compute_cluster IN CLUSTER compute_cluster FROM WEBHOOK
+  BODY FORMAT BYTES;
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_unified_clusters = true
+----
+COMPLETE 0
+
+statement ok
 CREATE SOURCE webhook_on_compute_cluster IN CLUSTER compute_cluster FROM WEBHOOK
   BODY FORMAT BYTES;
 

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -109,12 +109,36 @@ contains:cannot modify linked cluster "materialize_public_lg1"
   FORMAT JSON ENVELOPE DEBEZIUM
 contains:cannot modify linked cluster "materialize_public_lg1"
 > SET cluster = materialize_public_lg2
+
+> SELECT generate_series(0, 10)
+0
+1
+2
+3
+4
+5
+6
+7
+8
+9
+10
+
+> EXPLAIN SELECT * FROM v
+"Explained Query:\n  ReadStorage materialize.public.v\n"
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = false
+
 ! SELECT generate_series(0, 10)
 contains:cannot execute queries on cluster containing sources or sinks
 ! SUBSCRIBE v
 contains:cannot execute queries on cluster containing sources or sinks
 ! EXPLAIN SELECT * FROM v
 contains:cannot execute queries on cluster containing sources or sinks
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = true
+
 > SET cluster = default
 
 # Test that only the default clusters and replicas remain after dropping

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -35,18 +35,25 @@ contains:only one of IN CLUSTER or SIZE can be set
 ! ALTER SOURCE loadgen SET (SIZE = '1')
 contains:cannot change the size of a source or sink created with IN CLUSTER
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = false
+
 # Create indexes and materialized views in a storage cluster is banned.
 ! CREATE INDEX bad IN CLUSTER storage ON t (a)
 contains:cannot create this kind of item in a cluster that contains sources or sinks
 ! CREATE MATERIALIZED VIEW bad IN CLUSTER storage AS SELECT 1
 contains:cannot create this kind of item in a cluster that contains sources or sinks
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = true
+
+> CREATE CLUSTER REPLICA storage.r1 SIZE = '1'
+
 # Executing queries on a storage cluster is banned.
-! SELECT generate_series(1, 1)
-contains:cannot execute queries on cluster containing sources or sinks
+> SELECT generate_series(1, 1)
+1
 
 # Only one replica of a storage cluster is permitted.
-> CREATE CLUSTER REPLICA storage.r1 SIZE '1'
 ! CREATE CLUSTER REPLICA storage.r2 SIZE '1'
 contains:cannot create more than one replica of a cluster containing sources or sinks
 
@@ -60,9 +67,15 @@ contains:cannot create more than one replica of a cluster containing sources or 
 > SELECT generate_series(1, 1)
 1
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = false
+
 # Recreating the source is banned.
 ! CREATE SOURCE loadgen IN CLUSTER storage FROM LOAD GENERATOR COUNTER
 contains:cannot create source in cluster containing indexes or materialized views
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unified_clusters = true
 
 # Creating a second replica is now allowed.
 > CREATE CLUSTER REPLICA storage.r2 SIZE '1'


### PR DESCRIPTION
Also enable unified clusters by default in CI and adapt some existing
TD/SLT tests. This should make sense as unified clusters might end up as
the new default and are definitely a superset of functionality of
non-unified clusters.

Follow-up to https://github.com/MaterializeInc/materialize/pull/21846

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
