### PR TITLE
compute: ensure compute controller response delivery when clusters are dropped

### DIFF
--- a/test/testdrive/compute-dependencies.td
+++ b/test/testdrive/compute-dependencies.td
@@ -71,3 +71,25 @@ mv1             t2
 
 > SELECT count(*) > 0 FROM mz_internal.mz_compute_dependencies WHERE object_id LIKE 's%'
 true
+
+# Test that `mz_compute_dependencies` is cleaned up when a cluster is dropped.
+
+> CREATE CLUSTER cleanup SIZE '1'
+> CREATE INDEX idx_cleanup IN CLUSTER cleanup ON t1 (a)
+> CREATE MATERIALIZED VIEW mv_cleanup IN CLUSTER cleanup AS SELECT * FROM t2
+
+> SELECT object.name, import.name
+  FROM mz_internal.mz_compute_dependencies dep
+  LEFT JOIN mz_objects object ON dep.object_id = object.id
+  LEFT JOIN mz_objects import ON dep.dependency_id = import.id
+  WHERE object_id LIKE 'u%'
+idx_cleanup t1
+mv_cleanup  t2
+
+> DROP CLUSTER cleanup CASCADE
+
+> SELECT object.name, import.name
+  FROM mz_internal.mz_compute_dependencies dep
+  LEFT JOIN mz_objects object ON dep.object_id = object.id
+  LEFT JOIN mz_objects import ON dep.dependency_id = import.id
+  WHERE object_id LIKE 'u%'


### PR DESCRIPTION
This PR replaces the per-`Instance` `ready_responses` buffers with a single controller-global response channel. `Instance`s send controller responses into this channel, where they are then picked up by the `ComputeController` on the next call to `process`.

The benefit of this change is that no controller responses are lost when a cluster (and therefore an `Instance` object) is dropped. This fixes a leak caused by `ComputeDependencyUpdate` messages not reaching the coordinator.

### Motivation

  * This PR fixes a recognized bug.

Fixes #21956

### Tips for reviewer

There are some follow-up refactors we can make with this change:
* Push all controller responses through the new channel, instead of having two ways for responses to travel from `Instance`s to the `ComputeController`.
* Produce replica heartbeats directly in the `Instance` controller and remove the need for the `ComputeController` to care about replicas.

I'm not making these part of this PR because they are nice-to-have refactors and I don't want to mix them up with fixing the cleanup bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A