### PR TITLE
platform-checks: Add Check for unified clusters

### DIFF
--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import textwrap
 import time
 from inspect import getframeinfo, stack
 from typing import TYPE_CHECKING, Any
@@ -30,8 +31,8 @@ class Testdrive(Action):
     # Instruct pytest this class does not contain actual tests
     __test__ = False
 
-    def __init__(self, input: str) -> None:
-        self.input = input
+    def __init__(self, input: str, dedent: bool = True) -> None:
+        self.input = textwrap.dedent(input) if dedent else input
         self.handle: Any | None = None
         self.caller = getframeinfo(stack()[1][0])
 

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -14,6 +14,7 @@ from materialize.checks.array_type import *  # noqa: F401 F403
 from materialize.checks.boolean_type import *  # noqa: F401 F403
 from materialize.checks.cast import *  # noqa: F401 F403
 from materialize.checks.cluster import *  # noqa: F401 F403
+from materialize.checks.cluster_unification import *  #  noqa: F401 F403
 from materialize.checks.commit import *  # noqa: F401 F403
 from materialize.checks.constant_plan import *  # noqa: F401 F403
 from materialize.checks.create_index import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/cluster_unification.py
+++ b/misc/python/materialize/checks/cluster_unification.py
@@ -1,0 +1,106 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
+
+
+class UnifiedCluster(Check):
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse("0.71.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            """
+            $postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+            ALTER SYSTEM SET enable_unified_clusters = true
+
+            > CREATE CLUSTER shared_cluster_compute_first SIZE '1', REPLICATION FACTOR 1;
+            > CREATE CLUSTER shared_cluster_storage_first SIZE '1', REPLICATION FACTOR 1;
+            """
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            # Create either a source or a view as first object in cluster
+            Testdrive(
+                """
+                > CREATE SOURCE shared_cluster_storage_first_source
+                  IN CLUSTER shared_cluster_storage_first
+                  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+
+                > CREATE MATERIALIZED VIEW shared_cluster_compute_first_mv
+                  IN CLUSTER shared_cluster_compute_first
+                  AS SELECT COUNT(*) AS cnt FROM shared_cluster_storage_first_source
+
+                > CREATE DEFAULT INDEX
+                  IN CLUSTER shared_cluster_compute_first
+                  ON shared_cluster_compute_first_mv
+                """
+            ),
+            # Create the other type of object as a second object in the cluster that
+            # now already contains an object
+            Testdrive(
+                """
+                > CREATE SOURCE shared_cluster_compute_first_source
+                  IN CLUSTER shared_cluster_compute_first
+                  FROM LOAD GENERATOR COUNTER (SCALE FACTOR 0.01)
+
+                > CREATE MATERIALIZED VIEW shared_cluster_storage_first_mv
+                  IN CLUSTER shared_cluster_storage_first
+                  AS SELECT COUNT(*) AS cnt FROM shared_cluster_compute_first_source
+
+                > CREATE DEFAULT INDEX
+                  IN CLUSTER shared_cluster_storage_first
+                  ON shared_cluster_storage_first_mv
+                """
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            """
+            > SELECT COUNT(*) > 0 FROM shared_cluster_storage_first_source;
+            true
+
+            > SELECT cnt > 0 FROM shared_cluster_storage_first_mv;
+            true
+
+            > SELECT COUNT(*) > 0 FROM shared_cluster_compute_first_source;
+            true
+
+            > SELECT cnt > 0 FROM shared_cluster_compute_first_mv;
+            true
+
+            > SET cluster = shared_cluster_compute_first;
+            > SELECT COUNT(*) > 0 FROM mz_tables;
+            true
+
+            > SET cluster = shared_cluster_storage_first;
+            > SELECT COUNT(*) > 0 FROM mz_tables;
+            true
+
+            > SET cluster = default
+
+            ! DROP CLUSTER shared_cluster_compute_first;
+            contains: cannot drop cluster with active object
+
+            ! DROP CLUSTER shared_cluster_storage_first;
+            contains: cannot drop cluster with active object
+
+            ! ALTER CLUSTER shared_cluster_compute_first SET (REPLICATION FACTOR 2);
+            contains: cannot create more than one replica of a cluster containing sources or sinks
+
+            ! ALTER CLUSTER shared_cluster_storage_first SET (REPLICATION FACTOR 2);
+            contains: cannot create more than one replica of a cluster containing sources or sinks
+
+            """
+        )


### PR DESCRIPTION
Relates to #21846

### Motivation

We need a test to confirm that unified clusters work as expected across restarts and upgrades.


### Tips for reviewer

I made all Testdrive fragments pass their input through `dedent` in order to reduce the indentation levels of the check files.