### PR TITLE
Update columnation, replace CloneRegion with CopyRegion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 [[package]]
 name = "columnation"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/columnation.git#16e53d69878847979457f3d5ae867ebf4922f1ee"
+source = "git+https://github.com/MaterializeInc/columnation.git#2cd6d86e5ffabf98aef5cbef09a57f515eae7c55"
 dependencies = [
  "paste",
 ]

--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -92,7 +92,7 @@ pub enum ReductionType {
 }
 
 impl columnation::Columnation for ReductionType {
-    type InnerRegion = columnation::CloneRegion<ReductionType>;
+    type InnerRegion = columnation::CopyRegion<ReductionType>;
 }
 
 impl RustType<ProtoReductionType> for ReductionType {

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -24,7 +24,7 @@ use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use serde::{Deserialize, Serialize};
 use timely::communication::Allocate;
-use timely::container::columnation::{CloneRegion, Columnation};
+use timely::container::columnation::{Columnation, CopyRegion};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
@@ -426,7 +426,7 @@ struct DemuxOutput<'a, 'b> {
     schedules_histogram: OutputBuffer<'a, 'b, (ScheduleHistogramDatum, ())>,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 struct ChannelDatum {
     id: usize,
     source: (usize, usize),
@@ -434,17 +434,17 @@ struct ChannelDatum {
 }
 
 impl Columnation for ChannelDatum {
-    type InnerRegion = CloneRegion<Self>;
+    type InnerRegion = CopyRegion<Self>;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 struct ParkDatum {
     duration_pow: u128,
     requested_pow: Option<u128>,
 }
 
 impl Columnation for ParkDatum {
-    type InnerRegion = CloneRegion<Self>;
+    type InnerRegion = CopyRegion<Self>;
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -454,17 +454,17 @@ struct MessageDatum {
 }
 
 impl Columnation for MessageDatum {
-    type InnerRegion = CloneRegion<Self>;
+    type InnerRegion = CopyRegion<Self>;
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 struct ScheduleHistogramDatum {
     operator: usize,
     duration_pow: u128,
 }
 
 impl Columnation for ScheduleHistogramDatum {
-    type InnerRegion = CloneRegion<Self>;
+    type InnerRegion = CopyRegion<Self>;
 }
 
 /// Event handler of the demux operator.

--- a/src/repr/src/adt/mz_acl_item.rs
+++ b/src/repr/src/adt/mz_acl_item.rs
@@ -18,7 +18,7 @@ use std::str::FromStr;
 use crate::adt::system::Oid;
 use anyhow::{anyhow, Error};
 use bitflags::bitflags;
-use columnation::{CloneRegion, Columnation};
+use columnation::{Columnation, CopyRegion};
 use mz_ore::str::StrExt;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest::arbitrary::Arbitrary;
@@ -233,7 +233,7 @@ impl RustType<ProtoAclMode> for AclMode {
 }
 
 impl Columnation for AclMode {
-    type InnerRegion = CloneRegion<AclMode>;
+    type InnerRegion = CopyRegion<AclMode>;
 }
 
 impl Arbitrary for AclMode {
@@ -374,7 +374,7 @@ impl RustType<ProtoMzAclItem> for MzAclItem {
 }
 
 impl Columnation for MzAclItem {
-    type InnerRegion = CloneRegion<MzAclItem>;
+    type InnerRegion = CopyRegion<MzAclItem>;
 }
 
 /// A list of privileges granted to a role.
@@ -514,7 +514,7 @@ impl RustType<ProtoAclItem> for AclItem {
 }
 
 impl Columnation for AclItem {
-    type InnerRegion = CloneRegion<AclItem>;
+    type InnerRegion = CopyRegion<AclItem>;
 }
 
 /// A container of [`MzAclItem`]s that is optimized to look up an [`MzAclItem`] by the grantee.

--- a/src/repr/src/global_id.rs
+++ b/src/repr/src/global_id.rs
@@ -11,7 +11,7 @@ use std::fmt;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
-use columnation::{CloneRegion, Columnation};
+use columnation::{Columnation, CopyRegion};
 use mz_lowertest::MzReflect;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -121,5 +121,5 @@ impl RustType<ProtoGlobalId> for GlobalId {
 }
 
 impl Columnation for GlobalId {
-    type InnerRegion = CloneRegion<GlobalId>;
+    type InnerRegion = CopyRegion<GlobalId>;
 }

--- a/src/repr/src/role_id.rs
+++ b/src/repr/src/role_id.rs
@@ -12,7 +12,7 @@ use std::mem::size_of;
 use std::str::FromStr;
 
 use anyhow::{anyhow, Error};
-use columnation::{CloneRegion, Columnation};
+use columnation::{Columnation, CopyRegion};
 use mz_lowertest::MzReflect;
 use mz_proto::{RustType, TryFromProtoError};
 use proptest_derive::Arbitrary;
@@ -171,7 +171,7 @@ impl RustType<ProtoRoleId> for RoleId {
 }
 
 impl Columnation for RoleId {
-    type InnerRegion = CloneRegion<RoleId>;
+    type InnerRegion = CopyRegion<RoleId>;
 }
 
 #[mz_ore::test]

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -351,5 +351,5 @@ impl TryFrom<Numeric> for Timestamp {
 }
 
 impl columnation::Columnation for Timestamp {
-    type InnerRegion = columnation::CloneRegion<Timestamp>;
+    type InnerRegion = columnation::CopyRegion<Timestamp>;
 }


### PR DESCRIPTION
### Motivation

Columnation offered a `CloneRegion` in the past, but switched to a `CopyRegion` instead. Adjust Materialize to use the `CopyRegion` type instead. Fortunately, all our uses are indeed `Copy`, so no changes besides a rename required. https://github.com/frankmcsherry/columnation/pull/17 for context.

* This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
