### PR TITLE
adapter: Add more metrics

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -251,28 +251,41 @@ pub enum Message<T = mz_repr::Timestamp> {
 impl Message {
     /// Returns a string to identify the kind of [`Message`], useful for logging.
     pub const fn kind(&self) -> &'static str {
-        use Message::*;
-
         match self {
-            Command(_) => "command",
-            ControllerReady => "controller_ready",
-            PurifiedStatementReady(_) => "purified_statement_ready",
-            CreateConnectionValidationReady(_) => "create_connection_validation_ready",
-            SinkConnectionReady(_) => "sink_connection_ready",
-            WriteLockGrant(_) => "write_lock_grant",
-            GroupCommitInitiate(..) => "group_commit_initiate",
-            GroupCommitApply(..) => "group_commit_apply",
-            AdvanceTimelines => "advance_timelines",
-            ClusterEvent(_) => "cluster_event",
-            RemovePendingPeeks { .. } => "remove_pending_peeks",
-            LinearizeReads(_) => "linearize_reads",
-            StorageUsageFetch => "storage_usage_fetch",
-            StorageUsageUpdate(_) => "storage_usage_update",
-            RealTimeRecencyTimestamp { .. } => "real_time_recency_timestamp",
-            RetireExecute { .. } => "retire_execute",
-            ExecuteSingleStatementTransaction { .. } => "execute_single_statement_transaction",
-            PeekStageReady { .. } => "peek_stage_ready",
-            DrainStatementLog => "drain_statement_log",
+            Message::Command(msg) => match msg {
+                Command::CatalogSnapshot { .. } => "command-catalog_snapshot",
+                Command::Startup { .. } => "command-startup",
+                Command::Execute { .. } => "command-execute",
+                Command::Commit { .. } => "command-commit",
+                Command::CancelRequest { .. } => "command-cancel_request",
+                Command::PrivilegedCancelRequest { .. } => "command-privileged_cancel_request",
+                Command::AppendWebhook { .. } => "command-append_webhook",
+                Command::GetSystemVars { .. } => "command-get_system_vars",
+                Command::SetSystemVars { .. } => "command-set_system_vars",
+                Command::Terminate { .. } => "command-terminate",
+                Command::RetireExecute { .. } => "command-retire_execute",
+                Command::CheckConsistency { .. } => "command-check_consistency",
+            },
+            Message::ControllerReady => "controller_ready",
+            Message::PurifiedStatementReady(_) => "purified_statement_ready",
+            Message::CreateConnectionValidationReady(_) => "create_connection_validation_ready",
+            Message::SinkConnectionReady(_) => "sink_connection_ready",
+            Message::WriteLockGrant(_) => "write_lock_grant",
+            Message::GroupCommitInitiate(..) => "group_commit_initiate",
+            Message::GroupCommitApply(..) => "group_commit_apply",
+            Message::AdvanceTimelines => "advance_timelines",
+            Message::ClusterEvent(_) => "cluster_event",
+            Message::RemovePendingPeeks { .. } => "remove_pending_peeks",
+            Message::LinearizeReads(_) => "linearize_reads",
+            Message::StorageUsageFetch => "storage_usage_fetch",
+            Message::StorageUsageUpdate(_) => "storage_usage_update",
+            Message::RealTimeRecencyTimestamp { .. } => "real_time_recency_timestamp",
+            Message::RetireExecute { .. } => "retire_execute",
+            Message::ExecuteSingleStatementTransaction { .. } => {
+                "execute_single_statement_transaction"
+            }
+            Message::PeekStageReady { .. } => "peek_stage_ready",
+            Message::DrainStatementLog => "drain_statement_log",
         }
     }
 }

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -352,7 +352,7 @@ impl Coordinator {
         let label = should_block.then_some("true").unwrap_or("false");
         let histogram = self
             .metrics
-            .append_table_seconds
+            .append_table_duration_seconds
             .with_label_values(&[label]);
         let append_fut = self
             .controller

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -33,7 +33,7 @@ pub struct Metrics {
     pub statement_logging_actual_bytes: IntCounterVec,
     pub slow_message_handling: HistogramVec,
     pub optimization_notices: IntCounterVec,
-    pub append_table_seconds: HistogramVec,
+    pub append_table_duration_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -121,8 +121,8 @@ impl Metrics {
                 help: "Number of optimization notices per notice type.",
                 var_labels: ["notice_type"],
             )),
-            append_table_seconds: registry.register(metric!(
-                name: "mz_append_table_seconds",
+            append_table_duration_seconds: registry.register(metric!(
+                name: "mz_append_table_duration_seconds",
                 help: "Latency for appending to any (user or system) table.",
                 var_labels: ["is_blocking"],
                 buckets: histogram_seconds_buckets(0.128, 32.0),

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -33,6 +33,7 @@ pub struct Metrics {
     pub statement_logging_actual_bytes: IntCounterVec,
     pub slow_message_handling: HistogramVec,
     pub optimization_notices: IntCounterVec,
+    pub append_table_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -119,6 +120,12 @@ impl Metrics {
                 name: "mz_optimization_notices",
                 help: "Number of optimization notices per notice type.",
                 var_labels: ["notice_type"],
+            )),
+            append_table_seconds: registry.register(metric!(
+                name: "mz_append_table_seconds",
+                help: "Latency for appending to any (user or system) table.",
+                var_labels: ["is_blocking"],
+                buckets: histogram_seconds_buckets(0.128, 32.0),
             )),
         }
     }

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -190,7 +190,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.fetch_epoch, histogram)
@@ -200,7 +200,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.iter_key, histogram)
@@ -210,7 +210,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.since, histogram)
@@ -220,7 +220,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.upper, histogram)
@@ -230,7 +230,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.collection, histogram)
@@ -240,7 +240,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.iter, histogram)
@@ -250,7 +250,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.seal, histogram)
@@ -260,7 +260,7 @@ impl<'a> CountedStatements<'a> {
         self.inc(name);
         let histogram = self
             .metrics
-            .query_latency_seconds
+            .query_latency_duration_seconds
             .with_label_values(&[name]);
 
         (&self.stmts.compact, histogram)
@@ -436,7 +436,7 @@ impl StashFactory {
 pub(crate) struct Metrics {
     transactions: IntCounter,
     transaction_errors: IntCounterVec,
-    query_latency_seconds: HistogramVec,
+    query_latency_duration_seconds: HistogramVec,
 }
 
 impl Metrics {
@@ -451,7 +451,7 @@ impl Metrics {
                 help: "Total number of transaction errors.",
                 var_labels: ["cause"],
             )),
-            query_latency_seconds: registry.register(metric!(
+            query_latency_duration_seconds: registry.register(metric!(
                 name: "mz_query_latency",
                 help: "Latency for queries to CockroachDB",
                 var_labels: ["query_kind"],


### PR DESCRIPTION
In response to incident_74 we want to add more metrics around how long it takes us to query CRDB. This PR adds the following metrics:

1. Histograms for all of the queries the Stash makes.
2. Histogram for tables writes made by the Coordinator.

It also improves the tagging for the "slow coordinator message" metrics to include the subtype of `Command` that the coordinator is running.

### Motivation

Incident 74

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
