### PR TITLE
data-ingest: Roundtrip source/sink testing

### DIFF
--- a/misc/python/materialize/data_ingest/workload.py
+++ b/misc/python/materialize/data_ingest/workload.py
@@ -205,7 +205,9 @@ def execute_workload(
             if actual_result == expected_result:
                 if correct_once:
                     break
-                print("Check for correctness again to make sure the result is stable")
+                print(
+                    "Results match. Check for correctness again to make sure the result is stable"
+                )
                 correct_once = True
                 time.sleep(sleep_time)
                 continue

--- a/test/data-ingest/mzcompose.py
+++ b/test/data-ingest/mzcompose.py
@@ -10,7 +10,7 @@
 import random
 import time
 
-from materialize.data_ingest.executor import KafkaExecutor
+from materialize.data_ingest.executor import KafkaExecutor, KafkaRoundtripExecutor
 from materialize.data_ingest.workload import *  # noqa: F401 F403
 from materialize.data_ingest.workload import Workload, execute_workload
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
@@ -35,7 +35,10 @@ SERVICES = [
     ),
     SchemaRegistry(),
     # Fixed port so that we keep the same port after restarting Mz in disruptions
-    Materialized(ports=["16875:6875"]),
+    Materialized(
+        ports=["16875:6875"],
+        additional_system_parameter_defaults={"enable_table_keys": "true"},
+    ),
     Clusterd(name="clusterd1", options=["--scratch-directory=/mzdata/source_data"]),
 ]
 
@@ -84,7 +87,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     conn.autocommit = False
     conn.close()
 
-    executor_classes = [KafkaExecutor]
+    executor_classes = [KafkaRoundtripExecutor, KafkaExecutor]
     ports = {s: c.default_port(s) for s in services}
 
     for i, workload_class in enumerate(workloads):


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/21738

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
