### PR TITLE
zippy: Exercise cluster unification

### DIFF
--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -54,9 +54,12 @@ class CreateDebeziumSource(Action):
     def requires(cls) -> set[type[Capability]]:
         return {MzIsRunning, StoragedRunning, KafkaRunning, PostgresTableExists}
 
-    def __init__(self, capabilities: Capabilities) -> None:
+    def __init__(
+        self, capabilities: Capabilities, clusters: list[str] = ["storage", "default"]
+    ) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
+        cluster = random.choice(clusters)
         debezium_source_name = f"debezium_source_{postgres_table.name}"
         this_debezium_source = DebeziumSourceExists(name=debezium_source_name)
 
@@ -72,6 +75,7 @@ class CreateDebeziumSource(Action):
             self.debezium_source = this_debezium_source
             self.postgres_table = postgres_table
             self.debezium_source.postgres_table = self.postgres_table
+            self.cluster = cluster
         elif len(existing_debezium_sources) == 1:
             self.new_debezium_source = False
 
@@ -119,7 +123,7 @@ class CreateDebeziumSource(Action):
                     > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${{testdrive.schema-registry-url}}');
 
                     > CREATE SOURCE {self.debezium_source.name}
-                      IN CLUSTER storaged
+                      IN CLUSTER {self.cluster}
                       FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.{self.postgres_table.name}')
                       FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                       ENVELOPE DEBEZIUM

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -41,7 +41,12 @@ class MzStart(Action):
             )
 
         c.sql(
-            "ALTER CLUSTER default SET (MANAGED = false)", user="mz_system", port=6877
+            """
+            ALTER CLUSTER default SET (MANAGED = false);
+            ALTER SYSTEM SET enable_unified_clusters = true;
+            """,
+            user="mz_system",
+            port=6877,
         )
 
     def provides(self) -> list[Capability]:

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -157,10 +157,12 @@ class ClusterReplicas(Scenario):
             CreateReplica: 30,
             DropReplica: 10,
             CreateTopicParameterized(): 10,
-            CreateSourceParameterized(): 10,
+            # The default cluster may aquire additional replicas, so can not be used for sources
+            CreateSourceParameterized(clusters=["storage"]): 10,
             CreateTableParameterized(): 10,
             CreateViewParameterized(): 20,
-            CreateSinkParameterized(): 10,
+            # The default cluster may aquire additional replicas, so can not be used for sinks
+            CreateSinkParameterized(clusters=["storage"]): 10,
             ValidateView: 20,
             Ingest: 50,
             DML: 50,
@@ -266,7 +268,8 @@ class DataflowsLarge(Scenario):
             CreateTopicParameterized(
                 max_topics=2, envelopes_with_weights={Envelope.UPSERT: 100}
             ): 10,
-            CreateSourceParameterized(max_sources=10): 10,
+            # The default cluster may aquire additional replicas, so can not be used for sources
+            CreateSourceParameterized(max_sources=10, clusters=["storage"]): 10,
             CreateViewParameterized(
                 max_views=5, expensive_aggregates=True, max_inputs=5
             ): 10,

--- a/misc/python/materialize/zippy/sink_capabilities.py
+++ b/misc/python/materialize/zippy/sink_capabilities.py
@@ -23,8 +23,15 @@ class SinkExists(Capability):
         return "sink_{}"
 
     def __init__(
-        self, name: str, source_view: ViewExists, dest_view: ViewExists
+        self,
+        name: str,
+        source_view: ViewExists,
+        dest_view: ViewExists,
+        cluster_out: str,
+        cluster_in: str,
     ) -> None:
         self.name = name
         self.source_view = source_view
         self.dest_view = dest_view
+        self.cluster_out = cluster_out
+        self.cluster_in = cluster_in

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -165,7 +165,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.sql(
             """
-            CREATE CLUSTER storaged REPLICAS (r2 (
+            CREATE CLUSTER storage REPLICAS (r2 (
                 STORAGECTL ADDRESSES ['storaged:2100'],
                 STORAGE ADDRESSES ['storaged:2103'],
                 COMPUTECTL ADDRESSES ['storaged:2101'],


### PR DESCRIPTION
Randomly create sources either in the dedicated `storage` cluster, as would be the case with most customers, or in the `default` cluster, where they will co-mingle with the materialized views and thus exercise cluster unification.

Relates to #21846

### Motivation

Cluster unification needs to be added to the various testing frameworks in order to be exercised.