### PR TITLE
Add a LIMIT scenario to feature-benchmark, scalability benchmark and enable the LIMIT optimization for all workflows

### DIFF
--- a/misc/python/materialize/checks/peek_persist.py
+++ b/misc/python/materialize/checks/peek_persist.py
@@ -1,0 +1,60 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+
+class PeekPersist(Check):
+    """Make sure old data can still be read by the PeekPersist LIMIT optimization"""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            """
+            > CREATE TABLE peek_persist (f1 INTEGER);
+            > INSERT INTO peek_persist VALUES (1), (2), (3), (NULL);
+            """
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(s)
+            for s in [
+                """
+                > INSERT INTO peek_persist VALUES (NULL), (1), (2), (3);
+                > UPDATE peek_persist SET f1 = f1 + 1;
+            """,
+                """
+                > INSERT INTO peek_persist VALUES (3), (NULL), (1), (2);
+                > DELETE FROM peek_persist WHERE f1 = 4;
+            """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            """
+            > SELECT * FROM peek_persist LIMIT 100
+            <null>
+            <null>
+            <null>
+            1
+            2
+            2
+            2
+            3
+            3
+            3
+
+            ? EXPLAIN SELECT * FROM peek_persist LIMIT 100
+            Explained Query (fast path):
+              Finish limit=100 output=[#0]
+                PeekPersist materialize.public.peek_persist
+            """
+        )

--- a/misc/python/materialize/feature_benchmark/action.py
+++ b/misc/python/materialize/feature_benchmark/action.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import textwrap
 from collections.abc import Callable, Iterator
 
 from materialize.feature_benchmark.executor import Executor
@@ -65,8 +66,8 @@ class Kgen(Action):
 class TdAction(Action):
     """Use testdrive to run some queries without measuring"""
 
-    def __init__(self, td_str: str) -> None:
-        self._td_str = td_str
+    def __init__(self, td_str: str, dedent: bool = True) -> None:
+        self._td_str = textwrap.dedent(td_str) if dedent else td_str
         self._executor: Executor | None = None
 
     def run(

--- a/misc/python/materialize/feature_benchmark/measurement_source.py
+++ b/misc/python/materialize/feature_benchmark/measurement_source.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 import re
+import textwrap
 import time
 from collections.abc import Callable
 
@@ -41,8 +42,8 @@ class Td(MeasurementSource):
 
     """
 
-    def __init__(self, td_str: str) -> None:
-        self._td_str = td_str
+    def __init__(self, td_str: str, dedent: bool = True) -> None:
+        self._td_str = textwrap.dedent(td_str) if dedent else td_str
         self._executor: Executor | None = None
 
     def run(
@@ -53,11 +54,12 @@ class Td(MeasurementSource):
         executor = executor or self._executor
         assert executor
 
-        td_output = executor.Td(self._td_str)
         # Print each query once so that it is easier to reproduce regressions
         # based on just the logs from CI
         if executor.add_known_fragment(self._td_str):
-            print(td_output)
+            print(self._td_str)
+
+        td_output = executor.Td(self._td_str)
 
         lines = td_output.splitlines()
         lines = [l for l in lines if l]

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -74,6 +74,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_sink_doc_on_option": "true",
     "enable_assert_not_null": "true",
     "enable_specialized_arrangements": "true",
+    "persist_fast_path_limit": "1000",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -26,6 +26,11 @@ class SelectStar(Operation):
         return "SELECT * FROM t1;"
 
 
+class SelectLimit(Operation):
+    def sql_statement(self) -> str:
+        return "SELECT * FROM t1 LIMIT 1;"
+
+
 class SelectCount(Operation):
     def sql_statement(self) -> str:
         return "SELECT COUNT(*) FROM t1;"

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -11,6 +11,7 @@ from materialize.scalability.operation import Operation
 from materialize.scalability.operations import (
     InsertDefaultValues,
     SelectCount,
+    SelectLimit,
     SelectOne,
     SelectStar,
     SelectUnionAll,
@@ -32,6 +33,11 @@ class SelectOneWorkload(Workload):
 class SelectStarWorkload(Workload):
     def operations(self) -> list["Operation"]:
         return [SelectStar()]
+
+
+class SelectLimitWorkload(Workload):
+    def operations(self) -> list["Operation"]:
+        return [SelectLimit()]
 
 
 class SelectCountWorkload(Workload):

--- a/misc/python/materialize/zippy/mz_actions.py
+++ b/misc/python/materialize/zippy/mz_actions.py
@@ -49,6 +49,13 @@ class MzStart(Action):
             port=6877,
         )
 
+        # Make sure all eligible LIMIT queries use the PeekPersist optimization
+        c.sql(
+            "ALTER SYSTEM SET persist_fast_path_limit = 1000000000",
+            user="mz_system",
+            port=6877,
+        )
+
     def provides(self) -> list[Capability]:
         return [MzIsRunning()]
 

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -130,6 +130,8 @@ class ValidateView(Action):
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.view = random.choice(capabilities.get(ViewExists))
+        # Trigger the PeekPersist optimization
+        self.select_limit = random.choice(["", "LIMIT 1"])
         super().__init__(capabilities)
 
     def run(self, c: Composition) -> None:
@@ -141,14 +143,14 @@ class ValidateView(Action):
             c.testdrive(
                 dedent(
                     f"""
-                    > SELECT count_all, count_distinct, min_value, max_value FROM {self.view.name} /* expecting count_all = {(view_max-view_min)+1} count_distinct = {(view_max-view_min)+1} min_value = {view_min} max_value = {view_max} */ ;
+                    > SELECT count_all, count_distinct, min_value, max_value FROM {self.view.name} {self.select_limit} /* expecting count_all = {(view_max-view_min)+1} count_distinct = {(view_max-view_min)+1} min_value = {view_min} max_value = {view_max} */ ;
                     {(view_max-view_min)+1} {(view_max-view_min)+1} {view_min} {view_max}
                 """
                 )
                 if self.view.expensive_aggregates
                 else dedent(
                     f"""
-                    > SELECT count_all FROM {self.view.name} /* expecting count_all = {(view_max-view_min)+1} */ ;
+                    > SELECT count_all FROM {self.view.name} {self.select_limit} /* expecting count_all = {(view_max-view_min)+1} */ ;
                     {(view_max-view_min)+1}
                 """
                 )

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -9,6 +9,7 @@
 
 
 from math import ceil, floor
+from textwrap import dedent
 
 from parameterized import parameterized_class  # type: ignore
 
@@ -164,6 +165,33 @@ true
   /* B */
 """
             + "\n".join([str(x) for x in range(self.n() - 1000, self.n())])
+        )
+
+
+class FastPathLimit(FastPath):
+    """Benchmark the case SELECT * FROM source LIMIT <i> , optimized by #21615"""
+
+    def init(self) -> list[Action]:
+        return [
+            TdAction(
+                f"""
+                > CREATE MATERIALIZED VIEW v1 AS SELECT * FROM generate_series(1, {self.n()})
+                """
+            ),
+        ]
+
+    def benchmark(self) -> MeasurementSource:
+        return Td(
+            dedent(
+                """
+                > SELECT 1;
+                  /* A */
+                1
+                > SELECT * FROM v1 LIMIT 100
+                  /* B */
+                """
+            )
+            + "\n".join([str(x) for x in range(1, 101)])
         )
 
 

--- a/test/sqllogictest/order_by.slt
+++ b/test/sqllogictest/order_by.slt
@@ -874,11 +874,11 @@ CREATE TABLE t(x int, y int);
 
 # We could remove the TopK, but we don't do this on the slow path currently.
 query T multiline
-EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10) LIMIT 8;
+EXPLAIN SELECT * FROM (SELECT * FROM t LIMIT 10000) LIMIT 8000;
 ----
 Explained Query:
-  Finish limit=8 output=[#0, #1]
-    TopK limit=10
+  Finish limit=8000 output=[#0, #1]
+    TopK limit=10000
       ReadStorage materialize.public.t
 
 EOF

--- a/test/sqllogictest/persist-fast-path.slt
+++ b/test/sqllogictest/persist-fast-path.slt
@@ -184,3 +184,8 @@ query T
 SELECT * FROM t1 LIMIT 1 OFFSET 1;
 ----
 2
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET persist_fast_path_limit
+----
+COMPLETE 0


### PR DESCRIPTION
A query with LIMIT but no ORDER BY or index will use the PeekPersist optimization.

Relates to: #21615, #22042

### Motivation

This particular optimization is not being triggered by any other workload.