### PR TITLE
cloudtests: use logger also in mz repo

### DIFF
--- a/misc/python/materialize/cloudtest/app/application.py
+++ b/misc/python/materialize/cloudtest/app/application.py
@@ -8,11 +8,11 @@
 # by the Apache License, Version 2.0.
 
 import subprocess
-from textwrap import dedent
 
 from materialize import ui
 from materialize.cloudtest import DEFAULT_K8S_CLUSTER_NAME, DEFAULT_K8S_CONTEXT_NAME
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
+from materialize.cloudtest.util.common import log_subprocess_error
 
 
 class Application:
@@ -44,16 +44,7 @@ class Application:
 
             return subprocess.check_output(cmd, text=True)
         except subprocess.CalledProcessError as e:
-            print(
-                dedent(
-                    f"""
-                    cmd: {e.cmd}
-                    returncode: {e.returncode}
-                    stdout: {e.stdout}
-                    stderr: {e.stderr}
-                    """
-                )
-            )
+            log_subprocess_error(e)
             raise e
 
     def context(self) -> str:

--- a/misc/python/materialize/cloudtest/app/materialize_application.py
+++ b/misc/python/materialize/cloudtest/app/materialize_application.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
 import os
 import time
 from datetime import datetime, timedelta
@@ -33,6 +34,8 @@ from materialize.cloudtest.k8s.ssh import ssh_resources
 from materialize.cloudtest.k8s.testdrive import TestdrivePod
 from materialize.cloudtest.k8s.vpc_endpoints_cluster_role import VpcEndpointsClusterRole
 from materialize.cloudtest.util.wait import wait
+
+LOGGER = logging.getLogger(__name__)
 
 
 class MaterializeApplication(CloudtestApplicationBase):
@@ -135,7 +138,7 @@ class MaterializeApplication(CloudtestApplicationBase):
                 break
             except InterfaceError as e:
                 # Since we crash environmentd, we expect some errors that we swallow.
-                print(f"SQL interface not ready, {e} while SELECT 1. Waiting...")
+                LOGGER.info(f"SQL interface not ready, {e} while SELECT 1. Waiting...")
                 time.sleep(2)
 
     def set_environmentd_failpoints(self, failpoints: str) -> None:

--- a/misc/python/materialize/cloudtest/k8s/api/k8s_service.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_service.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 
+import logging
 from typing import Any
 
 import pg8000
@@ -16,6 +17,8 @@ from kubernetes.client import V1Service
 from pg8000 import Connection, Cursor
 
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
+
+LOGGER = logging.getLogger(__name__)
 
 
 class K8sService(K8sResource):
@@ -82,7 +85,7 @@ class K8sService(K8sResource):
         """Run a batch of SQL statements against the service."""
         with self.sql_cursor(port=port, user=user) as cursor:
             for statement in sqlparse.split(sql):
-                print(f"> {statement}")
+                LOGGER.info(f"> {statement}")
                 cursor.execute(statement)
 
     def sql_query(
@@ -93,6 +96,6 @@ class K8sService(K8sResource):
     ) -> Any:
         """Execute a SQL query against the service and return results."""
         with self.sql_cursor(port=port, user=user) as cursor:
-            print(f"> {sql}")
+            LOGGER.info(f"> {sql}")
             cursor.execute(sql)
             return cursor.fetchall()

--- a/misc/python/materialize/cloudtest/k8s/api/k8s_stateful_set.py
+++ b/misc/python/materialize/cloudtest/k8s/api/k8s_stateful_set.py
@@ -8,10 +8,14 @@
 # by the Apache License, Version 2.0.
 
 
+import logging
+
 from kubernetes.client import V1StatefulSet
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_resource import K8sResource
+
+LOGGER = logging.getLogger(__name__)
 
 
 class K8sStatefulSet(K8sResource):
@@ -41,7 +45,7 @@ class K8sStatefulSet(K8sResource):
     def replace(self) -> None:
         apps_v1_api = self.apps_api()
         name = self.name()
-        print(f"Replacing stateful set {name}...")
+        LOGGER.info(f"Replacing stateful set {name}...")
         self.stateful_set = self.generate_stateful_set()
         apps_v1_api.replace_namespaced_stateful_set(
             name=name, body=self.stateful_set, namespace=self.namespace()

--- a/misc/python/materialize/cloudtest/util/controller.py
+++ b/misc/python/materialize/cloudtest/util/controller.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # pyright: reportMissingImports=false
+import logging
 import socket
 import subprocess
 import urllib.parse
@@ -15,8 +16,10 @@ from dataclasses import dataclass
 from typing import Any
 
 from materialize.cloudtest.util.authentication import AuthConfig
-from materialize.cloudtest.util.common import eprint, retry
+from materialize.cloudtest.util.common import log_subprocess_error, retry
 from materialize.cloudtest.util.web_request import WebRequests
+
+LOGGER = logging.getLogger(__name__)
 
 
 @dataclass
@@ -130,13 +133,13 @@ def launch_controllers(controller_names: list[str], docker_env: dict[str, str]) 
             env=docker_env,
         )
     except subprocess.CalledProcessError as e:
-        eprint(e.returncode, e.stdout, e.stderr)
+        log_subprocess_error(e)
         raise
 
 
 def wait_for_controllers(*endpoints: Endpoint) -> None:
     for endpoint in endpoints:
-        eprint(f"Waiting for {endpoint.host_port} to be connectable...")
+        LOGGER.info(f"Waiting for {endpoint.host_port} to be connectable...")
         wait_for_connectable(endpoint.host_port)
 
 
@@ -149,5 +152,5 @@ def cleanup_controllers(docker_env: dict[str, str]) -> None:
             env=docker_env,
         )
     except subprocess.CalledProcessError as e:
-        eprint(e.returncode, e.stdout, e.stderr)
+        log_subprocess_error(e)
         raise

--- a/misc/python/materialize/cloudtest/util/jwt_key.py
+++ b/misc/python/materialize/cloudtest/util/jwt_key.py
@@ -8,14 +8,16 @@
 # by the Apache License, Version 2.0.
 
 import datetime
+import logging
 import uuid
+from textwrap import dedent
 
 import jwt
 import requests
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
-from materialize.cloudtest.util.common import eprint
+LOGGER = logging.getLogger(__name__)
 
 
 def _generate_jwt_keys() -> tuple[rsa.RSAPrivateKey, bytes]:
@@ -72,7 +74,15 @@ def fetch_jwt(email: str, password: str, host: str) -> str:
     try:
         res.raise_for_status()
     except Exception as e:
-        eprint(e, res, res.text)
+        LOGGER.error(
+            dedent(
+                f"""
+                e: {e}
+                res: {res}
+                res.text: {res.text}
+                """
+            )
+        )
         raise
 
     access_token: str = res.json()["accessToken"]

--- a/misc/python/materialize/cloudtest/util/sql.py
+++ b/misc/python/materialize/cloudtest/util/sql.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
 from typing import Any
 
 import psycopg
@@ -14,9 +15,10 @@ from psycopg.abc import Params, Query
 from psycopg.connection import Connection
 
 from materialize.cloudtest.util.authentication import AuthConfig
-from materialize.cloudtest.util.common import eprint
 from materialize.cloudtest.util.environment import Environment
 from materialize.cloudtest.util.web_request import WebRequests
+
+LOGGER = logging.getLogger(__name__)
 
 
 def sql_query(
@@ -70,7 +72,7 @@ def sql_query_pgwire(
     vars: Params | None = None,
 ) -> list[list[Any]]:
     with pgwire_sql_conn(auth, environment) as conn:
-        eprint(f"QUERY: {query}")
+        LOGGER.info(f"QUERY: {query}")
         return sql_query(conn, query, vars)
 
 
@@ -81,7 +83,7 @@ def sql_execute_pgwire(
     vars: Params | None = None,
 ) -> None:
     with pgwire_sql_conn(auth, environment) as conn:
-        eprint(f"QUERY: {query}")
+        LOGGER.info(f"QUERY: {query}")
         return sql_execute(conn, query, vars)
 
 

--- a/misc/python/materialize/cloudtest/util/wait.py
+++ b/misc/python/materialize/cloudtest/util/wait.py
@@ -7,14 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-
+import logging
 import subprocess
 
 from materialize import ui
 from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
-from materialize.cloudtest.util.common import log_subprocess_error
 from materialize.cloudtest.util.print_pods import print_pods
 from materialize.ui import UIError
+
+LOGGER = logging.getLogger(__name__)
 
 
 def wait(
@@ -59,7 +60,8 @@ def wait(
                 ui.progress("success!", finish=True)
                 return
         except subprocess.CalledProcessError as e:
-            log_subprocess_error(e)
+            # use a less verbose output than log_subprocess_error here
+            LOGGER.info(f"{e} {e.output.decode('ascii')}")
             error = e
 
     ui.progress(finish=True)

--- a/misc/python/materialize/cloudtest/util/wait.py
+++ b/misc/python/materialize/cloudtest/util/wait.py
@@ -12,6 +12,7 @@ import subprocess
 
 from materialize import ui
 from materialize.cloudtest import DEFAULT_K8S_CONTEXT_NAME
+from materialize.cloudtest.util.common import log_subprocess_error
 from materialize.cloudtest.util.print_pods import print_pods
 from materialize.ui import UIError
 
@@ -58,7 +59,7 @@ def wait(
                 ui.progress("success!", finish=True)
                 return
         except subprocess.CalledProcessError as e:
-            print(e, e.output)
+            log_subprocess_error(e)
             error = e
 
     ui.progress(finish=True)

--- a/misc/python/materialize/cloudtest/util/web_request.py
+++ b/misc/python/materialize/cloudtest/util/web_request.py
@@ -7,15 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-import sys
+import logging
 from collections.abc import Generator
 from contextlib import contextmanager
+from textwrap import dedent
 from typing import Any
 
 import requests
 
 from materialize.cloudtest.util.authentication import AuthConfig
-from materialize.cloudtest.util.common import eprint
+
+LOGGER = logging.getLogger(__name__)
 
 
 @contextmanager
@@ -23,11 +25,14 @@ def verbose_http_errors() -> Generator[None, None, None]:
     try:
         yield
     except requests.HTTPError as e:
-        print(
-            e.response.status_code,
-            e.response.reason,
-            e.response.content,
-            file=sys.stderr,
+        LOGGER.error(
+            dedent(
+                f"""
+                response status: {e.response.status_code}
+                response reason: {e.response.reason}
+                response content: {e.response.content}
+                """
+            )
         )
         raise
 
@@ -52,7 +57,7 @@ class WebRequests:
         path: str,
         timeout_in_sec: int | None = None,
     ) -> requests.Response:
-        eprint(f"GET {self.base_url}{path}")
+        LOGGER.info(f"GET {self.base_url}{path}")
 
         def try_get() -> requests.Response:
             with verbose_http_errors():
@@ -83,7 +88,7 @@ class WebRequests:
         json: Any,
         timeout_in_sec: int | None = None,
     ) -> requests.Response:
-        eprint(f"POST {self.base_url}{path}")
+        LOGGER.info(f"POST {self.base_url}{path}")
 
         def try_post() -> requests.Response:
             with verbose_http_errors():
@@ -115,7 +120,7 @@ class WebRequests:
         json: Any,
         timeout_in_sec: int | None = None,
     ) -> requests.Response:
-        eprint(f"PATCH {self.base_url}{path}")
+        LOGGER.info(f"PATCH {self.base_url}{path}")
 
         def try_patch() -> requests.Response:
             with verbose_http_errors():
@@ -147,7 +152,7 @@ class WebRequests:
         params: Any = None,
         timeout_in_sec: int | None = None,
     ) -> requests.Response:
-        eprint(f"DELETE {self.base_url}{path}")
+        LOGGER.info(f"DELETE {self.base_url}{path}")
 
         def try_delete() -> requests.Response:
             with verbose_http_errors():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,9 @@ ignore = [
   # Rust build artifacts are not subject to our static analysis.
   "target/",
 ]
+
+[tool.pytest.ini_options]
+log_cli = true
+log_cli_level = "INFO"
+# do not include the timestamp which is already provided by Buildkite
+log_cli_format = "[%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)"

--- a/test/cloudtest/test_compute.py
+++ b/test/cloudtest/test_compute.py
@@ -7,6 +7,8 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
+
 import pytest
 from pg8000.exceptions import InterfaceError
 
@@ -14,6 +16,8 @@ from materialize.cloudtest.app.materialize_application import MaterializeApplica
 from materialize.cloudtest.util.cluster import cluster_pod_name, cluster_service_name
 from materialize.cloudtest.util.exists import exists, not_exists
 from materialize.cloudtest.util.wait import wait
+
+LOGGER = logging.getLogger(__name__)
 
 
 def test_cluster_sizing(mz: MaterializeApplication) -> None:
@@ -48,7 +52,7 @@ def test_cluster_sizing(mz: MaterializeApplication) -> None:
 def test_cluster_shutdown(mz: MaterializeApplication, failpoint: str) -> None:
     """Test that dropping a cluster or replica causes the associated clusterds to shut down."""
 
-    print(f"Testing cluster shutdown with failpoint={failpoint}")
+    LOGGER.info(f"Testing cluster shutdown with failpoint={failpoint}")
 
     mz.set_environmentd_failpoints(failpoint)
 
@@ -59,7 +63,7 @@ def test_cluster_shutdown(mz: MaterializeApplication, failpoint: str) -> None:
         try:
             mz.environmentd.sql(sql)
         except InterfaceError as e:
-            print(f"Expected SQL error: {e}")
+            LOGGER.error(f"Expected SQL error: {e}")
 
     mz.environmentd.sql(
         "CREATE CLUSTER shutdown1 REPLICAS (shutdown_replica1 (SIZE '1'), shutdown_replica2 (SIZE '1'))"

--- a/test/cloudtest/test_compute_shared_fate.py
+++ b/test/cloudtest/test_compute_shared_fate.py
@@ -7,12 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
 import subprocess
 import time
 from textwrap import dedent
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.cluster import cluster_pod_name
+
+LOGGER = logging.getLogger(__name__)
 
 CLUSTER_SIZE = 8
 
@@ -97,7 +100,7 @@ def kill_clusterd(
 
     pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)
 
-    print(f"sending signal {signal} to pod {pod_name}...")
+    LOGGER.info(f"sending signal {signal} to pod {pod_name}...")
 
     try:
         mz.kubectl(

--- a/test/cloudtest/test_storage.py
+++ b/test/cloudtest/test_storage.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
 from textwrap import dedent
 
 import pytest
@@ -16,6 +17,8 @@ from materialize.cloudtest.app.materialize_application import MaterializeApplica
 from materialize.cloudtest.util.cluster import cluster_pod_name, cluster_service_name
 from materialize.cloudtest.util.exists import exists, not_exists
 from materialize.cloudtest.util.wait import wait
+
+LOGGER = logging.getLogger(__name__)
 
 
 def get_value_from_label(
@@ -158,7 +161,7 @@ def test_source_resizing(mz: MaterializeApplication) -> None:
 @pytest.mark.parametrize("failpoint", [False, True])
 @pytest.mark.skip(reason="Failpoints mess up the Mz instance #18000")
 def test_source_shutdown(mz: MaterializeApplication, failpoint: bool) -> None:
-    print("Starting test_source_shutdown")
+    LOGGER.info("Starting test_source_shutdown")
     if failpoint:
         mz.set_environmentd_failpoints("kubernetes_drop_service=return(error)")
 
@@ -204,7 +207,7 @@ def test_source_shutdown(mz: MaterializeApplication, failpoint: bool) -> None:
     try:
         mz.environmentd.sql("DROP SOURCE source1")
     except InterfaceError as e:
-        print(f"Expected SQL error: {e}")
+        LOGGER.error(f"Expected SQL error: {e}")
 
     if failpoint:
         # Disable failpoint here, this should end the crash loop of environmentd

--- a/test/cloudtest/test_storage_shared_fate.py
+++ b/test/cloudtest/test_storage_shared_fate.py
@@ -7,12 +7,15 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import logging
 import subprocess
 import time
 from textwrap import dedent
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.cluster import cluster_pod_name
+
+LOGGER = logging.getLogger(__name__)
 
 CLUSTER_SIZE = 8
 NUM_SOURCES = 4
@@ -131,7 +134,7 @@ def kill_clusterd(
 
     pod_name = cluster_pod_name(cluster_id, replica_id, compute_id)
 
-    print(f"sending signal {signal} to pod {pod_name}...")
+    LOGGER.info(f"sending signal {signal} to pod {pod_name}...")
 
     try:
         mz.kubectl(

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+import logging
+
 import pytest
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
@@ -20,6 +22,8 @@ from materialize.cloudtest.app.materialize_application import MaterializeApplica
 from materialize.cloudtest.util.wait import wait
 from materialize.util import MzVersion
 from materialize.version_list import VersionsFromDocs
+
+LOGGER = logging.getLogger(__name__)
 
 LAST_RELEASED_VERSION = VersionsFromDocs().minor_versions()[-1]
 
@@ -43,7 +47,7 @@ class CloudtestUpgrade(Scenario):
 @pytest.mark.long
 def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
-    print(
+    LOGGER.info(
         f"Testing upgrade from base version {LAST_RELEASED_VERSION} to current version"
     )
 


### PR DESCRIPTION
Use a proper logger **in cloudtests.**

### Motivation

It adjust resources used by cloud-repo's cloudtests to also use a proper logger (cloud [PR#7635](https://github.com/MaterializeInc/cloud/pull/7635/files)).

### Result
* Output before: https://buildkite.com/materialize/tests/builds/64763#018ae021-c51e-407d-9cb1-d16ae3161160
* Output after: https://buildkite.com/materialize/tests/builds/64795#018ae12e-b5c4-43bf-a622-b864a5650c93

### Discussion

@philip-stoev, @def-: What do you think about this PR?
* 👍 It removes a diff between mz repo and cloud repo.
* 👍 It allows better filtering by adjusting the log level.
* 👎 The output might contain a mix of logging and sysout (when cloud utility functions use utility functions defined elsewhere that do not use logging).
* 👎 It might make some logging output more verbose but we should be able to control that through the logging pattern.
* ➡️ We might want not to use it in some places to make it easier to copy SQL statements

```
-------------------------------- live log call ---------------------------------
[    INFO] > SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'shared_fate_replica' (k8s_service.py:99)[    INFO] sending signal SIGKILL to pod pod/cluster-u9-replica-u19-0... (test_compute_shared_fate.py:103)
[    INFO] > SELECT cluster_id, id FROM mz_cluster_replicas WHERE name = 'shared_fate_replica' (k8s_service.py:99)
[    INFO] sending signal SIGKILL to pod pod/cluster-u9-replica-u19-1... (test_compute_shared_fate.py:103)
```
