### PR TITLE
Inline functions standing out in pprof

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -611,6 +611,7 @@ impl Refines<()> for MzOffset {
 }
 
 impl PartialOrder for MzOffset {
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         self.offset.less_equal(&other.offset)
     }

--- a/src/timely-util/src/order.rs
+++ b/src/timely-util/src/order.rs
@@ -163,6 +163,7 @@ impl<P: Eq, T: PartialOrder> PartialOrder for Partitioned<P, T>
 where
     Interval<P>: PartialOrder,
 {
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         self.0.less_equal(&other.0)
     }
@@ -183,16 +184,19 @@ impl<P: Partition, T: Timestamp> Default for PartitionedSummary<P, T> {
 }
 
 impl<P: Partition, T: Timestamp> PartialOrder for PartitionedSummary<P, T> {
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         self.0.less_equal(&other.0)
     }
 }
 
 impl<P: Partition, T: Timestamp> PathSummary<Partitioned<P, T>> for PartitionedSummary<P, T> {
+    #[inline]
     fn results_in(&self, src: &Partitioned<P, T>) -> Option<Partitioned<P, T>> {
         self.0.results_in(&src.0).map(Partitioned)
     }
 
+    #[inline]
     fn followed_by(&self, other: &Self) -> Option<Self> {
         PathSummary::<Product<Interval<P>, T>>::followed_by(&self.0, &other.0)
             .map(PartitionedSummary)
@@ -224,6 +228,7 @@ pub enum Interval<P> {
 }
 
 impl<P: Ord + Eq> PartialOrder for Interval<P> {
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         use Interval::*;
         match (self, other) {
@@ -239,6 +244,7 @@ impl<P: Ord + Eq> PartialOrder for Interval<P> {
 }
 
 impl<P: Partition> PathSummary<Interval<P>> for Interval<P> {
+    #[inline]
     fn results_in(&self, src: &Interval<P>) -> Option<Interval<P>> {
         use std::cmp::{max, min};
 
@@ -274,6 +280,7 @@ impl<P: Partition> PathSummary<Interval<P>> for Interval<P> {
         }
     }
 
+    #[inline]
     fn followed_by(&self, other: &Self) -> Option<Self> {
         self.results_in(other)
     }
@@ -282,12 +289,14 @@ impl<P: Partition> PathSummary<Interval<P>> for Interval<P> {
 impl<P: Partition> Timestamp for Interval<P> {
     type Summary = Interval<P>;
 
+    #[inline]
     fn minimum() -> Self {
         Self::default()
     }
 }
 
 impl<P> Default for Interval<P> {
+    #[inline]
     fn default() -> Self {
         Self::Range(RangeBound::Bottom, RangeBound::Top)
     }
@@ -305,6 +314,7 @@ pub enum RangeBound<P> {
 }
 
 impl<P: PartialEq> PartialEq<P> for RangeBound<P> {
+    #[inline]
     fn eq(&self, other: &P) -> bool {
         match self {
             RangeBound::Bottom => false,
@@ -315,6 +325,7 @@ impl<P: PartialEq> PartialEq<P> for RangeBound<P> {
 }
 
 impl<P: PartialOrd> PartialOrd<P> for RangeBound<P> {
+    #[inline]
     fn partial_cmp(&self, other: &P) -> Option<Ordering> {
         match self {
             RangeBound::Bottom => Some(Ordering::Less),
@@ -359,17 +370,20 @@ impl<P> Partition for P where
 pub struct Reverse<T>(pub T);
 
 impl<T: PartialOrder> PartialOrder for Reverse<T> {
+    #[inline]
     fn less_equal(&self, other: &Self) -> bool {
         PartialOrder::less_equal(&other.0, &self.0)
     }
 }
 impl<T: PartialOrd> PartialOrd for Reverse<T> {
+    #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         other.0.partial_cmp(&self.0)
     }
 }
 
 impl<T: Ord> Ord for Reverse<T> {
+    #[inline]
     fn cmp(&self, other: &Self) -> Ordering {
         other.0.cmp(&self.0)
     }


### PR DESCRIPTION
Inline timestamp implementations, specifically those that stand out in CPU profiles in incident 75: https://pprof.me/3db718b/ shows that `<mz_timely_util::order::Interval<> as timely::order::PartialOrder>::less_equal` has a separate stack frame, which means it's not inlined. This makes sense because we're implementing a trait from a different crate, and Rust's inlining often cannot reliably cross crate boundaries.

  * This PR adds a feature that has not yet been specified.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
