### PR TITLE
Connect up the two filter-pushdown-related docs

### DIFF
--- a/doc/user/content/sql/functions/pushdown.md
+++ b/doc/user/content/sql/functions/pushdown.md
@@ -11,17 +11,16 @@ menu:
 {{</ private-preview >}}
 
 `try_parse_monotonic_iso8601_timestamp` parses a subset of [ISO 8601]
-timestamps that is chosen to both:
-
-- Match the 24 character length output of the javascript [Date.toISOString()]
-  function and
-- For which the lexicographical order corresponds to chronological order.
-
-In contrast to other parsing functions, inputs that fail to parse return `NULL`
+timestamps that matches the 24 character length output
+of the javascript [Date.toISOString()] function.
+Unlike other parsing functions, inputs that fail to parse return `NULL`
 instead of error.
 
-Combined, this allows `try_parse_monotonic_iso8601_timestamp` to be used with
-the [temporal filter pushdown] feature on `string` timestamps stored in [jsonb] columns.
+This allows `try_parse_monotonic_iso8601_timestamp` to be used with
+the [temporal filter pushdown] feature on `text` timestamps.
+This is particularly useful when working with
+[JSON sources](/sql/create-source/#json),
+or other external data sources that store timestamps as strings.
 
 Specifically, the accepted format is `YYYY-MM-DDThh:mm:ss.sssZ`:
 
@@ -39,6 +38,10 @@ Specifically, the accepted format is `YYYY-MM-DDThh:mm:ss.sssZ`:
 - A literal `.`
 - A 3-digit millisecond, left-padded with zeros followed by
 - A literal `Z`, indicating the UTC time zone.
+
+Ordinary `text`-to-`timestamp` casts will prevent a filter from being pushed down.
+Replacing those casts `try_parse_monotonic_iso8601_timestamp` can unblock that
+optimization for your query.
 
 ## Examples
 

--- a/doc/user/content/sql/functions/pushdown.md
+++ b/doc/user/content/sql/functions/pushdown.md
@@ -40,7 +40,7 @@ Specifically, the accepted format is `YYYY-MM-DDThh:mm:ss.sssZ`:
 - A literal `Z`, indicating the UTC time zone.
 
 Ordinary `text`-to-`timestamp` casts will prevent a filter from being pushed down.
-Replacing those casts `try_parse_monotonic_iso8601_timestamp` can unblock that
+Replacing those casts with `try_parse_monotonic_iso8601_timestamp` can unblock that
 optimization for your query.
 
 ## Examples

--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -238,8 +238,6 @@ This is often referred to as a **grace period**.
 
 ## Temporal filter pushdown
 
-{{< private-preview />}}
-
 All of the queries in the previous examples only return results based on recently-added events.
 Materialize can "push down" filters that match this pattern all the way down to its storage layer, skipping over old data that’s not relevant to the query.
 Here are the key benefits of this optimization:

--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -268,4 +268,4 @@ Source materialize.public.events
 
 The filter in our query appears in the `pushdown=` list at the bottom of the output, so the filter pushdown optimization will be able to filter out irrelevant ranges of data in that source and make the overall query more efficient.
 
-Some common functions, like casting from a string to a timestamp, can prevent filter pushdown for a query. For similar functions that _do_ allow pushdown, see [the pushdown functions documentation](/sql/functions/pushdown/).
+Some common functions, such as casting from a string to a timestamp, can prevent filter pushdown for a query. For similar functions that _do_ allow pushdown, see [the pushdown functions documentation](/sql/functions/pushdown/).

--- a/doc/user/content/transform-data/patterns/temporal-filters.md
+++ b/doc/user/content/transform-data/patterns/temporal-filters.md
@@ -267,3 +267,5 @@ Source materialize.public.events
 ```
 
 The filter in our query appears in the `pushdown=` list at the bottom of the output, so the filter pushdown optimization will be able to filter out irrelevant ranges of data in that source and make the overall query more efficient.
+
+Some common functions, like casting from a string to a timestamp, can prevent filter pushdown for a query. For similar functions that _do_ allow pushdown, see [the pushdown functions documentation](/sql/functions/pushdown/).


### PR DESCRIPTION
### Motivation

Inspired by some recent internal discussions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
