### PR TITLE
Add justification for `as` conversions in all_build_ids

### DIFF
--- a/src/build-id/src/lib.rs
+++ b/src/build-id/src/lib.rs
@@ -134,9 +134,7 @@ pub unsafe fn all_build_ids(
         // with `data` other than pass it to this callback, so nothing will be mutating
         // the object it points to while we're inside here.
         let state: &mut CallbackState = unsafe {
-            // Justification: `data` is a pointer to a `CallbackState`
-            #[allow(clippy::as_conversions)]
-            (data as *mut CallbackState)
+            data.cast::<CallbackState>()
                 .as_mut()
                 .expect("`data` cannot be null")
         };
@@ -264,13 +262,7 @@ pub unsafe fn all_build_ids(
     // SAFETY: `dl_iterate_phdr` has no documented restrictions on when
     // it can be called.
     unsafe {
-        // Justification: converting a pointer to void* is always
-        // valid
-        #[allow(clippy::as_conversions)]
-        dl_iterate_phdr(
-            Some(iterate_cb),
-            (&mut state) as *mut CallbackState as *mut c_void,
-        );
+        dl_iterate_phdr(Some(iterate_cb), std::ptr::addr_of_mut!(state).cast());
     };
     if let Some(err) = state.fatal_error {
         Err(err)

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -832,6 +832,9 @@ where
             retractions.log();
 
             let Some(&time) = frontier.get(0) else { return };
+            if import_id.is_user() {
+                println!("[btv] import frontier for {import_id:?}: {time}");
+            }
             for &export_id in export_ids.iter() {
                 logger.log(ComputeEvent::ImportFrontier {
                     import_id,

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -832,9 +832,6 @@ where
             retractions.log();
 
             let Some(&time) = frontier.get(0) else { return };
-            if import_id.is_user() {
-                println!("[btv] import frontier for {import_id:?}: {time}");
-            }
             for &export_id in export_ids.iter() {
                 logger.log(ComputeEvent::ImportFrontier {
                     import_id,


### PR DESCRIPTION
After https://github.com/MaterializeInc/materialize/pull/21936 lands, this code will become live, so now's a good time to finally document these.

@teskje 