### PR TITLE
dbt-materialize: Enable Grants

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 * Allow `cluster` configuration for `dbt test`.
 
+* Enable `grants` config for sources, seeds, tables, views and materialized views.
+
 ## 1.5.1 - 2023-07-24
 
 * Enable the `indexes` config for `table` materializations.

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_view.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/materialized_view.sql
@@ -38,6 +38,9 @@
   {{ create_indexes(target_relation) }}
   {% do persist_docs(target_relation, model) %}
 
+  {% set grant_config = config.get('grants') %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/seed.sql
@@ -78,6 +78,9 @@
     {{ sql }}
   {% endcall %}
 
+  {% set grant_config = config.get('grants') %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/source.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/source.sql
@@ -37,6 +37,9 @@
   {{ create_indexes(target_relation) }}
   {% do persist_docs(target_relation, model) %}
 
+  {% set grant_config = config.get('grants') %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/table.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/table.sql
@@ -39,6 +39,9 @@
   {{ create_indexes(target_relation) }}
   {% do persist_docs(target_relation, model) %}
 
+  {% set grant_config = config.get('grants') %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/view.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/view.sql
@@ -38,6 +38,9 @@
   {{ create_indexes(target_relation) }}
   {% do persist_docs(target_relation, model) %}
 
+  {% set grant_config = config.get('grants') %}
+  {% do apply_grants(target_relation, grant_config, should_revoke=should_revoke) %}
+
   {{ run_hooks(post_hooks, inside_transaction=False) }}
   {{ run_hooks(post_hooks, inside_transaction=True) }}
 

--- a/misc/dbt-materialize/tests/adapter/fixtures.py
+++ b/misc/dbt-materialize/tests/adapter/fixtures.py
@@ -30,10 +30,28 @@ test_materialized_view_index = """
     SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
 """
 
+test_materialized_view_grant = """
+{{ config(
+    materialized='materializedview',
+    grants={'select': ['bi', 'reporter']}
+) }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse')) _ (a, b)
+"""
+
 test_view_index = """
 {{ config(
     materialized='view',
     indexes=[{'default': True}]
+) }}
+
+    SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse'), (NULL, NULL)) _ (a, b)
+"""
+
+test_view_grant = """
+{{ config(
+    materialized='view',
+    grants={'select': ['bi', 'reporter']}
 ) }}
 
     SELECT * FROM (VALUES ('chicken', 'pig'), ('cow', 'horse'), (NULL, NULL)) _ (a, b)

--- a/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
+++ b/misc/dbt-materialize/tests/adapter/test_custom_materializations.py
@@ -20,6 +20,7 @@ from fixtures import (
     expected_indexes,
     test_materialized_view,
     test_materialized_view_index,
+    test_materialized_view_grant,
     test_relation_name_length,
     test_sink,
     test_source,
@@ -27,6 +28,7 @@ from fixtures import (
     test_subsources,
     test_table_index,
     test_view_index,
+    test_view_grant,
 )
 
 
@@ -47,6 +49,7 @@ class TestCustomMaterializations:
             "actual_indexes.sql": actual_indexes,
             "test_materialized_view.sql": test_materialized_view,
             "test_materialized_view_index.sql": test_materialized_view_index,
+            "test_materialized_view_grant.sql": test_materialized_view_grant,
             "test_relation_name_loooooooooooooooooonger_than_postgres_63_limit.sql": test_relation_name_length,
             "test_source.sql": test_source,
             "test_source_index.sql": test_source_index,
@@ -54,9 +57,13 @@ class TestCustomMaterializations:
             "test_sink.sql": test_sink,
             "test_table_index.sql": test_table_index,
             "test_view_index.sql": test_view_index,
+            "test_view_grant.sql": test_view_grant,
         }
 
     def test_custom_materializations(self, project):
+        project.run_sql("CREATE ROLE bi")
+        project.run_sql("CREATE ROLE reporter")
+
         # seed seeds
         results = run_dbt(["seed"])
         # seed result length
@@ -64,12 +71,12 @@ class TestCustomMaterializations:
         # run models
         results = run_dbt(["run"])
         # run result length
-        assert len(results) == 10
+        assert len(results) == 12
         # re-run models to ensure there are no lingering errors in recreating
         # the materializations
         results = run_dbt(["run"])
         # re-run result length
-        assert len(results) == 10
+        assert len(results) == 12
         # relations_equal
         check_relations_equal(
             project.adapter,


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Enable grant configuration for Materialize custom materializations (seeds, sources, tables, views, materialized views). Allows users to set RBAC permissions at the model level:
```
{{ config(grants={'select': ['bi', 'reporter']}) }}
```

or the project level within `dbt_project.yml':
```
models:
  +grants:
    select: ['bi', 'reporter']
```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
