### PR TITLE
persist: take a PersistClient future in shard_source

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -13,6 +13,7 @@ use std::any::Any;
 use std::collections::hash_map::DefaultHasher;
 use std::convert::Infallible;
 use std::fmt::Debug;
+use std::future::Future;
 use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 use std::sync::Arc;
@@ -38,11 +39,10 @@ use timely::PartialOrder;
 use tokio::sync::mpsc;
 use tracing::{debug, trace};
 
-use crate::cache::PersistClientCache;
 use crate::fetch::{FetchedPart, SerdeLeasedBatchPart};
 use crate::read::ListenEvent;
 use crate::stats::PartStats;
-use crate::{Diagnostics, PersistLocation, ShardId};
+use crate::{Diagnostics, PersistClient, ShardId};
 
 /// Creates a new source that reads from a persist shard, distributing the work
 /// of reading data to all timely workers.
@@ -66,11 +66,10 @@ use crate::{Diagnostics, PersistLocation, ShardId};
 /// using [`timely::dataflow::operators::generic::operator::empty`].
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
-pub fn shard_source<'g, K, V, T, D, F, DT, G>(
+pub fn shard_source<'g, K, V, T, D, F, DT, G, C>(
     scope: &mut Child<'g, G, T>,
     name: &str,
-    clients: Arc<PersistClientCache>,
-    location: PersistLocation,
+    client: impl Fn() -> C,
     shard_id: ShardId,
     as_of: Option<Antichain<G::Timestamp>>,
     until: Antichain<G::Timestamp>,
@@ -99,6 +98,7 @@ where
         Stream<Child<'g, G, T>, (usize, SerdeLeasedBatchPart)>,
         Rc<dyn Any>,
     ),
+    C: Future<Output = PersistClient> + 'static,
 {
     // WARNING! If emulating any of this code, you should read the doc string on
     // [`LeasedBatchPart`] and [`Subscribe`] or will likely run into intentional
@@ -125,8 +125,7 @@ where
     let (descs, descs_token) = shard_source_descs::<K, V, D, _, G>(
         &scope.parent,
         name,
-        Arc::clone(&clients),
-        location.clone(),
+        client(),
         shard_id.clone(),
         as_of,
         until,
@@ -145,9 +144,8 @@ where
         }
     };
 
-    let (parts, completed_fetches_stream, fetch_token) = shard_source_fetch(
-        &descs, name, clients, location, shard_id, key_schema, val_schema,
-    );
+    let (parts, completed_fetches_stream, fetch_token) =
+        shard_source_fetch(&descs, name, client(), shard_id, key_schema, val_schema);
     completed_fetches_stream.connect_loop(completed_fetches_feedback_handle);
 
     (
@@ -188,8 +186,7 @@ impl Drop for ActivateOnDrop {
 pub(crate) fn shard_source_descs<K, V, D, F, G>(
     scope: &G,
     name: &str,
-    clients: Arc<PersistClientCache>,
-    location: PersistLocation,
+    client: impl Future<Output = PersistClient> + 'static,
     shard_id: ShardId,
     as_of: Option<Antichain<G::Timestamp>>,
     until: Antichain<G::Timestamp>,
@@ -208,8 +205,6 @@ where
     // TODO: Figure out how to get rid of the TotalOrder bound :(.
     G::Timestamp: Timestamp + Lattice + Codec64 + TotalOrder,
 {
-    let cfg = clients.cfg().clone();
-    let metrics = Arc::clone(&clients.metrics);
     let worker_index = scope.index();
     let num_workers = scope.peers();
 
@@ -264,11 +259,7 @@ where
         tokio::pin!(token_is_dropped);
 
         let create_read_handle = async {
-            let client = clients
-                .open(location)
-                .await
-                .expect("location should be valid");
-            let read = client
+            let read = client.await
                 .open_leased_reader::<K, V, G::Timestamp, D>(
                     shard_id,
                     key_schema,
@@ -303,6 +294,8 @@ where
                 read
             }
         };
+        let cfg = read.cfg.clone();
+        let metrics = Arc::clone(&read.metrics);
 
         let as_of = as_of.unwrap_or_else(|| read.since().clone());
 
@@ -538,8 +531,7 @@ where
 pub(crate) fn shard_source_fetch<K, V, T, D, G>(
     descs: &Stream<G, (usize, SerdeLeasedBatchPart)>,
     name: &str,
-    clients: Arc<PersistClientCache>,
-    location: PersistLocation,
+    client: impl Future<Output = PersistClient> + 'static,
     shard_id: ShardId,
     key_schema: Arc<K::Schema>,
     val_schema: Arc<V::Schema>,
@@ -568,11 +560,8 @@ where
 
     let shutdown_button = builder.build(move |_capabilities| async move {
         let fetcher = {
-            let client = clients
-                .open(location.clone())
-                .await
-                .expect("location should be valid");
             client
+                .await
                 .create_batch_fetcher::<K, V, T, D>(
                     shard_id,
                     key_schema,
@@ -627,9 +616,8 @@ mod tests {
     use timely::dataflow::Scope;
     use timely::progress::Antichain;
 
-    use crate::cache::PersistClientCache;
     use crate::operators::shard_source::shard_source;
-    use crate::{Diagnostics, PersistLocation, ShardId};
+    use crate::{Diagnostics, ShardId};
 
     /// Verifies that a `shard_source` will downgrade it's output frontier to
     /// the `since` of the shard when no explicit `as_of` is given. Even if
@@ -641,14 +629,13 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_implicit_initial_as_of() {
-        let (persist_clients, location) = new_test_client_cache_and_location();
+        let persist_client = PersistClient::new_for_tests().await;
 
         let expected_frontier = 42;
         let shard_id = ShardId::new();
 
         initialize_shard(
-            &persist_clients,
-            location.clone(),
+            &persist_client,
             shard_id,
             Antichain::from_elem(expected_frontier),
         )
@@ -663,11 +650,10 @@ mod tests {
                         let token: Rc<dyn Any> = Rc::new(());
                         (descs.clone(), token)
                     };
-                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _>(
+                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _, _>(
                         scope,
                         "test_source",
-                        persist_clients,
-                        location,
+                        move || std::future::ready(persist_client.clone()),
                         shard_id,
                         None, // No explicit as_of!
                         until,
@@ -710,14 +696,13 @@ mod tests {
     #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
     #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn test_shard_source_explicit_initial_as_of() {
-        let (persist_clients, location) = new_test_client_cache_and_location();
+        let persist_client = PersistClient::new_for_tests().await;
 
         let expected_frontier = 42;
         let shard_id = ShardId::new();
 
         initialize_shard(
-            &persist_clients,
-            location.clone(),
+            &persist_client,
             shard_id,
             Antichain::from_elem(expected_frontier),
         )
@@ -733,11 +718,10 @@ mod tests {
                         let token: Rc<dyn Any> = Rc::new(());
                         (descs.clone(), token)
                     };
-                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _>(
+                    let (stream, token) = shard_source::<String, String, u64, u64, _, _, _, _>(
                         scope,
                         "test_source",
-                        persist_clients,
-                        location,
+                        move || std::future::ready(persist_client.clone()),
                         shard_id,
                         Some(as_of), // We specify the as_of explicitly!
                         until,
@@ -772,16 +756,10 @@ mod tests {
     }
 
     async fn initialize_shard(
-        persist_clients: &Arc<PersistClientCache>,
-        location: PersistLocation,
+        persist_client: &PersistClient,
         shard_id: ShardId,
         since: Antichain<u64>,
     ) {
-        let persist_client = persist_clients
-            .open(location.clone())
-            .await
-            .expect("client construction failed");
-
         let mut read_handle = persist_client
             .open_leased_reader::<String, String, u64, u64>(
                 shard_id,
@@ -793,14 +771,5 @@ mod tests {
             .expect("invalid usage");
 
         read_handle.downgrade_since(&since).await;
-    }
-
-    fn new_test_client_cache_and_location() -> (Arc<PersistClientCache>, PersistLocation) {
-        let persist_clients = PersistClientCache::new_no_metrics();
-
-        let persist_clients = Arc::new(persist_clients);
-        let location = PersistLocation::new_in_mem();
-
-        (persist_clients, location)
     }
 }

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -192,8 +192,13 @@ where
     let (fetched, token) = shard_source(
         &mut scope.clone(),
         &name,
-        persist_clients,
-        metadata.persist_location,
+        move || {
+            let (c, l) = (
+                Arc::clone(&persist_clients),
+                metadata.persist_location.clone(),
+            );
+            async move { c.open(l).await.unwrap() }
+        },
         metadata.data_shard,
         as_of,
         until.clone(),


### PR DESCRIPTION
Previously, it required an `Arc<PersistClientCache>` and a `PersistLocation`. This was mainly becuase that's what persist_source takes, which in turn is because at dataflow rendering time, it's difficult to evaluate Futures (e.g. `cache.open(location).await`).

Now, instead take any future that gives you a PersistClient (technically a Fn that returns these futures because we need two of them). This will make it considerably easier to use `shard_source` in tests as I'm about to do in an upcoming persist-txn PR.


### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
