### PR TITLE
sql: support typmods in the catalog

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -244,6 +244,7 @@ Field        | Type     | Meaning
 -------------|----------|--------
 `id`         | [`text`] | The ID of the list type.
 `element_id` | [`text`] | The IID of the list's element type.
+`element_modifiers` | [`int8 list`] | The element type modifiers, or `NULL` if none.
 
 ### `mz_map_types`
 
@@ -255,6 +256,8 @@ Field          | Type       | Meaning
 `id`           | [`text`]   | The ID of the map type.
 `key_id `      | [`text`]   | The ID of the map's key type.
 `value_id`     | [`text`]   | The ID of the map's value type.
+`key_modifiers` | [`int8 list`] | The key type modifiers, or `NULL` if none.
+`value_modifiers` | [`int8 list`] | The value type modifiers, or `NULL` if none.
 
 ### `mz_materialized_views`
 

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -68,9 +68,9 @@ use mz_sql::ast::Expr;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError as SqlCatalogError,
     CatalogItem as SqlCatalogItem, CatalogItemType as SqlCatalogItemType, CatalogItemType,
-    CatalogRole, CatalogSchema, CatalogType, CatalogTypeDetails, DefaultPrivilegeAclItem,
-    DefaultPrivilegeObject, EnvironmentId, IdReference, NameReference, RoleAttributes,
-    RoleMembership, RoleVars, SessionCatalog, SystemObjectType,
+    CatalogRecordField, CatalogRole, CatalogSchema, CatalogType, CatalogTypeDetails,
+    DefaultPrivilegeAclItem, DefaultPrivilegeObject, EnvironmentId, IdReference, NameReference,
+    RoleAttributes, RoleMembership, RoleVars, SessionCatalog, SystemObjectType,
 };
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::{
@@ -3025,15 +3025,23 @@ impl Catalog {
             CatalogType::Array { element_reference } => CatalogType::Array {
                 element_reference: name_to_id_map[element_reference],
             },
-            CatalogType::List { element_reference } => CatalogType::List {
+            CatalogType::List {
+                element_reference,
+                element_modifiers,
+            } => CatalogType::List {
                 element_reference: name_to_id_map[element_reference],
+                element_modifiers: element_modifiers.clone(),
             },
             CatalogType::Map {
                 key_reference,
                 value_reference,
+                key_modifiers,
+                value_modifiers,
             } => CatalogType::Map {
                 key_reference: name_to_id_map[key_reference],
                 value_reference: name_to_id_map[value_reference],
+                key_modifiers: key_modifiers.clone(),
+                value_modifiers: value_modifiers.clone(),
             },
             CatalogType::Range { element_reference } => CatalogType::Range {
                 element_reference: name_to_id_map[element_reference],
@@ -3041,8 +3049,10 @@ impl Catalog {
             CatalogType::Record { fields } => CatalogType::Record {
                 fields: fields
                     .into_iter()
-                    .map(|(column_name, reference)| {
-                        (column_name.clone(), name_to_id_map[reference])
+                    .map(|f| CatalogRecordField {
+                        name: f.name.clone(),
+                        type_reference: name_to_id_map[f.type_reference],
+                        type_modifiers: f.type_modifiers.clone(),
                     })
                     .collect(),
             },

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1801,7 +1801,15 @@ pub static MZ_LIST_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: MZ_CATALOG_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
-        .with_column("element_id", ScalarType::String.nullable(false)),
+        .with_column("element_id", ScalarType::String.nullable(false))
+        .with_column(
+            "element_modifiers",
+            ScalarType::List {
+                element_type: Box::new(ScalarType::Int64),
+                custom_id: None,
+            }
+            .nullable(true),
+        ),
     is_retained_metrics_object: false,
 });
 pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
@@ -1810,7 +1818,23 @@ pub static MZ_MAP_TYPES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("key_id", ScalarType::String.nullable(false))
-        .with_column("value_id", ScalarType::String.nullable(false)),
+        .with_column("value_id", ScalarType::String.nullable(false))
+        .with_column(
+            "key_modifiers",
+            ScalarType::List {
+                element_type: Box::new(ScalarType::Int64),
+                custom_id: None,
+            }
+            .nullable(true),
+        )
+        .with_column(
+            "value_modifiers",
+            ScalarType::List {
+                element_type: Box::new(ScalarType::Int64),
+                custom_id: None,
+            }
+            .nullable(true),
+        ),
     is_retained_metrics_object: false,
 });
 pub static MZ_ROLES: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -835,10 +835,13 @@ pub enum CatalogType<T: TypeReference> {
     Jsonb,
     List {
         element_reference: T::Reference,
+        element_modifiers: Vec<i64>,
     },
     Map {
         key_reference: T::Reference,
+        key_modifiers: Vec<i64>,
         value_reference: T::Reference,
+        value_modifiers: Vec<i64>,
     },
     Numeric,
     Oid,
@@ -849,7 +852,7 @@ pub enum CatalogType<T: TypeReference> {
         element_reference: T::Reference,
     },
     Record {
-        fields: Vec<(ColumnName, T::Reference)>,
+        fields: Vec<CatalogRecordField<T>>,
     },
     RegClass,
     RegProc,
@@ -862,6 +865,17 @@ pub enum CatalogType<T: TypeReference> {
     VarChar,
     Int2Vector,
     MzAclItem,
+}
+
+/// A description of a field in a [`CatalogType::Record`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CatalogRecordField<T: TypeReference> {
+    /// The name of the field.
+    pub name: ColumnName,
+    /// The ID of the type of the field.
+    pub type_reference: T::Reference,
+    /// Modifiers to apply to the type.
+    pub type_modifiers: Vec<i64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -177,6 +177,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 ----
 1  id  text
 2  element_id  text
+3  element_modifiers  list
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_map_types' ORDER BY position
@@ -184,6 +185,8 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 1  id  text
 2  key_id   text
 3  value_id  text
+4  key_modifiers  list
+5  value_modifiers  list
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_materialized_views' ORDER BY position

--- a/test/sqllogictest/create_type_mods.slt
+++ b/test/sqllogictest/create_type_mods.slt
@@ -1,0 +1,61 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Test that custom types support type modifiers.
+
+reset-server
+
+statement ok
+CREATE TYPE y1 AS (
+    "id" int4,
+    "name" text,
+    "num" numeric(3, 1),
+    "updatedAt" timestamp(3)
+)
+
+statement ok
+CREATE TABLE t1 (y y1)
+
+statement ok
+INSERT INTO t1 VALUES ((1, 'a', 1.234, '2001-02-03 04:05:06.123456789'))
+
+query T
+SELECT * FROM t1
+----
+(1,a,1.2,"2001-02-03 04:05:06.123")
+
+statement ok
+CREATE TYPE y2 AS LIST (ELEMENT TYPE = timestamp(2))
+
+query T
+SELECT '{''2001-02-03 04:05:06.123456789'', ''2001-02-03 04:05:06.987'', ''2001-02-03 04:05:06.5''}'::y2::text
+----
+{"2001-02-03 04:05:06.12","2001-02-03 04:05:06.99","2001-02-03 04:05:06.5"}
+
+query T
+SELECT element_modifiers::text FROM mz_list_types l JOIN mz_types t ON l.id=t.id AND t.name='y2'
+----
+{2}
+
+statement ok
+CREATE TYPE y3 AS MAP (KEY TYPE = text, VALUE TYPE = numeric(5, 2))
+
+statement ok
+CREATE TYPE y4 AS MAP (KEY TYPE = text, VALUE TYPE = y3)
+
+query T
+SELECT '{a=>{b=>1.2,c=>5.6789}}'::y4::text
+----
+{a=>{b=>1.2,c=>5.68}}
+
+query T
+SELECT value_modifiers::text FROM mz_map_types m JOIN mz_types t ON m.id=t.id AND t.name IN ('y3', 'y4') ORDER BY t.name
+----
+{5,2}
+NULL

--- a/test/sqllogictest/list.slt
+++ b/test/sqllogictest/list.slt
@@ -1986,9 +1986,6 @@ SELECT '{1}'::float4 list = '{2}'::float8 list
 query error ELEMENT TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_list AS LIST (ELEMENT TYPE=pg_enum)
 
-query error CREATE TYPE ... AS LIST option ELEMENT TYPE cannot accept type modifier on pg_catalog.numeric, you must use the default type
-CREATE TYPE typ_mod_list AS LIST (ELEMENT TYPE=numeric(38,0))
-
 query error CREATE TYPE ... AS LIST option ELEMENT TYPE can only use named data types, but found unnamed data type pg_catalog.int4 list. Use CREATE TYPE to create a named type first
 CREATE TYPE unnamed_element_list AS LIST (ELEMENT TYPE=int4 list)
 
@@ -2026,7 +2023,7 @@ SELECT '{{1,2}}'::int4_list_list_c::text;
 query error unknown catalog item 'bool list'
 CREATE TYPE nested_list AS LIST (ELEMENT TYPE = "bool list")
 
-statement ok
+query error db error: ERROR: cannot reference pseudo type pg_catalog\.list
 CREATE TYPE nested_list AS LIST (ELEMENT TYPE = list)
 
 # 🔬🔬 Check each valid non-array element type

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -33,9 +33,6 @@ CREATE TYPE tbl_map AS MAP (KEY TYPE = pg_enum, VALUE TYPE = text)
 query error VALUE TYPE must be of class type, but received pg_catalog.pg_enum which is of class view
 CREATE TYPE tbl_map AS MAP (KEY TYPE = text, VALUE TYPE = pg_enum)
 
-query error CREATE TYPE ... AS MAP option VALUE TYPE cannot accept type modifier on pg_catalog.numeric, you must use the default type
-CREATE TYPE typ_mod_map AS MAP (KEY TYPE = text, VALUE TYPE = numeric(38,0))
-
 query error CREATE TYPE ... AS MAP option VALUE TYPE can only use named data types, but found unnamed data type pg_catalog.int4 list. Use CREATE TYPE to create a named type first
 CREATE TYPE unnamed_element_map AS MAP (KEY TYPE = text, VALUE TYPE = int4 list)
 

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT * FROM mz_list_types;
+> SELECT id, element_id, element_modifiers::text FROM mz_list_types;
 
 > SHOW TYPES
 

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-> SELECT * FROM mz_map_types;
+> SELECT id, key_id, value_id, key_modifiers::text, value_modifiers::text FROM mz_map_types;
 
 > SHOW TYPES
 


### PR DESCRIPTION
Closes #11164
Fixes #4884

Adapted from the branch in #11164.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow the use of type modifiers (like `timestamp(3)`) in `CREATE TYPE`.