### PR TITLE
ci: Allow retrying each job

### DIFF
--- a/ci/cleanup/pipeline.yml
+++ b/ci/cleanup/pipeline.yml
@@ -20,8 +20,10 @@ steps:
       - us-east-1
     plugins:
        - ./ci/plugins/scratch-aws-access
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.cleanup.launchdarkly
     timeout_in_minutes: 10
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/deploy/pipeline.yml
+++ b/ci/deploy/pipeline.yml
@@ -15,9 +15,7 @@ steps:
       queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy/devsite
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.docker
     timeout_in_minutes: 30
@@ -25,9 +23,7 @@ steps:
       queue: linux-x86_64
     concurrency: 1
     concurrency_group: deploy/linux
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.pypi
     timeout_in_minutes: 30
@@ -35,9 +31,7 @@ steps:
     concurrency_group: deploy/pypi
     agents:
       queue: linux-x86_64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm
     timeout_in_minutes: 30
@@ -45,9 +39,7 @@ steps:
     concurrency_group: deploy/npm
     agents:
       queue: linux-x86_64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - label: ":bulb: Full SQL Logic Tests"
     trigger: sql-logic-tests

--- a/ci/deploy_mz/pipeline.yml
+++ b/ci/deploy_mz/pipeline.yml
@@ -12,9 +12,7 @@ steps:
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy-mz/version
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: linux-x86_64
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.linux
@@ -23,9 +21,7 @@ steps:
       queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy-mz/linux/x86_64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: linux-aarch64
     command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.linux
@@ -34,9 +30,7 @@ steps:
       queue: builder-linux-aarch64
     concurrency: 1
     concurrency_group: deploy-mz/linux/aarch64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/ci-builder run stable bin/pyactivate -m ci.deploy_mz.docker
     timeout_in_minutes: 30
@@ -47,9 +41,7 @@ steps:
       queue: linux-x86_64
     concurrency: 1
     concurrency_group: deploy-mz/docker
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/pyactivate -m ci.deploy_mz.macos
     agents:
@@ -57,9 +49,7 @@ steps:
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy-mz/macos/x86_64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - command: bin/pyactivate -m ci.deploy_mz.macos
     agents:
@@ -67,6 +57,4 @@ steps:
     timeout_in_minutes: 30
     concurrency: 1
     concurrency_group: deploy-mz/macos/aarch64
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/deploy_website/pipeline.yml
+++ b/ci/deploy_website/pipeline.yml
@@ -15,6 +15,4 @@ steps:
       queue: builder-linux-x86_64
     concurrency: 1
     concurrency_group: deploy/website
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/license/pipeline.yml
+++ b/ci/license/pipeline.yml
@@ -13,3 +13,4 @@ steps:
     command: ci/license/bump-change-date.sh
     agents:
       queue: linux
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/load/pipeline.yml
+++ b/ci/load/pipeline.yml
@@ -18,3 +18,4 @@ steps:
       AWS_DEFAULT_REGION: us-east-1
     plugins:
        - ./ci/plugins/scratch-aws-access
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/nightly/pipeline.yml
+++ b/ci/nightly/pipeline.yml
@@ -91,6 +91,7 @@ steps:
     branches: "!v*.*"
     agents:
       queue: builder-linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 
@@ -98,6 +99,7 @@ steps:
     if: build.source == "ui"
     agents:
       queue: linux
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 
@@ -112,6 +114,7 @@ steps:
           args: [--miri-full]
     agents:
       queue: builder-linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: feature-benchmark
     label: "Feature benchmark against 'latest'"
@@ -125,6 +128,7 @@ steps:
           args:
              - --other-tag
              - latest
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-matrix
     label: Kafka smoke test against previous Kafka versions
@@ -134,6 +138,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: kafka-matrix
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-multi-broker
     label: Kafka multi-broker test
@@ -143,6 +148,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: kafka-multi-broker
+    retry: {manual: {permit_on_passed: true}}
 
   - id: redpanda-testdrive
     label: ":panda_face: :racing_car: testdrive"
@@ -155,6 +161,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--redpanda, --aws-region=us-east-1]
+    retry: {manual: {permit_on_passed: true}}
 
 # Disabled due to taking too long for the value provided
 #  - id: redpanda-testdrive-aarch64
@@ -168,6 +175,7 @@ steps:
 #      - ./ci/plugins/mzcompose:
 #          composition: testdrive
 #          args: [--redpanda, --aws-region=us-east-1]
+#    retry: {manual: {permit_on_passed: true}}
 
   - id: limits
     label: "Product limits"
@@ -178,6 +186,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: limits
     timeout_in_minutes: 50
+    retry: {manual: {permit_on_passed: true}}
 
   - id: limits-instance-size
     label: "Instance size limits"
@@ -191,6 +200,7 @@ steps:
           composition: limits
           run: instance-size
     timeout_in_minutes: 50
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive-partitions-5
     label: ":racing_car: testdrive with --kafka-default-partitions 5"
@@ -203,6 +213,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-1, --kafka-default-partitions=5]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive-replicas-4
     label: ":racing_car: testdrive 4 replicas"
@@ -215,6 +226,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-1, --replicas=4]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive-size-1
     label: ":racing_car: testdrive with SIZE 1"
@@ -227,6 +239,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-1, --default-size=1]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive-size-8
     label: ":racing_car: testdrive with SIZE 8"
@@ -239,6 +252,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-1, --default-size=8]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive-in-cloudtest
     label: Full Testdrive in Cloudtest (K8s)
@@ -250,6 +264,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
           args: [-m=long, --aws-region=us-east-1, test/cloudtest/test_full_testdrive.py]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persistence-testdrive
     label: ":racing_car: testdrive with --persistent-user-tables"
@@ -262,6 +277,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: testdrive
           args: [--aws-region=us-east-1, --persistent-user-tables]
+    retry: {manual: {permit_on_passed: true}}
     skip: Persistence tests disabled
 
   - id: upsert-compaction-enabled
@@ -273,6 +289,7 @@ steps:
           composition: upsert
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-kafka-sources
     label: "Zippy Kafka Sources"
@@ -286,6 +303,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=55m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-kafka-parallel-insert
     label: "Zippy Kafka Parallel Insert"
@@ -297,6 +315,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=10000, --max-execution-time=55m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-user-tables
     label: "Zippy User Tables"
@@ -308,6 +327,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=UserTables, --actions=1000]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-postgres-cdc
     label: "Zippy Postgres CDC"
@@ -319,6 +339,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=PostgresCdc, --actions=10000, --max-execution-time=55m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-debezium-postgres
     label: "Zippy Debezium Postgres"
@@ -330,6 +351,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=DebeziumPostgres, --actions=10000, --max-execution-time=55m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-cluster-replicas
     label: "Zippy Cluster Replicas"
@@ -341,6 +363,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=30m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-crdb-latest
     label: "Zippy w/ latest CRDB"
@@ -354,6 +377,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=55m]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: secrets-aws-secrets-manager
     label: "Secrets AWS"
@@ -364,6 +388,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: secrets-aws-secrets-manager
+    retry: {manual: {permit_on_passed: true}}
 
   - id: secrets-local-file
     label: "Secrets Local File"
@@ -374,6 +399,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: secrets-local-file
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-restart-cockroach
     label: "Checks + restart Cockroach"
@@ -386,6 +412,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-restart-entire-mz
     label: "Checks + restart of the entire Mz"
@@ -398,6 +425,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-drop-create-default-replica
     label: "Checks parallel + DROP/CREATE replica"
@@ -410,6 +438,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-restart-clusterd-compute
     label: "Checks parallel + restart compute clusterd"
@@ -422,6 +451,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartClusterdCompute, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-restart-entire-mz
     label: "Checks parallel + restart of the entire Mz"
@@ -434,6 +464,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEntireMz, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-restart-environmentd-clusterd-storage
     label: "Checks parallel + restart of environmentd & storage clusterd"
@@ -446,6 +477,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-kill-clusterd-storage
     label: "Checks parallel + kill storage clusterd"
@@ -458,6 +490,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=KillClusterdStorage, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-parallel-restart-redpanda
     label: "Checks parallel + restart Redpanda & Debezium"
@@ -470,6 +503,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-entire-mz
     label: "Checks upgrade, whole-Mz restart"
@@ -481,6 +515,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMz]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-entire-mz-previous-version
     label: "Checks upgrade from previous version, whole-Mz restart"
@@ -492,6 +527,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMzPreviousVersion]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-entire-mz-two-versions
     label: "Checks upgrade across two versions"
@@ -503,6 +539,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMzTwoVersions]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-entire-mz-skip-version
     label: "Checks upgrade from X-2 directly to HEAD"
@@ -514,6 +551,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMzSkipVersion]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-entire-mz-four-versions
     label: "Checks upgrade across four versions"
@@ -525,6 +563,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeEntireMzFourVersions]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-clusterd-compute-first
     label: "Platform checks upgrade, restarting compute clusterd first"
@@ -536,6 +575,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeClusterdComputeFirst]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-clusterd-compute-last
     label: "Platform checks upgrade, restarting compute clusterd last"
@@ -547,6 +587,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=UpgradeClusterdComputeLast]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-upgrade-matrix
     label: "Random upgrades over the entire matrix"
@@ -558,6 +599,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: upgrade-matrix
           args: ["--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cloudtest-upgrade
     label: "Platform checks upgrade in Cloudtest/K8s"
@@ -569,6 +611,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
           args: [-m=long,  --aws-region=us-east-1, test/cloudtest/test_upgrade.py]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persist-maelstrom-single-node
     label: Long single-node Maelstrom coverage of persist
@@ -580,6 +623,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persist
           args: [--node-count=1, --consensus=mem, --blob=mem, --time-limit=600, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persist-maelstrom-multi-node
     label: Long multi-node Maelstrom coverage of persist with postgres consensus
@@ -591,6 +635,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persist
           args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persist-txn-maelstrom
     label: Maelstrom coverage of persist-txn
@@ -602,6 +647,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persist
           args: [--consensus=mem, --blob=mem, --persist-txn]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persistence-failpoints
     label: Persistence failpoints
@@ -613,6 +659,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: persistence
           run: failpoints
+    retry: {manual: {permit_on_passed: true}}
     skip: Persistence tests disabled
 
   - id: unused-deps
@@ -625,6 +672,7 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sql-feature-flags
     label: "SQL-level feature flags"
@@ -635,6 +683,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sql-feature-flags
+    retry: {manual: {permit_on_passed: true}}
 
   - id: launchdarkly
     label: "LaunchDarkly"
@@ -645,6 +694,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: launchdarkly
+    retry: {manual: {permit_on_passed: true}}
 
   - id: bounded-memory
     label: "Bounded Memory"
@@ -655,6 +705,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: bounded-memory
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cloud-canary
     label: "Canary Deploy in Staging Cloud"
@@ -668,6 +719,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: cloud-canary
     branches: "main v*.*"
+    retry: {manual: {permit_on_passed: true}}
 
   - id: output-consistency-test
     label: "Output consistency test"
@@ -679,6 +731,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: output-consistency
           args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlsmith
     label: "SQLsmith"
@@ -692,10 +745,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
           args: [--max-joins=1, --runtime=3000]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
@@ -707,10 +757,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
           args: [--max-joins=15, --explain-only, --runtime=3000]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlancer-pqs
     label: "SQLancer PQS"
@@ -722,10 +769,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=PQS, --no-qpg]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"
@@ -737,10 +781,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=NOREC]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlancer-query-partitioning
     label: "SQLancer QueryPartitioning"
@@ -752,10 +793,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=QUERY_PARTITIONING]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqlancer-having
     label: "SQLancer Having"
@@ -767,10 +805,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
           args: [--runtime=3000, --oracle=HAVING]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"
@@ -780,6 +815,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: crdb-restarts
+    retry: {manual: {permit_on_passed: true}}
 
   - id: pubsub-disruption
     label: "PubSub disruption"
@@ -789,6 +825,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: pubsub-disruption
+    retry: {manual: {permit_on_passed: true}}
 
   - id: data-ingest
     label: "Data Ingest"
@@ -799,10 +836,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: data-ingest
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: parallel-workload-dml
     label: "Parallel Workload (DML)"
@@ -814,10 +848,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000, --complexity=dml, --threads=8]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   - id: parallel-workload
     label: "Parallel Workload"
@@ -829,10 +860,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   # TODO: Reenable when #21954 is fixed
   #- id: parallel-workload-100-threads
@@ -845,10 +873,7 @@ steps:
   #    - ./ci/plugins/mzcompose:
   #        composition: parallel-workload
   #        args: [--runtime=3000, --threads=100]
-  #  # Allow retrying generally flaky tests even when they are green
-  #  retry:
-  #    manual:
-  #      permit_on_passed: true
+  #  retry: {manual: {permit_on_passed: true}}
 
   - id: parallel-workload-cancel
     label: "Parallel Workload (cancel)"
@@ -860,10 +885,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
           args: [--runtime=3000, --scenario=cancel]
-    # Allow retrying generally flaky tests even when they are green
-    retry:
-      manual:
-        permit_on_passed: true
+    retry: {manual: {permit_on_passed: true}}
 
   # TODO(def-) Enable after figuring out restoring catalog
   #- id: parallel-workload-kill
@@ -876,10 +898,7 @@ steps:
   #    - ./ci/plugins/mzcompose:
   #        composition: parallel-workload
   #        args: [--runtime=3000, --scenario=kill]
-  #  # Allow retrying generally flaky tests even when they are green
-  #  retry:
-  #    manual:
-  #      permit_on_passed: true
+  #  retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
     continue_on_failure: true
@@ -893,3 +912,4 @@ steps:
     priority: 1
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/release-qualification/pipeline.yml
+++ b/ci/release-qualification/pipeline.yml
@@ -39,6 +39,7 @@ steps:
     # sure we use the exact same version for testing here as was tagged and
     # will be released, and don't build our own version just for the tests.
     if: build.source == "ui" || build.source == "schedule"
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 
@@ -46,6 +47,7 @@ steps:
     if: build.source == "ui"
     agents:
       queue: linux
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 
@@ -60,6 +62,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaSourcesLarge, --actions=100000]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-dataflows-large
     label: "Large Zippy w/ complex dataflows"
@@ -72,6 +75,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=DataflowsLarge, --actions=35000]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-pg-cdc-large
     label: "Longer Zippy PogresCdc"
@@ -83,6 +87,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=PostgresCdcLarge, --actions=200000]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-cluster-replicas-large
     label: "Longer Zippy ClusterReplicas"
@@ -95,6 +100,7 @@ steps:
           composition: zippy
           # Execution times longer than 4h are apparently not feasible at this time due to #17845
           args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=4h]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-user-tables-large
     label: "Long Zippy w/ user tables"
@@ -106,6 +112,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=UserTablesLarge, --actions=200000]
+    retry: {manual: {permit_on_passed: true}}
 
 
   - id: feature-benchmark-scale-plus-one
@@ -117,6 +124,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: feature-benchmark
           args: [--other-tag=latest, --scale=+1]
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
     continue_on_failure: true
@@ -130,3 +138,4 @@ steps:
     priority: 1
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/security/pipeline.yml
+++ b/ci/security/pipeline.yml
@@ -14,3 +14,4 @@ steps:
     timeout_in_minutes: 5
     agents:
       queue: linux
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/slt/pipeline.yml
+++ b/ci/slt/pipeline.yml
@@ -14,6 +14,7 @@ steps:
     timeout_in_minutes: 60
     agents:
       queue: builder-linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 
@@ -28,6 +29,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
           run: sqllogictest
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
     continue_on_failure: true
@@ -41,3 +43,4 @@ steps:
     priority: 1
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -31,6 +31,7 @@ steps:
     priority: 1
     agents:
       queue: builder-linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: build-aarch64
     label: Build aarch64
@@ -43,6 +44,7 @@ steps:
     agents:
       queue: builder-linux-aarch64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: build-wasm
     label: Build WASM
@@ -53,6 +55,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: check-merge-with-target
     label: Merge skew cargo check
@@ -66,6 +69,7 @@ steps:
       queue: linux-x86_64
     if: "build.pull_request.id != null"
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: devel-docker-tags
     label: Tag development docker images
@@ -79,6 +83,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lint-fast
     label: Lint and rustfmt
@@ -89,6 +94,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lint-slow
     label: Clippy and doctests
@@ -101,6 +107,7 @@ steps:
     agents:
       queue: builder-linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lint-macos
     label: macOS Clippy
@@ -116,6 +123,7 @@ steps:
     agents:
       queue: mac
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lint-deps
     label: Lint dependencies
@@ -128,6 +136,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lint-docs
     label: Lint docs
@@ -140,6 +149,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: preview-docs
     label: Preview docs
@@ -149,6 +159,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cargo-test
     label: Cargo test
@@ -170,6 +181,7 @@ steps:
           composition: cargo-test
     agents:
       queue: builder-linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: miri-test
     label: Miri test (fast) %n
@@ -185,6 +197,7 @@ steps:
     agents:
       queue: builder-linux-x86_64
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: testdrive
     label: Testdrive %n
@@ -201,6 +214,7 @@ steps:
           args: [--aws-region=us-east-1]
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: upsert-compaction-disabled
     label: Upsert (compaction disabled)
@@ -214,6 +228,7 @@ steps:
           args: [--compaction-disabled]
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persistence
     label: Persistence tests
@@ -225,6 +240,7 @@ steps:
           composition: persistence
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cluster-tests
     label: Cluster tests %n
@@ -238,6 +254,7 @@ steps:
           composition: cluster
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cluster-isolation
     label: Cluster isolation test
@@ -250,6 +267,7 @@ steps:
           composition: cluster-isolation
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: replica-isolation
     label: Replica isolation
@@ -262,6 +280,7 @@ steps:
           composition: replica-isolation
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-ssl
     label: Kafka SSL smoke test
@@ -274,6 +293,7 @@ steps:
           composition: kafka-ssl
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-sasl-plain
     label: Kafka SASL PLAIN smoke test
@@ -286,6 +306,7 @@ steps:
           composition: kafka-sasl-plain
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: sqllogictest-fast
     label: Fast SQL logic tests %n
@@ -299,6 +320,7 @@ steps:
           composition: sqllogictest
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: chbench-demo
     label: chbench smoke test
@@ -311,6 +333,7 @@ steps:
     timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: restarts
     label: Restart test
@@ -322,6 +345,7 @@ steps:
           composition: restart
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: legacy-upgrade
     label: Legacy upgrade tests
@@ -334,6 +358,7 @@ steps:
           composition: legacy-upgrade
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: metabase-demo
     label: Metabase smoke test
@@ -345,6 +370,7 @@ steps:
           composition: metabase
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: dbt-materialize
     label: dbt-materialize tests
@@ -356,6 +382,7 @@ steps:
           composition: dbt-materialize
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: debezium-postgres
     label: Debezium Postgres tests
@@ -369,6 +396,7 @@ steps:
           run: postgres
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: debezium-sql-server
     label: Debezium SQL Server tests
@@ -382,6 +410,7 @@ steps:
           run: sql-server
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: debezium-mysql
     label: Debezium MySQL tests
@@ -395,6 +424,7 @@ steps:
           run: mysql
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: pg-cdc
     label: Postgres CDC tests
@@ -407,6 +437,7 @@ steps:
           composition: pg-cdc
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: pg-cdc-resumption
     label: Postgres CDC resumption tests
@@ -419,6 +450,7 @@ steps:
           composition: pg-cdc-resumption
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: ssh-connection
     label: SSH connection tests
@@ -431,6 +463,7 @@ steps:
           composition: ssh-connection
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-resumption
     label: Kafka resumption tests
@@ -442,6 +475,7 @@ steps:
           composition: kafka-resumption
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -455,6 +489,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=200]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: kafka-exactly-once
     label: Kafka exactly-once tests
@@ -466,6 +501,7 @@ steps:
           composition: kafka-exactly-once
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: persist-maelstrom
     label: Maelstrom coverage of persist
@@ -480,6 +516,7 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip # Randomized, shouldn't count for coverage
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-drop-create-default-replica
     label: "Checks + DROP/CREATE replica"
@@ -493,6 +530,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-no-restart-no-upgrade
     label: "Checks without restart or upgrade"
@@ -506,6 +544,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-restart-clusterd-compute
     label: "Checks + restart clusterd compute"
@@ -519,6 +558,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartClusterdCompute, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-restart-environmentd-clusterd-storage
     label: "Checks + restart of environmentd & storage clusterd"
@@ -532,6 +572,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartEnvironmentdClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-kill-clusterd-storage
     label: "Checks + kill storage clusterd"
@@ -545,6 +586,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: checks-restart-source-postgres
     label: "Checks + restart source Postgres"
@@ -558,6 +600,7 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: platform-checks
           args: [--scenario=RestartSourcePostgres, --check=PgCdc]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: cloudtest
     label: Cloudtest %n
@@ -573,6 +616,7 @@ steps:
       - ./ci/plugins/scratch-aws-access: ~
       - ./ci/plugins/cloudtest:
           args: [--exitfirst, -m, "not long", --aws-region=us-east-1, test/cloudtest/]
+    retry: {manual: {permit_on_passed: true}}
 
   - id: source-sink-errors
     label: "Source/Sink Error Reporting"
@@ -584,6 +628,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
+    retry: {manual: {permit_on_passed: true}}
 
   - id: storage-usage
     label: "Storage Usage Table Test"
@@ -595,6 +640,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: storage-usage
+    retry: {manual: {permit_on_passed: true}}
 
   - id: tracing
     label: "Tracing Fast Path"
@@ -607,6 +653,7 @@ steps:
           composition: tracing
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lang-csharp
     label: ":csharp: tests"
@@ -619,6 +666,7 @@ steps:
           composition: csharp
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lang-js
     label: ":js: tests"
@@ -631,6 +679,7 @@ steps:
           composition: js
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lang-java
     label: ":java: tests"
@@ -643,6 +692,7 @@ steps:
           composition: java
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: lang-python
     label: ":python: tests"
@@ -655,6 +705,7 @@ steps:
           composition: python
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - id: feature-benchmark-kafka-only
     label: "Feature benchmark (Kafka only)"
@@ -666,6 +717,7 @@ steps:
           composition: feature-benchmark
           args: [--scenario=KafkaUpsertUnique]
     coverage: skip
+    retry: {manual: {permit_on_passed: true}}
 
   - id: deploy-website
     label: Deploy website
@@ -761,10 +813,8 @@ steps:
     priority: 1
     agents:
       queue: builder-linux-x86_64
-    retry:
-      manual:
-        permit_on_passed: true
     coverage: only
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
     continue_on_failure: true
@@ -779,6 +829,7 @@ steps:
     priority: 1
     agents:
       queue: linux-x86_64
+    retry: {manual: {permit_on_passed: true}}
 
   - wait: ~
 


### PR DESCRIPTION
Sets the default value for manual retries to allow retrying successful jobs

As suggested in https://materializeinc.slack.com/archives/C01CFKM1QRF/p1696064390657009?thread_ts=1695990466.832369&cid=C01CFKM1QRF

https://buildkite.com/docs/pipelines/command-step#retry-attributes-manual-retry-attributes https://buildkite.com/docs/pipelines/defining-steps#step-defaults

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
