### PR TITLE
adapter: make all DurableTimestampOracle methods async

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3395,6 +3395,7 @@ name = "mz-adapter"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "bytes",
  "bytesize",
  "chrono",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 
 [dependencies]
 anyhow = "1.0.66"
+async-trait = "0.1.68"
 bytes = "1.3.0"
 bytesize = "1.1.0"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1697,7 +1697,7 @@ impl Coordinator {
 
         // Add builtin table updates the clear the contents of all system tables
         debug!("coordinator init: resetting system tables");
-        let read_ts = self.get_local_read_ts();
+        let read_ts = self.get_local_read_ts().await;
         for system_table in entries
             .iter()
             .filter(|entry| entry.is_table() && entry.id().is_system())
@@ -1900,7 +1900,7 @@ impl Coordinator {
             }
         });
 
-        self.schedule_storage_usage_collection();
+        self.schedule_storage_usage_collection().await;
         self.spawn_statement_logging_task();
         flags::tracing_config(self.catalog.system_config()).apply(&self.tracing_handle);
 

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -176,7 +176,7 @@ impl Coordinator {
     /// writes.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn try_group_commit(&mut self, permit: Option<GroupCommitPermit>) {
-        let timestamp = self.peek_local_write_ts();
+        let timestamp = self.peek_local_write_ts().await;
         let now = Timestamp::from((self.catalog().config().now)());
 
         // HACK: This is a special case to allow writes to the mz_sessions table to proceed even

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -798,7 +798,12 @@ impl Coordinator {
             .timeline()
             .cloned()
             .unwrap_or(Timeline::EpochMilliseconds);
-        let now = self.ensure_timeline_state(&timeline).await.oracle.read_ts();
+        let now = self
+            .ensure_timeline_state(&timeline)
+            .await
+            .oracle
+            .read_ts()
+            .await;
         let frontier = Antichain::from_elem(now);
         let as_of = SinkAsOf {
             frontier,

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -185,10 +185,10 @@ impl Coordinator {
         if let Err(err) = self.catalog_transact(None::<&Session>, ops).await {
             tracing::warn!("Failed to update storage metrics: {:?}", err);
         }
-        self.schedule_storage_usage_collection();
+        self.schedule_storage_usage_collection().await;
     }
 
-    pub fn schedule_storage_usage_collection(&self) {
+    pub async fn schedule_storage_usage_collection(&self) {
         // Instead of using an `tokio::timer::Interval`, we calculate the time until the next
         // usage collection and wait for that amount of time. This is so we can keep the intervals
         // consistent even across restarts. If collection takes too long, it is possible that
@@ -216,7 +216,7 @@ impl Coordinator {
                 .expect("storage usage collection interval must fit into u64");
         let offset =
             rngs::SmallRng::from_seed(seed).gen_range(0..storage_usage_collection_interval_ms);
-        let now_ts: EpochMillis = self.peek_local_write_ts().into();
+        let now_ts: EpochMillis = self.peek_local_write_ts().await.into();
 
         // 2) Determine the amount of ms between now and the next collection time.
         let previous_collection_ts =
@@ -667,7 +667,7 @@ impl Coordinator {
                 read_txn.txn.timestamp_context()
             {
                 let timestamp_oracle = self.get_timestamp_oracle(&timeline);
-                let read_ts = timestamp_oracle.read_ts();
+                let read_ts = timestamp_oracle.read_ts().await;
                 if timestamp <= read_ts {
                     ready_txns.push(read_txn);
                 } else {
@@ -751,14 +751,16 @@ impl Coordinator {
                 optimized_plan,
                 id_bundle,
             } => {
-                let result = self.sequence_explain_timestamp_finish(
-                    &mut ctx,
-                    format,
-                    cluster_id,
-                    optimized_plan,
-                    id_bundle,
-                    Some(real_time_recency_ts),
-                );
+                let result = self
+                    .sequence_explain_timestamp_finish(
+                        &mut ctx,
+                        format,
+                        cluster_id,
+                        optimized_plan,
+                        id_bundle,
+                        Some(real_time_recency_ts),
+                    )
+                    .await;
                 ctx.retire(result);
             }
             RealTimeRecencyContext::Peek {

--- a/src/adapter/src/coord/read_policy.rs
+++ b/src/adapter/src/coord/read_policy.rs
@@ -243,7 +243,7 @@ impl crate::coord::Coordinator {
             match timeline_context {
                 TimelineContext::TimelineDependent(timeline) => {
                     let TimelineState { oracle, .. } = self.ensure_timeline_state(&timeline).await;
-                    let read_ts = oracle.read_ts();
+                    let read_ts = oracle.read_ts().await;
                     let new_read_holds = self.initialize_read_holds(read_ts, &id_bundle);
                     let TimelineState { read_holds, .. } =
                         self.ensure_timeline_state(&timeline).await;

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -322,7 +322,8 @@ impl Coordinator {
                 self.sequence_explain_plan(ctx, plan, target_cluster).await;
             }
             Plan::ExplainTimestamp(plan) => {
-                self.sequence_explain_timestamp(ctx, plan, target_cluster);
+                self.sequence_explain_timestamp(ctx, plan, target_cluster)
+                    .await;
             }
             Plan::Insert(plan) => {
                 self.sequence_insert(ctx, plan).await;
@@ -641,7 +642,7 @@ impl Coordinator {
         self.sequence_create_role(None, plan).await
     }
 
-    pub(crate) fn sequence_explain_timestamp_finish(
+    pub(crate) async fn sequence_explain_timestamp_finish(
         &mut self,
         ctx: &mut ExecuteContext,
         format: ExplainFormat,
@@ -658,6 +659,7 @@ impl Coordinator {
             id_bundle,
             real_time_recency_ts,
         )
+        .await
     }
 
     pub(crate) fn allocate_transient_id(&mut self) -> Result<GlobalId, AdapterError> {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2225,14 +2225,17 @@ impl Coordinator {
         stage.validity.dependency_ids.extend(id_bundle.iter());
 
         let stats = {
-            match self.determine_timestamp(
-                ctx.session(),
-                &id_bundle,
-                &stage.when,
-                stage.cluster_id,
-                &stage.timeline_context,
-                None,
-            ) {
+            match self
+                .determine_timestamp(
+                    ctx.session(),
+                    &id_bundle,
+                    &stage.when,
+                    stage.cluster_id,
+                    &stage.timeline_context,
+                    None,
+                )
+                .await
+            {
                 Err(_) => Box::new(EmptyStatisticsOracle),
                 Ok(query_as_of) => self
                     .statistics_oracle(
@@ -2459,21 +2462,23 @@ impl Coordinator {
             self.index_oracle(cluster_id)
                 .sufficient_collections(&source_ids)
         });
-        let peek_plan = self.plan_peek(
-            dataflow,
-            ctx.session_mut(),
-            &when,
-            cluster_id,
-            view_id,
-            index_id,
-            timeline_context,
-            source_ids,
-            &id_bundle,
-            real_time_recency_ts,
-            key,
-            typ,
-            &finishing,
-        )?;
+        let peek_plan = self
+            .plan_peek(
+                dataflow,
+                ctx.session_mut(),
+                &when,
+                cluster_id,
+                view_id,
+                index_id,
+                timeline_context,
+                source_ids,
+                &id_bundle,
+                real_time_recency_ts,
+                key,
+                typ,
+                &finishing,
+            )
+            .await?;
 
         let determination = peek_plan.determination.clone();
 
@@ -2512,7 +2517,7 @@ impl Coordinator {
 
     /// Determines the query timestamp and acquires read holds on dependent sources
     /// if necessary.
-    fn sequence_peek_timestamp(
+    async fn sequence_peek_timestamp(
         &mut self,
         session: &mut Session,
         when: &QueryWhen,
@@ -2551,14 +2556,16 @@ impl Coordinator {
                         // If not in a transaction, use the source.
                         source_bundle
                     };
-                    let determination = self.determine_timestamp(
-                        session,
-                        determine_bundle,
-                        when,
-                        cluster_id,
-                        &timeline_context,
-                        real_time_recency_ts,
-                    )?;
+                    let determination = self
+                        .determine_timestamp(
+                            session,
+                            determine_bundle,
+                            when,
+                            cluster_id,
+                            &timeline_context,
+                            real_time_recency_ts,
+                        )
+                        .await?;
                     // We only need read holds if the read depends on a timestamp. We don't set the
                     // read holds here because it makes the code a bit more clear to handle the two
                     // cases for "is this the first statement in a transaction?" in an if/else block
@@ -2630,7 +2637,7 @@ impl Coordinator {
         Ok(determination)
     }
 
-    fn plan_peek(
+    async fn plan_peek(
         &mut self,
         mut dataflow: DataflowDescription<OptimizedMirRelationExpr>,
         session: &mut Session,
@@ -2647,15 +2654,17 @@ impl Coordinator {
         finishing: &RowSetFinishing,
     ) -> Result<PlannedPeek, AdapterError> {
         let conn_id = session.conn_id().clone();
-        let determination = self.sequence_peek_timestamp(
-            session,
-            when,
-            cluster_id,
-            timeline_context,
-            id_bundle,
-            &source_ids,
-            real_time_recency_ts,
-        )?;
+        let determination = self
+            .sequence_peek_timestamp(
+                session,
+                when,
+                cluster_id,
+                timeline_context,
+                id_bundle,
+                &source_ids,
+                real_time_recency_ts,
+            )
+            .await?;
 
         // Now that we have a timestamp, set the as of and resolve calls to mz_now().
         dataflow.set_as_of(determination.timestamp_context.antichain());
@@ -2785,7 +2794,8 @@ impl Coordinator {
                 cluster_id,
                 &timeline,
                 None,
-            )?
+            )
+            .await?
             .timestamp_context
             .timestamp_or_default();
 
@@ -3335,7 +3345,8 @@ impl Coordinator {
                 &id_bundle,
                 &source_ids,
                 None, // no real-time recency
-            )?
+            )
+            .await?
             .timestamp_context;
         let query_as_of = timestamp_context.antichain();
 
@@ -3686,7 +3697,7 @@ impl Coordinator {
         Ok((used_indexes, None, df_metainfo, transient_items))
     }
 
-    pub fn sequence_explain_timestamp(
+    pub async fn sequence_explain_timestamp(
         &mut self,
         mut ctx: ExecuteContext,
         plan: plan::ExplainTimestampPlan,
@@ -3731,14 +3742,16 @@ impl Coordinator {
                 });
             }
             None => {
-                let result = self.sequence_explain_timestamp_finish_inner(
-                    ctx.session_mut(),
-                    format,
-                    cluster_id,
-                    optimized_plan,
-                    id_bundle,
-                    None,
-                );
+                let result = self
+                    .sequence_explain_timestamp_finish_inner(
+                        ctx.session_mut(),
+                        format,
+                        cluster_id,
+                        optimized_plan,
+                        id_bundle,
+                        None,
+                    )
+                    .await;
                 ctx.retire(result);
             }
         }
@@ -3840,7 +3853,7 @@ impl Coordinator {
         }
     }
 
-    pub(super) fn sequence_explain_timestamp_finish_inner(
+    pub(super) async fn sequence_explain_timestamp_finish_inner(
         &mut self,
         session: &mut Session,
         format: ExplainFormat,
@@ -3859,15 +3872,17 @@ impl Coordinator {
         let source_ids = source.depends_on();
         let timeline_context = self.validate_timeline_context(source_ids.clone())?;
 
-        let determination = self.sequence_peek_timestamp(
-            session,
-            &QueryWhen::Immediately,
-            cluster_id,
-            timeline_context,
-            &id_bundle,
-            &source_ids,
-            real_time_recency_ts,
-        )?;
+        let determination = self
+            .sequence_peek_timestamp(
+                session,
+                &QueryWhen::Immediately,
+                cluster_id,
+                timeline_context,
+                &id_bundle,
+                &source_ids,
+                real_time_recency_ts,
+            )
+            .await?;
         let explanation = self.explain_timestamp(session, cluster_id, &id_bundle, determination);
 
         let s = if is_json {

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -290,6 +290,9 @@ impl<T: TimestampManipulation> DurableTimestampOracle<T> {
     }
 
     /// Peek current write timestamp.
+    // We make this function async to prepare for future changes, but it's not
+    // used right now.
+    #[allow(clippy::unused_async)]
     async fn peek_write_ts(&self) -> T {
         self.timestamp_oracle.peek_write_ts()
     }
@@ -298,6 +301,9 @@ impl<T: TimestampManipulation> DurableTimestampOracle<T> {
     /// persisted to disk.
     ///
     /// See [`TimestampOracle::read_ts`] for more details.
+    // We make this function async to prepare for future changes, but it's not
+    // used right now.
+    #[allow(clippy::unused_async)]
     pub async fn read_ts(&self) -> T {
         let ts = self.timestamp_oracle.read_ts();
         assert!(


### PR DESCRIPTION
We do this as preparation for introducing a TimestampOracle trait, which we eventually want to back by RPC or calls to an external consensus system, both of which require async'ness.

This also requires making the call stack up to timestamp oracle methods async.

Part of #22029 

### Tips for reviewer

This is potentially one of the more spicy commits because it adds `async` to some coordinator methods, and the @MaterializeInc/adapter team might have stronger opinions on that.
 
https://github.com/MaterializeInc/materialize/pull/21671 has this commit and all the follow-up commits for full #22029, it might be good to look at that for context.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
