### PR TITLE
rocksdb: ensure wbm handle is dropped before done-ness is communicated

### DIFF
--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -579,6 +579,7 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
             Command::Shutdown { done_sender } => {
                 db.cancel_all_background_work(true);
                 drop(db);
+                drop(write_buffer_handle);
                 let _ = done_sender.send(());
                 return;
             }


### PR DESCRIPTION
Closes: https://github.com/MaterializeInc/materialize/issues/22079

I believe before this change, the receiver of the done signal could see doneness before the wbm handle is dropped (as part of the thread drop glue. This issue only affects tests.

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
