### PR TITLE
test: Eliminate deadlock in DebugStashFactory

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3506,7 +3506,9 @@ impl Catalog {
         let catalog = Self::open_debug_stash_catalog_factory(&debug_stash_factory, now)
             .await
             .expect("unable to open debug stash");
-        f(catalog).await
+        let res = f(catalog).await;
+        debug_stash_factory.drop().await;
+        res
     }
 
     /// Opens a debug stash backed catalog using `debug_stash_factory`.
@@ -8051,6 +8053,7 @@ mod tests {
             // Re-opening the same stash resets the transient_revision to 1.
             assert_eq!(catalog.transient_revision(), 1);
         }
+        debug_stash_factory.drop().await;
     }
 
     #[mz_ore::test(tokio::test)]
@@ -8944,6 +8947,7 @@ mod tests {
                 item => panic!("expected view, got {}", item.typ()),
             }
         }
+        debug_stash_factory.drop().await;
     }
 
     #[mz_ore::test]

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -97,9 +97,10 @@ use mz_stash::DebugStashFactory;
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_is_initialized() {
-    let (_debug_factory, stash_config) = stash_config().await;
+    let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
     is_initialized(openable_state).await;
+    debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -108,6 +109,7 @@ async fn test_debug_is_initialized() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
     is_initialized(debug_openable_state).await;
+    debug_factory.drop().await;
 }
 
 async fn is_initialized<D: DurableCatalogState>(
@@ -137,9 +139,10 @@ async fn is_initialized<D: DurableCatalogState>(
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_get_deployment_generation() {
-    let (_debug_factory, stash_config) = stash_config().await;
+    let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
     get_deployment_generation(openable_state).await;
+    debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -148,6 +151,7 @@ async fn test_debug_get_deployment_generation() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
     get_deployment_generation(debug_openable_state).await;
+    debug_factory.drop().await;
 }
 
 async fn get_deployment_generation<D: DurableCatalogState>(
@@ -180,9 +184,10 @@ async fn get_deployment_generation<D: DurableCatalogState>(
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_open_check() {
-    let (_debug_factory, stash_config) = stash_config().await;
+    let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
     open_check(openable_state).await;
+    debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -191,6 +196,7 @@ async fn test_debug_open_check() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
     open_check(debug_openable_state).await;
+    debug_factory.drop().await;
 }
 
 async fn open_check<D: DurableCatalogState>(
@@ -256,9 +262,10 @@ async fn open_check<D: DurableCatalogState>(
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_open_read_only() {
-    let (_debug_factory, stash_config) = stash_config().await;
+    let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
     open_read_only(openable_state).await;
+    debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -267,6 +274,7 @@ async fn test_debug_open_read_only() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
     open_read_only(debug_openable_state).await;
+    debug_factory.drop().await;
 }
 
 async fn open_read_only<D: DurableCatalogState>(
@@ -303,9 +311,10 @@ async fn open_read_only<D: DurableCatalogState>(
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
 async fn test_open() {
-    let (_debug_factory, stash_config) = stash_config().await;
+    let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
     open(openable_state).await;
+    debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -314,6 +323,7 @@ async fn test_debug_open() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
     open(debug_openable_state).await;
+    debug_factory.drop().await;
 }
 
 async fn open<D: DurableCatalogState>(mut openable_state: impl OpenableDurableCatalogState<D>) {

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -670,6 +670,7 @@ async fn test_stash_readonly() {
     // The previous stash should still be the leader.
     assert!(stash_rw.confirm_leadership().await.is_ok());
     stash_rw.verify().await.unwrap();
+    factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -726,6 +727,7 @@ async fn test_stash_savepoint() {
         BTreeMap::from([(1, 2)])
     );
     stash_rw.verify().await.unwrap();
+    factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -739,6 +741,7 @@ async fn test_stash_fence() {
         _ => panic!("expected error"),
     });
     let _: StashCollection<String, String> = collection(&mut conn2, "c").await.unwrap();
+    factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -747,6 +750,7 @@ async fn test_stash_append() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
     test_append(|| async { factory.open().await }).await;
     factory.open().await.verify().await.unwrap();
+    factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
@@ -755,6 +759,7 @@ async fn test_stash_stash() {
     let factory = DebugStashFactory::try_new().await.expect("must succeed");
     test_stash(|| async { factory.open().await }).await;
     factory.open().await.verify().await.unwrap();
+    factory.drop().await;
 }
 
 async fn make_batch<K, V>(

--- a/src/stash/src/upgrade/v27_to_v28.rs
+++ b/src/stash/src/upgrade/v27_to_v28.rs
@@ -135,7 +135,7 @@ mod tests {
     use crate::upgrade::v27_to_v28::{
         objects_v27, objects_v28, ACL_MODE_USAGE, MZ_INTROSPECTION_ROLE_ID, PUBLIC_ROLE_ID,
     };
-    use crate::{DebugStashFactory, TypedCollection};
+    use crate::{Stash, TypedCollection};
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
@@ -148,198 +148,202 @@ mod tests {
             value: Some(objects_v28::role_id::Value::User(1)),
         };
 
-        // Connect to the Stash.
-        let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open().await;
+        Stash::with_debug_stash(|mut stash| async move {
+            // Insert a database.
+            let databases_v27: TypedCollection<
+                objects_v27::DatabaseKey,
+                objects_v27::DatabaseValue,
+            > = TypedCollection::new("database");
+            databases_v27
+                .insert_without_overwrite(
+                    &mut stash,
+                    vec![(
+                        objects_v27::DatabaseKey {
+                            id: Some(objects_v27::DatabaseId {
+                                value: Some(objects_v27::database_id::Value::User(42)),
+                            }),
+                        },
+                        objects_v27::DatabaseValue {
+                            name: "db".into(),
+                            owner_id: Some(OWNER_ROLE_ID_V27),
+                            privileges: vec![objects_v27::MzAclItem {
+                                grantee: Some(objects_v27::RoleId {
+                                    value: Some(objects_v27::role_id::Value::User(2)),
+                                }),
+                                grantor: Some(OWNER_ROLE_ID_V27),
+                                acl_mode: Some(ACL_MODE_USAGE_V27),
+                            }],
+                        },
+                    )],
+                )
+                .await
+                .unwrap();
 
-        // Insert a database.
-        let databases_v27: TypedCollection<objects_v27::DatabaseKey, objects_v27::DatabaseValue> =
-            TypedCollection::new("database");
-        databases_v27
-            .insert_without_overwrite(
-                &mut stash,
+            // Insert a schema.
+            let schemas_v27: TypedCollection<objects_v27::SchemaKey, objects_v27::SchemaValue> =
+                TypedCollection::new("schema");
+            schemas_v27
+                .insert_without_overwrite(
+                    &mut stash,
+                    vec![(
+                        objects_v27::SchemaKey {
+                            id: Some(objects_v27::SchemaId {
+                                value: Some(objects_v27::schema_id::Value::User(42)),
+                            }),
+                        },
+                        objects_v27::SchemaValue {
+                            database_id: Some(objects_v27::DatabaseId {
+                                value: Some(objects_v27::database_id::Value::User(42)),
+                            }),
+                            name: "sch".into(),
+                            owner_id: Some(OWNER_ROLE_ID_V27),
+                            privileges: vec![objects_v27::MzAclItem {
+                                grantee: Some(objects_v27::RoleId {
+                                    value: Some(objects_v27::role_id::Value::User(2)),
+                                }),
+                                grantor: Some(OWNER_ROLE_ID_V27),
+                                acl_mode: Some(ACL_MODE_USAGE_V27),
+                            }],
+                        },
+                    )],
+                )
+                .await
+                .unwrap();
+
+            // Run our migration.
+            stash
+                .with_transaction(|mut tx| {
+                    Box::pin(async move {
+                        upgrade(&mut tx).await?;
+                        Ok(())
+                    })
+                })
+                .await
+                .expect("migration failed");
+
+            // Read back the default privileges.
+            let default_privileges: TypedCollection<
+                objects_v28::DefaultPrivilegesKey,
+                objects_v28::DefaultPrivilegesValue,
+            > = TypedCollection::new("default_privileges");
+            let privileges = default_privileges.iter(&mut stash).await.unwrap();
+            // Filter down to just the keys and values to make comparisons easier.
+            let privileges: Vec<_> = privileges
+                .into_iter()
+                .map(|((key, value), _timestamp, _diff)| (key, value))
+                .collect();
+
+            assert!(privileges.contains(&(
+                objects_v28::DefaultPrivilegesKey {
+                    role_id: Some(PUBLIC_ROLE_ID),
+                    database_id: None,
+                    schema_id: None,
+                    object_type: objects_v28::ObjectType::Database.into(),
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                },
+                objects_v28::DefaultPrivilegesValue {
+                    privileges: Some(ACL_MODE_USAGE),
+                }
+            )));
+            assert!(privileges.contains(&(
+                objects_v28::DefaultPrivilegesKey {
+                    role_id: Some(PUBLIC_ROLE_ID),
+                    database_id: None,
+                    schema_id: None,
+                    object_type: objects_v28::ObjectType::Schema.into(),
+                    grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                },
+                objects_v28::DefaultPrivilegesValue {
+                    privileges: Some(ACL_MODE_USAGE),
+                }
+            )));
+
+            // Read back the databases.
+            let databases_v28: TypedCollection<
+                objects_v28::DatabaseKey,
+                objects_v28::DatabaseValue,
+            > = TypedCollection::new("database");
+            let databases = databases_v28.iter(&mut stash).await.unwrap();
+            // Filter down to just the keys and values to make comparisons easier.
+            let mut databases_v28: Vec<_> = databases
+                .into_iter()
+                .map(|((key, value), _timestamp, _diff)| (key, value))
+                .collect();
+            databases_v28.sort();
+
+            assert_eq!(
+                databases_v28,
                 vec![(
-                    objects_v27::DatabaseKey {
-                        id: Some(objects_v27::DatabaseId {
-                            value: Some(objects_v27::database_id::Value::User(42)),
+                    objects_v28::DatabaseKey {
+                        id: Some(objects_v28::DatabaseId {
+                            value: Some(objects_v28::database_id::Value::User(42)),
                         }),
                     },
-                    objects_v27::DatabaseValue {
+                    objects_v28::DatabaseValue {
                         name: "db".into(),
-                        owner_id: Some(OWNER_ROLE_ID_V27),
-                        privileges: vec![objects_v27::MzAclItem {
-                            grantee: Some(objects_v27::RoleId {
-                                value: Some(objects_v27::role_id::Value::User(2)),
-                            }),
-                            grantor: Some(OWNER_ROLE_ID_V27),
-                            acl_mode: Some(ACL_MODE_USAGE_V27),
-                        }],
+                        owner_id: Some(OWNER_ROLE_ID_V28),
+                        privileges: vec![
+                            objects_v28::MzAclItem {
+                                grantee: Some(objects_v28::RoleId {
+                                    value: Some(objects_v28::role_id::Value::User(2)),
+                                }),
+                                grantor: Some(OWNER_ROLE_ID_V28),
+                                acl_mode: Some(ACL_MODE_USAGE),
+                            },
+                            objects_v28::MzAclItem {
+                                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                                grantor: Some(OWNER_ROLE_ID_V28),
+                                acl_mode: Some(ACL_MODE_USAGE),
+                            }
+                        ],
                     },
                 )],
-            )
-            .await
-            .unwrap();
+            );
 
-        // Insert a schema.
-        let schemas_v27: TypedCollection<objects_v27::SchemaKey, objects_v27::SchemaValue> =
-            TypedCollection::new("schema");
-        schemas_v27
-            .insert_without_overwrite(
-                &mut stash,
+            // Read back the schemas.
+            let schemas_v28: TypedCollection<objects_v28::SchemaKey, objects_v28::SchemaValue> =
+                TypedCollection::new("schema");
+            let schemas = schemas_v28.iter(&mut stash).await.unwrap();
+            // Filter down to just the keys and values to make comparisons easier.
+            let mut schemas_v28: Vec<_> = schemas
+                .into_iter()
+                .map(|((key, value), _timestamp, _diff)| (key, value))
+                .collect();
+            schemas_v28.sort();
+
+            assert_eq!(
+                schemas_v28,
                 vec![(
-                    objects_v27::SchemaKey {
-                        id: Some(objects_v27::SchemaId {
-                            value: Some(objects_v27::schema_id::Value::User(42)),
+                    objects_v28::SchemaKey {
+                        id: Some(objects_v28::SchemaId {
+                            value: Some(objects_v28::schema_id::Value::User(42)),
                         }),
                     },
-                    objects_v27::SchemaValue {
-                        database_id: Some(objects_v27::DatabaseId {
-                            value: Some(objects_v27::database_id::Value::User(42)),
+                    objects_v28::SchemaValue {
+                        database_id: Some(objects_v28::DatabaseId {
+                            value: Some(objects_v28::database_id::Value::User(42)),
                         }),
                         name: "sch".into(),
-                        owner_id: Some(OWNER_ROLE_ID_V27),
-                        privileges: vec![objects_v27::MzAclItem {
-                            grantee: Some(objects_v27::RoleId {
-                                value: Some(objects_v27::role_id::Value::User(2)),
-                            }),
-                            grantor: Some(OWNER_ROLE_ID_V27),
-                            acl_mode: Some(ACL_MODE_USAGE_V27),
-                        }],
+                        owner_id: Some(OWNER_ROLE_ID_V28),
+                        privileges: vec![
+                            objects_v28::MzAclItem {
+                                grantee: Some(objects_v28::RoleId {
+                                    value: Some(objects_v28::role_id::Value::User(2)),
+                                }),
+                                grantor: Some(OWNER_ROLE_ID_V28),
+                                acl_mode: Some(ACL_MODE_USAGE),
+                            },
+                            objects_v28::MzAclItem {
+                                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
+                                grantor: Some(OWNER_ROLE_ID_V28),
+                                acl_mode: Some(ACL_MODE_USAGE),
+                            }
+                        ],
                     },
                 )],
-            )
-            .await
-            .unwrap();
-
-        // Run our migration.
-        stash
-            .with_transaction(|mut tx| {
-                Box::pin(async move {
-                    upgrade(&mut tx).await?;
-                    Ok(())
-                })
-            })
-            .await
-            .expect("migration failed");
-
-        // Read back the default privileges.
-        let default_privileges: TypedCollection<
-            objects_v28::DefaultPrivilegesKey,
-            objects_v28::DefaultPrivilegesValue,
-        > = TypedCollection::new("default_privileges");
-        let privileges = default_privileges.iter(&mut stash).await.unwrap();
-        // Filter down to just the keys and values to make comparisons easier.
-        let privileges: Vec<_> = privileges
-            .into_iter()
-            .map(|((key, value), _timestamp, _diff)| (key, value))
-            .collect();
-
-        assert!(privileges.contains(&(
-            objects_v28::DefaultPrivilegesKey {
-                role_id: Some(PUBLIC_ROLE_ID),
-                database_id: None,
-                schema_id: None,
-                object_type: objects_v28::ObjectType::Database.into(),
-                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
-            },
-            objects_v28::DefaultPrivilegesValue {
-                privileges: Some(ACL_MODE_USAGE),
-            }
-        )));
-        assert!(privileges.contains(&(
-            objects_v28::DefaultPrivilegesKey {
-                role_id: Some(PUBLIC_ROLE_ID),
-                database_id: None,
-                schema_id: None,
-                object_type: objects_v28::ObjectType::Schema.into(),
-                grantee: Some(MZ_INTROSPECTION_ROLE_ID),
-            },
-            objects_v28::DefaultPrivilegesValue {
-                privileges: Some(ACL_MODE_USAGE),
-            }
-        )));
-
-        // Read back the databases.
-        let databases_v28: TypedCollection<objects_v28::DatabaseKey, objects_v28::DatabaseValue> =
-            TypedCollection::new("database");
-        let databases = databases_v28.iter(&mut stash).await.unwrap();
-        // Filter down to just the keys and values to make comparisons easier.
-        let mut databases_v28: Vec<_> = databases
-            .into_iter()
-            .map(|((key, value), _timestamp, _diff)| (key, value))
-            .collect();
-        databases_v28.sort();
-
-        assert_eq!(
-            databases_v28,
-            vec![(
-                objects_v28::DatabaseKey {
-                    id: Some(objects_v28::DatabaseId {
-                        value: Some(objects_v28::database_id::Value::User(42)),
-                    }),
-                },
-                objects_v28::DatabaseValue {
-                    name: "db".into(),
-                    owner_id: Some(OWNER_ROLE_ID_V28),
-                    privileges: vec![
-                        objects_v28::MzAclItem {
-                            grantee: Some(objects_v28::RoleId {
-                                value: Some(objects_v28::role_id::Value::User(2)),
-                            }),
-                            grantor: Some(OWNER_ROLE_ID_V28),
-                            acl_mode: Some(ACL_MODE_USAGE),
-                        },
-                        objects_v28::MzAclItem {
-                            grantee: Some(MZ_INTROSPECTION_ROLE_ID),
-                            grantor: Some(OWNER_ROLE_ID_V28),
-                            acl_mode: Some(ACL_MODE_USAGE),
-                        }
-                    ],
-                },
-            )],
-        );
-
-        // Read back the schemas.
-        let schemas_v28: TypedCollection<objects_v28::SchemaKey, objects_v28::SchemaValue> =
-            TypedCollection::new("schema");
-        let schemas = schemas_v28.iter(&mut stash).await.unwrap();
-        // Filter down to just the keys and values to make comparisons easier.
-        let mut schemas_v28: Vec<_> = schemas
-            .into_iter()
-            .map(|((key, value), _timestamp, _diff)| (key, value))
-            .collect();
-        schemas_v28.sort();
-
-        assert_eq!(
-            schemas_v28,
-            vec![(
-                objects_v28::SchemaKey {
-                    id: Some(objects_v28::SchemaId {
-                        value: Some(objects_v28::schema_id::Value::User(42)),
-                    }),
-                },
-                objects_v28::SchemaValue {
-                    database_id: Some(objects_v28::DatabaseId {
-                        value: Some(objects_v28::database_id::Value::User(42)),
-                    }),
-                    name: "sch".into(),
-                    owner_id: Some(OWNER_ROLE_ID_V28),
-                    privileges: vec![
-                        objects_v28::MzAclItem {
-                            grantee: Some(objects_v28::RoleId {
-                                value: Some(objects_v28::role_id::Value::User(2)),
-                            }),
-                            grantor: Some(OWNER_ROLE_ID_V28),
-                            acl_mode: Some(ACL_MODE_USAGE),
-                        },
-                        objects_v28::MzAclItem {
-                            grantee: Some(MZ_INTROSPECTION_ROLE_ID),
-                            grantor: Some(OWNER_ROLE_ID_V28),
-                            acl_mode: Some(ACL_MODE_USAGE),
-                        }
-                    ],
-                },
-            )],
-        );
+            );
+        })
+        .await
+        .unwrap();
     }
 }

--- a/src/stash/src/upgrade/v32_to_v33.rs
+++ b/src/stash/src/upgrade/v32_to_v33.rs
@@ -57,108 +57,109 @@ mod tests {
     use super::upgrade;
 
     use crate::upgrade::v32_to_v33::{objects_v32, objects_v33, MZ_INTROSPECTION_ROLE_ID};
-    use crate::{DebugStashFactory, TypedCollection};
+    use crate::{Stash, TypedCollection};
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test() {
-        let factory: DebugStashFactory = DebugStashFactory::new().await;
-        let mut stash = factory.open().await;
+        Stash::with_debug_stash(|mut stash| async move {
+            let roles_v32: TypedCollection<objects_v32::RoleKey, objects_v32::RoleValue> =
+                TypedCollection::new("role");
 
-        let roles_v32: TypedCollection<objects_v32::RoleKey, objects_v32::RoleValue> =
-            TypedCollection::new("role");
+            let system_role_id_v32 = objects_v32::RoleId {
+                value: Some(objects_v32::role_id::Value::System(1)),
+            };
+            let introspection_role_id_v32 = objects_v32::RoleId {
+                value: Some(objects_v32::role_id::Value::System(2)),
+            };
 
-        let system_role_id_v32 = objects_v32::RoleId {
-            value: Some(objects_v32::role_id::Value::System(1)),
-        };
-        let introspection_role_id_v32 = objects_v32::RoleId {
-            value: Some(objects_v32::role_id::Value::System(2)),
-        };
+            roles_v32
+                .insert_without_overwrite(
+                    &mut stash,
+                    vec![
+                        (
+                            objects_v32::RoleKey {
+                                id: Some(system_role_id_v32),
+                            },
+                            objects_v32::RoleValue {
+                                name: "mz_system".to_string(),
+                                attributes: Some(objects_v32::RoleAttributes { inherit: true }),
+                                membership: Some(objects_v32::RoleMembership {
+                                    map: Default::default(),
+                                }),
+                            },
+                        ),
+                        (
+                            objects_v32::RoleKey {
+                                id: Some(introspection_role_id_v32),
+                            },
+                            objects_v32::RoleValue {
+                                name: "mz_introspection".to_string(),
+                                attributes: Some(objects_v32::RoleAttributes { inherit: true }),
+                                membership: Some(objects_v32::RoleMembership {
+                                    map: Default::default(),
+                                }),
+                            },
+                        ),
+                    ],
+                )
+                .await
+                .unwrap();
 
-        roles_v32
-            .insert_without_overwrite(
-                &mut stash,
+            // Run our migration.
+            stash
+                .with_transaction(|mut tx| {
+                    Box::pin(async move {
+                        upgrade(&mut tx).await?;
+                        Ok(())
+                    })
+                })
+                .await
+                .expect("migration failed");
+
+            let roles_v33: TypedCollection<objects_v33::RoleKey, objects_v33::RoleValue> =
+                TypedCollection::new("role");
+            let roles = roles_v33.iter(&mut stash).await.unwrap();
+
+            let system_role_id_v33 = objects_v33::RoleId {
+                value: Some(objects_v33::role_id::Value::System(1)),
+            };
+            let mut roles = roles
+                .into_iter()
+                .map(|((key, value), _timestamp, _diff)| (key, value))
+                .collect_vec();
+            roles.sort();
+            assert_eq!(
+                roles,
                 vec![
                     (
-                        objects_v32::RoleKey {
-                            id: Some(system_role_id_v32),
+                        objects_v33::RoleKey {
+                            id: Some(system_role_id_v33),
                         },
-                        objects_v32::RoleValue {
+                        objects_v33::RoleValue {
                             name: "mz_system".to_string(),
-                            attributes: Some(objects_v32::RoleAttributes { inherit: true }),
-                            membership: Some(objects_v32::RoleMembership {
+                            attributes: Some(objects_v33::RoleAttributes { inherit: true }),
+                            membership: Some(objects_v33::RoleMembership {
                                 map: Default::default(),
                             }),
                         },
                     ),
                     (
-                        objects_v32::RoleKey {
-                            id: Some(introspection_role_id_v32),
+                        objects_v33::RoleKey {
+                            id: Some(MZ_INTROSPECTION_ROLE_ID),
                         },
-                        objects_v32::RoleValue {
-                            name: "mz_introspection".to_string(),
-                            attributes: Some(objects_v32::RoleAttributes { inherit: true }),
-                            membership: Some(objects_v32::RoleMembership {
+                        objects_v33::RoleValue {
+                            name: "mz_support".to_string(),
+                            attributes: Some(objects_v33::RoleAttributes { inherit: true }),
+                            membership: Some(objects_v33::RoleMembership {
                                 map: Default::default(),
                             }),
                         },
-                    ),
-                ],
-            )
-            .await
-            .unwrap();
-
-        // Run our migration.
-        stash
-            .with_transaction(|mut tx| {
-                Box::pin(async move {
-                    upgrade(&mut tx).await?;
-                    Ok(())
-                })
-            })
-            .await
-            .expect("migration failed");
-
-        let roles_v33: TypedCollection<objects_v33::RoleKey, objects_v33::RoleValue> =
-            TypedCollection::new("role");
-        let roles = roles_v33.iter(&mut stash).await.unwrap();
-
-        let system_role_id_v33 = objects_v33::RoleId {
-            value: Some(objects_v33::role_id::Value::System(1)),
-        };
-        let mut roles = roles
-            .into_iter()
-            .map(|((key, value), _timestamp, _diff)| (key, value))
-            .collect_vec();
-        roles.sort();
-        assert_eq!(
-            roles,
-            vec![
-                (
-                    objects_v33::RoleKey {
-                        id: Some(system_role_id_v33),
-                    },
-                    objects_v33::RoleValue {
-                        name: "mz_system".to_string(),
-                        attributes: Some(objects_v33::RoleAttributes { inherit: true }),
-                        membership: Some(objects_v33::RoleMembership {
-                            map: Default::default(),
-                        }),
-                    },
-                ),
-                (
-                    objects_v33::RoleKey {
-                        id: Some(MZ_INTROSPECTION_ROLE_ID),
-                    },
-                    objects_v33::RoleValue {
-                        name: "mz_support".to_string(),
-                        attributes: Some(objects_v33::RoleAttributes { inherit: true }),
-                        membership: Some(objects_v33::RoleMembership {
-                            map: Default::default(),
-                        }),
-                    },
-                )
-            ]
-        );
+                    )
+                ]
+            );
+        })
+        .await
+        .unwrap();
     }
 }

--- a/src/stash/src/upgrade/v39_to_v40.rs
+++ b/src/stash/src/upgrade/v39_to_v40.rs
@@ -131,7 +131,7 @@ async fn migrate_audit_log(tx: &mut Transaction<'_>) -> Result<(), StashError> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::DebugStashFactory;
+    use crate::Stash;
 
     const AUDIT_LOG_COLLECTION_V40: TypedCollection<v40::AuditLogKey, ()> =
         TypedCollection::new("audit_log");
@@ -144,104 +144,104 @@ mod tests {
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test_cluster_replica_migration() {
-        let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open().await;
-
-        CLUSTER_REPLICA_COLLECTION
-            .insert_without_overwrite(
-                &mut stash,
-                [
-                    (
-                        v39::ClusterReplicaKey {
-                            id: Some(v39::ReplicaId {
-                                value: Some(v39::replica_id::Value::User(123)),
-                            }),
-                        },
-                        v39::ClusterReplicaValue {
-                            cluster_id: Some(v39::ClusterId {
-                                value: Some(v39::cluster_id::Value::User(456)),
-                            }),
-                            config: Some(v39::ReplicaConfig {
-                                idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
-                                    effort: 321,
+        Stash::with_debug_stash(|mut stash| async move {
+            CLUSTER_REPLICA_COLLECTION
+                .insert_without_overwrite(
+                    &mut stash,
+                    [
+                        (
+                            v39::ClusterReplicaKey {
+                                id: Some(v39::ReplicaId {
+                                    value: Some(v39::replica_id::Value::User(123)),
                                 }),
-                                location: Some(v39::replica_config::Location::Managed(
-                                    v39::replica_config::ManagedLocation {
-                                        availability_zone: Some("unavailability_zone".to_owned()),
-                                        disk: false,
-                                        size: "huge".to_owned(),
-                                    },
-                                )),
-                                logging: Some(v39::ReplicaLogging {
-                                    interval: Some(v39::Duration {
-                                        nanos: 1234,
-                                        secs: 13,
+                            },
+                            v39::ClusterReplicaValue {
+                                cluster_id: Some(v39::ClusterId {
+                                    value: Some(v39::cluster_id::Value::User(456)),
+                                }),
+                                config: Some(v39::ReplicaConfig {
+                                    idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
+                                        effort: 321,
                                     }),
-                                    log_logging: true,
-                                }),
-                            }),
-                            name: "moritz".to_owned(),
-                            owner_id: Some(v39::RoleId {
-                                value: Some(v39::role_id::Value::User(987)),
-                            }),
-                        },
-                    ),
-                    (
-                        v39::ClusterReplicaKey {
-                            id: Some(v39::ReplicaId {
-                                value: Some(v39::replica_id::Value::User(234)),
-                            }),
-                        },
-                        v39::ClusterReplicaValue {
-                            cluster_id: Some(v39::ClusterId {
-                                value: Some(v39::cluster_id::Value::User(345)),
-                            }),
-                            config: Some(v39::ReplicaConfig {
-                                idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
-                                    effort: 432,
-                                }),
-                                location: Some(v39::replica_config::Location::Managed(
-                                    v39::replica_config::ManagedLocation {
-                                        availability_zone: Some("Verfügbar".to_owned()),
-                                        disk: false,
-                                        size: "groß".to_owned(),
-                                    },
-                                )),
-                                logging: Some(v39::ReplicaLogging {
-                                    interval: Some(v39::Duration {
-                                        nanos: 4312,
-                                        secs: 11,
+                                    location: Some(v39::replica_config::Location::Managed(
+                                        v39::replica_config::ManagedLocation {
+                                            availability_zone: Some(
+                                                "unavailability_zone".to_owned(),
+                                            ),
+                                            disk: false,
+                                            size: "huge".to_owned(),
+                                        },
+                                    )),
+                                    logging: Some(v39::ReplicaLogging {
+                                        interval: Some(v39::Duration {
+                                            nanos: 1234,
+                                            secs: 13,
+                                        }),
+                                        log_logging: true,
                                     }),
-                                    log_logging: true,
                                 }),
-                            }),
-                            name: "someone".to_owned(),
-                            owner_id: Some(v39::RoleId {
-                                value: Some(v39::role_id::Value::User(876)),
-                            }),
-                        },
-                    ),
-                ],
-            )
-            .await
-            .expect("insert success");
+                                name: "moritz".to_owned(),
+                                owner_id: Some(v39::RoleId {
+                                    value: Some(v39::role_id::Value::User(987)),
+                                }),
+                            },
+                        ),
+                        (
+                            v39::ClusterReplicaKey {
+                                id: Some(v39::ReplicaId {
+                                    value: Some(v39::replica_id::Value::User(234)),
+                                }),
+                            },
+                            v39::ClusterReplicaValue {
+                                cluster_id: Some(v39::ClusterId {
+                                    value: Some(v39::cluster_id::Value::User(345)),
+                                }),
+                                config: Some(v39::ReplicaConfig {
+                                    idle_arrangement_merge_effort: Some(v39::ReplicaMergeEffort {
+                                        effort: 432,
+                                    }),
+                                    location: Some(v39::replica_config::Location::Managed(
+                                        v39::replica_config::ManagedLocation {
+                                            availability_zone: Some("Verfügbar".to_owned()),
+                                            disk: false,
+                                            size: "groß".to_owned(),
+                                        },
+                                    )),
+                                    logging: Some(v39::ReplicaLogging {
+                                        interval: Some(v39::Duration {
+                                            nanos: 4312,
+                                            secs: 11,
+                                        }),
+                                        log_logging: true,
+                                    }),
+                                }),
+                                name: "someone".to_owned(),
+                                owner_id: Some(v39::RoleId {
+                                    value: Some(v39::role_id::Value::User(876)),
+                                }),
+                            },
+                        ),
+                    ],
+                )
+                .await
+                .expect("insert success");
 
-        // Run the migration.
-        stash
-            .with_transaction(|mut tx| {
-                Box::pin(async move {
-                    upgrade(&mut tx).await?;
-                    Ok(())
+            // Run the migration.
+            stash
+                .with_transaction(|mut tx| {
+                    Box::pin(async move {
+                        upgrade(&mut tx).await?;
+                        Ok(())
+                    })
                 })
-            })
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-        let roles = CLUSTER_REPLICA_COLLECTION_V40
-            .peek_one(&mut stash)
-            .await
-            .expect("read v40");
-        insta::assert_debug_snapshot!(roles, @r###"
+            let roles = CLUSTER_REPLICA_COLLECTION_V40
+                .peek_one(&mut stash)
+                .await
+                .expect("read v40");
+            insta::assert_debug_snapshot!(roles, @r###"
         {
             ClusterReplicaKey {
                 id: Some(
@@ -373,65 +373,66 @@ mod tests {
             },
         }
         "###);
+        })
+        .await
+        .unwrap();
     }
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
     async fn smoke_test_audit_log_migration() {
-        let factory = DebugStashFactory::new().await;
-        let mut stash = factory.open().await;
-
-        AUDIT_LOG_COLLECTION
-            .insert_without_overwrite(
-                &mut stash,
-                [(
-                    v39::AuditLogKey {
-                        event: Some(v39::audit_log_key::Event::V1(v39::AuditLogEventV1 {
-                            id: 1234,
-                            user: Some(v39::StringWrapper {
-                                inner: "name".to_owned(),
-                            }),
-                            event_type: 2,
-                            object_type: 3,
-                            details: Some(
-                                v39::audit_log_event_v1::Details::CreateClusterReplicaV1(
-                                    v39::audit_log_event_v1::CreateClusterReplicaV1 {
-                                        cluster_id: "u23".to_owned(),
-                                        cluster_name: "my_cluster".to_owned(),
-                                        disk: false,
-                                        replica_id: Some(v39::StringWrapper {
-                                            inner: "u123".to_owned(),
-                                        }),
-                                        logical_size: "too small".to_owned(),
-                                        replica_name: "my_replica".to_owned(),
-                                    },
+        Stash::with_debug_stash(|mut stash| async move {
+            AUDIT_LOG_COLLECTION
+                .insert_without_overwrite(
+                    &mut stash,
+                    [(
+                        v39::AuditLogKey {
+                            event: Some(v39::audit_log_key::Event::V1(v39::AuditLogEventV1 {
+                                id: 1234,
+                                user: Some(v39::StringWrapper {
+                                    inner: "name".to_owned(),
+                                }),
+                                event_type: 2,
+                                object_type: 3,
+                                details: Some(
+                                    v39::audit_log_event_v1::Details::CreateClusterReplicaV1(
+                                        v39::audit_log_event_v1::CreateClusterReplicaV1 {
+                                            cluster_id: "u23".to_owned(),
+                                            cluster_name: "my_cluster".to_owned(),
+                                            disk: false,
+                                            replica_id: Some(v39::StringWrapper {
+                                                inner: "u123".to_owned(),
+                                            }),
+                                            logical_size: "too small".to_owned(),
+                                            replica_name: "my_replica".to_owned(),
+                                        },
+                                    ),
                                 ),
-                            ),
-                            occurred_at: Some(v39::EpochMillis { millis: 1600000 }),
-                        })),
-                    },
-                    (),
-                )],
-            )
-            .await
-            .expect("insert success");
+                                occurred_at: Some(v39::EpochMillis { millis: 1600000 }),
+                            })),
+                        },
+                        (),
+                    )],
+                )
+                .await
+                .expect("insert success");
 
-        // Run the migration.
-        stash
-            .with_transaction(|mut tx| {
-                Box::pin(async move {
-                    upgrade(&mut tx).await?;
-                    Ok(())
+            // Run the migration.
+            stash
+                .with_transaction(|mut tx| {
+                    Box::pin(async move {
+                        upgrade(&mut tx).await?;
+                        Ok(())
+                    })
                 })
-            })
-            .await
-            .unwrap();
+                .await
+                .unwrap();
 
-        let roles = AUDIT_LOG_COLLECTION_V40
-            .peek_one(&mut stash)
-            .await
-            .expect("read v40");
-        insta::assert_debug_snapshot!(roles, @r###"
+            let roles = AUDIT_LOG_COLLECTION_V40
+                .peek_one(&mut stash)
+                .await
+                .expect("read v40");
+            insta::assert_debug_snapshot!(roles, @r###"
         {
             AuditLogKey {
                 event: Some(
@@ -474,5 +475,8 @@ mod tests {
             }: (),
         }
         "###);
+        })
+        .await
+        .unwrap();
     }
 }


### PR DESCRIPTION
Previously, in the Drop impl of DebugStashFactory we were cleaning up the test schema created by the DebugStashFactory. In order to run the DROP command, we were blocking the async runtime, since the Drop impl can't be async. There were often other async tasks that had active CRDB transactions, especially when tests were run in parallel, that were now sitting idle because the runtime was blocked. The DROP SCHEMA command was waiting for these transactions to complete which caused a deadlock. CRDB eventually aborted active transactions after 5 minutes, but this was too long for tests that should take under a minute. A previous fix was to lower the idle transaction timeout to 1 second.

This commit updates DebugStashFactory so that the CRDB state is cleaned up in an async function that must be called before dropping the DebugStashFactory. The solution no longer blocks the entire runtime, so we don't have to abort transactions from parallel tests.

Works towards resolving #21891

### Motivation
This PR fixes a recognized bug.

### Tips for reviewer
The changed lines is very misleading. The vast majority comes from nesting tests inside of a closure. I highly recommend hiding whitespace.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
