### PR TITLE
persist-txn: add txns_progress dataflow operator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4636,6 +4636,7 @@ dependencies = [
 name = "mz-persist-txn"
 version = "0.0.0"
 dependencies = [
+ "crossbeam-channel",
  "differential-dataflow",
  "futures",
  "mz-ore",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4642,6 +4642,7 @@ dependencies = [
  "mz-ore",
  "mz-persist-client",
  "mz-persist-types",
+ "mz-timely-util",
  "prost",
  "timely",
  "tokio",

--- a/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
+++ b/src/persist-cli/src/maelstrom/txn_list_append_multi.rs
@@ -264,7 +264,7 @@ impl Transactor {
                 .data_reads
                 .get(data_id)
                 .expect("data handle was registered");
-            let data_read = data_read.clone("read_at").await;
+            let mut data_read = data_read.clone("read_at").await;
             // SUBTLE! Maelstrom txn-list-append requires that we be able to
             // reconstruct the order in which we appended list items. To avoid
             // needing to change the staged writes if our read_ts advances, we
@@ -276,18 +276,35 @@ impl Transactor {
             // TODO: It would be lovely to do this without cloning the
             // ReadHandle, but that would require adding a method to fetch the
             // un-advanced data in some `(lower, upper)`.
-            let target_inclusive = self
+            //
+            // TODO(txn): Use the timely operator instead to get additional
+            // coverage of it. In the meantime, hack access to the non-pub
+            // unblock_read by fetching a snapshot and throwing it away. This
+            // guarantees that the data shard is readable through read_ts.
+            let data_write = self
+                .client
+                .open_writer(
+                    *data_id,
+                    Arc::new(VecU8Schema),
+                    Arc::new(UnitSchema),
+                    Diagnostics::from_purpose("txn data"),
+                )
+                .await
+                .expect("data schema shouldn't change");
+            let _ = self
                 .txns
                 .read_cache()
-                .to_data_inclusive(data_id, read_ts)
-                .expect("data shard was registered");
+                .data_snapshot(data_id, read_ts)
+                .expect("data shard was registered")
+                .snapshot_and_fetch(&mut data_read, data_write)
+                .await;
             let mut subscribe = data_read
                 .subscribe(Antichain::from_elem(0))
                 .await
                 .expect("data shard is not compacted");
             let mut data = Vec::new();
             let mut progress_exclusive = 0;
-            while progress_exclusive <= target_inclusive {
+            while progress_exclusive <= read_ts {
                 let events = subscribe.fetch_next().await;
                 for event in events {
                     match event {
@@ -296,7 +313,7 @@ impl Transactor {
                             trace!(
                                 "{} read {} progress: {}",
                                 data_id,
-                                target_inclusive,
+                                read_ts,
                                 progress_exclusive
                             );
                         }
@@ -307,9 +324,9 @@ impl Transactor {
                                     let (k, ()) = (k.unwrap(), v.unwrap());
                                     (k, t, d)
                                 })
-                                .filter(|(_, t, _)| *t <= target_inclusive)
+                                .filter(|(_, t, _)| *t <= read_ts)
                                 .map(|x| {
-                                    trace!("{} read {} data: {:?}", data_id, target_inclusive, x);
+                                    trace!("{} read {} data: {:?}", data_id, read_ts, x);
                                     x
                                 });
                             data.extend(updates);

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -12,16 +12,14 @@
 use std::backtrace::Backtrace;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
-use std::future::Future;
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime};
+use std::time::Duration;
 
 use differential_dataflow::consolidation::consolidate_updates;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
-use futures::stream::{FuturesUnordered, StreamExt};
-use futures::{FutureExt, Stream};
+use futures::Stream;
 use mz_ore::now::EpochMillis;
 use mz_ore::task::RuntimeExt;
 use mz_persist::location::{Blob, SeqNo};
@@ -32,7 +30,7 @@ use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::runtime::Handle;
 use tokio::task::JoinHandle;
-use tracing::{debug, debug_span, instrument, trace_span, warn, Instrument};
+use tracing::{debug_span, instrument, warn, Instrument};
 use uuid::Uuid;
 
 use crate::cfg::PersistFeatureFlag;
@@ -42,11 +40,13 @@ use crate::fetch::{
 };
 use crate::internal::encoding::Schemas;
 use crate::internal::machine::Machine;
-use crate::internal::metrics::{Metrics, MetricsRetryStream};
-use crate::internal::state::{HollowBatch, HollowBatchPart, Since};
+use crate::internal::metrics::Metrics;
+use crate::internal::state::{HollowBatch, HollowBatchPart};
 use crate::internal::watch::StateWatch;
 use crate::iter::Consolidator;
 use crate::{parse_id, GarbageCollector, PersistConfig, ShardId};
+
+pub use crate::internal::state::Since;
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
 #[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -296,7 +296,12 @@ where
     pub async fn next(&mut self) -> (Vec<LeasedBatchPart<T>>, Antichain<T>) {
         let batch = self
             .handle
-            .next_listen_batch(&self.frontier, &mut self.watch)
+            .machine
+            .next_listen_batch(
+                &self.frontier,
+                &mut self.watch,
+                Some(&self.handle.reader_id),
+            )
             .await;
 
         // A lot of things across mz have to line up to hold the following
@@ -794,7 +799,7 @@ where
     /// # Panics
     /// - If `self` does not have record of issuing the [`LeasedBatchPart`], e.g.
     ///   it originated from from another `ReadHandle`.
-    pub(crate) fn process_returned_leased_part(&mut self, leased_part: LeasedBatchPart<T>) {
+    pub fn process_returned_leased_part(&mut self, leased_part: LeasedBatchPart<T>) {
         self.lease_returner.return_leased_part(leased_part)
     }
 
@@ -912,109 +917,6 @@ where
         let (_, maintenance) = self.machine.expire_leased_reader(&self.reader_id).await;
         maintenance.start_performing(&self.machine, &self.gc);
         self.explicitly_expired = true;
-    }
-
-    async fn next_listen_batch(
-        &mut self,
-        frontier: &Antichain<T>,
-        watch: &mut StateWatch<K, V, T, D>,
-    ) -> HollowBatch<T> {
-        let mut seqno = match self.machine.next_listen_batch(frontier) {
-            Ok(b) => return b,
-            Err(seqno) => seqno,
-        };
-
-        // The latest state still doesn't have a new frontier for us:
-        // watch+sleep in a loop until it does.
-        let sleeps = self.metrics.retries.next_listen_batch.stream(
-            self.cfg
-                .dynamic
-                .next_listen_batch_retry_params()
-                .into_retry(SystemTime::now())
-                .into_retry_stream(),
-        );
-
-        enum Wake<'a, K, V, T, D> {
-            Watch(&'a mut StateWatch<K, V, T, D>),
-            Sleep(MetricsRetryStream),
-        }
-        let mut wakes = FuturesUnordered::<
-            std::pin::Pin<Box<dyn Future<Output = Wake<K, V, T, D>> + Send + Sync>>,
-        >::new();
-        wakes.push(Box::pin(
-            watch
-                .wait_for_seqno_ge(seqno.next())
-                .map(Wake::Watch)
-                .instrument(trace_span!("snapshot::watch")),
-        ));
-        wakes.push(Box::pin(
-            sleeps
-                .sleep()
-                .map(Wake::Sleep)
-                .instrument(trace_span!("snapshot::sleep")),
-        ));
-
-        loop {
-            assert_eq!(wakes.len(), 2);
-            let wake = wakes.next().await.expect("wakes should be non-empty");
-            // Note that we don't need to fetch in the Watch case, because the
-            // Watch wakeup is a signal that the shared state has already been
-            // updated.
-            match &wake {
-                Wake::Watch(_) => self.metrics.watch.listen_woken_via_watch.inc(),
-                Wake::Sleep(_) => {
-                    self.metrics.watch.listen_woken_via_sleep.inc();
-                    self.machine
-                        .applier
-                        .fetch_and_update_state(Some(seqno))
-                        .await;
-                }
-            }
-
-            seqno = match self.machine.next_listen_batch(frontier) {
-                Ok(b) => {
-                    match &wake {
-                        Wake::Watch(_) => self.metrics.watch.listen_resolved_via_watch.inc(),
-                        Wake::Sleep(_) => self.metrics.watch.listen_resolved_via_sleep.inc(),
-                    }
-                    return b;
-                }
-                Err(seqno) => seqno,
-            };
-
-            // There might be some holdup in the next batch being
-            // produced. Perhaps we've quiesced a table or maybe a
-            // dataflow is taking a long time to start up because it has
-            // to read a lot of data. Heartbeat ourself so we don't
-            // accidentally lose our lease while we wait for things to
-            // resume.
-            self.maybe_heartbeat_reader().await;
-
-            // Wait a bit and try again. Intentionally don't ever log
-            // this at info level.
-            match wake {
-                Wake::Watch(watch) => wakes.push(Box::pin(
-                    async move {
-                        watch.wait_for_seqno_ge(seqno.next()).await;
-                        Wake::Watch(watch)
-                    }
-                    .instrument(trace_span!("snapshot::watch")),
-                )),
-                Wake::Sleep(sleeps) => {
-                    debug!(
-                        "{}: next_listen_batch didn't find new data, retrying in {:?}",
-                        self.reader_id,
-                        sleeps.next_sleep()
-                    );
-                    wakes.push(Box::pin(
-                        sleeps
-                            .sleep()
-                            .map(Wake::Sleep)
-                            .instrument(trace_span!("snapshot::sleep")),
-                    ));
-                }
-            }
-        }
     }
 
     /// Test helper for a [Self::listen] call that is expected to succeed.

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -12,6 +12,7 @@ futures = "0.3.25"
 mz-ore = { path = "../ore" }
 mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
+mz-timely-util = { path = "../timely-util" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tracing = "0.1.37"

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -18,6 +18,7 @@ tracing = "0.1.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
+crossbeam-channel = "0.5.8"
 tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -179,25 +179,26 @@
 //!
 //! ```
 //! # use mz_persist_client::{Diagnostics, PersistClient, ShardId};
+//! # use mz_persist_txn::operator::DataSubscribe;
 //! # use mz_persist_txn::txns::TxnsHandle;
-//! # use mz_persist_types::codec_impls::{UnitSchema, VecU8Schema};
+//! # use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 //! #
 //! # tokio::runtime::Runtime::new().unwrap().block_on(async {
-//! # let c = PersistClient::new_for_tests().await;
+//! # let client = PersistClient::new_for_tests().await;
 //! # mz_ore::test::init_logging();
 //! // Open a txn shard, initializing it if necessary.
-//! # let client = c.clone();
-//! let mut txns = TxnsHandle::<Vec<u8>, (), u64, i64>::open(
-//!     0u64, client, ShardId::new(), VecU8Schema.into(), UnitSchema.into()
+//! let txns_id = ShardId::new();
+//! let mut txns = TxnsHandle::<String, (), u64, i64>::open(
+//!     0u64, client.clone(), txns_id, StringSchema.into(), UnitSchema.into()
 //! ).await;
 //!
 //! // Register data shards to the txn set.
 //! let (d0, d1) = (ShardId::new(), ShardId::new());
-//! # let d0_write = c.open_writer(
-//! #    d0, VecU8Schema.into(), UnitSchema.into(), Diagnostics::for_tests()
+//! # let d0_write = client.open_writer(
+//! #    d0, StringSchema.into(), UnitSchema.into(), Diagnostics::for_tests()
 //! # ).await.unwrap();
-//! # let d1_write = c.open_writer(
-//! #    d1, VecU8Schema.into(), UnitSchema.into(), Diagnostics::for_tests()
+//! # let d1_write = client.open_writer(
+//! #    d1, StringSchema.into(), UnitSchema.into(), Diagnostics::for_tests()
 //! # ).await.unwrap();
 //! txns.register(1u64, [d0_write]).await.expect("not previously initialized");
 //! txns.register(2u64, [d1_write]).await.expect("not previously initialized");
@@ -209,8 +210,8 @@
 //! // but in the event of a crash, neither correctness nor liveness depend on
 //! // it.
 //! let mut txn = txns.begin();
-//! txn.write(&d0, vec![0], (), 1);
-//! txn.write(&d1, vec![1], (), -1);
+//! txn.write(&d0, "0".into(), (), 1);
+//! txn.write(&d1, "1".into(), (), -1);
 //! let tidy = txn.commit_at(&mut txns, 3).await.expect("ts 3 available")
 //!     // Make it available to reads by applying it.
 //!     .apply(&mut txns).await;
@@ -219,21 +220,19 @@
 //! // is also advanced by this. At the same time clean up after our last commit
 //! // (the tidy).
 //! let mut txn = txns.begin();
-//! txn.write(&d0, vec![2], (), 1);
+//! txn.write(&d0, "2".into(), (), 1);
 //! txn.tidy(tidy);
 //! txn.commit_at(&mut txns, 3).await.expect_err("ts 3 not available");
 //! let _tidy = txn.commit_at(&mut txns, 4).await.expect("ts 4 available")
 //!     .apply(&mut txns).await;
 //!
 //! // Read data shard(s) at some `read_ts`.
-//! //
-//! // TODO(txn): Replace this with the timely operator once it's added.
-//! # let mut d1_read = c.open_leased_reader::<Vec<u8>, (), u64, i64>(
-//! #     d1, VecU8Schema.into(), UnitSchema.into(), Diagnostics::for_tests(),
-//! # ).await.unwrap();
-//! let updates = d1_read.snapshot_and_fetch(
-//!     vec![txns.read_cache().to_data_inclusive(&d1, 4).unwrap()].into()
-//! ).await.unwrap();
+//! let mut subscribe = DataSubscribe::new("example", client, txns_id, d1, 4);
+//! while subscribe.progress() <= 4 {
+//!     subscribe.step();
+//! #   tokio::task::yield_now().await;
+//! }
+//! let updates = subscribe.output();
 //! # })
 //! ```
 //!
@@ -279,15 +278,15 @@ use mz_persist_types::{Codec, Codec64, StepForward};
 use prost::Message;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
-use tracing::debug;
+use tracing::{debug, instrument};
 
 pub mod error;
+pub mod operator;
 pub mod txn_read;
 pub mod txn_write;
 pub mod txns;
 
 // TODO(txn):
-// - Add frontier advancement operator.
 // - Closing/deleting data shards.
 // - Hold a critical since capability for each registered shard?
 // - Figure out the compaction story for both txn and data shard.
@@ -350,6 +349,7 @@ impl TxnsCodec for TxnsCodecDefault {
 }
 
 /// Helper for common logging for compare_and_append-ing a small amount of data.
+#[instrument(level = "debug", skip_all, fields(shard=%txns_or_data_write.shard_id()))]
 pub(crate) async fn small_caa<S, F, K, V, T, D>(
     name: F,
     txns_or_data_write: &mut WriteHandle<K, V, T, D>,
@@ -461,6 +461,7 @@ pub(crate) async fn empty_caa<S, F, K, V, T, D>(
 /// the work must have already been done by someone else. (Think how our compute
 /// replicas race to compute some MATERIALIZED VIEW, but they're all guaranteed
 /// to get the same answer.)
+#[instrument(level = "debug", skip_all, fields(shard=%data_write.shard_id()))]
 async fn apply_caa<K, V, T, D>(
     data_write: &mut WriteHandle<K, V, T, D>,
     batch_raw: &[u8],
@@ -545,7 +546,7 @@ pub mod tests {
     use mz_persist_client::{Diagnostics, PersistClient, ShardId};
     use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
 
-    use crate::txn_read::TxnsCache;
+    use crate::operator::DataSubscribe;
     use crate::txn_write::Txn;
 
     use super::*;
@@ -644,32 +645,10 @@ pub mod tests {
         #[allow(ungated_async_fn_track_caller)]
         #[track_caller]
         pub async fn assert_snapshot(&self, data_id: ShardId, as_of: u64) {
-            let txns_read = self
-                .client
-                .open_leased_reader(
-                    self.txns_id,
-                    Arc::new(ShardIdSchema),
-                    Arc::new(VecU8Schema),
-                    Diagnostics::for_tests(),
-                )
-                .await
-                .unwrap();
-            let mut txns_cache = TxnsCache::<u64>::open(0, txns_read).await;
-            txns_cache.update_gt(&as_of).await;
-            let translated_as_of = txns_cache.to_data_inclusive(&data_id, as_of).unwrap();
-            let mut data_read = reader(&self.client, data_id).await;
-            let actual = data_read
-                .snapshot_and_fetch(Antichain::from_elem(translated_as_of))
-                .await
-                .unwrap();
-            let actual = actual.into_iter().map(|((k, v), mut t, d)| {
-                let (k, ()) = (k.unwrap(), v.unwrap());
-                if t < as_of {
-                    t = as_of;
-                }
-                (k, t, d)
-            });
-            self.assert_eq(data_id, as_of, as_of + 1, actual)
+            let mut data_subscribe =
+                DataSubscribe::new("test", self.client.clone(), self.txns_id, data_id, as_of);
+            data_subscribe.step_past(as_of).await;
+            self.assert_eq(data_id, as_of, as_of + 1, data_subscribe.output().clone())
         }
     }
 

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -1,0 +1,436 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Timely operators for the crate
+
+use std::any::Any;
+use std::fmt::Debug;
+use std::future::Future;
+use std::rc::Rc;
+use std::sync::mpsc::TryRecvError;
+use std::sync::{mpsc, Arc};
+
+use differential_dataflow::difference::Semigroup;
+use differential_dataflow::lattice::Lattice;
+use mz_persist_client::operators::shard_source::shard_source;
+use mz_persist_client::{Diagnostics, PersistClient, ShardId};
+use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
+use mz_persist_types::{Codec, Codec64, StepForward};
+use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
+use timely::dataflow::channels::pact::Pipeline;
+use timely::dataflow::operators::capture::EventCore;
+use timely::dataflow::operators::{Capture, Leave, Map, Probe};
+use timely::dataflow::{ProbeHandle, Scope, Stream};
+use timely::order::TotalOrder;
+use timely::progress::{Antichain, Timestamp};
+use timely::scheduling::Scheduler;
+use timely::worker::Worker;
+use timely::{Data, WorkerConfig};
+
+use crate::txn_read::{DataListenNext, TxnsCache};
+use crate::{TxnsCodec, TxnsCodecDefault};
+
+/// An operator for translating physical data shard frontiers into logical ones.
+///
+/// A data shard in the txns set logically advances its upper each time a txn is
+/// committed, but the upper is not physically advanced unless that data shard
+/// was involved in the txn. This means that a shard_source (or any read)
+/// pointed at a data shard would appear to stall at the time of the most recent
+/// write. We fix this for shard_source by flowing its output through a new
+/// `txns_progress` dataflow operator, which ensures that the
+/// frontier/capability is advanced as the txns shard progresses, as long as the
+/// shard_source is up to date with the latest committed write to that data
+/// shard.
+///
+/// Example:
+///
+/// - A data shard has most recently been written to at 3.
+/// - The txns shard's upper is at 6.
+/// - We render a dataflow containing a shard_source with an as_of of 5.
+/// - A txn NOT involving the data shard is committed at 7.
+/// - A txn involving the data shard is committed at 9.
+///
+/// How it works:
+///
+/// - The shard_source operator is rendered. Its single output is hooked up as a
+///   _disconnected_ input to txns_progress. The txns_progress single output is
+///   a stream of the same type, which is used by downstream operators. This
+///   txns_progress operator is targeted at one data_shard; rendering a
+///   shard_source for a second data shard requires a second txns_progress
+///   operator.
+/// - The shard_source operator emits data through 3 and advances the frontier.
+/// - The txns_progress operator passes through these writes and frontier
+///   advancements unchanged. (Recall that it's always correct to read a data
+///   shard "normally", it just might stall.) Because the txns_progress operator
+///   knows there are no writes in `[3,5]`, it then downgrades its own
+///   capability past 5 (to 6). Because the input is disconnected, this means
+///   the overall frontier of the output is downgraded to 6.
+/// - The txns_progress operator learns about the write at 7 (the upper is now
+///   8). Because it knows that the data shard was not involved in this, it's
+///   free to downgrade its capability to 8.
+/// - The txns_progress operator learns about the write at 9 (the upper is now
+///   10). It knows that the data shard _WAS_ involved in this, so it forwards
+///   on data from its input until the input has progressed to 10, at which
+///   point it can itself downgrade to 10.
+pub fn txns_progress<K, V, T, D, P, C, G>(
+    passthrough: Stream<G, P>,
+    name: &str,
+    client: impl Future<Output = PersistClient> + 'static,
+    txns_id: ShardId,
+    data_id: ShardId,
+    as_of: T,
+    // TODO(txn): Get rid of these when we have a schemaless WriteHandle.
+    data_key_schema: Arc<K::Schema>,
+    data_val_schema: Arc<V::Schema>,
+) -> (Stream<G, P>, Rc<dyn Any>)
+where
+    K: Debug + Codec,
+    V: Debug + Codec,
+    T: Timestamp + Lattice + TotalOrder + StepForward + Codec64,
+    D: Data + Semigroup + Codec64 + Send + Sync,
+    P: Debug + Data,
+    C: TxnsCodec,
+    G: Scope<Timestamp = T>,
+{
+    let mut builder =
+        AsyncOperatorBuilder::new(format!("txns_progress({})", name), passthrough.scope());
+    let (mut passthrough_output, passthrough_stream) = builder.new_output();
+    let mut passthrough_input =
+        builder.new_input_connection(&passthrough, Pipeline, vec![Antichain::new()]);
+
+    let shutdown_button = builder.build(move |capabilities| async move {
+        let [mut cap]: [_; 1] = capabilities.try_into().expect("one capability per output");
+        let client = client.await;
+        let (txns_key_schema, txns_val_schema) = C::schemas();
+        let txns_read = client
+            .open_leased_reader::<C::Key, C::Val, _, _>(
+                txns_id,
+                Arc::new(txns_key_schema),
+                Arc::new(txns_val_schema),
+                Diagnostics::from_purpose("txns_progress"),
+            )
+            .await
+            .expect("schema shouldn't change");
+        let mut txns_cache = TxnsCache::<T, C>::open(txns_read).await;
+
+        txns_cache.update_gt(&as_of).await;
+        let snap = txns_cache
+            .data_snapshot(&data_id, as_of.clone())
+            .expect("data shard is registered");
+        let data_write = client
+            .open_writer::<K, V, T, D>(
+                data_id,
+                data_key_schema,
+                data_val_schema,
+                Diagnostics::from_purpose("data read physical upper"),
+            )
+            .await
+            .expect("schema shouldn't change");
+        let () = snap.unblock_read(data_write).await;
+
+        // We've ensured that the data shard's physical upper is past as_of, so
+        // start by passing through data and frontier updates from the input
+        // until it is past the as_of.
+        let mut read_data_past = as_of;
+        let mut output_progress_exclusive = T::minimum();
+        loop {
+            // TODO(txn): Do something more specific when the input returns None
+            // (is shut down). I _think_ we'll always return before this happens
+            // because we'll get a Progress event with an empty frontier, and so
+            // we could assert on this, but I want to be more sure before making
+            // that change.
+            while let Some(event) = passthrough_input.next_mut().await {
+                match event {
+                    // NB: Ignore the data_cap because this input is
+                    // disconnected.
+                    Event::Data(_data_cap, data) => {
+                        for data in data.drain(..) {
+                            passthrough_output.give(&cap, data).await;
+                        }
+                    }
+                    Event::Progress(progress) => {
+                        // We reached the empty frontier! Shut down.
+                        let Some(input_progress_exclusive) = progress.as_option() else {
+                            return;
+                        };
+
+                        // Recall that any reads of the data shard are always
+                        // correct, so given that we've passed through any data
+                        // from the input, that means we're free to pass through
+                        // frontier updates too.
+                        if &output_progress_exclusive < input_progress_exclusive {
+                            output_progress_exclusive.clone_from(input_progress_exclusive);
+                            cap.downgrade(&output_progress_exclusive);
+                        }
+                        if output_progress_exclusive > read_data_past {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Any time we hit this point, we've emitted everything known to be
+            // physically written to the data shard. Query the txns shard to
+            // find out what to do next given our current progress.
+            loop {
+                txns_cache.update_ge(&output_progress_exclusive).await;
+                let data_listen_next = txns_cache
+                    .data_listen_next(&data_id, output_progress_exclusive.clone())
+                    .expect("table should still exist");
+                match data_listen_next {
+                    // We've caught up to the txns upper and we have to wait for
+                    // it to advance before asking again.
+                    //
+                    // Note that we're asking again with the same input, but
+                    // once the cache is past progress_exclusive (as it will be
+                    // after this update_gt call), we're guaranteed to get an
+                    // answer.
+                    DataListenNext::WaitForTxnsProgress => {
+                        txns_cache.update_gt(&output_progress_exclusive).await;
+                        continue;
+                    }
+                    // The data shard got a write! Loop back above and pass
+                    // through data until we see it.
+                    DataListenNext::ReadDataPast(new_target) => {
+                        read_data_past = new_target;
+                        break;
+                    }
+                    // We know there are no writes in
+                    // `[output_progress_exclusive, new_progress)`, so advance
+                    // our output frontier.
+                    DataListenNext::EmitLogicalProgress(new_progress) => {
+                        assert!(output_progress_exclusive < new_progress);
+                        output_progress_exclusive = new_progress;
+                        cap.downgrade(&output_progress_exclusive);
+                        continue;
+                    }
+                }
+            }
+        }
+    });
+    (passthrough_stream, Rc::new(shutdown_button.press_on_drop()))
+}
+
+/// A helper for subscribing to a data shard using the timely operators.
+///
+/// This could instead be a wrapper around a [Subscribe], but it's only used in
+/// tests and maelstrom, so do it by wrapping the timely operators to get
+/// additional coverage. For the same reason, hardcode the K, V, T, D types.
+///
+/// [Subscribe]: mz_persist_client::read::Subscribe
+pub struct DataSubscribe {
+    worker: Worker<timely::communication::allocator::Thread>,
+    data: ProbeHandle<u64>,
+    txns: ProbeHandle<u64>,
+    capture: mpsc::Receiver<EventCore<u64, Vec<(String, u64, i64)>>>,
+    output: Vec<(String, u64, i64)>,
+
+    _tokens: Rc<dyn Any>,
+}
+
+impl std::fmt::Debug for DataSubscribe {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let DataSubscribe {
+            worker: _,
+            data,
+            txns,
+            capture: _,
+            output,
+            _tokens: _,
+        } = self;
+        f.debug_struct("DataSubscribe")
+            .field("data", data)
+            .field("txns", txns)
+            .field("output", output)
+            .finish_non_exhaustive()
+    }
+}
+
+impl DataSubscribe {
+    /// Creates a new [DataSubscribe].
+    pub fn new(
+        name: &str,
+        client: PersistClient,
+        txns_id: ShardId,
+        data_id: ShardId,
+        as_of: u64,
+    ) -> Self {
+        let mut worker = Worker::new(
+            WorkerConfig::default(),
+            timely::communication::allocator::Thread::new(),
+        );
+        let (data, txns, capture, tokens) = worker.dataflow::<u64, _, _>(|scope| {
+            let (data_stream, shard_source_token) = scope.scoped::<u64, _, _>("hybrid", |scope| {
+                let client = client.clone();
+                let (data_stream, token) = shard_source::<String, (), u64, i64, _, _, _, _>(
+                    scope,
+                    name,
+                    move || std::future::ready(client.clone()),
+                    data_id,
+                    Some(Antichain::from_elem(as_of)),
+                    Antichain::new(),
+                    false.then_some(|_, _: &_, _| unreachable!()),
+                    Arc::new(StringSchema),
+                    Arc::new(UnitSchema),
+                    |_| true,
+                );
+                (data_stream.leave(), token)
+            });
+            let (mut data, mut txns) = (ProbeHandle::new(), ProbeHandle::new());
+            let data_stream = data_stream.flat_map(|part| {
+                part.map(|((k, v), t, d)| {
+                    let (k, ()) = (k.unwrap(), v.unwrap());
+                    (k, t, d)
+                })
+            });
+            let data_stream = data_stream.probe_with(&mut data);
+            let (data_stream, txns_progress_token) =
+                txns_progress::<String, (), u64, i64, _, TxnsCodecDefault, _>(
+                    data_stream,
+                    name,
+                    std::future::ready(client.clone()),
+                    txns_id,
+                    data_id,
+                    as_of,
+                    Arc::new(StringSchema),
+                    Arc::new(UnitSchema),
+                );
+            let data_stream = data_stream.probe_with(&mut txns);
+            let tokens: Rc<dyn Any> = Rc::new((shard_source_token, txns_progress_token));
+            (data, txns, data_stream.capture(), tokens)
+        });
+        Self {
+            worker,
+            data,
+            txns,
+            capture,
+            output: Vec::new(),
+            _tokens: tokens,
+        }
+    }
+
+    /// Returns the exclusive progress of the dataflow.
+    pub fn progress(&self) -> u64 {
+        self.txns
+            .with_frontier(|f| f.as_option().expect("txns is not closed").clone())
+    }
+
+    /// Steps the dataflow, capturing output.
+    pub fn step(&mut self) {
+        // TODO: The activations based stepping in `sub.step` should be enough,
+        // but somehow it isn't in the `data_subscribe` unit test. The dataflow
+        // gets woken up again by something (I think a semaphore) after
+        // initially going to sleep. If this doesn't happen, we end up
+        // deadlocking in the first call to register a writer.
+        for _ in 0..1000 {
+            self.worker.step();
+        }
+        // Step while any worker thinks it has work to do.
+        while self.worker.activations().borrow().empty_for().is_some() {
+            self.worker.step();
+        }
+        loop {
+            let event = match self.capture.try_recv() {
+                Ok(x) => x,
+                Err(TryRecvError::Empty) | Err(TryRecvError::Disconnected) => break,
+            };
+            match event {
+                EventCore::Progress(_) => {}
+                EventCore::Messages(_, mut msgs) => self.output.append(&mut msgs),
+            }
+        }
+    }
+
+    /// Steps the dataflow past the given time, capturing output.
+    #[cfg(test)]
+    pub async fn step_past(&mut self, ts: u64) {
+        while self.txns.less_equal(&ts) {
+            self.step();
+            tokio::task::yield_now().await;
+        }
+    }
+
+    /// Returns captured output.
+    pub fn output(&self) -> &Vec<(String, u64, i64)> {
+        &self.output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::tests::writer;
+    use crate::txns::TxnsHandle;
+
+    use super::*;
+
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn data_subscribe() {
+        fn step(subs: &mut Vec<DataSubscribe>) {
+            for sub in subs.iter_mut() {
+                sub.step();
+            }
+        }
+
+        let client = PersistClient::new_for_tests().await;
+        let mut txns = TxnsHandle::expect_open(client.clone()).await;
+        let log = txns.new_log();
+        let d0 = ShardId::new();
+
+        // Start a subscription before the shard gets registered.
+        let mut subs = Vec::new();
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now register the shard. Also start a new subscription and step the
+        // previous one (plus repeat this for ever later step).
+        txns.register(1, [writer(&client, d0).await]).await.unwrap();
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now write something unrelated.
+        let d1 = txns.expect_register(2).await;
+        txns.expect_commit_at(3, d1, &["nope"], &log).await;
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now write to our shard before.
+        txns.expect_commit_at(4, d0, &["4"], &log).await;
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now write to our shard at the as_of.
+        txns.expect_commit_at(5, d0, &["5"], &log).await;
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now write to our shard past the as_of.
+        txns.expect_commit_at(6, d0, &["6"], &log).await;
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Now write something unrelated again.
+        txns.expect_commit_at(7, d1, &["nope"], &log).await;
+        subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
+        step(&mut subs);
+
+        // Verify that the dataflows can progress to the expected point.
+        for sub in subs.iter_mut() {
+            sub.step_past(7).await;
+            assert_eq!(sub.progress(), 8);
+        }
+
+        // Now verify that we read the right thing no matter when the dataflow
+        // started.
+        for mut sub in subs {
+            sub.step_past(7).await;
+            log.assert_eq(d0, 5, 8, sub.output().clone());
+        }
+    }
+}

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -423,8 +423,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // too slow
     async fn txns_cache_to_data_inclusive() {
         let mut txns = TxnsHandle::expect_open(PersistClient::new_for_tests().await).await;
+        let log = txns.new_log();
         let d0 = ShardId::new();
-        txns.expect_commit_at(3, d0, &[]).await;
+        txns.expect_commit_at(3, d0, &[], &log).await;
 
         let mut cache = TxnsCache::expect_open(3, &txns).await;
         assert_eq!(cache.progress_exclusive, 4);

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -12,13 +12,15 @@
 use std::collections::BTreeMap;
 use std::fmt::Debug;
 
+use differential_dataflow::difference::Semigroup;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::collections::HashMap;
-use mz_persist_client::read::{ListenEvent, ReadHandle, Subscribe};
+use mz_persist_client::error::UpperMismatch;
+use mz_persist_client::read::{ListenEvent, ReadHandle, Since, Subscribe};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::ShardId;
-use mz_persist_types::{Codec64, StepForward};
+use mz_persist_types::{Codec, Codec64, StepForward};
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use tracing::debug;
@@ -35,19 +37,22 @@ use crate::{TxnsCodec, TxnsCodecDefault, TxnsEntry};
 /// may be read normally, using snapshots, subscriptions, shard_source, etc,
 /// through the most recent non-empty write. However, the upper of the txns
 /// shard (and thus the logical upper of the data shard) may be arbitrarily far
-/// ahead of the physical upper of the data shard. As a result, we have to
-/// "translate" timestamps by synthesizing ranges of empty time that have not
-/// yet been committed (but are guaranteed to remain empty):
+/// ahead of the physical upper of the data shard. As a result, we do the
+/// following:
 ///
 /// - To take a snapshot of a data shard, the `as_of` is passed through
 ///   unchanged if the timestamp of that shard's latest non-empty write is past
-///   it. Otherwise, the timestamp of the latest non-empty write is used.
-///   Concretely, to read a snapshot as of `T`:
+///   it. Otherwise, we know the times between them have no writes and can fill
+///   them with empty updates. Concretely, to read a snapshot as of `T`:
 ///   - We read the txns shard contents up through and including `T`, blocking
 ///     until the upper passes `T` if necessary.
 ///   - We then find, for the requested data shard, the latest non-empty write
 ///     at a timestamp `T' <= T`.
-///   - We then take a normal snapshot on the data shard at `T'`.
+///   - We wait for `T'` to be applied by watching the data shard upper.
+///   - We `compare_and_append` empty updates for `(T', T]`, which is known by
+///     the txn system to not have writes for this shard (otherwise we'd have
+///     picked a different `T'`).
+///   - We read the snapshot at `T` as normal.
 /// - To iterate a listen on a data shard, when writes haven't been read yet
 ///   they are passed through unchanged, otherwise if the txns shard indicates
 ///   that there are ranges of empty time progress is returned, otherwise
@@ -61,9 +66,10 @@ use crate::{TxnsCodec, TxnsCodecDefault, TxnsEntry};
 /// Also note that the above is structured such that it is possible to write a
 /// timely operator with the data shard as an input, passing on all payloads
 /// unchanged and simply manipulating capabilities in response to data and txns
-/// shard progress. TODO(txn): Link to operator once it's added.
+/// shard progress. See [crate::operator::txns_progress].
 #[derive(Debug)]
 pub struct TxnsCache<T: Timestamp + Lattice + Codec64, C: TxnsCodec = TxnsCodecDefault> {
+    _txns_id: ShardId,
     pub(crate) progress_exclusive: T,
     txns_subscribe: Subscribe<C::Key, C::Val, T, i64>,
 
@@ -90,26 +96,29 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
         txns_write: &mut WriteHandle<C::Key, C::Val, T, i64>,
     ) -> Self {
         let () = crate::empty_caa(|| "txns init", txns_write, init_ts.clone()).await;
-        Self::open(init_ts, txns_read).await
+        let mut ret = Self::open(txns_read).await;
+        ret.update_gt(&init_ts).await;
+        ret
     }
 
-    pub(crate) async fn open(init_ts: T, txns_read: ReadHandle<C::Key, C::Val, T, i64>) -> Self {
+    pub(crate) async fn open(txns_read: ReadHandle<C::Key, C::Val, T, i64>) -> Self {
+        let _txns_id = txns_read.shard_id();
         // TODO(txn): Figure out the compaction story. This might require
         // sorting inserts before retractions within each timestamp.
+        let as_of = txns_read.since().clone();
         let subscribe = txns_read
-            .subscribe(Antichain::from_elem(T::minimum()))
+            .subscribe(as_of)
             .await
             .expect("handle holds a capability");
-        let mut ret = TxnsCache {
+        TxnsCache {
+            _txns_id,
             progress_exclusive: T::minimum(),
             txns_subscribe: subscribe,
             next_batch_id: 0,
             unapplied_batches: BTreeMap::new(),
             batch_idx: HashMap::new(),
             datas: BTreeMap::new(),
-        };
-        ret.update_gt(&init_ts).await;
-        ret
+        }
     }
 
     /// Returns the minimum timestamp at which the data shard can be read.
@@ -126,37 +135,115 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
         })
     }
 
-    /// Returns the greatest timestamp written to the data shard that is `<=`
-    /// the given timestamp.
+    /// Returns a token exchangeable for a snapshot of a data shard.
     ///
     /// A data shard might be definite at times past the physical upper because
     /// of invariants maintained by this txn system. As a result, this method
-    /// "translates" an `as_of` of a persist snapshot into the one that will
-    /// resolve on the physical shard.
+    /// discovers the latest write before the `as_of`.
     ///
     /// Callers must first wait for `update_gt` with the same or later timestamp
     /// to return. Panics otherwise.
     ///
-    /// Returns Err if that data has not been registered.
-    pub fn to_data_inclusive(&self, data_id: &ShardId, ts: T) -> Result<T, NotRegistered<T>> {
-        assert!(self.progress_exclusive > ts);
-        self.datas
-            .get(data_id)
-            .and_then(|all| {
-                let ret = all.iter().rev().find(|x| **x <= ts).cloned();
-                debug!(
-                    "to_data_inclusive {:.9} t={:?} ret={:?}: all={:?}",
-                    data_id.to_string(),
-                    ts,
-                    ret,
-                    all,
-                );
-                ret
-            })
-            .ok_or(NotRegistered {
-                data_id: *data_id,
-                ts: self.progress_exclusive.clone(),
-            })
+    /// Returns Err if that data shard has not been registered at the given ts.
+    pub fn data_snapshot(
+        &self,
+        data_id: &ShardId,
+        as_of: T,
+    ) -> Result<DataSnapshot<T>, NotRegistered<T>> {
+        assert!(self.progress_exclusive > as_of);
+        let all = self.datas.get(data_id).ok_or(NotRegistered {
+            data_id: *data_id,
+            ts: self.progress_exclusive.clone(),
+        })?;
+        let latest_write = all
+            .iter()
+            .rev()
+            .find(|x| **x <= as_of)
+            .unwrap_or(&as_of)
+            .clone();
+        let empty_to = all
+            .iter()
+            .find(|x| as_of < **x)
+            .unwrap_or(&self.progress_exclusive)
+            .clone();
+        debug!(
+            "translate_snapshot {:.9} latest_write={:?} as_of={:?} empty_to={:?}: all={:?}",
+            data_id.to_string(),
+            latest_write,
+            as_of,
+            empty_to,
+            all,
+        );
+        let ret = DataSnapshot {
+            data_id: data_id.clone(),
+            latest_write,
+            as_of,
+            empty_to,
+        };
+        assert_eq!(ret.validate(), Ok(()));
+        Ok(ret)
+    }
+
+    /// Returns the next action to take when iterating a Listen on a data shard.
+    ///
+    /// A data shard Listen is executed by repeatedly calling this method with
+    /// an exclusive progress frontier. The returned value indicates an action
+    /// to take. Some of these actions advance the progress frontier, which
+    /// results in calling this method again with a higher timestamp, and thus a
+    /// new action. See [DataListenNext] for specifications of the actions.
+    ///
+    /// Note that this is a state machine on `self.progress_exclusive` and the
+    /// listen progress. DataListenNext indicates which state transitions to
+    /// take.
+    ///
+    /// Returns Err if that data shard has not been registered at the given ts.
+    #[allow(clippy::unused_async)]
+    pub fn data_listen_next(
+        &self,
+        data_id: &ShardId,
+        ts: T,
+    ) -> Result<DataListenNext<T>, NotRegistered<T>> {
+        assert!(self.progress_exclusive >= ts);
+        let all = self.datas.get(data_id).ok_or(NotRegistered {
+            data_id: *data_id,
+            ts: self.progress_exclusive.clone(),
+        })?;
+        let ret = all
+            .last()
+            .filter(|x| ts <= **x)
+            .map(|ts| DataListenNext::ReadDataPast(ts.clone()));
+        debug!(
+            "{:.9} data_listen_next 1 {:?}->{:?}: all={:?}",
+            data_id.to_string(),
+            ts,
+            ret,
+            all,
+        );
+        if let Some(ret) = ret {
+            return Ok(ret);
+        }
+
+        // No writes were > ts, look to see if the txns upper has advanced
+        // past ts.
+        if ts < self.progress_exclusive {
+            debug!(
+                "{:.9} data_listen_next 2 {:?}->{:?}: all={:?}",
+                data_id.to_string(),
+                ts,
+                self.progress_exclusive,
+                all
+            );
+            return Ok(DataListenNext::EmitLogicalProgress(
+                self.progress_exclusive.clone(),
+            ));
+        }
+        // Nope, all caught up, we have to wait.
+        debug!(
+            "{:.9} data_listen_next {:?} waiting for progress",
+            data_id.to_string(),
+            ts
+        );
+        Ok(DataListenNext::WaitForTxnsProgress)
     }
 
     /// Returns the minimum timestamp not known to be applied by this cache.
@@ -362,14 +449,172 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     }
 }
 
+/// A token exchangeable for a data shard snapshot.
+///
+/// - Invariant: `latest_write <= as_of < empty_to`
+/// - Invariant: `(latest_write, empty_to)` has no committed writes (which means
+///   we can do an empty CaA of those times if we like).
+#[derive(Debug)]
+#[cfg_attr(test, derive(PartialEq))]
+pub struct DataSnapshot<T> {
+    data_id: ShardId,
+    latest_write: T,
+    as_of: T,
+    empty_to: T,
+}
+
+impl<T: Timestamp + Lattice + TotalOrder + Codec64> DataSnapshot<T> {
+    /// Unblocks reading a snapshot at `self.as_of` by waiting for the latest
+    /// write before that time and then running an empty CaA if necessary.
+    pub(crate) async fn unblock_read<K, V, D>(&self, mut data_write: WriteHandle<K, V, T, D>)
+    where
+        K: Debug + Codec,
+        V: Debug + Codec,
+        D: Semigroup + Codec64 + Send + Sync,
+    {
+        // First block until the latest write has been applied.
+        let () = data_write
+            .wait_for_upper_past(&Antichain::from_elem(self.latest_write.clone()))
+            .await;
+
+        // Now fill `(latest_write,as_of]` with empty updates, so we can read
+        // the shard at as_of normally.
+        //
+        // In practice, because CaA takes an exclusive upper, we actually fill
+        // `(latest_write, empty_to)`. It is an invariant of DataSnapshot that
+        // this range is empty and that as_of is "in the middle". We really only
+        // care about as_of being readable, so exit the loop as soon as this is
+        // the case, even if the upper is not empty_to.
+        //
+        // It's quite counter-intuitive for reads to involve writes, but I think
+        // this is fine. In particular, because writing empty updates to a
+        // persist shard is a metadata-only operation. It might result in things
+        // like GC maintenance or a CRDB write, but this is also true for
+        // registering a reader. On the balance, I think this is a _much_ better
+        // set of tradeoffs than the original plan of trying to translate read
+        // timestamps to the most recent write and reading that.
+        let mut data_upper = data_write
+            .shared_upper()
+            .into_option()
+            .expect("data shard should not be closed");
+        while data_upper <= self.as_of {
+            // It would be very bad if we accidentally filled any times <=
+            // latest_write with empty updates, so defensively assert on each
+            // iteration through the loop.
+            assert!(self.latest_write < data_upper);
+            debug!(
+                "CaA data snapshot {:.9} [{:?},{:?})",
+                self.data_id.to_string(),
+                data_upper,
+                self.empty_to,
+            );
+            assert!(self.latest_write <= self.as_of);
+            assert!(self.as_of < self.empty_to);
+            let res = data_write
+                .compare_and_append_batch(
+                    &mut [],
+                    Antichain::from_elem(data_upper.clone()),
+                    Antichain::from_elem(self.empty_to.clone()),
+                )
+                .await
+                .expect("usage was valid");
+            match res {
+                Ok(()) => {
+                    debug!(
+                        "CaA data snapshot {:.9} [{:?},{:?}) success",
+                        self.data_id.to_string(),
+                        data_upper,
+                        self.empty_to,
+                    );
+                    // Persist registers writes on the first write, so politely
+                    // expire the writer we just created, but (as a performance
+                    // optimization) only if we actually wrote something.
+                    data_write.expire().await;
+                    break;
+                }
+                Err(UpperMismatch { current, .. }) => {
+                    let current = current
+                        .into_option()
+                        .expect("txns shard should not be closed");
+                    debug!(
+                        "CaA data snapshot {:.9} [{:?},{:?}) mismatch actual={:?}",
+                        self.data_id.to_string(),
+                        data_upper,
+                        self.empty_to,
+                        current,
+                    );
+                    data_upper = current;
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// See [ReadHandle::snapshot_and_fetch].
+    pub async fn snapshot_and_fetch<K, V, D>(
+        &self,
+        data_read: &mut ReadHandle<K, V, T, D>,
+        // TODO(txn): It's quite surprising to require a WriteHandle for reads,
+        // see what we can do about making this nicer.
+        data_write: WriteHandle<K, V, T, D>,
+    ) -> Result<Vec<((Result<K, String>, Result<V, String>), T, D)>, Since<T>>
+    where
+        K: Debug + Codec + Ord,
+        V: Debug + Codec + Ord,
+        D: Semigroup + Codec64 + Send + Sync,
+    {
+        self.unblock_read(data_write).await;
+        data_read
+            .snapshot_and_fetch(Antichain::from_elem(self.as_of.clone()))
+            .await
+    }
+
+    fn validate(&self) -> Result<(), String> {
+        if !(self.latest_write <= self.as_of) {
+            return Err(format!(
+                "latest_write {:?} not <= as_of {:?}",
+                self.latest_write, self.as_of
+            ));
+        }
+        if !(self.as_of < self.empty_to) {
+            return Err(format!(
+                "as_of {:?} not < empty_to {:?}",
+                self.as_of, self.empty_to
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// The next action to take in a data shard `Listen`.
+///
+/// See [TxnsCache::data_listen_next].
+#[derive(Debug)]
+#[cfg_attr(any(test, debug_assertions), derive(PartialEq))]
+pub enum DataListenNext<T> {
+    /// Read the data shard normally, until this timestamp is less than what has
+    /// been read.
+    ReadDataPast(T),
+    /// It is known there there are no writes between the progress given to the
+    /// `data_listen_next` call and this timestamp. Advance the data shard
+    /// listen progress to this (exclusive) frontier.
+    EmitLogicalProgress(T),
+    /// The data shard listen has caught up to what has been written to the txns
+    /// shard. Wait for it to progress with `update_gt` and call
+    /// `data_listen_next` again.
+    WaitForTxnsProgress,
+}
+
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
     use mz_persist_client::{Diagnostics, PersistClient, ShardIdSchema};
     use mz_persist_types::codec_impls::VecU8Schema;
+    use DataListenNext::*;
 
-    use crate::tests::reader;
+    use crate::operator::DataSubscribe;
+    use crate::tests::{reader, writer};
     use crate::txns::TxnsHandle;
 
     use super::*;
@@ -390,7 +635,9 @@ mod tests {
                 )
                 .await
                 .unwrap();
-            TxnsCache::open(init_ts, txns_read).await
+            let mut ret = TxnsCache::open(txns_read).await;
+            ret.update_gt(&init_ts).await;
+            ret
         }
 
         pub(crate) async fn expect_snapshot(
@@ -400,12 +647,12 @@ mod tests {
             as_of: u64,
         ) -> Vec<String> {
             let mut data_read = reader(client, data_id).await;
+            let data_write = writer(client, data_id).await;
             self.update_gt(&as_of).await;
-            let translated_as_of = self
-                .to_data_inclusive(&data_read.shard_id(), as_of)
-                .unwrap();
-            let mut snapshot = data_read
-                .snapshot_and_fetch(Antichain::from_elem(translated_as_of))
+            let mut snapshot = self
+                .data_snapshot(&data_read.shard_id(), as_of)
+                .unwrap()
+                .snapshot_and_fetch(&mut data_read, data_write)
                 .await
                 .unwrap();
             snapshot.sort();
@@ -417,11 +664,29 @@ mod tests {
                 })
                 .collect()
         }
+
+        pub(crate) fn expect_subscribe(
+            &self,
+            client: &PersistClient,
+            data_id: ShardId,
+            as_of: u64,
+        ) -> DataSubscribe {
+            DataSubscribe::new("test", client.clone(), self._txns_id, data_id, as_of)
+        }
     }
 
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    async fn txns_cache_to_data_inclusive() {
+    async fn data_snapshot() {
+        fn ds(data_id: ShardId, latest_write: u64, as_of: u64, empty_to: u64) -> DataSnapshot<u64> {
+            DataSnapshot {
+                data_id,
+                latest_write,
+                as_of,
+                empty_to,
+            }
+        }
+
         let mut txns = TxnsHandle::expect_open(PersistClient::new_for_tests().await).await;
         let log = txns.new_log();
         let d0 = ShardId::new();
@@ -432,24 +697,26 @@ mod tests {
 
         // We can answer inclusive queries at < progress. The data shard isn't
         // registered yet, so it errors.
-        assert!(cache.to_data_inclusive(&d0, 3).is_err());
+        assert!(cache.data_snapshot(&d0, 3).is_err());
 
         // Register a data shard. Registration advances the physical upper, so
-        // we're able to read at the register ts.
+        // we're able to read before and at the register ts. We couldn't read at
+        // 3 before, but we can now.
         cache.push_register(d0, 4, 1);
         cache.progress_exclusive = 5;
-        assert_eq!(cache.to_data_inclusive(&d0, 4), Ok(4));
+        assert_eq!(cache.data_snapshot(&d0, 3), Ok(ds(d0, 3, 3, 4)));
+        assert_eq!(cache.data_snapshot(&d0, 4), Ok(ds(d0, 4, 4, 5)));
 
         // Advance time. Now we can resolve queries at higher times. Nothing got
         // written at 5, so we still read as_of 4.
         cache.progress_exclusive = 6;
-        assert_eq!(cache.to_data_inclusive(&d0, 5), Ok(4));
+        assert_eq!(cache.data_snapshot(&d0, 5), Ok(ds(d0, 4, 5, 6)));
 
         // Write a batch. Apply will advance the physical upper, so we read
         // as_of the commit ts.
         cache.push_append(d0, vec![0xA0], 6, 1);
         cache.progress_exclusive = 7;
-        assert_eq!(cache.to_data_inclusive(&d0, 6), Ok(6));
+        assert_eq!(cache.data_snapshot(&d0, 6), Ok(ds(d0, 6, 6, 7)));
 
         // An unrelated batch doesn't change the answer. Neither does retracting
         // the batch.
@@ -458,12 +725,107 @@ mod tests {
         cache.push_append(other, vec![0xB0], 7, 1);
         cache.push_append(d0, vec![0xA0], 7, -1);
         cache.progress_exclusive = 8;
-        assert_eq!(cache.to_data_inclusive(&d0, 7), Ok(6));
+        assert_eq!(cache.data_snapshot(&d0, 7), Ok(ds(d0, 6, 7, 8)));
 
         // All of the previous answers are still the same.
-        assert!(cache.to_data_inclusive(&d0, 3).is_err());
-        assert_eq!(cache.to_data_inclusive(&d0, 4), Ok(4));
-        assert_eq!(cache.to_data_inclusive(&d0, 5), Ok(4));
-        assert_eq!(cache.to_data_inclusive(&d0, 6), Ok(6));
+        assert_eq!(cache.data_snapshot(&d0, 3), Ok(ds(d0, 3, 3, 4)));
+        assert_eq!(cache.data_snapshot(&d0, 4), Ok(ds(d0, 4, 4, 6)));
+        assert_eq!(cache.data_snapshot(&d0, 5), Ok(ds(d0, 4, 5, 6)));
+        assert_eq!(cache.data_snapshot(&d0, 6), Ok(ds(d0, 6, 6, 8)));
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn txns_cache_data_listen_next() {
+        let mut txns = TxnsHandle::expect_open(PersistClient::new_for_tests().await).await;
+        let log = txns.new_log();
+        let d0 = ShardId::new();
+        txns.expect_commit_at(3, d0, &[], &log).await;
+
+        let mut cache = TxnsCache::expect_open(3, &txns).await;
+        assert_eq!(cache.progress_exclusive, 4);
+
+        // We can answer exclusive queries at <= progress. The data shard isn't
+        // registered yet, so they error.
+        assert!(cache.data_listen_next(&d0, 3).is_err());
+        assert!(cache.data_listen_next(&d0, 4).is_err());
+
+        // Register a data shard. Registration advances the physical upper, so
+        // we're able to read at the register ts.
+        cache.push_register(d0, 4, 1);
+        cache.progress_exclusive = 5;
+        assert_eq!(cache.data_listen_next(&d0, 4), Ok(ReadDataPast(4)));
+        assert_eq!(cache.data_listen_next(&d0, 5), Ok(WaitForTxnsProgress));
+
+        // Advance time. Now we can resolve queries at higher times. Nothing got
+        // written at 5, so the physical upper hasn't moved, but we're now
+        // guaranteed that `[5, 6)` is empty.
+        cache.progress_exclusive = 6;
+        assert_eq!(cache.data_listen_next(&d0, 5), Ok(EmitLogicalProgress(6)));
+
+        // Write a batch. Apply will advance the physical upper, so now we need
+        // to wait for the data upper to advance past the commit ts.
+        cache.push_append(d0, vec![0xA0], 6, 1);
+        cache.progress_exclusive = 7;
+        assert_eq!(cache.data_listen_next(&d0, 6), Ok(ReadDataPast(6)));
+
+        // An unrelated batch is another empty space guarantee. Ditto retracting
+        // the batch.
+        let other = ShardId::new();
+        cache.push_register(other, 7, 1);
+        cache.push_append(other, vec![0xB0], 7, 1);
+        cache.push_append(d0, vec![0xA0], 7, -1);
+        cache.progress_exclusive = 8;
+        assert_eq!(cache.data_listen_next(&d0, 7), Ok(EmitLogicalProgress(8)));
+
+        // Unlike a snapshot, the previous answers have changed! This is because
+        // it's silly (inefficient) to walk through the state machine for a big
+        // range of time once you know of a later write that advances the
+        // physical upper.
+        assert_eq!(cache.data_listen_next(&d0, 3), Ok(ReadDataPast(6)));
+        assert_eq!(cache.data_listen_next(&d0, 4), Ok(ReadDataPast(6)));
+        assert_eq!(cache.data_listen_next(&d0, 5), Ok(ReadDataPast(6)));
+        assert_eq!(cache.data_listen_next(&d0, 6), Ok(ReadDataPast(6)));
+    }
+
+    #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // too slow
+    async fn empty_to() {
+        let client = PersistClient::new_for_tests().await;
+        let mut txns = TxnsHandle::expect_open(client.clone()).await;
+        let d0 = txns.expect_register(1).await;
+
+        // During code review, we discussed an alternate implementation of
+        // empty_to that was an Option: None when we new about a write > the
+        // as_of, and Some when we didn't. The None case would mean that we
+        // don't need to CaA empty updates in. This is quite appealing, but
+        // would cause an issue with the guarantee that `apply_le(as_of)` is
+        // sufficient to unblock a read. Specifically:
+        //
+        // - Write at 3, but don't apply.
+        // - Write at 5, but don't apply.
+        // - Catch the cache up past the write at 5.
+        // - Run apply_le(4) to unblock a read a 4.
+        // - Run a snapshot at 4.
+        // - If nothing else applies the write at 5, the snapshot would
+        //   deadlock.
+        for ts in [3, 5] {
+            let mut txn = txns.begin();
+            txn.write(&d0, "3".into(), (), 1).await;
+            let _apply = txn.commit_at(&mut txns, ts).await.unwrap();
+        }
+        txns.txns_cache.update_gt(&5).await;
+        txns.apply_le(&4).await;
+        let snap = txns.txns_cache.data_snapshot(&d0, 4).unwrap();
+        let mut data_read = reader(&client, d0).await;
+        // This shouldn't deadlock.
+        let contents = snap
+            .snapshot_and_fetch(&mut data_read, writer(&client, d0).await)
+            .await
+            .unwrap();
+        assert_eq!(contents.len(), 1);
+
+        // Sanity check that the scenario played out like we said above.
+        assert_eq!(snap.empty_to, 5);
     }
 }


### PR DESCRIPTION
A data shard in the txns set logically advances its upper each time a
txn is committed, but the upper is not physically advanced unless that
data shard was involved in the txn. This means that a shard_source (or
any read) pointed at a data shard would appear to stall at the time of
the most recent write. We fix this for shard_source by flowing its
output through a new `txns_progress` dataflow operator, which ensures
that the frontier/capability is advanced as the txns shard progresses,
as long as the shard_source is up to date with the latest committed
write to that data shard.

Example:

- A data shard has most recently been written to at 3.
- The txns shard's upper is at 6.
- We render a dataflow containing a shard_source with an as_of of 5.
- A txn NOT involving the data shard is committed at 7.
- A txn involving the data shard is committed at 9.

How it works:

- The shard_source operator is rendered. Its single output is hooked up
  as a _disconnected_ input to txns_progress. The txns_progress single
  output is a stream of the same type, which is used by downstream
  operators. This txns_progress operator is targeted at one data_shard;
  rendering a shard_source for a second data shard requires a second
  txns_progress operator.
- The shard_source operator emits data through 3 and advances the
  frontier.
- The txns_progress operator passes through these writes and frontier
  advancements unchanged. (Recall that it's always correct to read a
  data shard "normally", it just might stall.) Because the txns_progress
  operator knows there are no writes in `[3,5]`, it then downgrades its
  own capability past 5 (to 6). Because the input is disconnected, this
  means the overall frontier of the output is downgraded to 6.
- The txns_progress operator learns about the write at 7 (the upper is
  now 8). Because it knows that the data shard was not involved in this,
  it's free to downgrade its capability to 8.
- The txns_progress operator learns about the write at 9 (the upper is
  now 10). It knows that the data shard _WAS_ involved in this, so it
  forwards on data from its input until the input has progressed to 10,
  at which point it can itself downgrade to 10.

A wrinkle! Initially, I had framed snapshot persist reads (including the
beginning of a subscription like shard_source) as a "translation" of the
as_of. So in the example above, we'd "translate" the as_of of 5 to be
the most recent write before that point (3) and start from there.
Unfortunately, this has two issues. First, it's quite inconvenient to
run async/await operations in mz dataflow construction. Second, a
snapshot (ditto the snapshot part of a subscription) guarantees that all
data has been advanced to the as_of. The txns_progress operator could do
this, but we'd forever have to consider it when making persist changes
(e.g. does a future consolidated shard_source operator work when
combined with this), which IMO is a deal breaker.

Instead, we now wait for the data shard's upper to advance past the most
recent write before the as_of (via the normal apply process). Then, we
physically advance the upper past the as_of with an empty CaA. It's
quite counter-intuitive for reads to involve writes, but I think this is
fine. In particular, because writing empty updates to a persist shard is
a metadata-only operation (we'll need to document a new guarantee that a
CaA of empty updates never results in compaction work, but this seems
like a reasonable guarantee). It might result in things like GC
maintenance or a CRDB write, but this is also true for registering a
reader. On the balance, I think this is a _much_ better set of tradeoffs
than the original plan.

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

@jkosh44 and @aljoscha, I'd love for both of you to take a look here: Aljoscha you're probably more familiar with timely operators context and quirks and Joe you're probably more skilled up on persist-txn (and this changes how reads work a bit).

I expect that the "write to do a read" part of this might be controversial! Let's hope on a huddle if you have questions, I'm happy to brainstorm alternatives.

@bkirwi There's one persist commit in here for you to look at. Happy to pull it out into a separate PR if you like, but I figured you might want to see it in the motivating context. Also happy to walk you through ☝️ the "write to do a read" and in particular the newly added expectations for an empty CaA.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
