### PR TITLE
mz_ore::task: add named spawn wrapper for JoinSet

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -18,6 +18,30 @@ disallowed-methods = [
     { path = "tokio::runtime::Runtime::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
     { path = "tokio::runtime::Runtime::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
 
+    # Note these wrappers aren't implemented yet, as we haven't needed them.
+    { path = "tokio::task::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::LocalSet::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+
+    # Note that `spawn_blocking` and the local varieties are not yet implemented, as they haven't been needed yet.
+    { path = "tokio::task::JoinSet::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::JoinSet::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::JoinSet::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::JoinSet::spawn_blocking_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::JoinSet::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::JoinSet::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+
+    # These are banned because we want to ensure people don't forget to use .name(...), so we require the use of `mz_ore`
+    { path = "tokio::task::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::Builder::spawn_blocking", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::Builder::spawn_blocking_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::join_set::Builder::spawn", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::join_set::Builder::spawn_on", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+    { path = "tokio::task::join_set::Builder::spawn_local", reason = "use the spawn wrappers in `mz_ore::task` instead" },
+
     { path = "rdkafka::config::ClientConfig::new", reason = "use the `client::create_new_client_config` wrapper in `kafka_util` instead" },
 
     { path = "aws_sdk_s3::Client::new", reason = "use the `mz_aws_s3_util::new_client` function instead" },

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -130,5 +130,9 @@ metrics = ["prometheus"]
 name = "future"
 required-features = ["async"]
 
+[[test]]
+name = "task"
+required-features = ["async"]
+
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
as discussed here: https://materializeinc.slack.com/archives/CMH6PG4CW/p1696277204738669?thread_ts=1696270074.609599&cid=CMH6PG4CW

@def- I had to adjust some stuff to get `mz_ore` to accept a `cargo test` without needing to built the whole repo (just that crate). I am not sure a `test` feature is the right route here, but we can fix in the future

### Motivation

  * This PR adds a known-desirable feature.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
