### PR TITLE
ci: Disable the "Nightly-on-risky" mechanism until a cost/benefit ana…

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -760,6 +760,7 @@ steps:
 
   - id: nightly-if-risky
     label: Nightly for risky PRs
+    skip: "Temporary disabled until a cost/beneft analysis"
     depends_on: devel-docker-tags
     trigger: nightlies
     async: true


### PR DESCRIPTION
…lysis

### Motivation

The CI spend has grown considerably so we are disabling the "Nightly-on-risky" functionality until a cost/benefit analysis could be performed.

Note that in this context "risky" means a PR that it as risk of breaking the CI due to e.g. changes in the SQL syntax, rather than risky in terms of the stability of the product. Therefore, the benefits were mainly in preventing random breakages of main, therefore decreasing the CI maintenance workload. Finding regressions early would have been a secondary, side benefit.

The PRs that triggered Nightly were PRs that made changes to the list of files in the `inputs` section of the Buildkite step.