### PR TITLE
ci: Terminate Buildkite agents that have run a failed CI job

### DIFF
--- a/ci/plugins/cloudtest/hooks/pre-exit
+++ b/ci/plugins/cloudtest/hooks/pre-exit
@@ -13,5 +13,11 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -ne "0" ] || [ "$BUILDKITE_LAST_HOOK_EXIT_STATUS" -ne "0" ]; then
+   ci_unimportant_heading "Buildkite job failure reported, terminating the Buildkite agent in case it is tainted"
+   # Supposedly the 'official' way of terminating the buildkite agent
+   kill -s SIGTERM "$(/bin/pidof buildkite-agent)"
+fi
+
 ci_unimportant_heading "cloudtest: Resetting..."
 bin/ci-builder run stable test/cloudtest/reset

--- a/ci/plugins/mzcompose/hooks/pre-exit
+++ b/ci/plugins/mzcompose/hooks/pre-exit
@@ -13,6 +13,12 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
+if [ "$BUILDKITE_COMMAND_EXIT_STATUS" -ne "0" ] || [ "$BUILDKITE_LAST_HOOK_EXIT_STATUS" -ne "0" ]; then
+   ci_unimportant_heading "Buildkite job failure reported, terminating the Buildkite agent in case it is tainted"
+   # Supposedly the 'official' way of terminating the buildkite agent
+   kill -s SIGTERM "$(/bin/pidof buildkite-agent)"
+fi
+
 ci_unimportant_heading ":docker: Cleaning up after mzcompose"
 
 run() {


### PR DESCRIPTION
Consider a Buildkite agent where a CI job has failed to be tainted by incomplete cleanup and terminate it.

This prevents a single problematic agent from causing generalized CI redness because additional CI jobs keep being scheduled on it and fail.

### Motivation

We had a case last week and another this week where a single agent ran out of disk space and/or had a directory left behind, causing it to fail all other CI jobs assigned to it.