### PR TITLE
tls-util: Don't depend on workspace-hack

### DIFF
--- a/src/tls-util/Cargo.toml
+++ b/src/tls-util/Cargo.toml
@@ -15,7 +15,10 @@ thiserror = "1.0.37"
 tokio = { version = "1.32.0", default-features = false, features = ["fs", "macros", "sync", "rt", "rt-multi-thread"] }
 tokio-postgres = { version = "0.7.8" }
 tracing = "0.1.37"
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
+
+[features]
+default = ["workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
### Motivation

* This PR refactors existing code.

We want to use the `mz-tls-util` crate in our Cloud infra, but we don't want to pull in all of the dependencies implied by the `workspace-hack`.