### PR TITLE
persist: also wrap Blob in Tasked

### DIFF
--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -193,6 +193,7 @@ impl PersistClientCache {
                 })
                 .await;
                 let blob = Arc::new(MetricsBlob::new(blob, Arc::clone(&self.metrics)));
+                let blob = Arc::new(Tasked(blob));
                 let task = blob_rtt_latency_task(
                     Arc::clone(&blob),
                     Arc::clone(&self.metrics),
@@ -221,7 +222,7 @@ impl PersistClientCache {
 /// start.
 #[allow(clippy::unused_async)]
 async fn blob_rtt_latency_task(
-    blob: Arc<MetricsBlob>,
+    blob: Arc<Tasked<MetricsBlob>>,
     metrics: Arc<Metrics>,
     measurement_interval: Duration,
 ) -> JoinHandle<()> {
@@ -266,7 +267,7 @@ async fn consensus_rtt_latency_task(
     metrics: Arc<Metrics>,
     measurement_interval: Duration,
 ) -> JoinHandle<()> {
-    mz_ore::task::spawn(|| "persist::blob_rtt_latency", async move {
+    mz_ore::task::spawn(|| "persist::consensus_rtt_latency", async move {
         // Use the tokio Instant for next_measurement because the reclock tests
         // mess with the tokio sleep clock.
         let mut next_measurement = tokio::time::Instant::now();


### PR DESCRIPTION
- The overhead seems to be minimal.
- It would be nice for the blob graphs to also have real latencies.
- Who knows it might even help.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
