### PR TITLE
test: Speed up auth tests

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -136,7 +136,7 @@ pub mod util;
 const EXPIRES_IN_SECS: u64 = 20;
 // Always start the refresh 5 seconds after getting a new claim. This helps reduce test
 // flakes where the refresh takes too long and the claim expires, while also limiting the amount of
-// time we sit around doing nothing.
+// time we sit around doing nothing waiting for a refresh.
 const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS - 5;
 
 /// A certificate authority for use in tests.

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -810,8 +810,10 @@ fn test_auth_expiry() {
     let encoding_key =
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
 
-    const EXPIRES_IN_SECS: u64 = 40;
-    const REFRESH_BEFORE_SECS: u64 = 20;
+    const EXPIRES_IN_SECS: u64 = 20;
+    // Always start the refresh immediately after getting a new claim. This helps reduce test
+    // flakes where the refresh takes too long and the claim expires.
+    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1690,8 +1692,10 @@ fn test_auth_admin_non_superuser() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 40;
-    const REFRESH_BEFORE_SECS: u64 = 20;
+    const EXPIRES_IN_SECS: u64 = 20;
+    // Always start the refresh immediately after getting a new claim. This helps reduce test
+    // flakes where the refresh takes too long and the claim expires.
+    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1798,8 +1802,10 @@ fn test_auth_admin_superuser() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 40;
-    const REFRESH_BEFORE_SECS: u64 = 20;
+    const EXPIRES_IN_SECS: u64 = 20;
+    // Always start the refresh immediately after getting a new claim. This helps reduce test
+    // flakes where the refresh takes too long and the claim expires.
+    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1868,7 +1874,7 @@ fn test_auth_admin_superuser() {
 
 #[mz_ore::test]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_admin_show_is_superuser() {
+fn test_auth_admin_superuser_revoked() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1906,8 +1912,10 @@ fn test_auth_admin_show_is_superuser() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 40;
-    const REFRESH_BEFORE_SECS: u64 = 20;
+    const EXPIRES_IN_SECS: u64 = 20;
+    // Always start the refresh immediately after getting a new claim. This helps reduce test
+    // flakes where the refresh takes too long and the claim expires.
+    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -131,6 +131,14 @@ use uuid::Uuid;
 
 pub mod util;
 
+// How long, in seconds, a claim is valid for. Increasing this value will decrease some test flakes
+// without increasing test time.
+const EXPIRES_IN_SECS: u64 = 20;
+// Always start the refresh 5 seconds after getting a new claim. This helps reduce test
+// flakes where the refresh takes too long and the claim expires, while also limiting the amount of
+// time we sit around doing nothing.
+const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS - 5;
+
 /// A certificate authority for use in tests.
 pub struct Ca {
     dir: TempDir,
@@ -810,10 +818,6 @@ fn test_auth_expiry() {
     let encoding_key =
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    // Always start the refresh immediately after getting a new claim. This helps reduce test
-    // flakes where the refresh takes too long and the claim expires.
-    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1692,10 +1696,6 @@ fn test_auth_admin_non_superuser() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    // Always start the refresh immediately after getting a new claim. This helps reduce test
-    // flakes where the refresh takes too long and the claim expires.
-    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1802,10 +1802,6 @@ fn test_auth_admin_superuser() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    // Always start the refresh immediately after getting a new claim. This helps reduce test
-    // flakes where the refresh takes too long and the claim expires.
-    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (_role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,
@@ -1912,10 +1908,6 @@ fn test_auth_admin_superuser_revoked() {
         EncodingKey::from_rsa_pem(&ca.pkey.private_key_to_pem_pkcs8().unwrap()).unwrap();
     let now = SYSTEM_TIME.clone();
 
-    const EXPIRES_IN_SECS: u64 = 20;
-    // Always start the refresh immediately after getting a new claim. This helps reduce test
-    // flakes where the refresh takes too long and the claim expires.
-    const REFRESH_BEFORE_SECS: u64 = EXPIRES_IN_SECS;
     let (role_tx, role_rx) = tokio::sync::mpsc::unbounded_channel();
     let frontegg_server = start_mzcloud(
         encoding_key,


### PR DESCRIPTION
The auth tests sometimes flake due to an expired authentication.

The auth tests start a fake materialize server that responds to Frontegg requests with generated claims. The tests use a constant, EXPIRES_IN_SECS, that is passed into the fake test server, so that all claims are returned with an exp field set to the current time minus EXPIRES_IN_SECS. The exp field is The time at which the claims expire, represented in seconds since the Unix epoch. Essentially EXPIRES_IN_SECS represents how many seconds the claims are valid as of when they're created.

The tests also use a constant, REFRESH_BEFORE_SECS, that determines how many seconds before the claims expire to start refreshing the claims. Essentially, we attempt to refresh a token REFRESH_BEFORE_SECS seconds before it expires.

The test flake happens when the refresh takes long enough that by the time the refresh is complete the token has already expired. As a result, as long as REFRESH_BEFORE_SECS <= EXPIRES_IN_SECS, the flakiness is completely determined by REFRESH_BEFORE_SECS, since that is the amount of time we have to complete the refresh.

This commit lowers EXPIRES_IN_SECS from 40 to 20 (REFRESH_BEFORE_SECS is set to 20) to decrease the time we wait for a token refresh without affecting test flakiness. A better more robust fix would use deterministic clocks to avoid all flakes.

Works towards resolving #22145

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
