### PR TITLE
platform-checks: Fix the version for the ReplicaAnnotations check

### DIFF
--- a/misc/python/materialize/checks/replica.py
+++ b/misc/python/materialize/checks/replica.py
@@ -139,7 +139,7 @@ class DropReplica(Check):
 
 class ReplicaAnnotations(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.70.0-dev")
+        return self.base_version >= MzVersion.parse("0.71.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(


### PR DESCRIPTION
replica annotations are not supported on v0.70


### Motivation

Nightly CI was failing.