### PR TITLE
mzcompose: Allow tests to opt out of the mz_sanity_restart check

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -701,13 +701,13 @@ class Composition:
     def sanity_restart_mz(self) -> None:
         """Restart Materialized if it is part of the composition to find
         problems with persisted objects, functions as a sanity check."""
-        # Exclude environmentd image, which is used in cloud-canary, and doesn't start up fully without clusterd images
         if (
             "materialized" in self.compose["services"]
-            and "materialize/environmentd"
-            not in self.compose["services"]["materialized"]["image"]
+            and "sanity_restart" in self.compose["services"]["materialized"]["labels"]
         ):
-            ui.header("Sanity Check: Restart Mz, verify source/sink/replica health")
+            ui.header(
+                "Sanity Restart: Restart Mz and verify source/sink/replica health"
+            )
             self.kill("materialized")
             # TODO(def-): Better way to detect when kill has finished
             time.sleep(3)
@@ -724,6 +724,10 @@ class Composition:
                 # Sources and cluster replicas need a few seconds to start up
                 print(f"Retrying ({i+1}/{NUM_RETRIES})...")
                 time.sleep(1)
+        else:
+            ui.header(
+                "Sanity Restart skipped because Mz not in services or `sanity_restart` label not set"
+            )
 
     def down(
         self,

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -159,6 +159,9 @@ class ServiceConfig(TypedDict, total=False):
     restart: str
     """Restart policy."""
 
+    labels: list[str]
+    """Container labels."""
+
 
 class Service:
     """A Docker Compose service in a `Composition`.

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -48,6 +48,7 @@ class Materialized(Service):
         system_parameter_defaults: dict[str, str] | None = None,
         additional_system_parameter_defaults: dict[str, str] | None = None,
         soft_assertions: bool = True,
+        sanity_restart: bool = True,
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
@@ -163,6 +164,9 @@ class Materialized(Service):
         # memory limit is known.
         if memory:
             config["deploy"] = {"resources": {"limits": {"memory": memory}}}
+
+        if sanity_restart:
+            config.setdefault("labels", []).append("sanity_restart")
 
         volumes = []
         if use_default_volumes:

--- a/test/cloud-canary/mzcompose.py
+++ b/test/cloud-canary/mzcompose.py
@@ -54,6 +54,8 @@ SERVICES = [
             "--orchestrator-process-secrets-directory=/mzdata/secrets",
             "--orchestrator-process-scratch-directory=/scratch",
         ],
+        # We can not restart this container at will, as it does not have clusterd
+        sanity_restart=False,
     ),
     Testdrive(),  # Overriden below
     Mz(


### PR DESCRIPTION
Certain tests are not compatible with the mz_sanity_restart mechanism, so allow them to opt out by setting `sanity_restart=False` on their `Materialized()` service.

### Motivation

In additon to `test/cloud-canary`, another workflow came up where the sanity restart is not desirable, so a more general algorithm to disable it is needed.