### PR TITLE
mzcompose: Allow tests to opt out of the mz_sanity_restart check (Par…

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -703,6 +703,7 @@ class Composition:
         problems with persisted objects, functions as a sanity check."""
         if (
             "materialized" in self.compose["services"]
+            and "labels" in self.compose["services"]["materialized"]
             and "sanity_restart" in self.compose["services"]["materialized"]["labels"]
         ):
             ui.header(


### PR DESCRIPTION
…t #2)

Check that the labels key exists before attempting to probe it.

### Motivation

`sanity_check=False` caused a `KeyError` exception