### PR TITLE
mzcompose: Allow mz_sanity_restart to work with override()

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -390,6 +390,25 @@ class Composition:
             # Run the next composition.
             yield
         finally:
+            # If sanity_check existed in the overriden service, but
+            # override() disabled it by removing the label,
+            # keep the sanity check disabled
+            if (
+                "materialized" in old_compose["services"]
+                and "labels" in old_compose["services"]["materialized"]
+                and "sanity_restart"
+                in old_compose["services"]["materialized"]["labels"]
+            ):
+                if (
+                    "labels" not in self.compose["services"]["materialized"]
+                    or "sanity_restart"
+                    not in self.compose["services"]["materialized"]["labels"]
+                ):
+                    print("sanity_restart disabled by override(), keeping it disabled")
+                    old_compose["services"]["materialized"]["labels"].remove(
+                        "sanity_restart"
+                    )
+
             # Restore the old composition.
             self.compose = old_compose
             self._write_compose()


### PR DESCRIPTION
If we are disabling the sanity check in override(), this directive needs to be persisted after the end of the override() so that mz_sanity_restart() is not called at the end of the test.

### Motivation

Previously, if override() disabled the sanity check, it would still run at the end of the test because the effects of override() were rolled back at the end of the override() block. Instead, the removal of the `sanity_restart` label should persist after the end of the override all the way to the end of the test.