### PR TITLE
ci: Reduce runtime in my nightlies

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -696,7 +696,7 @@ steps:
   - id: sqlsmith
     label: "SQLsmith"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       # A larger instance is needed since SQLsmith likes creating
       # large queries and going out of memory
@@ -704,62 +704,62 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=1, --runtime=3000]
+          args: [--max-joins=1, --runtime=1500]
 
   - id: sqlsmith-explain
     label: "SQLsmith explain"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith
-          args: [--max-joins=15, --explain-only, --runtime=3000]
+          args: [--max-joins=15, --explain-only, --runtime=1500]
 
   - id: sqlancer-pqs
     label: "SQLancer PQS"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3000, --oracle=PQS, --no-qpg]
+          args: [--runtime=1500, --oracle=PQS, --no-qpg]
 
   - id: sqlancer-norec
     label: "SQLancer NoREC"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3000, --oracle=NOREC]
+          args: [--runtime=1500, --oracle=NOREC]
 
   - id: sqlancer-query-partitioning
     label: "SQLancer QueryPartitioning"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3000, --oracle=QUERY_PARTITIONING]
+          args: [--runtime=1500, --oracle=QUERY_PARTITIONING]
 
   - id: sqlancer-having
     label: "SQLancer Having"
     artifact_paths: junit_*.xml
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlancer
-          args: [--runtime=3000, --oracle=HAVING]
+          args: [--runtime=1500, --oracle=HAVING]
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"
@@ -792,59 +792,59 @@ steps:
   - id: parallel-workload-dml
     label: "Parallel Workload (DML)"
     artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
-          args: [--runtime=3000, --complexity=dml, --threads=8]
+          args: [--runtime=1500, --complexity=dml, --threads=8]
 
   - id: parallel-workload
     label: "Parallel Workload"
     artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
-          args: [--runtime=3000]
+          args: [--runtime=1500]
 
   # TODO: Reenable when #21954 is fixed
   #- id: parallel-workload-100-threads
   #  label: "Parallel Workload (100 threads)"
   #  artifact_paths: [junit_*.xml, pw-*.log]
-  #  timeout_in_minutes: 60
+  #  timeout_in_minutes: 30
   #  agents:
   #    queue: builder-linux-x86_64
   #  plugins:
   #    - ./ci/plugins/mzcompose:
   #        composition: parallel-workload
-  #        args: [--runtime=3000, --threads=100]
+  #        args: [--runtime=1500, --threads=100]
 
   - id: parallel-workload-cancel
     label: "Parallel Workload (cancel)"
     artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 60
+    timeout_in_minutes: 30
     agents:
       queue: builder-linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: parallel-workload
-          args: [--runtime=3000, --scenario=cancel]
+          args: [--runtime=1500, --scenario=cancel]
 
   # TODO(def-) Enable after figuring out restoring catalog
   #- id: parallel-workload-kill
   #  label: "Parallel Workload (kill)"
   #  artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-  #  timeout_in_minutes: 60
+  #  timeout_in_minutes: 30
   #  agents:
   #    queue: builder-linux-x86_64
   #  plugins:
   #    - ./ci/plugins/mzcompose:
   #        composition: parallel-workload
-  #        args: [--runtime=3000, --scenario=kill]
+  #        args: [--runtime=1500, --scenario=kill]
 
   - id: incident-72-remediation
     label: "Remediation of incident 72"


### PR DESCRIPTION

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
