### PR TITLE
deps: Remove default features from `build-id`, `postgres-util`

### DIFF
--- a/src/build-id/Cargo.toml
+++ b/src/build-id/Cargo.toml
@@ -14,8 +14,8 @@ repository = "https://github.com/MaterializeInc/materialize"
 [dependencies]
 anyhow = "1.0.66"
 libc = "0.2.138"
-mz-ore = { path = "../ore", features = ["async"] }
-workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
+mz-ore = { path = "../ore", features = ["async"], default-features = false }
+workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
 [package.metadata.cargo-udeps.ignore]
 # "anyhow" and "mz-ore" only used on linux

--- a/src/postgres-util/Cargo.toml
+++ b/src/postgres-util/Cargo.toml
@@ -13,7 +13,7 @@ mz-ore = { path = "../ore", features = ["async"], optional = true }
 mz-proto = { path = "../proto", optional = true }
 mz-repr = { path = "../repr", optional = true }
 mz-ssh-util = { path = "../ssh-util", optional = true }
-mz-tls-util = { path = "../tls-util"}
+mz-tls-util = { path = "../tls-util", default-features = false }
 openssl = { version = "0.10.48", features = ["vendored"] }
 openssh = { version = "0.9.8", default-features = false, features = [
     "native-mux",


### PR DESCRIPTION
### Motivation

* This PR refactors existing code.

  We want to use `mz-tls-util` in our Cloud infra, and don't want to pull in all the `workspace-hack` dependencies with it.