### PR TITLE
storage: use health_operator to report sink status, not just source status

### DIFF
--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -159,6 +159,7 @@ impl<'a, O: Clone> HealthState<'a, O> {
 /// - `Debug`-printable.
 /// - `Ord`, where the order increases in severity. The state returned by `starting()` should
 /// be the minimum.
+// TODO(guswynn): the implementors of this trait are probably merge-able.
 pub(crate) trait HealthStatus: timely::ExchangeData + Debug + Ord {
     /// The user-readable name of the status state.
     fn name(&self) -> &'static str;

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -9,15 +9,34 @@
 
 //! Healthcheck common
 
+use std::any::Any;
+use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use differential_dataflow::lattice::Lattice;
+use differential_dataflow::Hashable;
+use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
+use mz_persist_client::PersistLocation;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{GlobalId, RelationDesc, Timestamp};
+use mz_storage_client::healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC;
+use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sources::SourceData;
+use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::operators::{Enter, Map};
+use timely::dataflow::scopes::Child;
+use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
+use tracing::{info, trace, warn};
+
+use crate::internal_control::InternalStorageCommand;
+use crate::render::sources::OutputIndex;
+use crate::source::types::{HealthStatus, HealthStatusUpdate};
 
 pub async fn write_to_persist(
     collection_id: GlobalId,
@@ -84,4 +103,270 @@ pub async fn write_to_persist(
     }
 
     handle.expire().await
+}
+
+/// How long to wait before initiating a `SuspendAndRestart` command, to
+/// prevent hot restart loops.
+const SUSPEND_AND_RESTART_DELAY: Duration = Duration::from_secs(30);
+
+
+struct HealthState<'a> {
+    source_id: GlobalId,
+    persist_details: Option<(ShardId, &'a PersistClient)>,
+    healths: Vec<Option<HealthStatus>>,
+    last_reported_status: Option<HealthStatus>,
+    halt_with: Option<HealthStatus>,
+}
+
+impl<'a> HealthState<'a> {
+    fn new(
+        source_id: GlobalId,
+        metadata: CollectionMetadata,
+        persist_clients: &'a BTreeMap<PersistLocation, PersistClient>,
+        worker_count: usize,
+    ) -> HealthState<'a> {
+        let persist_details = match (
+            metadata.status_shard,
+            persist_clients.get(&metadata.persist_location),
+        ) {
+            (Some(shard), Some(persist_client)) => Some((shard, persist_client)),
+            _ => None,
+        };
+
+        HealthState {
+            source_id,
+            persist_details,
+            healths: vec![None; worker_count],
+            last_reported_status: None,
+            halt_with: None,
+        }
+    }
+}
+
+/// Writes updates that come across `health_stream` to the collection's status shards, as identified
+/// by their `CollectionMetadata`.
+///
+/// Only one worker will be active and write to the status shard.
+///
+/// The `OutputIndex` values that come across `health_stream` must be a strict subset of those in
+/// `configs`'s keys.
+pub(crate) fn health_operator<'g, G: Scope<Timestamp = ()>>(
+    scope: &mut Child<'g, G, mz_repr::Timestamp>,
+    storage_state: &crate::storage_state::StorageState,
+    resume_uppers: BTreeMap<GlobalId, Antichain<mz_repr::Timestamp>>,
+    primary_source_id: GlobalId,
+    health_stream: &Stream<G, (OutputIndex, HealthStatusUpdate)>,
+    configs: BTreeMap<OutputIndex, (GlobalId, CollectionMetadata)>,
+) -> Rc<dyn Any> {
+    // Derived config options
+    let healthcheck_worker_id = scope.index();
+    let worker_count = scope.peers();
+    let now = storage_state.now.clone();
+    let persist_clients = Arc::clone(&storage_state.persist_clients);
+    let internal_cmd_tx = Rc::clone(&storage_state.internal_cmd_tx);
+
+    // Inject the originating worker id to each item before exchanging to the chosen worker
+    let health_stream = health_stream.map(move |status| (healthcheck_worker_id, status));
+
+    // We'll route all the work to a single arbitrary worker;
+    // there's not much to do, and we need a global view.
+    let chosen_worker_id = usize::cast_from(configs.keys().next().hashed()) % worker_count;
+    let is_active_worker = chosen_worker_id == healthcheck_worker_id;
+
+    let operator_name = format!("healthcheck({})", healthcheck_worker_id);
+    let mut health_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
+
+    let health = health_stream.enter(&scope);
+
+    let mut input = health_op.new_input(
+        &health,
+        Exchange::new(move |_| u64::cast_from(chosen_worker_id)),
+    );
+
+    // Construct a minimal number of persist clients
+    let persist_locations: BTreeSet<_> = configs
+        .values()
+        .filter_map(|(source_id, metadata)| {
+            if is_active_worker {
+                match &metadata.status_shard {
+                    Some(status_shard) => {
+                        info!("Health for source {source_id} being written to {status_shard}");
+                        Some(metadata.persist_location.clone())
+                    }
+                    None => {
+                        trace!("Health for source {source_id} not being written to status shard");
+                        None
+                    }
+                }
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    let button = health_op.build(move |mut _capabilities| async move {
+        // Convert the persist locations into persist clients
+        let mut persist_clients_per_location = BTreeMap::new();
+        for persist_location in persist_locations {
+            persist_clients_per_location.insert(
+                persist_location.clone(),
+                persist_clients
+                    .open(persist_location)
+                    .await
+                    .expect("error creating persist client for Healthchecker"),
+            );
+        }
+
+        let mut health_states: BTreeMap<_, _> = configs
+            .into_iter()
+            .map(|(output_idx, (id, metadata))| {
+                (
+                    output_idx,
+                    HealthState::new(id, metadata, &persist_clients_per_location, worker_count),
+                )
+            })
+            .collect();
+
+        // Write the initial starting state to the status shard for all managed sources
+        if is_active_worker {
+            for state in health_states.values() {
+                if !resume_uppers[&state.source_id].is_empty() {
+                    if let Some((status_shard, persist_client)) = state.persist_details {
+                        let status = HealthStatus::Starting;
+                        write_to_persist(
+                            state.source_id,
+                            status.name(),
+                            status.error(),
+                            now.clone(),
+                            persist_client,
+                            status_shard,
+                            &*MZ_SOURCE_STATUS_HISTORY_DESC,
+                            status.hint(),
+                        )
+                        .await;
+                    }
+                }
+            }
+        }
+
+        let mut outputs_seen = BTreeSet::new();
+        while let Some(event) = input.next_mut().await {
+            if let AsyncEvent::Data(_cap, rows) = event {
+                for (worker_id, (output_index, health_event)) in rows.drain(..) {
+                    let HealthState {
+                        source_id,
+                        healths,
+                        halt_with,
+                        ..
+                    } = match health_states.get_mut(&output_index) {
+                        Some(health) => health,
+                        // This is a health status update for a subsource that we did not request to
+                        // be generated, which means it doesn't have a GlobalId and should not be
+                        // propagated to the shard.
+                        None => continue,
+                    };
+
+                    let new_round = outputs_seen.insert(output_index);
+
+                    if !is_active_worker {
+                        warn!(
+                            "Health messages for source {source_id} passed to \
+                              an unexpected worker id: {healthcheck_worker_id}"
+                        )
+                    }
+
+                    let HealthStatusUpdate {
+                        update,
+                        should_halt,
+                    } = health_event;
+
+                    if should_halt {
+                        *halt_with = Some(update.clone());
+                    }
+
+                    let update = Some(update);
+                    // Keep the max of the messages in each round; this ensures that errors don't
+                    // get lost while also letting us frequently update to the newest status.
+                    if new_round || &healths[worker_id] < &update {
+                        healths[worker_id] = update;
+                    }
+                }
+
+                let mut halt_with_outer = None;
+
+                while let Some(output_index) = outputs_seen.pop_first() {
+                    let HealthState {
+                        source_id,
+                        healths,
+                        persist_details,
+                        last_reported_status,
+                        halt_with,
+                    } = health_states
+                        .get_mut(&output_index)
+                        .expect("known to exist");
+
+                    let overall_status = healths.iter().filter_map(Option::as_ref).max();
+
+                    if let Some(new_status) = overall_status {
+                        if last_reported_status.as_ref() != Some(&new_status) {
+                            info!(
+                                "Health transition for source {source_id}: \
+                                  {last_reported_status:?} -> {new_status:?}"
+                            );
+                            if let Some((status_shard, persist_client)) = persist_details {
+                                write_to_persist(
+                                    *source_id,
+                                    new_status.name(),
+                                    new_status.error(),
+                                    now.clone(),
+                                    persist_client,
+                                    *status_shard,
+                                    &*MZ_SOURCE_STATUS_HISTORY_DESC,
+                                    new_status.hint(),
+                                )
+                                .await;
+                            }
+
+                            *last_reported_status = Some(new_status.clone());
+                        }
+                    }
+
+                    // Set halt with if None.
+                    if halt_with_outer.is_none() && halt_with.is_some() {
+                        halt_with_outer = Some((*source_id, halt_with.clone()));
+                    }
+                }
+
+                // TODO(aljoscha): Instead of threading through the
+                // `should_halt` bit, we can give an internal command sender
+                // directly to the places where `should_halt = true` originates.
+                // We should definitely do that, but this is okay for a PoC.
+                if let Some((id, halt_with)) = halt_with_outer {
+                    mz_ore::soft_assert!(
+                        id == primary_source_id,
+                        "subsources should not produce halting errors, however {:?} halted while primary \
+                                            source is {:?}",
+                        id,
+                        primary_source_id
+                    );
+
+                    info!(
+                        "Broadcasting suspend-and-restart command because of {:?} after {:?} delay",
+                        halt_with, SUSPEND_AND_RESTART_DELAY
+                    );
+                    tokio::time::sleep(SUSPEND_AND_RESTART_DELAY).await;
+                    internal_cmd_tx.borrow_mut().broadcast(
+                        InternalStorageCommand::SuspendAndRestart {
+                            // Suspend and restart is expected to operate on the primary source and
+                            // not any of the subsources.
+                            id,
+                            reason: format!("{:?}", halt_with),
+                        },
+                    );
+                }
+            }
+        }
+    });
+
+    Rc::new(button.press_on_drop())
 }

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -88,7 +88,7 @@ pub mod source;
 pub mod statistics;
 pub mod storage_state;
 
-mod healthcheck;
+pub(crate) mod healthcheck;
 
 pub use decode::metrics::DecodeMetrics;
 pub use server::{serve, Config, Server};

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -315,7 +315,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 .connect_loop(feedback_handle);
 
             let health_stream = root_scope.concatenate(health_streams);
-            let health_token = crate::source::health_operator(
+            let health_token = crate::healthcheck::health_operator(
                 into_time_scope,
                 storage_state,
                 resume_uppers,

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -307,7 +307,16 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     (0, halt_status)
                 });
                 health_streams.push(sink_health.leave());
-                health_configs.insert(export.output_index, (export_id, export.storage_metadata));
+                use mz_storage_client::healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC;
+                health_configs.insert(
+                    export.output_index,
+                    crate::healthcheck::ObjectHealthConfig {
+                        id: export_id,
+                        schema: &*MZ_SOURCE_STATUS_HISTORY_DESC,
+                        status_shard: export.storage_metadata.status_shard,
+                        persist_location: export.storage_metadata.persist_location.clone(),
+                    },
+                );
             }
 
             into_time_scope
@@ -318,8 +327,16 @@ pub fn build_ingestion_dataflow<A: Allocate>(
             let health_token = crate::healthcheck::health_operator(
                 into_time_scope,
                 storage_state,
-                resume_uppers,
+                resume_uppers
+                    .iter()
+                    .filter_map(|(id, frontier)| {
+                        // If the collection isn't closed, then we will remark it as Starting as
+                        // the dataflow comes up.
+                        (!frontier.is_empty()).then_some(*id)
+                    })
+                    .collect(),
                 primary_source_id,
+                "source",
                 &health_stream,
                 health_configs,
             );

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -197,7 +197,7 @@
 //!
 //! Not yet documented
 
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::rc::Rc;
 
 use mz_ore::error::ErrorExt;
@@ -359,27 +359,57 @@ pub fn build_export_dataflow<A: Allocate>(
     let worker_logging = timely_worker.log_register().get("timely");
     let debug_name = id.to_string();
     let name = format!("Source dataflow: {debug_name}");
-    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, scope| {
+    timely_worker.dataflow_core(&name, worker_logging, Box::new(()), |_, root_scope| {
         // The scope.clone() occurs to allow import in the region.
         // We build a region here to establish a pattern of a scope inside the dataflow,
         // so that other similar uses (e.g. with iterative scopes) do not require weird
         // alternate type signatures.
-        scope.clone().region_named(&name, |region| {
+        root_scope.clone().scoped(&name, |scope| {
             let _debug_name = format!("{debug_name}-sinks");
             let _: &mut timely::dataflow::scopes::Child<
                 timely::dataflow::scopes::Child<TimelyWorker<A>, _>,
                 mz_repr::Timestamp,
-            > = region;
-            let mut tokens = BTreeMap::new();
-            let import_ids = BTreeSet::new();
-            crate::render::sinks::render_sink(
-                region,
+            > = scope;
+            let mut tokens = Vec::new();
+            let health_stream = crate::render::sinks::render_sink(
+                scope,
                 storage_state,
                 &mut tokens,
-                import_ids,
                 id,
                 &description,
             );
+
+            use mz_storage_client::healthcheck::MZ_SINK_STATUS_HISTORY_DESC;
+            let mut health_configs = BTreeMap::new();
+            health_configs.insert(
+                // There is only 1 sink (as opposed to many sub-sources), so we just use a single
+                // index.
+                0,
+                crate::healthcheck::ObjectHealthConfig {
+                    id,
+                    schema: &*MZ_SINK_STATUS_HISTORY_DESC,
+                    status_shard: description.status_id,
+                    persist_location: description.from_storage_metadata.persist_location.clone(),
+                },
+            );
+
+            // Note that sinks also have only 1 active worker, which simplifies the work that
+            // `health_operator` has to do internally.
+            let health_token = crate::healthcheck::health_operator(
+                scope,
+                storage_state,
+                [id].into_iter().collect(),
+                id,
+                "sink",
+                &health_stream,
+                health_configs,
+            );
+            tokens.push(health_token);
+
+            use crate::storage_state::SinkToken;
+            storage_state
+                .sink_tokens
+                .insert(id, SinkToken::new(Box::new(tokens)));
         })
     });
 }

--- a/src/storage/src/sink/healthcheck.rs
+++ b/src/storage/src/sink/healthcheck.rs
@@ -9,93 +9,10 @@
 
 //! Healthchecks for sinks
 use std::fmt::Display;
-use std::sync::Arc;
-
-use anyhow::Context;
-use mz_ore::now::NowFn;
-use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::{PersistClient, PersistLocation, ShardId};
-use mz_repr::GlobalId;
-use mz_storage_client::healthcheck::MZ_SINK_STATUS_HISTORY_DESC;
-use tracing::trace;
-
-use crate::healthcheck::write_to_persist;
-
-/// The Healthchecker is responsible for tracking the current state
-/// of a Timely worker for a source, as well as updating the relevant
-/// state collection based on it.
-#[derive(Debug)]
-pub struct Healthchecker {
-    /// Internal ID of the source (e.g. s1)
-    sink_id: GlobalId,
-    /// Current status of this source
-    current_status: Option<SinkStatus>,
-    /// PersistClient of the Healthchecker persist location
-    persist_client: PersistClient,
-    /// Status shard for the healthchecker
-    status_shard: ShardId,
-    /// The function that should be used to get the current time when updating upper
-    now: NowFn,
-}
-
-impl Healthchecker {
-    /// Create healthchecker for sink, recorded on `status_shard_id` at `persist_location`.
-    ///
-    /// This function initializes the Healthchecker in the `SinkStatus::Setup` state without writing to persistent
-    /// storage.
-    pub async fn new(
-        sink_id: GlobalId,
-        persist_clients: &Arc<PersistClientCache>,
-        persist_location: PersistLocation,
-        status_shard: ShardId,
-        now: NowFn,
-    ) -> anyhow::Result<Self> {
-        trace!("Initializing healthchecker for sink {sink_id}");
-        let persist_client = persist_clients
-            .open(persist_location)
-            .await
-            .context("error creating persist client for Healthchecker")?;
-
-        Ok(Self {
-            sink_id,
-            current_status: None,
-            persist_client,
-            status_shard,
-            now,
-        })
-    }
-
-    /// Process a [`SinkStatus`] emitted by a sink
-    pub async fn update_status(&mut self, status_update: SinkStatus) {
-        trace!(
-            "Processing status update: {status_update:?}, current status is {current_status:?}",
-            current_status = &self.current_status
-        );
-
-        // Only update status if it is a valid transition
-        if SinkStatus::can_transition(self.current_status.as_ref(), &status_update) {
-            write_to_persist(
-                self.sink_id,
-                status_update.name(),
-                status_update.error(),
-                self.now.clone(),
-                &self.persist_client,
-                self.status_shard,
-                &*MZ_SINK_STATUS_HISTORY_DESC,
-                status_update.hint(),
-            )
-            .await;
-
-            self.current_status = Some(status_update);
-        }
-    }
-}
 
 /// Identify the state a worker for a given source can be at a point in time
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize, PartialOrd, Ord)]
 pub enum SinkStatus {
-    /// Initial state of a Sink during initialization.
-    Setup,
     /// Intended to be the state while the `clusterd` process is initializing itself
     /// Pushed by the Healthchecker on creation.
     Starting,
@@ -111,64 +28,62 @@ pub enum SinkStatus {
         /// the `mz_sink_status_history` table.
         hint: Option<String>,
     },
-    /// Represents a irrecoverable failure in the pipeline. Data from this collection
-    /// is not queryable any longer. The only valid transition from Failed is Dropped.
-    Failed {
-        /// Error string used to populate the `error` column in the `mz_sink_status_history` table.
-        error: String,
-        /// Optional hint string which if present, will be added to the `details` column in
-        /// the `mz_sink_status_history` table.
-        hint: Option<String>,
-    },
-    /// Represents a sink that was dropped.
-    Dropped,
+    // Managed by the storage controller.
+    // Dropped,
+}
+
+impl crate::healthcheck::HealthStatus for SinkStatus {
+    fn name(&self) -> &'static str {
+        self.name()
+    }
+    fn error(&self) -> Option<&str> {
+        self.error()
+    }
+    fn hint(&self) -> Option<&str> {
+        self.hint()
+    }
+    fn should_halt(&self) -> bool {
+        matches!(self, Self::Stalled { .. })
+    }
+    fn can_transition_from(&self, other: Option<&Self>) -> bool {
+        Self::can_transition(other, self)
+    }
+    fn starting() -> Self {
+        Self::Starting
+    }
 }
 
 impl SinkStatus {
     fn name(&self) -> &'static str {
         match self {
-            SinkStatus::Setup => "setup",
             SinkStatus::Starting => "starting",
             SinkStatus::Running => "running",
             SinkStatus::Stalled { .. } => "stalled",
-            SinkStatus::Failed { .. } => "failed",
-            SinkStatus::Dropped => "dropped",
         }
     }
 
     fn error(&self) -> Option<&str> {
         match self {
             SinkStatus::Stalled { error, .. } => Some(&*error),
-            SinkStatus::Failed { error, .. } => Some(&*error),
-            SinkStatus::Setup => None,
             SinkStatus::Starting => None,
             SinkStatus::Running => None,
-            SinkStatus::Dropped => None,
         }
     }
 
     fn hint(&self) -> Option<&str> {
         match self {
             SinkStatus::Stalled { error: _, hint } => hint.as_deref(),
-            SinkStatus::Failed { error: _, hint } => hint.as_deref(),
-            SinkStatus::Setup => None,
             SinkStatus::Starting => None,
             SinkStatus::Running => None,
-            SinkStatus::Dropped => None,
         }
     }
 
     fn can_transition(old_status: Option<&SinkStatus>, new_status: &SinkStatus) -> bool {
         match old_status {
             None => true,
-            // Failed can only transition to Dropped
-            Some(SinkStatus::Failed { .. }) => matches!(new_status, SinkStatus::Dropped),
-            // Dropped is a terminal state
-            Some(SinkStatus::Dropped) => false,
             // All other states can transition freely to any other state
             Some(
-                old @ SinkStatus::Setup
-                | old @ SinkStatus::Starting
+                old @ SinkStatus::Starting
                 | old @ SinkStatus::Running
                 | old @ SinkStatus::Stalled { .. },
             ) => old != new_status,
@@ -184,33 +99,7 @@ impl Display for SinkStatus {
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use itertools::Itertools;
-    use mz_build_info::DUMMY_BUILD_INFO;
-    use mz_ore::collections::CollectionExt;
-    use mz_ore::metrics::MetricsRegistry;
-    use mz_ore::now::SYSTEM_TIME;
-    use mz_persist_client::cfg::PersistConfig;
-    use mz_persist_client::rpc::PubSubClientConnection;
-    use mz_persist_client::{Diagnostics, PersistLocation, ShardId};
-    use mz_persist_types::codec_impls::UnitSchema;
-    use mz_repr::Row;
-    use mz_storage_types::sources::SourceData;
-    use once_cell::sync::Lazy;
-    use timely::progress::Antichain;
-
     use super::*;
-
-    // Test suite
-    #[mz_ore::test(tokio::test(start_paused = true))]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn test_startup() {
-        let persist_cache = persist_cache();
-        let healthchecker = simple_healthchecker(ShardId::new(), 1, &persist_cache).await;
-
-        assert_eq!(healthchecker.current_status, None);
-    }
 
     fn stalled() -> SinkStatus {
         SinkStatus::Stalled {
@@ -219,200 +108,31 @@ mod tests {
         }
     }
 
-    fn failed() -> SinkStatus {
-        SinkStatus::Failed {
-            error: "".into(),
-            hint: None,
-        }
-    }
-
-    #[mz_ore::test(tokio::test(start_paused = true))]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn test_bootstrap_different_sources() {
-        let shard_id = ShardId::new();
-        let persist_cache = persist_cache();
-
-        // First healthchecker is for source u1
-        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
-
-        tokio::time::advance(Duration::from_millis(1)).await;
-
-        // Update status to Running
-        healthchecker.update_status(SinkStatus::Running).await;
-
-        // Start new healthchecker on the same shard for source u2
-        let healthchecker = simple_healthchecker(shard_id, 2, &persist_cache).await;
-
-        // It should ignore the state for source u1, and be at the Setup state
-        assert_eq!(healthchecker.current_status, None);
-    }
-
-    #[mz_ore::test(tokio::test(start_paused = true))]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn test_repeated_update() {
-        let shard_id = ShardId::new();
-        let persist_cache = persist_cache();
-        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
-        tokio::time::advance(Duration::from_millis(1)).await;
-
-        // Update status to Running
-        healthchecker.update_status(SinkStatus::Running).await;
-
-        // Now update status to Running multiple times, which is a no-op
-        tokio::time::advance(Duration::from_millis(1)).await;
-        healthchecker.update_status(SinkStatus::Running).await;
-        tokio::time::advance(Duration::from_millis(1)).await;
-        healthchecker.update_status(SinkStatus::Running).await;
-
-        // Check in the storage collection that there is just a single row
-        assert_eq!(
-            dump_storage_collection(shard_id, &persist_cache)
-                .await
-                .len(),
-            1
-        );
-
-        // Create another healthchecker with a different id, and also set it to Running
-        let mut healthchecker = simple_healthchecker(shard_id, 2, &persist_cache).await;
-        // Advance past the previous update, since each healthchecker has its own notion of time
-        tokio::time::advance(Duration::from_millis(2)).await;
-        healthchecker.update_status(SinkStatus::Running).await;
-
-        // Now we should have two rows in the storage collection, one for each source_id
-        assert_eq!(
-            dump_storage_collection(shard_id, &persist_cache)
-                .await
-                .len(),
-            2
-        );
-    }
-
-    #[mz_ore::test(tokio::test(start_paused = true))]
-    #[cfg_attr(miri, ignore)] //  unsupported operation: returning ready events from epoll_wait is not yet implemented
-    async fn test_forbidden_transition() {
-        let shard_id = ShardId::new();
-        let persist_cache = persist_cache();
-        let mut healthchecker = simple_healthchecker(shard_id, 1, &persist_cache).await;
-        tokio::time::advance(Duration::from_millis(1)).await;
-
-        // Update status to Running
-        healthchecker.update_status(SinkStatus::Running).await;
-
-        // Now update status to Failed
-        tokio::time::advance(Duration::from_millis(1)).await;
-        let error = String::from("some error here");
-        let hint = String::from("more explanation");
-        healthchecker
-            .update_status(SinkStatus::Failed {
-                error: error.clone(),
-                hint: Some(hint.clone()),
-            })
-            .await;
-        assert_eq!(
-            healthchecker.current_status,
-            Some(SinkStatus::Failed {
-                error: error.clone(),
-                hint: Some(hint.clone()),
-            })
-        );
-
-        // Validate that we can't transition back to Running
-        tokio::time::advance(Duration::from_millis(1)).await;
-        healthchecker.update_status(SinkStatus::Running).await;
-        assert_eq!(
-            healthchecker.current_status,
-            Some(SinkStatus::Failed {
-                error,
-                hint: Some(hint.clone())
-            })
-        );
-
-        // Check that the error message and the hint are persisted
-        let (error_message, hint_message) = dump_storage_collection(shard_id, &persist_cache)
-            .await
-            .into_iter()
-            .find_map(|row| {
-                let cols = row.unpack();
-                let error = cols[3];
-                let details = cols[4];
-                if !error.is_null() && !details.is_null() {
-                    let hint = details.unwrap_map().iter().into_first().1;
-                    Some((
-                        error.unwrap_str().to_string(),
-                        hint.unwrap_str().to_string(),
-                    ))
-                } else {
-                    None
-                }
-            })
-            .unwrap();
-        assert_eq!(error_message, "some error here");
-        assert_eq!(hint_message, "more explanation");
-    }
-
     #[mz_ore::test]
     fn test_can_transition() {
         let test_cases = [
             // Allowed transitions
             (
-                Some(SinkStatus::Setup),
-                vec![
-                    SinkStatus::Starting,
-                    SinkStatus::Running,
-                    stalled(),
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
-                true,
-            ),
-            (
                 Some(SinkStatus::Starting),
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Running,
-                    stalled(),
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
+                vec![SinkStatus::Running, stalled()],
                 true,
             ),
             (
                 Some(SinkStatus::Running),
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Starting,
-                    stalled(),
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
+                vec![SinkStatus::Starting, stalled()],
                 true,
             ),
             (
                 Some(stalled()),
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Starting,
-                    SinkStatus::Running,
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
+                vec![SinkStatus::Starting, SinkStatus::Running],
                 true,
             ),
-            (Some(failed()), vec![SinkStatus::Dropped], true),
             (
                 None,
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Starting,
-                    SinkStatus::Running,
-                    stalled(),
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
+                vec![SinkStatus::Starting, SinkStatus::Running, stalled()],
                 true,
             ),
             // Forbidden transitions
-            (Some(SinkStatus::Setup), vec![SinkStatus::Setup], false),
             (
                 Some(SinkStatus::Starting),
                 vec![SinkStatus::Starting],
@@ -420,29 +140,6 @@ mod tests {
             ),
             (Some(SinkStatus::Running), vec![SinkStatus::Running], false),
             (Some(stalled()), vec![stalled()], false),
-            (
-                Some(failed()),
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Starting,
-                    SinkStatus::Running,
-                    stalled(),
-                    failed(),
-                ],
-                false,
-            ),
-            (
-                Some(SinkStatus::Dropped),
-                vec![
-                    SinkStatus::Setup,
-                    SinkStatus::Starting,
-                    SinkStatus::Running,
-                    stalled(),
-                    failed(),
-                    SinkStatus::Dropped,
-                ],
-                false,
-            ),
         ];
 
         for test_case in test_cases {
@@ -459,88 +156,5 @@ mod tests {
                 );
             }
         }
-    }
-
-    // Auxiliary functions
-    fn persist_cache() -> Arc<PersistClientCache> {
-        Arc::new(PersistClientCache::new(
-            PersistConfig::new(&DUMMY_BUILD_INFO, SYSTEM_TIME.clone()),
-            &MetricsRegistry::new(),
-            |_, _| PubSubClientConnection::noop(),
-        ))
-    }
-
-    static PERSIST_LOCATION: Lazy<PersistLocation> = Lazy::new(|| PersistLocation {
-        blob_uri: "mem://".to_owned(),
-        consensus_uri: "mem://".to_owned(),
-    });
-
-    async fn new_healthchecker(
-        status_shard_id: ShardId,
-        source_id: GlobalId,
-        persist_clients: &Arc<PersistClientCache>,
-    ) -> Healthchecker {
-        let start = tokio::time::Instant::now();
-        let now_fn = NowFn::from(move || u64::try_from(start.elapsed().as_millis()).unwrap());
-
-        Healthchecker::new(
-            source_id,
-            persist_clients,
-            (*PERSIST_LOCATION).clone(),
-            status_shard_id,
-            now_fn,
-        )
-        .await
-        .expect("error creating healthchecker")
-    }
-
-    async fn simple_healthchecker(
-        status_shard_id: ShardId,
-        source_id: u64,
-        persist_clients: &Arc<PersistClientCache>,
-    ) -> Healthchecker {
-        new_healthchecker(
-            status_shard_id,
-            GlobalId::User(source_id),
-            &Arc::clone(persist_clients),
-        )
-        .await
-    }
-
-    async fn dump_storage_collection(
-        shard_id: ShardId,
-        persist_clients: &Arc<PersistClientCache>,
-    ) -> Vec<Row> {
-        let persist_client = persist_clients
-            .open((*PERSIST_LOCATION).clone())
-            .await
-            .unwrap();
-
-        let (write_handle, mut read_handle) = persist_client
-            .open::<SourceData, (), mz_repr::Timestamp, i64>(
-                shard_id,
-                Arc::new(MZ_SINK_STATUS_HISTORY_DESC.clone()),
-                Arc::new(UnitSchema),
-                Diagnostics::from_purpose("tests::dump_storage_collection"),
-            )
-            .await
-            .unwrap();
-
-        let upper = write_handle.upper();
-        let readable_upper = Antichain::from_elem(upper.elements()[0].step_back().unwrap());
-
-        read_handle
-            .snapshot_and_fetch(readable_upper)
-            .await
-            .unwrap()
-            .into_iter()
-            .map(
-                |((v, _), _, _): (
-                    (Result<SourceData, String>, Result<(), String>),
-                    mz_repr::Timestamp,
-                    i64,
-                )| { v.unwrap().0.unwrap() },
-            )
-            .collect_vec()
     }
 }

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -51,6 +51,7 @@ use rdkafka::producer::{BaseRecord, DeliveryResult, Producer, ProducerContext, T
 use rdkafka::{Offset, TopicPartitionList};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
+use timely::dataflow::channels::pushers::TeeCore;
 use timely::dataflow::operators::{Enter, Leave, Map};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp as _};
@@ -58,9 +59,8 @@ use timely::PartialOrder;
 use tokio::sync::Mutex;
 use tracing::{debug, error, info, warn};
 
-use crate::internal_control::{InternalCommandSender, InternalStorageCommand};
-use crate::render::sinks::{HealthcheckerArgs, SinkRender};
-use crate::sink::{Healthchecker, KafkaBaseMetrics, SinkStatus};
+use crate::render::sinks::SinkRender;
+use crate::sink::{KafkaBaseMetrics, SinkStatus};
 use crate::statistics::{SinkStatisticsMetrics, StorageStatistics};
 use crate::storage_state::StorageState;
 
@@ -96,8 +96,7 @@ where
         // TODO(benesch): errors should stream out through the sink,
         // if we figure out a protocol for that.
         _err_collection: Collection<G, DataflowError, Diff>,
-        healthchecker_args: HealthcheckerArgs,
-    ) -> Option<Rc<dyn Any>>
+    ) -> (Stream<G, SinkStatus>, Option<Rc<dyn Any>>)
     where
         G: Scope<Timestamp = Timestamp>,
     {
@@ -119,9 +118,7 @@ where
             Antichain::new()
         }));
 
-        let internal_cmd_tx = Rc::clone(&storage_state.internal_cmd_tx);
-
-        let token = kafka(
+        let (health, token) = kafka(
             sinked_collection,
             sink_id,
             self.clone(),
@@ -135,15 +132,13 @@ where
                 .expect("statistics initialized")
                 .clone(),
             storage_state.connection_context.clone(),
-            healthchecker_args,
-            internal_cmd_tx,
         );
 
         storage_state
             .sink_write_frontiers
             .insert(sink_id, shared_frontier);
 
-        Some(token)
+        (health, Some(token))
     }
 }
 
@@ -368,8 +363,20 @@ impl KafkaTxProducer {
     }
 }
 
+struct HealthOutputHandle {
+    health_cap: timely::dataflow::operators::Capability<Timestamp>,
+    // TODO(guswynn): We probably don't need this Mutex, but removing it
+    // is a large refactor of this entire module.
+    handle: Mutex<
+        mz_timely_util::builder_async::AsyncOutputHandle<
+            mz_repr::Timestamp,
+            Vec<SinkStatus>,
+            TeeCore<mz_repr::Timestamp, Vec<SinkStatus>>,
+        >,
+    >,
+}
+
 struct KafkaSinkState {
-    sink_id: GlobalId,
     name: String,
     topic: String,
     metrics: Arc<SinkMetrics>,
@@ -382,8 +389,7 @@ struct KafkaSinkState {
     progress_key: String,
     progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>>,
 
-    healthchecker: Option<Mutex<Healthchecker>>,
-    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
+    healthchecker: HealthOutputHandle,
     gate_ts: Rc<Cell<Option<Timestamp>>>,
 
     /// Timestamp of the latest progress record that was written out to Kafka.
@@ -403,16 +409,15 @@ struct KafkaSinkState {
 impl KafkaSinkState {
     // Until `try` blocks, we need this for using `fail_point!` correctly.
     async fn new(
+        sink_id: GlobalId,
         connection: KafkaSinkConnection,
         sink_name: String,
-        sink_id: &GlobalId,
         worker_id: String,
         write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
         metrics: &KafkaBaseMetrics,
         connection_context: &ConnectionContext,
         gate_ts: Rc<Cell<Option<Timestamp>>>,
-        internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
-        healthchecker: Option<Healthchecker>,
+        healthchecker: HealthOutputHandle,
     ) -> Self {
         let metrics = Arc::new(SinkMetrics::new(
             metrics,
@@ -429,12 +434,8 @@ impl KafkaSinkState {
             inner: MzClientContext::default(),
         };
 
-        let healthchecker = healthchecker.map(Mutex::new);
-
         let producer = halt_on_err(
             &healthchecker,
-            *sink_id,
-            &internal_cmd_tx,
             #[allow(clippy::redundant_closure_call)]
             (|| async {
                 fail::fail_point!("kafka_sink_creation_error", |_| Err(anyhow::anyhow!(
@@ -488,8 +489,6 @@ impl KafkaSinkState {
 
         let progress_client = halt_on_err(
             &healthchecker,
-            *sink_id,
-            &internal_cmd_tx,
             connection
                 .connection
                 .create_with_context(
@@ -508,7 +507,6 @@ impl KafkaSinkState {
         .await;
 
         KafkaSinkState {
-            sink_id: sink_id.clone(),
             name: sink_name,
             topic: connection.topic,
             metrics,
@@ -520,7 +518,6 @@ impl KafkaSinkState {
             progress_key: format!("mz-sink-{sink_id}"),
             progress_client: Some(Arc::new(progress_client)),
             healthchecker,
-            internal_cmd_tx,
             gate_ts,
             latest_progress_ts: Timestamp::minimum(),
             write_frontier,
@@ -900,28 +897,20 @@ impl KafkaSinkState {
 
     /// Report a SinkStatus::Stalled and then halt with the same message.
     pub async fn halt_on_err<T>(&self, result: Result<T, anyhow::Error>) -> T {
-        halt_on_err(
-            &self.healthchecker,
-            self.sink_id,
-            &self.internal_cmd_tx,
-            result,
-        )
+        halt_on_err(&self.healthchecker, result).await
+    }
+}
+
+async fn update_status(healthchecker: &HealthOutputHandle, status: SinkStatus) {
+    healthchecker
+        .handle
+        .lock()
         .await
-    }
+        .give(&healthchecker.health_cap, status)
+        .await;
 }
 
-async fn update_status(healthchecker: &Option<Mutex<Healthchecker>>, status: SinkStatus) {
-    if let Some(hc) = healthchecker {
-        hc.lock().await.update_status(status).await;
-    }
-}
-
-async fn halt_on_err<T>(
-    healthchecker: &Option<Mutex<Healthchecker>>,
-    sink_id: GlobalId,
-    internal_cmd_tx: &RefCell<dyn InternalCommandSender>,
-    result: Result<T, anyhow::Error>,
-) -> T {
+async fn halt_on_err<T>(healthchecker: &HealthOutputHandle, result: Result<T, anyhow::Error>) -> T {
     match result {
         Ok(t) => t,
         Err(error) => {
@@ -952,12 +941,6 @@ async fn halt_on_err<T>(
                 },
             )
             .await;
-            internal_cmd_tx
-                .borrow_mut()
-                .broadcast(InternalStorageCommand::SuspendAndRestart {
-                    id: sink_id.clone(),
-                    reason: error.to_string(),
-                });
 
             // Make sure to never return, preventing the sink from writing
             // out anything it might regret in the future.
@@ -984,9 +967,7 @@ fn kafka<G>(
     metrics: KafkaBaseMetrics,
     sink_statistics: StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>,
     connection_context: ConnectionContext,
-    healthchecker_args: HealthcheckerArgs,
-    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
-) -> Rc<dyn Any>
+) -> (Stream<G, SinkStatus>, Rc<dyn Any>)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -1051,8 +1032,6 @@ where
         metrics,
         sink_statistics,
         connection_context,
-        healthchecker_args,
-        internal_cmd_tx,
     )
 }
 
@@ -1078,9 +1057,7 @@ pub fn produce_to_kafka<G>(
     metrics: KafkaBaseMetrics,
     sink_statistics: StorageStatistics<SinkStatisticsUpdate, SinkStatisticsMetrics>,
     connection_context: ConnectionContext,
-    healthchecker_args: HealthcheckerArgs,
-    internal_cmd_tx: Rc<RefCell<dyn InternalCommandSender>>,
-) -> Rc<dyn Any>
+) -> (Stream<G, SinkStatus>, Rc<dyn Any>)
 where
     G: Scope<Timestamp = Timestamp>,
 {
@@ -1098,40 +1075,32 @@ where
 
     let mut input = builder.new_input(&stream, Exchange::new(move |_| hashed_id));
 
-    let button = builder.build(move |_capabilities| async move {
+    // The frontier of this output is never inspected, so we can just use a normal output,
+    // even if its frontier is connected to the input.
+    let (health_output, health_stream) = builder.new_output();
+
+    let button = builder.build(move |caps| async move {
+        let [health_cap]: [_; 1] = caps.try_into().unwrap();
+
         if !is_active_worker {
             return;
         }
 
-        let healthchecker = if let Some(status_shard_id) = healthchecker_args.status_shard_id {
-            let hc = Healthchecker::new(
-                id,
-                &healthchecker_args.persist_clients,
-                healthchecker_args.persist_location.clone(),
-                status_shard_id,
-                healthchecker_args.now_fn.clone(),
-            )
-            .await
-            .expect("error initializing healthchecker");
-            Some(hc)
-        } else {
-            None
-        };
         let mut s = KafkaSinkState::new(
+            id,
             connection,
             name,
-            &id,
             worker_id.to_string(),
             write_frontier,
             &metrics,
             &connection_context,
             Rc::clone(&shared_gate_ts),
-            internal_cmd_tx,
-            healthchecker,
+            HealthOutputHandle {
+                health_cap,
+                handle: Mutex::new(health_output),
+            },
         )
         .await;
-
-        s.update_status(SinkStatus::Starting).await;
 
         s.halt_on_err(
             s.producer
@@ -1333,7 +1302,7 @@ where
         }
     });
 
-    Rc::new(button.press_on_drop())
+    (health_stream, Rc::new(button.press_on_drop()))
 }
 
 /// Encodes a stream of `(Option<Row>, Option<Row>)` updates using the specified encoder.

--- a/src/storage/src/sink/mod.rs
+++ b/src/storage/src/sink/mod.rs
@@ -13,6 +13,6 @@ mod healthcheck;
 mod kafka;
 pub mod metrics;
 
-pub use healthcheck::{Healthchecker, SinkStatus};
+pub use healthcheck::SinkStatus;
 pub(crate) use metrics::KafkaBaseMetrics;
 pub use metrics::SinkBaseMetrics;

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -39,7 +39,6 @@ pub mod testscript;
 pub mod types;
 
 pub use kafka::KafkaSourceReader;
-pub(crate) use source_reader_pipeline::health_operator;
 pub use source_reader_pipeline::{
     create_raw_source, RawSourceCreationConfig, SourceCreationParams, SourceStatistics,
 };

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -26,7 +26,7 @@
 use std::any::Any;
 use std::cell::RefCell;
 use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 use std::convert::Infallible;
 use std::fmt::Display;
 use std::future::Future;
@@ -49,10 +49,8 @@ use mz_ore::error::ErrorExt;
 use mz_ore::now::NowFn;
 use mz_ore::vec::VecExt;
 use mz_persist_client::cache::PersistClientCache;
-use mz_persist_client::{PersistClient, PersistLocation, ShardId};
 use mz_repr::{Diff, GlobalId, RelationDesc, Row};
 use mz_storage_client::client::SourceStatisticsUpdate;
-use mz_storage_client::healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::SourceError;
@@ -64,21 +62,19 @@ use mz_timely_util::builder_async::{
 };
 use mz_timely_util::capture::UnboundedTokioCapture;
 use mz_timely_util::operator::StreamExt as _;
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::capture::capture::Capture;
 use timely::dataflow::operators::capture::Event;
-use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Enter, Leave, Map, Partition};
+use timely::dataflow::operators::{Broadcast, CapabilitySet, Concat, Leave, Partition};
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use timely::PartialOrder;
 use tokio::sync::mpsc::UnboundedReceiver;
-use tracing::{info, trace, warn};
+use tracing::{info, trace};
 
-use crate::healthcheck::write_to_persist;
-use crate::internal_control::InternalStorageCommand;
 use crate::render::sources::OutputIndex;
 use crate::source::metrics::SourceBaseMetrics;
 use crate::source::reclock::{ReclockBatch, ReclockError, ReclockFollower, ReclockOperator};
@@ -87,10 +83,6 @@ use crate::source::types::{
     SourceReaderError, SourceRender,
 };
 use crate::statistics::{SourceStatisticsMetrics, StorageStatistics};
-
-/// How long to wait before initiating a `SuspendAndRestart` command, to
-/// prevent hot restart loops.
-const SUSPEND_AND_RESTART_DELAY: Duration = Duration::from_secs(30);
 
 pub type SourceStatistics = StorageStatistics<SourceStatisticsUpdate, SourceStatisticsMetrics>;
 
@@ -357,267 +349,6 @@ where
         health.concat(&derived_health),
         token,
     )
-}
-
-struct HealthState<'a> {
-    source_id: GlobalId,
-    persist_details: Option<(ShardId, &'a PersistClient)>,
-    healths: Vec<Option<HealthStatus>>,
-    last_reported_status: Option<HealthStatus>,
-    halt_with: Option<HealthStatus>,
-}
-
-impl<'a> HealthState<'a> {
-    fn new(
-        source_id: GlobalId,
-        metadata: CollectionMetadata,
-        persist_clients: &'a BTreeMap<PersistLocation, PersistClient>,
-        worker_count: usize,
-    ) -> HealthState<'a> {
-        let persist_details = match (
-            metadata.status_shard,
-            persist_clients.get(&metadata.persist_location),
-        ) {
-            (Some(shard), Some(persist_client)) => Some((shard, persist_client)),
-            _ => None,
-        };
-
-        HealthState {
-            source_id,
-            persist_details,
-            healths: vec![None; worker_count],
-            last_reported_status: None,
-            halt_with: None,
-        }
-    }
-}
-
-/// Writes updates that come across `health_stream` to the collection's status shards, as identified
-/// by their `CollectionMetadata`.
-///
-/// Only one worker will be active and write to the status shard.
-///
-/// The `OutputIndex` values that come across `health_stream` must be a strict subset of those in
-/// `configs`'s keys.
-pub(crate) fn health_operator<'g, G: Scope<Timestamp = ()>>(
-    scope: &mut Child<'g, G, mz_repr::Timestamp>,
-    storage_state: &crate::storage_state::StorageState,
-    resume_uppers: BTreeMap<GlobalId, Antichain<mz_repr::Timestamp>>,
-    primary_source_id: GlobalId,
-    health_stream: &Stream<G, (OutputIndex, HealthStatusUpdate)>,
-    configs: BTreeMap<OutputIndex, (GlobalId, CollectionMetadata)>,
-) -> Rc<dyn Any> {
-    // Derived config options
-    let healthcheck_worker_id = scope.index();
-    let worker_count = scope.peers();
-    let now = storage_state.now.clone();
-    let persist_clients = Arc::clone(&storage_state.persist_clients);
-    let internal_cmd_tx = Rc::clone(&storage_state.internal_cmd_tx);
-
-    // Inject the originating worker id to each item before exchanging to the chosen worker
-    let health_stream = health_stream.map(move |status| (healthcheck_worker_id, status));
-
-    // We'll route all the work to a single arbitrary worker;
-    // there's not much to do, and we need a global view.
-    let chosen_worker_id = usize::cast_from(configs.keys().next().hashed()) % worker_count;
-    let is_active_worker = chosen_worker_id == healthcheck_worker_id;
-
-    let operator_name = format!("healthcheck({})", healthcheck_worker_id);
-    let mut health_op = AsyncOperatorBuilder::new(operator_name, scope.clone());
-
-    let health = health_stream.enter(&scope);
-
-    let mut input = health_op.new_input(
-        &health,
-        Exchange::new(move |_| u64::cast_from(chosen_worker_id)),
-    );
-
-    // Construct a minimal number of persist clients
-    let persist_locations: BTreeSet<_> = configs
-        .values()
-        .filter_map(|(source_id, metadata)| {
-            if is_active_worker {
-                match &metadata.status_shard {
-                    Some(status_shard) => {
-                        info!("Health for source {source_id} being written to {status_shard}");
-                        Some(metadata.persist_location.clone())
-                    }
-                    None => {
-                        trace!("Health for source {source_id} not being written to status shard");
-                        None
-                    }
-                }
-            } else {
-                None
-            }
-        })
-        .collect();
-
-    let button = health_op.build(move |mut _capabilities| async move {
-        // Convert the persist locations into persist clients
-        let mut persist_clients_per_location = BTreeMap::new();
-        for persist_location in persist_locations {
-            persist_clients_per_location.insert(
-                persist_location.clone(),
-                persist_clients
-                    .open(persist_location)
-                    .await
-                    .expect("error creating persist client for Healthchecker"),
-            );
-        }
-
-        let mut health_states: BTreeMap<_, _> = configs
-            .into_iter()
-            .map(|(output_idx, (id, metadata))| {
-                (
-                    output_idx,
-                    HealthState::new(id, metadata, &persist_clients_per_location, worker_count),
-                )
-            })
-            .collect();
-
-        // Write the initial starting state to the status shard for all managed sources
-        if is_active_worker {
-            for state in health_states.values() {
-                if !resume_uppers[&state.source_id].is_empty() {
-                    if let Some((status_shard, persist_client)) = state.persist_details {
-                        let status = HealthStatus::Starting;
-                        write_to_persist(
-                            state.source_id,
-                            status.name(),
-                            status.error(),
-                            now.clone(),
-                            persist_client,
-                            status_shard,
-                            &*MZ_SOURCE_STATUS_HISTORY_DESC,
-                            status.hint(),
-                        )
-                        .await;
-                    }
-                }
-            }
-        }
-
-        let mut outputs_seen = BTreeSet::new();
-        while let Some(event) = input.next_mut().await {
-            if let AsyncEvent::Data(_cap, rows) = event {
-                for (worker_id, (output_index, health_event)) in rows.drain(..) {
-                    let HealthState {
-                        source_id,
-                        healths,
-                        halt_with,
-                        ..
-                    } = match health_states.get_mut(&output_index) {
-                        Some(health) => health,
-                        // This is a health status update for a subsource that we did not request to
-                        // be generated, which means it doesn't have a GlobalId and should not be
-                        // propagated to the shard.
-                        None => continue,
-                    };
-
-                    let new_round = outputs_seen.insert(output_index);
-
-                    if !is_active_worker {
-                        warn!(
-                            "Health messages for source {source_id} passed to \
-                              an unexpected worker id: {healthcheck_worker_id}"
-                        )
-                    }
-
-                    let HealthStatusUpdate {
-                        update,
-                        should_halt,
-                    } = health_event;
-
-                    if should_halt {
-                        *halt_with = Some(update.clone());
-                    }
-
-                    let update = Some(update);
-                    // Keep the max of the messages in each round; this ensures that errors don't
-                    // get lost while also letting us frequently update to the newest status.
-                    if new_round || &healths[worker_id] < &update {
-                        healths[worker_id] = update;
-                    }
-                }
-
-                let mut halt_with_outer = None;
-
-                while let Some(output_index) = outputs_seen.pop_first() {
-                    let HealthState {
-                        source_id,
-                        healths,
-                        persist_details,
-                        last_reported_status,
-                        halt_with,
-                    } = health_states
-                        .get_mut(&output_index)
-                        .expect("known to exist");
-
-                    let overall_status = healths.iter().filter_map(Option::as_ref).max();
-
-                    if let Some(new_status) = overall_status {
-                        if last_reported_status.as_ref() != Some(&new_status) {
-                            info!(
-                                "Health transition for source {source_id}: \
-                                  {last_reported_status:?} -> {new_status:?}"
-                            );
-                            if let Some((status_shard, persist_client)) = persist_details {
-                                write_to_persist(
-                                    *source_id,
-                                    new_status.name(),
-                                    new_status.error(),
-                                    now.clone(),
-                                    persist_client,
-                                    *status_shard,
-                                    &*MZ_SOURCE_STATUS_HISTORY_DESC,
-                                    new_status.hint(),
-                                )
-                                .await;
-                            }
-
-                            *last_reported_status = Some(new_status.clone());
-                        }
-                    }
-
-                    // Set halt with if None.
-                    if halt_with_outer.is_none() && halt_with.is_some() {
-                        halt_with_outer = Some((*source_id, halt_with.clone()));
-                    }
-                }
-
-                // TODO(aljoscha): Instead of threading through the
-                // `should_halt` bit, we can give an internal command sender
-                // directly to the places where `should_halt = true` originates.
-                // We should definitely do that, but this is okay for a PoC.
-                if let Some((id, halt_with)) = halt_with_outer {
-                    mz_ore::soft_assert!(
-                        id == primary_source_id,
-                        "subsources should not produce halting errors, however {:?} halted while primary \
-                                            source is {:?}",
-                        id,
-                        primary_source_id
-                    );
-
-                    info!(
-                        "Broadcasting suspend-and-restart command because of {:?} after {:?} delay",
-                        halt_with, SUSPEND_AND_RESTART_DELAY
-                    );
-                    tokio::time::sleep(SUSPEND_AND_RESTART_DELAY).await;
-                    internal_cmd_tx.borrow_mut().broadcast(
-                        InternalStorageCommand::SuspendAndRestart {
-                            // Suspend and restart is expected to operate on the primary source and
-                            // not any of the subsources.
-                            id,
-                            reason: format!("{:?}", halt_with),
-                        },
-                    );
-                }
-            }
-        }
-    });
-
-    Rc::new(button.press_on_drop())
 }
 
 struct RemapClock {

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -140,6 +140,31 @@ impl HealthStatusUpdate {
     }
 }
 
+impl crate::healthcheck::HealthStatus for HealthStatusUpdate {
+    fn name(&self) -> &'static str {
+        self.update.name()
+    }
+    fn error(&self) -> Option<&str> {
+        self.update.error()
+    }
+    fn hint(&self) -> Option<&str> {
+        self.update.hint()
+    }
+    fn should_halt(&self) -> bool {
+        self.should_halt
+    }
+    fn can_transition_from(&self, other: Option<&Self>) -> bool {
+        if let Some(other) = other {
+            self.update != other.update
+        } else {
+            true
+        }
+    }
+    fn starting() -> Self {
+        Self::status(HealthStatus::Starting)
+    }
+}
+
 /// Source-agnostic wrapper for messages. Each source must implement a
 /// conversion to Message.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
In service of namespaces errors (as well as just general simplification), use the same mechanism to manage source and sink status reporting.

This is actually much cleaner, and I am happy with how much code was deleted.

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
