### PR TITLE
build: Use ThinLTO for Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,9 @@ object = { opt-level = 3 }
 rustc-demangle = { opt-level = 3 }
 
 [profile.release]
+# Compile time seems similar to "lto = false", runtime ~10% faster
+lto = "thin"
+
 # Emit full debug info, allowing us to easily analyze core dumps from
 # staging (and, in an emergency, also prod).
 #


### PR DESCRIPTION
Not set by default, see https://doc.rust-lang.org/stable/cargo/reference/profiles.html#release

I didn't really see a difference in compile time, both ~23 min before and after, but the compile time is not especially stable for me anyway.

Performance-wise (using feature benchmark) this seems to be an about 10% improvement, see the full data in: https://docs.google.com/spreadsheets/d/12aAx12hPSKSgfDLCY-lIQGHp8SSC2k-9OGO_LHlMcnk/edit#gid=454278686

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
