### PR TITLE
ci/mz_lsp_server: fix linux release binary path

### DIFF
--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -25,14 +25,18 @@ def main() -> None:
     assert repo.rd.cargo_workspace.crates["mz-lsp-server"].version == VERSION
 
     print("--- Building mz-lsp-server")
-    print(f"Roost toolchain: {rust_version()}")
+    # The bin/ci-builder uses target-xcompile as the volume and
+    # is where the binary release will be available.
+    path = Path("target-xcompile") / "release" / "mz-lsp-server"
     spawn.runv(
         ["cargo", "build", "--bin", "mz-lsp-server", "--release"],
         env=dict(os.environ, RUSTUP_TOOLCHAIN=rust_version()),
     )
+    mzbuild.chmod_x(path)
+
 
     print(f"--- Uploading {target} binary tarball")
-    deploy_util.deploy_tarball(target, Path("target") / "release" / "mz-lsp-server")
+    deploy_util.deploy_tarball(target, path)
 
     print("--- Publishing Debian package")
     filename = f"mz-lsp-server_{VERSION}_{repo.rd.arch.go_str()}.deb"

--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -34,7 +34,6 @@ def main() -> None:
     )
     mzbuild.chmod_x(path)
 
-
     print(f"--- Uploading {target} binary tarball")
     deploy_util.deploy_tarball(target, path)
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR solves a path issue during the binary release of the package `mz-lsp-server`. The `bin/ci-builder` release output is in `target-xcompile` rather than the normal `target`.

Logs [about the issue.](https://buildkite.com/materialize/deploy-lsp/builds/3#018afcb3-5389-4333-8906-bdefaabaeece/537-538)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
