### PR TITLE
.github: clarify decision log ordering in epic template

### DIFF
--- a/.github/ISSUE_TEMPLATE/04-epic.md
+++ b/.github/ISSUE_TEMPLATE/04-epic.md
@@ -56,7 +56,8 @@ Please use the "problem" issue template for work items.
 
 <!--
 Record all notable decisions as the project evolves, such as setting a target
-date or changing the epic's scope or its breakdown.
+date or changing the epic's scope or its breakdown. Please order entries in
+descending order (the latest update should be the top most item).
 
 Example:
 > * **18 September 2023.** Added Nullability control for Avro-formatted sinks #21722 as a work item.


### PR DESCRIPTION
Entries in the decision log should be ordered in descending order.
