### PR TITLE
ci: Fix trim_pipeline.py

### DIFF
--- a/misc/python/materialize/ci_util/trim_pipeline.py
+++ b/misc/python/materialize/ci_util/trim_pipeline.py
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Skips unselected tests in the pipeline.yml in the ci subdirectory provided as argument."""
+"""Skips unselected tests in the pipeline.template.yml in the ci subdirectory provided as argument."""
 
 import argparse
 import subprocess
@@ -29,7 +29,7 @@ def main() -> int:
         return 0
 
     # Otherwise, filter down to the selected tests.
-    with open(MZ_ROOT / "ci" / args.pipeline / "pipeline.yml") as f:
+    with open(MZ_ROOT / "ci" / args.pipeline / "pipeline.template.yml") as f:
         pipeline = yaml.safe_load(f.read())
     selected_tests = set(
         spawn.capture(["buildkite-agent", "meta-data", "get", "tests"]).splitlines()


### PR DESCRIPTION
Noticed too late in https://buildkite.com/materialize/release-qualification/builds/343#018aff81-07be-4af4-a0dc-67cb69d75c7c

Follow-up to https://github.com/MaterializeInc/materialize/pull/22192

Thanks to @nrainer-materialize for quickly noticing.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
