### PR TITLE
doc: update `EXPLAIN PLAN` docs

### DIFF
--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -34,9 +34,11 @@ The following three objects can be explained.
 
 Explained object | Description
 ------|-----
-**select_stmt** | Display the plan for an ad hoc `SELECT` statement.
-**INDEX index_name** | Display the plan for an existing index.
-**MATERIALIZED VIEW view_name** | Display the plan for an existing materialized view.
+**select_stmt** | Display a plan for an ad-hoc [`SELECT` statement](../select).
+**create_index** | Display a plan for a [`CREATE INDEX` statement](../create-index).
+**create_materialized_view** | Display a plan for a [`CREATE MATERIALIZED VIEW` statement](../create-materialized-view).
+**INDEX index_name** | Display the `OPTIMIZED` or `PHYSICAL` plan for an existing index.
+**MATERIALIZED VIEW view_name** | Display the `OPTIMIZED` or `PHYSICAL` plan for an existing materialized view.
 
 ### Output format
 
@@ -72,6 +74,7 @@ Modifier | Description
 **join_impls** | Render details about the implementation strategy of optimized MIR `Join` nodes.
 **keys** | Annotate each subplan with its unique keys.
 **types** | Annotate each subplan with its inferred type.
+**humanized_exprs** | Render `EXPLAIN AS TEXT` output with human-readable column references in operator expressions. **Warning**: SQL-level aliasing is not considered when inferring column names, so the plan output might become ambiguous if you use this modifier.
 **filter_pushdown** | **Private preview** For each source, include a `pushdown` field that explains which filters [can be pushed down](../../transform-data/patterns/temporal-filters/#temporal-filter-pushdown).
 
 ## Details

--- a/doc/user/layouts/partials/sql-grammar/explain-plan.svg
+++ b/doc/user/layouts/partials/sql-grammar/explain-plan.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="603" height="573">
+<svg xmlns="http://www.w3.org/2000/svg" width="603" height="661">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="80" height="32" rx="10"/>
@@ -111,30 +111,36 @@
    <rect x="277" y="451" width="96" height="32"/>
    <rect x="275" y="449" width="96" height="32" class="nonterminal"/>
    <text class="nonterminal" x="285" y="469">select_stmt</text>
-   <rect x="277" y="495" width="62" height="32" rx="10"/>
+   <rect x="277" y="495" width="104" height="32"/>
+   <rect x="275" y="493" width="104" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="285" y="513">create_index</text>
+   <rect x="277" y="539" width="186" height="32"/>
+   <rect x="275" y="537" width="186" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="285" y="557">create_materialized_view</text>
+   <rect x="277" y="583" width="62" height="32" rx="10"/>
    <rect x="275"
-         y="493"
+         y="581"
          width="62"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="285" y="513">INDEX</text>
-   <rect x="359" y="495" width="98" height="32"/>
-   <rect x="357" y="493" width="98" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="367" y="513">index_name</text>
-   <rect x="277" y="539" width="166" height="32" rx="10"/>
+   <text class="terminal" x="285" y="601">INDEX</text>
+   <rect x="359" y="583" width="98" height="32"/>
+   <rect x="357" y="581" width="98" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="367" y="601">index_name</text>
+   <rect x="277" y="627" width="166" height="32" rx="10"/>
    <rect x="275"
-         y="537"
+         y="625"
          width="166"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="285" y="557">MATERIALIZED VIEW</text>
-   <rect x="463" y="539" width="92" height="32"/>
-   <rect x="461" y="537" width="92" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="471" y="557">view_name</text>
+   <text class="terminal" x="285" y="645">MATERIALIZED VIEW</text>
+   <rect x="463" y="627" width="92" height="32"/>
+   <rect x="461" y="625" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="471" y="645">view_name</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-262 10 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m54 0 h10 m0 0 h80 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m98 0 h10 m0 0 h36 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m92 0 h10 m0 0 h42 m20 -164 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-442 306 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m40 -34 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m40 0 h10 m20 0 h10 m56 0 h10 m0 0 h2 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-476 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m96 0 h10 m0 0 h182 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h98 m-308 -10 v20 m318 0 v-20 m-318 20 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m166 0 h10 m0 0 h10 m92 0 h10 m23 -88 h-3"/>
+         d="m17 17 h2 m0 0 h10 m80 0 h10 m20 0 h10 m0 0 h262 m-292 0 h20 m272 0 h20 m-312 0 q10 0 10 10 m292 0 q0 -10 10 -10 m-302 10 v12 m292 0 v-12 m-292 12 q0 10 10 10 m272 0 q10 0 10 -10 m-262 10 h10 m0 0 h144 m-174 0 h20 m154 0 h20 m-194 0 q10 0 10 10 m174 0 q0 -10 10 -10 m-184 10 v12 m174 0 v-12 m-174 12 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m54 0 h10 m0 0 h80 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m134 0 h10 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m98 0 h10 m0 0 h36 m-164 -10 v20 m174 0 v-20 m-174 20 v24 m174 0 v-24 m-174 24 q0 10 10 10 m154 0 q10 0 10 -10 m-164 10 h10 m92 0 h10 m0 0 h42 m20 -164 h10 m58 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-442 306 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m68 0 h10 m20 0 h10 m124 0 h10 m-164 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m144 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-144 0 h10 m24 0 h10 m0 0 h100 m20 44 h10 m26 0 h10 m-338 0 h20 m318 0 h20 m-358 0 q10 0 10 10 m338 0 q0 -10 10 -10 m-348 10 v14 m338 0 v-14 m-338 14 q0 10 10 10 m318 0 q10 0 10 -10 m-328 10 h10 m0 0 h308 m40 -34 h10 m0 0 h168 m-198 0 h20 m178 0 h20 m-218 0 q10 0 10 10 m198 0 q0 -10 10 -10 m-208 10 v12 m198 0 v-12 m-198 12 q0 10 10 10 m178 0 q10 0 10 -10 m-188 10 h10 m40 0 h10 m20 0 h10 m56 0 h10 m0 0 h2 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v24 m98 0 v-24 m-98 24 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m42 -76 l2 0 m2 0 l2 0 m2 0 l2 0 m-476 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h58 m-88 0 h20 m68 0 h20 m-108 0 q10 0 10 10 m88 0 q0 -10 10 -10 m-98 10 v12 m88 0 v-12 m-88 12 q0 10 10 10 m68 0 q10 0 10 -10 m-78 10 h10 m48 0 h10 m40 -32 h10 m96 0 h10 m0 0 h182 m-318 0 h20 m298 0 h20 m-338 0 q10 0 10 10 m318 0 q0 -10 10 -10 m-328 10 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m104 0 h10 m0 0 h174 m-308 -10 v20 m318 0 v-20 m-318 20 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m186 0 h10 m0 0 h92 m-308 -10 v20 m318 0 v-20 m-318 20 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m62 0 h10 m0 0 h10 m98 0 h10 m0 0 h98 m-308 -10 v20 m318 0 v-20 m-318 20 v24 m318 0 v-24 m-318 24 q0 10 10 10 m298 0 q10 0 10 -10 m-308 10 h10 m166 0 h10 m0 0 h10 m92 0 h10 m23 -176 h-3"/>
    <polygon points="593 465 601 461 601 469"/>
    <polygon points="593 465 585 461 585 469"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -254,6 +254,8 @@ explain_plan ::=
   'FOR'?
   (
     select_stmt |
+    create_index |
+    create_materialized_view |
     'INDEX' index_name |
     'MATERIALIZED VIEW' view_name
   )


### PR DESCRIPTION
Update the docs to add the newly supported syntax introduced in some recently merged PRs (#21708, #21973, and #22021).

### Motivation

  * This PR adds a known-desirable feature.

We want to document the `EXPLAIN` syntax extensions that landed in the past weeks (they are all live in prod as of today).

### Tips for reviewer

The changes are exclusively in the `EXPLAIN PLAN` docs page. Here is [a direct preview link](https://preview.materialize.com/materialize/22195/sql/explain-plan/).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - The `EXPLAIN` syntax now supports `CREATE MATERIALIZED VIEW` and `CREATE INDEX` statement types as well as a `humanized_exprs` flag that can be used to produce more readable `EXPLAIN AS TEXT` output.
