### PR TITLE
Reverse-proxy web console on /internal-console route on envd internal http server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3998,6 +3998,7 @@ dependencies = [
  "humantime",
  "hyper",
  "hyper-openssl",
+ "hyper-tls",
  "include_dir",
  "itertools",
  "jsonwebtoken",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -29,6 +29,7 @@ http-body = "0.4.5"
 humantime = "2.1.0"
 hyper = { version = "0.14.23", features = ["http1", "server"] }
 hyper-openssl = "0.9.2"
+hyper-tls = { version = "0.5.0" }
 include_dir = "0.7.3"
 itertools = "0.10.5"
 jsonwebtoken = "8.2.0"

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -537,7 +537,7 @@ pub struct Args {
     #[clap(long, env = "HTTP_HOST_NAME")]
     http_host_name: Option<String>,
 
-    /// URL of the Web Console to redirect to from the /internal-console endpoint on the InternalHTTPServer
+    /// URL of the Web Console to proxy from the /internal-console endpoint on the InternalHTTPServer
     #[clap(long, env = "INTERNAL_CONSOLE_REDIRECT_URL")]
     internal_console_redirect_url: Option<String>,
 

--- a/src/environmentd/src/http/console.rs
+++ b/src/environmentd/src/http/console.rs
@@ -1,0 +1,88 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apach
+
+//! Console Impersonation HTTP endpoint.
+
+use std::sync::Arc;
+
+use axum::http::{Request, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Extension;
+use http::header::HOST;
+use http::HeaderValue;
+use hyper::client::HttpConnector;
+use hyper::Uri;
+use hyper::{Body, Client};
+use hyper_tls::HttpsConnector;
+
+pub(crate) struct ConsoleProxyConfig {
+    /// Hyper http client, supports https.
+    client: Client<HttpsConnector<HttpConnector>, Body>,
+
+    /// URL of upstream console to proxy to (e.g. <https://console.materialize.com>).
+    url: String,
+
+    /// Route this is being served from (e.g. /internal-console).
+    route_prefix: String,
+}
+
+impl ConsoleProxyConfig {
+    pub(crate) fn new(proxy_url: Option<String>, route_prefix: String) -> Self {
+        let mut url = proxy_url.unwrap_or("https://console.materialize.com".to_string());
+        if let Some(new) = url.strip_suffix('/') {
+            url = new.to_string();
+        }
+        Self {
+            client: Client::builder().build(HttpsConnector::new()),
+            url,
+            route_prefix,
+        }
+    }
+}
+
+/// The User Impersonation feature uses a Teleport proxy in front of the
+/// Internal HTTP Server, however Teleport has issues with CORS that prevent
+/// making requests to that Teleport-proxied app from our production console URLs.
+/// To avoid CORS and serve the Console from the same host as the Teleport app,
+/// this route proxies the upstream Console to handle requests for
+/// HTML, JS, and CSS static files.
+pub(crate) async fn handle_internal_console(
+    console_config: Extension<Arc<ConsoleProxyConfig>>,
+    mut req: Request<Body>,
+) -> Result<Response, StatusCode> {
+    let path = req.uri().path();
+    let mut path_query = req
+        .uri()
+        .path_and_query()
+        .map(|v| v.as_str())
+        .unwrap_or(path);
+    if let Some(stripped_path_query) = path_query.strip_prefix(&console_config.route_prefix) {
+        path_query = stripped_path_query;
+    }
+
+    let uri = Uri::try_from(format!("{}{}", &console_config.url, path_query)).unwrap();
+    let host = uri.host().unwrap().to_string();
+    // Preserve the request, but update the URI to point upstream.
+    *req.uri_mut() = uri;
+
+    // If vercel sees the request being served from a different host it tries to redirect to it's own.
+    req.headers_mut()
+        .insert(HOST, HeaderValue::from_str(&host).unwrap());
+
+    // Call this request against the upstream, return response directly.
+    Ok(console_config
+        .client
+        .request(req)
+        .await
+        .map_err(|err| {
+            tracing::warn!("Error retrieving console url: {}", err);
+            StatusCode::BAD_REQUEST
+        })?
+        .into_response())
+}

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -208,7 +208,7 @@ pub struct Config {
     pub deploy_generation: Option<u64>,
     /// Host name or URL for connecting to the HTTP server of this instance.
     pub http_host_name: Option<String>,
-    /// URL of the Web Console to redirect to from the /internal-console endpoint on the InternalHTTPServer
+    /// URL of the Web Console to proxy from the /internal-console endpoint on the InternalHTTPServer
     pub internal_console_redirect_url: Option<String>,
 
     // === Tracing options. ===

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -82,7 +82,7 @@ use std::fmt::Write;
 use std::io::Write as _;
 use std::net::Ipv4Addr;
 use std::process::{Command, Stdio};
-use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 use std::{iter, thread};
@@ -113,7 +113,7 @@ use postgres::SimpleQueryMessage;
 use postgres_array::Array;
 use rand::RngCore;
 use reqwest::blocking::Client;
-use reqwest::{redirect, Url};
+use reqwest::{header::CONTENT_TYPE, Url};
 use serde::{Deserialize, Serialize};
 use tempfile::TempDir;
 use tokio_postgres::error::SqlState;
@@ -2016,34 +2016,16 @@ fn test_concurrent_id_reuse() {
 }
 
 #[mz_ore::test]
-fn test_internal_console_redirect() {
-    let test_url =
-        Url::parse("https://test_org.test_region.internal.console.materialize.com").unwrap();
-
-    let config = util::Config::default()
-        .unsafe_mode()
-        .with_internal_console_redirect_url(Some(test_url.to_string()));
+fn test_internal_console_proxy() {
+    let config = util::Config::default();
     let server = util::start_server(config.clone()).unwrap();
 
-    let redirected = Arc::new(AtomicBool::new(false));
-    let cloned = Arc::clone(&redirected);
-    // Reqwest will default follow redirects, so we want to avoid that and introspect
-    // the redirect to make sure it's pointing to our test_url
-    let custom_redirect_policy = redirect::Policy::custom(move |attempt| {
-        tracing::debug!("Got redirect request to URL: {:?}", attempt.url());
-        if attempt.url() == &test_url {
-            cloned.store(true, Ordering::Relaxed);
-        }
-        attempt.stop()
-    });
-
     let res = Client::builder()
-        .redirect(custom_redirect_policy)
         .build()
         .unwrap()
         .get(
             Url::parse(&format!(
-                "http://{}/api/internal-console",
+                "http://{}/internal-console/styles.css",
                 server.inner.internal_http_local_addr()
             ))
             .unwrap(),
@@ -2051,8 +2033,11 @@ fn test_internal_console_redirect() {
         .send()
         .unwrap();
 
-    assert_eq!(res.status(), StatusCode::TEMPORARY_REDIRECT);
-    assert_eq!(redirected.load(Ordering::Relaxed), true);
+    assert_eq!(res.status().is_success(), true);
+    assert_contains!(
+        res.headers().get(CONTENT_TYPE).unwrap().to_str().unwrap(),
+        "text/css"
+    );
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature: This re-implements https://github.com/MaterializeInc/materialize/pull/21884 to act as a proxy rather than a redirect.

During testing of the original PR, we realized that the redirect flow was unworkable since teleport doesn't allow proxying through OPTIONS preflight requests in a cross-origin scenario, since the preflight requests get stripped of their teleport auth-cookies.

So the new design involves simply serving the Console from the same host as the environmentd HTTP server behind teleport, to avoid CORS entirely. The user would just visit <teleport-url>/internal-console to access the console and use the user-impersonation feature (after going through teleport auth).

The route now acts as a simple reverse-proxy for GET requests to the upstream console URL. We are re-using the existing environmentd url argument to avoid another version-gated change in the cloud environment-controller. I'll have a PR up soon to change the URL we pass from the environment-controller to each environmentd process.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

I tested this by using the console preview from https://github.com/MaterializeInc/console/pull/928 which supports non-root basenames, and running environmentd locally with that as the URL provided to the `--internal-console-redirect-url` flag. I then used ngrok.io to tunnel my local environmentd to a public URL with https support and verified the console could be loaded at <ngrok_url>/internal-console.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
