### PR TITLE
sql: Implement pg_catalog.pg_description

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -156,7 +156,7 @@ The `mz_comments` table stores optional comments (descriptions) for objects in t
 | -------------- |-------------| --------                                                                                     |
 | `id`           | [`text`]    | The ID of the object. Corresponds to [`mz_objects.id`](../mz_catalog/#mz_objects).           |
 | `object_type`  | [`text`]    | The type of object the comment is associated with.                                           |
-| `object_sub_id`| [`uint8`]   | For a comment on a column of a relation, this is the column number. For all other object types this column is `NULL`. |
+| `object_sub_id`| [`integer`] | For a comment on a column of a relation, this is the column number. For all other object types this column is `NULL`. |
 | `comment`      | [`text`]    | The comment itself.                                                                          |
 
 ### `mz_compute_dependencies`

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -1434,7 +1434,12 @@ impl CatalogState {
             CommentObjectId::ClusterReplica((_, replica_id)) => replica_id.to_string(),
         };
         let column_pos_datum = match column_pos {
-            Some(pos) => Datum::UInt64(CastFrom::cast_from(pos)),
+            Some(pos) => {
+                // TODO(parkmycar): https://github.com/MaterializeInc/materialize/issues/22246.
+                let pos =
+                    i32::try_from(pos).expect("we constrain this value in the planning layer");
+                Datum::Int32(pos)
+            }
             None => Datum::Null,
         };
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2871,7 +2871,7 @@ pub const PG_DESCRIPTION: BuiltinView = BuiltinView {
 SELECT
 	pg_obj.objoid,
 	pg_obj.classoid,
-	COALESCE(cmt.object_sub_id::INT4, 0) AS objsubid,
+	COALESCE(cmt.object_sub_id::pg_catalog.int4, 0) AS objsubid,
 	cmt.comment AS description
 FROM
 	(

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2281,7 +2281,7 @@ pub static MZ_COMMENTS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
         .with_column("object_type", ScalarType::String.nullable(false))
-        .with_column("object_sub_id", ScalarType::UInt64.nullable(true))
+        .with_column("object_sub_id", ScalarType::Int32.nullable(true))
         .with_column("comment", ScalarType::String.nullable(false)),
     is_retained_metrics_object: false,
 });
@@ -2890,7 +2890,7 @@ pub const PG_DESCRIPTION: BuiltinView = BuiltinView {
         SELECT
             pg_classoids.oid AS objoid,
             pg_classoids.classoid as classoid,
-            COALESCE(cmt.object_sub_id::pg_catalog.int4, 0) AS objsubid,
+            COALESCE(cmt.object_sub_id, 0) AS objsubid,
             cmt.comment AS description
         FROM
             pg_classoids

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1223,7 +1223,7 @@ pub struct CommentPlan {
     pub object_id: CommentObjectId,
     /// A sub-component of the object that this comment is associated with, e.g. a column.
     ///
-    /// TODO(parkmycar): Make this a newtype ColumnPos that accounts for SQL's 1-indexing.
+    /// TODO(parkmycar): <https://github.com/MaterializeInc/materialize/issues/22246>.
     pub sub_component: Option<usize>,
     /// The comment itself. If `None` that indicates we should clear the existing comment.
     pub comment: Option<String>,

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -100,7 +100,7 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 ----
 1  id  text
 2  object_type  text
-3  object_sub_id  uint8
+3  object_sub_id  integer
 4  comment  text
 
 query ITT

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -145,8 +145,8 @@ COMMENT ON COLUMN c.col_1 IS 'this_works';
 query TTT
 SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-view  NULL  this_is_a_view
 view  1  this_works
+view  NULL  this_is_a_view
 
 query IT
 SELECT objsubid, description FROM pg_description;
@@ -166,8 +166,8 @@ COMMENT ON MATERIALIZED VIEW mv IS 'mat_foo';
 query TTT
 SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-view  NULL  this_is_a_view
 view  1  this_works
+view  NULL  this_is_a_view
 materialized-view  NULL  mat_foo
 materialized-view  1  comment_mat_view_col
 
@@ -227,9 +227,9 @@ COMMENT ON COLUMN my_webhook.body IS 'json_blob';
 query TTT
 SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
+source  1  json_blob
 source  NULL  all_the_data
 cluster  NULL  careful_now
-source  1  json_blob
 
 query IT
 SELECT objsubid, description FROM pg_description;
@@ -246,10 +246,10 @@ COMMENT ON TYPE int4_list IS 'supercool_list';
 query TTT
 SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
+source  1  json_blob
 type  NULL  supercool_list
 source  NULL  all_the_data
 cluster  NULL  careful_now
-source  1  json_blob
 
 query IT
 SELECT objsubid, description FROM pg_description;

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -23,49 +23,36 @@ ALTER SYSTEM SET enable_webhook_sources = true
 ----
 COMPLETE 0
 
-# Helper view with object IDs.
-statement ok
-CREATE VIEW pg_description_view AS
-	SELECT
-		id, objsubid, description
-	FROM
-		pg_catalog.pg_description AS d
-		JOIN (
-				SELECT id, oid FROM mz_catalog.mz_objects
-				UNION ALL SELECT id, oid FROM mz_catalog.mz_schemas
-			)
-				AS mz_obj (id, oid) ON d.objoid = mz_obj.oid
-
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 
 statement ok
 COMMENT ON TABLE a IS 'foo_table';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2  table  NULL  foo_table
+table  NULL  foo_table
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u2  0  foo_table
+0  foo_table
 
 statement ok
 COMMENT ON COLUMN a.y IS 'load_bearing';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2  table  NULL  foo_table
-u2  table  2  load_bearing
+table  NULL  foo_table
+table  2  load_bearing
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u2  0  foo_table
-u2  2  load_bearing
+0  foo_table
+2  load_bearing
 
 statement ok
 CREATE TABLE b ( ts timestamptz );
@@ -73,19 +60,19 @@ CREATE TABLE b ( ts timestamptz );
 statement ok
 COMMENT ON COLUMN b.ts IS 'utc_timestamp';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2  table  NULL  foo_table
-u2  table  2  load_bearing
-u3  table  1  utc_timestamp
+table  NULL  foo_table
+table  2  load_bearing
+table  1  utc_timestamp
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u2  0  foo_table
-u2  2  load_bearing
-u3  1  utc_timestamp
+0  foo_table
+2  load_bearing
+1  utc_timestamp
 
 statement ok
 COMMENT ON TABLE b IS 'foo_table';
@@ -93,17 +80,17 @@ COMMENT ON TABLE b IS 'foo_table';
 statement ok
 DROP TABLE a;
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u3  table  NULL foo_table
-u3  table  1  utc_timestamp
+table  NULL foo_table
+table  1  utc_timestamp
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u3  0  foo_table
-u3  1  utc_timestamp
+0  foo_table
+1  utc_timestamp
 
 statement ok
 COMMENT ON TABLE b IS NULL
@@ -111,12 +98,12 @@ COMMENT ON TABLE b IS NULL
 statement ok
 COMMENT ON COLUMN b.ts IS NULL
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 statement error unknown catalog item 'c'
@@ -137,17 +124,17 @@ CREATE VIEW c (col_1, col_2) AS VALUES ('a', 'b');
 statement ok
 COMMENT ON VIEW c IS 'this_is_a_view';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u4  index NULL  speed_up
-u5  view  NULL  this_is_a_view
+index NULL  speed_up
+view  NULL  this_is_a_view
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u4  0  speed_up
-u5  0  this_is_a_view
+0  speed_up
+0  this_is_a_view
 
 statement ok
 DROP TABLE b CASCADE;
@@ -155,17 +142,17 @@ DROP TABLE b CASCADE;
 statement ok
 COMMENT ON COLUMN c.col_1 IS 'this_works';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u5  view  NULL  this_is_a_view
-u5  view  1  this_works
+view  NULL  this_is_a_view
+view  1  this_works
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u5  1  this_works
-u5  0  this_is_a_view
+1  this_works
+0  this_is_a_view
 
 statement ok
 CREATE MATERIALIZED VIEW mv ( x ) AS SELECT 1
@@ -176,21 +163,21 @@ COMMENT ON COLUMN mv.x IS 'comment_mat_view_col';
 statement ok
 COMMENT ON MATERIALIZED VIEW mv IS 'mat_foo';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u5  view  NULL  this_is_a_view
-u5  view  1  this_works
-u6  materialized-view  NULL  mat_foo
-u6  materialized-view  1  comment_mat_view_col
+view  NULL  this_is_a_view
+view  1  this_works
+materialized-view  NULL  mat_foo
+materialized-view  1  comment_mat_view_col
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u6  0  mat_foo
-u5  1  this_works
-u5  0  this_is_a_view
-u6  1  comment_mat_view_col
+0  mat_foo
+1  this_works
+0  this_is_a_view
+1  comment_mat_view_col
 
 statement ok
 DROP VIEW c;
@@ -198,12 +185,12 @@ DROP VIEW c;
 statement ok
 DROP MATERIALIZED VIEW mv;
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 statement ok
@@ -215,14 +202,14 @@ COMMENT ON CLUSTER comment_cluster IS 'careful_now';
 statement ok
 COMMENT ON CLUSTER REPLICA comment_cluster.r2 IS 'second_replicator';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2 cluster NULL careful_now
-u3 cluster-replica NULL second_replicator
+cluster NULL careful_now
+cluster-replica NULL second_replicator
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 statement ok
@@ -237,18 +224,18 @@ COMMENT ON SOURCE my_webhook IS 'all_the_data';
 statement ok
 COMMENT ON COLUMN my_webhook.body IS 'json_blob';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2 cluster NULL careful_now
-u7 source NULL all_the_data
-u7 source 1 json_blob
+source  NULL  all_the_data
+cluster  NULL  careful_now
+source  1  json_blob
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u7  1  json_blob
-u7  0  all_the_data
+1  json_blob
+0  all_the_data
 
 statement ok
 CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
@@ -256,20 +243,20 @@ CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 statement ok
 COMMENT ON TYPE int4_list IS 'supercool_list';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2 cluster NULL careful_now
-u7 source NULL all_the_data
-u8 type NULL supercool_list
-u7 source 1 json_blob
+type  NULL  supercool_list
+source  NULL  all_the_data
+cluster  NULL  careful_now
+source  1  json_blob
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u7 1 json_blob
-u7 0 all_the_data
-u8 0 supercool_list
+1 json_blob
+0 all_the_data
+0 supercool_list
 
 statement ok
 DROP CLUSTER comment_cluster CASCADE;
@@ -280,16 +267,16 @@ CREATE SECRET my_secret AS 'foobar';
 statement ok
 COMMENT ON SECRET my_secret IS 'supersecret';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u9 secret NULL supersecret
-u8 type NULL supercool_list
+secret NULL supersecret
+type NULL supercool_list
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u8  0  supercool_list
+0  supercool_list
 
 statement ok
 CREATE DATABASE comment_on_db;
@@ -309,16 +296,16 @@ DROP SECRET my_secret;
 statement ok
 DROP TYPE int4_list;
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2 database NULL this_is_my_db
-u7 schema NULL this_is_my_schema
+database NULL this_is_my_db
+schema NULL this_is_my_schema
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
-u7  0  this_is_my_schema
+0  this_is_my_schema
 
 statement ok
 DROP DATABASE comment_on_db;
@@ -334,13 +321,13 @@ CREATE ROLE student;
 statement ok
 COMMENT ON ROLE student IS 'limited_role';
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u2 role NULL limited_role
+role NULL limited_role
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 statement ok
@@ -364,14 +351,14 @@ COMMENT ON ROLE teacher IS 'foo';
 ----
 COMPLETE 0
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u3 role NULL foo
-u2 role NULL limited_role
+role NULL foo
+role NULL limited_role
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 simple conn=mz_system,user=mz_system
@@ -391,12 +378,12 @@ DROP ROLE student;
 statement ok
 DROP ROLE teacher;
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----
 
 statement error must be owner of DATABASE materialize
@@ -410,11 +397,11 @@ COMMENT ON DATABASE materialize IS 'main_db';
 ----
 COMPLETE 0
 
-query TTTT
-SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-u1 database NULL main_db
+database  NULL  main_db
 
-query TIT
-SELECT id, objsubid, description FROM pg_description_view;
+query IT
+SELECT objsubid, description FROM pg_description;
 ----

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -43,12 +43,12 @@ statement ok
 COMMENT ON TABLE a IS 'foo_table';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2  table  NULL  foo_table
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u2  0  foo_table
 
@@ -56,13 +56,13 @@ statement ok
 COMMENT ON COLUMN a.y IS 'load_bearing';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2  table  NULL  foo_table
 u2  table  2  load_bearing
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u2  0  foo_table
 u2  2  load_bearing
@@ -74,14 +74,14 @@ statement ok
 COMMENT ON COLUMN b.ts IS 'utc_timestamp';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2  table  NULL  foo_table
 u2  table  2  load_bearing
 u3  table  1  utc_timestamp
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u2  0  foo_table
 u2  2  load_bearing
@@ -94,13 +94,13 @@ statement ok
 DROP TABLE a;
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u3  table  NULL foo_table
 u3  table  1  utc_timestamp
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u3  0  foo_table
 u3  1  utc_timestamp
@@ -112,11 +112,11 @@ statement ok
 COMMENT ON COLUMN b.ts IS NULL
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 statement error unknown catalog item 'c'
@@ -138,13 +138,13 @@ statement ok
 COMMENT ON VIEW c IS 'this_is_a_view';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u4  index NULL  speed_up
 u5  view  NULL  this_is_a_view
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u4  0  speed_up
 u5  0  this_is_a_view
@@ -156,13 +156,13 @@ statement ok
 COMMENT ON COLUMN c.col_1 IS 'this_works';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u5  view  NULL  this_is_a_view
 u5  view  1  this_works
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u5  1  this_works
 u5  0  this_is_a_view
@@ -177,7 +177,7 @@ statement ok
 COMMENT ON MATERIALIZED VIEW mv IS 'mat_foo';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u5  view  NULL  this_is_a_view
 u5  view  1  this_works
@@ -185,7 +185,7 @@ u6  materialized-view  NULL  mat_foo
 u6  materialized-view  1  comment_mat_view_col
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u6  0  mat_foo
 u5  1  this_works
@@ -199,11 +199,11 @@ statement ok
 DROP MATERIALIZED VIEW mv;
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 statement ok
@@ -216,13 +216,13 @@ statement ok
 COMMENT ON CLUSTER REPLICA comment_cluster.r2 IS 'second_replicator';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2 cluster NULL careful_now
 u3 cluster-replica NULL second_replicator
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 statement ok
@@ -238,14 +238,14 @@ statement ok
 COMMENT ON COLUMN my_webhook.body IS 'json_blob';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2 cluster NULL careful_now
 u7 source NULL all_the_data
 u7 source 1 json_blob
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u7  1  json_blob
 u7  0  all_the_data
@@ -257,7 +257,7 @@ statement ok
 COMMENT ON TYPE int4_list IS 'supercool_list';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2 cluster NULL careful_now
 u7 source NULL all_the_data
@@ -265,7 +265,7 @@ u8 type NULL supercool_list
 u7 source 1 json_blob
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u7 1 json_blob
 u7 0 all_the_data
@@ -281,13 +281,13 @@ statement ok
 COMMENT ON SECRET my_secret IS 'supersecret';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u9 secret NULL supersecret
 u8 type NULL supercool_list
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u8  0  supercool_list
 
@@ -310,13 +310,13 @@ statement ok
 DROP TYPE int4_list;
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2 database NULL this_is_my_db
 u7 schema NULL this_is_my_schema
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 u7  0  this_is_my_schema
 
@@ -335,12 +335,12 @@ statement ok
 COMMENT ON ROLE student IS 'limited_role';
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u2 role NULL limited_role
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 statement ok
@@ -365,13 +365,13 @@ COMMENT ON ROLE teacher IS 'foo';
 COMPLETE 0
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u3 role NULL foo
 u2 role NULL limited_role
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 simple conn=mz_system,user=mz_system
@@ -392,11 +392,11 @@ statement ok
 DROP ROLE teacher;
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----
 
 statement error must be owner of DATABASE materialize
@@ -411,10 +411,10 @@ COMMENT ON DATABASE materialize IS 'main_db';
 COMPLETE 0
 
 query TTTT
-SELECT * FROM mz_internal.mz_comments;
+SELECT id, object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 u1 database NULL main_db
 
 query TIT
-SELECT * FROM pg_description_view;
+SELECT id, objsubid, description FROM pg_description_view;
 ----

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -23,6 +23,19 @@ ALTER SYSTEM SET enable_webhook_sources = true
 ----
 COMPLETE 0
 
+# Helper view with object IDs.
+statement ok
+CREATE VIEW pg_description_view AS
+	SELECT
+		id, objsubid, description
+	FROM
+		pg_catalog.pg_description AS d
+		JOIN (
+				SELECT id, oid FROM mz_catalog.mz_objects
+				UNION ALL SELECT id, oid FROM mz_catalog.mz_schemas
+			)
+				AS mz_obj (id, oid) ON d.objoid = mz_obj.oid
+
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 
@@ -32,7 +45,12 @@ COMMENT ON TABLE a IS 'foo_table';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u1  table  NULL  foo_table
+u2  table  NULL  foo_table
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u2  0  foo_table
 
 statement ok
 COMMENT ON COLUMN a.y IS 'load_bearing';
@@ -40,8 +58,14 @@ COMMENT ON COLUMN a.y IS 'load_bearing';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u1  table  NULL  foo_table
-u1  table  2  load_bearing
+u2  table  NULL  foo_table
+u2  table  2  load_bearing
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u2  0  foo_table
+u2  2  load_bearing
 
 statement ok
 CREATE TABLE b ( ts timestamptz );
@@ -52,9 +76,16 @@ COMMENT ON COLUMN b.ts IS 'utc_timestamp';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u1  table  NULL  foo_table
-u1  table  2  load_bearing
-u2  table  1  utc_timestamp
+u2  table  NULL  foo_table
+u2  table  2  load_bearing
+u3  table  1  utc_timestamp
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u2  0  foo_table
+u2  2  load_bearing
+u3  1  utc_timestamp
 
 statement ok
 COMMENT ON TABLE b IS 'foo_table';
@@ -65,8 +96,14 @@ DROP TABLE a;
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u2  table  NULL foo_table
-u2  table  1  utc_timestamp
+u3  table  NULL foo_table
+u3  table  1  utc_timestamp
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u3  0  foo_table
+u3  1  utc_timestamp
 
 statement ok
 COMMENT ON TABLE b IS NULL
@@ -76,6 +113,10 @@ COMMENT ON COLUMN b.ts IS NULL
 
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
+----
+
+query TIT
+SELECT * FROM pg_description_view;
 ----
 
 statement error unknown catalog item 'c'
@@ -99,8 +140,14 @@ COMMENT ON VIEW c IS 'this_is_a_view';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u3  index NULL  speed_up
-u4  view  NULL  this_is_a_view
+u4  index NULL  speed_up
+u5  view  NULL  this_is_a_view
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u4  0  speed_up
+u5  0  this_is_a_view
 
 statement ok
 DROP TABLE b CASCADE;
@@ -111,8 +158,14 @@ COMMENT ON COLUMN c.col_1 IS 'this_works';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u4  view  NULL  this_is_a_view
-u4  view  1  this_works
+u5  view  NULL  this_is_a_view
+u5  view  1  this_works
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u5  1  this_works
+u5  0  this_is_a_view
 
 statement ok
 CREATE MATERIALIZED VIEW mv ( x ) AS SELECT 1
@@ -126,10 +179,18 @@ COMMENT ON MATERIALIZED VIEW mv IS 'mat_foo';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u4  view  NULL  this_is_a_view
-u4  view  1  this_works
-u5  materialized-view  NULL  mat_foo
-u5  materialized-view  1  comment_mat_view_col
+u5  view  NULL  this_is_a_view
+u5  view  1  this_works
+u6  materialized-view  NULL  mat_foo
+u6  materialized-view  1  comment_mat_view_col
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u6  0  mat_foo
+u5  1  this_works
+u5  0  this_is_a_view
+u6  1  comment_mat_view_col
 
 statement ok
 DROP VIEW c;
@@ -139,6 +200,10 @@ DROP MATERIALIZED VIEW mv;
 
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
+----
+
+query TIT
+SELECT * FROM pg_description_view;
 ----
 
 statement ok
@@ -156,6 +221,10 @@ SELECT * FROM mz_internal.mz_comments;
 u2 cluster NULL careful_now
 u3 cluster-replica NULL second_replicator
 
+query TIT
+SELECT * FROM pg_description_view;
+----
+
 statement ok
 DROP CLUSTER REPLICA comment_cluster.r2;
 
@@ -172,8 +241,14 @@ query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
 u2 cluster NULL careful_now
-u6 source NULL all_the_data
-u6 source 1 json_blob
+u7 source NULL all_the_data
+u7 source 1 json_blob
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u7  1  json_blob
+u7  0  all_the_data
 
 statement ok
 CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
@@ -185,9 +260,16 @@ query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
 u2 cluster NULL careful_now
-u6 source NULL all_the_data
-u7 type NULL supercool_list
-u6 source 1 json_blob
+u7 source NULL all_the_data
+u8 type NULL supercool_list
+u7 source 1 json_blob
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u7 1 json_blob
+u7 0 all_the_data
+u8 0 supercool_list
 
 statement ok
 DROP CLUSTER comment_cluster CASCADE;
@@ -201,8 +283,13 @@ COMMENT ON SECRET my_secret IS 'supersecret';
 query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
-u8 secret NULL supersecret
-u7 type NULL supercool_list
+u9 secret NULL supersecret
+u8 type NULL supercool_list
+
+query TIT
+SELECT * FROM pg_description_view;
+----
+u8  0  supercool_list
 
 statement ok
 CREATE DATABASE comment_on_db;
@@ -228,6 +315,11 @@ SELECT * FROM mz_internal.mz_comments;
 u2 database NULL this_is_my_db
 u7 schema NULL this_is_my_schema
 
+query TIT
+SELECT * FROM pg_description_view;
+----
+u7  0  this_is_my_schema
+
 statement ok
 DROP DATABASE comment_on_db;
 
@@ -246,6 +338,10 @@ query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
 u2 role NULL limited_role
+
+query TIT
+SELECT * FROM pg_description_view;
+----
 
 statement ok
 CREATE TABLE foo ( x int8 );
@@ -274,6 +370,10 @@ SELECT * FROM mz_internal.mz_comments;
 u3 role NULL foo
 u2 role NULL limited_role
 
+query TIT
+SELECT * FROM pg_description_view;
+----
+
 simple conn=mz_system,user=mz_system
 REVOKE CREATEROLE ON SYSTEM FROM student;
 ----
@@ -295,6 +395,10 @@ query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
 
+query TIT
+SELECT * FROM pg_description_view;
+----
+
 statement error must be owner of DATABASE materialize
 COMMENT ON DATABASE materialize IS 'main_db';
 
@@ -310,3 +414,7 @@ query TTTT
 SELECT * FROM mz_internal.mz_comments;
 ----
 u1 database NULL main_db
+
+query TIT
+SELECT * FROM pg_description_view;
+----

--- a/test/sqllogictest/github-8241.slt
+++ b/test/sqllogictest/github-8241.slt
@@ -63,5 +63,6 @@ Only the following relations are available:
 "mz_catalog.mz_types"
 "mz_catalog.mz_views"
 "mz_internal.mz_aggregates"
+"mz_internal.mz_comments"
 "mz_internal.mz_object_dependencies"
 "mz_internal.mz_type_pg_metadata"

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -322,6 +322,7 @@ Only the following relations are available:
 "mz_catalog.mz_types"
 "mz_catalog.mz_views"
 "mz_internal.mz_aggregates"
+"mz_internal.mz_comments"
 "mz_internal.mz_object_dependencies"
 "mz_internal.mz_type_pg_metadata"
 

--- a/test/testdrive/pg-catalog.td
+++ b/test/testdrive/pg-catalog.td
@@ -75,7 +75,7 @@ name         nullable  type
 objoid       false     oid
 classoid     true      oid
 objsubid     false     integer
-description  true      text
+description  false     text
 
 > SHOW COLUMNS FROM pg_attribute
 name         nullable  type


### PR DESCRIPTION
This commit implements the pg_catalog.pg_description catalog view for all objects except for columns. Columns do now have OIDs so we had to exclude them from this view for now.

Works towards resolving #21466

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `pg_catalog.pg_description` view (https://www.postgresql.org/docs/16/catalog-pg-description.html).
