### PR TITLE
storage: handle edge cases in sink/source status truncation

### DIFF
--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -78,7 +78,8 @@
 //! Implementation of the storage controller trait.
 
 use std::any::Any;
-use std::collections::{BTreeMap, BTreeSet};
+use std::cmp::Reverse;
+use std::collections::{BTreeMap, BTreeSet, BinaryHeap};
 use std::fmt::Debug;
 use std::num::NonZeroI64;
 use std::str::FromStr;
@@ -2397,17 +2398,35 @@ where
     /// Effectively truncates the source status history shard except for the most recent updates
     /// from each ID.
     async fn partially_truncate_status_history(&mut self, collection: IntrospectionType) {
-        let keep_n = match collection {
-            IntrospectionType::SourceStatusHistory => {
-                self.config.keep_n_source_status_history_entries
-            }
-            IntrospectionType::SinkStatusHistory => self.config.keep_n_sink_status_history_entries,
+        let (keep_n, occurred_at_col, id_col) = match collection {
+            IntrospectionType::SourceStatusHistory => (
+                self.config.keep_n_source_status_history_entries,
+                healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("occurred_at"))
+                    .expect("schema has not changed")
+                    .0,
+                healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("source_id"))
+                    .expect("schema has not changed")
+                    .0,
+            ),
+            IntrospectionType::SinkStatusHistory => (
+                self.config.keep_n_sink_status_history_entries,
+                healthcheck::MZ_SINK_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("occurred_at"))
+                    .expect("schema has not changed")
+                    .0,
+                healthcheck::MZ_SINK_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("sink_id"))
+                    .expect("schema has not changed")
+                    .0,
+            ),
             _ => unreachable!(),
         };
 
         let id = self.introspection_ids[&collection];
 
-        let rows = match self.collections[&id].write_frontier.as_option() {
+        let mut rows = match self.collections[&id].write_frontier.as_option() {
             Some(f) if f > &T::minimum() => {
                 let as_of = f.step_back().unwrap();
 
@@ -2418,44 +2437,53 @@ where
             _ => return,
         };
 
-        let (occurred_at, _) = healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
-            .get_by_name(&ColumnName::from("occurred_at"))
-            .expect("schema has not changed");
-
-        let (source_id, _) = healthcheck::MZ_SOURCE_STATUS_HISTORY_DESC
-            .get_by_name(&ColumnName::from("source_id"))
-            .expect("schema has not changed");
-
-        // BTreeMap<SourceId, BTreeMap<OccurredAt, Row>>
-        let mut last_n_entries_per_id: BTreeMap<Datum, BTreeMap<Datum, Vec<Datum>>> =
+        // BTreeMap<Id, MinHeap<(OccurredAt, Row)>>, to track the
+        // earliest events for each id.
+        let mut last_n_entries_per_id: BTreeMap<Datum, BinaryHeap<Reverse<(Datum, Vec<Datum>)>>> =
             BTreeMap::new();
+
+        // Consolidate the snapshot, so we can process it correctly below.
+        differential_dataflow::consolidation::consolidate(&mut rows);
 
         let mut deletions = vec![];
 
         for (row, diff) in rows.iter() {
-            mz_ore::soft_assert!(
-                *diff == 1,
-                "only know how to operate over consolidated data"
+            let status_row = row.unpack();
+            let id = status_row[id_col];
+            let occurred_at = status_row[occurred_at_col];
+
+            // Duplicate rows ARE possible if many status changes happen in VERY quick succession,
+            // so we go ahead and handle them.
+            assert!(
+                *diff > 0,
+                "only know how to operate over consolidated data with diffs > 0, \
+                found diff {} for object {} in {:?}",
+                diff,
+                id,
+                collection
             );
 
-            let d = row.unpack();
-            let source_id = d[source_id];
-            let occurred_at = d[occurred_at];
+            // Consider duplicated rows separately.
+            for _ in 0..*diff {
+                let entries = last_n_entries_per_id.entry(id).or_default();
 
-            let entries = last_n_entries_per_id.entry(source_id).or_default();
+                // We CAN have multiple statuses (most likely Starting and Running) at the exact same
+                // millisecond, depending on how the `health_operator` is scheduled.
+                //
+                // Note that these will be arbitrarily ordered, so a Starting event might
+                // survive and a Running one won't. The next restart will remove the other,
+                // so we don't bother being careful about it.
+                //
+                // TODO(guswynn): unpack these into health-status objects and use
+                // their `Ord1 impl.
+                entries.push(Reverse((occurred_at, status_row.clone())));
 
-            let old = entries.insert(occurred_at, d.clone());
-            mz_ore::soft_assert!(
-                old.is_none(),
-                "expected only one status at each time, but got multiple at {:?}",
-                occurred_at
-            );
-
-            // Retain some number of entries, using pop_first to mark the oldest entries for
-            // deletion.
-            while entries.len() > keep_n {
-                if let Some((_, r)) = entries.pop_first() {
-                    deletions.push(r);
+                // Retain some number of entries, using pop to mark the oldest entries for
+                // deletion.
+                while entries.len() > keep_n {
+                    if let Some(Reverse((_, r))) = entries.pop() {
+                        deletions.push(r);
+                    }
                 }
             }
         }

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -306,7 +306,7 @@ where
 
         // Write the initial starting state to the status shard for all managed objects
         if is_active_worker {
-            for state in health_states.values() {
+            for state in health_states.values_mut() {
                 if mark_starting.contains(&state.id) {
                     if let Some((status_shard, persist_client)) = state.persist_details {
                         let status = O::starting();
@@ -321,6 +321,8 @@ where
                             status.hint(),
                         )
                         .await;
+
+                        state.last_reported_status = Some(status);
                     }
                 }
             }

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -385,6 +385,8 @@ def workflow_bound_size_mz_status_history(c: Composition) -> None:
     c.up("materialized")
 
     # Verify that we have fewer events now
+    # 7 because the truncation default is 5, and the restarted
+    # objects produce a new starting and running event.
     c.testdrive(
         service="testdrive_no_reset",
         input=dedent(


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/22207

this got worse with https://github.com/MaterializeInc/materialize/pull/22179, not sure why...

### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
