### PR TITLE
sql: allow Kafka SASL mechanisms in any case

### DIFF
--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -36,7 +36,7 @@ message ProtoKafkaConnectionTlsConfig {
 }
 
 message ProtoKafkaConnectionSaslConfig {
-    string mechanisms = 1;
+    string sasl_mechanism = 1;
     ProtoStringOrSecret username = 2;
     mz_repr.global_id.ProtoGlobalId password = 3;
     ProtoStringOrSecret tls_root_cert = 4;

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -258,7 +258,7 @@ pub struct KafkaTlsConfig {
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct SaslConfig {
-    pub mechanisms: String,
+    pub sasl_mechanism: String,
     pub username: StringOrSecret,
     pub password: GlobalId,
     pub tls_root_cert: Option<StringOrSecret>,
@@ -276,8 +276,8 @@ impl Arbitrary for SaslConfig {
             proptest::option::of(any::<StringOrSecret>()),
         )
             .prop_map(
-                |(mechanisms, username, password, tls_root_cert)| SaslConfig {
-                    mechanisms,
+                |(sasl_mechanism, username, password, tls_root_cert)| SaslConfig {
+                    sasl_mechanism,
                     username,
                     password,
                     tls_root_cert,
@@ -415,7 +415,7 @@ impl KafkaConnection {
                 }
             }
             Some(KafkaSecurity::Sasl(SaslConfig {
-                mechanisms,
+                sasl_mechanism: mechanisms,
                 username,
                 password,
                 tls_root_cert: certificate_authority,
@@ -563,7 +563,7 @@ impl RustType<ProtoKafkaConnectionTlsConfig> for KafkaTlsConfig {
 impl RustType<ProtoKafkaConnectionSaslConfig> for SaslConfig {
     fn into_proto(&self) -> ProtoKafkaConnectionSaslConfig {
         ProtoKafkaConnectionSaslConfig {
-            mechanisms: self.mechanisms.into_proto(),
+            sasl_mechanism: self.sasl_mechanism.into_proto(),
             username: Some(self.username.into_proto()),
             password: Some(self.password.into_proto()),
             tls_root_cert: self.tls_root_cert.into_proto(),
@@ -572,7 +572,7 @@ impl RustType<ProtoKafkaConnectionSaslConfig> for SaslConfig {
 
     fn from_proto(proto: ProtoKafkaConnectionSaslConfig) -> Result<Self, TryFromProtoError> {
         Ok(SaslConfig {
-            mechanisms: proto.mechanisms,
+            sasl_mechanism: proto.sasl_mechanism,
             username: proto
                 .username
                 .into_rust_if_some("ProtoKafkaConnectionSaslConfig::username")?,

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -9,6 +9,9 @@
 #
 # Test basic connection functionality
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_connection_validation_syntax = true
+
 ###
 # Test core functionality by creating, introspecting and dropping a connection
 ###
@@ -321,13 +324,30 @@ contains:under-specified security configuration
 
 > CREATE SECRET s AS '...';
 
-! CREATE CONNECTION kafka_sasl_lowercase_mechanism TO KAFKA (
+> CREATE CONNECTION kafka_sasl_lowercase_string_mechanism TO KAFKA (
     BROKER 'kafka:9092',
     SASL MECHANISMS = 'plain',
     SASL USERNAME = 'materialize',
     SASL PASSWORD = SECRET s
-  );
-contains:invalid SASL MECHANISM "plain": must be uppercase
+  ) WITH (VALIDATE = FALSE);
+> CREATE CONNECTION kafka_sasl_spongebob_string_mechanism TO KAFKA (
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = 'pLaIN',
+    SASL USERNAME = 'materialize',
+    SASL PASSWORD = SECRET s
+  ) WITH (VALIDATE = FALSE);
+> CREATE CONNECTION kafka_sasl_uppercase_ident_mechanism TO KAFKA (
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = PLAIN,
+    SASL USERNAME = 'materialize',
+    SASL PASSWORD = SECRET s
+  ) WITH (VALIDATE = FALSE);
+> CREATE CONNECTION kafka_sasl_spongebob_ident_mechanism TO KAFKA (
+    BROKER 'kafka:9092',
+    SASL MECHANISMS = pLaIN,
+    SASL USERNAME = 'materialize',
+    SASL PASSWORD = SECRET s
+  ) WITH (VALIDATE = FALSE);
 
 ! CREATE CONNECTION multiple_brokers TO KAFKA (
     BROKER 'kafka:9092, kafka:9093'


### PR DESCRIPTION
To avoid a usability pitfall due to identifier case folding. See comment within for details.

Also rename `mechanisms` to `sasl_mechanism` internally in the codebase for clarity. Despite the user-facing name, librdkafka only allows one SASL mechanism at a time.

Fix #22205.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow the value of the `SASL MECHANISM` option for Kafka connections to be specified in any case.
