### PR TITLE
ci: Fix coverage pipeline

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -59,8 +59,6 @@ so it is executed.""",
 
     parser.add_argument("--coverage", action="store_true")
     parser.add_argument("pipeline", type=str)
-    # TODO Empty argument, used in tests pipeline, remove
-    parser.add_argument("rest", nargs=argparse.REMAINDER)
     args = parser.parse_args()
 
     # Make sure we have an up to date view of main.

--- a/ci/test/mkpipeline.sh
+++ b/ci/test/mkpipeline.sh
@@ -43,7 +43,7 @@ steps:
   $bootstrap_steps
   - wait
   - label: mkpipeline
-    command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline test "$@"
+    command: bin/ci-builder run stable bin/pyactivate -m ci.mkpipeline test $@
     priority: 2
     agents:
       queue: linux


### PR DESCRIPTION
remainder args collided with --coverage and swallowed it. Fixed the mkpipeline.sh script so remainder is not needed anymore

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
