### PR TITLE
zippy: Rearrange the execution of the various Zippy scenarios in the CI

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -210,7 +210,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=55m]
+          args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m]
 
   - id: zippy-kafka-parallel-insert
     label: "Zippy Kafka Parallel Insert"
@@ -221,7 +221,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=10000, --max-execution-time=55m]
+          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=10000, --max-execution-time=30m]
 
   - id: zippy-user-tables
     label: "Zippy User Tables"
@@ -232,7 +232,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=UserTables, --actions=1000]
+          args: [--scenario=UserTables, --actions=10000, --max-execution-time=30m]
 
   - id: zippy-postgres-cdc
     label: "Zippy Postgres CDC"
@@ -243,7 +243,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=PostgresCdc, --actions=10000, --max-execution-time=55m]
+          args: [--scenario=PostgresCdc, --actions=10000, --max-execution-time=30m]
 
   - id: zippy-debezium-postgres
     label: "Zippy Debezium Postgres"
@@ -254,7 +254,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=DebeziumPostgres, --actions=10000, --max-execution-time=55m]
+          args: [--scenario=DebeziumPostgres, --actions=10000, --max-execution-time=30m]
 
   - id: zippy-cluster-replicas
     label: "Zippy Cluster Replicas"
@@ -278,7 +278,7 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: zippy
-          args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=55m]
+          args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=30m]
 
   - id: secrets-aws-secrets-manager
     label: "Secrets AWS"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -55,7 +55,7 @@ steps:
           args: [--scenario=DataflowsLarge, --actions=35000]
 
   - id: zippy-pg-cdc-large
-    label: "Longer Zippy PogresCdc"
+    label: "Large Zippy PogresCdc"
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
@@ -65,7 +65,7 @@ steps:
           composition: zippy
           args: [--scenario=PostgresCdcLarge, --actions=200000]
 
-  - id: zippy-cluster-replicas-large
+  - id: zippy-cluster-replicas-long
     label: "Longer Zippy ClusterReplicas"
     timeout_in_minutes: 2880
     agents:
@@ -78,7 +78,7 @@ steps:
           args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=4h]
 
   - id: zippy-user-tables-large
-    label: "Long Zippy w/ user tables"
+    label: "Large Zippy w/ user tables"
     timeout_in_minutes: 2880
     agents:
       queue: linux-x86_64-large
@@ -88,6 +88,27 @@ steps:
           composition: zippy
           args: [--scenario=UserTablesLarge, --actions=200000]
 
+  - id: zippy-debezium-postgres-long
+    label: "Longer Zippy Debezium Postgres"
+    timeout_in_minutes: 2880
+    agents:
+      queue: linux-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=DebeziumPostgres, --actions=1000000]
+
+  - id: zippy-kafka-parallel-insert
+    label: "Longer Zippy Kafka Parallel Insert"
+    timeout_in_minutes: 2880
+    agents:
+      queue: linux-x86_64-large
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=100000, --max-execution-time=8h]
 
   - id: feature-benchmark-scale-plus-one
     label: "Feature benchmark against 'latest' with --scale=+1"

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -290,7 +290,6 @@ class UserTablesLarge(Scenario):
             ): 10,
             CreateSinkParameterized(max_sinks=10): 10,
             ValidateView: 10,
-            Ingest: 50,
             DML: 50,
         }
 


### PR DESCRIPTION
- make the default Zippy execution time in Nightly to be 30 min

- in the Release Qualification pipeline, add longer versions of the zippy scenarios from Nightly that were previously missing.

- give more precise labels to the steps of the Release Qualification: "long" means a longer verison of the scenario from Nightly, whereas "large" means a specific scenario that is different in some dimension (either more database objects are involved or less kills happen in order for state to accumulate more realistically over the running time of the test)

### Motivation

Cost control.