### PR TITLE
ci: sync the description on deploy only if a README file exists

### DIFF
--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -557,7 +557,7 @@ class Image:
 
     def sync_description(self) -> None:
         """Sync the description to Docker Hub if the image is publishable
-        and either a description or a README.md file exists."""
+        and a README.md file exists."""
 
         if not self.publish:
             ui.say(f"{self.name} is not publishable")
@@ -565,7 +565,7 @@ class Image:
 
         readme_path = self.path / "README.md"
         has_readme = readme_path.exists()
-        if not (self.description or has_readme):
+        if not has_readme:
             ui.say(f"{self.name} has no README.md or description")
             return
 


### PR DESCRIPTION
This should fix https://github.com/MaterializeInc/materialize/pull/22223.

Tested successfully with https://buildkite.com/materialize/deploy/builds/11250.