### PR TITLE
*: remove the mz_view_{foreign}_keys tables

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1123,5 +1123,3 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_storage_shards -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_storage_usage_by_shard -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_type_pg_metadata -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_view_foreign_keys -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_view_keys -->

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -1504,29 +1504,6 @@ pub const MZ_ARRANGEMENT_RECORDS_RAW: BuiltinLog = BuiltinLog {
     variant: LogVariant::Differential(DifferentialLog::ArrangementRecords),
 };
 
-pub static MZ_VIEW_KEYS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
-    name: "mz_view_keys",
-    schema: MZ_INTERNAL_SCHEMA,
-    desc: RelationDesc::empty()
-        .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("column", ScalarType::UInt64.nullable(false))
-        .with_column("key_group", ScalarType::UInt64.nullable(false)),
-    is_retained_metrics_object: false,
-});
-pub static MZ_VIEW_FOREIGN_KEYS: Lazy<BuiltinTable> = Lazy::new(|| {
-    BuiltinTable {
-        name: "mz_view_foreign_keys",
-        schema: MZ_INTERNAL_SCHEMA,
-        desc: RelationDesc::empty()
-            .with_column("child_id", ScalarType::String.nullable(false))
-            .with_column("child_column", ScalarType::UInt64.nullable(false))
-            .with_column("parent_id", ScalarType::String.nullable(false))
-            .with_column("parent_column", ScalarType::UInt64.nullable(false))
-            .with_column("key_group", ScalarType::UInt64.nullable(false))
-            .with_key(vec![0, 1, 4]), // TODO: explain why this is a key.
-        is_retained_metrics_object: false,
-    }
-});
 pub static MZ_KAFKA_SINKS: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     name: "mz_kafka_sinks",
     schema: MZ_CATALOG_SCHEMA,
@@ -5117,8 +5094,6 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Log(&MZ_COMPUTE_FRONTIERS_PER_WORKER),
         Builtin::Log(&MZ_COMPUTE_IMPORT_FRONTIERS_PER_WORKER),
         Builtin::Log(&MZ_COMPUTE_DELAYS_HISTOGRAM_RAW),
-        Builtin::Table(&MZ_VIEW_KEYS),
-        Builtin::Table(&MZ_VIEW_FOREIGN_KEYS),
         Builtin::Table(&MZ_KAFKA_SINKS),
         Builtin::Table(&MZ_KAFKA_CONNECTIONS),
         Builtin::Table(&MZ_KAFKA_SOURCES),

--- a/src/compute-client/src/logging.rs
+++ b/src/compute-client/src/logging.rs
@@ -435,49 +435,6 @@ impl LogVariant {
                 .with_column("duration_ns", ScalarType::UInt64.nullable(false)),
         }
     }
-
-    /// Foreign key relations from the log variant to other log collections.
-    ///
-    /// The result is a list of other variants, and for each a list of local
-    /// and other column identifiers that can be equated.
-    pub fn foreign_keys(&self) -> Vec<(LogVariant, Vec<(usize, usize)>)> {
-        use LogVariant::{Compute, Differential, Timely};
-        match self {
-            Timely(TimelyLog::Operates) => vec![],
-            Timely(TimelyLog::Channels) => vec![],
-            Timely(TimelyLog::Elapsed) => vec![(Timely(TimelyLog::Operates), vec![(0, 0), (1, 1)])],
-            Timely(TimelyLog::Histogram) => {
-                vec![(Timely(TimelyLog::Operates), vec![(0, 0), (1, 1)])]
-            }
-            Timely(TimelyLog::Addresses) => {
-                vec![(Timely(TimelyLog::Operates), vec![(0, 0), (1, 1)])]
-            }
-            Timely(TimelyLog::Parks) => vec![],
-            Timely(TimelyLog::BatchesReceived)
-            | Timely(TimelyLog::BatchesSent)
-            | Timely(TimelyLog::MessagesReceived)
-            | Timely(TimelyLog::MessagesSent) => vec![
-                (Timely(TimelyLog::Channels), vec![(0, 0), (1, 1)]),
-                (Timely(TimelyLog::Channels), vec![(0, 0), (2, 2)]),
-            ],
-            Timely(TimelyLog::Reachability) => vec![],
-            Differential(DifferentialLog::ArrangementBatches)
-            | Differential(DifferentialLog::ArrangementRecords)
-            | Differential(DifferentialLog::Sharing)
-            | Compute(ComputeLog::ArrangementHeapSize)
-            | Compute(ComputeLog::ArrangementHeapCapacity)
-            | Compute(ComputeLog::ArrangementHeapAllocations) => {
-                vec![(Timely(TimelyLog::Operates), vec![(0, 0), (1, 1)])]
-            }
-            Compute(ComputeLog::DataflowCurrent) => vec![],
-            Compute(ComputeLog::FrontierCurrent) => vec![],
-            Compute(ComputeLog::ImportFrontierCurrent) => vec![],
-            Compute(ComputeLog::FrontierDelay) => vec![],
-            Compute(ComputeLog::PeekCurrent) => vec![],
-            Compute(ComputeLog::PeekDuration) => vec![],
-            Compute(ComputeLog::ShutdownDuration) => vec![],
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2133,7 +2133,7 @@ fn test_introspection_user_permissions() {
         .is_err());
 
     assert!(introspection_client
-        .query("SELECT * FROM mz_internal.mz_view_keys", &[])
+        .query("SELECT * FROM mz_internal.mz_comments", &[])
         .is_ok());
     assert!(introspection_client
         .query("SELECT * FROM mz_catalog.mz_tables", &[])
@@ -2146,7 +2146,7 @@ fn test_introspection_user_permissions() {
         .batch_execute("SET CLUSTER TO 'mz_system'")
         .unwrap();
     assert!(introspection_client
-        .query("SELECT * FROM mz_internal.mz_view_keys", &[])
+        .query("SELECT * FROM mz_internal.mz_comments", &[])
         .is_ok());
     assert!(introspection_client
         .query("SELECT * FROM mz_catalog.mz_tables", &[])
@@ -2160,7 +2160,7 @@ fn test_introspection_user_permissions() {
         .unwrap();
     assert!(introspection_client.query("SELECT * FROM t1", &[]).is_err());
     assert!(introspection_client
-        .query("SELECT * FROM mz_internal.mz_view_keys", &[])
+        .query("SELECT * FROM mz_internal.mz_comments", &[])
         .is_ok());
     assert!(introspection_client
         .query("SELECT * FROM mz_catalog.mz_tables", &[])

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -701,6 +701,4 @@ mz_storage_shards
 mz_storage_usage_by_shard
 mz_subscriptions
 mz_type_pg_metadata
-mz_view_foreign_keys
-mz_view_keys
 mz_webhook_sources

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -709,14 +709,6 @@ mz_type_pg_metadata
 BASE TABLE
 materialize
 mz_internal
-mz_view_foreign_keys
-BASE TABLE
-materialize
-mz_internal
-mz_view_keys
-BASE TABLE
-materialize
-mz_internal
 mz_webhook_sources
 BASE TABLE
 materialize

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -1230,6 +1230,6 @@ select
                as bool)) = mz_internal.mz_normalize_object_name(
             CAST(ref_4."schema_id" as text))
                ) as subq_7
-  where (select "child_id" from mz_internal.mz_view_foreign_keys limit 1)
+  where (select "id" from mz_internal.mz_comments limit 1)
        = subq_7."c0";
 ----

--- a/test/sqllogictest/unstable.slt
+++ b/test/sqllogictest/unstable.slt
@@ -9,10 +9,10 @@
 
 mode cockroach
 
-# mz_view_keys and mz_view_foreign_keys are unstable.
+# Objects in the mz_internal schema are.
 
 statement error cannot create view with unstable dependencies
-CREATE VIEW v AS SELECT object_id, column, key_group FROM mz_internal.mz_view_keys
+CREATE VIEW v AS SELECT id, object_type, comment FROM mz_internal.mz_comments
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
@@ -20,7 +20,7 @@ ALTER SYSTEM SET enable_rbac_checks TO false;
 COMPLETE 0
 
 statement error cannot create index with unstable dependencies
-CREATE DEFAULT INDEX ON mz_internal.mz_view_foreign_keys
+CREATE DEFAULT INDEX ON mz_internal.mz_comments
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM RESET enable_rbac_checks;
@@ -35,4 +35,4 @@ CREATE VIEW v AS SELECT id, oid, schema_id, name FROM mz_tables
 # SELECTs from unstable objects are allowed.
 
 statement ok
-SELECT object_id, column, key_group FROM mz_internal.mz_view_keys
+SELECT id, object_type, comment FROM mz_internal.mz_comments

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -568,8 +568,6 @@ mz_sessions
 mz_storage_usage_by_shard
 mz_subscriptions
 mz_type_pg_metadata
-mz_view_foreign_keys
-mz_view_keys
 mz_webhook_sources
 
 > SHOW VIEWS FROM mz_internal
@@ -659,7 +657,7 @@ test_table
 
 # `SHOW TABLES` and `mz_tables` should agree.
 > SELECT COUNT(*) FROM mz_tables WHERE id LIKE 's%'
-51
+49
 
 # There is one entry in mz_indexes for each field_number/expression of the index.
 > SELECT COUNT(id) FROM mz_indexes WHERE id LIKE 's%'

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -279,7 +279,7 @@ DROP INDEX sys_ind
 ALTER SYSTEM SET enable_rbac_checks TO false
 
 # Test that creating indexes on objects in the mz_internal schema fails
-! CREATE INDEX illegal_sys_ind ON mz_internal.mz_view_keys (object_id)
+! CREATE INDEX illegal_sys_ind ON mz_internal.mz_comments (id)
 contains:cannot create index with unstable dependencies
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize


### PR DESCRIPTION
This PR removes two system tables:

 * `mz_internal.mz_view_keys`
 * `mz_internal.mz_view_foreign_keys`

Neither of these tables is documented or works as one would expect from its name. They are also not documented and we are not aware of any valid use case for them. Better to remove them than keeping them around to cause confusion.

### Motivation

  * This PR fixes a previously unreported bug.

The contents of `mz_view_keys` and `mz_view_foreign_keys` are incomplete, only declaring keys for introspection sources, not for any other tables, sources, or views.

The proper fix is https://github.com/MaterializeInc/materialize/issues/15037 but we don't know when we'll get to it.

### Tips for reviewer

[Discussion in Slack.](https://materializeinc.slack.com/archives/CM7ATT65S/p1696589788239279)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
