### PR TITLE
adapter: Make existing enable_comment a feature flag

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5232,12 +5232,7 @@ pub fn plan_comment(
 ) -> Result<Plan, PlanError> {
     const MAX_COMMENT_LENGTH: usize = 1024;
 
-    if !scx.catalog.system_vars().enable_comment() {
-        return Err(PlanError::Unsupported {
-            feature: "COMMENT ON".to_string(),
-            issue_no: Some(20218),
-        });
-    }
+    scx.require_feature_flag(&vars::ENABLE_COMMENT)?;
 
     let CommentStatement { object, comment } = stmt;
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1376,13 +1376,6 @@ pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
-pub const ENABLE_COMMENT: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_comment"),
-    value: &false,
-    description: "Enables the COMMENT ON feature for objects in the database (Materialize).",
-    internal: false,
-};
-
 pub const MIN_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("min_timestamp_interval"),
     value: &Duration::from_millis(1000),
@@ -1716,6 +1709,12 @@ feature_flags!(
         "jemalloc heap memory profiling",
         false
     ),
+    (
+        enable_comment,
+        "Enables the COMMENT ON feature for objects in the database (Materialize).",
+        false, // default false
+        false  // internal false
+    )
 );
 
 /// Represents the input to a variable.
@@ -2422,7 +2421,6 @@ impl SystemVars {
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
             .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
             .with_var(&ENABLE_DEFAULT_CONNECTION_VALIDATION)
-            .with_var(&ENABLE_COMMENT)
             .with_var(&MIN_TIMESTAMP_INTERVAL)
             .with_var(&MAX_TIMESTAMP_INTERVAL)
             .with_var(&LOGGING_FILTER)
@@ -3083,11 +3081,6 @@ impl SystemVars {
     /// Returns the `enable_default_connection_validation` configuration parameter.
     pub fn enable_default_connection_validation(&self) -> bool {
         *self.expect_value(&ENABLE_DEFAULT_CONNECTION_VALIDATION)
-    }
-
-    /// Returns the `enable_comment` configuration parameter.
-    pub fn enable_comment(&self) -> bool {
-        *self.expect_value(&ENABLE_COMMENT)
     }
 
     /// Returns the `min_timestamp_interval` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1711,7 +1711,7 @@ feature_flags!(
     ),
     (
         enable_comment,
-        "Enables the COMMENT ON feature for objects in the database (Materialize).",
+        "the COMMENT ON feature for objects",
         false, // default false
         false  // internal false
     )

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -28,7 +28,7 @@ DateStyle                           "ISO, MDY"              "Sets the display fo
 emit_introspection_query_notice     on                      "Whether to print a notice when querying per-replica introspection sources."
 emit_timestamp_notice               off                     "Boolean flag indicating whether to send a NOTICE with timestamp explanations of queries (Materialize)."
 emit_trace_id_notice                off                     "Boolean flag indicating whether to send a NOTICE specifying the trace id when available (Materialize)."
-enable_comment                      off                     "Enables the COMMENT ON feature for objects in the database (Materialize)."
+enable_comment                      off                     "Whether the COMMENT ON feature for objects is allowed (Materialize)."
 enable_rbac_checks                  on                      "User facing global boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 enable_session_rbac_checks          off                     "User facing session boolean flag indicating whether to apply RBAC checks before executing statements (Materialize)."
 extra_float_digits                  3                       "Adjusts the number of digits displayed for floating-point values (PostgreSQL)."


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
From https://github.com/MaterializeInc/materialize/pull/22019#pullrequestreview-1661773212
> Even with MZ_UNSAFE_MODE=1 MZ_ALL_FEATURES=1 comment on is not yet enabled. In src/sql/src/session/vars.rs add enable_comment to feature_flags!.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
