### PR TITLE
docs: statement_timeout does not apply for SELECT

### DIFF
--- a/doc/user/layouts/shortcodes/session-variables.html
+++ b/doc/user/layouts/shortcodes/session-variables.html
@@ -34,5 +34,5 @@ server_version                              | Version-dependent         | **Read
 server_version_num                          | Version-dependent         | **Read-only.** The PostgreSQL compatible server version as an integer.
 sql_safe_updates                            | `false`                   | Boolean flag indicating whether to prohibit SQL statements that may be overly destructive.
 standard_conforming_strings                 | `true`                    | Boolean flag indicating whether ordinary string literals (`'...'`) should treat backslashes literally. The only supported value is `true`.
-statement_timeout                           | `10 seconds`              | The maximum allowed duration of `INSERT`, `SELECT`, `UPDATE`, and `DELETE` operations. If this value is specified without units, it is taken as milliseconds.
+statement_timeout                           | `10 seconds`              | The maximum allowed duration of `INSERT`, `UPDATE`, and `DELETE` operations. If this value is specified without units, it is taken as milliseconds.
 timezone                                    | `UTC`                     | The time zone for displaying and interpreting timestamps. The only supported value is `UTC`.


### PR DESCRIPTION
Discussion in https://materializeinc.slack.com/archives/C02FWJ94HME/p1696603172193219

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
