### PR TITLE
comments: Add CommentName to AstInfo

### DIFF
--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3911,47 +3911,47 @@ impl_display_t!(CommentStatement);
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CommentObjectType<T: AstInfo> {
     Table {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     View {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Column {
-        relation_name: UnresolvedItemName,
+        relation_name: T::ItemName,
         column_name: Ident,
     },
     MaterializedView {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Source {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Sink {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Index {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Func {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Connection {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Type {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Secret {
-        name: UnresolvedItemName,
+        name: T::ItemName,
     },
     Role {
-        name: Ident,
+        name: T::RoleName,
     },
     Database {
-        name: UnresolvedDatabaseName,
+        name: T::DatabaseName,
     },
     Schema {
-        name: UnresolvedSchemaName,
+        name: T::SchemaName,
     },
     Cluster {
         name: T::ClusterName,

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -3910,55 +3910,22 @@ impl_display_t!(CommentStatement);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum CommentObjectType<T: AstInfo> {
-    Table {
-        name: T::ItemName,
-    },
-    View {
-        name: T::ItemName,
-    },
-    Column {
-        relation_name: T::ItemName,
-        column_name: Ident,
-    },
-    MaterializedView {
-        name: T::ItemName,
-    },
-    Source {
-        name: T::ItemName,
-    },
-    Sink {
-        name: T::ItemName,
-    },
-    Index {
-        name: T::ItemName,
-    },
-    Func {
-        name: T::ItemName,
-    },
-    Connection {
-        name: T::ItemName,
-    },
-    Type {
-        name: T::ItemName,
-    },
-    Secret {
-        name: T::ItemName,
-    },
-    Role {
-        name: T::RoleName,
-    },
-    Database {
-        name: T::DatabaseName,
-    },
-    Schema {
-        name: T::SchemaName,
-    },
-    Cluster {
-        name: T::ClusterName,
-    },
-    ClusterReplica {
-        name: QualifiedReplica,
-    },
+    Table { name: T::ItemName },
+    View { name: T::ItemName },
+    Column { name: T::ColumnName },
+    MaterializedView { name: T::ItemName },
+    Source { name: T::ItemName },
+    Sink { name: T::ItemName },
+    Index { name: T::ItemName },
+    Func { name: T::ItemName },
+    Connection { name: T::ItemName },
+    Type { name: T::ItemName },
+    Secret { name: T::ItemName },
+    Role { name: T::RoleName },
+    Database { name: T::DatabaseName },
+    Schema { name: T::SchemaName },
+    Cluster { name: T::ClusterName },
+    ClusterReplica { name: QualifiedReplica },
 }
 
 impl<T: AstInfo> AstDisplay for CommentObjectType<T> {
@@ -3974,14 +3941,9 @@ impl<T: AstInfo> AstDisplay for CommentObjectType<T> {
                 f.write_str("VIEW ");
                 f.write_node(name);
             }
-            Column {
-                relation_name,
-                column_name,
-            } => {
+            Column { name } => {
                 f.write_str("COLUMN ");
-                f.write_node(relation_name);
-                f.write_str(".");
-                f.write_node(column_name);
+                f.write_node(name);
             }
             MaterializedView { name } => {
                 f.write_str("MATERIALIZED VIEW ");

--- a/src/sql-parser/src/ast/metadata.rs
+++ b/src/sql-parser/src/ast/metadata.rs
@@ -44,6 +44,8 @@ pub trait AstInfo: Clone {
     /// The type used for item references. Items are the subset of objects that are namespaced by a
     /// database and schema.
     type ItemName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
+    /// The type used for column references.
+    type ColumnName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for schema names.
     type SchemaName: AstDisplay + Clone + Hash + Debug + Eq + Ord;
     /// The type used for database names.
@@ -66,6 +68,7 @@ pub struct Raw;
 impl AstInfo for Raw {
     type NestedStatement = Statement<Raw>;
     type ItemName = RawItemName;
+    type ColumnName = RawColumnName;
     type SchemaName = UnresolvedSchemaName;
     type DatabaseName = UnresolvedDatabaseName;
     type ClusterName = RawClusterName;
@@ -124,6 +127,21 @@ where
         f.fold_item_name(self)
     }
 }
+
+#[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
+pub struct RawColumnName {
+    pub relation: RawItemName,
+    pub column: Ident,
+}
+
+impl AstDisplay for RawColumnName {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        f.write_node(&self.relation);
+        f.write_str(".");
+        f.write_node(&self.column);
+    }
+}
+impl_display!(RawColumnName);
 
 #[derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Clone)]
 pub enum RawClusterName {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -7698,44 +7698,44 @@ impl<'a> Parser<'a> {
             CLUSTER,
         ])? {
             TABLE => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Table { name }
             }
             VIEW => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::View { name }
             }
             MATERIALIZED => {
                 self.expect_keyword(VIEW)?;
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::MaterializedView { name }
             }
             SOURCE => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Source { name }
             }
             SINK => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Sink { name }
             }
             INDEX => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Index { name }
             }
             FUNCTION => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Func { name }
             }
             CONNECTION => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Connection { name }
             }
             TYPE => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Type { name }
             }
             SECRET => {
-                let name = self.parse_item_name()?;
+                let name = self.parse_raw_name()?;
                 CommentObjectType::Secret { name }
             }
             ROLE => {
@@ -7772,7 +7772,7 @@ impl<'a> Parser<'a> {
                 // The last identifier specifies the column of a relation.
                 let column_name = identifiers.pop().expect("checked length above");
                 CommentObjectType::Column {
-                    relation_name: UnresolvedItemName(identifiers),
+                    relation_name: RawItemName::Name(UnresolvedItemName(identifiers)),
                     column_name,
                 }
             }

--- a/src/sql-parser/tests/testdata/comment
+++ b/src/sql-parser/tests/testdata/comment
@@ -18,21 +18,21 @@ COMMENT ON TABLE my_table IS 'hello world this is a cool table.'
 ----
 COMMENT ON TABLE my_table IS 'hello world this is a cool table.'
 =>
-Comment(CommentStatement { object: Table { name: UnresolvedItemName([Ident("my_table")]) }, comment: Some("hello world this is a cool table.") })
+Comment(CommentStatement { object: Table { name: Name(UnresolvedItemName([Ident("my_table")])) }, comment: Some("hello world this is a cool table.") })
 
 parse-statement
 COMMENT ON VIEW amazing_view IS 'this view powers a 1,000,000x startup'
 ----
 COMMENT ON VIEW amazing_view IS 'this view powers a 1,000,000x startup'
 =>
-Comment(CommentStatement { object: View { name: UnresolvedItemName([Ident("amazing_view")]) }, comment: Some("this view powers a 1,000,000x startup") })
+Comment(CommentStatement { object: View { name: Name(UnresolvedItemName([Ident("amazing_view")])) }, comment: Some("this view powers a 1,000,000x startup") })
 
 parse-statement
 COMMENT ON COLUMN building.load_bearing_column IS 'do not move this column, it is load bearing'
 ----
 COMMENT ON COLUMN building.load_bearing_column IS 'do not move this column, it is load bearing'
 =>
-Comment(CommentStatement { object: Column { relation_name: UnresolvedItemName([Ident("building")]), column_name: Ident("load_bearing_column") }, comment: Some("do not move this column, it is load bearing") })
+Comment(CommentStatement { object: Column { relation_name: Name(UnresolvedItemName([Ident("building")])), column_name: Ident("load_bearing_column") }, comment: Some("do not move this column, it is load bearing") })
 
 parse-statement
 COMMENT ON TABLE my_table
@@ -46,63 +46,63 @@ COMMENT ON TABLE escaping IS 'it''s a single '' within a single '' string'
 ----
 COMMENT ON TABLE escaping IS 'it''s a single '' within a single '' string'
 =>
-Comment(CommentStatement { object: Table { name: UnresolvedItemName([Ident("escaping")]) }, comment: Some("it's a single ' within a single ' string") })
+Comment(CommentStatement { object: Table { name: Name(UnresolvedItemName([Ident("escaping")])) }, comment: Some("it's a single ' within a single ' string") })
 
 parse-statement
 COMMENT ON VIEW emoji_movie IS 'this movie was not that good 📉😭'
 ----
 COMMENT ON VIEW emoji_movie IS 'this movie was not that good 📉😭'
 =>
-Comment(CommentStatement { object: View { name: UnresolvedItemName([Ident("emoji_movie")]) }, comment: Some("this movie was not that good 📉😭") })
+Comment(CommentStatement { object: View { name: Name(UnresolvedItemName([Ident("emoji_movie")])) }, comment: Some("this movie was not that good 📉😭") })
 
 parse-statement
 COMMENT ON COLUMN cool_table.bad_column IS NULL
 ----
 COMMENT ON COLUMN cool_table.bad_column IS NULL
 =>
-Comment(CommentStatement { object: Column { relation_name: UnresolvedItemName([Ident("cool_table")]), column_name: Ident("bad_column") }, comment: None })
+Comment(CommentStatement { object: Column { relation_name: Name(UnresolvedItemName([Ident("cool_table")])), column_name: Ident("bad_column") }, comment: None })
 
 parse-statement
 COMMENT ON MATERIALIZED VIEW mz IS 'hello world'
 ----
 COMMENT ON MATERIALIZED VIEW mz IS 'hello world'
 =>
-Comment(CommentStatement { object: MaterializedView { name: UnresolvedItemName([Ident("mz")]) }, comment: Some("hello world") })
+Comment(CommentStatement { object: MaterializedView { name: Name(UnresolvedItemName([Ident("mz")])) }, comment: Some("hello world") })
 
 parse-statement
 COMMENT ON SINK kool_kafka IS 'i wish kafka was easier'
 ----
 COMMENT ON SINK kool_kafka IS 'i wish kafka was easier'
 =>
-Comment(CommentStatement { object: Sink { name: UnresolvedItemName([Ident("kool_kafka")]) }, comment: Some("i wish kafka was easier") })
+Comment(CommentStatement { object: Sink { name: Name(UnresolvedItemName([Ident("kool_kafka")])) }, comment: Some("i wish kafka was easier") })
 
 parse-statement
 COMMENT ON SOURCE pg_src IS 'ingest data all the time!'
 ----
 COMMENT ON SOURCE pg_src IS 'ingest data all the time!'
 =>
-Comment(CommentStatement { object: Source { name: UnresolvedItemName([Ident("pg_src")]) }, comment: Some("ingest data all the time!") })
+Comment(CommentStatement { object: Source { name: Name(UnresolvedItemName([Ident("pg_src")])) }, comment: Some("ingest data all the time!") })
 
 parse-statement
 COMMENT ON INDEX my_db.x.fast IS 'this is a super fast index'
 ----
 COMMENT ON INDEX my_db.x.fast IS 'this is a super fast index'
 =>
-Comment(CommentStatement { object: Index { name: UnresolvedItemName([Ident("my_db"), Ident("x"), Ident("fast")]) }, comment: Some("this is a super fast index") })
+Comment(CommentStatement { object: Index { name: Name(UnresolvedItemName([Ident("my_db"), Ident("x"), Ident("fast")])) }, comment: Some("this is a super fast index") })
 
 parse-statement
 COMMENT ON FUNCTION ai_func IS 'ai in a bottle $$$'
 ----
 COMMENT ON FUNCTION ai_func IS 'ai in a bottle $$$'
 =>
-Comment(CommentStatement { object: Func { name: UnresolvedItemName([Ident("ai_func")]) }, comment: Some("ai in a bottle $$$") })
+Comment(CommentStatement { object: Func { name: Name(UnresolvedItemName([Ident("ai_func")])) }, comment: Some("ai in a bottle $$$") })
 
 parse-statement
 COMMENT ON CONNECTION kafka_super_prod IS 'yep'
 ----
 COMMENT ON CONNECTION kafka_super_prod IS 'yep'
 =>
-Comment(CommentStatement { object: Connection { name: UnresolvedItemName([Ident("kafka_super_prod")]) }, comment: Some("yep") })
+Comment(CommentStatement { object: Connection { name: Name(UnresolvedItemName([Ident("kafka_super_prod")])) }, comment: Some("yep") })
 
 parse-statement
 COMMENT ON ROLE space_monkey IS 'should be our mascot'
@@ -144,11 +144,11 @@ COMMENT ON TYPE special_int IS 'not enough bits'
 ----
 COMMENT ON TYPE special_int IS 'not enough bits'
 =>
-Comment(CommentStatement { object: Type { name: UnresolvedItemName([Ident("special_int")]) }, comment: Some("not enough bits") })
+Comment(CommentStatement { object: Type { name: Name(UnresolvedItemName([Ident("special_int")])) }, comment: Some("not enough bits") })
 
 parse-statement
 COMMENT ON SECRET api_key IS 'shhhhhh'
 ----
 COMMENT ON SECRET api_key IS 'shhhhhh'
 =>
-Comment(CommentStatement { object: Secret { name: UnresolvedItemName([Ident("api_key")]) }, comment: Some("shhhhhh") })
+Comment(CommentStatement { object: Secret { name: Name(UnresolvedItemName([Ident("api_key")])) }, comment: Some("shhhhhh") })

--- a/src/sql-parser/tests/testdata/comment
+++ b/src/sql-parser/tests/testdata/comment
@@ -32,7 +32,7 @@ COMMENT ON COLUMN building.load_bearing_column IS 'do not move this column, it i
 ----
 COMMENT ON COLUMN building.load_bearing_column IS 'do not move this column, it is load bearing'
 =>
-Comment(CommentStatement { object: Column { relation_name: Name(UnresolvedItemName([Ident("building")])), column_name: Ident("load_bearing_column") }, comment: Some("do not move this column, it is load bearing") })
+Comment(CommentStatement { object: Column { name: RawColumnName { relation: Name(UnresolvedItemName([Ident("building")])), column: Ident("load_bearing_column") } }, comment: Some("do not move this column, it is load bearing") })
 
 parse-statement
 COMMENT ON TABLE my_table
@@ -60,7 +60,7 @@ COMMENT ON COLUMN cool_table.bad_column IS NULL
 ----
 COMMENT ON COLUMN cool_table.bad_column IS NULL
 =>
-Comment(CommentStatement { object: Column { relation_name: Name(UnresolvedItemName([Ident("cool_table")])), column_name: Ident("bad_column") }, comment: None })
+Comment(CommentStatement { object: Column { name: RawColumnName { relation: Name(UnresolvedItemName([Ident("cool_table")])), column: Ident("bad_column") } }, comment: None })
 
 parse-statement
 COMMENT ON MATERIALIZED VIEW mz IS 'hello world'

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5262,9 +5262,7 @@ pub fn plan_comment(
         | com_ty @ CommentObjectType::Sink { name }
         | com_ty @ CommentObjectType::Type { name }
         | com_ty @ CommentObjectType::Secret { name } => {
-            let name = normalize::unresolved_item_name(name.clone())?;
-            let item = scx.catalog.resolve_item(&name)?;
-
+            let item = scx.get_item_by_resolved_name(name)?;
             match (com_ty, item.item_type()) {
                 (CommentObjectType::Table { .. }, CatalogItemType::Table) => {
                     (CommentObjectId::Table(item.id()), None)
@@ -5323,16 +5321,15 @@ pub fn plan_comment(
             relation_name,
             column_name,
         } => {
-            let name = normalize::unresolved_item_name(relation_name.clone())?;
-            let item = scx.catalog.resolve_item(&name)?;
-
+            let item = scx.get_item_by_resolved_name(relation_name)?;
             let column_name = normalize::column_name(column_name.clone());
             let desc = item.desc(&scx.catalog.resolve_full_name(item.name()))?;
 
             // Check to make sure this column exists.
             let Some((pos, _ty)) = desc.get_by_name(&column_name) else {
+                let name = relation_name.full_item_name().clone();
                 return Err(PlanError::UnknownColumn {
-                    table: Some(name),
+                    table: Some(name.into()),
                     column: column_name,
                 });
             };
@@ -5352,21 +5349,14 @@ pub fn plan_comment(
                 }
             }
         }
-        CommentObjectType::Role { name } => {
-            let role = scx.catalog.resolve_role(name.as_str())?;
-            (CommentObjectId::Role(role.id()), None)
-        }
+        CommentObjectType::Role { name } => (CommentObjectId::Role(name.id), None),
         CommentObjectType::Database { name } => {
-            let database = scx.resolve_database(name)?;
-            (CommentObjectId::Database(database.id()), None)
+            (CommentObjectId::Database(*name.database_id()), None)
         }
-        CommentObjectType::Schema { name } => {
-            let schema = scx.resolve_schema(name.clone())?;
-            (
-                CommentObjectId::Schema((*schema.database(), *schema.id())),
-                None,
-            )
-        }
+        CommentObjectType::Schema { name } => (
+            CommentObjectId::Schema((*name.database_spec(), *name.schema_spec())),
+            None,
+        ),
         CommentObjectType::Cluster { name } => (CommentObjectId::Cluster(name.id), None),
         CommentObjectType::ClusterReplica { name } => {
             let replica = scx.catalog.resolve_cluster_replica(name)?;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -5317,23 +5317,8 @@ pub fn plan_comment(
                 }
             }
         }
-        CommentObjectType::Column {
-            relation_name,
-            column_name,
-        } => {
-            let item = scx.get_item_by_resolved_name(relation_name)?;
-            let column_name = normalize::column_name(column_name.clone());
-            let desc = item.desc(&scx.catalog.resolve_full_name(item.name()))?;
-
-            // Check to make sure this column exists.
-            let Some((pos, _ty)) = desc.get_by_name(&column_name) else {
-                let name = relation_name.full_item_name().clone();
-                return Err(PlanError::UnknownColumn {
-                    table: Some(name.into()),
-                    column: column_name,
-                });
-            };
-
+        CommentObjectType::Column { name } => {
+            let (item, pos) = scx.get_column_by_resolved_name(name)?;
             match item.item_type() {
                 CatalogItemType::Table => (CommentObjectId::Table(item.id()), Some(pos + 1)),
                 CatalogItemType::Source => (CommentObjectId::Source(item.id()), Some(pos + 1)),


### PR DESCRIPTION
This PR cleans up some rough edges that exist for comments around name resolution of objects. Previously we relied on types like `UnresolvedItemName` that we'd then "manually" resolve in planning. In this PR we refactor the `COMMENT ON` code paths to use the associated types on the `AstInfo` trait, e.g. `AstInfo::ItemName`, which performs automatic name resolution.

This PR also adds a new associated type to `AstInfo` called `ColumnName` which provides a similar level of automatic name resolution as the other associated types.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

The PR is broken into two commits:

1. Refactors the existing variants of `CommentObjectType` to use `T::ItemName` instead of `UnresolvedItemName`.
2. Adds a new associated type to `AstInfo` called `CommentName`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
