### PR TITLE
Fix a bug in `inline_if_not_too_big`

### DIFF
--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -974,7 +974,7 @@ impl PredicatePushdown {
                     map_exprs[c - input_arity].visit_post(&mut |e| {
                         if let MirScalarExpr::Column(c) = e {
                             if *c >= input_arity {
-                                if !support.insert(*c) {
+                                if support.insert(*c) {
                                     workset.push(*c);
                                 }
                             }

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -923,6 +923,35 @@ Source materialize.public.t
 
 EOF
 
+# Regression test for https://github.com/MaterializeInc/materialize/issues/22257
+# The transitive closure computation in `inline_if_not_too_big` has to do more than one step here. For this, later map
+# expressions should mention only the previous map expression, but not earlier ones. Also, there has to be at least
+# 3 map expressions, so that adding the support of the last one doesn't immediately cover all of the map expressions.
+query T multiline
+EXPLAIN
+SELECT * FROM (
+  SELECT z2 * 4 AS z3
+  FROM (
+    SELECT z1 + 1 AS z2
+    FROM (
+      SELECT x, y, x*y AS z1
+      FROM t
+    )
+  )
+)
+WHERE z3 > 5;
+----
+Explained Query:
+  Project (#2)
+    Filter (#2 > 5)
+      Map ((((#0 * #1) + 1) * 4))
+        ReadStorage materialize.public.t
+
+Source materialize.public.t
+  filter=(((((#0 * #1) + 1) * 4) > 5))
+
+EOF
+
 # Test when `push_filters_through_map` runs into the inlining limit: The source shouldn't have the filter pushed down
 # into it.
 query T multiline


### PR DESCRIPTION
Fixes the release blocker #22257.

`support.insert(*c)` returns true when it was _not_ present in the set, in which case we have to attend to that expression too.

The comment on the added test explains why the existing tests did not catch this.

### Motivation

  * This PR fixes a recognized bug: #22257

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
