### PR TITLE
buildkite: Retry the devel-docker-tags CI step up to 2 times

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -80,6 +80,11 @@ steps:
     agents:
       queue: linux-x86_64
     coverage: skip
+    # Fortify against intermittent DockerHub issues
+    retry:
+      automatic:
+        - exit_status: 1
+          limit: 2
 
   - id: lint-fast
     label: Lint and rustfmt


### PR DESCRIPTION
Tagging the devel images in DockerHub can fail because of intermittent issues. This impacts the following:
- the Nightly canary will attempt to run the image in the cloud and fail
- bisection attempts can be more difficult if not all intermediate images are available on DockerHub

Because the CI step contains several individual operations involving DockerHub, we use a global Buildkite-level retry as opposed to attempting to retry each operation separately.


### Motivation

This failure:

https://buildkite.com/materialize/tests/builds/65414#018b06f4-2e5a-4478-acf0-c9f2a344ddbe

caused this failure:

https://buildkite.com/materialize/nightlies/builds/4645#018b13a6-be64-478f-a878-da746f836545