### PR TITLE
ci: annotate error in try command

### DIFF
--- a/misc/shlib/shlib.bash
+++ b/misc/shlib/shlib.bash
@@ -83,6 +83,7 @@ try() {
         # The command failed. Tell Buildkite to uncollapse this log section, so
         # that the errors are immediately visible.
         in_ci && ci_uncollapse_current_section
+        echo "^^^ above command failed"
     fi
     ((++ci_try_total))
 }


### PR DESCRIPTION
### Motivation

Make it more obvious which command caused an error.