### PR TITLE
ci: Add SQLsmith to Release Qualification

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -622,9 +622,7 @@ steps:
     artifact_paths: junit_*.xml
     timeout_in_minutes: 30
     agents:
-      # A larger instance is needed since SQLsmith likes creating
-      # large queries and going out of memory
-      queue: builder-linux-x86_64
+      queue: linux-x86_64
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqlsmith

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -99,6 +99,29 @@ steps:
           composition: feature-benchmark
           args: [--other-tag=latest, --scale=+1]
 
+  - id: sqlsmith-long
+    label: "SQLsmith"
+    artifact_paths: junit_*.xml
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sqlsmith
+          args: [--max-joins=1, --runtime=6000]
+
+  - id: sqlsmith-explain-long
+    label: "SQLsmith explain"
+    artifact_paths: junit_*.xml
+    timeout_in_minutes: 120
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sqlsmith
+          args: [--max-joins=15, --explain-only, --runtime=6000]
+
+
   - wait: ~
     continue_on_failure: true
 

--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-# Build and run SQLsmith ported for Materialize
+# Build and run SQLsmith, a random query generator, ported for Materialize
 
 MZFROM ubuntu-base
 


### PR DESCRIPTION
2 hour runs. Also let SQLsmith run with fewer resources now following refinements

As discussed in QA team sync

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
