### PR TITLE
websocket: Do continuous auth validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,7 @@ dependencies = [
  "hyper-openssl",
  "hyper-tls",
  "include_dir",
+ "insta",
  "itertools",
  "jsonwebtoken",
  "libc",

--- a/src/environmentd/Cargo.toml
+++ b/src/environmentd/Cargo.toml
@@ -110,6 +110,7 @@ assert_cmd = "2.0.5"
 bytes = "1.3.0"
 datadriven = "0.6.0"
 fallible-iterator = "0.2.0"
+insta = "1.32"
 itertools = "0.10.5"
 jsonwebtoken = "8.2.0"
 mz-pgrepr = { path = "../pgrepr" }

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -308,6 +308,12 @@ impl Authentication {
     ) -> Result<ValidatedClaims, Error> {
         validate_access_token(&self.validation_config, token, expected_email)
     }
+
+    /// Returns a [`Future`] that resolves when the provided claims have expired.
+    pub fn valid_until(&self, claims: &ValidatedClaims) -> BoxFuture<'static, ()> {
+        let valid_for = valid_for(&self.validation_config.now, claims);
+        Box::pin(tokio::time::sleep(valid_for))
+    }
 }
 
 #[derive(Clone, Derivative)]


### PR DESCRIPTION
This PR updates our websocket handler to continuously validate the initially provided user authentication. Based on the changes introduced in https://github.com/MaterializeInc/materialize/pull/22184, it essentially polls the `valid_until` Future in the already existing `select!` loop we have that also checks a timeout.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/17934

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
