### PR TITLE
RBAC: Always enable RBAC for system roles

### DIFF
--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -90,14 +90,6 @@ impl Coordinator {
 
         let session_catalog = self.catalog.for_session(ctx.session());
 
-        if let Err(e) = introspection::user_privilege_hack(
-            &session_catalog,
-            ctx.session(),
-            &plan,
-            &resolved_ids,
-        ) {
-            return ctx.retire(Err(e));
-        }
         if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &plan) {
             return ctx.retire(Err(e));
         }

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -67,8 +67,12 @@ macro_rules! rbac_preamble {
             ));
         };
 
-        // Skip RBAC checks if RBAC is disabled.
-        if !is_rbac_enabled_for_session($catalog.system_vars(), $session_vars) {
+        // Skip RBAC checks if RBAC is disabled. However, we never skip RBAC checks for system
+        // roles. This allows us to limit access of system users even when RBAC is off.
+        if !is_rbac_enabled_for_session($catalog.system_vars(), $session_vars)
+            && !$role_metadata.current_role.is_system()
+            && !$role_metadata.session_role.is_system()
+        {
             return Ok(());
         }
 

--- a/test/sqllogictest/mz-support-privileges.slt
+++ b/test/sqllogictest/mz-support-privileges.slt
@@ -1,0 +1,49 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Tests that assert the privileges that are assumed to be always granted to
+# the mz_support user.
+
+statement ok
+CREATE TABLE t (a INT)
+
+simple conn=mz_support,user=mz_support
+SET CLUSTER TO default
+----
+COMPLETE 0
+
+# The mz_support user cannot execute `SELECT ...` commands.
+simple conn=mz_support,user=mz_support
+SELECT * FROM t
+----
+db error: ERROR: permission denied for TABLE "materialize.public.t"
+
+# The mz_support user cannot execute `INSERT ...` commands.
+simple conn=mz_support,user=mz_support
+INSERT INTO t VALUES (42)
+----
+db error: ERROR: permission denied for TABLE "materialize.public.t"
+
+# The mz_support user cannot execute `UPDATE ...` commands.
+simple conn=mz_support,user=mz_support
+UPDATE t SET a = 5
+----
+db error: ERROR: permission denied for TABLE "materialize.public.t"
+
+# The mz_support user cannot execute `DELETE ...` commands.
+simple conn=mz_support,user=mz_support
+DELETE FROM t WHERE a IS NOT NULL
+----
+db error: ERROR: permission denied for TABLE "materialize.public.t"
+
+# The mz_support user cannot execute create objects.
+simple conn=mz_support,user=mz_support
+CREATE VIEW vv AS SELECT 66
+----
+db error: ERROR: permission denied for SCHEMA "materialize.public"

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -19,7 +19,7 @@ $ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testd
 
 # The mz_support user can list database sources.
 $ postgres-execute connection=mz_support
-SHOW SOURCEs;
+SHOW SOURCES;
 
 # The mz_support user can execute `SHOW CREATE ...` commands.
 $ postgres-execute connection=mz_support
@@ -45,3 +45,7 @@ EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_
 # We can uncomment this test once all regular commands are executed from `mz_support`
 # ! SELECT * FROM bids
 # contains:permission denied for SOURCE "materialize.public.bids"
+
+# The mz_support user can filter SHOW commands on user objects.
+$ postgres-execute connection=mz_support
+SHOW INDEXES ON bids;

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -11,7 +11,7 @@
 # the mz_support user. This test can be rewritten to validate the output of the
 # `connection=mz_support` command once we have `SET ROLE` working.
 
-$ postgres-connect name=mz_support url=postgres://mz_support:mz_support@${testdrive.materialize-internal-sql-addr}
+$ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
 
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES WITH (size = '1');
 
@@ -40,3 +40,7 @@ EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id);
 # The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
 $ postgres-execute connection=mz_support
 EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
+
+# The mz_support user can filter SHOW commands on user objects.
+$ postgres-execute connection=mz_support
+SHOW INDEXES ON bids;

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -40,7 +40,3 @@ EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id);
 # The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
 $ postgres-execute connection=mz_support
 EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
-
-# The mz_support user can filter SHOW commands on user objects.
-$ postgres-execute connection=mz_support
-SHOW INDEXES ON bids;

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -11,7 +11,7 @@
 # the mz_support user. This test can be rewritten to validate the output of the
 # `connection=mz_support` command once we have `SET ROLE` working.
 
-$ postgres-connect name=mz_support url=postgres://mz_support:materialize@${testdrive.materialize-internal-sql-addr}
+$ postgres-connect name=mz_support url=postgres://mz_support:mz_support@${testdrive.materialize-internal-sql-addr}
 
 > CREATE SOURCE auction_house FROM LOAD GENERATOR AUCTION FOR ALL TABLES WITH (size = '1');
 
@@ -40,12 +40,3 @@ EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id);
 # The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
 $ postgres-execute connection=mz_support
 EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
-
-# The mz_support user cannot execute `SELECT ...` commands.
-# We can uncomment this test once all regular commands are executed from `mz_support`
-# ! SELECT * FROM bids
-# contains:permission denied for SOURCE "materialize.public.bids"
-
-# The mz_support user can filter SHOW commands on user objects.
-$ postgres-execute connection=mz_support
-SHOW INDEXES ON bids;


### PR DESCRIPTION
This commit ensures that RBAC is always enabled for system roles. This allows us to ensure that we always gate the privilege of system roles, even when RBAC is disabled, without needing specialized hacky privilege functions. The specialized hacky privilege functions are not as expressive as RBAC and don't always provide us with the proper semantics.


### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
