### PR TITLE
auth/metrics: Refactor and add missing metrics

### DIFF
--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -17,7 +17,7 @@ use futures::future::BoxFuture;
 use jsonwebtoken::{Algorithm, DecodingKey, Validation};
 use mz_ore::cast::{CastLossy, ReinterpretCast};
 use mz_ore::collections::HashMap;
-use mz_ore::metrics::{MetricsFutureExt, MetricsRegistry};
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NowFn;
 use mz_repr::user::ExternalUserMetadata;
 use serde::{Deserialize, Serialize};
@@ -191,18 +191,12 @@ impl Authentication {
                     let url = self.admin_api_token_url.clone();
                     let validate_config = self.validation_config.clone();
                     let metrics = self.metrics.clone();
-                    let request_hist = self
-                        .metrics
-                        .request_duration_seconds
-                        .with_label_values(&["exchange_secret_for_token"]);
 
                     let name = format!("frontegg-auth-request-{}", req.client_id);
                     mz_ore::task::spawn(move || name, async move {
                         // Make the actual request.
                         let result = client
-                            .exchange_client_secret_for_token(req_, &url)
-                            .wall_time()
-                            .observe(request_hist)
+                            .exchange_client_secret_for_token(req_, &url, &metrics)
                             .await;
 
                         // Validate the returned JWT.
@@ -479,13 +473,8 @@ fn continuously_refresh(
                 },
             }
 
-            let request_hist = metrics
-                .request_duration_seconds
-                .with_label_values(&["refresh"]);
             let current_response = client
-                .refresh_token(&refresh_url, &latest_response.refresh_token)
-                .wall_time()
-                .observe(request_hist)
+                .refresh_token(&refresh_url, &latest_response.refresh_token, &metrics)
                 .await;
 
             // If we failed to refresh, then close the channel.
@@ -495,18 +484,7 @@ fn continuously_refresh(
                     resp
                 }
                 Err(err) => {
-                    // Maintain metrics of our success rates.
-                    let status = match &err {
-                        Error::ReqwestError(e) => e
-                            .status()
-                            .map(|s| s.to_string())
-                            .unwrap_or("other".to_string()),
-                        _ => "other".to_string(),
-                    };
-                    metrics
-                        .request_count
-                        .with_label_values(&["refresh", &status])
-                        .inc();
+                    tracing::warn!(?id, ?err, "failed to refresh");
 
                     // Dropping the channel will close it.
                     drop(refresh_tx);

--- a/src/frontegg-auth/src/client/tokens.rs
+++ b/src/frontegg-auth/src/client/tokens.rs
@@ -7,8 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use mz_ore::metrics::MetricsFutureExt;
 use uuid::Uuid;
 
+use crate::metrics::Metrics;
 use crate::{Client, Error};
 
 impl Client {
@@ -17,17 +19,27 @@ impl Client {
         &self,
         request: ApiTokenArgs,
         admin_api_token_url: &str,
+        metrics: &Metrics,
     ) -> Result<ApiTokenResponse, Error> {
-        let result = self
+        let name = "exchange_secret_for_token";
+        let histogram = metrics.request_duration_seconds.with_label_values(&[name]);
+
+        let response = self
             .client
             .post(admin_api_token_url)
             .json(&request)
             .send()
-            .await?
-            .error_for_status()?
-            .json()
+            .wall_time()
+            .observe(histogram)
             .await?;
 
+        let status = response.status().to_string();
+        metrics
+            .request_count
+            .with_label_values(&[name, &status])
+            .inc();
+
+        let result = response.error_for_status()?.json().await?;
         Ok(result)
     }
 
@@ -36,17 +48,31 @@ impl Client {
         &self,
         refresh_url: &str,
         refresh_token: &str,
+        metrics: &Metrics,
     ) -> Result<ApiTokenResponse, Error> {
-        let res = self
+        let name = "refresh_token";
+        let histogram = metrics.request_duration_seconds.with_label_values(&[name]);
+
+        let response = self
             .client
             .post(refresh_url)
             .json(&RefreshToken { refresh_token })
             .send()
-            .await?
+            .wall_time()
+            .observe(histogram)
+            .await?;
+
+        let status = response.status().to_string();
+        metrics
+            .request_count
+            .with_label_values(&[name, &status])
+            .inc();
+
+        let result = response
             .error_for_status()?
             .json::<ApiTokenResponse>()
             .await?;
-        Ok(res)
+        Ok(result)
     }
 }
 
@@ -75,6 +101,7 @@ pub struct RefreshToken<'a> {
 #[cfg(test)]
 mod tests {
     use axum::{routing::post, Router};
+    use mz_ore::metrics::MetricsRegistry;
     use reqwest::StatusCode;
     use std::net::{IpAddr, Ipv4Addr, SocketAddr};
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -82,6 +109,7 @@ mod tests {
     use uuid::Uuid;
 
     use super::ApiTokenResponse;
+    use crate::metrics::Metrics;
     use crate::{ApiTokenArgs, Client};
 
     #[mz_ore::test(tokio::test)]
@@ -135,12 +163,15 @@ mod tests {
             code: u16,
             should_retry: bool,
         ) -> Result<(), String> {
+            let registry = MetricsRegistry::new();
+            let metrics = Metrics::register_into(&registry);
+
             let args = ApiTokenArgs {
                 client_id: Uuid::new_v4(),
                 secret: Uuid::new_v4(),
             };
             let exchange_result = client
-                .exchange_client_secret_for_token(args, &format!("http://{addr}/{code}"))
+                .exchange_client_secret_for_token(args, &format!("http://{addr}/{code}"), &metrics)
                 .await
                 .map(|_| ())
                 .map_err(|e| e.to_string());
@@ -149,7 +180,7 @@ mod tests {
             assert_eq!(prev_count, expected_count);
 
             let refresh_result = client
-                .refresh_token(&format!("http://{addr}/{code}"), "test")
+                .refresh_token(&format!("http://{addr}/{code}"), "test", &metrics)
                 .await
                 .map(|_| ())
                 .map_err(|e| e.to_string());


### PR DESCRIPTION
This PR refactors our Prometheus metrics within the Frontegg Auth controller code. While we have the critical metrics, i.e. count of failures to refresh, we are missing some other metrics that would be good to have, e.g. overall count and status of requests to exchange secret for token.

I realized these metrics were missing when adding Grafana dashboards to track them

### Motivation

  * This PR adds a feature that has not yet been specified.

Adds more metrics around our Frontegg authentication code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a internal metrics tracking
