### PR TITLE
sql: Fix null element handling in aclexplode

### DIFF
--- a/src/expr/src/scalar.proto
+++ b/src/expr/src/scalar.proto
@@ -819,5 +819,7 @@ message ProtoEvalError {
         ProtoDateDiffOverflow date_diff_overflow = 72;
         string if_null_error = 73;
         google.protobuf.Empty length_too_large = 74;
+        google.protobuf.Empty acl_array_null_element = 75;
+        google.protobuf.Empty mz_acl_array_null_element = 76;
     }
 }

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -2409,6 +2409,8 @@ pub enum EvalError {
     // printer.
     IfNullError(String),
     LengthTooLarge,
+    AclArrayNullElement,
+    MzAclArrayNullElement,
 }
 
 impl fmt::Display for EvalError {
@@ -2597,6 +2599,10 @@ impl fmt::Display for EvalError {
             }
             EvalError::IfNullError(s) => f.write_str(s),
             EvalError::LengthTooLarge => write!(f, "requested length too large"),
+            EvalError::AclArrayNullElement => write!(f, "ACL arrays must not contain null values"),
+            EvalError::MzAclArrayNullElement => {
+                write!(f, "MZ_ACL arrays must not contain null values")
+            }
         }
     }
 }
@@ -2847,6 +2853,8 @@ impl RustType<ProtoEvalError> for EvalError {
             }),
             EvalError::IfNullError(s) => IfNullError(s.clone()),
             EvalError::LengthTooLarge => LengthTooLarge(()),
+            EvalError::AclArrayNullElement => AclArrayNullElement(()),
+            EvalError::MzAclArrayNullElement => MzAclArrayNullElement(()),
         };
         ProtoEvalError { kind: Some(kind) }
     }
@@ -2964,6 +2972,8 @@ impl RustType<ProtoEvalError> for EvalError {
                 }),
                 IfNullError(v) => Ok(EvalError::IfNullError(v)),
                 LengthTooLarge(()) => Ok(EvalError::LengthTooLarge),
+                AclArrayNullElement(()) => Ok(EvalError::AclArrayNullElement),
+                MzAclArrayNullElement(()) => Ok(EvalError::MzAclArrayNullElement),
             },
             None => Err(TryFromProtoError::missing_field("ProtoEvalError::kind")),
         }

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -555,7 +555,9 @@ mod columnation {
                         | e @ EvalError::InvalidBase64EndSequence
                         | e @ EvalError::InvalidTimezoneInterval
                         | e @ EvalError::InvalidTimezoneConversion
-                        | e @ EvalError::LengthTooLarge => e.clone(),
+                        | e @ EvalError::LengthTooLarge
+                        | e @ EvalError::AclArrayNullElement
+                        | e @ EvalError::MzAclArrayNullElement => e.clone(),
                         EvalError::Unsupported { feature, issue_no } => EvalError::Unsupported {
                             feature: self.string_region.copy(feature),
                             issue_no: *issue_no,

--- a/test/sqllogictest/aclitem.slt
+++ b/test/sqllogictest/aclitem.slt
@@ -300,6 +300,9 @@ SELECT aclexplode(ARRAY[makeaclitem(1, 2, 'SELECT, INSERT, DELETE', false), make
 (2,1,INSERT,f)
 (2,1,SELECT,f)
 
+query error ACL arrays must not contain null values
+SELECT aclexplode(array[null]::aclitem[]);
+
 # mz_aclexplode
 
 query T
@@ -309,6 +312,9 @@ SELECT mz_internal.mz_aclexplode(ARRAY[mz_internal.make_mz_aclitem('u1', 'u2', '
 (u2,u1,DELETE,f)
 (u2,u1,INSERT,f)
 (u2,u1,SELECT,f)
+
+query error MZ_ACL arrays must not contain null values
+SELECT mz_internal.mz_aclexplode(array[null]::mz_aclitem[]);
 
 # Test casting to/from aclitem and mz_aclitem
 


### PR DESCRIPTION
This functions removes a panic that happens when an array with NULL elements is passed to the aclexplode or mz_aclexplode functions. Instead of panicking an error is now returned.

Fixes #22275

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove panic from calling `aclexplode` with an array with null elements.
