### PR TITLE
mz: adds support for macOS keychain

### DIFF
--- a/src/mz/src/context.rs
+++ b/src/mz/src/context.rs
@@ -149,7 +149,7 @@ impl Context {
             admin_client_builder.build(AdminClientConfig {
                 authentication: Authentication::AppPassword(
                     profile
-                        .app_password()
+                        .app_password(config_file.vault())
                         .ok_or(Error::AppPasswordMissing)?
                         .parse()?,
                 ),
@@ -170,7 +170,7 @@ impl Context {
         // this happens because profile is 'a static, and adding it to the profile context would make also the context 'a, etc.
         let sql_client = SqlClient::new(SqlClientConfig {
             app_password: profile
-                .app_password()
+                .app_password(config_file.vault())
                 .ok_or(Error::AppPasswordMissing)?
                 .parse()?,
         });

--- a/src/mz/src/error.rs
+++ b/src/mz/src/error.rs
@@ -126,4 +126,8 @@ pub enum Error {
     /// Error that occurs when attempting to find the home directory.
     #[error("An error occurred while trying to find the home directory.")]
     HomeDirNotFoundError,
+    /// Error that raises when the security framework for macOS
+    /// to retrieve or set passwords to  the keychain fails.
+    #[error(transparent)]
+    MacOsSecurityError(#[from] security_framework::base::Error),
 }


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Re-adds support for the vault feature in macOS, enabling users to utilize the macOS keychain instead of storing the app password in a file. If the host is a Linux environment, nothing changes.

This PR also removes unused tests moved to the CI/Buildkite.

[Related PR](https://github.com/MaterializeInc/materialize/issues/21254)

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
