### PR TITLE
Assorted doc & mz cli changes for aws/us-west-2 launch

### DIFF
--- a/doc/developer/platform/ux.md
+++ b/doc/developer/platform/ux.md
@@ -538,6 +538,7 @@ by Materialize Cloud:
 
   * aws:us-east-1
   * aws:eu-west-1
+  * aws:us-west-2
 
 ### Cluster
 

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -30,6 +30,7 @@ Region        | Day of week | Time
 --------------|-------------|-----------------------------
 aws/eu-west-1 | Wednesday   | 2100-2300 [Europe/Dublin]
 aws/us-east-1 | Thursday    | 0500-0700 [America/New_York]
+aws/us-west-2 | Thursday    | 0200-0400 [America/Los_Angeles]
 
 {{< note >}}
 Upgrade windows follow any daylight saving time or summer time rules

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -1,7 +1,7 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [Size](/sql/create-cluster-replica#size).
-`AVAILABILITY ZONE`                 | `text`     | The availability zone of the underlying clodu provider in which to provision the replica. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1` or `eu-west-1`, e.g. `use1-az1`. Note that you must use the zone's ID, not its name.
+`AVAILABILITY ZONE`                 | `text`     | The availability zone of the underlying clodu provider in which to provision the replica. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1`, `eu-west-1`, or `us-west-2`, e.g. `use1-az1`. Note that you must use the zone's ID, not its name.
 `INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.<br>Default: `1s`
 `INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data.<br>Default: `FALSE`
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | ***Unstable.** This option may be changed or removed at any time.*<br>The amount of effort the replica should exert on compacting arrangements during idle periods.

--- a/src/cloud-api/src/client/cloud_provider.rs
+++ b/src/cloud-api/src/client/cloud_provider.rs
@@ -67,6 +67,7 @@ impl CloudProvider {
         match self.id.as_str() {
             "aws/us-east-1" => Ok(CloudProviderRegion::AwsUsEast1),
             "aws/eu-west-1" => Ok(CloudProviderRegion::AwsEuWest1),
+            "aws/us-west-2" => Ok(CloudProviderRegion::AwsUsWest2),
             _ => Err(Error::CloudProviderRegionParseError),
         }
     }
@@ -83,6 +84,9 @@ pub enum CloudProviderRegion {
     /// Represents `aws/eu-west-1` cloud provider and region
     #[serde(rename = "aws/eu-west-1")]
     AwsEuWest1,
+    /// Represents `aws/us-west-2` cloud provider and region
+    #[serde(rename = "aws/us-west-2")]
+    AwsUsWest2,
 }
 
 impl CloudProviderRegion {
@@ -91,6 +95,7 @@ impl CloudProviderRegion {
         match cloud_provider.id.as_str() {
             "aws/us-east-1" => Ok(CloudProviderRegion::AwsUsEast1),
             "aws/eu-west-1" => Ok(CloudProviderRegion::AwsEuWest1),
+            "aws/us-west-2" => Ok(CloudProviderRegion::AwsUsWest2),
             _ => Err(Error::CloudProviderRegionParseError),
         }
     }
@@ -101,6 +106,7 @@ impl Display for CloudProviderRegion {
         match self {
             CloudProviderRegion::AwsUsEast1 => write!(f, "aws/us-east-1"),
             CloudProviderRegion::AwsEuWest1 => write!(f, "aws/eu-west-1"),
+            CloudProviderRegion::AwsUsWest2 => write!(f, "aws/us-west-2"),
         }
     }
 }
@@ -112,6 +118,7 @@ impl FromStr for CloudProviderRegion {
         match s.to_lowercase().as_str() {
             "aws/us-east-1" => Ok(CloudProviderRegion::AwsUsEast1),
             "aws/eu-west-1" => Ok(CloudProviderRegion::AwsEuWest1),
+            "aws/us-west-2" => Ok(CloudProviderRegion::AwsUsWest2),
             _ => Err(Error::CloudProviderRegionParseError),
         }
     }

--- a/src/mz/README.md
+++ b/src/mz/README.md
@@ -55,6 +55,7 @@ SUBCOMMANDS:
    ```
    aws/us-east-1  enabled
    aws/eu-west-1  disabled
+   aws/us-west-2  disabled
    ```
 
 4. Launch a SQL shell connected to one of the enabled regions in your

--- a/test/mz-e2e/mzcompose.py
+++ b/test/mz-e2e/mzcompose.py
@@ -26,7 +26,7 @@ from materialize.mzcompose.composition import (
 )
 from materialize.mzcompose.services.mz import Mz
 
-REGION = "aws/us-east-1"
+REGION = "aws/us-west-2"
 ENVIRONMENT = os.getenv("ENVIRONMENT", "production")
 USERNAME = os.getenv("NIGHTLY_MZ_USERNAME", "infra+bot@materialize.com")
 APP_PASSWORD = os.environ["MZ_CLI_APP_PASSWORD"]
@@ -207,10 +207,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         # Enable, disable and show are already tested.
         output = c.run("mz", "region", "list", "--format", "json", capture=True)
         regions = json.loads(output.stdout)
-        us_region = regions[0]
-        if us_region["region"] != "aws/us-east-1":
-            us_region = regions[1]
-        assert "enabled" == us_region["status"]
+        us_region = None
+        for region in regions:
+            if region["region"] == REGION:
+                us_region = region
+        assert us_region is not None and "enabled" == us_region["status"]
 
         # Verify the content is ok
         print(f"Path: {psql_config_path}")


### PR DESCRIPTION
### Motivation

Update docs and the MZ CLI interfaces for the `aws/us-west-2` launch. We likely don't want to merge this until the region setup is finalized and ready to roll out.

  * This PR adds a known-desirable feature.
Part of the work in https://github.com/MaterializeInc/cloud/issues/7598

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
