### PR TITLE
doc/user: Fix XML Sitemap in Docs

### DIFF
--- a/doc/user/layouts/sitemap.xml
+++ b/doc/user/layouts/sitemap.xml
@@ -1,3 +1,8 @@
+{{/* Copyright Materialize, Inc. All rights reserved. Use of this software is
+governed by the Business Source License included in the LICENSE file at the root
+of this repository. As of the Change Date specified in that file, in accordance
+with the Business Source License, use of this software will be governed by the
+Apache License, Version 2.0. */}}
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{- range .Data.Pages -}}

--- a/doc/user/layouts/sitemap.xml
+++ b/doc/user/layouts/sitemap.xml
@@ -1,0 +1,13 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{- range .Data.Pages -}}
+    {{- if .Permalink -}}
+      <url>
+        <loc>https://materialize.com{{ .Permalink }}</loc>
+        {{- if not .Lastmod.IsZero -}}
+          <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>
+        {{- end -}}
+      </url>
+    {{- end -}}
+  {{- end -}}
+</urlset>


### PR DESCRIPTION
Because we set the `baseUrl` to `/docs` in the hugo deploy config here:

https://github.com/MaterializeInc/materialize/blob/935afcafc74f69cb27adf4fab2ac93c698cb5b91/ci/deploy_website/website.sh#L37

the XML sitemap here: https://materialize.com/docs/sitemap.xml

 has relative links:
<img width="488" alt="image" src="https://github.com/MaterializeInc/materialize/assets/11527560/8dc9d182-6ed3-4b0c-9e8e-3c8c0caaa92b">

This PR adds a `sitemap.xml` file in the layouts directory that overrides automatic sitemap generation and automatically adds the absolute url to the path.

I could have just changed to `hugo --gc --baseURL https://materialize.com/docs --destination public/docs` but I was worried that it might break some unrelated functionality.