### PR TITLE
sql: Fix SHOW filter privileges

### DIFF
--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -276,7 +276,6 @@ pub fn check_plan(
         plan,
         active_conns,
         target_cluster_id,
-        resolved_ids,
         role_metadata.current_role,
     );
     debug!("rbac requirements {rbac_requirements:?} for plan {plan:?}");
@@ -302,7 +301,6 @@ fn generate_rbac_requirements(
     plan: &Plan,
     active_conns: &BTreeMap<u32, RoleId>,
     target_cluster_id: Option<ClusterId>,
-    resolved_ids: &ResolvedIds,
     role_id: RoleId,
 ) -> RbacRequirements {
     match plan {
@@ -619,7 +617,7 @@ fn generate_rbac_requirements(
         Plan::ShowColumns(plan::ShowColumnsPlan {
             id,
             select_plan,
-            new_resolved_ids,
+            new_resolved_ids: _,
         }) => {
             let mut privileges = vec![(
                 SystemObjectId::Object(catalog.get_item(id).name().qualifiers.clone().into()),
@@ -632,7 +630,6 @@ fn generate_rbac_requirements(
                 &Plan::Select(select_plan.clone()),
                 active_conns,
                 target_cluster_id,
-                new_resolved_ids,
                 role_id,
             )
             .privileges
@@ -651,7 +648,7 @@ fn generate_rbac_requirements(
             copy_to: _,
         }) => {
             let mut privileges =
-                generate_read_privileges(catalog, resolved_ids.0.iter().cloned(), role_id);
+                generate_read_privileges(catalog, source.depends_on().into_iter(), role_id);
             if let Some(privilege) =
                 generate_cluster_usage_privileges(source, target_cluster_id, role_id)
             {
@@ -663,7 +660,7 @@ fn generate_rbac_requirements(
             }
         }
         Plan::Subscribe(plan::SubscribePlan {
-            from: _,
+            from,
             with_snapshot: _,
             when: _,
             up_to: _,
@@ -672,7 +669,7 @@ fn generate_rbac_requirements(
             output: _,
         }) => {
             let mut privileges =
-                generate_read_privileges(catalog, resolved_ids.0.iter().cloned(), role_id);
+                generate_read_privileges(catalog, from.depends_on().into_iter(), role_id);
             if let Some(cluster_id) = target_cluster_id {
                 privileges.push((
                     SystemObjectId::Object(cluster_id.into()),

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -40,3 +40,7 @@ EXPLAIN OPTIMIZED PLAN FOR CREATE INDEX ON v(auction_id);
 # The mz_support user can execute `EXPLAIN TIMESTAMP ...` commands.
 $ postgres-execute connection=mz_support
 EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_id FROM bids b JOIN users u ON(b.buyer = u.id);
+
+# The mz_support user can filter SHOW commands on user objects.
+$ postgres-execute connection=mz_support
+SHOW INDEXES ON bids;


### PR DESCRIPTION
When a user executes a command like `SHOW INDEXES ON t`, the command gets expanded to something like `SELECT _ FROM mz_indexes WHERE on_id = <ID-of-t>`. The user isn't actually reading from t and therefore doesn't need any SELECT privileges on t. However, since t was mentioned by name, the RBAC code gets confused and thinks that privileges are needed directly on t.

This commit fixes the issue described above so that a user can execute `SHOW INDEXES ON t` without needing SELECT privileges on t.

Fixes #22245

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Correct required privileges on objects used to filter SHOW commands.
