### PR TITLE
balancerd: support HTTPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3643,6 +3643,7 @@ dependencies = [
  "bytesize",
  "clap",
  "futures",
+ "hyper-openssl",
  "jsonwebtoken",
  "mz-build-info",
  "mz-frontegg-auth",

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -13,6 +13,7 @@ bytes = "1.3.0"
 bytesize = "1.1.0"
 clap = { version = "3.2.24", features = ["derive", "env"] }
 futures = "0.3.25"
+hyper-openssl = "0.9.2"
 jsonwebtoken = "8.2.0"
 mz-build-info = { path = "../build-info" }
 mz-frontegg-auth = { path = "../frontegg-auth" }

--- a/src/balancerd/src/main.rs
+++ b/src/balancerd/src/main.rs
@@ -75,6 +75,11 @@
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
 
+//! Manages a single Materialize environment.
+//!
+//! It listens for SQL connections on port 6875 (MTRL) and for HTTP connections
+//! on port 6876.
+
 use mz_balancerd::BUILD_INFO;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
@@ -113,7 +118,7 @@ fn main() {
     let (_, _tracing_guard) = runtime
         .block_on(args.tracing.configure_tracing(
             StaticTracingConfig {
-                service_name: "balancer",
+                service_name: "balancerd",
                 build_info: BUILD_INFO,
             },
             MetricsRegistry::new(),

--- a/src/balancerd/src/service.rs
+++ b/src/balancerd/src/service.rs
@@ -29,7 +29,7 @@ pub struct Args {
     #[clap(flatten)]
     tls: TlsCliArgs,
 
-    /// Static resolver address to use for local testing.
+    /// Static pgwire resolver address to use for local testing.
     #[clap(long, value_name = "HOST:PORT")]
     static_resolver_addr: Option<SocketAddr>,
     /// Frontegg resolver address template. `{}` is replaced with the user's frontegg tenant id to
@@ -39,6 +39,11 @@ pub struct Args {
         requires_all = &["frontegg-jwk", "frontegg-api-token-url", "frontegg-admin-role"],
     )]
     frontegg_resolver_template: Option<String>,
+    /// HTTPS resolver address template. `{}` is replaced with the first subdomain of the HTTPS SNI
+    /// host address to get a DNS address. The first IP that address resolves to is the proxy
+    /// destinaiton.
+    #[clap(long, value_name = "HOST.{}.NAME:PORT")]
+    https_resolver_template: String,
 
     /// JWK used to validate JWTs during Frontegg authentication as a PEM public
     /// key. Can optionally be base64 encoded with the URL-safe alphabet.
@@ -92,6 +97,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         args.pgwire_listen_addr,
         args.https_listen_addr,
         resolver,
+        args.https_resolver_template,
         args.tls.into_config()?,
     );
     let metrics = Metrics::new(&config, &metrics_registry);


### PR DESCRIPTION
Add HTTPS support to the balancer. There's a new required argument for this.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a