### PR TITLE
testdrive: Support default_timeout in pg connections

### DIFF
--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -322,10 +322,13 @@ impl State {
     }
 
     pub async fn reset_materialize(&mut self) -> Result<(), anyhow::Error> {
-        let (inner_client, _) = postgres_client(&format!(
-            "postgres://mz_system:materialize@{}",
-            self.materialize_internal_sql_addr
-        ))
+        let (inner_client, _) = postgres_client(
+            &format!(
+                "postgres://mz_system:materialize@{}",
+                self.materialize_internal_sql_addr
+            ),
+            self.default_timeout,
+        )
         .await?;
         inner_client
             .batch_execute("ALTER SYSTEM RESET ALL")

--- a/src/testdrive/src/action/postgres/connect.rs
+++ b/src/testdrive/src/action/postgres/connect.rs
@@ -25,7 +25,7 @@ pub async fn run_connect(
     let url = cmd.args.string("url")?;
     cmd.args.done()?;
 
-    let (client, _) = postgres_client(&url).await?;
+    let (client, _) = postgres_client(&url, state.default_timeout).await?;
     state.postgres_clients.insert(name.clone(), client);
     Ok(ControlFlow::Continue)
 }

--- a/src/testdrive/src/action/postgres/execute.rs
+++ b/src/testdrive/src/action/postgres/execute.rs
@@ -22,7 +22,7 @@ pub async fn run_execute(
 
     let client;
     let client = if connection.starts_with("postgres://") {
-        let (client_inner, _) = postgres_client(&connection).await?;
+        let (client_inner, _) = postgres_client(&connection, state.default_timeout).await?;
         client = client_inner;
         &client
     } else {

--- a/src/testdrive/src/action/postgres/verify_slot.rs
+++ b/src/testdrive/src/action/postgres/verify_slot.rs
@@ -26,7 +26,7 @@ pub async fn run_verify_slot(
     let active: bool = cmd.args.parse("active")?;
     cmd.args.done()?;
 
-    let (client, conn_handle) = postgres_client(&connection).await?;
+    let (client, conn_handle) = postgres_client(&connection, state.default_timeout).await?;
 
     Retry::default()
         .initial_backoff(Duration::from_millis(50))

--- a/src/testdrive/src/util/postgres.rs
+++ b/src/testdrive/src/util/postgres.rs
@@ -8,8 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use std::str::FromStr;
+use std::time::Duration;
 
-use anyhow::{bail, Context};
+use anyhow::{anyhow, bail, Context};
+use mz_ore::retry::Retry;
 use mz_ore::task;
 use mz_tls_util::make_tls;
 use tokio::task::JoinHandle;
@@ -50,11 +52,17 @@ pub fn config_url(config: &Config) -> Result<Url, anyhow::Error> {
 
 pub async fn postgres_client(
     url: &str,
+    default_timeout: Duration,
 ) -> Result<(Client, JoinHandle<Result<(), tokio_postgres::Error>>), anyhow::Error> {
-    let tls = make_tls(&Config::from_str(url)?)?;
-    let (client, connection) = tokio_postgres::connect(url, tls)
-        .await
-        .context("connecting to postgres")?;
+    let (client, connection) = Retry::default()
+        .max_duration(default_timeout)
+        .retry_async_canceling(|_| async move {
+            let pgconfig = &mut Config::from_str(url)?;
+            pgconfig.connect_timeout(default_timeout);
+            let tls = make_tls(pgconfig)?;
+            pgconfig.connect(tls).await.map_err(|e| anyhow!(e))
+        })
+        .await?;
 
     println!("Connecting to PostgreSQL server at {}...", url);
     let handle = task::spawn(|| "postgres_client_task", connection);


### PR DESCRIPTION
like `$ postgres-connect` and `$ postgres-execute`

As noted by @jkosh44

The documentation states: https://github.com/MaterializeInc/materialize/blob/main/doc/developer/testdrive.md

> A timeout at least that long will be applied to all operations.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
