### PR TITLE
catalog: Create DurableType trait for objects

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2523,7 +2523,6 @@ impl Catalog {
                                     ResolvedDatabaseSpecifier::Id(id) => Some(*id),
                                 };
                                 tx.update_schema(
-                                    database_id,
                                     schema_id,
                                     schema.clone().into_durable_schema(database_id),
                                 )?;
@@ -2904,11 +2903,7 @@ impl Catalog {
                                 .replica_mut(*replica_id)
                                 .expect("catalog out of sync");
                             replica.owner_id = new_owner;
-                            tx.update_cluster_replica(
-                                *cluster_id,
-                                *replica_id,
-                                replica.clone().into(),
-                            )?;
+                            tx.update_cluster_replica(*replica_id, replica.clone().into())?;
                             builtin_table_updates.extend(state.pack_cluster_replica_update(
                                 *cluster_id,
                                 &replica_name,
@@ -2948,7 +2943,6 @@ impl Catalog {
                                 ResolvedDatabaseSpecifier::Id(id) => Some(id),
                             };
                             tx.update_schema(
-                                database_id.copied(),
                                 schema_id,
                                 schema.clone().into_durable_schema(database_id.copied()),
                             )?;

--- a/src/adapter/src/catalog/objects.rs
+++ b/src/adapter/src/catalog/objects.rs
@@ -342,7 +342,8 @@ impl From<CatalogEntry> for mz_catalog::Item {
     fn from(entry: CatalogEntry) -> mz_catalog::Item {
         mz_catalog::Item {
             id: entry.id,
-            name: entry.name,
+            schema_id: entry.name.qualifiers.schema_spec.into(),
+            name: entry.name.item,
             create_sql: entry.item.into_serialized(),
             owner_id: entry.owner_id,
             privileges: entry.privileges.into_all_values().collect(),

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -35,7 +35,8 @@ use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql::catalog::{
-    CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogItemType, CatalogType,
+    CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem, CatalogItemType, CatalogSchema,
+    CatalogType,
 };
 use mz_sql::func::OP_IMPLS;
 use mz_sql::names::{
@@ -1539,7 +1540,15 @@ impl Catalog {
                     continue;
                 }
                 Err(e) => {
-                    let name = c.resolve_full_name(&item.name, None);
+                    let schema = c.state().find_schema(&item.schema_id);
+                    let name = QualifiedItemName {
+                        qualifiers: ItemQualifiers {
+                            database_spec: schema.database().clone(),
+                            schema_spec: schema.id().clone(),
+                        },
+                        item: item.name,
+                    };
+                    let name = c.resolve_full_name(&name, None);
                     return Err(Error::new(ErrorKind::Corruption {
                         detail: format!("failed to deserialize item {} ({}): {}", item.id, name, e),
                     }));
@@ -1551,7 +1560,15 @@ impl Catalog {
             if let Some(dependent_items) = awaiting_id_dependencies.remove(&item.id) {
                 items.extend(dependent_items);
             }
-            let full_name = c.resolve_full_name(&item.name, None);
+            let schema = c.state().find_schema(&item.schema_id);
+            let name = QualifiedItemName {
+                qualifiers: ItemQualifiers {
+                    database_spec: schema.database().clone(),
+                    schema_spec: schema.id().clone(),
+                },
+                item: item.name,
+            };
+            let full_name = c.resolve_full_name(&name, None);
             if let Some(dependent_items) = awaiting_name_dependencies.remove(&full_name.to_string())
             {
                 items.extend(dependent_items);
@@ -1560,7 +1577,7 @@ impl Catalog {
             c.state.insert_item(
                 item.id,
                 oid,
-                item.name,
+                name,
                 catalog_item,
                 item.owner_id,
                 PrivilegeMap::from_mz_acl_items(item.privileges),
@@ -1571,11 +1588,20 @@ impl Catalog {
         if let Some((missing_dep, mut dependents)) = awaiting_id_dependencies.into_iter().next() {
             let mz_catalog::Item {
                 id,
+                schema_id,
                 name,
                 create_sql: _,
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
+            let schema = c.state().find_schema(&schema_id);
+            let name = QualifiedItemName {
+                qualifiers: ItemQualifiers {
+                    database_spec: schema.database().clone(),
+                    schema_spec: schema.id().clone(),
+                },
+                item: name,
+            };
             let name = c.resolve_full_name(&name, None);
             return Err(Error::new(ErrorKind::Corruption {
                 detail: format!(
@@ -1590,11 +1616,20 @@ impl Catalog {
         if let Some((missing_dep, mut dependents)) = awaiting_name_dependencies.into_iter().next() {
             let mz_catalog::Item {
                 id,
+                schema_id,
                 name,
                 create_sql: _,
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
+            let schema = c.state().find_schema(&schema_id);
+            let name = QualifiedItemName {
+                qualifiers: ItemQualifiers {
+                    database_spec: schema.database().clone(),
+                    schema_spec: schema.id().clone(),
+                },
+                item: name,
+            };
             let name = c.resolve_full_name(&name, None);
             return Err(Error::new(ErrorKind::Corruption {
                 detail: format!(

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1540,7 +1540,7 @@ impl Catalog {
                     continue;
                 }
                 Err(e) => {
-                    let schema = c.state().find_schema(&item.schema_id);
+                    let schema = c.state().find_non_temp_schema(&item.schema_id);
                     let name = QualifiedItemName {
                         qualifiers: ItemQualifiers {
                             database_spec: schema.database().clone(),
@@ -1560,7 +1560,7 @@ impl Catalog {
             if let Some(dependent_items) = awaiting_id_dependencies.remove(&item.id) {
                 items.extend(dependent_items);
             }
-            let schema = c.state().find_schema(&item.schema_id);
+            let schema = c.state().find_non_temp_schema(&item.schema_id);
             let name = QualifiedItemName {
                 qualifiers: ItemQualifiers {
                     database_spec: schema.database().clone(),
@@ -1594,7 +1594,7 @@ impl Catalog {
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
-            let schema = c.state().find_schema(&schema_id);
+            let schema = c.state().find_non_temp_schema(&schema_id);
             let name = QualifiedItemName {
                 qualifiers: ItemQualifiers {
                     database_spec: schema.database().clone(),
@@ -1622,7 +1622,7 @@ impl Catalog {
                 owner_id: _,
                 privileges: _,
             } = dependents.remove(0);
-            let schema = c.state().find_schema(&schema_id);
+            let schema = c.state().find_non_temp_schema(&schema_id);
             let name = QualifiedItemName {
                 qualifiers: ItemQualifiers {
                     database_spec: schema.database().clone(),

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1239,10 +1239,12 @@ impl CatalogState {
         }
     }
 
-    pub(super) fn find_schema(&self, schema_id: &SchemaId) -> &Schema {
+    pub(super) fn find_non_temp_schema(&self, schema_id: &SchemaId) -> &Schema {
         self.database_by_id
             .values()
             .filter_map(|database| database.schemas_by_id.get(schema_id))
+            .chain(self.ambient_schemas_by_id.values())
+            .filter(|schema| schema.id() == &SchemaSpecifier::from(*schema_id))
             .into_first()
     }
 

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1239,6 +1239,13 @@ impl CatalogState {
         }
     }
 
+    pub(super) fn find_schema(&self, schema_id: &SchemaId) -> &Schema {
+        self.database_by_id
+            .values()
+            .filter_map(|database| database.schemas_by_id.get(schema_id))
+            .into_first()
+    }
+
     pub fn get_mz_catalog_schema_id(&self) -> &SchemaId {
         &self.ambient_schemas_by_name[MZ_CATALOG_SCHEMA]
     }

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -28,17 +28,22 @@ use std::time::Duration;
 
 // Structs used to pass information to outside modules.
 
-/// A trait for representing `Self` as a key (`K`) value (`V`) pair for the purpose of storing this
-/// value durably.
+/// A trait for representing `Self` as a key-value pair of type
+/// `(K, V)` for the purpose of storing this value durably.
 ///
 /// To encode a key-value pair, use [`DurableType::into_key_value`].
 ///
 /// To decode a key-value pair, use [`DurableType::from_key_value`].
+///
+/// This trait is based on [`RustType`], however it is meant to
+/// convert the types used in [`RustType`] to a more consumable and
+/// condensed type.
 pub(crate) trait DurableType<K, V>: Sized {
-    /// Consume and convert `Self` into a key (`K`) value (`V`) pair.
+    /// Consume and convert `Self` into a `(K, V)` key-value pair.
     fn into_key_value(self) -> (K, V);
 
-    /// Consume and convert a key (`K`) value (`V`) pair back into a `Self` value.
+    /// Consume and convert a `(K, V)` key-value pair back into a
+    /// `Self` value.
     fn from_key_value(key: K, value: V) -> Self;
 }
 

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -19,7 +19,7 @@ use mz_sql::catalog::{
     CatalogItemType, DefaultPrivilegeAclItem, DefaultPrivilegeObject, ObjectType, RoleAttributes,
     RoleMembership, RoleVars,
 };
-use mz_sql::names::{CommentObjectId, DatabaseId, QualifiedItemName, SchemaId};
+use mz_sql::names::{CommentObjectId, DatabaseId, SchemaId};
 use mz_stash_types::objects::{proto, RustType, TryFromProtoError};
 use mz_storage_types::sources::Timeline;
 use proptest_derive::Arbitrary;
@@ -28,12 +28,48 @@ use std::time::Duration;
 
 // Structs used to pass information to outside modules.
 
+/// A trait for representing `Self` as a key (`K`) value (`V`) pair for the purpose of storing this
+/// value durably.
+///
+/// To encode a key-value pair, use [`DurableType::into_key_value`].
+///
+/// To decode a key-value pair, use [`DurableType::from_key_value`].
+pub(crate) trait DurableType<K, V>: Sized {
+    /// Consume and convert `Self` into a key (`K`) value (`V`) pair.
+    fn into_key_value(self) -> (K, V);
+
+    /// Consume and convert a key (`K`) value (`V`) pair back into a `Self` value.
+    fn from_key_value(key: K, value: V) -> Self;
+}
+
 #[derive(Debug, Clone)]
 pub struct Database {
     pub id: DatabaseId,
     pub name: String,
     pub owner_id: RoleId,
     pub privileges: Vec<MzAclItem>,
+}
+
+impl DurableType<DatabaseKey, DatabaseValue> for Database {
+    fn into_key_value(self) -> (DatabaseKey, DatabaseValue) {
+        (
+            DatabaseKey { id: self.id },
+            DatabaseValue {
+                name: self.name,
+                owner_id: self.owner_id,
+                privileges: self.privileges,
+            },
+        )
+    }
+
+    fn from_key_value(key: DatabaseKey, value: DatabaseValue) -> Self {
+        Self {
+            id: key.id,
+            name: value.name,
+            owner_id: value.owner_id,
+            privileges: value.privileges,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +81,30 @@ pub struct Schema {
     pub privileges: Vec<MzAclItem>,
 }
 
+impl DurableType<SchemaKey, SchemaValue> for Schema {
+    fn into_key_value(self) -> (SchemaKey, SchemaValue) {
+        (
+            SchemaKey { id: self.id },
+            SchemaValue {
+                database_id: self.database_id,
+                name: self.name,
+                owner_id: self.owner_id,
+                privileges: self.privileges,
+            },
+        )
+    }
+
+    fn from_key_value(key: SchemaKey, value: SchemaValue) -> Self {
+        Self {
+            id: key.id,
+            name: value.name,
+            database_id: value.database_id,
+            owner_id: value.owner_id,
+            privileges: value.privileges,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Role {
     pub id: RoleId,
@@ -52,6 +112,30 @@ pub struct Role {
     pub attributes: RoleAttributes,
     pub membership: RoleMembership,
     pub vars: RoleVars,
+}
+
+impl DurableType<RoleKey, RoleValue> for Role {
+    fn into_key_value(self) -> (RoleKey, RoleValue) {
+        (
+            RoleKey { id: self.id },
+            RoleValue {
+                name: self.name,
+                attributes: self.attributes,
+                membership: self.membership,
+                vars: self.vars,
+            },
+        )
+    }
+
+    fn from_key_value(key: RoleKey, value: RoleValue) -> Self {
+        Self {
+            id: key.id,
+            name: value.name,
+            attributes: value.attributes,
+            membership: value.membership,
+            vars: value.vars,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -62,6 +146,32 @@ pub struct Cluster {
     pub owner_id: RoleId,
     pub privileges: Vec<MzAclItem>,
     pub config: ClusterConfig,
+}
+
+impl DurableType<ClusterKey, ClusterValue> for Cluster {
+    fn into_key_value(self) -> (ClusterKey, ClusterValue) {
+        (
+            ClusterKey { id: self.id },
+            ClusterValue {
+                name: self.name,
+                linked_object_id: self.linked_object_id,
+                owner_id: self.owner_id,
+                privileges: self.privileges,
+                config: self.config,
+            },
+        )
+    }
+
+    fn from_key_value(key: ClusterKey, value: ClusterValue) -> Self {
+        Self {
+            id: key.id,
+            name: value.name,
+            linked_object_id: value.linked_object_id,
+            owner_id: value.owner_id,
+            privileges: value.privileges,
+            config: value.config,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialOrd, PartialEq, Eq, Ord)]
@@ -157,6 +267,32 @@ pub struct ClusterReplica {
     pub name: String,
     pub config: ReplicaConfig,
     pub owner_id: RoleId,
+}
+
+impl DurableType<ClusterReplicaKey, ClusterReplicaValue> for ClusterReplica {
+    fn into_key_value(self) -> (ClusterReplicaKey, ClusterReplicaValue) {
+        (
+            ClusterReplicaKey {
+                id: self.replica_id,
+            },
+            ClusterReplicaValue {
+                cluster_id: self.cluster_id,
+                name: self.name,
+                config: self.config,
+                owner_id: self.owner_id,
+            },
+        )
+    }
+
+    fn from_key_value(key: ClusterReplicaKey, value: ClusterReplicaValue) -> Self {
+        Self {
+            cluster_id: value.cluster_id,
+            replica_id: key.id,
+            name: value.name,
+            config: value.config,
+            owner_id: value.owner_id,
+        }
+    }
 }
 
 // The on-disk replica configuration does not match the in-memory replica configuration, so we need
@@ -331,10 +467,37 @@ pub struct ComputeReplicaLogging {
 #[derive(Debug, Clone)]
 pub struct Item {
     pub id: GlobalId,
-    pub name: QualifiedItemName,
+    pub schema_id: SchemaId,
+    pub name: String,
     pub create_sql: String,
     pub owner_id: RoleId,
     pub privileges: Vec<MzAclItem>,
+}
+
+impl DurableType<ItemKey, ItemValue> for Item {
+    fn into_key_value(self) -> (ItemKey, ItemValue) {
+        (
+            ItemKey { gid: self.id },
+            ItemValue {
+                schema_id: self.schema_id,
+                name: self.name,
+                create_sql: self.create_sql,
+                owner_id: self.owner_id,
+                privileges: self.privileges,
+            },
+        )
+    }
+
+    fn from_key_value(key: ItemKey, value: ItemValue) -> Self {
+        Self {
+            id: key.gid,
+            schema_id: value.schema_id,
+            name: value.name,
+            create_sql: value.create_sql,
+            owner_id: value.owner_id,
+            privileges: value.privileges,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq)]
@@ -363,10 +526,77 @@ pub struct SystemObjectMapping {
     pub unique_identifier: SystemObjectUniqueIdentifier,
 }
 
+impl DurableType<GidMappingKey, GidMappingValue> for SystemObjectMapping {
+    fn into_key_value(self) -> (GidMappingKey, GidMappingValue) {
+        (
+            GidMappingKey {
+                schema_name: self.description.schema_name,
+                object_type: self.description.object_type,
+                object_name: self.description.object_name,
+            },
+            GidMappingValue {
+                id: match self.unique_identifier.id {
+                    GlobalId::System(id) => id,
+                    GlobalId::User(_) => unreachable!("GID mapping cannot use a User ID"),
+                    GlobalId::Transient(_) => unreachable!("GID mapping cannot use a Transient ID"),
+                    GlobalId::Explain => unreachable!("GID mapping cannot use an Explain ID"),
+                },
+                fingerprint: self.unique_identifier.fingerprint,
+            },
+        )
+    }
+
+    fn from_key_value(key: GidMappingKey, value: GidMappingValue) -> Self {
+        Self {
+            description: SystemObjectDescription {
+                schema_name: key.schema_name,
+                object_type: key.object_type,
+                object_name: key.object_name,
+            },
+            unique_identifier: SystemObjectUniqueIdentifier {
+                id: GlobalId::System(value.id),
+                fingerprint: value.fingerprint,
+            },
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DefaultPrivilege {
     pub object: DefaultPrivilegeObject,
     pub acl_item: DefaultPrivilegeAclItem,
+}
+
+impl DurableType<DefaultPrivilegesKey, DefaultPrivilegesValue> for DefaultPrivilege {
+    fn into_key_value(self) -> (DefaultPrivilegesKey, DefaultPrivilegesValue) {
+        (
+            DefaultPrivilegesKey {
+                role_id: self.object.role_id,
+                database_id: self.object.database_id,
+                schema_id: self.object.schema_id,
+                object_type: self.object.object_type,
+                grantee: self.acl_item.grantee,
+            },
+            DefaultPrivilegesValue {
+                privileges: self.acl_item.acl_mode,
+            },
+        )
+    }
+
+    fn from_key_value(key: DefaultPrivilegesKey, value: DefaultPrivilegesValue) -> Self {
+        Self {
+            object: DefaultPrivilegeObject {
+                role_id: key.role_id,
+                database_id: key.database_id,
+                schema_id: key.schema_id,
+                object_type: key.object_type,
+            },
+            acl_item: DefaultPrivilegeAclItem {
+                grantee: key.grantee,
+                acl_mode: value.privileges,
+            },
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -376,10 +606,50 @@ pub struct Comment {
     pub comment: String,
 }
 
+impl DurableType<CommentKey, CommentValue> for Comment {
+    fn into_key_value(self) -> (CommentKey, CommentValue) {
+        (
+            CommentKey {
+                object_id: self.object_id,
+                sub_component: self.sub_component,
+            },
+            CommentValue {
+                comment: self.comment,
+            },
+        )
+    }
+
+    fn from_key_value(key: CommentKey, value: CommentValue) -> Self {
+        Self {
+            object_id: key.object_id,
+            sub_component: key.sub_component,
+            comment: value.comment,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct IdAlloc {
     pub name: String,
     pub next_id: u64,
+}
+
+impl DurableType<IdAllocKey, IdAllocValue> for IdAlloc {
+    fn into_key_value(self) -> (IdAllocKey, IdAllocValue) {
+        (
+            IdAllocKey { name: self.name },
+            IdAllocValue {
+                next_id: self.next_id,
+            },
+        )
+    }
+
+    fn from_key_value(key: IdAllocKey, value: IdAllocValue) -> Self {
+        Self {
+            name: key.name,
+            next_id: value.next_id,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -388,10 +658,42 @@ pub struct Config {
     pub value: u64,
 }
 
+impl DurableType<ConfigKey, ConfigValue> for Config {
+    fn into_key_value(self) -> (ConfigKey, ConfigValue) {
+        (
+            ConfigKey { key: self.key },
+            ConfigValue { value: self.value },
+        )
+    }
+
+    fn from_key_value(key: ConfigKey, value: ConfigValue) -> Self {
+        Self {
+            key: key.key,
+            value: value.value,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct Setting {
     pub name: String,
     pub value: String,
+}
+
+impl DurableType<SettingKey, SettingValue> for Setting {
+    fn into_key_value(self) -> (SettingKey, SettingValue) {
+        (
+            SettingKey { name: self.name },
+            SettingValue { value: self.value },
+        )
+    }
+
+    fn from_key_value(key: SettingKey, value: SettingValue) -> Self {
+        Self {
+            name: key.name,
+            value: value.value,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -400,15 +702,72 @@ pub struct TimelineTimestamp {
     pub ts: mz_repr::Timestamp,
 }
 
+impl DurableType<TimestampKey, TimestampValue> for TimelineTimestamp {
+    fn into_key_value(self) -> (TimestampKey, TimestampValue) {
+        (
+            TimestampKey {
+                id: self.timeline.to_string(),
+            },
+            TimestampValue { ts: self.ts },
+        )
+    }
+
+    fn from_key_value(key: TimestampKey, value: TimestampValue) -> Self {
+        Self {
+            timeline: key.id.parse().expect("invalid timeline persisted"),
+            ts: value.ts,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct SystemConfiguration {
     pub name: String,
     pub value: String,
 }
 
-// Structs used internally to represent on disk-state.
+impl DurableType<ServerConfigurationKey, ServerConfigurationValue> for SystemConfiguration {
+    fn into_key_value(self) -> (ServerConfigurationKey, ServerConfigurationValue) {
+        (
+            ServerConfigurationKey { name: self.name },
+            ServerConfigurationValue { value: self.value },
+        )
+    }
+
+    fn from_key_value(key: ServerConfigurationKey, value: ServerConfigurationValue) -> Self {
+        Self {
+            name: key.name,
+            value: value.value,
+        }
+    }
+}
+
+impl DurableType<SystemPrivilegesKey, SystemPrivilegesValue> for MzAclItem {
+    fn into_key_value(self) -> (SystemPrivilegesKey, SystemPrivilegesValue) {
+        (
+            SystemPrivilegesKey {
+                grantee: self.grantee,
+                grantor: self.grantor,
+            },
+            SystemPrivilegesValue {
+                acl_mode: self.acl_mode,
+            },
+        )
+    }
+
+    fn from_key_value(key: SystemPrivilegesKey, value: SystemPrivilegesValue) -> Self {
+        Self {
+            grantee: key.grantee,
+            grantor: key.grantor,
+            acl_mode: value.acl_mode,
+        }
+    }
+}
+
+// Structs used internally to represent on-disk state.
 
 /// A snapshot of the current on-disk state.
+#[derive(Debug, Clone)]
 pub struct Snapshot {
     pub databases: BTreeMap<proto::DatabaseKey, proto::DatabaseValue>,
     pub schemas: BTreeMap<proto::SchemaKey, proto::SchemaValue>,
@@ -452,6 +811,25 @@ impl Snapshot {
             default_privileges: BTreeMap::new(),
             system_privileges: BTreeMap::new(),
         }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.databases.is_empty()
+            && self.schemas.is_empty()
+            && self.roles.is_empty()
+            && self.items.is_empty()
+            && self.comments.is_empty()
+            && self.clusters.is_empty()
+            && self.cluster_replicas.is_empty()
+            && self.introspection_sources.is_empty()
+            && self.id_allocator.is_empty()
+            && self.configs.is_empty()
+            && self.settings.is_empty()
+            && self.timestamps.is_empty()
+            && self.system_object_mappings.is_empty()
+            && self.system_configurations.is_empty()
+            && self.default_privileges.is_empty()
+            && self.system_privileges.is_empty()
     }
 }
 
@@ -962,17 +1340,6 @@ pub struct RoleValue {
     pub(crate) attributes: RoleAttributes,
     pub(crate) membership: RoleMembership,
     pub(crate) vars: RoleVars,
-}
-
-impl From<Role> for RoleValue {
-    fn from(role: Role) -> Self {
-        RoleValue {
-            name: role.name,
-            attributes: role.attributes,
-            membership: role.membership,
-            vars: role.vars,
-        }
-    }
 }
 
 impl RustType<proto::RoleValue> for RoleValue {


### PR DESCRIPTION
This commit creates a DurableType trait that converts between durable catalog structs used to pass information to outside modules and durable catalog structs used internally to represent on-disk state. This allows us to remove duplicate code, better organize the conversion code, and ensures that all implementers of `DurableCatalogState` use the same exact conversions.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
