### PR TITLE
Remove the enable_arrangement_size_logging flag

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -26,7 +26,6 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
         dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
-        enable_arrangement_size_logging: Some(config.enable_arrangement_size_logging()),
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         persist: persist_config(config),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -68,6 +68,5 @@ message ProtoComputeParameters {
     optional bool enable_mz_join_core = 4;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
-    optional bool enable_arrangement_size_logging = 7;
-    optional bool enable_jemalloc_profiling = 8;
+    optional bool enable_jemalloc_profiling = 7;
 }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -361,8 +361,6 @@ pub struct ComputeParameters {
     pub dataflow_max_inflight_bytes: Option<usize>,
     /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
     pub enable_mz_join_core: Option<bool>,
-    /// Enable arrangement size logging
-    pub enable_arrangement_size_logging: Option<bool>,
     /// Whether to activate jemalloc heap profiling.
     pub enable_jemalloc_profiling: Option<bool>,
     /// Persist client configuration.
@@ -380,7 +378,6 @@ impl ComputeParameters {
             max_result_size,
             dataflow_max_inflight_bytes,
             enable_mz_join_core,
-            enable_arrangement_size_logging,
             enable_jemalloc_profiling,
             persist,
             tracing,
@@ -395,9 +392,6 @@ impl ComputeParameters {
         }
         if enable_mz_join_core.is_some() {
             self.enable_mz_join_core = enable_mz_join_core;
-        }
-        if enable_arrangement_size_logging.is_some() {
-            self.enable_arrangement_size_logging = enable_arrangement_size_logging;
         }
         if enable_jemalloc_profiling.is_some() {
             self.enable_jemalloc_profiling = enable_jemalloc_profiling;
@@ -419,7 +413,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
         ProtoComputeParameters {
             max_result_size: self.max_result_size.into_proto(),
             dataflow_max_inflight_bytes: self.dataflow_max_inflight_bytes.into_proto(),
-            enable_arrangement_size_logging: self.enable_arrangement_size_logging.into_proto(),
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             persist: Some(self.persist.into_proto()),
@@ -432,7 +425,6 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
         Ok(Self {
             max_result_size: proto.max_result_size.into_rust()?,
             dataflow_max_inflight_bytes: proto.dataflow_max_inflight_bytes.into_rust()?,
-            enable_arrangement_size_logging: proto.enable_arrangement_size_logging.into_rust()?,
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             persist: proto

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -86,8 +86,6 @@ pub struct ComputeState {
     pub metrics: ComputeMetrics,
     /// A process-global handle to tracing configuration.
     tracing_handle: Arc<TracingHandle>,
-    /// Enable arrangement size logging
-    pub enable_arrangement_size_logging: bool,
 }
 
 impl ComputeState {
@@ -115,7 +113,6 @@ impl ComputeState {
             linear_join_impl: Default::default(),
             metrics,
             tracing_handle,
-            enable_arrangement_size_logging: Default::default(),
         }
     }
 
@@ -194,7 +191,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         let ComputeParameters {
             max_result_size,
             dataflow_max_inflight_bytes,
-            enable_arrangement_size_logging,
             enable_mz_join_core,
             enable_jemalloc_profiling,
             persist,
@@ -207,9 +203,6 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         }
         if let Some(v) = dataflow_max_inflight_bytes {
             self.compute_state.dataflow_max_inflight_bytes = v;
-        }
-        if let Some(v) = enable_arrangement_size_logging {
-            self.compute_state.enable_arrangement_size_logging = v;
         }
         if let Some(v) = enable_mz_join_core {
             self.compute_state.linear_join_impl = match v {
@@ -368,7 +361,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             panic!("dataflow server has already initialized logging");
         }
 
-        let (logger, traces) = logging::initialize(self.timely_worker, self.compute_state, config);
+        let (logger, traces) = logging::initialize(self.timely_worker, config);
 
         // Install traces as maintained indexes
         for (log, trace) in traces {

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -42,11 +42,7 @@ where
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times marked completed in the output stream, and probing this stream
     /// is the correct way to determine that times in the shared trace are committed.
-    fn mz_arrange<Tr>(
-        &self,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<Self::Scope, TraceAgent<Tr>>
+    fn mz_arrange<Tr>(&self, name: &str) -> Arranged<Self::Scope, TraceAgent<Tr>>
     where
         Self::Key: ExchangeData + Hashable,
         Self::Val: ExchangeData,
@@ -67,12 +63,7 @@ where
     /// This operator arranges a stream of values into a shared trace, whose contents it maintains.
     /// This trace is current for all times marked completed in the output stream, and probing this stream
     /// is the correct way to determine that times in the shared trace are committed.
-    fn mz_arrange_core<P, Tr>(
-        &self,
-        pact: P,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<Self::Scope, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<Self::Scope, TraceAgent<Tr>>
     where
         P: ParallelizationContract<
             <Self::Scope as ScopeParent>::Timestamp,
@@ -106,11 +97,7 @@ where
     type Val = V;
     type R = R;
 
-    fn mz_arrange<Tr>(
-        &self,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<G, TraceAgent<Tr>>
+    fn mz_arrange<Tr>(&self, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         K: ExchangeData + Hashable,
         V: ExchangeData,
@@ -121,20 +108,10 @@ where
     {
         // Allow access to `arrange_named` because we're within Mz's wrapper.
         #[allow(clippy::disallowed_methods)]
-        let arranged = self.arrange_named(name);
-        if enable_arrangement_size_logging {
-            arranged.log_arrangement_size()
-        } else {
-            arranged
-        }
+        self.arrange_named(name).log_arrangement_size()
     }
 
-    fn mz_arrange_core<P, Tr>(
-        &self,
-        pact: P,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<G, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K, V), G::Timestamp, R)>,
         Tr: Trace + TraceReader<Key = K, Val = V, Time = G::Timestamp, R = R> + 'static,
@@ -143,12 +120,7 @@ where
     {
         // Allow access to `arrange_named` because we're within Mz's wrapper.
         #[allow(clippy::disallowed_methods)]
-        let arranged = self.arrange_core(pact, name);
-        if enable_arrangement_size_logging {
-            arranged.log_arrangement_size()
-        } else {
-            arranged
-        }
+        self.arrange_core(pact, name).log_arrangement_size()
     }
 }
 
@@ -175,11 +147,7 @@ where
     type Val = ();
     type R = R;
 
-    fn mz_arrange<Tr>(
-        &self,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<G, TraceAgent<Tr>>
+    fn mz_arrange<Tr>(&self, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         K: ExchangeData + Hashable,
         R: ExchangeData,
@@ -187,26 +155,17 @@ where
         Tr::Batch: Batch,
         Arranged<G, TraceAgent<Tr>>: ArrangementSize,
     {
-        self.0
-            .map(|d| (d, ()))
-            .mz_arrange(name, enable_arrangement_size_logging)
+        self.0.map(|d| (d, ())).mz_arrange(name)
     }
 
-    fn mz_arrange_core<P, Tr>(
-        &self,
-        pact: P,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-    ) -> Arranged<G, TraceAgent<Tr>>
+    fn mz_arrange_core<P, Tr>(&self, pact: P, name: &str) -> Arranged<G, TraceAgent<Tr>>
     where
         P: ParallelizationContract<G::Timestamp, ((K, ()), G::Timestamp, R)>,
         Tr: Trace + TraceReader<Key = K, Val = (), Time = G::Timestamp, R = R> + 'static,
         Tr::Batch: Batch,
         Arranged<G, TraceAgent<Tr>>: ArrangementSize,
     {
-        self.0
-            .map(|d| (d, ()))
-            .mz_arrange_core(pact, name, enable_arrangement_size_logging)
+        self.0.map(|d| (d, ())).mz_arrange_core(pact, name)
     }
 }
 

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -30,12 +30,7 @@ where
     G::Timestamp: Lattice + Ord,
 {
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
-    fn mz_reduce_abelian<L, T2>(
-        &self,
-        name: &str,
-        enable_arrangement_size_logging: bool,
-        logic: L,
-    ) -> Arranged<G, TraceAgent<T2>>
+    fn mz_reduce_abelian<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
     where
         T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
         T2::Val: Data,
@@ -46,12 +41,8 @@ where
     {
         // Allow access to `reduce_abelian` since we're within Mz's wrapper.
         #[allow(clippy::disallowed_methods)]
-        let arranged = self.reduce_abelian::<_, T2>(name, logic);
-        if enable_arrangement_size_logging {
-            arranged.log_arrangement_size()
-        } else {
-            arranged
-        }
+        self.reduce_abelian::<_, T2>(name, logic)
+            .log_arrangement_size()
     }
 }
 
@@ -81,7 +72,6 @@ where
         &self,
         name1: &str,
         name2: &str,
-        enable_arrangement_size_logging: bool,
         logic1: L1,
         logic2: L2,
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
@@ -109,7 +99,6 @@ where
         &self,
         name1: &str,
         name2: &str,
-        enable_arrangement_size_logging: bool,
         logic1: L1,
         logic2: L2,
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
@@ -127,10 +116,8 @@ where
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {
-        let arranged1 =
-            self.mz_reduce_abelian::<L1, T1>(name1, enable_arrangement_size_logging, logic1);
-        let arranged2 =
-            self.mz_reduce_abelian::<L2, T2>(name2, enable_arrangement_size_logging, logic2);
+        let arranged1 = self.mz_reduce_abelian::<L1, T1>(name1, logic1);
+        let arranged2 = self.mz_reduce_abelian::<L2, T2>(name2, logic2);
         (arranged1, arranged2)
     }
 }

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -38,7 +38,6 @@ use timely::{Container, Data};
 use tracing::error;
 use uuid::Uuid;
 
-use crate::compute_state::ComputeState;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{ComputeLog, EventQueue, LogVariant, SharedLoggingState};
 use crate::typedefs::{KeysValsHandle, RowSpine};
@@ -154,7 +153,6 @@ pub(super) fn construct<A: Allocate + 'static>(
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<ComputeEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-    compute_state: &ComputeState,
 ) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
@@ -383,10 +381,7 @@ pub(super) fn construct<A: Allocate + 'static>(
                             (row_key, row_val)
                         }
                     })
-                    .mz_arrange::<RowSpine<_, _, _, _>>(
-                        &format!("ArrangeByKey {:?}", variant),
-                        compute_state.enable_arrangement_size_logging,
-                    )
+                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("ArrangeByKey {:?}", variant))
                     .trace;
                 traces.insert(variant.clone(), (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -30,7 +30,6 @@ use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Filter, InputCapability};
 
-use crate::compute_state::ComputeState;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::compute::ComputeEvent;
 use crate::logging::{DifferentialLog, EventQueue, LogVariant, SharedLoggingState};
@@ -49,7 +48,6 @@ pub(super) fn construct<A: Allocate>(
     config: &mz_compute_client::logging::LoggingConfig,
     event_queue: EventQueue<DifferentialEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
-    compute_state: &ComputeState,
 ) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
     let logging_interval_ms = std::cmp::max(1, config.interval.as_millis());
     let worker_id = worker.index();
@@ -133,7 +131,6 @@ pub(super) fn construct<A: Allocate>(
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
                 Exchange::new(move |_| u64::cast_from(worker_id)),
                 "PreArrange Differential sharing",
-                compute_state.enable_arrangement_size_logging,
             );
 
         let sharing = sharing.as_collection(move |op, ()| {
@@ -176,10 +173,7 @@ pub(super) fn construct<A: Allocate>(
                             (row_key, row_val)
                         }
                     })
-                    .mz_arrange::<RowSpine<_, _, _, _>>(
-                        &format!("ArrangeByKey {:?}", variant),
-                        compute_state.enable_arrangement_size_logging,
-                    )
+                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("ArrangeByKey {:?}", variant))
                     .trace;
                 traces.insert(variant.clone(), (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/logging/initialize.rs
+++ b/src/compute/src/logging/initialize.rs
@@ -21,7 +21,6 @@ use timely::logging::{Logger, TimelyEvent};
 use timely::progress::reachability::logging::TrackerEvent;
 
 use crate::arrangement::manager::TraceBundle;
-use crate::compute_state::ComputeState;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::logging::compute::ComputeEvent;
 use crate::logging::reachability::ReachabilityEvent;
@@ -33,7 +32,6 @@ use crate::logging::{BatchLogger, EventQueue, SharedLoggingState};
 /// retrieving logged records.
 pub fn initialize<A: Allocate + 'static>(
     worker: &mut timely::worker::Worker<A>,
-    compute_state: &ComputeState,
     config: &LoggingConfig,
 ) -> (super::compute::Logger, BTreeMap<LogVariant, TraceBundle>) {
     let interval_ms = std::cmp::max(1, config.interval.as_millis())
@@ -51,7 +49,6 @@ pub fn initialize<A: Allocate + 'static>(
     let mut context = LoggingContext {
         worker,
         config,
-        compute_state,
         interval_ms,
         now,
         start_offset,
@@ -80,7 +77,6 @@ pub fn initialize<A: Allocate + 'static>(
 struct LoggingContext<'a, A: Allocate> {
     worker: &'a mut timely::worker::Worker<A>,
     config: &'a LoggingConfig,
-    compute_state: &'a ComputeState,
     interval_ms: u64,
     now: Instant,
     start_offset: Duration,
@@ -99,27 +95,23 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
             self.config,
             self.t_event_queue.clone(),
             Rc::clone(&self.shared_state),
-            self.compute_state,
         ));
         traces.extend(super::reachability::construct(
             self.worker,
             self.config,
             self.r_event_queue.clone(),
-            self.compute_state,
         ));
         traces.extend(super::differential::construct(
             self.worker,
             self.config,
             self.d_event_queue.clone(),
             Rc::clone(&self.shared_state),
-            self.compute_state,
         ));
         traces.extend(super::compute::construct(
             self.worker,
             self.config,
             self.c_event_queue.clone(),
             Rc::clone(&self.shared_state),
-            self.compute_state,
         ));
 
         let errs = self
@@ -127,12 +119,7 @@ impl<A: Allocate + 'static> LoggingContext<'_, A> {
             .dataflow_named("Dataflow: logging errors", |scope| {
                 let collection: KeyCollection<_, DataflowError, Diff> =
                     Collection::empty(scope).into();
-                collection
-                    .mz_arrange(
-                        "Arrange logging err",
-                        self.compute_state.enable_arrangement_size_logging,
-                    )
-                    .trace
+                collection.mz_arrange("Arrange logging err").trace
             });
 
         traces

--- a/src/compute/src/logging/reachability.rs
+++ b/src/compute/src/logging/reachability.rs
@@ -26,7 +26,6 @@ use timely::communication::Allocate;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Filter;
 
-use crate::compute_state::ComputeState;
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{EventQueue, LogVariant, TimelyLog};
 use crate::typedefs::{KeysValsHandle, RowSpine};
@@ -49,7 +48,6 @@ pub(super) fn construct<A: Allocate>(
     worker: &mut timely::worker::Worker<A>,
     config: &LoggingConfig,
     event_queue: EventQueue<ReachabilityEvent>,
-    compute_state: &ComputeState,
 ) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
     let interval_ms = std::cmp::max(1, config.interval.as_millis());
 
@@ -110,7 +108,6 @@ pub(super) fn construct<A: Allocate>(
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
                 Exchange::new(|(((_, _, _, _, w, _), ()), _, _)| u64::cast_from(*w)),
                 "PreArrange Timely reachability",
-                compute_state.enable_arrangement_size_logging,
             );
 
         let mut result = BTreeMap::new();
@@ -151,10 +148,7 @@ pub(super) fn construct<A: Allocate>(
                 );
 
                 let trace = updates
-                    .mz_arrange::<RowSpine<_, _, _, _>>(
-                        &format!("Arrange {:?}", variant),
-                        compute_state.enable_arrangement_size_logging,
-                    )
+                    .mz_arrange::<RowSpine<_, _, _, _>>(&format!("Arrange {:?}", variant))
                     .trace;
                 result.insert(variant.clone(), (trace, Rc::clone(&token)));
             }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -96,7 +96,6 @@ where
     pub(super) shutdown_token: ShutdownToken,
     /// The implementation to use for rendering linear joins.
     pub(super) linear_join_impl: LinearJoinImpl,
-    pub(super) enable_arrangement_size_logging: bool,
 }
 
 impl<S: Scope, V: Data + columnation::Columnation> Context<S, V>
@@ -124,7 +123,6 @@ where
             bindings: BTreeMap::new(),
             shutdown_token: Default::default(),
             linear_join_impl: Default::default(),
-            enable_arrangement_size_logging: Default::default(),
         }
     }
 }
@@ -736,7 +734,6 @@ where
         input_key: Option<Vec<MirScalarExpr>>,
         input_mfp: MapFilterProject,
         until: Antichain<mz_repr::Timestamp>,
-        enable_arrangement_size_logging: bool,
     ) -> Self {
         if collections == Default::default() {
             return self;
@@ -785,13 +782,9 @@ where
                     Ok::<(Row, Row), DataflowError>((key_row, val_row))
                 });
 
-                let oks = oks_keyed
-                    .mz_arrange::<RowSpine<Row, Row, _, _>>(&name, enable_arrangement_size_logging);
+                let oks = oks_keyed.mz_arrange::<RowSpine<Row, Row, _, _>>(&name);
                 let errs: KeyCollection<_, _, _> = errs.concat(&errs_keyed).into();
-                let errs = errs.mz_arrange::<ErrSpine<_, _, _>>(
-                    &format!("{}-errors", name),
-                    enable_arrangement_size_logging,
-                );
+                let errs = errs.mz_arrange::<ErrSpine<_, _, _>>(&format!("{}-errors", name));
                 self.arranged
                     .insert(key, ArrangementFlavor::Local(oks, errs));
             }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -160,7 +160,6 @@ where
                     inputs[stage_plan.lookup_relation].enter_region(inner),
                     stage_plan,
                     &mut errors,
-                    self.enable_arrangement_size_logging,
                 );
                 // Update joined results and capture any errors.
                 joined = JoinedFlavor::Collection(stream);
@@ -218,7 +217,6 @@ fn differential_join<G, T>(
         lookup_relation: _,
     }: LinearStagePlan,
     errors: &mut Vec<Collection<G, DataflowError, Diff>>,
-    enable_arrangement_size_logging: bool,
 ) -> Collection<G, Row, Diff>
 where
     G: Scope,
@@ -249,8 +247,7 @@ where
         });
 
         errors.push(errs);
-        let arranged =
-            keyed.mz_arrange::<RowSpine<_, _, _, _>>("JoinStage", enable_arrangement_size_logging);
+        let arranged = keyed.mz_arrange::<RowSpine<_, _, _, _>>("JoinStage");
         joined = JoinedFlavor::Local(arranged);
     }
 

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -168,10 +168,7 @@ where
         let errs: KeyCollection<_, _, _> = err_input.concatenate(errors).into();
         CollectionBundle::from_columns(
             0..key_arity,
-            ArrangementFlavor::Local(
-                arrangement,
-                errs.mz_arrange("Arrange bundle err", self.enable_arrangement_size_logging),
-            ),
+            ArrangementFlavor::Local(arrangement, errs.mz_arrange("Arrange bundle err")),
         )
     }
 
@@ -298,14 +295,10 @@ where
         let aggregate_types_err = aggregate_types.clone();
         use differential_dataflow::collection::concatenate;
         let (oks, errs) = concatenate(scope, to_concat)
-            .mz_arrange::<RowSpine<_, _, _, _>>(
-                "Arrange ReduceCollation",
-                self.enable_arrangement_size_logging,
-            )
+            .mz_arrange::<RowSpine<_, _, _, _>>("Arrange ReduceCollation")
             .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
                 "ReduceCollation",
                 "ReduceCollation Errors",
-                self.enable_arrangement_size_logging,
                 {
                     let mut row_buf = Row::default();
                     move |_key, input, output| {
@@ -433,14 +426,10 @@ where
         let error_logger = self.error_logger();
 
         let (output, errors) = collection
-            .mz_arrange::<RowSpine<_, _, _, _>>(
-                "Arranged DistinctBy",
-                self.enable_arrangement_size_logging,
-            )
+            .mz_arrange::<RowSpine<_, _, _, _>>("Arranged DistinctBy")
             .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
                 "DistinctBy",
                 "DistinctByErrorCheck",
-                self.enable_arrangement_size_logging,
                 |_key, _input, output| {
                     // We're pushing an empty row here because the key is implicitly added by the
                     // arrangement, and the permutation logic takes care of using the key part of the
@@ -497,25 +486,18 @@ where
                 .push(result.as_collection(move |key, val| (key.clone(), (index, val.clone()))));
         }
         let output = differential_dataflow::collection::concatenate(&mut input.scope(), to_collect)
-            .mz_arrange::<RowSpine<_, _, _, _>>(
-                "Arranged ReduceFuseBasic input",
-                self.enable_arrangement_size_logging,
-            )
-            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-                "ReduceFuseBasic",
-                self.enable_arrangement_size_logging,
-                {
-                    let mut row_buf = Row::default();
-                    move |_key, input, output| {
-                        let mut row_packer = row_buf.packer();
-                        for ((_, row), _) in input.iter() {
-                            let datum = row.unpack_first();
-                            row_packer.push(datum);
-                        }
-                        output.push((row_buf.clone(), 1));
+            .mz_arrange::<RowSpine<_, _, _, _>>("Arranged ReduceFuseBasic input")
+            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceFuseBasic", {
+                let mut row_buf = Row::default();
+                move |_key, input, output| {
+                    let mut row_packer = row_buf.packer();
+                    for ((_, row), _) in input.iter() {
+                        let datum = row.unpack_first();
+                        row_packer.push(datum);
                     }
-                },
-            );
+                    output.push((row_buf.clone(), 1));
+                }
+            });
         (
             output,
             err_output.expect("expected to validate in at least one aggregate"),
@@ -573,30 +555,23 @@ where
             }
         }
 
-        let arranged = partial.mz_arrange::<RowSpine<_, Row, _, _>>(
-            "Arranged ReduceInaccumulable",
-            self.enable_arrangement_size_logging,
-        );
-        let oks = arranged.mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-            "ReduceInaccumulable",
-            self.enable_arrangement_size_logging,
-            {
-                let mut row_buf = Row::default();
-                move |_key, source, target| {
-                    // We respect the multiplicity here (unlike in hierarchical aggregation)
-                    // because we don't know that the aggregation method is not sensitive
-                    // to the number of records.
-                    let iter = source.iter().flat_map(|(v, w)| {
-                        // Note that in the non-positive case, this is wrong, but harmless because
-                        // our other reduction will produce an error.
-                        let count = usize::try_from(*w).unwrap_or(0);
-                        std::iter::repeat(v.iter().next().unwrap()).take(count)
-                    });
-                    row_buf.packer().push(func.eval(iter, &RowArena::new()));
-                    target.push((row_buf.clone(), 1));
-                }
-            },
-        );
+        let arranged = partial.mz_arrange::<RowSpine<_, Row, _, _>>("Arranged ReduceInaccumulable");
+        let oks = arranged.mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceInaccumulable", {
+            let mut row_buf = Row::default();
+            move |_key, source, target| {
+                // We respect the multiplicity here (unlike in hierarchical aggregation)
+                // because we don't know that the aggregation method is not sensitive
+                // to the number of records.
+                let iter = source.iter().flat_map(|(v, w)| {
+                    // Note that in the non-positive case, this is wrong, but harmless because
+                    // our other reduction will produce an error.
+                    let count = usize::try_from(*w).unwrap_or(0);
+                    std::iter::repeat(v.iter().next().unwrap()).take(count)
+                });
+                row_buf.packer().push(func.eval(iter, &RowArena::new()));
+                target.push((row_buf.clone(), 1));
+            }
+        });
 
         // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here, but
         // we then wouldn't be able to do this error check conditionally.  See its documentation for the
@@ -606,7 +581,6 @@ where
 
             let errs = arranged.mz_reduce_abelian::<_, ErrValSpine<_, _, _>>(
                 "ReduceInaccumulable Error Check",
-                self.enable_arrangement_size_logging,
                 move |_key, source, target| {
                     // Negative counts would be surprising, but until we are 100% certain we won't
                     // see them, we should report when we do. We may want to bake even more info
@@ -641,13 +615,9 @@ where
 
         let input: KeyCollection<_, _, _> = input.into();
         input
-            .mz_arrange::<RowSpine<(Row, Row), _, _, _>>(
-                "Arranged ReduceInaccumulable",
-                self.enable_arrangement_size_logging,
-            )
+            .mz_arrange::<RowSpine<(Row, Row), _, _, _>>("Arranged ReduceInaccumulable")
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
                 "ReduceInaccumulable",
-                self.enable_arrangement_size_logging,
                 move |_, source, t| {
                     if let Some(err) = R::into_error() {
                         for (value, count) in source.iter() {
@@ -761,10 +731,8 @@ where
             let error_logger = self.error_logger();
             // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
             // view mz_internal.mz_expected_group_size_advice.
-            let arranged = partial.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>(
-                "Arrange ReduceMinsMaxes",
-                self.enable_arrangement_size_logging,
-            );
+            let arranged =
+                partial.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>("Arrange ReduceMinsMaxes");
             // Note that we would prefer to use `mz_timely_util::reduce::ReduceExt::reduce_pair` here,
             // but we then wouldn't be able to do this error check conditionally.  See its documentation
             // for the rationale around using a second reduction here.
@@ -772,7 +740,6 @@ where
                 let errs = arranged
                     .mz_reduce_abelian::<_, ErrValSpine<_, _, _>>(
                         "ReduceMinsMaxes Error Check",
-                        self.enable_arrangement_size_logging,
                         move |_key, source, target| {
                             // Negative counts would be surprising, but until we are 100% certain we wont
                             // see them, we should report when we do. We may want to bake even more info
@@ -793,23 +760,19 @@ where
                 err_output = Some(errs.leave_region());
             }
             arranged
-                .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-                    "ReduceMinsMaxes",
-                    self.enable_arrangement_size_logging,
-                    {
-                        let mut row_buf = Row::default();
-                        move |_key, source: &[(&Vec<Row>, Diff)], target: &mut Vec<(Row, Diff)>| {
-                            let mut row_packer = row_buf.packer();
-                            for (aggr_index, func) in aggr_funcs.iter().enumerate() {
-                                let iter = source.iter().map(|(values, _cnt)| {
-                                    values[aggr_index].iter().next().unwrap()
-                                });
-                                row_packer.push(func.eval(iter, &RowArena::new()));
-                            }
-                            target.push((row_buf.clone(), 1));
+                .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMinsMaxes", {
+                    let mut row_buf = Row::default();
+                    move |_key, source: &[(&Vec<Row>, Diff)], target: &mut Vec<(Row, Diff)>| {
+                        let mut row_packer = row_buf.packer();
+                        for (aggr_index, func) in aggr_funcs.iter().enumerate() {
+                            let iter = source
+                                .iter()
+                                .map(|(values, _cnt)| values[aggr_index].iter().next().unwrap());
+                            row_packer.push(func.eval(iter, &RowArena::new()));
                         }
-                    },
-                )
+                        target.push((row_buf.clone(), 1));
+                    }
+                })
                 .leave_region()
         });
         (arranged_output, err_output)
@@ -838,15 +801,12 @@ where
         let error_logger = self.error_logger();
         // NOTE(vmarcos): The input operator name below is used in the tuning advice built-in
         // view mz_internal.mz_expected_group_size_advice.
-        let arranged_input = input.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>(
-            "Arranged MinsMaxesHierarchical input",
-            self.enable_arrangement_size_logging,
-        );
+        let arranged_input =
+            input.mz_arrange::<RowSpine<_, Vec<Row>, _, _>>("Arranged MinsMaxesHierarchical input");
 
         arranged_input
             .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
                 "Reduced Fallibly MinsMaxesHierarchical",
-                self.enable_arrangement_size_logging,
                 move |key, source, target| {
                     if let Some(err) = R::into_error() {
                         // Should negative accumulations reach us, we should loudly complain.
@@ -943,28 +903,21 @@ where
         });
         let partial: KeyCollection<_, _, _> = partial.into();
         let output = partial
-            .mz_arrange::<RowKeySpine<_, _, Vec<ReductionMonoid>>>(
-                "ArrangeMonotonic",
-                self.enable_arrangement_size_logging,
-            )
-            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-                "ReduceMonotonic",
-                self.enable_arrangement_size_logging,
-                {
-                    let mut row_buf = Row::default();
-                    move |_key, input, output| {
-                        let mut row_packer = row_buf.packer();
-                        let accum = &input[0].1;
-                        for monoid in accum.iter() {
-                            use ReductionMonoid::*;
-                            match monoid {
-                                Min(row) | Max(row) => row_packer.extend(row.iter()),
-                            }
+            .mz_arrange::<RowKeySpine<_, _, Vec<ReductionMonoid>>>("ArrangeMonotonic")
+            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("ReduceMonotonic", {
+                let mut row_buf = Row::default();
+                move |_key, input, output| {
+                    let mut row_packer = row_buf.packer();
+                    let accum = &input[0].1;
+                    for monoid in accum.iter() {
+                        use ReductionMonoid::*;
+                        match monoid {
+                            Min(row) | Max(row) => row_packer.extend(row.iter()),
                         }
-                        output.push((row_buf.clone(), 1));
                     }
-                },
-            );
+                    output.push((row_buf.clone(), 1));
+                }
+            });
         (output, errs)
     }
 
@@ -1221,13 +1174,9 @@ where
                     (key, row_buf.clone())
                 })
                 .map(|k| (k, ()))
-                .mz_arrange::<RowKeySpine<(Row, Row), _, _>>(
-                    "Arranged Accumulable",
-                    self.enable_arrangement_size_logging,
-                )
+                .mz_arrange::<RowKeySpine<(Row, Row), _, _>>("Arranged Accumulable")
                 .mz_reduce_abelian::<_, RowKeySpine<_, _, _>>(
                     "Reduced Accumulable",
-                    self.enable_arrangement_size_logging,
                     move |_k, _s, t| t.push(((), 1)),
                 )
                 .as_collection(|k, _| k.clone())
@@ -1254,14 +1203,10 @@ where
         let error_logger = self.error_logger();
         let err_full_aggrs = full_aggrs.clone();
         let (arranged_output, arranged_errs) = collection
-            .mz_arrange::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>(
-                "ArrangeAccumulable",
-                self.enable_arrangement_size_logging,
-            )
+            .mz_arrange::<RowKeySpine<_, _, (Vec<Accum>, Diff)>>("ArrangeAccumulable")
             .reduce_pair::<_, RowSpine<_, _, _, _>, _, ErrValSpine<_, _, _>>(
                 "ReduceAccumulable",
                 "AccumulableErrorCheck",
-                self.enable_arrangement_size_logging,
                 {
                     let mut row_buf = Row::default();
                     move |_key, input, output| {

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -29,7 +29,6 @@ use crate::typedefs::RowSpine;
 fn threshold_arrangement<G, T, R, L>(
     arrangement: &R,
     name: &str,
-    enable_arrangement_size_logging: bool,
     logic: L,
 ) -> Arranged<G, TraceAgent<RowSpine<Row, Row, G::Timestamp, Diff>>>
 where
@@ -39,7 +38,7 @@ where
     R: MzReduce<G, Row, Row, Diff>,
     L: Fn(&Diff) -> bool + 'static,
 {
-    arrangement.mz_reduce_abelian(name, enable_arrangement_size_logging, move |_key, s, t| {
+    arrangement.mz_reduce_abelian(name, move |_key, s, t| {
         for (record, count) in s.iter() {
             if logic(count) {
                 t.push(((*record).clone(), *count));
@@ -55,7 +54,6 @@ where
 pub fn build_threshold_basic<G, T>(
     input: CollectionBundle<G, Row, T>,
     key: Vec<MirScalarExpr>,
-    enable_arrangement_size_logging: bool,
 ) -> CollectionBundle<G, Row, T>
 where
     G: Scope,
@@ -67,26 +65,13 @@ where
         .expect("Arrangement ensured to exist");
     match arrangement {
         ArrangementFlavor::Local(oks, errs) => {
-            let oks = threshold_arrangement(
-                &oks,
-                "Threshold local",
-                enable_arrangement_size_logging,
-                |count| *count > 0,
-            );
+            let oks = threshold_arrangement(&oks, "Threshold local", |count| *count > 0);
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
         ArrangementFlavor::Trace(_, oks, errs) => {
-            let oks = threshold_arrangement(
-                &oks,
-                "Threshold trace",
-                enable_arrangement_size_logging,
-                |count| *count > 0,
-            );
+            let oks = threshold_arrangement(&oks, "Threshold trace", |count| *count > 0);
             let errs: KeyCollection<_, _, _> = errs.as_collection(|k, _| k.clone()).into();
-            let errs = errs.mz_arrange(
-                "Arrange threshold basic err",
-                enable_arrangement_size_logging,
-            );
+            let errs = errs.mz_arrange("Arrange threshold basic err");
             CollectionBundle::from_expressions(key, ArrangementFlavor::Local(oks, errs))
         }
     }
@@ -110,7 +95,7 @@ where
                 // We do not need to apply the permutation here,
                 // since threshold doesn't inspect the values, but only
                 // their counts.
-                build_threshold_basic(input, key, self.enable_arrangement_size_logging)
+                build_threshold_basic(input, key)
             }
         }
     }

--- a/src/compute/src/render/top_k.rs
+++ b/src/compute/src/render/top_k.rs
@@ -277,12 +277,7 @@ where
         let input = collection.map(move |((key, hash), row)| ((key, hash % modulus), row));
         let (oks, errs) = if validating {
             let stage = build_topk_negated_stage::<S, Result<Row, Row>>(
-                &input,
-                order_key,
-                offset,
-                limit,
-                arity,
-                self.enable_arrangement_size_logging,
+                &input, order_key, offset, limit, arity,
             );
 
             let error_logger = self.error_logger();
@@ -298,14 +293,7 @@ where
             (oks, Some(errs))
         } else {
             (
-                build_topk_negated_stage::<S, Row>(
-                    &input,
-                    order_key,
-                    offset,
-                    limit,
-                    arity,
-                    self.enable_arrangement_size_logging,
-                ),
+                build_topk_negated_stage::<S, Row>(&input, order_key, offset, limit, arity),
                 None,
             )
         };
@@ -372,20 +360,13 @@ where
         });
         let result = partial
             .map(|k| (k, ()))
-            .mz_arrange::<RowSpine<Row, _, _, _>>(
-                "Arranged MonotonicTop1 partial",
-                self.enable_arrangement_size_logging,
-            )
-            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-                "MonotonicTop1",
-                self.enable_arrangement_size_logging,
-                {
-                    move |_key, input, output| {
-                        let accum: &monoids::Top1Monoid = &input[0].1;
-                        output.push((accum.row.clone(), 1));
-                    }
-                },
-            );
+            .mz_arrange::<RowSpine<Row, _, _, _>>("Arranged MonotonicTop1 partial")
+            .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("MonotonicTop1", {
+                move |_key, input, output| {
+                    let accum: &monoids::Top1Monoid = &input[0].1;
+                    output.push((accum.row.clone(), 1));
+                }
+            });
         // TODO(#7331): Here we discard the arranged output.
         (result.as_collection(|_k, v| v.clone()), errs)
     }
@@ -397,7 +378,6 @@ fn build_topk_negated_stage<G, R>(
     offset: usize,
     limit: Option<usize>,
     arity: usize,
-    enable_arrangement_size_logging: bool,
 ) -> Collection<G, ((Row, u64), R), Diff>
 where
     G: Scope,
@@ -409,94 +389,87 @@ where
     // NOTE(vmarcos): The arranged input operator name below is used in the tuning advice
     // built-in view mz_internal.mz_expected_group_size_advice.
     input
-        .mz_arrange::<RowSpine<(Row, u64), _, _, _>>(
-            "Arranged TopK input",
-            enable_arrangement_size_logging,
-        )
-        .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>(
-            "Reduced TopK input",
-            enable_arrangement_size_logging,
-            {
-                move |_key, source, target: &mut Vec<(R, Diff)>| {
-                    if let Some(err) = R::into_error() {
-                        for (row, diff) in source.iter() {
-                            if diff.is_positive() {
-                                continue;
-                            }
-                            target.push((err((*row).clone()), -1));
-                            return;
-                        }
-                    }
-
-                    // Determine if we must actually shrink the result set.
-                    // TODO(benesch): avoid dangerous `as` conversion.
-                    #[allow(clippy::as_conversions)]
-                    let must_shrink = offset > 0
-                        || limit
-                            .map(|l| source.iter().map(|(_, d)| *d).sum::<Diff>() as usize > l)
-                            .unwrap_or(false);
-                    if !must_shrink {
-                        return;
-                    }
-
-                    // First go ahead and emit all records
+        .mz_arrange::<RowSpine<(Row, u64), _, _, _>>("Arranged TopK input")
+        .mz_reduce_abelian::<_, RowSpine<_, _, _, _>>("Reduced TopK input", {
+            move |_key, source, target: &mut Vec<(R, Diff)>| {
+                if let Some(err) = R::into_error() {
                     for (row, diff) in source.iter() {
-                        target.push((R::ok((*row).clone()), diff.clone()));
-                    }
-                    // local copies that may count down to zero.
-                    let mut offset = offset;
-                    let mut limit = limit;
-
-                    // The order in which we should produce rows.
-                    let mut indexes = (0..source.len()).collect::<Vec<_>>();
-                    // We decode the datums once, into a common buffer for efficiency.
-                    // Each row should contain `arity` columns; we should check that.
-                    let mut buffer = Vec::with_capacity(arity * source.len());
-                    for (index, row) in source.iter().enumerate() {
-                        buffer.extend(row.0.iter());
-                        assert_eq!(buffer.len(), arity * (index + 1));
-                    }
-                    let width = buffer.len() / source.len();
-
-                    //todo: use arrangements or otherwise make the sort more performant?
-                    indexes.sort_by(|left, right| {
-                        let left = &buffer[left * width..][..width];
-                        let right = &buffer[right * width..][..width];
-                        // Note: source was originally ordered by the u8 array representation
-                        // of rows, but left.cmp(right) uses Datum::cmp.
-                        mz_expr::compare_columns(&order_key, left, right, || left.cmp(right))
-                    });
-
-                    // We now need to lay out the data in order of `buffer`, but respecting
-                    // the `offset` and `limit` constraints.
-                    for index in indexes.into_iter() {
-                        let (row, mut diff) = source[index];
-                        if !diff.is_positive() {
+                        if diff.is_positive() {
                             continue;
                         }
-                        // If we are still skipping early records ...
-                        if offset > 0 {
-                            let to_skip = std::cmp::min(offset, usize::try_from(diff).unwrap());
-                            offset -= to_skip;
-                            diff -= Diff::try_from(to_skip).unwrap();
-                        }
-                        // We should produce at most `limit` records.
-                        // TODO(benesch): avoid dangerous `as` conversion.
-                        #[allow(clippy::as_conversions)]
-                        if let Some(limit) = &mut limit {
-                            diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
-                            *limit -= diff as usize;
-                        }
-                        // Output the indicated number of rows.
-                        if diff > 0 {
-                            // Emit retractions for the elements actually part of
-                            // the set of TopK elements.
-                            target.push((R::ok(row.clone()), -diff));
-                        }
+                        target.push((err((*row).clone()), -1));
+                        return;
                     }
                 }
-            },
-        )
+
+                // Determine if we must actually shrink the result set.
+                // TODO(benesch): avoid dangerous `as` conversion.
+                #[allow(clippy::as_conversions)]
+                let must_shrink = offset > 0
+                    || limit
+                        .map(|l| source.iter().map(|(_, d)| *d).sum::<Diff>() as usize > l)
+                        .unwrap_or(false);
+                if !must_shrink {
+                    return;
+                }
+
+                // First go ahead and emit all records
+                for (row, diff) in source.iter() {
+                    target.push((R::ok((*row).clone()), diff.clone()));
+                }
+                // local copies that may count down to zero.
+                let mut offset = offset;
+                let mut limit = limit;
+
+                // The order in which we should produce rows.
+                let mut indexes = (0..source.len()).collect::<Vec<_>>();
+                // We decode the datums once, into a common buffer for efficiency.
+                // Each row should contain `arity` columns; we should check that.
+                let mut buffer = Vec::with_capacity(arity * source.len());
+                for (index, row) in source.iter().enumerate() {
+                    buffer.extend(row.0.iter());
+                    assert_eq!(buffer.len(), arity * (index + 1));
+                }
+                let width = buffer.len() / source.len();
+
+                //todo: use arrangements or otherwise make the sort more performant?
+                indexes.sort_by(|left, right| {
+                    let left = &buffer[left * width..][..width];
+                    let right = &buffer[right * width..][..width];
+                    // Note: source was originally ordered by the u8 array representation
+                    // of rows, but left.cmp(right) uses Datum::cmp.
+                    mz_expr::compare_columns(&order_key, left, right, || left.cmp(right))
+                });
+
+                // We now need to lay out the data in order of `buffer`, but respecting
+                // the `offset` and `limit` constraints.
+                for index in indexes.into_iter() {
+                    let (row, mut diff) = source[index];
+                    if !diff.is_positive() {
+                        continue;
+                    }
+                    // If we are still skipping early records ...
+                    if offset > 0 {
+                        let to_skip = std::cmp::min(offset, usize::try_from(diff).unwrap());
+                        offset -= to_skip;
+                        diff -= Diff::try_from(to_skip).unwrap();
+                    }
+                    // We should produce at most `limit` records.
+                    // TODO(benesch): avoid dangerous `as` conversion.
+                    #[allow(clippy::as_conversions)]
+                    if let Some(limit) = &mut limit {
+                        diff = std::cmp::min(diff, Diff::try_from(*limit).unwrap());
+                        *limit -= diff as usize;
+                    }
+                    // Output the indicated number of rows.
+                    if diff > 0 {
+                        // Emit retractions for the elements actually part of
+                        // the set of TopK elements.
+                        target.push((R::ok(row.clone()), -diff));
+                    }
+                }
+            }
+        })
         .as_collection(|k, v| (k.clone(), v.clone()))
 }
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1677,11 +1677,6 @@ feature_flags!(
         "MANAGED, AVAILABILITY ZONES syntax"
     ),
     (
-        enable_arrangement_size_logging,
-        "arrangement size logging",
-        true
-    ),
-    (
         statement_logging_use_reproducible_rng,
         "statement logging with reproducible RNG"
     ),
@@ -4740,7 +4735,6 @@ pub fn is_tracing_var(name: &str) -> bool {
 pub fn is_compute_config_var(name: &str) -> bool {
     name == MAX_RESULT_SIZE.name()
         || name == DATAFLOW_MAX_INFLIGHT_BYTES.name()
-        || name == ENABLE_ARRANGEMENT_SIZE_LOGGING.name()
         || name == ENABLE_MZ_JOIN_CORE.name()
         || name == ENABLE_JEMALLOC_PROFILING.name()
         || is_persist_config_var(name)

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -300,21 +300,6 @@ true true true true true
 
 > SELECT records, batches, size, capacity, allocations FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 
-# Test arrangement size logging disabled works
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_arrangement_size_logging = false
-
-> CREATE INDEX ii_t4 ON t4(c)
-
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size, capacity, allocations FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
-true true 0 0 0
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_arrangement_size_logging = true
-
-> DROP INDEX ii_t4
-
 # Test arrangement size logging for error dataflows
 
 > CREATE TABLE t5(a int)


### PR DESCRIPTION
Fixes #21131


### Tips for reviewer

This is a very mechanical change that removes the `enable_arrangement_size_logging` flag. Unfortunately, some reformatting happens, so best viewed with whitespace changes hidden!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
