### PR TITLE
stash: only warn on connection errors

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -474,7 +474,7 @@ impl Stash {
         let (client, connection) = tokio_postgres::connect(url, tls).await?;
         mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
             if let Err(e) = connection.await {
-                tracing::error!("postgres stash connection error: {}", e);
+                tracing::warn!("postgres stash connection error: {}", e);
             }
         });
         client
@@ -541,7 +541,7 @@ impl Stash {
         let (mut client, connection) = self.config.lock().await.connect(self.tls.clone()).await?;
         mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
             if let Err(e) = connection.await {
-                tracing::error!("postgres stash connection error: {}", e);
+                tracing::warn!("postgres stash connection error: {}", e);
             }
         });
         // The Config is shared with the Consolidator, so we update the application name in the
@@ -1281,7 +1281,7 @@ impl Consolidator {
             || "tokio-postgres stash consolidation connection",
             async move {
                 if let Err(e) = connection.await {
-                    tracing::error!("postgres stash connection error: {}", e);
+                    tracing::warn!("postgres stash connection error: {}", e);
                 }
             },
         );
@@ -1356,7 +1356,7 @@ impl DebugStashFactory {
         let (client, connection) = tokio_postgres::connect(&url, tls.clone()).await?;
         mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {
             if let Err(e) = connection.await {
-                tracing::error!("postgres stash connection error: {e}");
+                tracing::warn!("postgres stash connection error: {e}");
             }
         });
         client


### PR DESCRIPTION
They are already retried, and these aren't actionable.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a