### PR TITLE
mzcompose: Disable sanity_restart for certain workloads

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -47,6 +47,7 @@ class StartMz(MzcomposeAction):
             external_cockroach=True,
             environment_extra=self.environment_extra,
             system_parameter_defaults=self.system_parameter_defaults,
+            sanity_restart=False,
         )
 
         with c.override(mz):

--- a/misc/python/materialize/scalability/endpoints.py
+++ b/misc/python/materialize/scalability/endpoints.py
@@ -109,7 +109,9 @@ class MaterializeContainer(MaterializeNonRemote):
 
     def up(self) -> None:
         self.composition.down(destroy_volumes=True)
-        with self.composition.override(Materialized(image=self.image)):
+        with self.composition.override(
+            Materialized(image=self.image, sanity_restart=False)
+        ):
             self.composition.up("materialized")
             self._port = self.composition.default_port("materialized")
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -141,6 +141,7 @@ def run_one_scenario(
             additional_system_parameter_defaults=additional_system_parameter_defaults,
             external_cockroach=True,
             external_minio=True,
+            sanity_restart=False,
         )
 
         with c.override(mz):

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -36,7 +36,7 @@ SERVICES = [
     Clusterd(
         name="clusterd_compute_1"
     ),  # Started by some Scenarios, defined here only for the teardown
-    Materialized(external_cockroach=True),
+    Materialized(external_cockroach=True, sanity_restart=False),
     TestdriveService(
         default_timeout="300s",
         no_reset=True,

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -38,7 +38,10 @@ from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
 
 RESULTS_DIR = MZ_ROOT / "test" / "scalability" / "results"
-SERVICES = [Materialized(image="materialize/materialized:latest"), Postgres()]
+SERVICES = [
+    Materialized(image="materialize/materialized:latest", sanity_restart=False),
+    Postgres(),
+]
 
 
 def initialize_worker(local: threading.local, lock: threading.Lock):

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -153,6 +153,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             default_size=args.size or Materialized.Size.DEFAULT_SIZE,
             external_minio=True,
             external_cockroach=True,
+            sanity_restart=False,
         ),
     ):
         c.up("materialized")


### PR DESCRIPTION
- for the feature and scalability benchmarks, as repeated restarts slow everything down
- for the platform checks and Zippy, as they manage their own server restarts

### Motivation

sanity_restart remains enabled for all workflows that do not explicitly disable it, so the extra coverage provided by this feature is mostly retained. However, for workflows that want to control restarts tightly, it makes sense for the sanity_restart to not interfere.