### PR TITLE
ci: testdrive: register further errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -826,6 +826,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2018,6 +2033,16 @@ name = "fallible-streaming-iterator"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fast-float"
@@ -4300,6 +4325,7 @@ dependencies = [
  "chrono",
  "clap",
  "crossbeam",
+ "fancy-regex",
  "mz-avro",
  "mz-ccsr",
  "mz-ore",

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0.66"
 chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
 crossbeam = "0.8.2"
+fancy-regex = "0.11.0"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["cli", "network", "async"] }

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -105,6 +105,9 @@ pub enum MzKafkaError {
     /// Unsupported broker version
     #[error("Unsupported broker version")]
     UnsupportedBrokerVersion,
+    /// Connection to broker failed
+    #[error("Broker transport failure")]
+    BrokerTransportFailure,
     /// SASL authentication required
     #[error("SASL authentication required")]
     SASLAuthenticationRequired,
@@ -148,6 +151,8 @@ impl FromStr for MzKafkaError {
             Ok(Self::SSLAuthenticationRequired)
         } else if s.contains("probably due to broker version < 0.10") {
             Ok(Self::UnsupportedBrokerVersion)
+        } else if s.contains("Disconnected while requesting ApiVersion") {
+            Ok(Self::BrokerTransportFailure)
         } else {
             Err(())
         }

--- a/src/kafka-util/src/client.rs
+++ b/src/kafka-util/src/client.rs
@@ -9,6 +9,7 @@
 
 //! Helpers for working with Kafka's client API.
 
+use fancy_regex::Regex;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::str::FromStr;
@@ -108,6 +109,9 @@ pub enum MzKafkaError {
     /// Connection to broker failed
     #[error("Broker transport failure")]
     BrokerTransportFailure,
+    /// All brokers down
+    #[error("All brokers down")]
+    AllBrokersDown,
     /// SASL authentication required
     #[error("SASL authentication required")]
     SASLAuthenticationRequired,
@@ -153,6 +157,8 @@ impl FromStr for MzKafkaError {
             Ok(Self::UnsupportedBrokerVersion)
         } else if s.contains("Disconnected while requesting ApiVersion") {
             Ok(Self::BrokerTransportFailure)
+        } else if Regex::new(r"(\d+)/\1 brokers are down").unwrap().is_match(s).unwrap_or_default() {
+            Ok(Self::AllBrokersDown)
         } else {
             Err(())
         }


### PR DESCRIPTION
Adding entries for:

### BrokerTransportFailure
```
2023-09-15T14:21:00.627484Z  INFO librdkafka: FAIL [thrd:host.docker.internal:32058/bootstrap]: host.docker.internal:32058/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 0ms in state APIVERSION_QUERY)
2023-09-15T14:21:00.628274Z  INFO librdkafka: FAIL [thrd:host.docker.internal:32058/bootstrap]: host.docker.internal:32058/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 0ms in state APIVERSION_QUERY)
2023-09-15T14:21:00.628474Z ERROR librdkafka: Global error: BrokerTransportFailure (Local: Broker transport failure): host.docker.internal:32058/bootstrap: Disconnected while requesting ApiVersion: might be caused by incorrect security.protocol configuration (connecting to a SSL listener?) or broker version is < 0.10 (see api.version.request) (after 0ms in state APIVERSION_QUERY)
```

### AllBrokersDown
```
2023-10-11T08:53:23.823526Z ERROR mz_kafka_util::client: failed to parse kafka error 1/1 brokers are down
2023-10-11T08:53:23.823528Z  WARN librdkafka: error: Global error: AllBrokersDown (Local: All broker connections are down): 1/1 brokers are down
```