### PR TITLE
Platform checks upsert

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -455,7 +455,7 @@ steps:
     label: "Platform checks upgrade, restarting compute clusterd first"
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
@@ -466,7 +466,7 @@ steps:
     label: "Platform checks upgrade, restarting compute clusterd last"
     timeout_in_minutes: 30
     agents:
-      queue: linux-x86_64
+      queue: builder-linux-x86_64
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:

--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -71,7 +71,12 @@ from materialize.checks.threshold import *  # noqa: F401 F403
 from materialize.checks.top_k import *  # noqa: F401 F403
 from materialize.checks.update import *  # noqa: F401 F403
 from materialize.checks.upsert import *  # noqa: F401 F403
+from materialize.checks.upsert_enrich import *  # noqa: F401 F403
+from materialize.checks.upsert_many_columns import *  # noqa: F401 F403
+from materialize.checks.upsert_many_rows import *  # noqa: F401 F403
+from materialize.checks.upsert_many_updates import *  # noqa: F401 F403
 from materialize.checks.upsert_shrink_grow import *  # noqa: F401 F403
+from materialize.checks.upsert_wide import *  # noqa: F401 F403
 from materialize.checks.uuid import *  # noqa: F401 F403
 from materialize.checks.webhook import *  # noqa: F401 F403
 from materialize.checks.window_functions import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/alter_index.py
+++ b/misc/python/materialize/checks/alter_index.py
@@ -32,10 +32,6 @@ class AlterIndex(Check):
                 $ kafka-ingest format=avro topic=alter-index schema=${schema} repeat=10000
                 {"f1": "A${kafka-ingest.iteration}"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE alter_index_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-alter-index-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/misc/python/materialize/checks/debezium.py
+++ b/misc/python/materialize/checks/debezium.py
@@ -49,10 +49,6 @@ class DebeziumPostgres(Check):
 
                 $ schema-registry-wait subject=postgres.public.debezium_table-value
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 # UPSERT is requred due to https://github.com/MaterializeInc/materialize/issues/14211
                 > CREATE SOURCE debezium_source1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'postgres.public.debezium_table')

--- a/misc/python/materialize/checks/error.py
+++ b/misc/python/materialize/checks/error.py
@@ -147,10 +147,6 @@ class DecodeError(Check):
                 $ kafka-ingest format=avro topic=decode-error schema=${schema-f1} repeat=1
                 {"f1": "A"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE decode_error
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -205,10 +201,6 @@ class DecodeErrorUpsertValue(Check):
                 key0: {"f1": 1}
                 key1: {"f1": 2}
                 key2: {"f1": 3}
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE decode_error_upsert_value
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-upsert-value-${testdrive.seed}')
@@ -296,10 +288,6 @@ class DecodeErrorUpsertKey(Check):
                 $ kafka-ingest topic=decode-error-upsert-key key-format=avro format=bytes key-schema=${key-schema}
                 {"f1": 1} value1
                 {"f1": 2} value2
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE decode_error_upsert_key
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-decode-error-upsert-key-${testdrive.seed}')

--- a/misc/python/materialize/checks/json_source.py
+++ b/misc/python/materialize/checks/json_source.py
@@ -29,8 +29,6 @@ class JsonSource(Check):
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-json
                 "object":{"a":"b","c":"d"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
                 > CREATE SOURCE format_jsonA
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-json-${testdrive.seed}')
                   KEY FORMAT JSON

--- a/misc/python/materialize/checks/kafka_formats.py
+++ b/misc/python/materialize/checks/kafka_formats.py
@@ -53,8 +53,6 @@ class KafkaFormats(Check):
                   format=protobuf descriptor-file=test.proto message=Value
                 {"key1": "key1A", "key2": "key1B"} {"value1": "value1A", "value2": "value1B"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
                 > CREATE SOURCE format_bytes1
                   IN CLUSTER kafka_formats
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-format-bytes-${testdrive.seed}')

--- a/misc/python/materialize/checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/multiple_partitions.py
@@ -35,10 +35,6 @@ class MultiplePartitions(Check):
                 $ kafka-ingest format=avro key-format=avro topic=multiple-partitions-topic key-schema=${keyschema} schema=${schema} repeat=100
                 {"key1": "A${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE multiple_partitions_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-multiple-partitions-topic-${testdrive.seed}', TOPIC METADATA REFRESH INTERVAL MS 500)
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -129,6 +129,14 @@ class ConfigureMz(MzcomposeAction):
                 + "\n".join(system_settings)
             )
 
+        input += dedent(
+            """
+            > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+
+            > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
+            """
+        )
+
         self.handle = e.testdrive(input=input)
         e.system_settings.update(system_settings)
 

--- a/misc/python/materialize/checks/range.py
+++ b/misc/python/materialize/checks/range.py
@@ -57,10 +57,6 @@ class Range(Check):
             $ kafka-ingest format=avro topic=ranges schema=${schema} repeat=10
             {"f1": "A${kafka-ingest.iteration}"}
 
-            > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-            > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
             > CREATE SOURCE range_source
               FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-ranges-${testdrive.seed}')
               FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/misc/python/materialize/checks/rename_source.py
+++ b/misc/python/materialize/checks/rename_source.py
@@ -36,10 +36,6 @@ class RenameSource(Check):
                 $ kafka-ingest format=avro topic=rename-source schema=${rename-source-schema}
                 {"f1": "A"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE rename_source1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-rename-source-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/misc/python/materialize/checks/sink.py
+++ b/misc/python/materialize/checks/sink.py
@@ -64,10 +64,6 @@ class SinkUpsert(Check):
                 $ kafka-ingest format=avro key-format=avro topic=sink-source key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "D3${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE sink_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-source-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -97,10 +93,6 @@ class SinkUpsert(Check):
                 {"key1": "I2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 {"key1": "U2${kafka-ingest.iteration}"} {"f1": "B${kafka-ingest.iteration}"}
                 {"key1": "D2${kafka-ingest.iteration}"}
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SINK sink_sink2 FROM sink_source_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink2')
@@ -148,10 +140,6 @@ class SinkUpsert(Check):
                 U3 C 1000
 
                 # We check the contents of the sink topics by re-ingesting them.
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE sink_view1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink1')
@@ -239,10 +227,6 @@ class SinkTables(Check):
 
                 > CREATE MATERIALIZED VIEW sink_large_transaction_view AS SELECT f1 - 1 AS f1 , f2 FROM sink_large_transaction_table;
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SINK sink_large_transaction_sink1 FROM sink_large_transaction_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -269,10 +253,6 @@ class SinkTables(Check):
             dedent(
                 """
                 # We check the contents of the sink topics by re-ingesting them.
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE sink_large_transaction_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-large-transaction-sink-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -345,10 +325,6 @@ class SinkNullDefaults(Check):
                 $ kafka-ingest format=avro key-format=avro topic=sink-source-null key-schema=${keyschema} schema=${schema} repeat=1000
                 {"key1": "D3${kafka-ingest.iteration}"} {"f1": null, "f2": {"long": ${kafka-ingest.iteration}}}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE sink_source_null
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink-source-null-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -379,10 +355,6 @@ class SinkNullDefaults(Check):
                 {"key1": "I2${kafka-ingest.iteration}"} {"f1": {"string": "B${kafka-ingest.iteration}"}, "f2": null}
                 {"key1": "U2${kafka-ingest.iteration}"} {"f1": null, "f2": {"long": ${kafka-ingest.iteration}}}
                 {"key1": "D2${kafka-ingest.iteration}"}
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SINK sink_sink_null2 FROM sink_source_null_view
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink-null2')
@@ -459,10 +431,6 @@ class SinkNullDefaults(Check):
                 U3 A <null> 1000
 
                 # We check the contents of the sink topics by re-ingesting them.
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE sink_view_null1
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'sink-sink-null1')

--- a/misc/python/materialize/checks/top_k.py
+++ b/misc/python/materialize/checks/top_k.py
@@ -87,10 +87,6 @@ class MonotonicTopK(Check):
                 $ kafka-ingest format=avro topic=monotonic-topk schema=${schema} repeat=1
                 {"f1": "A"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE monotonic_topk_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-monotonic-topk-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -152,10 +148,6 @@ class MonotonicTop1(Check):
 
                 $ kafka-ingest format=avro topic=monotonic-top1 schema=${schema} repeat=1
                 {"f1": "A"}
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE monotonic_top1_source
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-monotonic-top1-${testdrive.seed}')

--- a/misc/python/materialize/checks/upsert.py
+++ b/misc/python/materialize/checks/upsert.py
@@ -30,10 +30,6 @@ class UpsertInsert(Check):
                 $ kafka-ingest format=avro key-format=avro topic=upsert-insert key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "A${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE upsert_insert
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-insert-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -84,10 +80,6 @@ class UpsertUpdate(Check):
                 $ kafka-ingest format=avro key-format=avro topic=upsert-update key-schema=${keyschema} schema=${schema} repeat=10000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "A${kafka-ingest.iteration}"}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
-
                 > CREATE SOURCE upsert_update
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-update-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
@@ -134,10 +126,6 @@ class UpsertDelete(Check):
 
                 $ kafka-ingest format=avro key-format=avro topic=upsert-delete key-schema=${keyschema} schema=${schema} repeat=30000
                 {"key1": "${kafka-ingest.iteration}"} {"f1": "${kafka-ingest.iteration}"}
-
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
 
                 > CREATE SOURCE upsert_delete
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-delete-${testdrive.seed}')

--- a/misc/python/materialize/checks/upsert_enrich.py
+++ b/misc/python/materialize/checks/upsert_enrich.py
@@ -1,0 +1,106 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+PAD_128B = "X" * 128
+# 1000 and not 1024 to keep entire Kafka message under 1M
+PAD_1K = "Y" * 1000
+
+# A schema that allows null values
+SCHEMA = dedent(
+    """
+       $ set keyschema={
+           "type": "record",
+           "name": "Key",
+           "fields": [
+               {"name": "key1", "type": "string"}
+           ]
+         }
+
+       $ set schema={
+           "type" : "record",
+           "name" : "test",
+           "fields" : [
+               {"name":"f1", "type": ["null", "string"], "default": null }
+           ]
+         }
+    """
+)
+
+
+class UpsertEnrichValue(Check):
+    """Progressively enrich records that started their lives as null values.
+    Progressively empoverish records that started as very large values.
+    """
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            SCHEMA
+            + dedent(
+                f"""
+                $ kafka-create-topic topic=upsert-enrich-value
+                # 'A...' records start as NULLs
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "A${{kafka-ingest.iteration}}"}} {{"f1": null}}
+
+                # 'B...' records start as 1Ks
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "B${{kafka-ingest.iteration}}"}} {{"f1": {{"string":"{PAD_1K}"}}}}
+
+                > CREATE SOURCE upsert_enrich_value
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-enrich-value-${{testdrive.seed}}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_enrich_value_view AS
+                  SELECT LEFT(key1, 1) AS key_left, LEFT(f1, 1) AS value_left, RIGHT(f1, 1),
+                  LENGTH(f1), COUNT(*), SUM(CASE WHEN f1 IS NULL THEN 1 ELSE 0 END) AS nulls, COUNT(f1) AS not_nulls
+                  FROM upsert_enrich_value
+                  GROUP BY LEFT(key1, 1), f1
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(SCHEMA + dedent(s))
+            for s in [
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "A${{kafka-ingest.iteration}}"}} {{"f1": {{"string":"{PAD_128B}"}}}}
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "B${{kafka-ingest.iteration}}"}} {{"f1": {{"string":"{PAD_128B}"}}}}
+                """,
+                f"""
+                # 'A...' records will now be enriched to 1Ks
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "A${{kafka-ingest.iteration}}"}} {{"f1": {{"string":"{PAD_1K}"}}}}
+
+                # 'B...' records will now be enpoverished to NULLs
+                $ kafka-ingest format=avro key-format=avro topic=upsert-enrich-value key-schema=${{keyschema}} schema=${{schema}} repeat=1000
+                {{"key1": "B${{kafka-ingest.iteration}}"}} {{"f1": null}}
+
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_enrich_value_view
+                A Y Y 1000 1000 0 1000
+                B <null> <null> <null> 1000 1000 0
+                """
+            )
+        )

--- a/misc/python/materialize/checks/upsert_many_columns.py
+++ b/misc/python/materialize/checks/upsert_many_columns.py
@@ -1,0 +1,171 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+
+MANY_KEYS = ", ".join(
+    [f'{{"name": "key{i+1}", "type": "string"}}' for i in range(1000)]
+)
+MANY_VALUES = ", ".join(
+    [f'{{"name": "f{i+1}", "type": "string"}}' for i in range(1000)]
+)
+
+MANY_KEYS_SCHEMA = dedent(
+    f"""
+    $ set keyschema={{
+      "type" : "record",
+      "name" : "Key",
+      "fields" : [ {MANY_KEYS} ]
+      }}
+
+    $ set schema={{
+      "type" : "record",
+      "name" : "test",
+      "fields" : [
+        {{"name":"f1", "type":"string"}}
+      ]
+      }}
+    """
+)
+
+MANY_VALUES_SCHEMA = dedent(
+    f"""
+   $ set keyschema={{
+     "type": "record",
+     "name": "Key",
+     "fields": [
+       {{"name": "key1", "type": "string"}}
+     ]
+     }}
+
+   $ set schema={{
+     "type" : "record",
+     "name" : "test",
+     "fields" : [ {MANY_VALUES} ]
+     }}
+   """
+)
+
+
+class UpsertManyValueColumns(Check):
+    """Upsert 1K value columns"""
+
+    DATA_A = ", ".join([f'"f{i+1}": "A{i+1}XYZ"' for i in range(1000)])
+    DATA_B = ", ".join([f'"f{i+1}": "B{i+1}XYZ"' for i in range(1000)])
+    DATA_C = ", ".join([f'"f{i+1}": "C{i+1}XYZ"' for i in range(1000)])
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            MANY_VALUES_SCHEMA
+            + dedent(
+                f"""
+                $ kafka-create-topic topic=upsert-many-value-columns
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-value-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "1"}} {{ {UpsertManyValueColumns.DATA_A} }}
+                {{"key1": "2"}} {{ {UpsertManyValueColumns.DATA_A} }}
+                {{"key1": "3"}} {{ {UpsertManyValueColumns.DATA_A} }}
+
+                > CREATE SOURCE upsert_many_value_columns
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-many-value-columns-${{testdrive.seed}}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_many_value_columns_view AS
+                  SELECT key1, f1, f1000
+                  FROM upsert_many_value_columns
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(MANY_VALUES_SCHEMA + dedent(s))
+            for s in [
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-value-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "1"}} {{ {UpsertManyValueColumns.DATA_B} }}
+                {{"key1": "2"}}
+                """,
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-value-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "1"}} {{ {UpsertManyValueColumns.DATA_C} }}
+                {{"key1": "3"}}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_many_value_columns_view
+                1 C1XYZ C1000XYZ
+                """
+            )
+        )
+
+
+class UpsertManyKeyColumns(Check):
+    """Upsert 1K key columns"""
+
+    KEYS_A = ", ".join([f'"key{i+1}": "A{i+1}XYZ"' for i in range(1000)])
+    KEYS_B = ", ".join([f'"key{i+1}": "B{i+1}XYZ"' for i in range(1000)])
+    KEYS_C = ", ".join([f'"key{i+1}": "C{i+1}XYZ"' for i in range(1000)])
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            MANY_KEYS_SCHEMA
+            + dedent(
+                f"""
+                $ kafka-create-topic topic=upsert-many-key-columns
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-key-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{ {UpsertManyKeyColumns.KEYS_A} }} {{ "f1" : "X" }}
+                {{ {UpsertManyKeyColumns.KEYS_B} }} {{ "f1" : "X" }}
+                {{ {UpsertManyKeyColumns.KEYS_C} }} {{ "f1" : "X" }}
+
+                > CREATE SOURCE upsert_many_key_columns
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-many-key-columns-${{testdrive.seed}}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_many_key_columns_view AS
+                  SELECT key1, key1000, f1
+                  FROM upsert_many_key_columns
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(MANY_KEYS_SCHEMA + dedent(s))
+            for s in [
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-key-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{ {UpsertManyKeyColumns.KEYS_A} }} {{ "f1" : "Y" }}
+                {{ {UpsertManyKeyColumns.KEYS_B} }}
+                """,
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-key-columns key-schema=${{keyschema}} schema=${{schema}}
+                {{ {UpsertManyKeyColumns.KEYS_A} }} {{ "f1" : "Z" }}
+                {{ {UpsertManyKeyColumns.KEYS_C} }}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_many_key_columns_view
+                A1XYZ A1000XYZ Z
+                """
+            )
+        )

--- a/misc/python/materialize/checks/upsert_many_rows.py
+++ b/misc/python/materialize/checks/upsert_many_rows.py
@@ -1,0 +1,80 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+
+
+class UpsertManyRows(Check):
+    """Upsert 1M rows"""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+            + dedent(
+                """
+                $ kafka-create-topic topic=upsert-many-rows
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "A${kafka-ingest.iteration}"} {"f1": "X"}
+                {"key1": "B${kafka-ingest.iteration}"} {"f1": "X"}
+                {"key1": "C${kafka-ingest.iteration}"} {"f1": "X"}
+
+                > CREATE SOURCE upsert_many_rows
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-many-rows-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_many_rows_view AS
+                  SELECT f1, COUNT(*) AS count_rows, COUNT(DISTINCT key1) AS count_keys
+                  FROM upsert_many_rows
+                  GROUP BY f1
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD) + dedent(s))
+            for s in [
+                """
+                # Update the As
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "A${kafka-ingest.iteration}"} {"f1": "Y"}
+
+                # Delete the Bs
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "B${kafka-ingest.iteration}"}
+                """,
+                """
+                # Update the As again
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "A${kafka-ingest.iteration}"} {"f1": "Z"}
+
+                # Delete the Cs
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "C${kafka-ingest.iteration}"}
+
+                # Insert some more
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-rows key-schema=${keyschema} schema=${schema} repeat=1000000
+                {"key1": "D${kafka-ingest.iteration}"} {"f1": "Z"}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_many_rows_view
+                Z 2000000 2000000
+                """
+            )
+        )

--- a/misc/python/materialize/checks/upsert_many_updates.py
+++ b/misc/python/materialize/checks/upsert_many_updates.py
@@ -1,0 +1,82 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+
+INCREMENTS = 100000
+
+
+class UpsertManyUpdates(Check):
+    """Update the same row over and over"""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+            + dedent(
+                """
+                $ kafka-create-topic topic=upsert-many-updates
+                $ kafka-ingest format=avro key-format=avro topic=upsert-many-updates key-schema=${keyschema} schema=${schema}
+                {"key1": "A"} {"f1": "0"}
+
+                > CREATE SOURCE upsert_many_updates
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-many-updates-${testdrive.seed}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_many_updates_view AS
+                  SELECT f1 FROM upsert_many_updates
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        # Construct inputs for $kafka-ingest where every update is a separate Kafka message to be ingested
+        increment1 = "\n".join(
+            [f"""{{"key1": "A"}} {{"f1": "{i+1}"}}""" for i in range(INCREMENTS)]
+        )
+        increment2 = "\n".join(
+            [
+                f"""{{"key1": "A"}} {{"f1": "{INCREMENTS+i+1}"}}"""
+                for i in range(INCREMENTS)
+            ]
+        )
+
+        return [
+            Testdrive(
+                dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+                + dedent(
+                    """
+                    $ kafka-ingest format=avro key-format=avro topic=upsert-many-updates key-schema=${keyschema} schema=${schema}
+                    """
+                )
+                + increment1
+            ),
+            Testdrive(
+                dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+                + dedent(
+                    """
+                    $ kafka-ingest format=avro key-format=avro topic=upsert-many-updates key-schema=${keyschema} schema=${schema}
+                    """
+                )
+                + increment2
+            ),
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                f"""
+                > SELECT * FROM upsert_many_updates
+                A {INCREMENTS*2}
+                """
+            )
+        )

--- a/misc/python/materialize/checks/upsert_shrink_grow.py
+++ b/misc/python/materialize/checks/upsert_shrink_grow.py
@@ -30,10 +30,6 @@ class ShrinkGrow:
                 $ kafka-ingest format=avro key-format=avro topic=upsert-update-{name} key-schema=${{keyschema}} schema=${{schema}} repeat=10000
                 {{"key1": "${{kafka-ingest.iteration}}"}} {{"f1": "A${{kafka-ingest.iteration}}{pads[0]}A"}}
 
-                > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${{testdrive.kafka-addr}}';
-
-                > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${{testdrive.schema-registry-url}}';
-
                 > CREATE SOURCE upsert_update_{name}
                   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-update-{name}-${{testdrive.seed}}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn

--- a/misc/python/materialize/checks/upsert_wide.py
+++ b/misc/python/materialize/checks/upsert_wide.py
@@ -1,0 +1,149 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+
+PAD_100K = "X" * (100 * 1024)
+PAD_500K = "Y" * (500 * 1024)
+PAD_1M = "Z" * (1000 * 1024)
+
+
+class UpsertWideValue(Check):
+    """Perform upsert over records with a very long/wide value."""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+            + dedent(
+                f"""
+                $ kafka-create-topic topic=upsert-wide-value
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A"}} {{"f1": "{PAD_100K}"}}
+
+                > CREATE SOURCE upsert_wide_value
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-wide-value-${{testdrive.seed}}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_wide_value_view AS
+                  SELECT LEFT(f1, 1), RIGHT(f1, 1),
+                  LENGTH(f1)
+                  FROM upsert_wide_value
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD) + dedent(s))
+            for s in [
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A"}} {{"f1": "{PAD_1M}"}}
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "B"}} {{"f1": "{PAD_500K}"}}
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "C"}} {{"f1": "{PAD_1M}"}}
+                """,
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A"}} {{"f1": "{PAD_500K}"}}
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "B"}} {{"f1": "{PAD_1M}"}}
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-value key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "C"}} {{"f1": "{PAD_100K}"}}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_wide_value_view
+                X X 102400
+                Y Y 512000
+                Z Z 1024000
+                """
+            )
+        )
+
+
+class UpsertWideKey(Check):
+    """Perform upsert over records with a very long/wide key."""
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+            + dedent(
+                f"""
+                $ kafka-create-topic topic=upsert-wide-key
+
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-key key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A{PAD_1M}"}} {{"f1": "A1"}}
+                {{"key1": "B{PAD_1M}"}} {{"f1": "B1"}}
+                {{"key1": "C{PAD_1M}"}} {{"f1": "C1"}}
+
+                > CREATE SOURCE upsert_wide_key
+                  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-upsert-wide-key-${{testdrive.seed}}')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE UPSERT
+
+                > CREATE MATERIALIZED VIEW upsert_wide_key_view AS
+                  SELECT LEFT(key1, 1), RIGHT(key1, 1),
+                  LENGTH(key1), f1
+                  FROM upsert_wide_key
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD) + dedent(s))
+            for s in [
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-key key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A{PAD_1M}"}} {{"f1": "A2"}}
+                {{"key1": "D{PAD_1M}"}} {{"f1": "D1"}}
+
+                # Delete B ...
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-key key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "B{PAD_1M}"}}
+                """,
+                f"""
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-key key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "A{PAD_1M}"}} {{"f1": "A3"}}
+                {{"key1": "E{PAD_1M}"}} {{"f1": "E1"}}
+
+                # Delete C ...
+                $ kafka-ingest format=avro key-format=avro topic=upsert-wide-key key-schema=${{keyschema}} schema=${{schema}}
+                {{"key1": "C{PAD_1M}"}}
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM upsert_wide_key_view
+                A Z 1024001 A3
+                D Z 1024001 D1
+                E Z 1024001 E1
+                """
+            )
+        )


### PR DESCRIPTION
- #22259
```
commit 70eb1679bdb65be4155fdde9e592538b5890e3e2 (HEAD -> platform-checks-upsert, origin/platform-checks-upsert)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Wed Oct 11 13:05:22 2023 +0200

    platform-checks: Additional checks around UPSERT sources
    
    Various UPSERT scenarios that exercise additional situations
    that could happen in a Kafka topic:
    - many rows, wide rows
    - many columns or many-part keys.
    - many updates over the same key
    - extending a record from a NULL to a very large value
    - shrinking a record in the opposite direction
    
    Closes #22259

commit 7938467cf83a80b26b1c6fed66bb3437423d3d26
Author: Philip Stoev <pstoev@materialize.com>
Date:   Wed Oct 11 13:00:23 2023 +0200

    platform-checks: Provide a shared Kafka and CSR connection
    
    Create singleton Kafka and CSR connect
```
### Motivation

Recent and past incidents have shown that, depending on the shape of the UPSERT data, bugs can crop up, including during upgrade. Going forward I expect more tinkering from engineering in the area, which already includes several intermediate, in-memory and on-disk representations for upsert data (protobuf, rocksdb, various hash tables, you name it)

In order to fortify the product against future regressions, implement a bunch of more UPSERT workloads in Platform Checks.

### Tips for reviewer

One commit removes a bunch of `CREATE CONNECTION IF NOT EXISTS` testdrive statements.