### PR TITLE
catalog: Remove initialize TODO comment

### DIFF
--- a/src/catalog/src/initialize.rs
+++ b/src/catalog/src/initialize.rs
@@ -469,7 +469,6 @@ pub async fn initialize(
         DEFAULT_USER_CLUSTER_ID,
         DEFAULT_USER_CLUSTER_NAME,
         None,
-        // TODO(jkosh44) is this right?
         Vec::new(),
         MZ_SYSTEM_ROLE_ID,
         cluster_privileges,


### PR DESCRIPTION
A TODO comment was previously committed accidentally in the catalog initialization logic in commit
935afcafc74f69cb27adf4fab2ac93c698cb5b91. The comment was about checking if it was correct to initialize the default cluster with no introspection sources. It is in fact correct to initialize the default cluster with no introspection sources, so this commit removes the comment.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
