### PR TITLE
fix: Re-order code to avoid terminating too early

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -468,14 +468,22 @@ where
 
             // `recv_timeout()` is cancel-safe as per it's docs.
             Some(timeout) = self.adapter_client.recv_timeout() => {
-                let e: AdapterError =timeout.into();
-                let error_response = e.into_response(Severity::Fatal);
+                let err: AdapterError = timeout.into();
+                let conn_id = self.adapter_client.session().conn_id();
+                tracing::warn!("session timed out, conn_id {}", conn_id);
+
+                // Process the error, doing any state cleanup.
+                let error_response = err.into_response(Severity::Fatal);
+                let error_state = self.error(error_response).await;
+
+                // Terminate __after__ we do any cleanup.
                 self.adapter_client.terminate().await;
+
                 // We must wait for the client to send a request before we can send the error response.
                 // Due to the PG wire protocol, we can't send an ErrorResponse unless it is in response
                 // to a client message.
                 let _ = self.conn.recv().await?;
-                return self.error(error_response).await;
+                return error_state;
             },
             // `recv()` is cancel-safe as per it's docs.
             message = self.conn.recv() => message?,


### PR DESCRIPTION
Earlier today we saw a [panic](https://materializeinc.sentry.io/issues/4540633283/?project=6780145&referrer=github_integration) when trying to rollback a transaction, because the `inner` of an `AdapterClient` was `None`. When looking through the code this state seems possible if we are in the `TransactionStatus::Started` or `TransactionStatus::InTransactionImplicit` states when a timeout occurs.

Previously we would terminate the session, setting `inner = None`, and then as part of processing the error, attempt to rollback the transaction which needed `inner` to send a message to the Coordinator. This PR re-orders that code so we first rollback the transaction, and then terminate.

I couldn't seem to repro the error, because I couldn't reliably get into the necessary transaction states, but more than happy to try if someone can give me some guidance.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/22316

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
