### PR TITLE
adapter: Support comments for columns in composite types

### DIFF
--- a/misc/python/materialize/checks/all_checks.py
+++ b/misc/python/materialize/checks/all_checks.py
@@ -15,6 +15,7 @@ from materialize.checks.boolean_type import *  # noqa: F401 F403
 from materialize.checks.cast import *  # noqa: F401 F403
 from materialize.checks.cluster import *  # noqa: F401 F403
 from materialize.checks.cluster_unification import *  #  noqa: F401 F403
+from materialize.checks.comment import *  # noqa: F401 F403
 from materialize.checks.commit import *  # noqa: F401 F403
 from materialize.checks.constant_plan import *  # noqa: F401 F403
 from materialize.checks.create_index import *  # noqa: F401 F403

--- a/misc/python/materialize/checks/comment.py
+++ b/misc/python/materialize/checks/comment.py
@@ -1,0 +1,97 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
+
+
+class Comment(Check):
+    """Test comments on types and tables, as well as the comment export as avro sink schema docs"""
+
+    def _can_run(self, e: Executor) -> bool:
+        return self.base_version >= MzVersion.parse("0.74.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+            > CREATE TYPE comment_type AS (x text, y int, z int)
+            > CREATE TYPE comment_int4_list AS LIST (ELEMENT TYPE = int4)
+            > CREATE TABLE comment_table (f1 comment_type, f2 comment_int4_list, f3 int)
+
+            > CREATE CONNECTION IF NOT EXISTS kafka_conn FOR KAFKA BROKER '${testdrive.kafka-addr}';
+            > CREATE CONNECTION IF NOT EXISTS csr_conn FOR CONFLUENT SCHEMA REGISTRY URL '${testdrive.schema-registry-url}';
+            > CREATE SINK comment_sink1 FROM comment_table
+              INTO KAFKA CONNECTION kafka_conn (TOPIC 'comment-sink1')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+              ENVELOPE DEBEZIUM
+            """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > COMMENT ON TYPE comment_type IS 'comment on comment_type';
+                > COMMENT ON COLUMN comment_type.x IS 'comment on comment_type.x';
+                > COMMENT ON TYPE comment_int4_list IS 'comment on comment_type';
+                > COMMENT ON TABLE comment_table IS 'comment on comment_table';
+                > COMMENT ON COLUMN comment_table.f1 IS 'comment on comment_table.f1';
+
+                > CREATE SINK comment_sink2 FROM comment_table
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'comment-sink2')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+            """,
+                """
+                > COMMENT ON COLUMN comment_type.y IS 'comment on comment_type.y';
+                > COMMENT ON COLUMN comment_table.f2 IS 'comment on comment_table.f2';
+
+                > CREATE SINK comment_sink3 FROM comment_table
+                  INTO KAFKA CONNECTION kafka_conn (TOPIC 'comment-sink3')
+                  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+                  ENVELOPE DEBEZIUM
+            """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > COMMENT ON COLUMN comment_type.z IS 'comment on comment_type.z';
+                > COMMENT ON COLUMN comment_table.f3 IS 'comment on comment_table.f3';
+
+                > SELECT name, object_type, object_sub_id, comment FROM mz_internal.mz_comments JOIN mz_objects ON mz_comments.id = mz_objects.id WHERE name LIKE 'comment_%';
+                comment_table table 1 "comment on comment_table.f1"
+                comment_table table 2 "comment on comment_table.f2"
+                comment_table table 3 "comment on comment_table.f3"
+                comment_table table <null> "comment on comment_table"
+                comment_type type 1 "comment on comment_type.x"
+                comment_type type 2 "comment on comment_type.y"
+                comment_type type 3 "comment on comment_type.z"
+                comment_type type <null> "comment on comment_type"
+                comment_int4_list type <null> "comment on comment_type"
+
+                $ schema-registry-verify schema-type=avro subject=comment-sink1-value
+                {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","fields":[{"name":"f1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","fields":[{"name":"x","type":["null","string"]},{"name":"y","type":["null","int"]},{"name":"z","type":["null","int"]}]}]},{"name":"f2","type":["null",{"type":"array","items":["null","int"]}]},{"name":"f3","type":["null","int"]}]}]},{"name":"after","type":["null","row"]}]}
+
+                $ schema-registry-verify schema-type=avro subject=comment-sink2-value
+                {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","doc":"comment on comment_table","fields":[{"name":"f1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on comment_type","fields":[{"name":"x","type":["null","string"],"doc":"comment on comment_type.x"},{"name":"y","type":["null","int"]},{"name":"z","type":["null","int"]}]}],"doc":"comment on comment_table.f1"},{"name":"f2","type":["null",{"type":"array","items":["null","int"]}]},{"name":"f3","type":["null","int"]}]}]},{"name":"after","type":["null","row"]}]}
+
+                $ schema-registry-verify schema-type=avro subject=comment-sink3-value
+                {"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","doc":"comment on comment_table","fields":[{"name":"f1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on comment_type","fields":[{"name":"x","type":["null","string"],"doc":"comment on comment_type.x"},{"name":"y","type":["null","int"],"doc":"comment on comment_type.y"},{"name":"z","type":["null","int"]}]}],"doc":"comment on comment_table.f1"},{"name":"f2","type":["null",{"type":"array","items":["null","int"]}],"doc":"comment on comment_table.f2"},{"name":"f3","type":["null","int"]}]}]},{"name":"after","type":["null","row"]}]}
+            """
+            )
+        )

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -52,9 +52,9 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::catalog::{
     CatalogCluster, CatalogClusterReplica, CatalogDatabase, CatalogError as SqlCatalogError,
     CatalogItem as SqlCatalogItem, CatalogItemType as SqlCatalogItemType, CatalogItemType,
-    CatalogRecordField, CatalogRole, CatalogSchema, CatalogType, CatalogTypeDetails,
-    DefaultPrivilegeAclItem, DefaultPrivilegeObject, EnvironmentId, IdReference, NameReference,
-    RoleAttributes, RoleMembership, RoleVars, SessionCatalog, SystemObjectType,
+    CatalogRole, CatalogSchema, CatalogType, CatalogTypeDetails, DefaultPrivilegeAclItem,
+    DefaultPrivilegeObject, EnvironmentId, IdReference, NameReference, RoleAttributes,
+    RoleMembership, RoleVars, SessionCatalog, SystemObjectType,
 };
 use mz_sql::names::{
     CommentObjectId, DatabaseId, FullItemName, FullSchemaName, ItemQualifiers, ObjectId,
@@ -360,14 +360,7 @@ impl Catalog {
                 element_reference: name_to_id_map[element_reference],
             },
             CatalogType::Record { fields } => CatalogType::Record {
-                fields: fields
-                    .into_iter()
-                    .map(|f| CatalogRecordField {
-                        name: f.name.clone(),
-                        type_reference: name_to_id_map[f.type_reference],
-                        type_modifiers: f.type_modifiers.clone(),
-                    })
-                    .collect(),
+                fields: fields.clone(),
             },
             CatalogType::Bool => CatalogType::Bool,
             CatalogType::Bytes => CatalogType::Bytes,
@@ -4021,7 +4014,6 @@ impl ExprHumanizer for ConnCatalog<'_> {
             .try_map(|entry| {
                 Ok::<_, SqlCatalogError>(
                     entry
-                        .item()
                         .desc(&self.resolve_full_name(entry.name()))?
                         .iter_names()
                         .cloned()

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -219,7 +219,7 @@ impl CatalogState {
                         Some(entry) => {
                             // TODO: Refactor this to use if-let chains, once they're stable.
                             #[allow(clippy::unnecessary_unwrap)]
-                            if !entry.is_relation() && col_pos.is_some() {
+                            if !entry.has_columns() && col_pos.is_some() {
                                 let col_pos = col_pos.expect("checked above");
                                 comment_inconsistencies.push(CommentInconsistency::NonRelation(
                                     comment_object_id,

--- a/src/adapter/src/catalog/objects.rs
+++ b/src/adapter/src/catalog/objects.rs
@@ -1849,10 +1849,6 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
         self.name()
     }
 
-    fn has_columns(&self) -> bool {
-        self.has_columns()
-    }
-
     fn id(&self) -> GlobalId {
         self.id()
     }

--- a/src/adapter/src/catalog/objects.rs
+++ b/src/adapter/src/catalog/objects.rs
@@ -34,9 +34,9 @@ use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Expr;
 use mz_sql::catalog::{
     CatalogClusterReplica, CatalogError as SqlCatalogError, CatalogItem as SqlCatalogItem,
-    CatalogItemType as SqlCatalogItemType, CatalogItemType, CatalogSchema, CatalogType,
-    CatalogTypeDetails, DefaultPrivilegeAclItem, DefaultPrivilegeObject, IdReference,
-    RoleAttributes, RoleMembership, RoleVars, SystemObjectType,
+    CatalogItemType as SqlCatalogItemType, CatalogItemType, CatalogSchema, CatalogTypeDetails,
+    DefaultPrivilegeAclItem, DefaultPrivilegeObject, IdReference, RoleAttributes, RoleMembership,
+    RoleVars, SystemObjectType,
 };
 use mz_sql::names::{
     Aug, CommentObjectId, DatabaseId, FullItemName, QualifiedItemName, QualifiedSchemaName,
@@ -705,26 +705,16 @@ pub struct Type {
     pub create_sql: String,
     #[serde(skip)]
     pub details: CatalogTypeDetails<IdReference>,
+    pub desc: Option<RelationDesc>,
     pub resolved_ids: ResolvedIds,
 }
 
 impl Type {
     pub fn desc(&self, name: String) -> Result<RelationDesc, SqlCatalogError> {
-        match &self.details {
-            CatalogTypeDetails {
-                typ: CatalogType::Record { fields },
-                ..
-            } => {
-                let columns = fields
-                    .iter()
-                    .map(|field| (field.name.clone(), field.typ.clone()));
-                Ok(RelationDesc::from_names_and_types(columns))
-            }
-            _ => Err(SqlCatalogError::InvalidDependency {
-                name,
-                typ: CatalogItemType::Type,
-            }),
-        }
+        self.desc.clone().ok_or(SqlCatalogError::InvalidDependency {
+            name,
+            typ: CatalogItemType::Type,
+        })
     }
 }
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1186,6 +1186,13 @@ impl Catalog {
         // Insert into catalog
         for typ in builtin_types {
             let element_id = name_to_id_map[typ.name];
+
+            // Assert that no built-in types are record types so that we don't
+            // need to bother to build a description. Only record types need
+            // descriptions.
+            let desc = None;
+            assert!(!matches!(typ.details.typ, CatalogType::Record { .. }));
+
             self.state.insert_item(
                 element_id,
                 typ.oid,
@@ -1199,6 +1206,7 @@ impl Catalog {
                 CatalogItem::Type(Type {
                     create_sql: format!("CREATE TYPE {}", typ.name),
                     details: typ.details.clone(),
+                    desc,
                     resolved_ids: ResolvedIds(BTreeSet::new()),
                 }),
                 MZ_SYSTEM_ROLE_ID,

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -615,7 +615,9 @@ impl Coordinator {
         match stmt {
             // `CREATE SOURCE` statements must be purified off the main
             // coordinator thread of control.
-            stmt @ (Statement::CreateSource(_) | Statement::AlterSource(_)) => {
+            stmt @ (Statement::CreateSource(_)
+            | Statement::AlterSource(_)
+            | Statement::CreateSink(_)) => {
                 let internal_cmd_tx = self.internal_cmd_tx.clone();
                 let conn_id = ctx.session().conn_id().clone();
                 let catalog = self.owned_catalog();

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -459,6 +459,10 @@ impl Coordinator {
                 self.sequence_plan(ctx, plan, ResolvedIds(BTreeSet::new()))
                     .await
             }
+            Ok(Plan::CreateSink(create_sink)) => {
+                self.sequence_plan(ctx, Plan::CreateSink(create_sink), resolved_ids)
+                    .await;
+            }
             Ok(p) => {
                 unreachable!("{:?} is not purified", p)
             }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1192,6 +1192,7 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         let typ = catalog::Type {
             create_sql: plan.typ.create_sql,
+            desc: plan.typ.inner.desc(&self.catalog().for_session(session))?,
             details: CatalogTypeDetails {
                 array_id: None,
                 typ: plan.typ.inner,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -30,7 +30,7 @@ use mz_proto::IntoRustIfSome;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
-use mz_repr::{ColumnName, ColumnType, GlobalId, RelationDesc};
+use mz_repr::{ColumnName, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_stash_types::objects::{proto, RustType, TryFromProtoError};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
@@ -51,7 +51,7 @@ use crate::names::{
 use crate::normalize;
 use crate::plan::statement::ddl::PlannedRoleAttributes;
 use crate::plan::statement::StatementDesc;
-use crate::plan::{PlanError, PlanNotice};
+use crate::plan::{query, PlanError, PlanNotice};
 use crate::session::vars::{OwnedVarInput, SystemVars};
 
 /// A catalog keeps track of SQL objects and session state available to the
@@ -855,7 +855,7 @@ pub enum CatalogType<T: TypeReference> {
         element_reference: T::Reference,
     },
     Record {
-        fields: Vec<CatalogRecordField>,
+        fields: Vec<CatalogRecordField<T>>,
     },
     RegClass,
     RegProc,
@@ -870,13 +870,41 @@ pub enum CatalogType<T: TypeReference> {
     MzAclItem,
 }
 
+impl CatalogType<IdReference> {
+    /// Returns the relation description for the type, if the type is a record
+    /// type.
+    pub fn desc(&self, catalog: &dyn SessionCatalog) -> Result<Option<RelationDesc>, PlanError> {
+        match &self {
+            CatalogType::Record { fields } => {
+                let mut desc = RelationDesc::empty();
+                for f in fields {
+                    let name = f.name.clone();
+                    let ty = query::scalar_type_from_catalog(
+                        catalog,
+                        f.type_reference,
+                        &f.type_modifiers,
+                    )?;
+                    // TODO: support plumbing `NOT NULL` constraints through
+                    // `CREATE TYPE`.
+                    let ty = ty.nullable(true);
+                    desc = desc.with_column(name, ty);
+                }
+                Ok(Some(desc))
+            }
+            _ => Ok(None),
+        }
+    }
+}
+
 /// A description of a field in a [`CatalogType::Record`].
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CatalogRecordField {
+pub struct CatalogRecordField<T: TypeReference> {
     /// The name of the field.
     pub name: ColumnName,
-    /// The type of column
-    pub typ: ColumnType,
+    /// The ID of the type of the field.
+    pub type_reference: T::Reference,
+    /// Modifiers to apply to the type.
+    pub type_modifiers: Vec<i64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -619,9 +619,6 @@ pub trait CatalogItem {
     /// an index), it returns an error.
     fn desc(&self, name: &FullItemName) -> Result<Cow<RelationDesc>, CatalogError>;
 
-    /// Reports whether this catalog item has columns.
-    fn has_columns(&self) -> bool;
-
     /// Returns the resolved function.
     ///
     /// If the catalog item is not of a type that produces functions (i.e.,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -30,7 +30,7 @@ use mz_proto::IntoRustIfSome;
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem, PrivilegeMap};
 use mz_repr::explain::ExprHumanizer;
 use mz_repr::role_id::RoleId;
-use mz_repr::{ColumnName, GlobalId, RelationDesc};
+use mz_repr::{ColumnName, ColumnType, GlobalId, RelationDesc};
 use mz_sql_parser::ast::{Expr, QualifiedReplica, UnresolvedItemName};
 use mz_stash_types::objects::{proto, RustType, TryFromProtoError};
 use mz_storage_types::connections::inline::{ConnectionResolver, ReferencedConnection};
@@ -619,6 +619,9 @@ pub trait CatalogItem {
     /// an index), it returns an error.
     fn desc(&self, name: &FullItemName) -> Result<Cow<RelationDesc>, CatalogError>;
 
+    /// Reports whether this catalog item has columns.
+    fn has_columns(&self) -> bool;
+
     /// Returns the resolved function.
     ///
     /// If the catalog item is not of a type that produces functions (i.e.,
@@ -855,7 +858,7 @@ pub enum CatalogType<T: TypeReference> {
         element_reference: T::Reference,
     },
     Record {
-        fields: Vec<CatalogRecordField<T>>,
+        fields: Vec<CatalogRecordField>,
     },
     RegClass,
     RegProc,
@@ -872,13 +875,11 @@ pub enum CatalogType<T: TypeReference> {
 
 /// A description of a field in a [`CatalogType::Record`].
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CatalogRecordField<T: TypeReference> {
+pub struct CatalogRecordField {
     /// The name of the field.
     pub name: ColumnName,
-    /// The ID of the type of the field.
-    pub type_reference: T::Reference,
-    /// Modifiers to apply to the type.
-    pub type_modifiers: Vec<i64>,
+    /// The type of column
+    pub typ: ColumnType,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -483,6 +483,13 @@ impl ResolvedItemName {
             _ => panic!("cannot call object_full_name on non-object"),
         }
     }
+
+    pub fn item_id(&self) -> &GlobalId {
+        match self {
+            ResolvedItemName::Item { id, .. } => id,
+            _ => panic!("cannot call item_id on non-object"),
+        }
+    }
 }
 
 impl AstDisplay for ResolvedItemName {

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5378,17 +5378,7 @@ pub fn scalar_type_from_catalog(
                 CatalogType::Record { fields } => {
                     let scalars: Vec<(ColumnName, ColumnType)> = fields
                         .iter()
-                        .map(|f| {
-                            let scalar_type =
-                                scalar_type_from_catalog(scx, f.type_reference, &f.type_modifiers)?;
-                            Ok((
-                                f.name.clone(),
-                                ColumnType {
-                                    scalar_type,
-                                    nullable: true,
-                                },
-                            ))
-                        })
+                        .map(|f| Ok((f.name.clone(), f.typ.clone())))
                         .collect::<Result<Vec<_>, PlanError>>()?;
                     Ok(ScalarType::Record {
                         fields: scalars,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -5233,26 +5233,23 @@ pub fn scalar_type_from_sql(
             })
         }
         ResolvedDataType::Named { id, modifiers, .. } => {
-            scalar_type_from_catalog(scx, *id, modifiers)
+            scalar_type_from_catalog(scx.catalog, *id, modifiers)
         }
         ResolvedDataType::Error => unreachable!("should have been caught in name resolution"),
     }
 }
 
 pub fn scalar_type_from_catalog(
-    scx: &StatementContext,
+    catalog: &dyn SessionCatalog,
     id: GlobalId,
     modifiers: &[i64],
 ) -> Result<ScalarType, PlanError> {
-    let entry = scx.catalog.get_item(&id);
+    let entry = catalog.get_item(&id);
     let type_details = match entry.type_details() {
         Some(type_details) => type_details,
         None => sql_bail!(
             "{} does not refer to a type",
-            scx.catalog
-                .resolve_full_name(entry.name())
-                .to_string()
-                .quoted()
+            catalog.resolve_full_name(entry.name()).to_string().quoted()
         ),
     };
     match &type_details.typ {
@@ -5335,14 +5332,14 @@ pub fn scalar_type_from_catalog(
             if !modifiers.is_empty() {
                 sql_bail!(
                     "{} does not support type modifiers",
-                    scx.catalog.resolve_full_name(entry.name()).to_string()
+                    catalog.resolve_full_name(entry.name()).to_string()
                 );
             }
             match t {
                 CatalogType::Array {
                     element_reference: element_id,
                 } => Ok(ScalarType::Array(Box::new(scalar_type_from_catalog(
-                    scx,
+                    catalog,
                     *element_id,
                     modifiers,
                 )?))),
@@ -5351,7 +5348,7 @@ pub fn scalar_type_from_catalog(
                     element_modifiers,
                 } => Ok(ScalarType::List {
                     element_type: Box::new(scalar_type_from_catalog(
-                        scx,
+                        catalog,
                         *element_id,
                         element_modifiers,
                     )?),
@@ -5364,7 +5361,7 @@ pub fn scalar_type_from_catalog(
                     value_modifiers,
                 } => Ok(ScalarType::Map {
                     value_type: Box::new(scalar_type_from_catalog(
-                        scx,
+                        catalog,
                         *value_id,
                         value_modifiers,
                     )?),
@@ -5373,12 +5370,25 @@ pub fn scalar_type_from_catalog(
                 CatalogType::Range {
                     element_reference: element_id,
                 } => Ok(ScalarType::Range {
-                    element_type: Box::new(scalar_type_from_catalog(scx, *element_id, &[])?),
+                    element_type: Box::new(scalar_type_from_catalog(catalog, *element_id, &[])?),
                 }),
                 CatalogType::Record { fields } => {
                     let scalars: Vec<(ColumnName, ColumnType)> = fields
                         .iter()
-                        .map(|f| Ok((f.name.clone(), f.typ.clone())))
+                        .map(|f| {
+                            let scalar_type = scalar_type_from_catalog(
+                                catalog,
+                                f.type_reference,
+                                &f.type_modifiers,
+                            )?;
+                            Ok((
+                                f.name.clone(),
+                                ColumnType {
+                                    scalar_type,
+                                    nullable: true,
+                                },
+                            ))
+                        })
                         .collect::<Result<Vec<_>, PlanError>>()?;
                     Ok(ScalarType::Record {
                         fields: scalars,
@@ -5406,7 +5416,7 @@ pub fn scalar_type_from_catalog(
                 CatalogType::Pseudo => {
                     sql_bail!(
                         "cannot reference pseudo type {}",
-                        scx.catalog.resolve_full_name(entry.name()).to_string()
+                        catalog.resolve_full_name(entry.name()).to_string()
                     )
                 }
                 CatalogType::RegClass => Ok(ScalarType::RegClass),

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -2843,7 +2843,7 @@ pub fn plan_create_type(
             }
             _ => {
                 // Validate that the modifiers are actually valid.
-                scalar_type_from_catalog(scx, id, &modifiers)?;
+                scalar_type_from_catalog(scx.catalog, id, &modifiers)?;
 
                 Ok((id, modifiers))
             }
@@ -2888,11 +2888,10 @@ pub fn plan_create_type(
                 let data_type = column_def.data_type;
                 let key = ident(column_def.name.clone());
                 let (id, modifiers) = validate_data_type(scx, data_type, "", &key)?;
-                let scalar_type =
-                    crate::plan::query::scalar_type_from_catalog(scx, id, &modifiers)?;
                 fields.push(CatalogRecordField {
                     name: ColumnName::from(key.clone()),
-                    typ: scalar_type.nullable(true),
+                    type_reference: id,
+                    type_modifiers: modifiers,
                 });
             }
             CatalogType::Record { fields }

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -247,7 +247,45 @@ statement ok
 CREATE TYPE custom_type AS (x integer, y int4_list);
 
 statement ok
+CREATE TYPE custom_map_type AS MAP (KEY TYPE = text, VALUE TYPE = custom_type)
+
+statement ok
+COMMENT ON TYPE custom_map_type IS 'custom_map_type_comment';
+
+statement error cannot be depended upon
+COMMENT ON COLUMN custom_map_type.key IS 'comment_on_key';
+
+statement ok
+CREATE TYPE custom_list_type AS LIST (ELEMENT TYPE = custom_type)
+
+statement ok
+COMMENT ON TYPE custom_list_type IS 'custom_list_type_comment';
+
+statement error cannot be depended upon
+COMMENT ON COLUMN custom_list_type.element IS 'comment_on_element';
+
+statement error cannot be depended upon
+COMMENT ON COLUMN custom_map_type.key IS 'comment_on_key';
+
+statement ok
 COMMENT ON TYPE custom_type IS 'custom_type_comment';
+
+query TTT
+SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
+----
+source   1      json_blob
+type     NULL   supercool_list
+source   NULL   all_the_data
+cluster  NULL   careful_now
+type     NULL   custom_type_comment
+type     NULL   custom_map_type_comment
+type     NULL   custom_list_type_comment
+
+statement ok
+DROP TYPE custom_map_type;
+
+statement ok
+DROP TYPE custom_list_type;
 
 statement ok
 COMMENT ON COLUMN custom_type.x IS 'custom_type_x_comment';

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -243,13 +243,28 @@ CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 statement ok
 COMMENT ON TYPE int4_list IS 'supercool_list';
 
+statement ok
+CREATE TYPE custom_type AS (x integer, y int4_list);
+
+statement ok
+COMMENT ON TYPE custom_type IS 'custom_type_comment';
+
+statement ok
+COMMENT ON COLUMN custom_type.x IS 'custom_type_x_comment';
+
+statement ok
+COMMENT ON COLUMN custom_type.y IS 'custom_type_y_comment';
+
 query TTT
 SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
-source  1  json_blob
-type  NULL  supercool_list
-source  NULL  all_the_data
-cluster  NULL  careful_now
+source   1      json_blob
+type     NULL   supercool_list
+source   NULL   all_the_data
+cluster  NULL   careful_now
+type     NULL   custom_type_comment
+type     1      custom_type_x_comment
+type     2      custom_type_y_comment
 
 query IT
 SELECT objsubid, description FROM pg_description;
@@ -257,6 +272,9 @@ SELECT objsubid, description FROM pg_description;
 1 json_blob
 0 all_the_data
 0 supercool_list
+0 custom_type_comment
+1 custom_type_x_comment
+2 custom_type_y_comment
 
 statement ok
 DROP CLUSTER comment_cluster CASCADE;
@@ -272,11 +290,17 @@ SELECT object_type, object_sub_id, comment FROM mz_internal.mz_comments;
 ----
 secret NULL supersecret
 type NULL supercool_list
+type     NULL   custom_type_comment
+type     1      custom_type_x_comment
+type     2      custom_type_y_comment
 
 query IT
 SELECT objsubid, description FROM pg_description;
 ----
 0  supercool_list
+0 custom_type_comment
+1 custom_type_x_comment
+2 custom_type_y_comment
 
 statement ok
 CREATE DATABASE comment_on_db;
@@ -292,6 +316,9 @@ COMMENT ON SCHEMA comment_on_schema IS 'this_is_my_schema';
 
 statement ok
 DROP SECRET my_secret;
+
+statement ok
+DROP TYPE custom_type;
 
 statement ok
 DROP TYPE int4_list;

--- a/test/testdrive/kafka-avro-sinks-doc-comments.td
+++ b/test/testdrive/kafka-avro-sinks-doc-comments.td
@@ -22,6 +22,7 @@ ALTER SYSTEM SET enable_sink_doc_on_option = true;
 > COMMENT ON COLUMN t.c3 IS 'comment on column t.c3 with a ''';
 > COMMENT ON COLUMN t.c4 IS 'comment on column t.c4 with an äöü';
 > COMMENT ON TYPE point IS 'comment on type point';
+> COMMENT ON COLUMN point.x IS 'comment on column point.x';
 
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}');
@@ -41,17 +42,18 @@ ALTER SYSTEM SET enable_sink_doc_on_option = true;
    DOC ON COLUMN t.c4 = 'doc on t.c4',
    KEY DOC ON TYPE point = 'key doc on point',
    VALUE DOC ON TYPE point = 'value doc on point',
-   KEY DOC ON TYPE t = 'key doc on t'
+   KEY DOC ON TYPE t = 'key doc on t',
+   VALUE DOC ON COLUMN point.y = 'value doc on point.y'
   )
   ENVELOPE UPSERT;
 
 > SHOW CREATE SINK sink1;
 name                            create_sql
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
- "materialize.public.sink1"  "CREATE SINK \"materialize\".\"public\".\"sink1\" FROM \"materialize\".\"public\".\"t\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-sink1-${testdrive.seed}') KEY (\"c2\") NOT ENFORCED FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" (DOC ON COLUMN \"materialize\".\"public\".\"t\".c1 = 'doc on t.c1', VALUE DOC ON COLUMN \"materialize\".\"public\".\"t\".c2 = 'value doc on t.c2', KEY DOC ON COLUMN \"materialize\".\"public\".\"t\".c2 = 'key doc on t.c2', DOC ON COLUMN \"materialize\".\"public\".\"t\".c4 = 'doc on t.c4', KEY DOC ON TYPE \"materialize\".\"public\".\"point\" = 'key doc on point', VALUE DOC ON TYPE \"materialize\".\"public\".\"point\" = 'value doc on point', KEY DOC ON TYPE \"materialize\".\"public\".\"t\" = 'key doc on t', DOC ON TYPE \"materialize\".\"public\".\"point\" = 'comment on type point', DOC ON TYPE \"materialize\".\"public\".\"t\" = 'comment on table t with a \\\\ \\', DOC ON COLUMN \"materialize\".\"public\".\"t\".c3 = 'comment on column t.c3 with a ''') ENVELOPE UPSERT"
+materialize.public.sink1 "CREATE SINK \"materialize\".\"public\".\"sink1\" FROM \"materialize\".\"public\".\"t\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-sink1-${testdrive.seed}') KEY (\"c2\") NOT ENFORCED FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" (DOC ON COLUMN \"materialize\".\"public\".\"t\".c1 = 'doc on t.c1', VALUE DOC ON COLUMN \"materialize\".\"public\".\"t\".c2 = 'value doc on t.c2', KEY DOC ON COLUMN \"materialize\".\"public\".\"t\".c2 = 'key doc on t.c2', DOC ON COLUMN \"materialize\".\"public\".\"t\".c4 = 'doc on t.c4', KEY DOC ON TYPE \"materialize\".\"public\".\"point\" = 'key doc on point', VALUE DOC ON TYPE \"materialize\".\"public\".\"point\" = 'value doc on point', KEY DOC ON TYPE \"materialize\".\"public\".\"t\" = 'key doc on t', VALUE DOC ON COLUMN \"materialize\".\"public\".\"point\".y = 'value doc on point.y', DOC ON TYPE \"materialize\".\"public\".\"point\" = 'comment on type point', DOC ON COLUMN \"materialize\".\"public\".\"point\".x = 'comment on column point.x', DOC ON TYPE \"materialize\".\"public\".\"t\" = 'comment on table t with a \\\\ \\', DOC ON COLUMN \"materialize\".\"public\".\"t\".c3 = 'comment on column t.c3 with a ''') ENVELOPE UPSERT"
 
 $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.seed}-value
-{"type":"record","name":"envelope","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"value doc on point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}],"doc":"doc on t.c1"},{"name":"c2","type":"string","doc":"value doc on t.c2"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"value doc on point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}]}],"doc":"doc on t.c4"}]}
+{"type":"record","name":"envelope","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"value doc on point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"],"doc":"value doc on point.y"}]}],"doc":"doc on t.c1"},{"name":"c2","type":"string","doc":"value doc on t.c2"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"value doc on point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"],"doc":"value doc on point.y"}]}]}],"doc":"doc on t.c4"}]}
 
 $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.seed}-key
 {"type":"record","name":"row","doc":"key doc on t","fields":[{"name":"c2","type":"string","doc":"key doc on t.c2"}]}
@@ -63,7 +65,7 @@ $ schema-registry-verify schema-type=avro subject=testdrive-sink1-${testdrive.se
   ENVELOPE UPSERT;
 
 $ schema-registry-verify schema-type=avro subject=testdrive-sink2-${testdrive.seed}-value
-{"type":"record","name":"envelope","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}]},{"name":"c2","type":"string"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}]}],"doc":"comment on column t.c4 with an äöü"}]}
+{"type":"record","name":"envelope","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"]}]}]},{"name":"c2","type":"string"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"]}]}]}],"doc":"comment on column t.c4 with an äöü"}]}
 
 > CREATE SINK sink3 FROM t
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-sink3-${testdrive.seed}')
@@ -75,7 +77,7 @@ $ schema-registry-verify schema-type=avro subject=testdrive-sink2-${testdrive.se
   ENVELOPE DEBEZIUM;
 
 $ schema-registry-verify schema-type=avro subject=testdrive-sink3-${testdrive.seed}-value
-{"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}]},{"name":"c2","type":"string","doc":"doc on t.c2"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"]},{"name":"y","type":["null","int"]}]}]}],"doc":"comment on column t.c4 with an äöü"}]}]},{"name":"after","type":["null","row"]}]}
+{"type":"record","name":"envelope","fields":[{"name":"before","type":["null",{"type":"record","name":"row","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c1","type":["null",{"type":"record","name":"record0","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"]}]}]},{"name":"c2","type":"string","doc":"doc on t.c2"},{"name":"c3","type":["null",{"type":"map","values":["null","boolean"]}],"doc":"comment on column t.c3 with a '"},{"name":"c4","type":["null",{"type":"array","items":["null",{"type":"record","name":"record1","namespace":"com.materialize.sink","doc":"comment on type point","fields":[{"name":"x","type":["null","int"],"doc":"comment on column point.x"},{"name":"y","type":["null","int"]}]}]}],"doc":"comment on column t.c4 with an äöü"}]}]},{"name":"after","type":["null","row"]}]}
 
 $ schema-registry-verify schema-type=avro subject=testdrive-sink3-${testdrive.seed}-key
 {"type":"record","name":"row","doc":"comment on table t with a \\\\ \\","fields":[{"name":"c2","type":"string","doc":"doc on t.c2"}]}


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

This PR adds the support for resolving columns of composite types so that they can be used in `COMMENT ON COLUMN` and `CREATE SINK ... DOC ON` queries.

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/22210

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
