### PR TITLE
Enable introspection debugging by default on new replicas

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3158,7 +3158,7 @@ pub fn plan_create_cluster(
 
         let compute = plan_compute_replica_config(
             introspection_interval,
-            introspection_debugging.unwrap_or(false),
+            introspection_debugging.unwrap_or(true),
             idle_arrangement_merge_effort,
         )?;
 
@@ -3237,7 +3237,7 @@ generate_extracted_config!(
     (Disk, bool),
     (IdleArrangementMergeEffort, u32),
     (Internal, bool, Default(false)),
-    (IntrospectionDebugging, bool, Default(false)),
+    (IntrospectionDebugging, bool, Default(true)),
     (IntrospectionInterval, OptionalInterval),
     (Size, String),
     (StorageAddresses, Vec<String>),


### PR DESCRIPTION
This changes the behavior when creating new replicas: Instead of defaulting to false for introspection debugging, we default to true. This causes the introspection dataflows show up in introspection sources, which can cause more work, but also allows to attribute processing time where we currently tap in the dark.

This PR can cause a higher CPU utilization, and quick manual tests showed an increase in the 3-5% range, although this needs to be validated again.

TODO: Consider adding a feature flag to control this behavior. It is not immediately clear how this feature flag would work because we store the introspection configuration in the catalog and have no mechanism to distinguish a default from an explicit value.

### Motivation

This PR adds a known-desirable feature: MaterializeInc/database-issues#6690


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
