### PR TITLE
doc/user: polish v0.72 release notes

### DIFF
--- a/doc/user/content/releases/v0.72.md
+++ b/doc/user/content/releases/v0.72.md
@@ -1,11 +1,15 @@
 ---
 title: "Materialize v0.72"
 date: 2023-10-11
-released: false
+released: true
+patch: 1
 ---
 
 ## v0.72.0
 
-{{< warning >}}
-This version of Materialize is not yet released.
-{{< /warning >}}
+#### Bug fixes and other improvements
+
+* Refactor [`mz_internal.mz_dataflow_arrangement_sizes`](/sql/system-catalog/mz_internal/#mz_dataflow_arrangement_sizes)
+to include **all active dataflows**, not just the ones referenced from the
+system catalog. This makes debugging issues like high memory usage caused by
+arrangements more intuitive for users.

--- a/doc/user/content/releases/v0.73.md
+++ b/doc/user/content/releases/v0.73.md
@@ -1,0 +1,11 @@
+---
+title: "Materialize v0.73"
+date: 2023-10-18
+released: false
+---
+
+## v0.73.0
+
+{{< warning >}}
+This version of Materialize is not yet released.
+{{< /warning >}}


### PR DESCRIPTION
**WIP** Release notes for v0.72. 🏯 

@alex-hunt-materialize @joacoc: this covers the step of bumping the release version in the docs.

### Tips for reviewer

* Skipped #22082, since it has no user impact, and #22075 as we wait for statement logging to be unconditionally enabled for all environments.