### PR TITLE
Pre-arrange Differential introspection sources

### DIFF
--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -115,19 +115,31 @@ pub(super) fn construct<A: Allocate>(
 
         // Encode the contents of each logging stream into its expected `Row` format.
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementBatches);
-        let arrangement_batches = batches.as_collection().map(move |op| {
-            packer.pack_slice(&[
-                Datum::UInt64(u64::cast_from(op)),
-                Datum::UInt64(u64::cast_from(worker_id)),
-            ])
-        });
+        let arrangement_batches = batches
+            .as_collection()
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
+                Exchange::new(move |_| u64::cast_from(worker_id)),
+                "PreArrange Differential batches",
+            )
+            .as_collection(move |op, ()| {
+                packer.pack_slice(&[
+                    Datum::UInt64(u64::cast_from(*op)),
+                    Datum::UInt64(u64::cast_from(worker_id)),
+                ])
+            });
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementRecords);
-        let arrangement_records = records.as_collection().map(move |op| {
-            packer.pack_slice(&[
-                Datum::UInt64(u64::cast_from(op)),
-                Datum::UInt64(u64::cast_from(worker_id)),
-            ])
-        });
+        let arrangement_records = records
+            .as_collection()
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
+                Exchange::new(move |_| u64::cast_from(worker_id)),
+                "PreArrange Differential records",
+            )
+            .as_collection(move |op, ()| {
+                packer.pack_slice(&[
+                    Datum::UInt64(u64::cast_from(*op)),
+                    Datum::UInt64(u64::cast_from(worker_id)),
+                ])
+            });
 
         let mut packer = PermutedRowPacker::new(DifferentialLog::Sharing);
         let sharing = sharing
@@ -135,14 +147,13 @@ pub(super) fn construct<A: Allocate>(
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
                 Exchange::new(move |_| u64::cast_from(worker_id)),
                 "PreArrange Differential sharing",
-            );
-
-        let sharing = sharing.as_collection(move |op, ()| {
-            packer.pack_slice(&[
-                Datum::UInt64(u64::cast_from(*op)),
-                Datum::UInt64(u64::cast_from(worker_id)),
-            ])
-        });
+            )
+            .as_collection(move |op, ()| {
+                packer.pack_slice(&[
+                    Datum::UInt64(u64::cast_from(*op)),
+                    Datum::UInt64(u64::cast_from(worker_id)),
+                ])
+            });
 
         use DifferentialLog::*;
         let logs = [
@@ -172,8 +183,8 @@ type OutputBuffer<'a, 'b, D> = ConsolidateBuffer<'a, 'b, Timestamp, D, Diff, Pus
 
 /// Bundled output buffers used by the demux operator.
 struct DemuxOutput<'a, 'b> {
-    batches: OutputBuffer<'a, 'b, usize>,
-    records: OutputBuffer<'a, 'b, usize>,
+    batches: OutputBuffer<'a, 'b, (usize, ())>,
+    records: OutputBuffer<'a, 'b, (usize, ())>,
     sharing: OutputBuffer<'a, 'b, (usize, ())>,
 }
 
@@ -226,10 +237,10 @@ impl DemuxHandler<'_, '_, '_> {
     fn handle_batch(&mut self, event: BatchEvent) {
         let ts = self.ts();
         let op = event.operator;
-        self.output.batches.give(self.cap, (op, ts, 1));
+        self.output.batches.give(self.cap, ((op, ()), ts, 1));
 
         let diff = Diff::try_from(event.length).expect("must fit");
-        self.output.records.give(self.cap, (op, ts, diff));
+        self.output.records.give(self.cap, ((op, ()), ts, diff));
         self.notify_arrangement_size(op);
     }
 
@@ -238,12 +249,12 @@ impl DemuxHandler<'_, '_, '_> {
 
         let ts = self.ts();
         let op = event.operator;
-        self.output.batches.give(self.cap, (op, ts, -1));
+        self.output.batches.give(self.cap, ((op, ()), ts, -1));
 
         let diff = Diff::try_from(done).expect("must fit")
             - Diff::try_from(event.length1 + event.length2).expect("must fit");
         if diff != 0 {
-            self.output.records.give(self.cap, (op, ts, diff));
+            self.output.records.give(self.cap, ((op, ()), ts, diff));
         }
         self.notify_arrangement_size(op);
     }
@@ -251,11 +262,11 @@ impl DemuxHandler<'_, '_, '_> {
     fn handle_drop(&mut self, event: DropEvent) {
         let ts = self.ts();
         let op = event.operator;
-        self.output.batches.give(self.cap, (op, ts, -1));
+        self.output.batches.give(self.cap, ((op, ()), ts, -1));
 
         let diff = -Diff::try_from(event.length).expect("must fit");
         if diff != 0 {
-            self.output.records.give(self.cap, (op, ts, diff));
+            self.output.records.give(self.cap, ((op, ()), ts, diff));
         }
         self.notify_arrangement_size(op);
     }


### PR DESCRIPTION
In a quick test, this reduces the number of rows feeding into the output as follows:
* Batches: 70%
* Records: 26%

Tested with introspection debugging turned on.

### Motivation

  * This PR adds a feature that has not yet been specified: Make the introspection dataflows as fast as possible.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
