### PR TITLE
Add a websocket route to the Internal HTTP API

### DIFF
--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -106,7 +106,7 @@ pub enum TlsMode {
 #[derive(Clone)]
 pub struct WsState {
     frontegg: Arc<Option<FronteggAuthentication>>,
-    adapter_client: mz_adapter::Client,
+    adapter_client_rx: Delayed<mz_adapter::Client>,
     active_connection_count: SharedConnectionCounter,
 }
 
@@ -135,13 +135,13 @@ impl HttpServer {
         adapter_client_tx
             .send(adapter_client.clone())
             .expect("rx known to be live");
-
+        let adapter_client_rx_shared = adapter_client_rx.shared();
         let base_router = base_router(BaseRouterConfig { profiling: false })
             .layer(middleware::from_fn(move |req, next| {
                 let base_frontegg = Arc::clone(&base_frontegg);
                 async move { http_auth(req, next, tls_mode, &base_frontegg).await }
             }))
-            .layer(Extension(adapter_client_rx.shared()))
+            .layer(Extension(adapter_client_rx_shared.clone()))
             .layer(Extension(Arc::clone(&active_connection_count)))
             .layer(
                 CorsLayer::new()
@@ -156,12 +156,11 @@ impl HttpServer {
                     .expose_headers(Any)
                     .max_age(Duration::from_secs(60) * 60),
             );
-
         let ws_router = Router::new()
             .route("/api/experimental/sql", routing::get(sql::handle_sql_ws))
             .with_state(WsState {
                 frontegg,
-                adapter_client: adapter_client.clone(),
+                adapter_client_rx: adapter_client_rx_shared,
                 active_connection_count,
             });
 
@@ -375,6 +374,7 @@ impl InternalHttpServer {
             "/internal-console".to_string(),
         ));
 
+        let adapter_client_rx_shared = adapter_client_rx.shared();
         let router = base_router(BaseRouterConfig { profiling: true })
             .route(
                 "/metrics",
@@ -439,9 +439,22 @@ impl InternalHttpServer {
                 routing::get(console::handle_internal_console),
             )
             .layer(middleware::from_fn(internal_http_auth))
-            .layer(Extension(adapter_client_rx.shared()))
+            .layer(Extension(adapter_client_rx_shared.clone()))
             .layer(Extension(console_config))
-            .layer(Extension(active_connection_count));
+            .layer(Extension(Arc::clone(&active_connection_count)));
+
+        let ws_router = Router::new()
+            .route("/api/experimental/sql", routing::get(sql::handle_sql_ws))
+            // This middleware extracts the MZ user from the x-materialize-user http header.
+            // Normally, browser-initiated websocket requests do not support headers, however for the
+            // Internal HTTP Server the browser would be connecting through teleport, which should
+            // attach the x-materialize-user header to all requests it proxies to this api.
+            .layer(middleware::from_fn(internal_http_auth))
+            .with_state(WsState {
+                frontegg: Arc::new(None),
+                adapter_client_rx: adapter_client_rx_shared,
+                active_connection_count,
+            });
 
         let leader_router = Router::new()
             .route("/api/leader/status", routing::get(handle_leader_status))
@@ -451,7 +464,10 @@ impl InternalHttpServer {
                 ready_to_promote,
             })));
 
-        let router = router.merge(leader_router).apply_default_layers(metrics);
+        let router = router
+            .merge(ws_router)
+            .merge(leader_router)
+            .apply_default_layers(metrics);
 
         InternalHttpServer { router }
     }
@@ -484,7 +500,10 @@ impl Server for InternalHttpServer {
         let router = self.router.clone();
         Box::pin(async {
             let http = hyper::server::conn::Http::new();
-            http.serve_connection(conn, router).err_into().await
+            http.serve_connection(conn, router)
+                .with_upgrades()
+                .err_into()
+                .await
         })
     }
 }
@@ -500,7 +519,7 @@ enum ConnProtocol {
 }
 
 #[derive(Clone, Debug)]
-struct AuthedUser(User);
+pub struct AuthedUser(User);
 
 pub struct AuthedClient {
     pub client: SessionClient,
@@ -685,9 +704,10 @@ async fn http_auth<B>(
 async fn init_ws(
     WsState {
         frontegg,
-        adapter_client,
+        adapter_client_rx,
         active_connection_count,
     }: &WsState,
+    existing_user: &Option<AuthedUser>,
     ws: &mut WebSocket,
 ) -> Result<AuthedClient, anyhow::Error> {
     // TODO: Add a timeout here to prevent resource leaks by clients that
@@ -709,8 +729,8 @@ async fn init_ws(
             }
         }
     };
-    let (creds, options) = if frontegg.is_some() {
-        match ws_auth {
+    let (user, options) = if frontegg.is_some() {
+        let (creds, options) = match ws_auth {
             WebSocketAuth::Basic {
                 user,
                 password,
@@ -726,16 +746,31 @@ async fn init_ws(
                 let creds = Credentials::Token { token };
                 (creds, options)
             }
+            WebSocketAuth::OptionsOnly { options: _ } => {
+                anyhow::bail!("Missing auth information!");
+            }
+        };
+        (auth(frontegg, creds).await?, options)
+    } else if let Some(user) = existing_user {
+        // If we're not using frontegg and we have an existing user provided by an
+        // upstream middleware, just use the options field from the auth message
+        match ws_auth {
+            WebSocketAuth::OptionsOnly { options }
+            | WebSocketAuth::Basic {
+                user: _,
+                password: _,
+                options,
+            }
+            | WebSocketAuth::Bearer { token: _, options } => (user.clone(), options),
         }
     } else if let WebSocketAuth::Basic { user, options, .. } = ws_auth {
-        (Credentials::User(user), options)
+        (auth(frontegg, Credentials::User(user)).await?, options)
     } else {
         anyhow::bail!("unexpected")
     };
-    let user = auth(frontegg, creds).await?;
 
     let client = AuthedClient::new(
-        adapter_client,
+        &adapter_client_rx.clone().await?,
         user,
         Arc::clone(active_connection_count),
         options,

--- a/src/environmentd/src/http.rs
+++ b/src/environmentd/src/http.rs
@@ -160,7 +160,7 @@ impl HttpServer {
             .route("/api/experimental/sql", routing::get(sql::handle_sql_ws))
             .with_state(WsState {
                 frontegg,
-                adapter_client_rx: adapter_client_rx,
+                adapter_client_rx,
                 active_connection_count,
             });
 
@@ -452,7 +452,7 @@ impl InternalHttpServer {
             .layer(middleware::from_fn(internal_http_auth))
             .with_state(WsState {
                 frontegg: Arc::new(None),
-                adapter_client_rx: adapter_client_rx,
+                adapter_client_rx,
                 active_connection_count,
             });
 

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -73,7 +73,7 @@ pub async fn handle_sql_ws(
     // An upstream middleware may have already provided the user for us
     let user = existing_user.and_then(|Extension(user)| Some(user));
     ws.max_message_size(MAX_REQUEST_SIZE)
-        .on_upgrade(|ws| async move { run_ws(&state, &user, ws).await })
+        .on_upgrade(|ws| async move { run_ws(&state, user, ws).await })
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -96,7 +96,7 @@ pub enum WebSocketAuth {
     },
 }
 
-async fn run_ws(state: &WsState, user: &Option<AuthedUser>, mut ws: WebSocket) {
+async fn run_ws(state: &WsState, user: Option<AuthedUser>, mut ws: WebSocket) {
     let mut client = match init_ws(state, user, &mut ws).await {
         Ok(client) => client,
         Err(e) => {

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -17,7 +17,7 @@ use async_trait::async_trait;
 use axum::extract::ws::{CloseFrame, Message, WebSocket};
 use axum::extract::{State, WebSocketUpgrade};
 use axum::response::IntoResponse;
-use axum::Json;
+use axum::{Extension, Json};
 use futures::future::BoxFuture;
 use futures::Future;
 use http::StatusCode;
@@ -43,7 +43,7 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 use tracing::debug;
 use tungstenite::protocol::frame::coding::CloseCode;
 
-use crate::http::{init_ws, AuthedClient, WsState, MAX_REQUEST_SIZE};
+use crate::http::{init_ws, AuthedClient, AuthedUser, WsState, MAX_REQUEST_SIZE};
 
 pub async fn handle_sql(
     mut client: AuthedClient,
@@ -67,10 +67,13 @@ struct ErrorResponse {
 
 pub async fn handle_sql_ws(
     State(state): State<WsState>,
+    existing_user: Option<Extension<AuthedUser>>,
     ws: WebSocketUpgrade,
 ) -> impl IntoResponse {
+    // An upstream middleware may have already provided the user for us
+    let user = existing_user.and_then(|Extension(user)| Some(user));
     ws.max_message_size(MAX_REQUEST_SIZE)
-        .on_upgrade(|ws| async move { run_ws(&state, ws).await })
+        .on_upgrade(|ws| async move { run_ws(&state, &user, ws).await })
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -87,10 +90,14 @@ pub enum WebSocketAuth {
         #[serde(default)]
         options: BTreeMap<String, String>,
     },
+    OptionsOnly {
+        #[serde(default)]
+        options: BTreeMap<String, String>,
+    },
 }
 
-async fn run_ws(state: &WsState, mut ws: WebSocket) {
-    let mut client = match init_ws(state, &mut ws).await {
+async fn run_ws(state: &WsState, user: &Option<AuthedUser>, mut ws: WebSocket) {
+    let mut client = match init_ws(state, user, &mut ws).await {
         Ok(client) => client,
         Err(e) => {
             // We omit most detail from the error message we send to the client, to

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -90,7 +90,7 @@ use std::{iter, thread};
 use anyhow::bail;
 use chrono::{DateTime, Utc};
 use futures::FutureExt;
-use http::StatusCode;
+use http::{Request, StatusCode};
 use itertools::Itertools;
 use mz_environmentd::http::{
     BecomeLeaderResponse, BecomeLeaderResult, LeaderStatus, LeaderStatusResponse,
@@ -2108,6 +2108,67 @@ fn test_internal_http_auth() {
     tracing::info!("response: {res:?}");
     // invalid header returns an error
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED, "{:?}", res.text());
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // too slow
+fn test_internal_ws_auth() {
+    let server = util::start_server(util::Config::default()).unwrap();
+
+    // Create our WebSocket.
+    let ws_url = server.internal_ws_addr();
+    let req = Request::builder()
+        .uri(ws_url.as_str())
+        .method("GET")
+        .header("Host", ws_url.host_str().unwrap())
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header("Sec-WebSocket-Key", "foobar")
+        // Set our user to the mz_support user
+        .header("x-materialize-user", "mz_support")
+        .body(())
+        .unwrap();
+
+    let (mut ws, _resp) = tungstenite::connect(req).unwrap();
+    let options = BTreeMap::from([(
+        "application_name".to_string(),
+        "billion_dollar_idea".to_string(),
+    )]);
+    util::auth_with_ws(&mut ws, options).unwrap();
+
+    // Query to make sure we get back the correct user, which should be
+    // set from the headers passed with the websocket request.
+    let json = "{\"query\":\"SELECT current_user;\"}";
+    let json: serde_json::Value = serde_json::from_str(json).unwrap();
+    ws.send(Message::Text(json.to_string())).unwrap();
+
+    let mut read_msg = || -> WebSocketResponse {
+        let msg = ws.read().unwrap();
+        let msg = msg.into_text().expect("response should be text");
+        serde_json::from_str(&msg).unwrap()
+    };
+    let starting = read_msg();
+    let columns = read_msg();
+    let row_val = read_msg();
+
+    if !matches!(starting, WebSocketResponse::CommandStarting(_)) {
+        panic!("wrong message!, {starting:?}");
+    };
+
+    if let WebSocketResponse::Rows(rows) = columns {
+        let names: Vec<&str> = rows.columns.iter().map(|c| c.name.as_str()).collect();
+        assert_eq!(names, ["current_user"]);
+    } else {
+        panic!("wrong message!, {columns:?}");
+    };
+
+    if let WebSocketResponse::Row(row) = row_val {
+        let expected = serde_json::Value::String("mz_support".to_string());
+        assert_eq!(row, [expected]);
+    } else {
+        panic!("wrong message!, {row_val:?}");
+    }
 }
 
 #[mz_ore::test]

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -818,14 +818,25 @@ pub fn auth_with_ws(
     ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
     options: BTreeMap<String, String>,
 ) -> Result<Vec<WebSocketResponse>, anyhow::Error> {
-    ws.send(Message::Text(
-        serde_json::to_string(&WebSocketAuth::Basic {
-            user: "materialize".into(),
-            password: "".into(),
-            options,
-        })
-        .unwrap(),
-    ))?;
+    auth_with_ws_impl(
+        ws,
+        Message::Text(
+            serde_json::to_string(&WebSocketAuth::Basic {
+                user: "materialize".into(),
+                password: "".into(),
+                options,
+            })
+            .unwrap(),
+        ),
+    )
+}
+
+pub fn auth_with_ws_impl(
+    ws: &mut WebSocket<MaybeTlsStream<TcpStream>>,
+    auth_message: Message,
+) -> Result<Vec<WebSocketResponse>, anyhow::Error> {
+    ws.send(auth_message)?;
+
     // Wait for initial ready response.
     let mut msgs = Vec::new();
     loop {

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -594,6 +594,14 @@ impl Server {
         ))
         .unwrap()
     }
+
+    pub fn internal_ws_addr(&self) -> Url {
+        Url::parse(&format!(
+            "ws://{}/api/experimental/sql",
+            self.inner.internal_http_local_addr()
+        ))
+        .unwrap()
+    }
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]


### PR DESCRIPTION
### Motivation

  * This PR adds a known-desirable feature: Fixes: https://github.com/MaterializeInc/materialize/issues/22303

See issue for details ^

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

The auth changes to websocket handling should only come into play when used in the InternalAPIServer which itself attaches the `internal_http_auth` middleware, but would appreciate eyes double-checking that: https://github.com/MaterializeInc/materialize/blob/856f69d03272e1eab6e32f2dec339d83eb7dcf20/src/environmentd/src/http.rs#L460

I also noticed that the default for that middleware is the system user, not the support user, which contradicts the issue written by @benesch , but I think is consistent with the previous behavior before the header existed. Looking for opinions on whether I should change this to mz_support, and what might break if I do.

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
