### PR TITLE
Fix off-by-one addresses in pprof

### DIFF
--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -260,7 +260,13 @@ mz_fg_version: 1
             sample.value.push(value);
 
             for addr in stack.addrs.iter().rev() {
-                let addr = u64::cast_from(*addr);
+                // See the comment
+                // [here](https://github.com/rust-lang/backtrace-rs/blob/master/src/symbolize/mod.rs#L123-L147)
+                // for why we need to subtract one. tl;dr addresses
+                // in stack traces are actually the return address of
+                // the called function, which is one past the call
+                // itself.
+                let addr = u64::cast_from(*addr) - 1;
 
                 let loc_id = *location_ids.entry(addr).or_insert_with(|| {
                     // pprof_types.proto says the location id may be the address, but Polar Signals

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -266,6 +266,11 @@ mz_fg_version: 1
                 // in stack traces are actually the return address of
                 // the called function, which is one past the call
                 // itself.
+                //
+                // Of course, the `call` instruction can be more than one byte, so after subtracting
+                // one, we might point somewhere in the middle of it, rather
+                // than to the beginning of the instruction. That's fine; symbolization
+                // tools don't seem to get confused by this.
                 let addr = u64::cast_from(*addr) - 1;
 
                 let loc_id = *location_ids.entry(addr).or_insert_with(|| {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -261,7 +261,7 @@ mz_fg_version: 1
 
             for addr in stack.addrs.iter().rev() {
                 // See the comment
-                // [here](https://github.com/rust-lang/backtrace-rs/blob/master/src/symbolize/mod.rs#L123-L147)
+                // [here](https://github.com/rust-lang/backtrace-rs/blob/036d4909e1fb9c08c2bb0f59ac81994e39489b2f/src/symbolize/mod.rs#L123-L147)
                 // for why we need to subtract one. tl;dr addresses
                 // in stack traces are actually the return address of
                 // the called function, which is one past the call


### PR DESCRIPTION
Addresses in stack frames need to be adjusted (by subtracting one) to point to the call address, rather than the return address, before symbolization.

See [Raymond Chen's article](https://devblogs.microsoft.com/oldnewthing/20170505-00/?p=96116) for a good explanation.

### Motivation

  * This PR fixes a recognized bug.

    Heap pprofs give nonsensical results for some frames; see [here](https://materializeinc.slack.com/archives/C049UQ3RSF4/p1696958948348269) for details.
    
### Tips for reviewer

This should be explained fully by the comment in the Backtrace crate, which I have linked to from our code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.

Manually checked that results in the Go pprof tool look sensical (they didn't before).

- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Hi Marta. No user-facing changes.
