### PR TITLE
pgwire: check for closed clients in send_rows

### DIFF
--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -1772,6 +1772,7 @@ where
                 let cancel_fut = self.adapter_client.canceled();
                 let notice_fut = self.adapter_client.session().recv_notice();
                 tokio::select! {
+                    err = self.conn.wait_closed() => return Err(err),
                     _ = time::sleep_until(deadline.unwrap_or_else(tokio::time::Instant::now)), if deadline.is_some() => FetchResult::Rows(None),
                     notice = notice_fut => {
                         FetchResult::Notice(notice)


### PR DESCRIPTION
It may take arbitrarily long for Materialize to return rows for a query. Possibly forever, if the query is a `SUBSCRIBE` or unchanging relation. This commit teaches Materialize to periodically check whether the client has hung up and, if so, terminate the session, which prevents a small resource leak when a connection abandons a stalled query.

We do this check in the many other places where we wait for rows in the pgwire protocol handler; we just happened to miss this place.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Tips for reviewer

Needs a test. Basically:

  * Create a `SUBSCRIBE` _without_ wrapping it in `COPY`.
  * Observe the subscription in `mz_internal.mz_subscriptions` from another connection.
  * Terminate the connection.
  * Observe that the subscription is not cleaned up promptly.

With this commit, the subscription is cleaned up within a second of the connection terminating.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
