### PR TITLE
ci: output consistency test: reduce timeout

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -608,7 +608,7 @@ steps:
 
   - id: output-consistency-test
     label: "Output consistency test"
-    timeout_in_minutes: 58
+    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
     artifact_paths: junit_*.xml


### PR DESCRIPTION
Average runtime is 23 minutes.