### PR TITLE
tests: Add platform-check and parallel-workload support for ASSERT NOT NULL

### DIFF
--- a/misc/python/materialize/checks/materialized_views.py
+++ b/misc/python/materialize/checks/materialized_views.py
@@ -10,6 +10,8 @@ from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
 
 
 class MaterializedViews(Check):
@@ -62,6 +64,86 @@ class MaterializedViews(Check):
                 T1B 10000
                 T2B 10000
                 T3B 10000
+           """
+            )
+        )
+
+
+class MaterializedViewsAssertNotNull(Check):
+    def _can_run(self, e: Executor) -> bool:
+        # CREATE ROLE not compatible with older releases
+        return self.base_version >= MzVersion.parse("0.73.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE TABLE not_null_table (x INT, y INT, z INT);
+                > INSERT INTO not_null_table VALUES (NULL, 2, 3), (4, NULL, 6), (7, 8, NULL);
+                > CREATE MATERIALIZED VIEW not_null_view1 WITH (ASSERT NOT NULL x) AS SELECT * FROM not_null_table;
+            """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW not_null_view2 WITH (ASSERT NOT NULL y) AS SELECT * FROM not_null_table;
+                > INSERT INTO not_null_table VALUES (NULL, 12, 13), (14, NULL, 16), (17, 18, NULL);
+                """,
+                """
+                > CREATE MATERIALIZED VIEW not_null_view3 WITH (ASSERT NOT NULL z) AS SELECT * FROM not_null_table;
+                > INSERT INTO not_null_table VALUES (NULL, 22, 23), (24, NULL, 26), (27, 28, NULL);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                ! SELECT * FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3
+                contains: column 3 must not be null
+
+                > DELETE FROM not_null_table WHERE x IS NULL;
+
+                > SELECT * FROM not_null_view1
+                4 <null> 6
+                7 8 <null>
+                14 <null> 16
+                17 18 <null>
+                24 <null> 26
+                27 28 <null>
+
+                > DELETE FROM not_null_table WHERE y IS NULL;
+
+                > SELECT * FROM not_null_view2
+                7 8 <null>
+                17 18 <null>
+                27 28 <null>
+
+                > DELETE FROM not_null_table WHERE z IS NULL;
+
+                > SELECT * FROM not_null_view3
+
+                > INSERT INTO not_null_table VALUES (NULL, 2, 3), (4, NULL, 6), (7, 8, NULL);
+
+                ! SELECT * FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3
+                contains: column 3 must not be null
            """
             )
         )

--- a/misc/python/materialize/checks/materialized_views.py
+++ b/misc/python/materialize/checks/materialized_views.py
@@ -113,6 +113,24 @@ class MaterializedViewsAssertNotNull(Check):
                 ! SELECT * FROM not_null_view3
                 contains: column 3 must not be null
 
+                ! SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+                contains: column 3 must not be null
+
+                ! SELECT y FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT z FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT x FROM not_null_view3
+                contains: column 3 must not be null
+
                 > DELETE FROM not_null_table WHERE x IS NULL;
 
                 > SELECT * FROM not_null_view1
@@ -131,6 +149,18 @@ class MaterializedViewsAssertNotNull(Check):
                 27 28 <null>
 
                 > DELETE FROM not_null_table WHERE z IS NULL;
+
+                ? EXPLAIN SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view1
+
+                ? EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view2
+
+                ? EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view3
 
                 > SELECT * FROM not_null_view3
 


### PR DESCRIPTION
Introduced in https://github.com/MaterializeInc/materialize/pull/22248

Part of https://github.com/MaterializeInc/materialize/issues/21738

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
