### PR TITLE
ci-builder: Allow passing in MZ_DEV_BUILD_SHA

### DIFF
--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -183,6 +183,7 @@ case "$cmd" in
             --env NPM_TOKEN
             --env POLAR_SIGNALS_API_TOKEN
             --env PYPI_TOKEN
+            --env MZ_DEV_BUILD_SHA
             # For Miri with nightly Rust
             --env ZOOKEEPER_ADDR
             --env KAFKA_ADDRS


### PR DESCRIPTION
As a workaround for building in git worktrees:
```
error: external command exited with status 1: error: unable to determine Git SHA; either build from working Git clone (see https://materialize.com/docs/install/#build-from-source), or specify SHA manually by setting MZ_DEV_BUILD_SHA environment variable
   --> src/persist-client/src/lib.rs:172:35
    |
172 | pub const BUILD_INFO: BuildInfo = build_info!();
    |                                   ^^^^^^^^^^^^^
    |
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
