### PR TITLE
sql: Fix panic in cast from float8 to numeric

### DIFF
--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -437,7 +437,7 @@ fn round_numeric_binary<'a>(a: Datum<'a>, b: Datum<'a>) -> Result<Datum<'a>, Eva
         // Ensure rescale doesn't exceed max precision by putting a ceiling on
         // b equal to the maximum remaining scale the value can support.
         let max_remaining_scale = u32::from(numeric::NUMERIC_DATUM_MAX_PRECISION)
-            - (numeric::get_precision(&a) - u32::from(numeric::get_scale(&a)));
+            - (numeric::get_precision(&a) - numeric::get_scale(&a));
         b = match i32::try_from(max_remaining_scale) {
             Ok(max_remaining_scale) => std::cmp::min(b, max_remaining_scale),
             Err(_) => b,

--- a/src/pgrepr/src/value/numeric.rs
+++ b/src/pgrepr/src/value/numeric.rs
@@ -52,7 +52,7 @@ impl ToSql for Numeric {
         out: &mut BytesMut,
     ) -> Result<IsNull, Box<dyn Error + 'static + Send + Sync>> {
         let mut d = self.0 .0.clone();
-        let scale = u16::from(numeric::get_scale(&d));
+        let scale = u16::try_from(numeric::get_scale(&d))?;
         let is_zero = d.is_zero();
         let is_nan = d.is_nan();
         let is_neg = d.is_negative() && !is_zero;

--- a/src/repr/src/adt/numeric.rs
+++ b/src/repr/src/adt/numeric.rs
@@ -663,12 +663,12 @@ pub fn get_precision<const N: usize>(n: &Decimal<N>) -> u32 {
 }
 
 /// Returns `n`'s scale, i.e. the number of digits used after the decimal point.
-pub fn get_scale(n: &Numeric) -> u8 {
+pub fn get_scale(n: &Numeric) -> u32 {
     let exp = n.exponent();
     if exp >= 0 {
         0
     } else {
-        u8::try_from(-exp).unwrap()
+        exp.unsigned_abs()
     }
 }
 
@@ -693,7 +693,7 @@ fn rescale_within_max_precision(n: &mut Numeric) -> Result<(), anyhow::Error> {
     if current_precision > u32::from(NUMERIC_DATUM_MAX_PRECISION) {
         if n.exponent() < 0 {
             let precision_diff = current_precision - u32::from(NUMERIC_DATUM_MAX_PRECISION);
-            let current_scale = get_scale(n);
+            let current_scale = u8::try_from(get_scale(n))?;
             let scale_diff = current_scale - u8::try_from(precision_diff).unwrap();
             rescale(n, scale_diff)?;
         } else {

--- a/test/sqllogictest/type-promotion.slt
+++ b/test/sqllogictest/type-promotion.slt
@@ -1615,3 +1615,6 @@ values ('2023-01-01T00:00:00.666'::timestamp(6)) union all values ('2023-01-01T0
 ----
 2023-01-01 00:00:00.666+00
 2023-01-01 00:00:00.667+00
+
+query error numeric field overflow
+SELECT '1e-307'::float8::numeric


### PR DESCRIPTION
Fixes: #22340

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
