### PR TITLE
SQL: Fix usages of SET cluster TO default

### DIFF
--- a/misc/python/materialize/checks/cluster_unification.py
+++ b/misc/python/materialize/checks/cluster_unification.py
@@ -88,7 +88,7 @@ class UnifiedCluster(Check):
             > SELECT COUNT(*) > 0 FROM mz_tables;
             true
 
-            > SET cluster = default
+            > SET cluster = "default"
 
             ! DROP CLUSTER shared_cluster_compute_first;
             contains: cannot drop cluster with active object

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1597,7 +1597,7 @@ fn test_github_12951() {
         client1.batch_execute("DROP CLUSTER foo CASCADE").unwrap();
         client2_cancel.cancel_query(postgres::NoTls).unwrap();
         client2
-            .batch_execute("ROLLBACK; SET CLUSTER = default")
+            .batch_execute("ROLLBACK; SET CLUSTER = 'default'")
             .unwrap();
         assert_eq!(
             client2
@@ -1620,7 +1620,7 @@ fn test_github_12951() {
         client2.batch_execute("BEGIN; SELECT * FROM t1").unwrap();
         client1.batch_execute("DROP CLUSTER foo CASCADE").unwrap();
         client2
-            .batch_execute("COMMIT; SET CLUSTER = default")
+            .batch_execute("COMMIT; SET CLUSTER = 'default'")
             .unwrap();
         assert_eq!(
             client2
@@ -1657,7 +1657,7 @@ fn test_subscribe_outlive_cluster() {
         .unwrap();
     client2_cancel.cancel_query(postgres::NoTls).unwrap();
     client2
-        .batch_execute("ROLLBACK; SET CLUSTER = default")
+        .batch_execute("ROLLBACK; SET CLUSTER = 'default'")
         .unwrap();
     assert_eq!(
         client2

--- a/src/environmentd/tests/testdata/http/post
+++ b/src/environmentd/tests/testdata/http/post
@@ -248,7 +248,7 @@ http
 {"results":[{"tag":"SELECT 1","rows":[["v"]],"desc":{"columns":[{"name":"name","type_oid":25,"type_len":-1,"type_mod":-1}]},"notices":[]}]}
 
 http
-{"query":"SET cluster = default"}
+{"query":"SET cluster = 'default'"}
 ----
 200 OK
 {"results":[{"ok":"SET","notices":[],"parameters":[{"name":"cluster","value":"default"}]}]}

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -1450,7 +1450,7 @@ def workflow_test_system_table_indexes(c: Composition) -> None:
             input=dedent(
                 """
         $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
-        SET CLUSTER TO DEFAULT;
+        SET CLUSTER TO "DEFAULT";
         CREATE DEFAULT INDEX ON mz_views;
 
         > SELECT id FROM mz_indexes WHERE id like 'u%';
@@ -2441,7 +2441,7 @@ def workflow_test_metrics_retention_across_restart(c: Composition) -> None:
     # collect the `since` frontiers we want.
     def collect_sinces() -> tuple[int, int]:
         explain = c.sql_query(
-            "SET cluster = default;"
+            "SET cluster = 'default';"
             "EXPLAIN TIMESTAMP FOR SELECT * FROM mz_cluster_replicas;"
         )[0][0]
         table_since = parse_since_from_explain(explain)

--- a/test/sqllogictest/github-11568.slt
+++ b/test/sqllogictest/github-11568.slt
@@ -29,7 +29,7 @@ statement ok
 create index i1 on t1 (f2)
 
 statement ok
-set cluster = default
+set cluster = "default"
 
 statement ok
 begin;

--- a/test/sqllogictest/mz-support-privileges.slt
+++ b/test/sqllogictest/mz-support-privileges.slt
@@ -14,7 +14,7 @@ statement ok
 CREATE TABLE t (a INT)
 
 simple conn=mz_support,user=mz_support
-SET CLUSTER TO default
+SET CLUSTER TO "default"
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/schemas.slt
+++ b/test/sqllogictest/schemas.slt
@@ -75,7 +75,7 @@ SELECT current_schemas(true)
 {mz_catalog,pg_catalog}
 
 statement ok
-SET cluster = default
+SET cluster = "default"
 
 statement error no schema has been selected to create in
 CREATE TABLE t (i INT)

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -877,7 +877,7 @@ statement ok
 COMMIT
 
 statement ok
-SET CLUSTER TO default
+SET CLUSTER TO "default"
 
 statement ok
 BEGIN
@@ -892,7 +892,7 @@ statement ok
 COMMIT
 
 statement ok
-SET CLUSTER TO default
+SET CLUSTER TO "default"
 
 # Test that the cluster is selected at the start of a transaction and doesn't change.
 

--- a/test/testdrive/indexes.td
+++ b/test/testdrive/indexes.td
@@ -36,7 +36,7 @@ $ kafka-ingest topic=data format=avro schema=${writer-schema}
 > SHOW INDEXES ON data
 name    on  cluster key
 --------------------------------------------------------------------------
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Sources can have default indexes added
 > CREATE DEFAULT INDEX ON data
@@ -46,7 +46,7 @@ name    on  cluster key
 name                on      cluster             key
 -------------------------------------------------------------------------------------------
 data_primary_idx    data    <VARIABLE_OUTPUT>   {a,b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > SELECT index_position FROM mz_index_columns WHERE index_id LIKE '%u%'
 index_position
@@ -69,7 +69,7 @@ position         name
 > SHOW INDEXES ON data_view
 name    on  cluster key
 --------------------------------------------------------------------------
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Views can have default indexes added
 > CREATE DEFAULT INDEX ON data_view
@@ -79,7 +79,7 @@ name    on  cluster key
 name                    on          cluster             key
 ---------------------------------------------------------------------------------------------------
 data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Materialized views do not have indexes automatically created
 > CREATE MATERIALIZED VIEW matv AS
@@ -89,7 +89,7 @@ data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 > SHOW INDEXES ON matv
 name    on  cluster key
 --------------------------------------------------------------------------
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Materialized views can have default indexes added
 > CREATE DEFAULT INDEX ON matv
@@ -99,7 +99,7 @@ name    on  cluster key
 name                on      cluster             key
 --------------------------------------------------------------------------------------------
 matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # IF NOT EXISTS prevents adding multiple default indexes
 > CREATE DEFAULT INDEX IF NOT EXISTS ON data_view
@@ -109,7 +109,7 @@ matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 name                    on          cluster             key
 -------------------------------------------------------------------------------------------------
 data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Additional default indexes have the same structure as the first
 > CREATE DEFAULT INDEX ON matv
@@ -120,7 +120,7 @@ name                on      cluster             key
 ------------------------------------------------------------------------------------------------
 matv_primary_idx    matv    <VARIABLE_OUTPUT>   {b}
 matv_primary_idx1   matv    <VARIABLE_OUTPUT>   {b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Default indexes can be named
 > CREATE DEFAULT INDEX named_idx ON data_view
@@ -131,7 +131,7 @@ name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
 data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   {a,b}
 named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP INDEX data_view_primary_idx
 > DROP INDEX named_idx
@@ -144,7 +144,7 @@ named_idx               data_view   <VARIABLE_OUTPUT>   {a,b}
 name            on          cluster             key
 -------------------------------------------------------------------------------------------
 data_view_a_idx data_view   <VARIABLE_OUTPUT>   {a}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP INDEX data_view_a_idx
 
@@ -158,7 +158,7 @@ name                    on          cluster             key
 -----------------------------------------------------------------------------------------------
 data_view_b_a_idx       data_view   <VARIABLE_OUTPUT>   {b,a}
 data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP INDEX data_view_b_a_idx
 > DROP INDEX data_view_expr_a_idx
@@ -171,7 +171,7 @@ data_view_expr_a_idx    data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 name        on          cluster             key
 ---------------------------------------------------------------------------------------------
 named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP INDEX named_idx
 
@@ -184,7 +184,7 @@ named_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
 name                    on          cluster             key
 ------------------------------------------------------------------------------------------------------
 data_view_primary_idx   data_view   <VARIABLE_OUTPUT>   "{b - a,a}"
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > SHOW CREATE INDEX data_view_primary_idx
 name                                     create_sql
@@ -217,7 +217,7 @@ contains:unknown catalog item 'nonexistent'
 ! SHOW INDEXES ON foo_primary_idx
 contains:cannot show indexes on materialize.public.foo_primary_idx because it is a index
 
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > CREATE CLUSTER clstr REPLICAS (r1 (SIZE '1'))
 > CREATE DEFAULT INDEX IN CLUSTER clstr ON foo;
@@ -228,7 +228,7 @@ foo_primary_idx1    foo clstr   {a,b,z}
 > SHOW INDEXES FROM public WHERE name = 'foo_primary_idx1'
 foo_primary_idx1    foo clstr   {a,b,z}
 
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 > DROP TABLE foo CASCADE
 > DROP SOURCE data CASCADE
 
@@ -240,7 +240,7 @@ contains:Cannot specify both FROM and ON
 ! SHOW INDEXES FROM nonexistent
 contains:unknown schema 'nonexistent'
 
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > CREATE TABLE bar ();
 > CREATE INDEX bar_ind ON bar ();
@@ -248,7 +248,7 @@ contains:unknown schema 'nonexistent'
 > SET CLUSTER TO mz_introspection
 > SHOW INDEXES
 bar_ind bar <VARIABLE_OUTPUT> {}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP TABLE bar CASCADE
 > CREATE SCHEMA foo
@@ -258,13 +258,13 @@ bar_ind bar <VARIABLE_OUTPUT> {}
 > SET CLUSTER TO mz_introspection
 > SHOW INDEXES ON foo.bar
 bar_ind bar <VARIABLE_OUTPUT> {a}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > DROP CLUSTER clstr CASCADE;
 
 # Test creating indexes on system objects
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
-SET CLUSTER TO default
+SET CLUSTER TO "default"
 CREATE INDEX sys_ind ON mz_array_types (id)
 
 > SET CLUSTER TO mz_introspection
@@ -272,7 +272,7 @@ CREATE INDEX sys_ind ON mz_array_types (id)
 sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
 > SHOW INDEXES FROM mz_catalog WHERE name = 'sys_ind'
 sys_ind mz_array_types  <VARIABLE_OUTPUT>   {id}
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 $ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
 DROP INDEX sys_ind

--- a/test/testdrive/linked-clusters.td
+++ b/test/testdrive/linked-clusters.td
@@ -139,7 +139,7 @@ contains:cannot execute queries on cluster containing sources or sinks
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unified_clusters = true
 
-> SET cluster = default
+> SET cluster = "default"
 
 # Test that only the default clusters and replicas remain after dropping
 # the sources.

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -848,7 +848,7 @@ ReduceMinsMaxes
 "Reduced TopK input"
 "Reduced TopK input"
 
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 # Check dataflows of our logging infrastructure with log_logging
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -96,7 +96,7 @@ contains:cannot create source in cluster with more than one replica
 contains:cannot drop cluster with active objects
 > DROP CLUSTER storage CASCADE
 
-> SET cluster = default
+> SET cluster = "default"
 
 # Test that a cluster can contain multiple sources and sinks, and verify that
 # the sources and sinks produce the correct output.

--- a/test/testdrive/system-cluster.td
+++ b/test/testdrive/system-cluster.td
@@ -63,7 +63,7 @@ mv default
 #! CREATE MATERIALIZED VIEW mv1 AS SELECT MIN(1)
 #contains:system cluster 'mz_system' cannot be modified
 
-> SET CLUSTER TO default
+> SET CLUSTER TO "default"
 
 > CREATE TABLE temp (a INT)
 


### PR DESCRIPTION
The syntax `SET var TO default` or `SET var = default`, causes var to reset to its default value. This can cause confusion with clusters because by default every environment has a cluster named "default". It was common to type `SET cluster TO default` as a way to change the cluster to the cluster named "default". However, that doesn't work in the general case if the default value for `cluster` has been changed for a role. It used to work fine because `"default"` was the default value for clusters, and we hadn't implemented changing the default value of session variables. Recently we implemented the ability to change the default value of session variables for a role.

This commit changes all internal usages of `SET cluster TO default` to `SET cluster TO "default"` and `SET cluster = default` to `SET cluster = "default"`.

Works towards resolving #22351

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - here are no user-facing behavior changes. 
