### PR TITLE
Doc: Add PrivateLink validate section

### DIFF
--- a/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-kafka.md
@@ -88,6 +88,14 @@ and retrieve the AWS principal needed to configure the AWS PrivateLink service.
 
 ## Validate the AWS PrivateLink connection
 
+Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+
+```sql
+VALIDATE CONNECTION privatelink_svc;
+```
+
+If no validation error is returned, move to the next step.
+
 ## Create a source connection
 
 In Materialize, create a source connection that uses the AWS PrivateLink connection you just configured:

--- a/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
+++ b/doc/user/layouts/shortcodes/network-security/privatelink-postgres.md
@@ -75,6 +75,14 @@
 
 ## Validate the AWS PrivateLink connection
 
+Validate the AWS PrivateLink connection you created using the [`VALIDATE CONNECTION`](/sql/validate-connection) command:
+
+```sql
+VALIDATE CONNECTION privatelink_svc;
+```
+
+If no validation error is returned, move to the next step.
+
 ## Create a source connection
 
 In Materialize, create a source connection that uses the AWS PrivateLink connection you just configured:


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Just noticed that the PrivateLink validate step was omitted in the initial [connection validation docs PR](https://github.com/MaterializeInc/materialize/pull/20996/files).