### PR TITLE
tini and materialize user for balancerd

### DIFF
--- a/misc/images/balancerd/Dockerfile
+++ b/misc/images/balancerd/Dockerfile
@@ -10,8 +10,14 @@
 MZFROM ubuntu-base
 
 RUN apt-get update \
-    && apt-get -qy install ca-certificates
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        tini \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize
 
 COPY mz-balancerd /usr/local/bin/balancerd
 
-ENTRYPOINT ["balancerd"]
+USER materialize
+
+ENTRYPOINT ["tini", "--", "balancerd"]


### PR DESCRIPTION
Adds tini as the entrypoint for the balancerd image, and runs as the materialize user rather than root.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.
Pods get stuck in terminating until the termination timeout, since PID handles signals differently. Tini will handle them for us, and also perform other init tasks like reaping zombies.
Running as root is a security risk, so lets create our own user.



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] This PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way) and therefore is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
