### PR TITLE
storage: make decode_and_mfp yield more often

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -180,6 +180,7 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
         storage_sink_minimum_batch_updates: Some(
             config.storage_persist_sink_minimum_batch_updates(),
         ),
+        storage_source_decode_fuel: Some(config.storage_source_decode_fuel()),
         next_listen_batch_retryer: Some(RetryParameters {
             initial_backoff: config.persist_next_listen_batch_retryer_initial_backoff(),
             multiplier: config.persist_next_listen_batch_retryer_multiplier(),

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -236,8 +236,6 @@ pub fn build_compute_dataflow<A: Allocate>(
                         dataflow.until.clone(),
                         mfp.as_mut(),
                         Some(flow_control),
-                        // Copy the logic in DeltaJoin/Get/Join to start.
-                        |_timer, count| count > 1_000_000,
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -102,8 +102,6 @@ where
         Antichain::new(), // we want all updates
         None,             // no MFP
         None,             // no flow control
-        // Copy the logic in DeltaJoin/Get/Join to start.
-        |_timer, count| count > 1_000_000,
     );
     use differential_dataflow::AsCollection;
     let persist_collection = ok_stream

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -19,6 +19,7 @@ message ProtoPersistParameters {
     mz_proto.ProtoDuration consensus_connect_timeout = 3;
     optional uint64 sink_minimum_batch_updates = 4;
     optional uint64 storage_sink_minimum_batch_updates = 8;
+    optional uint64 storage_source_decode_fuel = 21;
     optional ProtoRetryParameters next_listen_batch_retryer = 5;
     optional uint64 stats_audit_percent = 9;
     optional bool stats_collection_enabled = 6;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1086,6 +1086,15 @@ const STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES: ServerVar<usize> = ServerVar {
     internal: true
 };
 
+/// Controls [`mz_persist_client::cfg::PersistConfig::storage_source_decode_fuel`].
+const STORAGE_SOURCE_DECODE_FUEL: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("storage_source_decode_fuel"),
+    value: &PersistConfig::DEFAULT_STORAGE_SOURCE_DECODE_FUEL,
+    description: "The maximum amount of work to do in the persist_source mfp_and_decode \
+                  operator before yielding.",
+    internal: true,
+};
+
 const STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("storage_record_source_sink_namespaced_errors"),
     value: &true,
@@ -2459,6 +2468,7 @@ impl SystemVars {
             .with_var(&STORAGE_SHRINK_UPSERT_UNUSED_BUFFERS_BY_RATIO)
             .with_var(&PERSIST_SINK_MINIMUM_BATCH_UPDATES)
             .with_var(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
+            .with_var(&STORAGE_SOURCE_DECODE_FUEL)
             .with_var(&STORAGE_RECORD_SOURCE_SINK_NAMESPACED_ERRORS)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
@@ -3052,6 +3062,10 @@ impl SystemVars {
     /// Returns the `storage_persist_sink_minimum_batch_updates` configuration parameter.
     pub fn storage_persist_sink_minimum_batch_updates(&self) -> usize {
         *self.expect_value(&STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES)
+    }
+
+    pub fn storage_source_decode_fuel(&self) -> usize {
+        *self.expect_value(&STORAGE_SOURCE_DECODE_FUEL)
     }
 
     /// Returns the `storage_record_source_sink_namespaced_errors` configuration parameter.
@@ -4879,6 +4893,7 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()
         || name == STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()
         || name == STORAGE_PERSIST_SINK_MINIMUM_BATCH_UPDATES.name()
+        || name == STORAGE_SOURCE_DECODE_FUEL.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP.name()

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -56,8 +56,6 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         timely::progress::Antichain::new(),
         None,
         None,
-        // Copy the logic in DeltaJoin/Get/Join to start.
-        |_timer, count| count > 1_000_000,
     );
     tokens.push(source_token);
 

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -360,8 +360,6 @@ where
                                     Antichain::new(),
                                     None,
                                     None,
-                                    // Copy the logic in DeltaJoin/Get/Join to start.
-                                    |_timer, count| count > 1_000_000,
                                 );
                             let (tx_source_ok, tx_source_err) = (
                                 tx_source_ok_stream.as_collection(),
@@ -483,8 +481,6 @@ where
                                         Antichain::new(),
                                         None,
                                         flow_control,
-                                        // Copy the logic in DeltaJoin/Get/Join to start.
-                                        |_timer, count| count > 1_000_000,
                                     );
                                     (
                                         stream.as_collection(),


### PR DESCRIPTION
We've seen evidence in production of this operator often going more than 5s without yielding, especially during rehydration and large unindexed SELECTs. This affects interactivity as well as the time between when a timely-driven Future is woken and when it is scheduled again.

Attempt to fix this with two tweaks to our yield heuristics. First, decrease the fuel between yields from 1_000_000 to 100_000. Second, also count each mfp evaluation against our fuel, in case it contains a restrictive filter.

The new 100_000 constant comes from eyeballing a replica in prod that was non-interactive. At the time, it was decoding ~300k rows per second, so 100k doesn't seem terribly low in comparison.

Touches #21626

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Gonna sanity check the any performance regression from this with a nightlies run, in particular the feature bench.

For context, one of the affected replicas is spending about 3.4 cores out of 6 to decode a little under 300k rows per second (~11 μs each).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
