### PR TITLE
catalog: Implement DurableType for introspection

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -21,7 +21,9 @@ use uuid::Uuid;
 use mz_catalog::builtin::{
     Builtin, Fingerprint, BUILTINS, BUILTIN_CLUSTERS, BUILTIN_PREFIXES, BUILTIN_ROLES,
 };
-use mz_catalog::objects::{SystemObjectDescription, SystemObjectUniqueIdentifier};
+use mz_catalog::objects::{
+    IntrospectionSourceIndex, SystemObjectDescription, SystemObjectUniqueIdentifier,
+};
 use mz_catalog::SystemObjectMapping;
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_compute_client::logging::LogVariant;
@@ -659,7 +661,11 @@ impl Catalog {
                 .set_introspection_source_indexes(
                     new_indexes
                         .iter()
-                        .map(|(log, index_id)| (id, log.name, *index_id))
+                        .map(|(log, index_id)| IntrospectionSourceIndex {
+                            cluster_id: id,
+                            name: log.name.to_string(),
+                            index_id: *index_id,
+                        })
                         .collect(),
                 )
                 .await?;

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -91,12 +91,12 @@ use mz_sql::catalog::CatalogError as SqlCatalogError;
 use mz_stash::DebugStashFactory;
 use mz_stash_types::StashError;
 
-use crate::objects::Snapshot;
 pub use crate::objects::{
     Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, Comment,
     Database, DefaultPrivilege, Item, ReplicaConfig, ReplicaLocation, Role, Schema,
     SystemConfiguration, SystemObjectMapping, TimelineTimestamp,
 };
+use crate::objects::{IntrospectionSourceIndex, Snapshot};
 use crate::stash::{Connection, DebugOpenableConnection, OpenableConnection};
 pub use crate::stash::{
     StashConfig, ALL_COLLECTIONS, AUDIT_LOG_COLLECTION, CLUSTER_COLLECTION,
@@ -359,7 +359,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /// Panics if the provided id is not a system id.
     async fn set_introspection_source_indexes(
         &mut self,
-        mappings: Vec<(ClusterId, &str, GlobalId)>,
+        mappings: Vec<IntrospectionSourceIndex>,
     ) -> Result<(), Error>;
 
     /// Persist the configuration of a replica.

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -94,7 +94,6 @@ pub use crate::objects::{
     SystemConfiguration, SystemObjectMapping, TimelineTimestamp,
 };
 use crate::objects::{IntrospectionSourceIndex, Snapshot};
-use crate::objects::{IntrospectionSourceIndex, Snapshot};
 use crate::stash::{Connection, DebugOpenableConnection, OpenableConnection};
 pub use crate::stash::{
     StashConfig, ALL_COLLECTIONS, AUDIT_LOG_COLLECTION, CLUSTER_COLLECTION,

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -265,6 +265,48 @@ pub struct IntrospectionSourceIndex {
     pub index_id: GlobalId,
 }
 
+impl DurableType<ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue>
+    for IntrospectionSourceIndex
+{
+    fn into_key_value(
+        self,
+    ) -> (
+        ClusterIntrospectionSourceIndexKey,
+        ClusterIntrospectionSourceIndexValue,
+    ) {
+        let index_id = match self.index_id {
+            GlobalId::System(id) => id,
+            GlobalId::User(_) => {
+                unreachable!("cluster introspection source index mapping cannot use a User ID")
+            }
+            GlobalId::Transient(_) => {
+                unreachable!("cluster introspection source index mapping cannot use a Transient ID")
+            }
+            GlobalId::Explain => {
+                unreachable!("cluster introspection source index mapping cannot use an Explain ID")
+            }
+        };
+        (
+            ClusterIntrospectionSourceIndexKey {
+                cluster_id: self.cluster_id,
+                name: self.name,
+            },
+            ClusterIntrospectionSourceIndexValue { index_id },
+        )
+    }
+
+    fn from_key_value(
+        key: ClusterIntrospectionSourceIndexKey,
+        value: ClusterIntrospectionSourceIndexValue,
+    ) -> Self {
+        Self {
+            cluster_id: key.cluster_id,
+            name: key.name,
+            index_id: GlobalId::System(value.index_id),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ClusterReplica {
     pub cluster_id: ClusterId,

--- a/src/catalog/src/transaction.rs
+++ b/src/catalog/src/transaction.rs
@@ -13,10 +13,10 @@ use crate::objects::{
     ClusterKey, ClusterReplica, ClusterReplicaKey, ClusterReplicaValue, ClusterValue, CommentKey,
     CommentValue, ConfigKey, ConfigValue, Database, DatabaseKey, DatabaseValue,
     DefaultPrivilegesKey, DefaultPrivilegesValue, DurableType, GidMappingKey, GidMappingValue,
-    IdAllocKey, IdAllocValue, Item, ItemKey, ItemValue, ReplicaConfig, Role, RoleKey, RoleValue,
-    Schema, SchemaKey, SchemaValue, ServerConfigurationKey, ServerConfigurationValue, SettingKey,
-    SettingValue, StorageUsageKey, SystemObjectMapping, SystemPrivilegesKey, SystemPrivilegesValue,
-    TimestampKey, TimestampValue,
+    IdAllocKey, IdAllocValue, IntrospectionSourceIndex, Item, ItemKey, ItemValue, ReplicaConfig,
+    Role, RoleKey, RoleValue, Schema, SchemaKey, SchemaValue, ServerConfigurationKey,
+    ServerConfigurationValue, SettingKey, SettingValue, StorageUsageKey, SystemObjectMapping,
+    SystemPrivilegesKey, SystemPrivilegesValue, TimestampKey, TimestampValue,
 };
 use crate::objects::{ClusterConfig, ClusterVariant};
 use crate::{
@@ -411,19 +411,14 @@ impl<'a> Transaction<'a> {
         };
 
         for (builtin, index_id) in introspection_source_indexes {
-            let index_id = if let GlobalId::System(id) = index_id {
-                id
-            } else {
-                panic!("non-system id provided")
+            let introspection_source_index = IntrospectionSourceIndex {
+                cluster_id,
+                name: builtin.name.to_string(),
+                index_id,
             };
+            let (key, value) = introspection_source_index.into_key_value();
             self.introspection_sources
-                .insert(
-                    ClusterIntrospectionSourceIndexKey {
-                        cluster_id,
-                        name: builtin.name.to_string(),
-                    },
-                    ClusterIntrospectionSourceIndexValue { index_id },
-                )
+                .insert(key, value)
                 .expect("no uniqueness violation");
         }
 
@@ -537,20 +532,20 @@ impl<'a> Transaction<'a> {
         mappings: impl Iterator<Item = (ClusterId, impl Iterator<Item = (String, GlobalId)>)>,
     ) -> Result<(), Error> {
         for (cluster_id, updates) in mappings {
-            for (name, id) in updates {
-                let index_id = if let GlobalId::System(index_id) = id {
-                    index_id
-                } else {
-                    panic!("Introspection source index should have a system id")
+            for (name, index_id) in updates {
+                let introspection_source_index = IntrospectionSourceIndex {
+                    cluster_id,
+                    name,
+                    index_id,
                 };
-                let prev = self.introspection_sources.set(
-                    ClusterIntrospectionSourceIndexKey { cluster_id, name },
-                    Some(ClusterIntrospectionSourceIndexValue { index_id }),
-                )?;
+                let (key, value) = introspection_source_index.into_key_value();
+
+                let prev = self.introspection_sources.set(key, Some(value))?;
                 if prev.is_none() {
-                    return Err(
-                        SqlCatalogError::FailedBuiltinSchemaMigration(format!("{id}")).into(),
-                    );
+                    return Err(SqlCatalogError::FailedBuiltinSchemaMigration(format!(
+                        "{index_id}"
+                    ))
+                    .into());
                 }
             }
         }


### PR DESCRIPTION
This commit is a followup to 4d3131f90d5dacd2a3b9912d8265f856481516ce and implements the DurableType trait for IntrospectionSourceIndexes. That object was mistakenly left out of the previous commit.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
