### PR TITLE
parser: Fix regression in parsing of timestamp as identifier

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -525,118 +525,138 @@ impl<'a> Parser<'a> {
         // because the `date` type name is not followed by a string literal, but
         // in fact is a valid expression that should parse as the column name
         // "date".
-        maybe!(self.maybe_parse(|parser| {
-            let data_type = parser.parse_data_type()?;
-            if data_type.to_string().as_str() == "interval" {
-                Ok(Expr::Value(parser.parse_interval_value()?))
-            } else {
-                Ok(Expr::Cast {
-                    expr: Box::new(Expr::Value(Value::String(parser.parse_literal_string()?))),
-                    data_type,
-                })
-            }
-        }));
-
-        let tok = self
-            .next_token()
-            .ok_or_else(|| self.error(self.peek_prev_pos(), "Unexpected EOF".to_string()))?;
-        let expr = match tok {
-            Token::LBracket => {
-                self.prev_token();
-                let function = self.parse_named_function()?;
-                Ok(Expr::Function(function))
-            }
-            Token::Keyword(TRUE) | Token::Keyword(FALSE) | Token::Keyword(NULL) => {
-                self.prev_token();
-                Ok(Expr::Value(self.parse_value()?))
-            }
-            Token::Keyword(ARRAY) => self.parse_array(),
-            Token::Keyword(LIST) => self.parse_list(),
-            Token::Keyword(CASE) => self.parse_case_expr(),
-            Token::Keyword(CAST) => self.parse_cast_expr(),
-            Token::Keyword(COALESCE) => {
-                self.parse_homogenizing_function(HomogenizingFunction::Coalesce)
-            }
-            Token::Keyword(GREATEST) => {
-                self.parse_homogenizing_function(HomogenizingFunction::Greatest)
-            }
-            Token::Keyword(LEAST) => self.parse_homogenizing_function(HomogenizingFunction::Least),
-            Token::Keyword(NULLIF) => self.parse_nullif_expr(),
-            Token::Keyword(EXISTS) => self.parse_exists_expr(),
-            Token::Keyword(EXTRACT) => self.parse_extract_expr(),
-            Token::Keyword(INTERVAL) => Ok(Expr::Value(self.parse_interval_value()?)),
-            // having timestamps separately here because errors are swallowed by the maybe! block
-            Token::Keyword(TIMESTAMP) | Token::Keyword(TIMESTAMPTZ) => {
-                self.prev_token();
-                let data_type = self.parse_data_type()?;
-                Ok(Expr::Cast {
-                    expr: Box::new(Expr::Value(Value::String(self.parse_literal_string()?))),
-                    data_type,
-                })
-            }
-            Token::Keyword(NOT) => Ok(Expr::Not {
-                expr: Box::new(self.parse_subexpr(Precedence::PrefixNot)?),
-            }),
-            Token::Keyword(ROW) => self.parse_row_expr(),
-            Token::Keyword(TRIM) => self.parse_trim_expr(),
-            Token::Keyword(POSITION) if self.peek_token() == Some(Token::LParen) => {
-                self.parse_position_expr()
-            }
-            Token::Keyword(SUBSTRING) => self.parse_substring_expr(),
-            Token::Keyword(kw) if kw.is_reserved() => {
-                return Err(self.error(
-                    self.peek_prev_pos(),
-                    "expected expression, but found reserved keyword".into(),
-                ));
-            }
-            Token::Keyword(id) => self.parse_qualified_identifier(id.into()),
-            Token::Ident(id) => self.parse_qualified_identifier(Ident::new(id)),
-            Token::Op(op) if op == "-" => {
-                if let Some(Token::Number(n)) = self.peek_token() {
-                    let n = match n.parse::<f64>() {
-                        Ok(n) => n,
-                        Err(_) => {
-                            return Err(
-                                self.error(self.peek_prev_pos(), format!("invalid number {}", n))
-                            )
-                        }
-                    };
-                    if n != 0.0 {
-                        self.prev_token();
-                        return Ok(Expr::Value(self.parse_value()?));
-                    }
+        let maybe_data_type = |parser: &mut Parser| match parser.parse_data_type() {
+            Ok(data_type) => {
+                if data_type.to_string().as_str() == "interval" {
+                    Ok(Expr::Value(parser.parse_interval_value()?))
+                } else {
+                    Ok(Expr::Cast {
+                        expr: Box::new(Expr::Value(Value::String(parser.parse_literal_string()?))),
+                        data_type,
+                    })
                 }
+            }
+            Err(e) => Err(e),
+        };
 
-                Ok(Expr::Op {
+        maybe!(self.maybe_parse(maybe_data_type));
+
+        let maybe_prefix_expr = |parser: &mut Parser| {
+            let tok = parser.next_token().ok_or_else(|| {
+                parser.error(parser.peek_prev_pos(), "Unexpected EOF".to_string())
+            })?;
+            let expr = match tok {
+                Token::LBracket => {
+                    parser.prev_token();
+                    let function = parser.parse_named_function()?;
+                    Ok(Expr::Function(function))
+                }
+                Token::Keyword(TRUE) | Token::Keyword(FALSE) | Token::Keyword(NULL) => {
+                    parser.prev_token();
+                    Ok(Expr::Value(parser.parse_value()?))
+                }
+                Token::Keyword(ARRAY) => parser.parse_array(),
+                Token::Keyword(LIST) => parser.parse_list(),
+                Token::Keyword(CASE) => parser.parse_case_expr(),
+                Token::Keyword(CAST) => parser.parse_cast_expr(),
+                Token::Keyword(COALESCE) => {
+                    parser.parse_homogenizing_function(HomogenizingFunction::Coalesce)
+                }
+                Token::Keyword(GREATEST) => {
+                    parser.parse_homogenizing_function(HomogenizingFunction::Greatest)
+                }
+                Token::Keyword(LEAST) => {
+                    parser.parse_homogenizing_function(HomogenizingFunction::Least)
+                }
+                Token::Keyword(NULLIF) => parser.parse_nullif_expr(),
+                Token::Keyword(EXISTS) => parser.parse_exists_expr(),
+                Token::Keyword(EXTRACT) => parser.parse_extract_expr(),
+                Token::Keyword(INTERVAL) => Ok(Expr::Value(parser.parse_interval_value()?)),
+                Token::Keyword(NOT) => Ok(Expr::Not {
+                    expr: Box::new(parser.parse_subexpr(Precedence::PrefixNot)?),
+                }),
+                Token::Keyword(ROW) => parser.parse_row_expr(),
+                Token::Keyword(TRIM) => parser.parse_trim_expr(),
+                Token::Keyword(POSITION) if parser.peek_token() == Some(Token::LParen) => {
+                    parser.parse_position_expr()
+                }
+                Token::Keyword(SUBSTRING) => parser.parse_substring_expr(),
+                Token::Keyword(kw) if kw.is_reserved() => {
+                    return Err(parser.error(
+                        parser.peek_prev_pos(),
+                        "expected expression, but found reserved keyword".into(),
+                    ));
+                }
+                Token::Keyword(id @ TIMESTAMP) | Token::Keyword(id @ TIMESTAMPTZ) => {
+                    // If the execution reaches here, timestamp/timestamptz could not be evaluated
+                    // to valid data types above. These can now only be identifiers, not functions
+                    let parsed = parser.parse_qualified_identifier(id.into())?;
+                    if matches!(parsed, Expr::Function(_)) {
+                        return Err(parser.error(
+                            parser.peek_prev_pos(),
+                            "timestamp/timestamptz as data_type should have already been resolved!"
+                                .into(),
+                        ));
+                    }
+                    Ok(parsed)
+                }
+                Token::Keyword(id) => parser.parse_qualified_identifier(id.into()),
+                Token::Ident(id) => parser.parse_qualified_identifier(Ident::new(id)),
+                Token::Op(op) if op == "-" => {
+                    if let Some(Token::Number(n)) = parser.peek_token() {
+                        let n = match n.parse::<f64>() {
+                            Ok(n) => n,
+                            Err(_) => {
+                                return Err(parser.error(
+                                    parser.peek_prev_pos(),
+                                    format!("invalid number {}", n),
+                                ))
+                            }
+                        };
+                        if n != 0.0 {
+                            parser.prev_token();
+                            return Ok(Expr::Value(parser.parse_value()?));
+                        }
+                    }
+
+                    Ok(Expr::Op {
+                        op: Op::bare(op),
+                        expr1: Box::new(parser.parse_subexpr(Precedence::PrefixPlusMinus)?),
+                        expr2: None,
+                    })
+                }
+                Token::Op(op) if op == "+" => Ok(Expr::Op {
                     op: Op::bare(op),
-                    expr1: Box::new(self.parse_subexpr(Precedence::PrefixPlusMinus)?),
+                    expr1: Box::new(parser.parse_subexpr(Precedence::PrefixPlusMinus)?),
                     expr2: None,
-                })
-            }
-            Token::Op(op) if op == "+" => Ok(Expr::Op {
-                op: Op::bare(op),
-                expr1: Box::new(self.parse_subexpr(Precedence::PrefixPlusMinus)?),
-                expr2: None,
-            }),
-            Token::Op(op) if op == "~" => Ok(Expr::Op {
-                op: Op::bare(op),
-                expr1: Box::new(self.parse_subexpr(Precedence::Other)?),
-                expr2: None,
-            }),
-            Token::Number(_) | Token::String(_) | Token::HexString(_) => {
-                self.prev_token();
-                Ok(Expr::Value(self.parse_value()?))
-            }
-            Token::Parameter(n) => Ok(Expr::Parameter(n)),
-            Token::LParen => {
-                let expr = self.parse_parenthesized_expr()?;
-                self.expect_token(&Token::RParen)?;
-                Ok(expr)
-            }
-            unexpected => self.expected(self.peek_prev_pos(), "an expression", Some(unexpected)),
-        }?;
+                }),
+                Token::Op(op) if op == "~" => Ok(Expr::Op {
+                    op: Op::bare(op),
+                    expr1: Box::new(parser.parse_subexpr(Precedence::Other)?),
+                    expr2: None,
+                }),
+                Token::Number(_) | Token::String(_) | Token::HexString(_) => {
+                    parser.prev_token();
+                    Ok(Expr::Value(parser.parse_value()?))
+                }
+                Token::Parameter(n) => Ok(Expr::Parameter(n)),
+                Token::LParen => {
+                    let expr = parser.parse_parenthesized_expr()?;
+                    parser.expect_token(&Token::RParen)?;
+                    Ok(expr)
+                }
+                unexpected => {
+                    parser.expected(parser.peek_prev_pos(), "an expression", Some(unexpected))
+                }
+            }?;
+            Ok(expr)
+        };
 
-        Ok(expr)
+        maybe!(self.maybe_parse(maybe_prefix_expr));
+
+        // If execution reaches here, it means none of the above maybe! branches were valid
+        // Returning the error when parsing data_type
+        maybe_data_type(self)
     }
 
     /// Parses an expression that appears in parentheses, like `(1 + 1)` or
@@ -5226,13 +5246,26 @@ impl<'a> Parser<'a> {
 
     /// Parse a signed literal integer.
     fn parse_literal_int(&mut self) -> Result<i64, ParserError> {
+        let negative = self.consume_token(&Token::Op("-".into()));
         match self.next_token() {
-            Some(Token::Number(s)) => s.parse::<i64>().map_err(|e| {
-                self.error(
-                    self.peek_prev_pos(),
-                    format!("Could not parse '{}' as i64: {}", s, e),
-                )
-            }),
+            Some(Token::Number(s)) => {
+                let n = s.parse::<i64>().map_err(|e| {
+                    self.error(
+                        self.peek_prev_pos(),
+                        format!("Could not parse '{}' as i64: {}", s, e),
+                    )
+                })?;
+                if negative {
+                    n.checked_neg().ok_or_else(|| {
+                        self.error(
+                            self.peek_prev_pos(),
+                            format!("Could not parse '{}' as i64: overflows i64", s),
+                        )
+                    })
+                } else {
+                    Ok(n)
+                }
+            }
             other => self.expected(self.peek_prev_pos(), "literal integer", other),
         }
     }
@@ -5413,12 +5446,7 @@ impl<'a> Parser<'a> {
     // parses the precision in timestamp(<precision>) and timestamptz(<precision>)
     fn parse_timestamp_precision(&mut self) -> Result<Vec<i64>, ParserError> {
         if self.consume_token(&Token::LParen) {
-            let typ_mod = self.parse_literal_uint()?.try_into().map_err(|_| {
-                self.error(
-                    self.index,
-                    "number too large to fit in target type".to_string(),
-                )
-            })?;
+            let typ_mod = self.parse_literal_int()?;
             self.expect_token(&Token::RParen)?;
             Ok(vec![typ_mod])
         } else {

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -173,30 +173,22 @@ Cast { expr: Value(String("invalid timestamptx")), data_type: Other { name: Name
 parse-scalar
 TIMESTAMP(-1) '1999-01-01 01:23:34.555'
 ----
-error: Expected literal unsigned integer, found operator "-"
-TIMESTAMP(-1) '1999-01-01 01:23:34.555'
-          ^
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [-1] } }
 
 parse-scalar
 TIMESTAMPTZ(-1) '1999-01-01 01:23:34.555'
 ----
-error: Expected literal unsigned integer, found operator "-"
-TIMESTAMPTZ(-1) '1999-01-01 01:23:34.555'
-            ^
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [-1] } }
 
 parse-scalar
 TIMESTAMP(-1) WITH TIME ZONE '1999-01-01 01:23:34.555'
 ----
-error: Expected literal unsigned integer, found operator "-"
-TIMESTAMP(-1) WITH TIME ZONE '1999-01-01 01:23:34.555'
-          ^
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamptz")])), typ_mod: [-1] } }
 
 parse-scalar
 TIMESTAMP(-1) WITHOUT TIME ZONE '1999-01-01 01:23:34.555'
 ----
-error: Expected literal unsigned integer, found operator "-"
-TIMESTAMP(-1) WITHOUT TIME ZONE '1999-01-01 01:23:34.555'
-          ^
+Cast { expr: Value(String("1999-01-01 01:23:34.555")), data_type: Other { name: Name(UnresolvedItemName([Ident("timestamp")])), typ_mod: [-1] } }
 
 parse-scalar
 TIMESTAMP(3) '1970-01-01T00:00:00.666666666'
@@ -241,30 +233,30 @@ Cast { expr: Value(String("1970-01-01T00:00:00.666666666")), data_type: Other { 
 parse-scalar
 TIMESTAMP(9223372036854775808) '1970-01-01T00:00:00.666666666'
 ----
-error: number too large to fit in target type
+error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
 TIMESTAMP(9223372036854775808) '1970-01-01T00:00:00.666666666'
-   ^
+          ^
 
 parse-scalar
 TIMESTAMPTZ(9223372036854775808) '1970-01-01T00:00:00.666666666'
 ----
-error: number too large to fit in target type
+error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
 TIMESTAMPTZ(9223372036854775808) '1970-01-01T00:00:00.666666666'
-   ^
+            ^
 
 parse-scalar
 TIMESTAMP(9223372036854775808) WITH TIME ZONE '1970-01-01T00:00:00.666666666'
 ----
-error: number too large to fit in target type
+error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
 TIMESTAMP(9223372036854775808) WITH TIME ZONE '1970-01-01T00:00:00.666666666'
-   ^
+          ^
 
 parse-scalar
 TIMESTAMP(9223372036854775808) WITHOUT TIME ZONE '1970-01-01T00:00:00.666666666'
 ----
-error: number too large to fit in target type
+error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
 TIMESTAMP(9223372036854775808) WITHOUT TIME ZONE '1970-01-01T00:00:00.666666666'
-   ^
+          ^
 
 parse-scalar
 INTERVAL '1' YEAR

--- a/src/sql-parser/tests/testdata/literal
+++ b/src/sql-parser/tests/testdata/literal
@@ -233,30 +233,30 @@ Cast { expr: Value(String("1970-01-01T00:00:00.666666666")), data_type: Other { 
 parse-scalar
 TIMESTAMP(9223372036854775808) '1970-01-01T00:00:00.666666666'
 ----
-error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
+error: extra token after expression
 TIMESTAMP(9223372036854775808) '1970-01-01T00:00:00.666666666'
-          ^
+                               ^
 
 parse-scalar
 TIMESTAMPTZ(9223372036854775808) '1970-01-01T00:00:00.666666666'
 ----
-error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
+error: extra token after expression
 TIMESTAMPTZ(9223372036854775808) '1970-01-01T00:00:00.666666666'
-            ^
+                                 ^
 
 parse-scalar
 TIMESTAMP(9223372036854775808) WITH TIME ZONE '1970-01-01T00:00:00.666666666'
 ----
-error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
+error: extra token after expression
 TIMESTAMP(9223372036854775808) WITH TIME ZONE '1970-01-01T00:00:00.666666666'
-          ^
+                               ^
 
 parse-scalar
 TIMESTAMP(9223372036854775808) WITHOUT TIME ZONE '1970-01-01T00:00:00.666666666'
 ----
-error: Could not parse '9223372036854775808' as i64: number too large to fit in target type
+error: extra token after expression
 TIMESTAMP(9223372036854775808) WITHOUT TIME ZONE '1970-01-01T00:00:00.666666666'
-          ^
+                               ^
 
 parse-scalar
 INTERVAL '1' YEAR

--- a/src/sql-parser/tests/testdata/scalar
+++ b/src/sql-parser/tests/testdata/scalar
@@ -232,9 +232,7 @@ parse-scalar roundtrip
 parse-scalar roundtrip
 (id::timestamp(5) with time zone::timestamp(-1) without time zone  )  ::  double precision::text
 ----
-error: Expected literal unsigned integer, found operator "-"
-(id::timestamp(5) with time zone::timestamp(-1) without time zone  )  ::  double precision::text
-                                            ^
+(id::timestamptz(5)::timestamp(-1))::float8::text
 
 parse-scalar roundtrip
 CAST(c::jsonb->>'f' AS timestamptz)

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1370,7 +1370,7 @@ SELECT now() + null;
 NULL
 
 # Test timestamp precision.
-query error Expected literal unsigned integer
+query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT '1970-01-01T00:00:00.666666'::timestamp(-1);
 
 query error db error: ERROR: precision for type timestamp or timestamptz must be between 0 and 6
@@ -1562,16 +1562,16 @@ SELECT timestamp(5) '95143-12-31 17:59:59.1235+00' = timestamp(4) '95143-12-31 1
 ----
 true
 
-query error Expected literal unsigned integer
+query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT timestamp(-1) '95143-12-31 23:59:59.123456789+06';
 
-query error Expected literal unsigned integer
+query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT timestamp(-1) with time zone '95143-12-31 23:59:59.123456789+06';
 
-query error Expected literal unsigned integer
+query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT '95143-12-31 23:59:59.123456789+06'::timestamp(-1);
 
-query error Expected literal unsigned integer
+query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT timestamptz(-1) '95143-12-31 23:59:59.123456789+06';
 
 query error number too large to fit in target type
@@ -1613,3 +1613,24 @@ Map (adjust_timestamp_precision(text_to_timestamp("95143-12-31 23:59:59.12345678
     - ()
 
 EOF
+
+statement ok
+CREATE table t (timestamp string);
+
+statement ok
+INSERT INTO t VALUES('2012-03-05');
+
+query T
+SELECT * from t ORDER BY timestamp;
+----
+2012-03-05
+
+query T
+SELECT * from t ORDER BY t.timestamp;
+----
+2012-03-05
+
+query T
+SELECT timestamp::timestamp from t ORDER BY t.timestamp;
+----
+2012-03-05 00:00:00

--- a/test/sqllogictest/dates-times.slt
+++ b/test/sqllogictest/dates-times.slt
@@ -1574,13 +1574,15 @@ SELECT '95143-12-31 23:59:59.123456789+06'::timestamp(-1);
 query error precision for type timestamp or timestamptz must be between 0 and 6
 SELECT timestamptz(-1) '95143-12-31 23:59:59.123456789+06';
 
-query error number too large to fit in target type
+# Note: we regressed the error messages for the following
+# See <https://github.com/MaterializeInc/materialize/issues/22397>
+query error Expected end of statement
 SELECT timestamp(10000000000000000000) '95143-12-31 23:59:59.123456789+06';
 
-query error number too large to fit in target type
+query error Expected end of statement
 SELECT timestamptz(10000000000000000000) '95143-12-31 23:59:59.123456789+06';
 
-query error number too large to fit in target type
+query error Expected end of statement
 SELECT timestamp(9223372036854775808) '95143-12-31 23:59:59.123456789+06';
 
 # checking we are not converting between the same precision again

--- a/test/testdrive/dates-times.td
+++ b/test/testdrive/dates-times.td
@@ -108,7 +108,7 @@ $ kafka-verify-data format=avro sink=materialize.public.ts_precision_sink sort-m
 {"key": true} {"key": true, "ts": 123456, "ts0": 0, "ts1": 100, "ts2": 120, "ts3": 123, "ts4": 123500, "ts5": 123460, "ts6": 123456, "tstz": 123456, "tstz0": 0, "tstz1": 100, "tstz2": 120, "tstz3": 123, "tstz4": 123500, "tstz5": 123460, "tstz6": 123456}
 
 ! SELECT '1970-01-01T00:00:00.123456'::timestamp(-1)
-contains:Expected literal unsigned integer
+contains:precision for type timestamp or timestamptz must be between 0 and 6
 
 ! SELECT '1970-01-01T00:00:00.123456'::timestamp(7)
 contains:precision for type timestamp or timestamptz must be between 0 and 6


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/22397

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @def- In case you have more tests in mind