### PR TITLE
catalog: Remove stash from durable catalog errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3509,7 +3509,6 @@ dependencies = [
  "mz-sql-parser",
  "mz-ssh-util",
  "mz-stash",
- "mz-stash-types",
  "mz-storage-client",
  "mz-storage-types",
  "mz-tls-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "thiserror",
  "tokio",
  "tokio-postgres",
  "tracing",

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -55,7 +55,6 @@ mz-sql = { path = "../sql" }
 mz-sql-parser = { path = "../sql-parser" }
 mz-ssh-util = { path = "../ssh-util" }
 mz-stash = { path = "../stash" }
-mz-stash-types = { path = "../stash-types" }
 mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 mz-tls-util = { path = "../tls-util" }

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -70,8 +70,6 @@ pub enum ErrorKind {
     Unstructured(String),
     #[error(transparent)]
     Durable(#[from] mz_catalog::DurableCatalogError),
-    #[error("stash in unexpected state")]
-    UnexpectedStashState,
     #[error(transparent)]
     Uuid(#[from] uuid::Error),
     #[error("role \"{role_name}\" is a member of role \"{member_name}\"")]

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -69,7 +69,7 @@ pub enum ErrorKind {
     #[error("{0}")]
     Unstructured(String),
     #[error(transparent)]
-    Stash(#[from] mz_stash_types::StashError),
+    Durable(#[from] mz_catalog::DurableCatalogError),
     #[error("stash in unexpected state")]
     UnexpectedStashState,
     #[error(transparent)]
@@ -119,15 +119,9 @@ impl From<SqlCatalogError> for Error {
     }
 }
 
-impl From<mz_stash_types::StashError> for Error {
-    fn from(e: mz_stash_types::StashError) -> Error {
-        Error::new(ErrorKind::from(e))
-    }
-}
-
 impl From<TryFromProtoError> for Error {
     fn from(e: TryFromProtoError) -> Error {
-        Error::new(ErrorKind::from(mz_stash_types::StashError::from(e)))
+        Error::from(mz_catalog::CatalogError::from(e))
     }
 }
 
@@ -137,11 +131,11 @@ impl From<uuid::Error> for Error {
     }
 }
 
-impl From<mz_catalog::Error> for Error {
-    fn from(e: mz_catalog::Error) -> Self {
+impl From<mz_catalog::CatalogError> for Error {
+    fn from(e: mz_catalog::CatalogError) -> Self {
         match e {
-            mz_catalog::Error::Catalog(e) => Error::new(ErrorKind::from(e)),
-            mz_catalog::Error::Stash(e) => Error::new(ErrorKind::from(e)),
+            mz_catalog::CatalogError::Catalog(e) => Error::new(ErrorKind::from(e)),
+            mz_catalog::CatalogError::Durable(e) => Error::new(ErrorKind::from(e)),
         }
     }
 }

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -708,8 +708,8 @@ impl From<catalog::Error> for AdapterError {
     }
 }
 
-impl From<mz_catalog::Error> for AdapterError {
-    fn from(e: mz_catalog::Error) -> Self {
+impl From<mz_catalog::CatalogError> for AdapterError {
+    fn from(e: mz_catalog::CatalogError) -> Self {
         catalog::Error::from(e).into()
     }
 }

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -22,7 +22,6 @@ use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     CreateIndexStatement, FetchStatement, Ident, Raw, RawClusterName, RawItemName, Statement,
 };
-use mz_stash_types::StashError;
 use mz_storage_types::controller::StorageError;
 use mz_transform::TransformError;
 use tokio::sync::mpsc::UnboundedSender;
@@ -295,22 +294,22 @@ impl ShouldHalt for AdapterError {
 impl ShouldHalt for crate::catalog::Error {
     fn should_halt(&self) -> bool {
         match &self.kind {
-            crate::catalog::ErrorKind::Stash(e) => e.should_halt(),
+            crate::catalog::ErrorKind::Durable(e) => e.should_halt(),
             _ => false,
         }
     }
 }
 
-impl ShouldHalt for mz_catalog::Error {
+impl ShouldHalt for mz_catalog::CatalogError {
     fn should_halt(&self) -> bool {
         match &self {
-            Self::Stash(e) => e.should_halt(),
+            Self::Durable(e) => e.should_halt(),
             _ => false,
         }
     }
 }
 
-impl ShouldHalt for StashError {
+impl ShouldHalt for mz_catalog::DurableCatalogError {
     fn should_halt(&self) -> bool {
         self.is_unrecoverable()
     }
@@ -334,7 +333,7 @@ impl ShouldHalt for StorageError {
             | StorageError::DataflowError(_)
             | StorageError::InvalidAlterSource { .. }
             | StorageError::ShuttingDown(_) => false,
-            StorageError::IOError(e) => e.should_halt(),
+            StorageError::IOError(e) => e.is_unrecoverable(),
         }
     }
 }

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -32,6 +32,7 @@ postgres-openssl = { version = "0.5.0" }
 serde = "1.0.152"
 serde_json = "1.0.89"
 tracing = "0.1.37"
+thiserror = "1.0.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -1,0 +1,144 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::fmt;
+use std::fmt::{Debug, Formatter};
+
+use mz_proto::TryFromProtoError;
+use mz_sql::catalog::CatalogError as SqlCatalogError;
+use mz_stash_types::{InternalStashError, StashError, MIN_STASH_VERSION, STASH_VERSION};
+
+#[derive(Debug)]
+pub enum CatalogError {
+    Catalog(SqlCatalogError),
+    Durable(DurableCatalogError),
+}
+
+impl std::error::Error for CatalogError {}
+
+impl fmt::Display for CatalogError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            CatalogError::Catalog(e) => write!(f, "{e}"),
+            CatalogError::Durable(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<SqlCatalogError> for CatalogError {
+    fn from(e: SqlCatalogError) -> Self {
+        Self::Catalog(e)
+    }
+}
+
+impl From<DurableCatalogError> for CatalogError {
+    fn from(e: DurableCatalogError) -> Self {
+        Self::Durable(e)
+    }
+}
+
+impl From<StashError> for CatalogError {
+    fn from(e: StashError) -> Self {
+        Self::Durable(e.into())
+    }
+}
+
+impl From<TryFromProtoError> for CatalogError {
+    fn from(e: TryFromProtoError) -> Self {
+        Self::Durable(e.into())
+    }
+}
+
+/// An error that can occur while interacting with a durable catalog.
+#[derive(Debug)]
+pub enum DurableCatalogError {
+    /// Catalog has been fenced by another writer.
+    Fence(String),
+    /// The persisted catalog's version is too old for the current catalog to migrate.
+    IncompatibleVersion(u64),
+    /// Catalog is uninitialized.
+    Uninitialized,
+    /// Catalog is not in a writable state.
+    NotWritable(String),
+    /// Unable to serialize/deserialize Protobuf message.
+    Proto(TryFromProtoError),
+    /// Misc errors from the Stash implementation.
+    ///
+    /// Once the Stash implementation is removed we can remove this variant.
+    MiscStash(StashError),
+}
+
+impl DurableCatalogError {
+    /// Reports whether the error is unrecoverable (retrying will never succeed,
+    /// or a retry is not safe due to an indeterminate state).
+    pub fn is_unrecoverable(&self) -> bool {
+        match self {
+            DurableCatalogError::Fence(_) | DurableCatalogError::NotWritable(_) => true,
+            DurableCatalogError::MiscStash(e) => e.is_unrecoverable(),
+            _ => false,
+        }
+    }
+
+    /// Reports whether the error can be recovered if we opened the catalog in a writeable mode.
+    pub fn can_recover_with_write_mode(&self) -> bool {
+        match self {
+            DurableCatalogError::NotWritable(_) => true,
+            DurableCatalogError::MiscStash(e) => e.can_recover_with_write_mode(),
+            _ => false,
+        }
+    }
+
+    /// The underlying operation failed in a way that must be resolved by retrying.
+    pub fn should_retry(&self) -> bool {
+        match self {
+            DurableCatalogError::MiscStash(e) => e.should_retry(),
+            _ => false,
+        }
+    }
+}
+
+impl std::error::Error for DurableCatalogError {}
+
+impl fmt::Display for DurableCatalogError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            DurableCatalogError::Fence(e) => f.write_str(e),
+            DurableCatalogError::IncompatibleVersion(v) => write!(f, "incompatible Catalog version {v}, minimum: {MIN_STASH_VERSION}, current: {STASH_VERSION}"),
+            DurableCatalogError::Uninitialized => write!(f, "uninitialized"),
+            DurableCatalogError::NotWritable(e) => f.write_str(e),
+            DurableCatalogError::Proto(e) => write!(f, "proto: {e}"),
+            DurableCatalogError::MiscStash(e) => write!(f, "{e}"),
+        }
+    }
+}
+
+impl From<StashError> for DurableCatalogError {
+    fn from(e: StashError) -> Self {
+        // We're not really supposed to look at the inner error, but we'll make an exception here.
+        match e.inner {
+            InternalStashError::Fence(msg) => DurableCatalogError::Fence(msg),
+            InternalStashError::IncompatibleVersion(version) => {
+                DurableCatalogError::IncompatibleVersion(version)
+            }
+            InternalStashError::Uninitialized => DurableCatalogError::Uninitialized,
+            InternalStashError::StashNotWritable(msg) => DurableCatalogError::NotWritable(msg),
+            InternalStashError::Proto(e) => DurableCatalogError::Proto(e),
+            InternalStashError::Postgres(_)
+            | InternalStashError::PeekSinceUpper(_)
+            | InternalStashError::Decoding(_)
+            | InternalStashError::Other(_) => DurableCatalogError::MiscStash(e),
+        }
+    }
+}
+
+impl From<TryFromProtoError> for DurableCatalogError {
+    fn from(e: TryFromProtoError) -> Self {
+        DurableCatalogError::Proto(e)
+    }
+}

--- a/src/catalog/src/error.rs
+++ b/src/catalog/src/error.rs
@@ -7,8 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 
 use mz_proto::TryFromProtoError;
 use mz_sql::catalog::CatalogError as SqlCatalogError;

--- a/src/catalog/src/initialize.rs
+++ b/src/catalog/src/initialize.rs
@@ -29,11 +29,11 @@ use mz_storage_types::sources::Timeline;
 use crate::builtin::BUILTIN_ROLES;
 use crate::objects::{DefaultPrivilegesKey, DefaultPrivilegesValue};
 use crate::{
-    BootstrapArgs, ClusterConfig, ClusterVariant, ClusterVariantManaged, Error, ReplicaConfig,
-    ReplicaLocation, Role, Schema, Transaction, AUDIT_LOG_ID_ALLOC_KEY, DATABASE_ID_ALLOC_KEY,
-    SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY,
-    SYSTEM_REPLICA_ID_ALLOC_KEY, USER_CLUSTER_ID_ALLOC_KEY, USER_REPLICA_ID_ALLOC_KEY,
-    USER_ROLE_ID_ALLOC_KEY,
+    BootstrapArgs, CatalogError, ClusterConfig, ClusterVariant, ClusterVariantManaged,
+    ReplicaConfig, ReplicaLocation, Role, Schema, Transaction, AUDIT_LOG_ID_ALLOC_KEY,
+    DATABASE_ID_ALLOC_KEY, SCHEMA_ID_ALLOC_KEY, STORAGE_USAGE_ID_ALLOC_KEY,
+    SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY, USER_CLUSTER_ID_ALLOC_KEY,
+    USER_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
 };
 
 /// The key used within the "config" collection where we store the deploy generation.
@@ -66,7 +66,7 @@ pub async fn initialize(
     options: &BootstrapArgs,
     now: EpochMillis,
     deploy_generation: Option<u64>,
-) -> Result<(), Error> {
+) -> Result<(), CatalogError> {
     // Collect audit events so we can commit them once at the very end.
     let mut audit_events = vec![];
 

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -81,16 +81,13 @@
 
 use async_trait::async_trait;
 use std::collections::BTreeMap;
-use std::fmt;
-use std::fmt::{Debug, Formatter};
+use std::fmt::Debug;
 use std::num::NonZeroI64;
 use std::time::Duration;
 
-use mz_proto::TryFromProtoError;
-use mz_sql::catalog::CatalogError as SqlCatalogError;
 use mz_stash::DebugStashFactory;
-use mz_stash_types::StashError;
 
+pub use crate::error::{CatalogError, DurableCatalogError};
 use crate::objects::Snapshot;
 pub use crate::objects::{
     Cluster, ClusterConfig, ClusterReplica, ClusterVariant, ClusterVariantManaged, Comment,
@@ -121,6 +118,7 @@ mod stash;
 mod transaction;
 
 pub mod builtin;
+mod error;
 pub mod initialize;
 pub mod objects;
 
@@ -133,42 +131,6 @@ const USER_REPLICA_ID_ALLOC_KEY: &str = "replica";
 const SYSTEM_REPLICA_ID_ALLOC_KEY: &str = "system_replica";
 pub const AUDIT_LOG_ID_ALLOC_KEY: &str = "auditlog";
 pub const STORAGE_USAGE_ID_ALLOC_KEY: &str = "storage_usage";
-
-#[derive(Debug)]
-pub enum Error {
-    Catalog(SqlCatalogError),
-    // TODO(jkosh44) make this more generic.
-    Stash(StashError),
-}
-
-impl std::error::Error for Error {}
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
-        match self {
-            Error::Catalog(e) => write!(f, "{e}"),
-            Error::Stash(e) => write!(f, "{e}"),
-        }
-    }
-}
-
-impl From<SqlCatalogError> for Error {
-    fn from(e: SqlCatalogError) -> Self {
-        Self::Catalog(e)
-    }
-}
-
-impl From<StashError> for Error {
-    fn from(e: StashError) -> Self {
-        Self::Stash(e)
-    }
-}
-
-impl From<TryFromProtoError> for Error {
-    fn from(e: TryFromProtoError) -> Error {
-        Error::Stash(mz_stash_types::StashError::from(e))
-    }
-}
 
 #[derive(Clone, Debug)]
 pub struct BootstrapArgs {
@@ -193,7 +155,7 @@ pub trait OpenableDurableCatalogState<D: DurableCatalogState>: Debug + Send {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<D, Error>;
+    ) -> Result<D, CatalogError>;
 
     /// Opens the catalog in read only mode. All mutating methods
     /// will return an error.
@@ -204,7 +166,7 @@ pub trait OpenableDurableCatalogState<D: DurableCatalogState>: Debug + Send {
         &mut self,
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
-    ) -> Result<D, Error>;
+    ) -> Result<D, CatalogError>;
 
     /// Opens the catalog in a writeable mode. Optionally initializes the
     /// catalog, if it has not been initialized, and perform any migrations
@@ -214,13 +176,13 @@ pub trait OpenableDurableCatalogState<D: DurableCatalogState>: Debug + Send {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<D, Error>;
+    ) -> Result<D, CatalogError>;
 
     /// Reports if the catalog state has been initialized.
-    async fn is_initialized(&mut self) -> Result<bool, Error>;
+    async fn is_initialized(&mut self) -> Result<bool, CatalogError>;
 
     /// Get the deployment generation of this instance.
-    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, Error>;
+    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 }
 
 // TODO(jkosh44) No method should take &mut self, but due to stash implementations we need it.
@@ -243,22 +205,22 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// Returns the version of Materialize that last wrote to the catalog.
     ///
     /// If the catalog is uninitialized this will return None.
-    async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error>;
+    async fn get_catalog_content_version(&mut self) -> Result<Option<String>, CatalogError>;
 
     /// Get all clusters.
-    async fn get_clusters(&mut self) -> Result<Vec<Cluster>, Error>;
+    async fn get_clusters(&mut self) -> Result<Vec<Cluster>, CatalogError>;
 
     /// Get all cluster replicas.
-    async fn get_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, Error>;
+    async fn get_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, CatalogError>;
 
     /// Get all databases.
-    async fn get_databases(&mut self) -> Result<Vec<Database>, Error>;
+    async fn get_databases(&mut self) -> Result<Vec<Database>, CatalogError>;
 
     /// Get all schemas.
-    async fn get_schemas(&mut self) -> Result<Vec<Schema>, Error>;
+    async fn get_schemas(&mut self) -> Result<Vec<Schema>, CatalogError>;
 
     /// Get all system items.
-    async fn get_system_items(&mut self) -> Result<Vec<SystemObjectMapping>, Error>;
+    async fn get_system_items(&mut self) -> Result<Vec<SystemObjectMapping>, CatalogError>;
 
     /// Get all introspection source indexes.
     ///
@@ -266,52 +228,53 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     async fn get_introspection_source_indexes(
         &mut self,
         cluster_id: ClusterId,
-    ) -> Result<BTreeMap<String, GlobalId>, Error>;
+    ) -> Result<BTreeMap<String, GlobalId>, CatalogError>;
 
     /// Get all roles.
-    async fn get_roles(&mut self) -> Result<Vec<Role>, Error>;
+    async fn get_roles(&mut self) -> Result<Vec<Role>, CatalogError>;
 
     /// Get all default privileges.
-    async fn get_default_privileges(&mut self) -> Result<Vec<DefaultPrivilege>, Error>;
+    async fn get_default_privileges(&mut self) -> Result<Vec<DefaultPrivilege>, CatalogError>;
 
     /// Get all system privileges.
-    async fn get_system_privileges(&mut self) -> Result<Vec<MzAclItem>, Error>;
+    async fn get_system_privileges(&mut self) -> Result<Vec<MzAclItem>, CatalogError>;
 
     /// Get all system configurations.
-    async fn get_system_configurations(&mut self) -> Result<Vec<SystemConfiguration>, Error>;
+    async fn get_system_configurations(&mut self)
+        -> Result<Vec<SystemConfiguration>, CatalogError>;
 
     /// Get all comments.
-    async fn get_comments(&mut self) -> Result<Vec<Comment>, Error>;
+    async fn get_comments(&mut self) -> Result<Vec<Comment>, CatalogError>;
 
     /// Get all timelines and their persisted timestamps.
     // TODO(jkosh44) This should be removed once the timestamp oracle is extracted.
-    async fn get_timestamps(&mut self) -> Result<Vec<TimelineTimestamp>, Error>;
+    async fn get_timestamps(&mut self) -> Result<Vec<TimelineTimestamp>, CatalogError>;
 
     /// Get the persisted timestamp of a timeline.
     // TODO(jkosh44) This should be removed once the timestamp oracle is extracted.
     async fn get_timestamp(
         &mut self,
         timeline: &Timeline,
-    ) -> Result<Option<mz_repr::Timestamp>, Error>;
+    ) -> Result<Option<mz_repr::Timestamp>, CatalogError>;
 
     /// Get all audit log events.
-    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, Error>;
+    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, CatalogError>;
 
     /// Get the next ID of `id_type`, without allocating it.
-    async fn get_next_id(&mut self, id_type: &str) -> Result<u64, Error>;
+    async fn get_next_id(&mut self, id_type: &str) -> Result<u64, CatalogError>;
 
     /// Get the next system replica id without allocating it.
-    async fn get_next_system_replica_id(&mut self) -> Result<u64, Error> {
+    async fn get_next_system_replica_id(&mut self) -> Result<u64, CatalogError> {
         self.get_next_id(SYSTEM_REPLICA_ID_ALLOC_KEY).await
     }
 
     /// Get the next user replica id without allocating it.
-    async fn get_next_user_replica_id(&mut self) -> Result<u64, Error> {
+    async fn get_next_user_replica_id(&mut self) -> Result<u64, CatalogError> {
         self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
 
     /// Get a snapshot of the catalog.
-    async fn snapshot(&mut self) -> Result<Snapshot, Error>;
+    async fn snapshot(&mut self) -> Result<Snapshot, CatalogError>;
 
     // TODO(jkosh44) Implement this for the catalog debug tool.
     /*    /// Dumps the entire catalog contents in human readable JSON.
@@ -325,21 +288,22 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     fn is_read_only(&self) -> bool;
 
     /// Creates a new durable catalog state transaction.
-    async fn transaction(&mut self) -> Result<Transaction, Error>;
+    async fn transaction(&mut self) -> Result<Transaction, CatalogError>;
 
     /// Commits a durable catalog state transaction.
-    async fn commit_transaction(&mut self, txn_batch: TransactionBatch) -> Result<(), Error>;
+    async fn commit_transaction(&mut self, txn_batch: TransactionBatch)
+        -> Result<(), CatalogError>;
 
     /// Confirms that this catalog is connected as the current leader.
     ///
     /// NB: We may remove this in later iterations of Pv2.
-    async fn confirm_leadership(&mut self) -> Result<(), Error>;
+    async fn confirm_leadership(&mut self) -> Result<(), CatalogError>;
 
     /// Set's the connection timeout for the underlying durable store.
     async fn set_connect_timeout(&mut self, connect_timeout: Duration);
 
     /// Persist the version of Materialize that last wrote to the catalog.
-    async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), Error>;
+    async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), CatalogError>;
 
     /// Gets all storage usage events and permanently deletes from the catalog those
     /// that happened more than the retention period ago from boot_ts.
@@ -347,10 +311,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: mz_repr::Timestamp,
-    ) -> Result<Vec<VersionedStorageUsage>, Error>;
+    ) -> Result<Vec<VersionedStorageUsage>, CatalogError>;
 
     /// Persist system items.
-    async fn set_system_items(&mut self, mappings: Vec<SystemObjectMapping>) -> Result<(), Error>;
+    async fn set_system_items(
+        &mut self,
+        mappings: Vec<SystemObjectMapping>,
+    ) -> Result<(), CatalogError>;
 
     /// Persist introspection source indexes.
     ///
@@ -360,7 +327,7 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     async fn set_introspection_source_indexes(
         &mut self,
         mappings: Vec<(ClusterId, &str, GlobalId)>,
-    ) -> Result<(), Error>;
+    ) -> Result<(), CatalogError>;
 
     /// Persist the configuration of a replica.
     /// This accepts only one item, as we currently use this only for the default cluster
@@ -371,51 +338,51 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         name: String,
         config: ReplicaConfig,
         owner_id: RoleId,
-    ) -> Result<(), Error>;
+    ) -> Result<(), CatalogError>;
 
     /// Persist new global timestamp for a timeline.
     async fn set_timestamp(
         &mut self,
         timeline: &Timeline,
         timestamp: mz_repr::Timestamp,
-    ) -> Result<(), Error>;
+    ) -> Result<(), CatalogError>;
 
     /// Persist the deployment generation of this instance.
-    async fn set_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), Error>;
+    async fn set_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), CatalogError>;
 
     /// Allocates and returns `amount` IDs of `id_type`.
-    async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, Error>;
+    async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, CatalogError>;
 
     /// Allocates and returns `amount` system [`GlobalId`]s.
-    async fn allocate_system_ids(&mut self, amount: u64) -> Result<Vec<GlobalId>, Error> {
+    async fn allocate_system_ids(&mut self, amount: u64) -> Result<Vec<GlobalId>, CatalogError> {
         let id = self.allocate_id("system", amount).await?;
 
         Ok(id.into_iter().map(GlobalId::System).collect())
     }
 
     /// Allocates and returns a user [`GlobalId`].
-    async fn allocate_user_id(&mut self) -> Result<GlobalId, Error> {
+    async fn allocate_user_id(&mut self) -> Result<GlobalId, CatalogError> {
         let id = self.allocate_id("user", 1).await?;
         let id = id.into_element();
         Ok(GlobalId::User(id))
     }
 
     /// Allocates and returns a system [`ClusterId`].
-    async fn allocate_system_cluster_id(&mut self) -> Result<ClusterId, Error> {
+    async fn allocate_system_cluster_id(&mut self) -> Result<ClusterId, CatalogError> {
         let id = self.allocate_id(SYSTEM_CLUSTER_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ClusterId::System(id))
     }
 
     /// Allocates and returns a user [`ClusterId`].
-    async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, Error> {
+    async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, CatalogError> {
         let id = self.allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ClusterId::User(id))
     }
 
     /// Allocates and returns a user [`ReplicaId`].
-    async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, Error> {
+    async fn allocate_user_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {
         let id = self.allocate_id(USER_REPLICA_ID_ALLOC_KEY, 1).await?;
         let id = id.into_element();
         Ok(ReplicaId::User(id))

--- a/src/catalog/src/stash.rs
+++ b/src/catalog/src/stash.rs
@@ -48,7 +48,7 @@ use crate::transaction::{
     TransactionBatch,
 };
 use crate::{
-    initialize, BootstrapArgs, DurableCatalogState, Error, OpenableDurableCatalogState,
+    initialize, BootstrapArgs, CatalogError, DurableCatalogState, OpenableDurableCatalogState,
     ReadOnlyDurableCatalogState,
 };
 
@@ -190,7 +190,7 @@ impl OpenableDurableCatalogState<Connection> for OpenableConnection {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.open_stash_savepoint().await?;
         let stash = self.stash.take().expect("opened above");
         retry_open(stash, now, bootstrap_args, deploy_generation).await
@@ -201,7 +201,7 @@ impl OpenableDurableCatalogState<Connection> for OpenableConnection {
         &mut self,
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.open_stash_read_only().await?;
         let stash = self.stash.take().expect("opened above");
         retry_open(stash, now, bootstrap_args, None).await
@@ -213,13 +213,13 @@ impl OpenableDurableCatalogState<Connection> for OpenableConnection {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.open_stash().await?;
         let stash = self.stash.take().expect("opened above");
         retry_open(stash, now, bootstrap_args, deploy_generation).await
     }
 
-    async fn is_initialized(&mut self) -> Result<bool, Error> {
+    async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
         let stash = match &mut self.stash {
             None => match self.open_stash_read_only().await {
                 Ok(stash) => stash,
@@ -231,7 +231,7 @@ impl OpenableDurableCatalogState<Connection> for OpenableConnection {
         stash.is_initialized().await.err_into()
     }
 
-    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, Error> {
+    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         let stash = match &mut self.stash {
             None => match self.open_stash_read_only().await {
                 Ok(stash) => stash,
@@ -265,7 +265,7 @@ async fn retry_open(
     now: NowFn,
     bootstrap_args: &BootstrapArgs,
     deploy_generation: Option<u64>,
-) -> Result<Connection, Error> {
+) -> Result<Connection, CatalogError> {
     let retry = Retry::default()
         .clamp_backoff(Duration::from_secs(1))
         .max_duration(Duration::from_secs(30))
@@ -279,7 +279,7 @@ async fn retry_open(
             }
             Err((given_stash, err)) => {
                 stash = given_stash;
-                let should_retry = matches!(&err, Error::Stash(se) if se.should_retry());
+                let should_retry = matches!(&err, CatalogError::Durable(e) if e.should_retry());
                 if !should_retry || retry.next().await.is_none() {
                     return Err(err);
                 }
@@ -294,7 +294,7 @@ async fn open_inner(
     now: NowFn,
     bootstrap_args: &BootstrapArgs,
     deploy_generation: Option<u64>,
-) -> Result<Connection, (Stash, Error)> {
+) -> Result<Connection, (Stash, CatalogError)> {
     // Initialize the Stash if it hasn't been already
     let is_init = match stash.is_initialized().await {
         Ok(is_init) => is_init,
@@ -391,7 +391,7 @@ pub struct Connection {
 }
 
 impl Connection {
-    async fn get_setting(&mut self, key: &str) -> Result<Option<String>, Error> {
+    async fn get_setting(&mut self, key: &str) -> Result<Option<String>, CatalogError> {
         let v = SETTING_COLLECTION
             .peek_key_one(
                 &mut self.stash,
@@ -403,7 +403,7 @@ impl Connection {
         Ok(v.map(|v| v.value))
     }
 
-    async fn set_setting(&mut self, key: &str, value: &str) -> Result<(), Error> {
+    async fn set_setting(&mut self, key: &str, value: &str) -> Result<(), CatalogError> {
         let key = proto::SettingKey {
             name: key.to_string(),
         };
@@ -423,12 +423,12 @@ impl ReadOnlyDurableCatalogState for Connection {
         self.stash.epoch()
     }
 
-    async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error> {
+    async fn get_catalog_content_version(&mut self) -> Result<Option<String>, CatalogError> {
         self.get_setting("catalog_content_version").await
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_clusters(&mut self) -> Result<Vec<Cluster>, Error> {
+    async fn get_clusters(&mut self) -> Result<Vec<Cluster>, CatalogError> {
         let entries = CLUSTER_COLLECTION.peek_one(&mut self.stash).await?;
         let clusters = entries
             .into_iter()
@@ -440,7 +440,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, Error> {
+    async fn get_cluster_replicas(&mut self) -> Result<Vec<ClusterReplica>, CatalogError> {
         let entries = CLUSTER_REPLICA_COLLECTION.peek_one(&mut self.stash).await?;
         let replicas = entries
             .into_iter()
@@ -452,7 +452,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_databases(&mut self) -> Result<Vec<Database>, Error> {
+    async fn get_databases(&mut self) -> Result<Vec<Database>, CatalogError> {
         let entries = DATABASES_COLLECTION.peek_one(&mut self.stash).await?;
         let databases = entries
             .into_iter()
@@ -464,7 +464,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_schemas(&mut self) -> Result<Vec<Schema>, Error> {
+    async fn get_schemas(&mut self) -> Result<Vec<Schema>, CatalogError> {
         let entries = SCHEMAS_COLLECTION.peek_one(&mut self.stash).await?;
         let schemas = entries
             .into_iter()
@@ -476,7 +476,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_system_items(&mut self) -> Result<Vec<SystemObjectMapping>, Error> {
+    async fn get_system_items(&mut self) -> Result<Vec<SystemObjectMapping>, CatalogError> {
         let entries = SYSTEM_GID_MAPPING_COLLECTION
             .peek_one(&mut self.stash)
             .await?;
@@ -492,7 +492,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     async fn get_introspection_source_indexes(
         &mut self,
         cluster_id: ClusterId,
-    ) -> Result<BTreeMap<String, GlobalId>, Error> {
+    ) -> Result<BTreeMap<String, GlobalId>, CatalogError> {
         let entries = CLUSTER_INTROSPECTION_SOURCE_INDEX_COLLECTION
             .peek_one(&mut self.stash)
             .await?;
@@ -517,7 +517,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_roles(&mut self) -> Result<Vec<Role>, Error> {
+    async fn get_roles(&mut self) -> Result<Vec<Role>, CatalogError> {
         let entries = ROLES_COLLECTION.peek_one(&mut self.stash).await?;
         let roles = entries
             .into_iter()
@@ -529,7 +529,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_default_privileges(&mut self) -> Result<Vec<DefaultPrivilege>, Error> {
+    async fn get_default_privileges(&mut self) -> Result<Vec<DefaultPrivilege>, CatalogError> {
         Ok(DEFAULT_PRIVILEGES_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -540,7 +540,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_system_privileges(&mut self) -> Result<Vec<MzAclItem>, Error> {
+    async fn get_system_privileges(&mut self) -> Result<Vec<MzAclItem>, CatalogError> {
         Ok(SYSTEM_PRIVILEGES_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -551,7 +551,9 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_system_configurations(&mut self) -> Result<Vec<SystemConfiguration>, Error> {
+    async fn get_system_configurations(
+        &mut self,
+    ) -> Result<Vec<SystemConfiguration>, CatalogError> {
         Ok(SYSTEM_CONFIGURATION_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -562,7 +564,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_comments(&mut self) -> Result<Vec<Comment>, Error> {
+    async fn get_comments(&mut self) -> Result<Vec<Comment>, CatalogError> {
         let comments = COMMENTS_COLLECTION
             .peek_one(&mut self.stash)
             .await?
@@ -575,7 +577,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_timestamps(&mut self) -> Result<Vec<TimelineTimestamp>, Error> {
+    async fn get_timestamps(&mut self) -> Result<Vec<TimelineTimestamp>, CatalogError> {
         let entries = TIMESTAMP_COLLECTION.peek_one(&mut self.stash).await?;
         let timestamps = entries
             .into_iter()
@@ -587,7 +589,10 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_timestamp(&mut self, timeline: &Timeline) -> Result<Option<Timestamp>, Error> {
+    async fn get_timestamp(
+        &mut self,
+        timeline: &Timeline,
+    ) -> Result<Option<Timestamp>, CatalogError> {
         let key = proto::TimestampKey {
             id: timeline.to_string(),
         };
@@ -601,7 +606,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "info", skip_all)]
-    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, Error> {
+    async fn get_audit_logs(&mut self) -> Result<Vec<VersionedEvent>, CatalogError> {
         let entries = AUDIT_LOG_COLLECTION.peek_one(&mut self.stash).await?;
         let logs: Vec<_> = entries
             .into_keys()
@@ -613,7 +618,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn get_next_id(&mut self, id_type: &str) -> Result<u64, Error> {
+    async fn get_next_id(&mut self, id_type: &str) -> Result<u64, CatalogError> {
         ID_ALLOCATOR_COLLECTION
             .peek_key_one(
                 &mut self.stash,
@@ -628,7 +633,7 @@ impl ReadOnlyDurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn snapshot(&mut self) -> Result<Snapshot, Error> {
+    async fn snapshot(&mut self) -> Result<Snapshot, CatalogError> {
         let (
             databases,
             schemas,
@@ -727,13 +732,16 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(name = "storage::transaction", level = "debug", skip_all)]
-    async fn transaction(&mut self) -> Result<Transaction, Error> {
+    async fn transaction(&mut self) -> Result<Transaction, CatalogError> {
         let snapshot = self.snapshot().await?;
         Transaction::new(self, snapshot)
     }
 
     #[tracing::instrument(name = "storage::transaction", level = "debug", skip_all)]
-    async fn commit_transaction(&mut self, txn_batch: TransactionBatch) -> Result<(), Error> {
+    async fn commit_transaction(
+        &mut self,
+        txn_batch: TransactionBatch,
+    ) -> Result<(), CatalogError> {
         async fn add_batch<'tx, K, V>(
             tx: &'tx mz_stash::Transaction<'tx>,
             batches: &mut Vec<AppendBatch>,
@@ -933,7 +941,7 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn confirm_leadership(&mut self) -> Result<(), Error> {
+    async fn confirm_leadership(&mut self) -> Result<(), CatalogError> {
         Ok(self.stash.confirm_leadership().await?)
     }
 
@@ -942,7 +950,7 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), Error> {
+    async fn set_catalog_content_version(&mut self, new_version: &str) -> Result<(), CatalogError> {
         self.set_setting("catalog_content_version", new_version)
             .await
     }
@@ -952,7 +960,7 @@ impl DurableCatalogState for Connection {
         &mut self,
         retention_period: Option<Duration>,
         boot_ts: Timestamp,
-    ) -> Result<Vec<VersionedStorageUsage>, Error> {
+    ) -> Result<Vec<VersionedStorageUsage>, CatalogError> {
         // If no usage retention period is set, set the cutoff to MIN so nothing
         // is removed.
         let cutoff_ts = match retention_period {
@@ -989,7 +997,10 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn set_system_items(&mut self, mappings: Vec<SystemObjectMapping>) -> Result<(), Error> {
+    async fn set_system_items(
+        &mut self,
+        mappings: Vec<SystemObjectMapping>,
+    ) -> Result<(), CatalogError> {
         if mappings.is_empty() {
             return Ok(());
         }
@@ -1008,7 +1019,7 @@ impl DurableCatalogState for Connection {
     async fn set_introspection_source_indexes(
         &mut self,
         mappings: Vec<(ClusterId, &str, GlobalId)>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         if mappings.is_empty() {
             return Ok(());
         }
@@ -1044,7 +1055,7 @@ impl DurableCatalogState for Connection {
         name: String,
         config: ReplicaConfig,
         owner_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let key = ClusterReplicaKey { id: replica_id }.into_proto();
         let val = ClusterReplicaValue {
             cluster_id,
@@ -1054,7 +1065,7 @@ impl DurableCatalogState for Connection {
         }
         .into_proto();
         CLUSTER_REPLICA_COLLECTION
-            .upsert_key(&mut self.stash, key, |_| Ok::<_, Error>(val))
+            .upsert_key(&mut self.stash, key, |_| Ok::<_, CatalogError>(val))
             .await??;
         Ok(())
     }
@@ -1064,13 +1075,13 @@ impl DurableCatalogState for Connection {
         &mut self,
         timeline: &Timeline,
         timestamp: Timestamp,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let key = proto::TimestampKey {
             id: timeline.to_string(),
         };
         let (prev, next) = TIMESTAMP_COLLECTION
             .upsert_key(&mut self.stash, key, move |_| {
-                Ok::<_, Error>(TimestampValue { ts: timestamp }.into_proto())
+                Ok::<_, CatalogError>(TimestampValue { ts: timestamp }.into_proto())
             })
             .await??;
         if let Some(prev) = prev {
@@ -1080,7 +1091,7 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn set_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), Error> {
+    async fn set_deploy_generation(&mut self, deploy_generation: u64) -> Result<(), CatalogError> {
         CONFIG_COLLECTION
             .upsert_key(
                 &mut self.stash,
@@ -1088,7 +1099,7 @@ impl DurableCatalogState for Connection {
                     key: DEPLOY_GENERATION.into(),
                 },
                 move |_| {
-                    Ok::<_, Error>(proto::ConfigValue {
+                    Ok::<_, CatalogError>(proto::ConfigValue {
                         value: deploy_generation,
                     })
                 },
@@ -1098,7 +1109,7 @@ impl DurableCatalogState for Connection {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, Error> {
+    async fn allocate_id(&mut self, id_type: &str, amount: u64) -> Result<Vec<u64>, CatalogError> {
         if amount == 0 {
             return Ok(Vec::new());
         }
@@ -1111,7 +1122,7 @@ impl DurableCatalogState for Connection {
                 let id = prev.expect("must exist").next_id;
                 match id.checked_add(amount) {
                     Some(next_gid) => Ok(IdAllocValue { next_id: next_gid }.into_proto()),
-                    None => Err(Error::from(SqlCatalogError::IdExhaustion)),
+                    None => Err(CatalogError::from(SqlCatalogError::IdExhaustion)),
                 }
             })
             .await??;
@@ -1172,7 +1183,7 @@ impl OpenableDurableCatalogState<Connection> for DebugOpenableConnection<'_> {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.openable_connection
             .open_savepoint(now, bootstrap_args, deploy_generation)
             .await
@@ -1182,7 +1193,7 @@ impl OpenableDurableCatalogState<Connection> for DebugOpenableConnection<'_> {
         &mut self,
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.openable_connection
             .open_read_only(now, bootstrap_args)
             .await
@@ -1193,17 +1204,17 @@ impl OpenableDurableCatalogState<Connection> for DebugOpenableConnection<'_> {
         now: NowFn,
         bootstrap_args: &BootstrapArgs,
         deploy_generation: Option<u64>,
-    ) -> Result<Connection, Error> {
+    ) -> Result<Connection, CatalogError> {
         self.openable_connection
             .open(now, bootstrap_args, deploy_generation)
             .await
     }
 
-    async fn is_initialized(&mut self) -> Result<bool, Error> {
+    async fn is_initialized(&mut self) -> Result<bool, CatalogError> {
         self.openable_connection.is_initialized().await
     }
 
-    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, Error> {
+    async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         self.openable_connection.get_deployment_generation().await
     }
 }

--- a/src/catalog/src/transaction.rs
+++ b/src/catalog/src/transaction.rs
@@ -20,9 +20,9 @@ use crate::objects::{
 };
 use crate::objects::{ClusterConfig, ClusterVariant};
 use crate::{
-    BootstrapArgs, DurableCatalogState, Error, ReplicaLocation, Snapshot, DATABASE_ID_ALLOC_KEY,
-    SCHEMA_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY, SYSTEM_REPLICA_ID_ALLOC_KEY,
-    USER_ROLE_ID_ALLOC_KEY,
+    BootstrapArgs, CatalogError, DurableCatalogState, ReplicaLocation, Snapshot,
+    DATABASE_ID_ALLOC_KEY, SCHEMA_ID_ALLOC_KEY, SYSTEM_CLUSTER_ID_ALLOC_KEY,
+    SYSTEM_REPLICA_ID_ALLOC_KEY, USER_ROLE_ID_ALLOC_KEY,
 };
 use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
@@ -44,7 +44,9 @@ use mz_storage_types::sources::Timeline;
 use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
-pub(crate) fn add_new_builtin_clusters_migration(txn: &mut Transaction<'_>) -> Result<(), Error> {
+pub(crate) fn add_new_builtin_clusters_migration(
+    txn: &mut Transaction<'_>,
+) -> Result<(), CatalogError> {
     let cluster_names: BTreeSet<_> = txn
         .clusters
         .items()
@@ -74,7 +76,7 @@ pub(crate) fn add_new_builtin_clusters_migration(txn: &mut Transaction<'_>) -> R
 pub(crate) fn add_new_builtin_cluster_replicas_migration(
     txn: &mut Transaction<'_>,
     bootstrap_args: &BootstrapArgs,
-) -> Result<(), Error> {
+) -> Result<(), CatalogError> {
     let cluster_lookup: BTreeMap<_, _> = txn
         .clusters
         .items()
@@ -185,7 +187,7 @@ impl<'a> Transaction<'a> {
             default_privileges,
             system_privileges,
         }: Snapshot,
-    ) -> Result<Transaction, Error> {
+    ) -> Result<Transaction, CatalogError> {
         Ok(Transaction {
             durable_catalog,
             databases: TableTransaction::new(databases, |a: &DatabaseValue, b| a.name == b.name)?,
@@ -240,7 +242,7 @@ impl<'a> Transaction<'a> {
         database_name: &str,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
-    ) -> Result<DatabaseId, Error> {
+    ) -> Result<DatabaseId, CatalogError> {
         let id = self.get_and_increment_id(DATABASE_ID_ALLOC_KEY.to_string())?;
         // TODO(parkertimmerman): Support creating databases in the System namespace.
         let id = DatabaseId::User(id);
@@ -254,7 +256,7 @@ impl<'a> Transaction<'a> {
         database_name: &str,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         match self.databases.insert(
             DatabaseKey { id },
             DatabaseValue {
@@ -274,7 +276,7 @@ impl<'a> Transaction<'a> {
         schema_name: &str,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
-    ) -> Result<SchemaId, Error> {
+    ) -> Result<SchemaId, CatalogError> {
         let id = self.get_and_increment_id(SCHEMA_ID_ALLOC_KEY.to_string())?;
         // TODO(parkertimmerman): Support creating schemas in the System namespace.
         let id = SchemaId::User(id);
@@ -295,7 +297,7 @@ impl<'a> Transaction<'a> {
         schema_name: String,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         match self.schemas.insert(
             SchemaKey { id: schema_id },
             SchemaValue {
@@ -316,7 +318,7 @@ impl<'a> Transaction<'a> {
         attributes: RoleAttributes,
         membership: RoleMembership,
         vars: RoleVars,
-    ) -> Result<RoleId, Error> {
+    ) -> Result<RoleId, CatalogError> {
         let id = self.get_and_increment_id(USER_ROLE_ID_ALLOC_KEY.to_string())?;
         let id = RoleId::User(id);
         self.insert_role(id, name, attributes, membership, vars)?;
@@ -330,7 +332,7 @@ impl<'a> Transaction<'a> {
         attributes: RoleAttributes,
         membership: RoleMembership,
         vars: RoleVars,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         match self.roles.insert(
             RoleKey { id },
             RoleValue {
@@ -355,7 +357,7 @@ impl<'a> Transaction<'a> {
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
         config: ClusterConfig,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         self.insert_cluster(
             cluster_id,
             cluster_name,
@@ -375,7 +377,7 @@ impl<'a> Transaction<'a> {
         introspection_source_indexes: Vec<(&'static BuiltinLog, GlobalId)>,
         privileges: Vec<MzAclItem>,
         config: ClusterConfig,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         self.insert_cluster(
             cluster_id,
             cluster_name,
@@ -396,7 +398,7 @@ impl<'a> Transaction<'a> {
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
         config: ClusterConfig,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         if let Err(_) = self.clusters.insert(
             ClusterKey { id: cluster_id },
             ClusterValue {
@@ -435,7 +437,7 @@ impl<'a> Transaction<'a> {
         cluster_id: ClusterId,
         cluster_name: &str,
         cluster_to_name: &str,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let key = ClusterKey { id: cluster_id };
 
         match self.clusters.update(|k, v| {
@@ -455,7 +457,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn check_migration_has_run(&mut self, name: String) -> Result<bool, Error> {
+    pub fn check_migration_has_run(&mut self, name: String) -> Result<bool, CatalogError> {
         let key = SettingKey { name };
         // If the key does not exist, then the migration has not been run.
         let has_run = self.settings.get(&key).as_ref().is_some();
@@ -463,7 +465,7 @@ impl<'a> Transaction<'a> {
         Ok(has_run)
     }
 
-    pub fn mark_migration_has_run(&mut self, name: String) -> Result<(), Error> {
+    pub fn mark_migration_has_run(&mut self, name: String) -> Result<(), CatalogError> {
         let key = SettingKey { name };
         let val = SettingValue {
             value: true.to_string(),
@@ -478,7 +480,7 @@ impl<'a> Transaction<'a> {
         replica_id: ReplicaId,
         replica_name: &QualifiedReplica,
         replica_to_name: &str,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let key = ClusterReplicaKey { id: replica_id };
 
         match self.cluster_replicas.update(|k, v| {
@@ -505,7 +507,7 @@ impl<'a> Transaction<'a> {
         replica_name: &str,
         config: ReplicaConfig,
         owner_id: RoleId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         if let Err(_) = self.cluster_replicas.insert(
             ClusterReplicaKey { id: replica_id },
             ClusterReplicaValue {
@@ -535,7 +537,7 @@ impl<'a> Transaction<'a> {
     pub fn update_introspection_source_index_gids(
         &mut self,
         mappings: impl Iterator<Item = (ClusterId, impl Iterator<Item = (String, GlobalId)>)>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         for (cluster_id, updates) in mappings {
             for (name, id) in updates {
                 let index_id = if let GlobalId::System(index_id) = id {
@@ -565,7 +567,7 @@ impl<'a> Transaction<'a> {
         create_sql: String,
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         match self.items.insert(
             ItemKey { gid: id },
             ItemValue {
@@ -585,7 +587,7 @@ impl<'a> Transaction<'a> {
         &mut self,
         timeline: Timeline,
         ts: mz_repr::Timestamp,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         match self.timestamps.insert(
             TimestampKey {
                 id: timeline.to_string(),
@@ -597,7 +599,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn get_and_increment_id(&mut self, key: String) -> Result<u64, Error> {
+    pub fn get_and_increment_id(&mut self, key: String) -> Result<u64, CatalogError> {
         let id = self
             .id_allocator
             .items()
@@ -612,7 +614,11 @@ impl<'a> Transaction<'a> {
         Ok(id)
     }
 
-    pub(crate) fn insert_id_allocator(&mut self, name: String, next_id: u64) -> Result<(), Error> {
+    pub(crate) fn insert_id_allocator(
+        &mut self,
+        name: String,
+        next_id: u64,
+    ) -> Result<(), CatalogError> {
         match self
             .id_allocator
             .insert(IdAllocKey { name: name.clone() }, IdAllocValue { next_id })
@@ -622,7 +628,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn remove_database(&mut self, id: &DatabaseId) -> Result<(), Error> {
+    pub fn remove_database(&mut self, id: &DatabaseId) -> Result<(), CatalogError> {
         let prev = self.databases.set(DatabaseKey { id: *id }, None)?;
         if prev.is_some() {
             Ok(())
@@ -635,7 +641,7 @@ impl<'a> Transaction<'a> {
         &mut self,
         database_id: &Option<DatabaseId>,
         schema_id: &SchemaId,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let prev = self.schemas.set(SchemaKey { id: *schema_id }, None)?;
         if prev.is_some() {
             Ok(())
@@ -648,7 +654,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn remove_role(&mut self, name: &str) -> Result<(), Error> {
+    pub fn remove_role(&mut self, name: &str) -> Result<(), CatalogError> {
         let roles = self.roles.delete(|_k, v| v.name == name);
         assert!(
             roles.iter().all(|(k, _)| k.id.is_user()),
@@ -663,7 +669,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn remove_cluster(&mut self, id: ClusterId) -> Result<(), Error> {
+    pub fn remove_cluster(&mut self, id: ClusterId) -> Result<(), CatalogError> {
         let deleted = self.clusters.delete(|k, _v| k.id == id);
         if deleted.is_empty() {
             Err(SqlCatalogError::UnknownCluster(id.to_string()).into())
@@ -681,7 +687,7 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    pub fn remove_cluster_replica(&mut self, id: ReplicaId) -> Result<(), Error> {
+    pub fn remove_cluster_replica(&mut self, id: ReplicaId) -> Result<(), CatalogError> {
         let deleted = self.cluster_replicas.delete(|k, _v| k.id == id);
         if deleted.len() == 1 {
             Ok(())
@@ -697,7 +703,7 @@ impl<'a> Transaction<'a> {
     ///
     /// Runtime is linear with respect to the total number of items in the stash.
     /// DO NOT call this function in a loop, use [`Self::remove_items`] instead.
-    pub fn remove_item(&mut self, id: GlobalId) -> Result<(), Error> {
+    pub fn remove_item(&mut self, id: GlobalId) -> Result<(), CatalogError> {
         let prev = self.items.set(ItemKey { gid: id }, None)?;
         if prev.is_some() {
             Ok(())
@@ -712,7 +718,7 @@ impl<'a> Transaction<'a> {
     ///
     /// NOTE: On error, there still may be some items removed from the transaction. It is
     /// up to the called to either abort the transaction or commit.
-    pub fn remove_items(&mut self, ids: BTreeSet<GlobalId>) -> Result<(), Error> {
+    pub fn remove_items(&mut self, ids: BTreeSet<GlobalId>) -> Result<(), CatalogError> {
         let n = self.items.delete(|k, _v| ids.contains(&k.gid)).len();
         if n == ids.len() {
             Ok(())
@@ -729,7 +735,7 @@ impl<'a> Transaction<'a> {
     ///
     /// Runtime is linear with respect to the total number of items in the stash.
     /// DO NOT call this function in a loop, use [`Self::update_items`] instead.
-    pub fn update_item(&mut self, id: GlobalId, item: Item) -> Result<(), Error> {
+    pub fn update_item(&mut self, id: GlobalId, item: Item) -> Result<(), CatalogError> {
         let n = self.items.update(|k, v| {
             if k.gid == id {
                 let item = item.clone();
@@ -756,7 +762,7 @@ impl<'a> Transaction<'a> {
     ///
     /// NOTE: On error, there still may be some items updated in the transaction. It is
     /// up to the called to either abort the transaction or commit.
-    pub fn update_items(&mut self, items: BTreeMap<GlobalId, Item>) -> Result<(), Error> {
+    pub fn update_items(&mut self, items: BTreeMap<GlobalId, Item>) -> Result<(), CatalogError> {
         let n = self.items.update(|k, v| {
             if let Some(item) = items.get(&k.gid) {
                 // Schema IDs cannot change.
@@ -785,7 +791,7 @@ impl<'a> Transaction<'a> {
     /// Runtime is linear with respect to the total number of items in the stash.
     /// DO NOT call this function in a loop, implement and use some `Self::update_roles` instead.
     /// You should model it after [`Self::update_items`].
-    pub fn update_role(&mut self, id: RoleId, role: Role) -> Result<(), Error> {
+    pub fn update_role(&mut self, id: RoleId, role: Role) -> Result<(), CatalogError> {
         let n = self.roles.update(move |k, _v| {
             if k.id == id {
                 let role = role.clone();
@@ -810,7 +816,7 @@ impl<'a> Transaction<'a> {
     pub fn update_system_object_mappings(
         &mut self,
         mappings: BTreeMap<GlobalId, SystemObjectMapping>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let n = self.system_gid_mapping.update(|_k, v| {
             if let Some(mapping) = mappings.get(&GlobalId::System(v.id)) {
                 let (_, new_value) = mapping.clone().into_key_value();
@@ -834,7 +840,7 @@ impl<'a> Transaction<'a> {
     ///
     /// Runtime is linear with respect to the total number of clusters in the stash.
     /// DO NOT call this function in a loop.
-    pub fn update_cluster(&mut self, id: ClusterId, cluster: Cluster) -> Result<(), Error> {
+    pub fn update_cluster(&mut self, id: ClusterId, cluster: Cluster) -> Result<(), CatalogError> {
         let n = self.clusters.update(|k, _v| {
             if k.id == id {
                 let (_, new_value) = cluster.clone().into_key_value();
@@ -861,7 +867,7 @@ impl<'a> Transaction<'a> {
         &mut self,
         replica_id: ReplicaId,
         replica: ClusterReplica,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let n = self.cluster_replicas.update(|k, _v| {
             if k.id == replica_id {
                 let (_, new_value) = replica.clone().into_key_value();
@@ -884,7 +890,11 @@ impl<'a> Transaction<'a> {
     ///
     /// Runtime is linear with respect to the total number of databases in the stash.
     /// DO NOT call this function in a loop.
-    pub fn update_database(&mut self, id: DatabaseId, database: Database) -> Result<(), Error> {
+    pub fn update_database(
+        &mut self,
+        id: DatabaseId,
+        database: Database,
+    ) -> Result<(), CatalogError> {
         let n = self.databases.update(|k, _v| {
             if id == k.id {
                 let (_, new_value) = database.clone().into_key_value();
@@ -907,7 +917,11 @@ impl<'a> Transaction<'a> {
     ///
     /// Runtime is linear with respect to the total number of schemas in the stash.
     /// DO NOT call this function in a loop.
-    pub fn update_schema(&mut self, schema_id: SchemaId, schema: Schema) -> Result<(), Error> {
+    pub fn update_schema(
+        &mut self,
+        schema_id: SchemaId,
+        schema: Schema,
+    ) -> Result<(), CatalogError> {
         let n = self.schemas.update(|k, _v| {
             if schema_id == k.id {
                 let schema = schema.clone();
@@ -934,7 +948,7 @@ impl<'a> Transaction<'a> {
         object_type: ObjectType,
         grantee: RoleId,
         privileges: Option<AclMode>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         self.default_privileges.set(
             DefaultPrivilegesKey {
                 role_id,
@@ -954,7 +968,7 @@ impl<'a> Transaction<'a> {
         grantee: RoleId,
         grantor: RoleId,
         acl_mode: Option<AclMode>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         self.system_privileges.set(
             SystemPrivilegesKey { grantee, grantor },
             acl_mode.map(|acl_mode| SystemPrivilegesValue { acl_mode }),
@@ -967,7 +981,7 @@ impl<'a> Transaction<'a> {
         object_id: CommentObjectId,
         sub_component: Option<usize>,
         comment: Option<String>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), CatalogError> {
         let key = CommentKey {
             object_id,
             sub_component,
@@ -981,7 +995,7 @@ impl<'a> Transaction<'a> {
     pub fn drop_comments(
         &mut self,
         object_id: CommentObjectId,
-    ) -> Result<Vec<(CommentObjectId, Option<usize>, String)>, Error> {
+    ) -> Result<Vec<(CommentObjectId, Option<usize>, String)>, CatalogError> {
         let deleted = self.comments.delete(|k, _v| k.object_id == object_id);
         let deleted = deleted
             .into_iter()
@@ -991,7 +1005,7 @@ impl<'a> Transaction<'a> {
     }
 
     /// Upserts persisted system configuration `name` to `value`.
-    pub fn upsert_system_config(&mut self, name: &str, value: String) -> Result<(), Error> {
+    pub fn upsert_system_config(&mut self, name: &str, value: String) -> Result<(), CatalogError> {
         let key = ServerConfigurationKey {
             name: name.to_string(),
         };
@@ -1024,7 +1038,7 @@ impl<'a> Transaction<'a> {
         assert!(prev.is_some());
     }
 
-    pub(crate) fn insert_config(&mut self, key: String, value: u64) -> Result<(), Error> {
+    pub(crate) fn insert_config(&mut self, key: String, value: u64) -> Result<(), CatalogError> {
         match self
             .configs
             .insert(ConfigKey { key: key.clone() }, ConfigValue { value })
@@ -1039,7 +1053,7 @@ impl<'a> Transaction<'a> {
     /// must be fatal to the calling process. We do not panic/halt inside this function itself so
     /// that errors can bubble up during initialization.
     #[tracing::instrument(level = "debug", skip_all)]
-    pub async fn commit(self) -> Result<(), Error> {
+    pub async fn commit(self) -> Result<(), CatalogError> {
         let txn_batch = TransactionBatch {
             databases: self.databases.pending(),
             schemas: self.schemas.pending(),

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -87,8 +87,8 @@
 // END LINT CONFIG
 
 use mz_catalog::{
-    debug_stash_backed_catalog_state, stash_backed_catalog_state, BootstrapArgs,
-    DurableCatalogState, Error, OpenableDurableCatalogState, StashConfig,
+    debug_stash_backed_catalog_state, stash_backed_catalog_state, BootstrapArgs, CatalogError,
+    DurableCatalogState, OpenableDurableCatalogState, StashConfig,
 };
 use mz_ore::now::SYSTEM_TIME;
 use mz_repr::role_id::RoleId;
@@ -209,8 +209,8 @@ async fn open_check<D: DurableCatalogState>(
             .await
             .unwrap_err();
         match err {
-            Error::Catalog(_) => panic!("unexpected catalog error"),
-            Error::Stash(e) => assert!(e.can_recover_with_write_mode()),
+            CatalogError::Catalog(_) => panic!("unexpected catalog error"),
+            CatalogError::Durable(e) => assert!(e.can_recover_with_write_mode()),
         }
 
         // Initialize the stash.
@@ -286,8 +286,8 @@ async fn open_read_only<D: DurableCatalogState>(
         .await
         .unwrap_err();
     match err {
-        Error::Catalog(_) => panic!("unexpected catalog error"),
-        Error::Stash(e) => assert!(e.can_recover_with_write_mode()),
+        CatalogError::Catalog(_) => panic!("unexpected catalog error"),
+        CatalogError::Durable(e) => assert!(e.can_recover_with_write_mode()),
     }
 
     // Initialize the stash.


### PR DESCRIPTION
This commit makes the durable catalog errors in the mz_catalog crate more generic by mostly removing all mention of the stash from them. The adapter now does not ever directly deal with StashErrors. This allows us to return more generic errors from other durable catalog implementations.

Works towards resolving #20953

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
