### PR TITLE
fix SQL persistence for materialized view with ASSERT NOT NULL

### DIFF
--- a/misc/python/materialize/checks/materialized_views.py
+++ b/misc/python/materialize/checks/materialized_views.py
@@ -10,6 +10,8 @@ from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
+from materialize.util import MzVersion
 
 
 class MaterializedViews(Check):
@@ -62,6 +64,86 @@ class MaterializedViews(Check):
                 T1B 10000
                 T2B 10000
                 T3B 10000
+           """
+            )
+        )
+
+
+class MaterializedViewsAssertNotNull(Check):
+    def _can_run(self, e: Executor) -> bool:
+        # CREATE ROLE not compatible with older releases
+        return self.base_version >= MzVersion.parse("0.73.0-dev")
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > CREATE TABLE not_null_table (x INT, y INT, z INT);
+                > INSERT INTO not_null_table VALUES (NULL, 2, 3), (4, NULL, 6), (7, 8, NULL);
+                > CREATE MATERIALIZED VIEW not_null_view1 WITH (ASSERT NOT NULL x) AS SELECT * FROM not_null_table;
+            """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(dedent(s))
+            for s in [
+                """
+                > CREATE MATERIALIZED VIEW not_null_view2 WITH (ASSERT NOT NULL y) AS SELECT * FROM not_null_table;
+                > INSERT INTO not_null_table VALUES (NULL, 12, 13), (14, NULL, 16), (17, 18, NULL);
+                """,
+                """
+                > CREATE MATERIALIZED VIEW not_null_view3 WITH (ASSERT NOT NULL z) AS SELECT * FROM not_null_table;
+                > INSERT INTO not_null_table VALUES (NULL, 22, 23), (24, NULL, 26), (27, 28, NULL);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                ! SELECT * FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3
+                contains: column 3 must not be null
+
+                > DELETE FROM not_null_table WHERE x IS NULL;
+
+                > SELECT * FROM not_null_view1
+                4 <null> 6
+                7 8 <null>
+                14 <null> 16
+                17 18 <null>
+                24 <null> 26
+                27 28 <null>
+
+                > DELETE FROM not_null_table WHERE y IS NULL;
+
+                > SELECT * FROM not_null_view2
+                7 8 <null>
+                17 18 <null>
+                27 28 <null>
+
+                > DELETE FROM not_null_table WHERE z IS NULL;
+
+                > SELECT * FROM not_null_view3
+
+                > INSERT INTO not_null_table VALUES (NULL, 2, 3), (4, NULL, 6), (7, 8, NULL);
+
+                ! SELECT * FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3
+                contains: column 3 must not be null
            """
             )
         )

--- a/misc/python/materialize/checks/materialized_views.py
+++ b/misc/python/materialize/checks/materialized_views.py
@@ -113,6 +113,24 @@ class MaterializedViewsAssertNotNull(Check):
                 ! SELECT * FROM not_null_view3
                 contains: column 3 must not be null
 
+                ! SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+                contains: column 1 must not be null
+
+                ! SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+                contains: column 2 must not be null
+
+                ! SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+                contains: column 3 must not be null
+
+                ! SELECT y FROM not_null_view1
+                contains: column 1 must not be null
+
+                ! SELECT z FROM not_null_view2
+                contains: column 2 must not be null
+
+                ! SELECT x FROM not_null_view3
+                contains: column 3 must not be null
+
                 > DELETE FROM not_null_table WHERE x IS NULL;
 
                 > SELECT * FROM not_null_view1
@@ -132,9 +150,25 @@ class MaterializedViewsAssertNotNull(Check):
 
                 > DELETE FROM not_null_table WHERE z IS NULL;
 
+                ? EXPLAIN SELECT * FROM not_null_view1 WHERE x IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view1
+
+                ? EXPLAIN SELECT * FROM not_null_view2 WHERE y IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view2
+
+                ? EXPLAIN SELECT * FROM not_null_view3 WHERE z IS NOT NULL
+                Explained Query:
+                  ReadStorage materialize.public.not_null_view3
+
                 > SELECT * FROM not_null_view3
 
                 > INSERT INTO not_null_table VALUES (NULL, 2, 3), (4, NULL, 6), (7, 8, NULL);
+
+                > INSERT INTO not_null_table VALUES (NULL, 12, 13), (14, NULL, 16), (17, 18, NULL);
+
+                > INSERT INTO not_null_table VALUES (NULL, 22, 23), (24, NULL, 26), (27, 28, NULL);
 
                 ! SELECT * FROM not_null_view1
                 contains: column 1 must not be null

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -1269,6 +1269,18 @@ impl<T: AstInfo> AstDisplay for CreateMaterializedViewStatement<T> {
             f.write_node(cluster);
         }
 
+        if !self.non_null_assertions.is_empty() {
+            f.write_str(" WITH (");
+            for (i, nna) in self.non_null_assertions.iter().enumerate() {
+                f.write_str("ASSERT NOT NULL ");
+                f.write_node(nna);
+                if i + 1 != self.non_null_assertions.len() {
+                    f.write_str(", ")
+                }
+            }
+            f.write_str(")");
+        }
+
         f.write_str(" AS ");
         f.write_node(&self.query);
     }


### PR DESCRIPTION


### Motivation

  * This PR fixes a recognized bug.

    Discovered by @def- while testing: https://github.com/MaterializeInc/materialize/pull/22339

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.

This PR does NOT have adequate test coverage by itself, but this companion PR: https://github.com/MaterializeInc/materialize/pull/22339 should have adequate coverage.

- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes a bug where `ASSERT NOT NULL` options on materialized views were not persisted across restart of the environment.
