### PR TITLE
catalog: Remove Option from epoch API

### DIFF
--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -235,10 +235,8 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     /// guaranteed that no two [`DurableCatalogState`]s will return the same value
     /// for their epoch.
     ///
-    /// None is returned if the catalog hasn't been opened yet.
-    ///
     /// NB: We may remove this in later iterations of Pv2.
-    fn epoch(&mut self) -> Option<NonZeroI64>;
+    fn epoch(&mut self) -> NonZeroI64;
 
     /// Returns the version of Materialize that last wrote to the catalog.
     ///

--- a/src/catalog/src/stash.rs
+++ b/src/catalog/src/stash.rs
@@ -419,8 +419,10 @@ impl Connection {
 
 #[async_trait]
 impl ReadOnlyDurableCatalogState for Connection {
-    fn epoch(&mut self) -> Option<NonZeroI64> {
-        self.stash.epoch()
+    fn epoch(&mut self) -> NonZeroI64 {
+        self.stash
+            .epoch()
+            .expect("a opened stash should always have an epoch number")
     }
 
     async fn get_catalog_content_version(&mut self) -> Result<Option<String>, Error> {

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -93,6 +93,7 @@ use mz_catalog::{
 use mz_ore::now::SYSTEM_TIME;
 use mz_repr::role_id::RoleId;
 use mz_stash::DebugStashFactory;
+use std::num::NonZeroI64;
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
@@ -183,27 +184,27 @@ async fn get_deployment_generation<D: DurableCatalogState>(
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-async fn test_open_check() {
+async fn test_open_savepoint() {
     let (debug_factory, stash_config) = stash_config().await;
     let openable_state = stash_backed_catalog_state(stash_config);
-    open_check(openable_state).await;
+    open_savepoint(openable_state).await;
     debug_factory.drop().await;
 }
 
 #[mz_ore::test(tokio::test)]
 #[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
-async fn test_debug_open_check() {
+async fn test_debug_open_savepoint() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state = debug_stash_backed_catalog_state(&debug_factory);
-    open_check(debug_openable_state).await;
+    open_savepoint(debug_openable_state).await;
     debug_factory.drop().await;
 }
 
-async fn open_check<D: DurableCatalogState>(
+async fn open_savepoint<D: DurableCatalogState>(
     mut openable_state: impl OpenableDurableCatalogState<D>,
 ) {
     {
-        // Can't open a read-only stash until it's been initialized.
+        // Can't open a savepoint catalog until it's been initialized.
         let err = openable_state
             .open_savepoint(SYSTEM_TIME.clone(), &bootstrap_args(), None)
             .await
@@ -215,10 +216,14 @@ async fn open_check<D: DurableCatalogState>(
 
         // Initialize the stash.
         {
-            let _ = openable_state
+            let mut state = openable_state
                 .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
                 .await
                 .unwrap();
+            assert_eq!(
+                state.epoch(),
+                NonZeroI64::new(2).expect("known to be non-zero")
+            );
         }
 
         // Open catalog in check mode.
@@ -226,6 +231,11 @@ async fn open_check<D: DurableCatalogState>(
             .open_savepoint(SYSTEM_TIME.clone(), &bootstrap_args(), None)
             .await
             .unwrap();
+        // Savepoint catalogs do not increment the epoch.
+        assert_eq!(
+            state.epoch(),
+            NonZeroI64::new(2).expect("known to be non-zero")
+        );
 
         // Perform write.
         let mut txn = state.transaction().await.unwrap();
@@ -292,16 +302,25 @@ async fn open_read_only<D: DurableCatalogState>(
 
     // Initialize the stash.
     {
-        let _ = openable_state
+        let mut state = openable_state
             .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
             .await
             .unwrap();
+        assert_eq!(
+            state.epoch(),
+            NonZeroI64::new(2).expect("known to be non-zero")
+        );
     }
 
     let mut state = openable_state
         .open_read_only(SYSTEM_TIME.clone(), &bootstrap_args())
         .await
         .unwrap();
+    // Read-only catalogs do not increment the epoch.
+    assert_eq!(
+        state.epoch(),
+        NonZeroI64::new(2).expect("known to be non-zero")
+    );
     let err = state.set_deploy_generation(42).await.unwrap_err();
     assert!(err
         .to_string()
@@ -327,14 +346,32 @@ async fn test_debug_open() {
 }
 
 async fn open<D: DurableCatalogState>(mut openable_state: impl OpenableDurableCatalogState<D>) {
-    let mut state = openable_state
-        .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
-        .await
-        .unwrap();
+    {
+        let mut state = openable_state
+            .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
+            .await
+            .unwrap();
 
-    // Check for initial clusters to ensure the catalog was opened properly.
-    let clusters = state.get_clusters().await.unwrap();
-    assert_eq!(clusters.len(), 3);
+        assert_eq!(
+            state.epoch(),
+            NonZeroI64::new(2).expect("known to be non-zero")
+        );
+        // Check for initial clusters to ensure the catalog was opened properly.
+        let clusters = state.get_clusters().await.unwrap();
+        assert_eq!(clusters.len(), 3);
+    }
+    // Reopening the catalog will increment the epoch.
+    {
+        let mut state = openable_state
+            .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            state.epoch(),
+            NonZeroI64::new(3).expect("known to be non-zero")
+        );
+    }
 }
 
 async fn stash_config() -> (DebugStashFactory, StashConfig) {

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -433,9 +433,7 @@ impl Listeners {
         {
             bail!("bootstrap default cluster replica size is unknown");
         }
-        let envd_epoch = adapter_storage
-            .epoch()
-            .expect("a real environmentd should always have an epoch number");
+        let envd_epoch = adapter_storage.epoch();
 
         // Initialize storage usage client.
         let storage_usage_client = StorageUsageClient::open(


### PR DESCRIPTION
This commit updates the `epoch()` method in `DurableCatalogState` to remove the `Option`. Opened catalogs will always have an epoch, and will never return `None` from `epoch()`. The only way to get an instance of `DurableCatalogState` is by opening the catalog. Therefore, there's no reason to return an `Option` from `epoch()`.

### Motivation
 This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
