### PR TITLE
ci: Save services.log when downing composition

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -49,6 +49,7 @@ fi
 
 ci_collapsed_heading ":docker: Purging all existing docker containers and volumes, regardless of origin"
 docker ps --all --quiet | xargs --no-run-if-empty docker rm --force --volumes
+rm -f services.log
 
 ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
 mzcompose --mz-quiet build

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -62,7 +62,8 @@ fi
 
 ci_unimportant_heading "Upload log artifacts"
 
-run logs --no-color > services.log
+# services.log might already exist and contain logs from before composition was downed
+run logs --no-color >> services.log
 # shellcheck disable=SC2024
 sudo journalctl --merge --since "$(cat step_start_timestamp)" > journalctl-merge.log
 netstat -ant > netstat-ant.log

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -33,7 +33,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from inspect import Traceback, getframeinfo, getmembers, isfunction, stack
 from tempfile import TemporaryFile
-from typing import Any, cast
+from typing import Any, TextIO, cast
 
 import pg8000
 import sqlparse
@@ -243,8 +243,8 @@ class Composition:
     def invoke(
         self,
         *args: str,
-        capture: bool = False,
-        capture_stderr: bool = False,
+        capture: bool | TextIO = False,
+        capture_stderr: bool | TextIO = False,
         stdin: str | None = None,
         check: bool = True,
         max_tries: int = 1,
@@ -253,8 +253,10 @@ class Composition:
 
         Args:
             args: The arguments to pass to `docker compose`.
-            capture: Whether to capture the child's stdout stream.
-            capture_stderr: Whether to capture the child's stderr stream.
+            capture: Whether to capture the child's stdout stream, can be an
+                opened file to capture stdout into the file directly.
+            capture_stderr: Whether to capture the child's stderr stream, can
+                be an opened file to capture stderr into the file directly.
             input: A string to provide as stdin for the command.
         """
 
@@ -265,10 +267,10 @@ class Composition:
 
         stdout = None
         if capture:
-            stdout = subprocess.PIPE
+            stdout = subprocess.PIPE if capture == True else capture
         stderr = None
         if capture_stderr:
-            stderr = subprocess.PIPE
+            stderr = subprocess.PIPE if capture_stderr == True else capture_stderr
         project_name_args = (
             ("--project-name", self.project_name) if self.project_name else ()
         )
@@ -775,9 +777,10 @@ class Composition:
         if sanity_restart_mz:
             self.sanity_restart_mz()
 
-        logs = self.invoke("logs", "--no-color", capture=True).stdout
+        # Capture logs into services.log since they will be lost otherwise
+        # after dowing a composition.
         with open(MZ_ROOT / "services.log", "a") as f:
-            f.write(logs)
+            self.invoke("logs", "--no-color", capture=f)
 
         self.invoke(
             "down",

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -40,7 +40,7 @@ import sqlparse
 import yaml
 from pg8000 import Connection, Cursor
 
-from materialize import mzbuild, spawn, ui
+from materialize import MZ_ROOT, mzbuild, spawn, ui
 from materialize.mzcompose import loader
 from materialize.mzcompose.service import Service
 from materialize.ui import UIError
@@ -774,6 +774,10 @@ class Composition:
         """
         if sanity_restart_mz:
             self.sanity_restart_mz()
+
+        logs = self.invoke("logs", "--no-color", capture=True).stdout
+        with open(MZ_ROOT / "services.log", "a") as f:
+            f.write(logs)
 
         self.invoke(
             "down",

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -767,7 +767,7 @@ mod tests {
         let res = spawn(|| "test", async move {
             s.get::<(), (), u64, i64, _, _>(
                 s1,
-                || async { panic!("boom") },
+                || async { panic!("forced panic") },
                 &Diagnostics::for_tests(),
             )
             .await

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -239,7 +239,7 @@ def workflow_test_github_12251(c: Composition) -> None:
         SET statement_timeout = '1 s';
         CREATE TABLE IF NOT EXISTS log_table (f1 TEXT);
         CREATE TABLE IF NOT EXISTS panic_table (f1 TEXT);
-        INSERT INTO panic_table VALUES ('panic!');
+        INSERT INTO panic_table VALUES ('forced panic');
         -- Crash loop the cluster with the table's index
         INSERT INTO log_table SELECT mz_internal.mz_panic(f1) FROM panic_table;
         """

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -237,7 +237,7 @@ ALTER SYSTEM SET enable_unstable_dependencies = true;
   BODY FORMAT TEXT
   CHECK (
     WITH (HEADERS)
-    mz_internal.mz_panic('webhook panic test') = headers::text
+    mz_internal.mz_panic('forced panic') = headers::text
   );
 
 $ webhook-append name=webhook_validation_panic status=500


### PR DESCRIPTION
See discussion in https://materializeinc.slack.com/archives/C01LKF361MZ/p1697133686692179

Follow-up fixes in ci-logged-errors-detect

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
