### PR TITLE
ci: Enable assert not null by default

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -71,6 +71,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_jemalloc_profiling": "true",
     "enable_comment": "true",
     "enable_sink_doc_on_option": "true",
+    "enable_assert_not_null": "true",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -569,6 +569,11 @@ DROP CLUSTER other CASCADE
 
 # `ASSERT NOT NULL` in materialized views
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_assert_not_null to OFF;
+----
+COMPLETE 0
+
 ## Feature flag should be off by default
 statement error ASSERT NOT NULL for materialized views is not supported
 CREATE MATERIALIZED VIEW mv_feature_off(x) WITH (ASSERT NOT NULL x) AS VALUES (1);


### PR DESCRIPTION
Fixes broken tests: https://buildkite.com/materialize/tests/builds/65864#018b27d9-9050-4cbd-aa8d-fdb5fb697f34

Merge skew between https://github.com/MaterializeInc/materialize/pull/22353 and https://github.com/MaterializeInc/materialize/pull/22364

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
