### PR TITLE
Document contract on features for parsing

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3338,6 +3338,9 @@ impl Catalog {
         // [Catalog::open]. Existing catalog items might have been created while a
         // specific feature flag turned on, so we need to ensure that this is also the
         // case during catalog rehydration in order to avoid panics.
+        // WARNING / CONTRACT: The session catalog with all features enabled should be used
+        // exclusively for parsing and obtaining an mz_sql::plan::Plan. After this step,
+        // feature flag configuration must not be overridden.
         session_catalog.system_vars_mut().enable_all_feature_flags();
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -688,6 +688,9 @@ impl CatalogState {
         // [Catalog::open]. Existing catalog items might have been created while a
         // specific feature flag turned on, so we need to ensure that this is also the
         // case during catalog rehydration in order to avoid panics.
+        // WARNING / CONTRACT: The session catalog with all features enabled should be used
+        // exclusively for parsing and obtaining an an mz_sql::plan::Plan. After this step,
+        // feature flag configuration must not be overridden.
         session_catalog.system_vars_mut().enable_all_feature_flags();
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;


### PR DESCRIPTION
This commit adds comments documenting the expected contract for enabling all features when parsing catalog items, in particular during catalog open. Features must not be overridden after parsing and obtaining an mz_sql::plan::Plan.

### Motivation

   * This PR documents expectations in existing code.

### Tips for reviewer

See Slack threads: [1](https://materializeinc.slack.com/archives/C02FWJ94HME/p1697122283511199), [2](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1697111310746449).

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
