### PR TITLE
Improve error message when parsing cluster/replica names

### DIFF
--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3870,11 +3870,13 @@ impl<'a> Parser<'a> {
         let pos = self.peek_pos();
         let cluster = self.parse_identifier()?;
         if !self.consume_token(&Token::Dot) {
-            return self.expected(
+            self.prev_token();
+
+            self.expected(
                 pos,
                 format!("cluster_identifier.replica_identifier"),
-                Some(Token::Ident(cluster.to_string())),
-            );
+                self.peek_token(),
+            )
         } else {
             let replica = self.parse_identifier()?;
             Ok(QualifiedReplica { cluster, replica })

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3867,10 +3867,18 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_cluster_replica_name(&mut self) -> Result<QualifiedReplica, ParserError> {
+        let pos = self.peek_pos();
         let cluster = self.parse_identifier()?;
-        self.expect_token(&Token::Dot)?;
-        let replica = self.parse_identifier()?;
-        Ok(QualifiedReplica { cluster, replica })
+        if !self.consume_token(&Token::Dot) {
+            return self.expected(
+                pos,
+                format!("cluster_identifier.replica_identifier"),
+                Some(Token::Ident(cluster.to_string())),
+            );
+        } else {
+            let replica = self.parse_identifier()?;
+            Ok(QualifiedReplica { cluster, replica })
+        }
     }
 
     fn parse_create_table(&mut self) -> Result<Statement<Raw>, ParserError> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3867,13 +3867,12 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_cluster_replica_name(&mut self) -> Result<QualifiedReplica, ParserError> {
-        let pos = self.peek_pos();
         let cluster = self.parse_identifier()?;
         if !self.consume_token(&Token::Dot) {
             self.prev_token();
 
             self.expected(
-                pos,
+                self.peek_pos(),
                 "cluster_identifier.replica_identifier",
                 self.peek_token(),
             )

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -3874,7 +3874,7 @@ impl<'a> Parser<'a> {
 
             self.expected(
                 pos,
-                format!("cluster_identifier.replica_identifier"),
+                "cluster_identifier.replica_identifier",
                 self.peek_token(),
             )
         } else {

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -1771,9 +1771,9 @@ DropObjects(DropObjectsStatement { object_type: Cluster, if_exists: true, names:
 parse-statement
 DROP CLUSTER REPLICA r1, r2
 ----
-error: Expected dot, found comma
+error: Expected cluster_identifier.replica_identifier, found identifier "r1"
 DROP CLUSTER REPLICA r1, r2
-                       ^
+                     ^
 
 parse-statement
 DROP CLUSTER REPLICA IF EXISTS cluster.replica
@@ -1785,9 +1785,9 @@ DropObjects(DropObjectsStatement { object_type: ClusterReplica, if_exists: true,
 parse-statement
 DROP CLUSTER REPLICA IF EXISTS replica
 ----
-error: Expected dot, found EOF
+error: Expected cluster_identifier.replica_identifier, found REPLICA
 DROP CLUSTER REPLICA IF EXISTS replica
-                                      ^
+                               ^
 
 parse-statement
 DROP CLUSTER IF EXISTS cluster CASCADE

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -482,7 +482,7 @@ mz_system r1 1
 statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'
 
-statement error db error: ERROR: Expected dot, found RENAME
+statement error db error: ERROR: Expected cluster_identifier.replica_identifier, found DEFAULT
 ALTER CLUSTER REPLICA default RENAME TO bar_foo
 
 statement ok


### PR DESCRIPTION
The commit improves the parser error for when only a replica identifier is specified when a cluster identifier/replica identifier pair is expected. This has previously confused customers:

> I tried changing the name with alter cluster replica 'small_replica' rename to 'r1';  but this chucks back an error as well ERROR:  Expected dot, found RENAME. I tried using the cluster replica id and different arrangements of the quotation marks just to be sure

The commit changes the error from
```
staging > alter cluster replica small_replica rename to r1;
ERROR:  Expected dot, found RENAME
LINE 1: alter cluster replica small_replica rename to r1;
                                            ^
```
to
```
staging > alter cluster replica small_replica rename to r1;
ERROR:  Expected cluster_identifier.replica_identifier, found identifier "small_replica"
LINE 1: alter cluster replica small_replica rename to r1;
                              ^
```
### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
