### PR TITLE
docs: Add docs to default privileges

### DIFF
--- a/doc/user/content/sql/alter-default-privileges.md
+++ b/doc/user/content/sql/alter-default-privileges.md
@@ -20,7 +20,13 @@ themselves any privilege on an object that they own.
 
 The `REVOKE` variant of `ALTER DEFAULT PRIVILEGES` is used to revoke previously created default
 privileges on objects created in the future. It will not revoke any privileges on objects that have
-already been created.
+already been created. When revoking a default privilege, all the fields in the revoke statement
+(`target_role`, `schema_name`, `database_name`, `privilege`, `grantee`) must exactly match an
+existing default privilege. The existing default privileges can easily be viewed by the following
+query: `SELECT * FROM mz_internal.mz_show_default_privileges`.
+
+All new environments are created with a single default privilege, `USAGE` is granted on all `TYPES`
+to the `PUBLIC` role. This can be revoked like any other default privilege.
 
 ## Syntax
 


### PR DESCRIPTION

### Motivation
Add docs

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
