### PR TITLE
Use the new `Optimize` API for `CREATE INDEX`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1413,6 +1413,45 @@ impl Coordinator {
                             .entry(idx.cluster_id)
                             .or_insert_with(BTreeSet::new)
                             .insert(entry.id());
+                    } else if enable_unified_optimizer_api {
+                        let (mut df, df_metainfo) = self
+                            .dataflow_builder(idx.cluster_id)
+                            .build_index_dataflow(entry.id())?;
+
+                        // Note: ideally, the optimized_plan should be computed and
+                        // set when the CatalogItem is re-constructed (in
+                        // parse_item).
+                        //
+                        // However, it's not clear how exactly to change
+                        // `load_catalog_items` to accommodate for the
+                        // `build_index_dataflow` call above.
+                        self.catalog_mut()
+                            .set_optimized_plan(entry.id(), df.clone());
+                        self.catalog_mut()
+                            .set_dataflow_metainfo(entry.id(), df_metainfo);
+
+                        let as_of = self.bootstrap_index_as_of(
+                            &df,
+                            idx.cluster_id,
+                            idx.is_retained_metrics_object,
+                        );
+                        df.set_as_of(as_of);
+
+                        // What follows is morally equivalent to `self.ship_dataflow(df, idx.cluster_id)`,
+                        // but we cannot call that as it will also downgrade the read hold on the index.
+                        policy_entry
+                            .compute_ids
+                            .entry(idx.cluster_id)
+                            .or_insert_with(Default::default)
+                            .extend(df.export_ids());
+
+                        let df = self.must_finalize_dataflow(df, idx.cluster_id);
+                        self.catalog_mut().set_physical_plan(entry.id(), df.clone());
+
+                        self.controller
+                            .active_compute()
+                            .create_dataflow(idx.cluster_id, df)
+                            .unwrap_or_terminate("cannot fail to create dataflows");
                     } else {
                         let (mut df, df_metainfo) = self
                             .dataflow_builder(idx.cluster_id)

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -211,10 +211,20 @@ impl Coordinator {
                 }
             }
             Plan::CreateIndex(plan) => {
-                let result = self
-                    .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
+                if enable_unified_optimizer_api {
+                    let result = self
+                        .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                } else {
+                    // Allow while the introduction of the new optimizer API in
+                    // #20569 is in progress.
+                    #[allow(deprecated)]
+                    let result = self
+                        .sequence_create_index_deprecated(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
             }
             Plan::CreateType(plan) => {
                 let result = self

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -16,7 +16,6 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
-use differential_dataflow::lattice::Lattice;
 use futures::future::BoxFuture;
 use itertools::Itertools;
 use maplit::btreeset;
@@ -31,7 +30,7 @@ use mz_expr::{
 use mz_ore::collections::CollectionExt;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::vec::VecExt;
-use mz_ore::{soft_assert, soft_panic_or_log, task};
+use mz_ore::{soft_assert, task};
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::explain::{
@@ -1111,29 +1110,54 @@ impl Coordinator {
     ) -> Result<ExecuteResponse, AdapterError> {
         let plan::CreateIndexPlan {
             name,
-            index,
+            index:
+                plan::Index {
+                    create_sql,
+                    on,
+                    keys,
+                    cluster_id,
+                },
             options,
             if_not_exists,
         } = plan;
 
-        // An index must be created on a specific cluster.
-        let cluster_id = index.cluster_id;
-
         self.ensure_cluster_can_host_compute_item(&name, cluster_id)?;
 
-        let empty_key = index.keys.is_empty();
-
+        // Collect optimizer parameters
+        let compute_instance = self
+            .instance_snapshot(cluster_id)
+            .expect("compute instance does not exist");
         let id = self.catalog_mut().allocate_user_id().await?;
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build an INDEX optimizer.
+        let mut optimizer = optimize::OptimizeIndex::new(
+            self.owned_catalog(),
+            compute_instance,
+            id,
+            optimizer_config,
+        );
+
+        // MIR ⇒ MIR optimization (global)
+        let index_plan = optimize::Index::new(&name, &on, &keys);
+        let global_mir_plan = optimizer.optimize(index_plan)?;
+        // Timestamp selection
+        let since = self.least_valid_read(&global_mir_plan.id_bundle());
+        let global_mir_plan = global_mir_plan.resolve(since);
+        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
+
         let index = catalog::Index {
-            create_sql: index.create_sql,
-            keys: index.keys,
-            on: index.on,
+            create_sql,
+            keys,
+            on,
             conn_id: None,
             resolved_ids,
             cluster_id,
             is_retained_metrics_object: false,
             custom_logical_compaction_window: None,
         };
+
         let oid = self.catalog_mut().allocate_oid()?;
         let on = self.catalog().get_entry(&index.on);
         // Indexes have the same owner as their parent relation.
@@ -1146,25 +1170,24 @@ impl Coordinator {
             owner_id,
         };
         match self
-            .catalog_transact_with(Some(session.conn_id()), vec![op], |txn| {
-                let mut builder = txn.dataflow_builder(cluster_id);
-                let (df, df_metainfo) = builder.build_index_dataflow(id)?;
-                Ok((df, df_metainfo))
-            })
+            .catalog_transact_conn(Some(session.conn_id()), vec![op])
             .await
         {
-            Ok((df, mut df_metainfo)) => {
-                if empty_key {
-                    df_metainfo.push_optimizer_notice_dedup(OptimizerNotice::IndexKeyEmpty);
-                }
+            Ok(_) => {
+                // Save plan structures.
+                self.catalog_mut()
+                    .set_optimized_plan(id, global_mir_plan.df_desc().clone());
+                self.catalog_mut()
+                    .set_physical_plan(id, global_lir_plan.df_desc().clone());
+                self.catalog_mut()
+                    .set_dataflow_metainfo(id, global_lir_plan.df_meta().clone());
 
-                self.emit_optimizer_notices(session, &df_metainfo.optimizer_notices);
+                // Emit notices.
+                self.emit_optimizer_notices(session, &global_lir_plan.df_meta().optimizer_notices);
 
-                self.catalog_mut().set_optimized_plan(id, df.clone());
-                self.catalog_mut().set_dataflow_metainfo(id, df_metainfo);
+                let df_desc = global_lir_plan.unapply().0;
 
-                let df = self.must_ship_dataflow(df, cluster_id).await;
-                self.catalog_mut().set_physical_plan(id, df);
+                self.ship_dataflow_new(df_desc, cluster_id).await;
 
                 self.set_index_options(id, options).expect("index enabled");
                 Ok(ExecuteResponse::CreatedIndex)
@@ -3645,23 +3668,31 @@ impl Coordinator {
             tracing::warn!("EXPLAIN ... BROKEN <query> is known to leak memory, use with caution");
         }
 
-        // Initialize helper context
-        // -------------------------
+        // Initialize optimizer context
+        // ----------------------------
 
-        let target_cluster_id = index.cluster_id;
         let compute_instance = self
-            .instance_snapshot(target_cluster_id)
+            .instance_snapshot(index.cluster_id)
             .expect("compute instance does not exist");
         let exported_index_id = self.allocate_transient_id()?;
-        let state = self.catalog().state();
+        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+
+        // Build a MATERIALIZED VIEW optimizer for this view.
+        let mut optimizer = optimize::OptimizeIndex::new(
+            self.owned_catalog(),
+            compute_instance,
+            exported_index_id,
+            optimizer_config,
+        );
+
+        // Create a transient catalog item
+        // -------------------------------
+
         let on_entry = self.catalog.get_entry(&index.on);
         let full_name = self.catalog.resolve_full_name(&name, on_entry.conn_id());
         let on_desc = on_entry
             .desc(&full_name)
             .expect("can only create indexes on items with a valid description");
-
-        // Create a transient catalog item
-        // -------------------------------
 
         let mut transient_items = BTreeMap::new();
         transient_items.insert(exported_index_id, {
@@ -3672,90 +3703,47 @@ impl Coordinator {
             )
         });
 
-        // Global optimization
-        // -------------------
-        let (mut df, df_metainfo) = catch_unwind(broken, "global", || {
-            // This code should mirror the sequence of steps performed in
-            // `build_index_dataflow`. We cannot call `build_index_dataflow`
-            // here directly because it assumes that the index is present in the
-            // catalog as an `IndexEntry`. However, in the condtext of `EXPLAIN
-            // CREATE` we don't want to do actually modify the catalog state.
+        // Execute the various stages of the optimization pipeline
+        // -------------------------------------------------------
 
-            let mut df_builder = DataflowBuilder::new(self.catalog().state(), compute_instance);
-            let mut df = DataflowDesc::new(full_name.to_string());
+        let (df_desc, df_meta, used_indexes) = catch_unwind(broken, "optimize", || {
+            // MIR ⇒ MIR optimization (global)
+            let index_plan = optimize::Index::new(&name, &index.on, &index.keys);
+            let global_mir_plan = optimizer.optimize(index_plan)?;
 
-            df_builder.import_into_dataflow(&index.on, &mut df)?;
-
-            for desc in df.objects_to_build.iter_mut() {
-                prep_relation_expr(state, &mut desc.plan, ExprPrepStyle::Index)?;
-            }
-
-            let mut index_description = IndexDesc {
-                on_id: index.on,
-                key: index.keys.clone(),
+            // Collect the list of indexes used by the dataflow at this point
+            let used_indexes = {
+                let df_desc = global_mir_plan.df_desc();
+                let df_meta = global_mir_plan.df_meta();
+                UsedIndexes::new(
+                    df_desc
+                        .index_imports
+                        .iter()
+                        .map(|(id, _index_import)| {
+                            (*id, df_meta.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
+                        })
+                        .collect(),
+                )
             };
 
-            for key in index_description.key.iter_mut() {
-                prep_scalar_expr(state, key, ExprPrepStyle::Index)?;
-            }
+            // Timestamp selection
+            let since = self.least_valid_read(&global_mir_plan.id_bundle());
+            let global_mir_plan = global_mir_plan.resolve(since);
 
-            df.export_index(exported_index_id, index_description, on_desc.typ().clone());
+            // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+            let global_lir_plan = optimizer.optimize(global_mir_plan)?;
 
-            // Optimize the dataflow across views, and any other ways that appeal.
-            let df_metainfo = mz_transform::optimize_dataflow(
-                &mut df,
-                &df_builder,
-                &mz_transform::EmptyStatisticsOracle,
-            )?;
+            let (df_desc, df_meta) = global_lir_plan.unapply();
 
-            Ok::<_, AdapterError>((df, df_metainfo))
-        })?;
-
-        // Collect the list of indexes used by the dataflow at this point
-        let used_indexes = UsedIndexes::new(
-            df
-                .index_imports
-                .iter()
-                .map(|(id, _index_import)| {
-                    (*id, df_metainfo.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
-                })
-                .collect(),
-        );
-
-        // Finalization
-        // ------------
-
-        // In the actual sequencing of `CREATE INDEX` statements, the following
-        // DataflowDescription manipulations happen in the `ship_dataflow` call.
-        // However, since we don't want to ship, we have temporary duplicated
-        // the code below. This will be resolved once we implement the proposal
-        // from #20569.
-
-        // If the only outputs of the dataflow are sinks, we might be able to
-        // turn off the computation early, if they all have non-trivial
-        // `up_to`s.
-        //
-        // TODO: This should never be the case here so we can probably remove
-        // the entire thing.
-        if df.index_exports.is_empty() {
-            soft_panic_or_log!("unexpectedly setting df.until for an index");
-            df.until = Antichain::from_elem(Timestamp::MIN);
-            for (_, sink) in &df.sink_exports {
-                df.until.join_assign(&sink.up_to);
-            }
-        }
-
-        // Execute the `optimize/finalize_dataflow` stage.
-        let df = catch_unwind(broken, "finalize_dataflow", || {
-            self.finalize_dataflow(df, target_cluster_id)
+            Ok::<_, AdapterError>((df_desc, df_meta, used_indexes))
         })?;
 
         // Trace the resulting plan for the top-level `optimize` path.
-        trace_plan(&df);
+        trace_plan(&df_desc);
 
         // Return objects that need to be passed to the `ExplainContext`
         // when rendering explanations for the various trace entries.
-        Ok((used_indexes, None, df_metainfo, transient_items))
+        Ok((used_indexes, None, df_meta, transient_items))
     }
 
     pub async fn sequence_explain_timestamp(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3189,9 +3189,25 @@ impl Coordinator {
                 index,
                 broken,
             } => {
-                self.explain_create_index_optimizer_pipeline(name, index, broken, root_dispatch)
+                if enable_unified_optimizer_api {
+                    // Please see the docs on `explain_query_optimizer_pipeline` above.
+                    self.explain_create_index_optimizer_pipeline(name, index, broken, root_dispatch)
+                        .with_subscriber(&optimizer_trace)
+                        .await
+                } else {
+                    // Allow while the introduction of the new optimizer API in
+                    // #20569 is in progress.
+                    #[allow(deprecated)]
+                    // Please see the docs on `explain_query_optimizer_pipeline` above.
+                    self.explain_create_index_optimizer_pipeline_deprecated(
+                        name,
+                        index,
+                        broken,
+                        root_dispatch,
+                    )
                     .with_subscriber(&optimizer_trace)
                     .await
+                }
             }
         };
 
@@ -4407,7 +4423,7 @@ impl Coordinator {
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
-    fn set_index_options(
+    pub(super) fn set_index_options(
         &mut self,
         id: GlobalId,
         options: Vec<IndexOption>,

--- a/src/adapter/src/coord/sequencer/old_optimizer_api.rs
+++ b/src/adapter/src/coord/sequencer/old_optimizer_api.rs
@@ -18,20 +18,25 @@
 use std::collections::BTreeMap;
 
 use differential_dataflow::lattice::Lattice;
+use mz_compute_types::dataflows::{DataflowDesc, IndexDesc};
 use mz_controller_types::ClusterId;
 use mz_expr::CollectionPlan;
+use mz_ore::soft_panic_or_log;
 use mz_repr::explain::{TransientItem, UsedIndexes};
 use mz_repr::{ColumnName, GlobalId, RelationDesc, Timestamp};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{ObjectId, QualifiedItemName, ResolvedIds};
-use mz_sql::plan::{self, MaterializedView};
+use mz_sql::plan::{self, Index, MaterializedView};
 use mz_storage_client::controller::{CollectionDescription, DataSource, DataSourceOther};
 use mz_transform::dataflow::DataflowMetainfo;
+use mz_transform::optimizer_notices::OptimizerNotice;
 use timely::progress::Antichain;
 use tracing::Level;
 
 use crate::catalog::CatalogItem;
-use crate::coord::dataflows::DataflowBuilder;
+use crate::coord::dataflows::{
+    prep_relation_expr, prep_scalar_expr, DataflowBuilder, ExprPrepStyle,
+};
 use crate::coord::peek::FastPathPlan;
 use crate::coord::sequencer::inner::catch_unwind;
 use crate::coord::{Coordinator, DEFAULT_LOGICAL_COMPACTION_WINDOW_TS};
@@ -40,6 +45,245 @@ use crate::util::ResultExt;
 use crate::{catalog, AdapterError, AdapterNotice, ExecuteResponse, TimestampProvider};
 
 impl Coordinator {
+    // Indexes
+    // -----------------
+
+    /// This should mirror the operational semantics of
+    /// `Coordinator::sequence_create_index`.
+    #[deprecated = "This is being replaced by sequence_create_index (see #20569)."]
+    #[tracing::instrument(level = "debug", skip(self))]
+    pub(super) async fn sequence_create_index_deprecated(
+        &mut self,
+        session: &mut Session,
+        plan: plan::CreateIndexPlan,
+        resolved_ids: ResolvedIds,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let plan::CreateIndexPlan {
+            name,
+            index,
+            options,
+            if_not_exists,
+        } = plan;
+
+        // An index must be created on a specific cluster.
+        let cluster_id = index.cluster_id;
+
+        self.ensure_cluster_can_host_compute_item(&name, cluster_id)?;
+
+        let empty_key = index.keys.is_empty();
+
+        let id = self.catalog_mut().allocate_user_id().await?;
+        let index = catalog::Index {
+            create_sql: index.create_sql,
+            keys: index.keys,
+            on: index.on,
+            conn_id: None,
+            resolved_ids,
+            cluster_id,
+            is_retained_metrics_object: false,
+            custom_logical_compaction_window: None,
+        };
+        let oid = self.catalog_mut().allocate_oid()?;
+        let on = self.catalog().get_entry(&index.on);
+        // Indexes have the same owner as their parent relation.
+        let owner_id = *on.owner_id();
+        let op = catalog::Op::CreateItem {
+            id,
+            oid,
+            name: name.clone(),
+            item: CatalogItem::Index(index),
+            owner_id,
+        };
+        match self
+            .catalog_transact_with(Some(session.conn_id()), vec![op], |txn| {
+                let mut builder = txn.dataflow_builder(cluster_id);
+                let (df, df_metainfo) = builder.build_index_dataflow(id)?;
+                Ok((df, df_metainfo))
+            })
+            .await
+        {
+            Ok((df, mut df_metainfo)) => {
+                if empty_key {
+                    df_metainfo.push_optimizer_notice_dedup(OptimizerNotice::IndexKeyEmpty);
+                }
+
+                self.emit_optimizer_notices(session, &df_metainfo.optimizer_notices);
+
+                self.catalog_mut().set_optimized_plan(id, df.clone());
+                self.catalog_mut().set_dataflow_metainfo(id, df_metainfo);
+
+                let df = self.must_ship_dataflow(df, cluster_id).await;
+                self.catalog_mut().set_physical_plan(id, df);
+
+                self.set_index_options(id, options).expect("index enabled");
+                Ok(ExecuteResponse::CreatedIndex)
+            }
+            Err(AdapterError::Catalog(catalog::Error {
+                kind: catalog::ErrorKind::Sql(CatalogError::ItemAlreadyExists(_, _)),
+            })) if if_not_exists => {
+                session.add_notice(AdapterNotice::ObjectAlreadyExists {
+                    name: name.item,
+                    ty: "index",
+                });
+                Ok(ExecuteResponse::CreatedIndex)
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    /// Run the index optimization explanation pipeline. This function must be called with
+    /// an `OptimizerTrace` `tracing` subscriber, using `.with_subscriber(...)`.
+    /// The `root_dispatch` should be the global `tracing::Dispatch`.
+    ///
+    /// This should mirror the operational semantics of
+    /// `Coordinator::explain_create_index_optimizer_pipeline`.
+    //
+    // WARNING, ENTERING SPOOKY ZONE 3.0
+    //
+    // Please read the docs on `explain_query_optimizer_pipeline` before changing this function.
+    //
+    // Currently this method does not need to use the global `Dispatch` like
+    // `explain_query_optimizer_pipeline`, but it is passed in case changes to this function
+    // require it.
+    #[deprecated = "This is being replaced by explain_create_index_optimizer_pipeline (see #20569)."]
+    #[tracing::instrument(target = "optimizer", level = "trace", name = "optimize", skip_all)]
+    pub(crate) async fn explain_create_index_optimizer_pipeline_deprecated(
+        &mut self,
+        name: QualifiedItemName,
+        index: Index,
+        broken: bool,
+        _root_dispatch: tracing::Dispatch,
+    ) -> Result<
+        (
+            UsedIndexes,
+            Option<FastPathPlan>,
+            DataflowMetainfo,
+            BTreeMap<GlobalId, TransientItem>,
+        ),
+        AdapterError,
+    > {
+        use mz_repr::explain::trace_plan;
+
+        if broken {
+            tracing::warn!("EXPLAIN ... BROKEN <query> is known to leak memory, use with caution");
+        }
+
+        // Initialize helper context
+        // -------------------------
+
+        let target_cluster_id = index.cluster_id;
+        let compute_instance = self
+            .instance_snapshot(target_cluster_id)
+            .expect("compute instance does not exist");
+        let exported_index_id = self.allocate_transient_id()?;
+        let state = self.catalog().state();
+        let on_entry = self.catalog.get_entry(&index.on);
+        let full_name = self.catalog.resolve_full_name(&name, on_entry.conn_id());
+        let on_desc = on_entry
+            .desc(&full_name)
+            .expect("can only create indexes on items with a valid description");
+
+        // Create a transient catalog item
+        // -------------------------------
+
+        let mut transient_items = BTreeMap::new();
+        transient_items.insert(exported_index_id, {
+            TransientItem::new(
+                Some(full_name.to_string()),
+                Some(full_name.item.to_string()),
+                Some(on_desc.iter_names().map(|c| c.to_string()).collect()),
+            )
+        });
+
+        // Global optimization
+        // -------------------
+        let (mut df, df_metainfo) = catch_unwind(broken, "global", || {
+            // This code should mirror the sequence of steps performed in
+            // `build_index_dataflow`. We cannot call `build_index_dataflow`
+            // here directly because it assumes that the index is present in the
+            // catalog as an `IndexEntry`. However, in the condtext of `EXPLAIN
+            // CREATE` we don't want to do actually modify the catalog state.
+
+            let mut df_builder = DataflowBuilder::new(self.catalog().state(), compute_instance);
+            let mut df = DataflowDesc::new(full_name.to_string());
+
+            df_builder.import_into_dataflow(&index.on, &mut df)?;
+
+            for desc in df.objects_to_build.iter_mut() {
+                prep_relation_expr(state, &mut desc.plan, ExprPrepStyle::Index)?;
+            }
+
+            let mut index_description = IndexDesc {
+                on_id: index.on,
+                key: index.keys.clone(),
+            };
+
+            for key in index_description.key.iter_mut() {
+                prep_scalar_expr(state, key, ExprPrepStyle::Index)?;
+            }
+
+            df.export_index(exported_index_id, index_description, on_desc.typ().clone());
+
+            // Optimize the dataflow across views, and any other ways that appeal.
+            let df_metainfo = mz_transform::optimize_dataflow(
+                &mut df,
+                &df_builder,
+                &mz_transform::EmptyStatisticsOracle,
+            )?;
+
+            Ok::<_, AdapterError>((df, df_metainfo))
+        })?;
+
+        // Collect the list of indexes used by the dataflow at this point
+        let used_indexes = UsedIndexes::new(
+            df
+                .index_imports
+                .iter()
+                .map(|(id, _index_import)| {
+                    (*id, df_metainfo.index_usage_types.get(id).expect("prune_and_annotate_dataflow_index_imports should have been called already").clone())
+                })
+                .collect(),
+        );
+
+        // Finalization
+        // ------------
+
+        // In the actual sequencing of `CREATE INDEX` statements, the following
+        // DataflowDescription manipulations happen in the `ship_dataflow` call.
+        // However, since we don't want to ship, we have temporary duplicated
+        // the code below. This will be resolved once we implement the proposal
+        // from #20569.
+
+        // If the only outputs of the dataflow are sinks, we might be able to
+        // turn off the computation early, if they all have non-trivial
+        // `up_to`s.
+        //
+        // TODO: This should never be the case here so we can probably remove
+        // the entire thing.
+        if df.index_exports.is_empty() {
+            soft_panic_or_log!("unexpectedly setting df.until for an index");
+            df.until = Antichain::from_elem(Timestamp::MIN);
+            for (_, sink) in &df.sink_exports {
+                df.until.join_assign(&sink.up_to);
+            }
+        }
+
+        // Execute the `optimize/finalize_dataflow` stage.
+        let df = catch_unwind(broken, "finalize_dataflow", || {
+            self.finalize_dataflow(df, target_cluster_id)
+        })?;
+
+        // Trace the resulting plan for the top-level `optimize` path.
+        trace_plan(&df);
+
+        // Return objects that need to be passed to the `ExplainContext`
+        // when rendering explanations for the various trace entries.
+        Ok((used_indexes, None, df_metainfo, transient_items))
+    }
+
+    // MaterializedViews
+    // -----------------
+
     /// This should mirror the operational semantics of
     /// `Coordinator::sequence_create_materialized_view`.
     #[deprecated = "This is being replaced by sequence_create_materialized_view (see #20569)."]

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -50,9 +50,11 @@
 //! For details, see the `20230714_optimizer_interface.md` design doc in this
 //! repository.
 
+mod index;
 mod materialized_view;
 
 // Re-export optimzier structs
+pub use index::{Index, OptimizeIndex};
 pub use materialized_view::OptimizeMaterializedView;
 
 use mz_compute_types::dataflows::DataflowDescription;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1779,7 +1779,7 @@ feature_flags!(
     ),
     (
         enable_unified_optimizer_api,
-        "use the new unified optimzier API in bootstrap() and coordinator methods",
+        "use the new unified optimizer API in bootstrap() and coordinator methods",
         true
     ),
     (


### PR DESCRIPTION
- Add an `OptimizeIndex` struct that implements `Optimize`.
- Integrate `OptimizeIndex` in the `CREATE INDEX` code paths.

### Motivation

  * This PR adds a known-desirable feature.

Part of the integration process of the `Optimize` API proposed in #20569 according to the rollout plan from the design doc.

### Tips for reviewer

See commit messages for details. This follows the rollout plan from #20569:

- Old code paths are still available in `old_optimzier_api.rs` behind a feature flag.
- The new code paths are selected by default.
- Some due diligence is needed to not allow the two paths to diverge in the brief period while they co-exist in `main`. The current plan is to remove them one week after a successful deployment.

@MaterializeInc/testing we should be worried if we see failures in [CI](https://buildkite.com/materialize/tests/builds?branch=aalexandrov%3Aoptimize_index) / [Nightlies](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Aoptimize_index) runs for the PR branch that can be attributed to index creation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
