### PR TITLE
[persist] Make new-style consolidation metrics match the older ones

### DIFF
--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -391,6 +391,11 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         handle,
                         maybe_unconsolidated,
                     } => {
+                        if handle.is_finished() {
+                            self.metrics.compaction.parts_prefetched.inc();
+                        } else {
+                            self.metrics.compaction.parts_waited.inc()
+                        }
                         self.metrics.consolidation.parts_fetched.inc();
                         *part = ConsolidationPart::from_encoded(
                             handle.await??,
@@ -460,7 +465,6 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         }
                         _ => continue,
                     };
-                    self.metrics.compaction.parts_prefetched.inc();
 
                     let maybe_unconsolidated = data.maybe_unconsolidated();
                     let span = debug_span!("compaction::prefetch");


### PR DESCRIPTION
Two things:
- The new code was not reporting time spent waiting for data in compaction; fixed. (We still don't report "heap population", since there's no equivalent anymore.)
- The "prefetch" metric was incremented whenever a prefetch started, but originally it was only incremented when the prefetch _completed_ before it was needed. Restore this to the original meaning.

After this change we see quite a bit more "waiting" vs. "prefetching" in the new code path, but I think this reflects a meaningful change between the two. The old code would wait on the first part of the first run, load that up, then wait on the first part of the second run; the new code waits on all runs concurrently... so the average wait starts sooner, even though it doesn't actually take any longer to fetch every part.

Other than that exception, the metrics look very similar across the two codepaths.

### Motivation

Previously-unreported metrics bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
