### PR TITLE
sql: pretty print SHOW CREATE [MATERIALIZED] VIEW

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5224,6 +5224,7 @@ dependencies = [
  "mz-secrets",
  "mz-sql-lexer",
  "mz-sql-parser",
+ "mz-sql-pretty",
  "mz-stash-types",
  "mz-storage-types",
  "mz-tracing",

--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -80,7 +80,7 @@ mod util;
 
 use mz_sql_parser::ast::*;
 use mz_sql_parser::parser::{parse_statements, ParserStatementError};
-use pretty::*;
+use pretty::RcDoc;
 
 use crate::doc::{
     doc_create_materialized_view, doc_create_view, doc_display, doc_insert, doc_select_statement,
@@ -88,7 +88,7 @@ use crate::doc::{
 
 const TAB: isize = 4;
 
-pub fn to_doc(v: &Statement<Raw>) -> RcDoc {
+fn to_doc<T: AstInfo>(v: &Statement<T>) -> RcDoc {
     match v {
         Statement::Select(v) => doc_select_statement(v),
         Statement::Insert(v) => doc_insert(v),
@@ -98,19 +98,18 @@ pub fn to_doc(v: &Statement<Raw>) -> RcDoc {
     }
 }
 
-pub fn to_pretty(stmt: &Statement<Raw>, width: usize) -> String {
-    let mut w = Vec::new();
-    to_doc(stmt).render(width, &mut w).unwrap();
-    let mut s = String::from_utf8(w).unwrap();
-    s.push(';');
-    s
+/// Pretty prints a statement at a width.
+pub fn to_pretty<T: AstInfo>(stmt: &Statement<T>, width: usize) -> String {
+    format!("{};", to_doc(stmt).pretty(width))
 }
 
+/// Parses `str` into SQL statements and pretty prints them.
 pub fn pretty_strs(str: &str, width: usize) -> Result<Vec<String>, ParserStatementError> {
     let stmts = parse_statements(str)?;
     Ok(stmts.iter().map(|s| to_pretty(&s.ast, width)).collect())
 }
 
+/// Parses `str` into a single SQL statement and pretty prints it.
 pub fn pretty_str(str: &str, width: usize) -> Result<String, ParserStatementError> {
     Ok(pretty_strs(str, width)?.join("\n\n"))
 }

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -41,6 +41,7 @@ mz-repr = { path = "../repr", features = ["tracing_"] }
 mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }
+mz-sql-pretty = { path = "../sql-pretty" }
 mz-sql-lexer = { path = "../sql-lexer" }
 mz-stash-types = { path = "../stash-types" }
 mz-storage-types = { path = "../storage-types" }


### PR DESCRIPTION
This changes from the stable to not stable output for identifiers (only double quoted if needed), so is a slight backward incompatible change.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Change `SHOW CREATE [MATERIALIZED] VIEW` to pretty print output instead of always using a single line.