### PR TITLE
compute: time based linear join yielding

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -26,6 +26,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
         dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
+        linear_join_yielding: None,
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_specialized_arrangements: Some(config.enable_specialized_arrangements()),

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -10,12 +10,13 @@
 use std::time::Duration;
 
 use mz_compute_client::protocol::command::ComputeParameters;
+use mz_compute_types::dataflows::YieldSpec;
 use mz_orchestrator::scheduling_config::{ServiceSchedulingConfig, ServiceTopologySpreadConfig};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_persist_client::cfg::{PersistParameters, RetryParameters};
 use mz_service::params::GrpcClientParameters;
-use mz_sql::session::vars::SystemVars;
+use mz_sql::session::vars::{SystemVars, DEFAULT_LINEAR_JOIN_YIELDING};
 use mz_storage_types::parameters::{
     StorageMaxInflightBytesConfig, StorageParameters, UpsertAutoSpillConfig,
 };
@@ -23,16 +24,38 @@ use mz_tracing::params::TracingParameters;
 
 /// Return the current compute configuration, derived from the system configuration.
 pub fn compute_config(config: &SystemVars) -> ComputeParameters {
+    let linear_join_yielding = config.linear_join_yielding();
+    let linear_join_yielding = parse_yield_spec(linear_join_yielding).unwrap_or_else(|| {
+        tracing::error!("invalid `linear_join_yielding` config: {linear_join_yielding}");
+        parse_yield_spec(&DEFAULT_LINEAR_JOIN_YIELDING).expect("default is valid")
+    });
+
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
         dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
-        linear_join_yielding: None,
+        linear_join_yielding: Some(linear_join_yielding),
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_specialized_arrangements: Some(config.enable_specialized_arrangements()),
         persist: persist_config(config),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),
+    }
+}
+
+fn parse_yield_spec(s: &str) -> Option<YieldSpec> {
+    let parts: Vec<_> = s.split(':').collect();
+    match &parts[..] {
+        ["work", amount] => {
+            let amount = amount.parse().ok()?;
+            Some(YieldSpec::ByWork(amount))
+        }
+        ["time", millis] => {
+            let millis = millis.parse().ok()?;
+            let duration = Duration::from_millis(millis);
+            Some(YieldSpec::ByTime(duration))
+        }
+        _ => None,
     }
 }
 

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -70,4 +70,5 @@ message ProtoComputeParameters {
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
     optional bool enable_jemalloc_profiling = 7;
     optional bool enable_specialized_arrangements = 8;
+    mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
 }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -10,7 +10,7 @@
 //! Compute protocol commands.
 
 use mz_cluster_client::client::{ClusterStartupEpoch, TimelyConfig, TryIntoTimelyConfig};
-use mz_compute_types::dataflows::DataflowDescription;
+use mz_compute_types::dataflows::{DataflowDescription, YieldSpec};
 use mz_expr::RowSetFinishing;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_persist_client::cfg::PersistParameters;
@@ -359,6 +359,8 @@ pub struct ComputeParameters {
     pub max_result_size: Option<u32>,
     /// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
     pub dataflow_max_inflight_bytes: Option<usize>,
+    /// The yielding behavior with which linear joins should be rendered.
+    pub linear_join_yielding: Option<YieldSpec>,
     /// Whether rendering should use `mz_join_core` rather than DD's `JoinCore::join_core`.
     pub enable_mz_join_core: Option<bool>,
     /// Whether to activate jemalloc heap profiling.
@@ -379,6 +381,7 @@ impl ComputeParameters {
         let ComputeParameters {
             max_result_size,
             dataflow_max_inflight_bytes,
+            linear_join_yielding,
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_specialized_arrangements,
@@ -392,6 +395,9 @@ impl ComputeParameters {
         }
         if dataflow_max_inflight_bytes.is_some() {
             self.dataflow_max_inflight_bytes = dataflow_max_inflight_bytes;
+        }
+        if linear_join_yielding.is_some() {
+            self.linear_join_yielding = linear_join_yielding;
         }
         if enable_mz_join_core.is_some() {
             self.enable_mz_join_core = enable_mz_join_core;
@@ -420,6 +426,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
         ProtoComputeParameters {
             max_result_size: self.max_result_size.into_proto(),
             dataflow_max_inflight_bytes: self.dataflow_max_inflight_bytes.into_proto(),
+            linear_join_yielding: self.linear_join_yielding.into_proto(),
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             enable_specialized_arrangements: self.enable_specialized_arrangements.into_proto(),
@@ -433,6 +440,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
         Ok(Self {
             max_result_size: proto.max_result_size.into_rust()?,
             dataflow_max_inflight_bytes: proto.dataflow_max_inflight_bytes.into_rust()?,
+            linear_join_yielding: proto.linear_join_yielding.into_rust()?,
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             enable_specialized_arrangements: proto.enable_specialized_arrangements.into_rust()?,

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -13,6 +13,7 @@ import "compute-types/src/plan.proto";
 import "compute-types/src/sinks.proto";
 import "compute-types/src/sources.proto";
 import "expr/src/scalar.proto";
+import "proto/src/proto.proto";
 import "repr/src/antichain.proto";
 import "repr/src/global_id.proto";
 import "repr/src/relation_and_scalar.proto";
@@ -62,4 +63,11 @@ message ProtoIndexDesc {
 message ProtoBuildDesc {
     mz_repr.global_id.ProtoGlobalId id = 1;
     plan.ProtoPlan plan = 2;
+}
+
+message ProtoYieldSpec {
+    oneof kind {
+        uint64 by_work = 1;
+        mz_proto.ProtoDuration by_time = 2;
+    }
 }

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -42,7 +42,7 @@ use timely::progress::{Antichain, Timestamp};
 use crate::arrangement::manager::SpecializedTraceHandle;
 use crate::extensions::arrange::{KeyCollection, MzArrange};
 use crate::render::errors::ErrorLogger;
-use crate::render::join::LinearJoinImpl;
+use crate::render::join::LinearJoinSpec;
 use crate::typedefs::{ErrSpine, RowSpine, TraceErrHandle, TraceRowHandle};
 
 // Local type definition to avoid the horror in signatures.
@@ -98,8 +98,8 @@ where
     pub bindings: BTreeMap<Id, CollectionBundle<S, T>>,
     /// A token that operators can probe to know whether the dataflow is shutting down.
     pub(super) shutdown_token: ShutdownToken,
-    /// The implementation to use for rendering linear joins.
-    pub(super) linear_join_impl: LinearJoinImpl,
+    /// Specification for rendering linear joins.
+    pub(super) linear_join_spec: LinearJoinSpec,
     pub(super) enable_specialized_arrangements: bool,
 }
 
@@ -127,7 +127,7 @@ where
             until: dataflow.until.clone(),
             bindings: BTreeMap::new(),
             shutdown_token: Default::default(),
-            linear_join_impl: Default::default(),
+            linear_join_spec: Default::default(),
             enable_specialized_arrangements: Default::default(),
         }
     }

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -11,10 +11,13 @@
 //!
 //! Consult [LinearJoinPlan] documentation for details.
 
+use std::time::Instant;
+
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::operators::arrange::arrangement::Arranged;
 use differential_dataflow::trace::TraceReader;
 use differential_dataflow::{AsCollection, Collection, Data};
+use mz_compute_types::dataflows::YieldSpec;
 use mz_compute_types::plan::join::linear_join::{LinearJoinPlan, LinearStagePlan};
 use mz_compute_types::plan::join::JoinClosure;
 use mz_repr::fixed_length::IntoRowByTypes;
@@ -36,16 +39,36 @@ use crate::typedefs::RowSpine;
 /// Available linear join implementations.
 ///
 /// See the `mz_join_core` module docs for our rationale for providing two join implementations.
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub enum LinearJoinImpl {
-    #[default]
     Materialize,
     DifferentialDataflow,
 }
 
-impl LinearJoinImpl {
-    /// Run this join implementation on the provided arrangements.
-    fn run<G, Tr1, Tr2, L, I, K, V1, V2>(
+/// Specification of how linear joins are to be executed.
+///
+/// Note that currently `yielding` only affects the `Materialize` join implementation, as the DD
+/// join doesn't allow configuring its yielding behavior. Merging [#390] would fix this.
+///
+/// [#390]: https://github.com/TimelyDataflow/differential-dataflow/pull/390
+#[derive(Clone, Copy)]
+pub struct LinearJoinSpec {
+    pub implementation: LinearJoinImpl,
+    pub yielding: YieldSpec,
+}
+
+impl Default for LinearJoinSpec {
+    fn default() -> Self {
+        Self {
+            implementation: LinearJoinImpl::Materialize,
+            yielding: YieldSpec::ByWork(1_000_000),
+        }
+    }
+}
+
+impl LinearJoinSpec {
+    /// Render a join operator according to this specification.
+    fn render<G, Tr1, Tr2, L, I, K, V1, V2>(
         &self,
         arranged1: &Arranged<G, Tr1>,
         arranged2: &Arranged<G, Tr2>,
@@ -63,13 +86,21 @@ impl LinearJoinImpl {
         V1: Data,
         V2: Data,
     {
-        match self {
-            Self::DifferentialDataflow => {
+        use LinearJoinImpl::*;
+        use YieldSpec::*;
+
+        match (self.implementation, self.yielding) {
+            (DifferentialDataflow, _) => {
                 differential_dataflow::operators::JoinCore::join_core(arranged1, arranged2, result)
             }
-            Self::Materialize => mz_join_core(arranged1, arranged2, result, |_start, work| {
-                work >= 1_000_000
-            }),
+            (Materialize, ByWork(limit)) => {
+                let yield_fn = move |_start, work| work >= limit;
+                mz_join_core(arranged1, arranged2, result, yield_fn)
+            }
+            (Materialize, ByTime(limit)) => {
+                let yield_fn = move |start: Instant, _work| start.elapsed() >= limit;
+                mz_join_core(arranged1, arranged2, result, yield_fn)
+            }
         }
     }
 }
@@ -162,7 +193,7 @@ where
                 // Different variants of `joined` implement this differently,
                 // and the logic is centralized there.
                 let stream = differential_join(
-                    self.linear_join_impl,
+                    self.linear_join_spec,
                     joined,
                     inputs[stage_plan.lookup_relation].enter_region(inner),
                     stage_plan,
@@ -214,7 +245,7 @@ where
 /// version of the join of previous inputs. This is split into its own method
 /// to enable reuse of code with different types of `prev_keyed`.
 fn differential_join<G, T>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     mut joined: JoinedFlavor<G, T>,
     lookup_relation: CollectionBundle<G, T>,
     LinearStagePlan {
@@ -275,14 +306,14 @@ where
         JoinedFlavor::Local(local) => match arrangement {
             ArrangementFlavor::Local(oks, errs1) => {
                 let (oks, errs2) =
-                    dispatch_differential_join_inner_local_local(join_impl, local, oks, closure);
+                    dispatch_differential_join_inner_local_local(join_spec, local, oks, closure);
                 errors.push(errs1.as_collection(|k, _v| k.clone()));
                 errors.extend(errs2);
                 oks
             }
             ArrangementFlavor::Trace(_gid, oks, errs1) => {
                 let (oks, errs2) =
-                    dispatch_differential_join_inner_local_trace(join_impl, local, oks, closure);
+                    dispatch_differential_join_inner_local_trace(join_spec, local, oks, closure);
                 errors.push(errs1.as_collection(|k, _v| k.clone()));
                 errors.extend(errs2);
                 oks
@@ -291,14 +322,14 @@ where
         JoinedFlavor::Trace(trace) => match arrangement {
             ArrangementFlavor::Local(oks, errs1) => {
                 let (oks, errs2) =
-                    dispatch_differential_join_inner_trace_local(join_impl, trace, oks, closure);
+                    dispatch_differential_join_inner_trace_local(join_spec, trace, oks, closure);
                 errors.push(errs1.as_collection(|k, _v| k.clone()));
                 errors.extend(errs2);
                 oks
             }
             ArrangementFlavor::Trace(_gid, oks, errs1) => {
                 let (oks, errs2) =
-                    dispatch_differential_join_inner_trace_trace(join_impl, trace, oks, closure);
+                    dispatch_differential_join_inner_trace_trace(join_spec, trace, oks, closure);
                 errors.push(errs1.as_collection(|k, _v| k.clone()));
                 errors.extend(errs2);
                 oks
@@ -309,7 +340,7 @@ where
 
 /// Dispatches valid combinations of arrangements where the type-specialized keys match.
 fn dispatch_differential_join_inner_local_local<G>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     prev_keyed: SpecializedArrangement<G>,
     next_input: SpecializedArrangement<G>,
     closure: JoinClosure,
@@ -331,7 +362,7 @@ where
                 .zip(next_key_types.iter())
                 .all(|(c1, c2)| c1.scalar_type == c2.scalar_type));
             differential_join_inner(
-                join_impl,
+                join_spec,
                 prev_keyed,
                 next_input,
                 Some(prev_key_types),
@@ -343,7 +374,7 @@ where
         (
             SpecializedArrangement::RowRow(prev_keyed),
             SpecializedArrangement::RowRow(next_input),
-        ) => differential_join_inner(join_impl, prev_keyed, next_input, None, None, None, closure),
+        ) => differential_join_inner(join_spec, prev_keyed, next_input, None, None, None, closure),
         (SpecializedArrangement::Bytes9Row(key_types, _), SpecializedArrangement::RowRow(_)) => {
             panic!(
                 "Invalid combination of type specializations: key types differ! \
@@ -363,7 +394,7 @@ where
 
 /// Dispatches valid combinations of arrangement-trace where the type-specialized keys match.
 fn dispatch_differential_join_inner_local_trace<G, T>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     prev_keyed: SpecializedArrangement<G>,
     next_input: SpecializedArrangementImport<G, T>,
     closure: JoinClosure,
@@ -386,7 +417,7 @@ where
                 .zip(next_key_types.iter())
                 .all(|(c1, c2)| c1.scalar_type == c2.scalar_type));
             differential_join_inner(
-                join_impl,
+                join_spec,
                 prev_keyed,
                 next_input,
                 Some(prev_key_types),
@@ -398,7 +429,7 @@ where
         (
             SpecializedArrangement::RowRow(prev_keyed),
             SpecializedArrangementImport::RowRow(next_input),
-        ) => differential_join_inner(join_impl, prev_keyed, next_input, None, None, None, closure),
+        ) => differential_join_inner(join_spec, prev_keyed, next_input, None, None, None, closure),
         (
             SpecializedArrangement::Bytes9Row(key_types, _),
             SpecializedArrangementImport::RowRow(_),
@@ -420,7 +451,7 @@ where
 
 /// Dispatches valid combinations of trace-arrangement where the type-specialized keys match.
 fn dispatch_differential_join_inner_trace_local<G, T>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     prev_keyed: SpecializedArrangementImport<G, T>,
     next_input: SpecializedArrangement<G>,
     closure: JoinClosure,
@@ -443,7 +474,7 @@ where
                 .zip(next_key_types.iter())
                 .all(|(c1, c2)| c1.scalar_type == c2.scalar_type));
             differential_join_inner(
-                join_impl,
+                join_spec,
                 prev_keyed,
                 next_input,
                 Some(prev_key_types),
@@ -455,7 +486,7 @@ where
         (
             SpecializedArrangementImport::RowRow(prev_keyed),
             SpecializedArrangement::RowRow(next_input),
-        ) => differential_join_inner(join_impl, prev_keyed, next_input, None, None, None, closure),
+        ) => differential_join_inner(join_spec, prev_keyed, next_input, None, None, None, closure),
         (
             SpecializedArrangementImport::Bytes9Row(key_types, _),
             SpecializedArrangement::RowRow(_),
@@ -477,7 +508,7 @@ where
 
 /// Dispatches valid combinations of trace-arrangement where the type-specialized keys match.
 fn dispatch_differential_join_inner_trace_trace<G, T>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     prev_keyed: SpecializedArrangementImport<G, T>,
     next_input: SpecializedArrangementImport<G, T>,
     closure: JoinClosure,
@@ -500,7 +531,7 @@ where
                 .zip(next_key_types.iter())
                 .all(|(c1, c2)| c1.scalar_type == c2.scalar_type));
             differential_join_inner(
-                join_impl,
+                join_spec,
                 prev_keyed,
                 next_input,
                 Some(prev_key_types),
@@ -512,7 +543,7 @@ where
         (
             SpecializedArrangementImport::RowRow(prev_keyed),
             SpecializedArrangementImport::RowRow(next_input),
-        ) => differential_join_inner(join_impl, prev_keyed, next_input, None, None, None, closure),
+        ) => differential_join_inner(join_spec, prev_keyed, next_input, None, None, None, closure),
         (
             SpecializedArrangementImport::Bytes9Row(key_types, _),
             SpecializedArrangementImport::RowRow(_),
@@ -539,7 +570,7 @@ where
 /// The return type includes an optional error collection, which may be
 /// `None` if we can determine that `closure` cannot error.
 fn differential_join_inner<G, T, Tr1, Tr2, K, V1, V2>(
-    join_impl: LinearJoinImpl,
+    join_spec: LinearJoinSpec,
     prev_keyed: Arranged<G, Tr1>,
     next_input: Arranged<G, Tr2>,
     key_types: Option<Vec<ColumnType>>,
@@ -569,8 +600,8 @@ where
     let mut new_buf = Row::default();
 
     if closure.could_error() {
-        let (oks, err) = join_impl
-            .run(&prev_keyed, &next_input, move |key, old, new| {
+        let (oks, err) = join_spec
+            .render(&prev_keyed, &next_input, move |key, old, new| {
                 let key = key.into_row(&mut key_buf, key_types.as_deref());
                 let old = old.into_row(&mut old_buf, prev_types.as_deref());
                 let new = new.into_row(&mut new_buf, next_types.as_deref());
@@ -593,7 +624,7 @@ where
 
         (oks.as_collection(), Some(err.as_collection()))
     } else {
-        let oks = join_impl.run(&prev_keyed, &next_input, move |key, old, new| {
+        let oks = join_spec.render(&prev_keyed, &next_input, move |key, old, new| {
             let key = key.into_row(&mut key_buf, key_types.as_deref());
             let old = old.into_row(&mut old_buf, prev_types.as_deref());
             let new = new.into_row(&mut new_buf, next_types.as_deref());

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -67,7 +67,9 @@ impl LinearJoinImpl {
             Self::DifferentialDataflow => {
                 differential_dataflow::operators::JoinCore::join_core(arranged1, arranged2, result)
             }
-            Self::Materialize => mz_join_core(arranged1, arranged2, result),
+            Self::Materialize => mz_join_core(arranged1, arranged2, result, |_start, work| {
+                work >= 1_000_000
+            }),
         }
     }
 }

--- a/src/compute/src/render/join/mod.rs
+++ b/src/compute/src/render/join/mod.rs
@@ -15,4 +15,4 @@ mod delta_join;
 mod linear_join;
 mod mz_join_core;
 
-pub use linear_join::LinearJoinImpl;
+pub use linear_join::{LinearJoinImpl, LinearJoinSpec};

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -150,7 +150,7 @@ mod threshold;
 mod top_k;
 
 pub use context::CollectionBundle;
-pub use join::LinearJoinImpl;
+pub use join::{LinearJoinImpl, LinearJoinSpec};
 
 /// Assemble the "compute"  side of a dataflow, i.e. all but the sources.
 ///
@@ -289,7 +289,7 @@ pub fn build_compute_dataflow<A: Allocate>(
         if recursive {
             scope.clone().iterative::<PointStamp<u64>, _, _>(|region| {
                 let mut context = Context::for_dataflow_in(&dataflow, region.clone());
-                context.linear_join_impl = compute_state.linear_join_impl;
+                context.linear_join_spec = compute_state.linear_join_spec;
                 context.enable_specialized_arrangements =
                     compute_state.enable_specialized_arrangements;
 
@@ -351,7 +351,7 @@ pub fn build_compute_dataflow<A: Allocate>(
         } else {
             scope.clone().region_named(&build_name, |region| {
                 let mut context = Context::for_dataflow_in(&dataflow, region.clone());
-                context.linear_join_impl = compute_state.linear_join_impl;
+                context.linear_join_spec = compute_state.linear_join_spec;
                 context.enable_specialized_arrangements =
                     compute_state.enable_specialized_arrangements;
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1296,6 +1296,16 @@ const ENABLE_MZ_JOIN_CORE: ServerVar<bool> = ServerVar {
     internal: true,
 };
 
+pub static DEFAULT_LINEAR_JOIN_YIELDING: Lazy<String> = Lazy::new(|| "work:1000000".into());
+static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
+    name: UncasedStr::new("linear_join_yielding"),
+    value: &DEFAULT_LINEAR_JOIN_YIELDING,
+    description:
+        "The yielding behavior compute rendering should apply for linear join operators. Either \
+         'work:<amount>' or 'time:<milliseconds>'.",
+    internal: true,
+});
+
 pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_default_connection_validation"),
     value: &true,
@@ -2471,6 +2481,7 @@ impl SystemVars {
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
             .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
+            .with_var(&LINEAR_JOIN_YIELDING)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
             .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
             .with_var(&ENABLE_SPECIALIZED_ARRANGEMENTS)
@@ -3126,6 +3137,11 @@ impl SystemVars {
     /// Returns the `enable_mz_join_core` configuration parameter.
     pub fn enable_mz_join_core(&self) -> bool {
         *self.expect_value(&ENABLE_MZ_JOIN_CORE)
+    }
+
+    /// Returns the `linear_join_yielding` configuration parameter.
+    pub fn linear_join_yielding(&self) -> &String {
+        self.expect_value(&LINEAR_JOIN_YIELDING)
     }
 
     /// Returns the `enable_storage_shard_finalization` configuration parameter.
@@ -4797,6 +4813,7 @@ pub fn is_tracing_var(name: &str) -> bool {
 pub fn is_compute_config_var(name: &str) -> bool {
     name == MAX_RESULT_SIZE.name()
         || name == DATAFLOW_MAX_INFLIGHT_BYTES.name()
+        || name == LINEAR_JOIN_YIELDING.name()
         || name == ENABLE_MZ_JOIN_CORE.name()
         || name == ENABLE_JEMALLOC_PROFILING.name()
         || name == ENABLE_SPECIALIZED_ARRANGEMENTS.name()


### PR DESCRIPTION
This PR adds support for configuring compute rendering so that it employs time-based (rather than work-based) yielding for linear joins implemented by `mz_join_core`.

The changes made here include:
* Providing `mz_join_core` with a `yield_fn` that allows configuring the yielding strategy from outside (1st commit).
* Plumbing a yield spec through compute so the `mz_join_core` yielding behavior can be configured through `UpdateConfiguration` commands (2nd commit).
* Adding a new system var, `linear_join_yielding`, to allow changing the yield spec from LD (3rd commit). 

So far the default is still the previous behavior of yielding after 1 million updates produced (i.e. `work:1000000`). Once we were able to validate that time-based yielding doesn't produce significant regressions, we can make that the default.

### Example

As a data point that time-based yielding can improve things, consider the example from #22390:

```sql
CREATE TABLE t (a int);
CREATE MATERIALIZED VIEW mv AS SELECT (t1.a + t2.a) % 2 FROM t t1, t t2;
INSERT INTO t SELECT generate_series(1, 10000);
```

On my system, the join's duration histogram looks like this:

* with `work:1000000`:
  ```
    id  | name |          dataflow_name          | count |    duration     | duration_ns
  ------+------+---------------------------------+-------+-----------------+-------------
   3126 | Join | Dataflow: materialize.public.mv |     1 | 00:00:34.359738 | 34359738368
  ```
* with `time:100`: 
  ```
    id  | name |          dataflow_name          | count |    duration     | duration_ns
  ------+------+---------------------------------+-------+-----------------+-------------
   5347 | Join | Dataflow: materialize.public.mv |   295 | 00:00:00.134217 | 134217728
  ```

### Motivation

  * This PR fixes a recognized bug.

Addresses #22390 and touches #21626.

### Tips for reviewer

Changing yielding behavior of operators is always scary because it can have implications on flow control. That's why this PR introduces time-based yielding in the most careful way possible, by gating it behind a system var and keeping it off by default. We need to run further tests to validate the new yielding strategy. I assume that unbilled replicas will be very helpful for this!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
