### PR TITLE
sql: Implement SHOW PRIVILEGES command

### DIFF
--- a/doc/user/content/sql/grant-privilege.md
+++ b/doc/user/content/sql/grant-privilege.md
@@ -112,6 +112,7 @@ The privileges required to execute this statement are:
 
 ## Related pages
 
+- [SHOW PRIVILEGES](../show-privileges)
 - [CREATE ROLE](../create-role)
 - [ALTER ROLE](../alter-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/content/sql/revoke-privilege.md
+++ b/doc/user/content/sql/revoke-privilege.md
@@ -113,6 +113,7 @@ The privileges required to execute this statement are:
 
 ## Related pages
 
+- [SHOW PRIVILEGES](../show-privileges)
 - [CREATE ROLE](../create-role)
 - [ALTER ROLE](../alter-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/content/sql/show-privileges.md
+++ b/doc/user/content/sql/show-privileges.md
@@ -1,0 +1,78 @@
+---
+title: "SHOW PRIVILEGES"
+description: "`SHOW PRIVILEGES` lists the privileges granted in Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`SHOW PRIVILEGES` lists the privileges granted as part of [access control](/manage/access-control/) in Materialize.
+
+## Syntax
+
+{{< diagram "show-privileges.svg" >}}
+
+Field                                               | Use
+----------------------------------------------------|--------------------------------------------------
+_object_name_                                       | Only shows privileges for a specific object type.
+_role_name_                                         | Only shows privileges granted directly or indirectly to _role_name_.
+
+## Examples
+
+```sql
+SHOW PRIVILEGES;
+```
+
+```nofmt
+  grantor  |   grantee   |  database   | schema |    name     | object_type | privilege_type
+-----------+-------------+-------------+--------+-------------+-------------+----------------
+ mz_system | PUBLIC      | materialize |        | public      | schema      | USAGE
+ mz_system | PUBLIC      |             |        | default     | cluster     | USAGE
+ mz_system | PUBLIC      |             |        | materialize | database    | USAGE
+ mz_system | materialize | materialize |        | public      | schema      | CREATE
+ mz_system | materialize | materialize |        | public      | schema      | USAGE
+ mz_system | materialize |             |        | default     | cluster     | CREATE
+ mz_system | materialize |             |        | default     | cluster     | USAGE
+ mz_system | materialize |             |        | materialize | database    | CREATE
+ mz_system | materialize |             |        | materialize | database    | USAGE
+ mz_system | materialize |             |        |             | system      | CREATECLUSTER
+ mz_system | materialize |             |        |             | system      | CREATEDB
+ mz_system | materialize |             |        |             | system      | CREATEROLE
+```
+
+```sql
+SHOW PRIVILEGES ON SCHEMAS;
+```
+
+```nofmt
+  grantor  |   grantee   |  database   | schema |  name  | object_type | privilege_type
+-----------+-------------+-------------+--------+--------+-------------+----------------
+ mz_system | PUBLIC      | materialize |        | public | schema      | USAGE
+ mz_system | materialize | materialize |        | public | schema      | CREATE
+ mz_system | materialize | materialize |        | public | schema      | USAGE
+```
+
+```sql
+SHOW PRIVILEGES FOR materialize;
+```
+
+```nofmt
+  grantor  |   grantee   |  database   | schema |    name     | object_type | privilege_type
+-----------+-------------+-------------+--------+-------------+-------------+----------------
+ mz_system | materialize | materialize |        | public      | schema      | CREATE
+ mz_system | materialize | materialize |        | public      | schema      | USAGE
+ mz_system | materialize |             |        | default     | cluster     | CREATE
+ mz_system | materialize |             |        | default     | cluster     | USAGE
+ mz_system | materialize |             |        | materialize | database    | CREATE
+ mz_system | materialize |             |        | materialize | database    | USAGE
+ mz_system | materialize |             |        |             | system      | CREATECLUSTER
+ mz_system | materialize |             |        |             | system      | CREATEDB
+ mz_system | materialize |             |        |             | system      | CREATEROLE
+```
+
+## Related pages
+
+- [GRANT PRIVILEGE](../grant-privilege)
+- [REVOKE PRIVILEGE](../revoke-privilege)
+- [access control](/manage/access-control/)

--- a/doc/user/layouts/partials/sql-grammar/show-privileges.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-privileges.svg
@@ -1,0 +1,107 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="523" height="463">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="102" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="102"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">PRIVILEGES</text>
+   <rect x="257" y="35" width="40" height="32" rx="10"/>
+   <rect x="255"
+         y="33"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="265" y="53">ON</text>
+   <rect x="337" y="35" width="74" height="32" rx="10"/>
+   <rect x="335"
+         y="33"
+         width="74"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="53">TABLES</text>
+   <rect x="337" y="79" width="66" height="32" rx="10"/>
+   <rect x="335"
+         y="77"
+         width="66"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="97">TYPES</text>
+   <rect x="337" y="123" width="84" height="32" rx="10"/>
+   <rect x="335"
+         y="121"
+         width="84"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="141">SECRETS</text>
+   <rect x="337" y="167" width="124" height="32" rx="10"/>
+   <rect x="335"
+         y="165"
+         width="124"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="185">CONNECTIONS</text>
+   <rect x="337" y="211" width="106" height="32" rx="10"/>
+   <rect x="335"
+         y="209"
+         width="106"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="229">DATABASES</text>
+   <rect x="337" y="255" width="90" height="32" rx="10"/>
+   <rect x="335"
+         y="253"
+         width="90"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="273">SCHEMAS</text>
+   <rect x="337" y="299" width="94" height="32" rx="10"/>
+   <rect x="335"
+         y="297"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="317">CLUSTERS</text>
+   <rect x="337" y="343" width="78" height="32" rx="10"/>
+   <rect x="335"
+         y="341"
+         width="78"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="345" y="361">SYSTEM</text>
+   <rect x="319" y="429" width="48" height="32" rx="10"/>
+   <rect x="317"
+         y="427"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="327" y="447">FOR</text>
+   <rect x="387" y="429" width="88" height="32"/>
+   <rect x="385" y="427" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="395" y="447">role_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m102 0 h10 m20 0 h10 m0 0 h234 m-264 0 h20 m244 0 h20 m-284 0 q10 0 10 10 m264 0 q0 -10 10 -10 m-274 10 v12 m264 0 v-12 m-264 12 q0 10 10 10 m244 0 q10 0 10 -10 m-254 10 h10 m40 0 h10 m20 0 h10 m74 0 h10 m0 0 h50 m-164 0 h20 m144 0 h20 m-184 0 q10 0 10 10 m164 0 q0 -10 10 -10 m-174 10 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m66 0 h10 m0 0 h58 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m84 0 h10 m0 0 h40 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m124 0 h10 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m106 0 h10 m0 0 h18 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m90 0 h10 m0 0 h34 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m94 0 h10 m0 0 h30 m-154 -10 v20 m164 0 v-20 m-164 20 v24 m164 0 v-24 m-164 24 q0 10 10 10 m144 0 q10 0 10 -10 m-154 10 h10 m78 0 h10 m0 0 h46 m42 -340 l2 0 m2 0 l2 0 m2 0 l2 0 m-246 394 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h166 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v12 m196 0 v-12 m-196 12 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m48 0 h10 m0 0 h10 m88 0 h10 m23 -32 h-3"/>
+   <polygon points="513 411 521 407 521 415"/>
+   <polygon points="513 411 505 407 505 415"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -437,6 +437,8 @@ show_views ::=
   'SHOW' 'VIEWS' ('FROM' schema_name)?
 show_objects ::=
   'SHOW' 'OBJECTS' ('FROM' schema_name)?
+show_privileges ::=
+  'SHOW' 'PRIVILEGES' ('ON' ('TABLES' | 'TYPES' | 'SECRETS' | 'CONNECTIONS' | 'DATABASES' | 'SCHEMAS' | 'CLUSTERS' | 'SYSTEM'))? ('FOR' role_name)?
 string_agg ::=
   'string_agg' '(' value ',' delimiter    ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 subscribe_stmt ::=

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2448,6 +2448,10 @@ pub enum ShowObjectType<T: AstInfo> {
     Subsource {
         on_source: Option<T::ItemName>,
     },
+    Privileges {
+        object_type: Option<SystemObjectType>,
+        role: Option<T::RoleName>,
+    },
 }
 /// `SHOW <object>S`
 ///
@@ -2468,6 +2472,7 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
     fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
         f.write_str("SHOW");
         f.write_str(" ");
+
         f.write_str(match &self.object_type {
             ShowObjectType::Table => "TABLES",
             ShowObjectType::View => "VIEWS",
@@ -2485,6 +2490,7 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
             ShowObjectType::Database => "DATABASES",
             ShowObjectType::Schema { .. } => "SCHEMAS",
             ShowObjectType::Subsource { .. } => "SUBSOURCES",
+            ShowObjectType::Privileges { .. } => "PRIVILEGES",
         });
 
         if let ShowObjectType::Index { on_object, .. } = &self.object_type {
@@ -2522,6 +2528,20 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
             if let Some(on_source) = on_source {
                 f.write_str(" ON ");
                 f.write_node(on_source);
+            }
+        }
+
+        if let ShowObjectType::Privileges { object_type, role } = &self.object_type {
+            if let Some(object_type) = object_type {
+                f.write_str(" ON ");
+                f.write_node(object_type);
+                if let SystemObjectType::Object(_) = object_type {
+                    f.write_str("S");
+                }
+            }
+            if let Some(role) = role {
+                f.write_str(" FOR ");
+                f.write_node(role);
             }
         }
 
@@ -2864,7 +2884,7 @@ impl<T: AstInfo> AstDisplay for InsertSource<T> {
 }
 impl_display_t!(InsertSource);
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
 pub enum ObjectType {
     Table,
     View,
@@ -2930,6 +2950,22 @@ impl AstDisplay for ObjectType {
     }
 }
 impl_display!(ObjectType);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Copy)]
+pub enum SystemObjectType {
+    System,
+    Object(ObjectType),
+}
+
+impl AstDisplay for SystemObjectType {
+    fn fmt<W: fmt::Write>(&self, f: &mut AstFormatter<W>) {
+        match self {
+            SystemObjectType::System => f.write_str("SYSTEM"),
+            SystemObjectType::Object(object) => f.write_node(object),
+        }
+    }
+}
+impl_display!(SystemObjectType);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum ShowStatementFilter<T: AstInfo> {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6345,6 +6345,8 @@ impl<'a> Parser<'a> {
             Ok(ShowStatement::ShowVariable(ShowVariableStatement {
                 variable: Ident::from("cluster"),
             }))
+        } else if self.parse_keyword(PRIVILEGES) {
+            self.parse_show_privileges()
         } else if self.parse_keywords(&[CREATE, VIEW]) {
             Ok(ShowStatement::ShowCreateView(ShowCreateViewStatement {
                 view_name: self.parse_raw_name()?,
@@ -6416,6 +6418,24 @@ impl<'a> Parser<'a> {
         } else {
             Ok(None)
         }
+    }
+
+    fn parse_show_privileges(&mut self) -> Result<ShowStatement<Raw>, ParserError> {
+        let object_type = if self.parse_keyword(ON) {
+            Some(self.expect_plural_system_object_type_for_privileges()?)
+        } else {
+            None
+        };
+        let role = if self.parse_keyword(FOR) {
+            Some(self.parse_identifier()?)
+        } else {
+            None
+        };
+        Ok(ShowStatement::ShowObjects(ShowObjectsStatement {
+            object_type: ShowObjectType::Privileges { object_type, role },
+            from: None,
+            filter: self.parse_show_statement_filter()?,
+        }))
     }
 
     fn parse_inspect(&mut self) -> Result<ShowStatement<Raw>, ParserError> {
@@ -7673,6 +7693,51 @@ impl<'a> Parser<'a> {
                 DATABASES => ObjectType::Database,
                 SCHEMAS => ObjectType::Schema,
                 SUBSOURCES => ObjectType::Subsource,
+                _ => unreachable!(),
+            },
+        )
+    }
+
+    /// Bail out if the current token is not a privilege object type in the plural form, or consume and
+    /// return it if it is.
+    fn expect_plural_system_object_type_for_privileges(
+        &mut self,
+    ) -> Result<SystemObjectType, ParserError> {
+        if let Some(object_type) = self.parse_one_of_keywords(&[VIEWS, SOURCES]) {
+            return parser_err!(
+                self,
+                self.peek_prev_pos(),
+                format!("For object type {object_type}, you must specify 'TABLES'")
+            );
+        }
+        if self.parse_keywords(&[MATERIALIZED, VIEWS]) {
+            self.prev_token();
+            return parser_err!(
+                self,
+                self.peek_prev_pos(),
+                format!("For object type MATERIALIZED VIEWS, you must specify 'TABLES'")
+            );
+        }
+
+        Ok(
+            match self.expect_one_of_keywords(&[
+                SYSTEM,
+                TABLES,
+                TYPES,
+                CLUSTERS,
+                SECRETS,
+                CONNECTIONS,
+                DATABASES,
+                SCHEMAS,
+            ])? {
+                SYSTEM => SystemObjectType::System,
+                TABLES => SystemObjectType::Object(ObjectType::Table),
+                TYPES => SystemObjectType::Object(ObjectType::Type),
+                CLUSTERS => SystemObjectType::Object(ObjectType::Cluster),
+                SECRETS => SystemObjectType::Object(ObjectType::Secret),
+                CONNECTIONS => SystemObjectType::Object(ObjectType::Connection),
+                DATABASES => SystemObjectType::Object(ObjectType::Database),
+                SCHEMAS => SystemObjectType::Object(ObjectType::Schema),
                 _ => unreachable!(),
             },
         )

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -686,3 +686,52 @@ SHOW CONNECTIONS
 SHOW CONNECTIONS
 =>
 Show(ShowObjects(ShowObjectsStatement { object_type: Connection, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES
+----
+SHOW PRIVILEGES
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Privileges { object_type: None, role: None }, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES ON TABLES
+----
+SHOW PRIVILEGES ON TABLES
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Privileges { object_type: Some(Object(Table)), role: None }, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES FOR joe
+----
+SHOW PRIVILEGES FOR joe
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Privileges { object_type: None, role: Some(Ident("joe")) }, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES ON CLUSTERS  FOR mike
+----
+SHOW PRIVILEGES ON CLUSTERS FOR mike
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Privileges { object_type: Some(Object(Cluster)), role: Some(Ident("mike")) }, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES ON SYSTEM
+----
+SHOW PRIVILEGES ON SYSTEM
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: Privileges { object_type: Some(System), role: None }, from: None, filter: None }))
+
+parse-statement
+SHOW PRIVILEGES ON MATERIALIZED VIEWS
+----
+error: For object type MATERIALIZED VIEWS, you must specify 'TABLES'
+SHOW PRIVILEGES ON MATERIALIZED VIEWS
+                   ^
+
+parse-statement
+SHOW PRIVILEGES ON SOURCES
+----
+error: For object type SOURCES, you must specify 'TABLES'
+SHOW PRIVILEGES ON SOURCES
+                   ^

--- a/src/sql/src/plan/statement/show.rs
+++ b/src/sql/src/plan/statement/show.rs
@@ -20,6 +20,7 @@ use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     ShowCreateConnectionStatement, ShowCreateMaterializedViewStatement, ShowObjectType,
+    SystemObjectType,
 };
 use query::QueryContext;
 
@@ -32,7 +33,7 @@ use crate::ast::{
 use crate::catalog::{CatalogItemType, SessionCatalog};
 use crate::names::{
     self, Aug, NameSimplifier, ResolvedClusterName, ResolvedDatabaseName, ResolvedIds,
-    ResolvedItemName, ResolvedSchemaName,
+    ResolvedItemName, ResolvedRoleName, ResolvedSchemaName,
 };
 use crate::parse;
 use crate::plan::scope::Scope;
@@ -337,6 +338,10 @@ pub fn show_objects<'a>(
         ShowObjectType::Schema { from: db_from } => {
             assert!(from.is_none(), "parser should reject from");
             show_schemas(scx, db_from, filter)
+        }
+        ShowObjectType::Privileges { object_type, role } => {
+            assert!(from.is_none(), "parser should reject from");
+            show_privileges(scx, object_type, role, filter)
         }
     }
 }
@@ -692,6 +697,52 @@ pub fn show_secrets<'a>(
     );
 
     ShowSelect::new(scx, query, filter, None, Some(&["name"]))
+}
+
+pub fn show_privileges<'a>(
+    scx: &'a StatementContext<'a>,
+    object_type: Option<SystemObjectType>,
+    role: Option<ResolvedRoleName>,
+    filter: Option<ShowStatementFilter<Aug>>,
+) -> Result<ShowSelect<'a>, PlanError> {
+    let mut query_filter = Vec::new();
+    if let Some(object_type) = object_type {
+        query_filter.push(format!(
+            "object_type = '{}'",
+            object_type.to_string().to_lowercase()
+        ));
+    }
+    if let Some(role) = role {
+        let name = role.name;
+        query_filter.push(format!("CASE WHEN grantee = 'PUBLIC' THEN true ELSE pg_has_role('{name}', grantee, 'USAGE') END"));
+    }
+    let query_filter = if query_filter.len() > 0 {
+        format!("WHERE {}", itertools::join(query_filter, " AND "))
+    } else {
+        "".to_string()
+    };
+
+    let query = format!(
+        "SELECT grantor, grantee, database, schema, name, object_type, privilege_type
+        FROM mz_internal.mz_show_all_privileges
+        {query_filter}",
+    );
+
+    ShowSelect::new(
+        scx,
+        query,
+        filter,
+        None,
+        Some(&[
+            "grantor",
+            "grantee",
+            "database",
+            "schema",
+            "name",
+            "object_type",
+            "privilege_type",
+        ]),
+    )
 }
 
 /// An intermediate result when planning a `SHOW` query.

--- a/test/sqllogictest/rbac_views.slt
+++ b/test/sqllogictest/rbac_views.slt
@@ -355,6 +355,93 @@ materialize,r1,materialize,public,t,table,SELECT
 materialize,r2,materialize,public,t,table,SELECT
 COMPLETE 23
 
+query TTTTTTT
+SELECT * FROM (SHOW PRIVILEGES) ORDER BY object_type, database, schema, name, grantee
+----
+materialize  PUBLIC       NULL         NULL    c            cluster   USAGE
+materialize  materialize  NULL         NULL    c            cluster   USAGE
+materialize  materialize  NULL         NULL    c            cluster   CREATE
+materialize  r1           NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   CREATE
+materialize  r4           NULL         NULL    c            cluster   CREATE
+mz_system    PUBLIC       NULL         NULL    default      cluster  USAGE
+mz_system    materialize  NULL         NULL    default      cluster  USAGE
+mz_system    materialize  NULL         NULL    default      cluster  CREATE
+materialize  PUBLIC       NULL         NULL    d            database  CREATE
+materialize  materialize  NULL         NULL    d            database  USAGE
+materialize  materialize  NULL         NULL    d            database  CREATE
+materialize  r1           NULL         NULL    d            database  USAGE
+materialize  r1           NULL         NULL    d            database  CREATE
+materialize  r2           NULL         NULL    d            database  USAGE
+materialize  r4           NULL         NULL    d            database  CREATE
+mz_system    PUBLIC       NULL         NULL    materialize  database  USAGE
+mz_system    materialize  NULL         NULL    materialize  database  USAGE
+mz_system    materialize  NULL         NULL    materialize  database  CREATE
+materialize  PUBLIC       d            NULL    public       schema  USAGE
+materialize  materialize  d            NULL    public       schema  USAGE
+materialize  materialize  d            NULL    public       schema  CREATE
+mz_system    PUBLIC       materialize  NULL    public       schema  USAGE
+mz_system    materialize  materialize  NULL    public       schema  USAGE
+mz_system    materialize  materialize  NULL    public       schema  CREATE
+materialize  PUBLIC       materialize  NULL    s            schema  USAGE
+materialize  materialize  materialize  NULL    s            schema  USAGE
+materialize  materialize  materialize  NULL    s            schema  CREATE
+materialize  r1           materialize  NULL    s            schema  USAGE
+materialize  r3           materialize  NULL    s            schema  USAGE
+materialize  r5           materialize  NULL    s            schema  USAGE
+materialize  r5           materialize  NULL    s            schema  CREATE
+mz_system    PUBLIC       NULL         NULL    NULL         system    CREATECLUSTER
+mz_system    materialize  NULL         NULL    NULL         system    CREATEDB
+mz_system    materialize  NULL         NULL    NULL         system    CREATEROLE
+mz_system    materialize  NULL         NULL    NULL         system    CREATECLUSTER
+mz_system    r1           NULL         NULL    NULL         system    CREATEDB
+mz_system    r1           NULL         NULL    NULL         system    CREATECLUSTER
+mz_system    r2           NULL         NULL    NULL         system    CREATEROLE
+mz_system    r4           NULL         NULL    NULL         system    CREATECLUSTER
+materialize  PUBLIC       materialize  public  t            table  INSERT
+materialize  materialize  materialize  public  t            table  DELETE
+materialize  materialize  materialize  public  t            table  INSERT
+materialize  materialize  materialize  public  t            table  SELECT
+materialize  materialize  materialize  public  t            table  UPDATE
+materialize  r1           materialize  public  t            table  INSERT
+materialize  r1           materialize  public  t            table  SELECT
+materialize  r2           materialize  public  t            table  SELECT
+materialize  r5           materialize  public  t            table  DELETE
+
+query TTTTTTT
+SELECT * FROM (SHOW PRIVILEGES ON CLUSTERS) ORDER BY object_type, database, schema, name, grantee
+----
+materialize  PUBLIC       NULL         NULL    c            cluster   USAGE
+materialize  materialize  NULL         NULL    c            cluster   USAGE
+materialize  materialize  NULL         NULL    c            cluster   CREATE
+materialize  r1           NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   CREATE
+materialize  r4           NULL         NULL    c            cluster   CREATE
+mz_system    PUBLIC       NULL         NULL    default      cluster  USAGE
+mz_system    materialize  NULL         NULL    default      cluster  USAGE
+mz_system    materialize  NULL         NULL    default      cluster  CREATE
+
+query TTTTTTT
+SELECT * FROM (SHOW PRIVILEGES FOR r2) ORDER BY object_type, database, schema, name, grantee
+----
+materialize  PUBLIC       NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   USAGE
+materialize  r3           NULL         NULL    c            cluster   CREATE
+mz_system    PUBLIC       NULL         NULL    default      cluster  USAGE
+materialize  PUBLIC       NULL         NULL    d            database  CREATE
+materialize  r2           NULL         NULL    d            database  USAGE
+mz_system    PUBLIC       NULL         NULL    materialize  database  USAGE
+materialize  PUBLIC       d            NULL    public       schema  USAGE
+mz_system    PUBLIC       materialize  NULL    public       schema  USAGE
+materialize  PUBLIC       materialize  NULL    s            schema  USAGE
+materialize  r3           materialize  NULL    s            schema  USAGE
+mz_system    PUBLIC       NULL         NULL    NULL         system    CREATECLUSTER
+mz_system    r2           NULL         NULL    NULL         system    CREATEROLE
+materialize  PUBLIC       materialize  public  t            table  INSERT
+materialize  r2           materialize  public  t            table  SELECT
+
 # SHOW DEFAULT PRIVILEGES
 
 statement ok


### PR DESCRIPTION
This commit implements a SHOW PRIVILEGES command that allow users to display all privileges. The command allows optional filtering on object type or role grantee.

Works towards resolving #20452

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `SHOW PRIVILEGES` command.
