### PR TITLE
sql: Implement SHOW ROLE MEMBERSHIP command

### DIFF
--- a/doc/user/content/sql/grant-role.md
+++ b/doc/user/content/sql/grant-role.md
@@ -41,6 +41,7 @@ The privileges required to execute this statement are:
 
 ## Related pages
 
+- [SHOW ROLE MEMBERSHIP](../show-role-membership)
 - [CREATE ROLE](../create-role)
 - [ALTER ROLE](../alter-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/content/sql/revoke-role.md
+++ b/doc/user/content/sql/revoke-role.md
@@ -46,6 +46,7 @@ The privileges required to execute this statement are:
 
 ## Related pages
 
+- [SHOW ROLE MEMBERSHIP](../show-role-membership)
 - [CREATE ROLE](../create-role)
 - [ALTER ROLE](../alter-role)
 - [DROP ROLE](../drop-role)

--- a/doc/user/content/sql/show-role-membership.md
+++ b/doc/user/content/sql/show-role-membership.md
@@ -1,0 +1,51 @@
+---
+title: "SHOW ROLE MEMBERSHIP"
+description: "`SHOW ROLE MEMBERSHIP` lists the role memberships in Materialize."
+menu:
+  main:
+    parent: 'commands'
+
+---
+
+`SHOW ROLE MEMBERSHIP` lists the role memberships as part of [access control](/manage/access-control/) in Materialize.
+
+## Syntax
+
+{{< diagram "show-role-membership.svg" >}}
+
+Field                                               | Use
+----------------------------------------------------|--------------------------------------------------
+_role_name_                                         | Only shows role memberships granted directly or indirectly to _role_name_.
+
+## Examples
+
+```sql
+SHOW ROLE MEMBERSHIP;
+```
+
+```nofmt
+ role | member |  grantor
+------+--------+-----------
+ r2   | r1     | mz_system
+ r3   | r2     | mz_system
+ r4   | r3     | mz_system
+ r6   | r5     | mz_system
+```
+
+```sql
+SHOW ROLE MEMBERSHIP FOR r2;
+```
+
+```nofmt
+ role | member |  grantor
+------+--------+-----------
+ r2   | r1     | mz_system
+ r3   | r2     | mz_system
+ r4   | r3     | mz_system
+```
+
+## Related pages
+
+- [GRANT ROLE](../grant-role)
+- [REVOKE ROLE](../revoke-role)
+- [access control](/manage/access-control/)

--- a/doc/user/layouts/partials/sql-grammar/show-role-membership.svg
+++ b/doc/user/layouts/partials/sql-grammar/show-role-membership.svg
@@ -1,0 +1,43 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="549" height="69">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="31" y="3" width="64" height="32" rx="10"/>
+   <rect x="29"
+         y="1"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="39" y="21">SHOW</text>
+   <rect x="115" y="3" width="56" height="32" rx="10"/>
+   <rect x="113"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="123" y="21">ROLE</text>
+   <rect x="191" y="3" width="114" height="32" rx="10"/>
+   <rect x="189"
+         y="1"
+         width="114"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="199" y="21">MEMBERSHIP</text>
+   <rect x="345" y="35" width="48" height="32" rx="10"/>
+   <rect x="343"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="353" y="53">FOR</text>
+   <rect x="413" y="35" width="88" height="32"/>
+   <rect x="411" y="33" width="88" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="421" y="53">role_name</text>
+   <path class="line"
+         d="m17 17 h2 m0 0 h10 m64 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m114 0 h10 m20 0 h10 m0 0 h166 m-196 0 h20 m176 0 h20 m-216 0 q10 0 10 10 m196 0 q0 -10 10 -10 m-206 10 v12 m196 0 v-12 m-196 12 q0 10 10 10 m176 0 q10 0 10 -10 m-186 10 h10 m48 0 h10 m0 0 h10 m88 0 h10 m23 -32 h-3"/>
+   <polygon points="539 17 547 13 547 21"/>
+   <polygon points="539 17 531 13 531 21"/>
+</svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -437,6 +437,8 @@ show_views ::=
   'SHOW' 'VIEWS' ('FROM' schema_name)?
 show_objects ::=
   'SHOW' 'OBJECTS' ('FROM' schema_name)?
+show_role_membership ::=
+  'SHOW' 'ROLE' 'MEMBERSHIP' ('FOR' role_name)?
 string_agg ::=
   'string_agg' '(' value ',' delimiter    ( 'ORDER' 'BY' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? ( ',' col_ref ( 'ASC' | 'DESC' )? ( 'NULLS LAST' | 'NULLS FIRST' )? )* )? ')' ('FILTER' '(' 'WHERE' filter_clause ')')?
 subscribe_stmt ::=

--- a/src/sql-lexer/src/keywords.txt
+++ b/src/sql-lexer/src/keywords.txt
@@ -222,6 +222,7 @@ Materialize
 Materialized
 Max
 Mechanisms
+Membership
 Merge
 Message
 Metadata

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -2448,6 +2448,9 @@ pub enum ShowObjectType<T: AstInfo> {
     Subsource {
         on_source: Option<T::ItemName>,
     },
+    RoleMembership {
+        role: Option<T::RoleName>,
+    },
 }
 /// `SHOW <object>S`
 ///
@@ -2485,6 +2488,7 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
             ShowObjectType::Database => "DATABASES",
             ShowObjectType::Schema { .. } => "SCHEMAS",
             ShowObjectType::Subsource { .. } => "SUBSOURCES",
+            ShowObjectType::RoleMembership { .. } => "ROLE MEMBERSHIP",
         });
 
         if let ShowObjectType::Index { on_object, .. } = &self.object_type {
@@ -2523,6 +2527,14 @@ impl<T: AstInfo> AstDisplay for ShowObjectsStatement<T> {
                 f.write_str(" ON ");
                 f.write_node(on_source);
             }
+        }
+
+        if let ShowObjectType::RoleMembership {
+            role: Some(role), ..
+        } = &self.object_type
+        {
+            f.write_str(" FOR ");
+            f.write_node(role);
         }
 
         if let Some(filter) = &self.filter {

--- a/src/sql-parser/src/parser.rs
+++ b/src/sql-parser/src/parser.rs
@@ -6345,6 +6345,18 @@ impl<'a> Parser<'a> {
             Ok(ShowStatement::ShowVariable(ShowVariableStatement {
                 variable: Ident::from("cluster"),
             }))
+        } else if self.parse_keyword(ROLE) {
+            self.expect_keyword(MEMBERSHIP)?;
+            let role = if self.parse_keyword(FOR) {
+                Some(self.parse_identifier()?)
+            } else {
+                None
+            };
+            Ok(ShowStatement::ShowObjects(ShowObjectsStatement {
+                object_type: ShowObjectType::RoleMembership { role },
+                from: None,
+                filter: self.parse_show_statement_filter()?,
+            }))
         } else if self.parse_keywords(&[CREATE, VIEW]) {
             Ok(ShowStatement::ShowCreateView(ShowCreateViewStatement {
                 view_name: self.parse_raw_name()?,

--- a/src/sql-parser/tests/testdata/show
+++ b/src/sql-parser/tests/testdata/show
@@ -686,3 +686,17 @@ SHOW CONNECTIONS
 SHOW CONNECTIONS
 =>
 Show(ShowObjects(ShowObjectsStatement { object_type: Connection, from: None, filter: None }))
+
+parse-statement
+SHOW ROLE MEMBERSHIP
+----
+SHOW ROLE MEMBERSHIP
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: RoleMembership { role: None }, from: None, filter: None }))
+
+parse-statement
+SHOW ROLE MEMBERSHIP FOR joe
+----
+SHOW ROLE MEMBERSHIP FOR joe
+=>
+Show(ShowObjects(ShowObjectsStatement { object_type: RoleMembership { role: Some(Ident("joe")) }, from: None, filter: None }))

--- a/test/sqllogictest/rbac_views.slt
+++ b/test/sqllogictest/rbac_views.slt
@@ -63,6 +63,19 @@ r2,r1,mz_system
 r3,r2,mz_system
 COMPLETE 2
 
+query TTT
+SELECT * FROM (SHOW ROLE MEMBERSHIP) ORDER BY role, member
+----
+r2  r1  mz_system
+r3  r2  mz_system
+r5  r4  mz_system
+
+query TTT
+SELECT * FROM (SHOW ROLE MEMBERSHIP FOR r2) ORDER BY role, member
+----
+r2  r1  mz_system
+r3  r2  mz_system
+
 # SHOW SYSTEM PRIVILEGES
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
This commit implements a SHOW ROLE MEMBERSHIP command that allow users to display all role membership. The command allows optional filtering on role or member.

Works towards resolving #20452

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add the `SHOW ROLE MEMBERSHIP` command.
