### PR TITLE
test/lang/python: test that terminated bare subscribes are noticed

### DIFF
--- a/test/lang/python/requirements.txt
+++ b/test/lang/python/requirements.txt
@@ -1,4 +1,4 @@
 psycopg==3.1.10
 psycopg-binary==3.1.10
-psycopg2==2.8.6
+psycopg2==2.9.9
 SQLAlchemy==1.3.20


### PR DESCRIPTION
Add a test for the issue fixed in https://github.com/MaterializeInc/materialize/pull/22337, in which Materialize would not
notice if a client hung up if the connection was waiting for rows from a
bare `SUBSCRIBE` statement (i.e., a `SUBSCRIBE` not wrapped in a
`COPY`).

### Motivation

  * This PR adds tests to lock in a previous bug fix.

### Tips for reviewer

😮‍💨 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
