### PR TITLE
ci: Improve tests pipeline runtime, group tests

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -98,7 +98,8 @@ so it is executed.""",
     if args.coverage:
         pipeline["env"]["CI_BUILDER_SCCACHE"] = 1
         pipeline["env"]["CI_COVERAGE_ENABLED"] = 1
-        for step in pipeline["steps"]:
+
+        def visit(step: dict[str, Any]) -> None:
             # Coverage runs are slower
             if "timeout_in_minutes" in step:
                 step["timeout_in_minutes"] *= 3
@@ -107,10 +108,25 @@ so it is executed.""",
                 step["skip"] = True
             if step.get("id") == "build-x86_64":
                 step["name"] = "Build x86_64 with coverage"
-    else:
+
         for step in pipeline["steps"]:
+            visit(step)
+            # Groups can't be nested, so handle them explicitly here instead of recursing
+            if "group" in step:
+                for inner_step in step.get("steps", []):
+                    visit(inner_step)
+
+    else:
+
+        def visit(step: dict[str, Any]) -> None:
             if step.get("coverage") == "only":
                 step["skip"] = True
+
+        for step in pipeline["steps"]:
+            visit(step)
+            if "group" in step:
+                for inner_step in step.get("steps", []):
+                    visit(inner_step)
 
     prioritize_pipeline(pipeline)
 
@@ -120,11 +136,17 @@ so it is executed.""",
 
     # Remove the Materialize-specific keys from the configuration that are
     # only used to inform how to trim the pipeline and for coverage runs.
-    for step in pipeline["steps"]:
+    def visit(step: dict[str, Any]) -> None:
         if "inputs" in step:
             del step["inputs"]
         if "coverage" in step:
             del step["coverage"]
+
+    for step in pipeline["steps"]:
+        visit(step)
+        if "group" in step:
+            for inner_step in step.get("steps", []):
+                visit(inner_step)
 
     spawn.runv(
         ["buildkite-agent", "pipeline", "upload"], stdin=yaml.dump(pipeline).encode()
@@ -167,7 +189,12 @@ def prioritize_pipeline(pipeline: Any) -> None:
 
 def permit_rerunning_successful_steps(pipeline: Any) -> None:
     for config in pipeline["steps"]:
-        if "trigger" in config or "wait" in config or "block" in config:
+        if (
+            "trigger" in config
+            or "wait" in config
+            or "block" in config
+            or "group" in config
+        ):
             continue
         config.setdefault("retry", {}).setdefault("manual", {}).setdefault(
             "permit_on_passed", True
@@ -197,11 +224,15 @@ def add_test_selection_block(pipeline: Any, pipeline_name: str) -> None:
     else:
         return
 
-    for step in pipeline["steps"]:
-        if "id" not in step or step["id"] in ("analyze", "build-x86_64"):
-            continue
+    def visit(step: dict[str, Any]) -> None:
+        if "id" in step and step["id"] not in ("analyze", "build-x86_64"):
+            selection_step["fields"][0]["options"].append({"value": step["id"]})
 
-        selection_step["fields"][0]["options"].append({"value": step["id"]})
+    for step in pipeline["steps"]:
+        visit(step)
+        if "group" in step:
+            for inner_step in step.get("steps", []):
+                visit(inner_step)
 
     pipeline["steps"].insert(0, selection_step)
 
@@ -224,9 +255,10 @@ def trim_pipeline(pipeline: Any, coverage: bool) -> None:
     deps = repo.resolve_dependencies(image for image in repo)
 
     steps = OrderedDict()
-    for config in pipeline["steps"]:
-        if "wait" in config:
-            continue
+
+    def to_step(config: dict[str, Any]) -> PipelineStep | None:
+        if "wait" in config or "group" in config:
+            return None
         step = PipelineStep(config["id"])
         if "inputs" in config:
             for inp in config["inputs"]:
@@ -251,7 +283,16 @@ def trim_pipeline(pipeline: Any, coverage: bool) -> None:
                     elif plugin_name == "./ci/plugins/cloudtest":
                         step.image_dependencies.add(deps["environmentd"])
                         step.image_dependencies.add(deps["clusterd"])
-        steps[step.id] = step
+
+        return step
+
+    for config in pipeline["steps"]:
+        if step := to_step(config):
+            steps[step.id] = step
+        if "group" in config:
+            for inner_config in config.get("steps", []):
+                if inner_step := to_step(inner_config):
+                    steps[inner_step.id] = inner_step
 
     # Find all the steps whose inputs have changed with respect to main.
     # We delegate this hard work to Git.
@@ -293,8 +334,17 @@ def trim_pipeline(pipeline: Any, coverage: bool) -> None:
 
     # Restrict the pipeline to the needed steps.
     pipeline["steps"] = [
-        step for step in pipeline["steps"] if "wait" in step or step["id"] in needed
+        step
+        for step in pipeline["steps"]
+        if "wait" in step or "group" in step or step["id"] in needed
     ]
+    for step in pipeline["steps"]:
+        if "group" in step:
+            step["steps"] = [
+                inner_step
+                for inner_step in step.get("steps", [])
+                if inner_step["id"] in needed
+            ]
 
 
 def have_paths_changed(globs: Iterable[str]) -> bool:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -69,30 +69,105 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: kafka-multi-broker
 
-  - id: redpanda-testdrive
-    label: ":panda_face: :racing_car: testdrive"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--redpanda, --aws-region=us-east-1]
+  - group: Testdrive
+    key: testdrive
+    steps:
+      - id: redpanda-testdrive
+        label: ":panda_face: :racing_car: testdrive"
+        timeout_in_minutes: 600
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--redpanda, --aws-region=us-east-1]
 
-# Disabled due to taking too long for the value provided
-#  - id: redpanda-testdrive-aarch64
-#    label: ":panda_face: :racing_car: testdrive aarch64"
-#    timeout_in_minutes: 600
-#    agents:
-#      queue: linux-aarch64
-#    artifact_paths: junit_*.xml
-#    plugins:
-#      - ./ci/plugins/scratch-aws-access: ~
-#      - ./ci/plugins/mzcompose:
-#          composition: testdrive
-#          args: [--redpanda, --aws-region=us-east-1]
+      # Disabled due to taking too long for the value provided
+      #  - id: redpanda-testdrive-aarch64
+      #    label: ":panda_face: :racing_car: testdrive aarch64"
+      #    timeout_in_minutes: 600
+      #    agents:
+      #      queue: linux-aarch64
+      #    artifact_paths: junit_*.xml
+      #    plugins:
+      #      - ./ci/plugins/scratch-aws-access: ~
+      #      - ./ci/plugins/mzcompose:
+      #          composition: testdrive
+      #          args: [--redpanda, --aws-region=us-east-1]
+
+      - id: testdrive-partitions-5
+        label: ":racing_car: testdrive with --kafka-default-partitions 5"
+        timeout_in_minutes: 600
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--aws-region=us-east-1, --kafka-default-partitions=5]
+
+      - id: testdrive-replicas-4
+        label: ":racing_car: testdrive 4 replicas"
+        timeout_in_minutes: 600
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--aws-region=us-east-1, --replicas=4]
+
+      - id: testdrive-size-1
+        label: ":racing_car: testdrive with SIZE 1"
+        timeout_in_minutes: 600
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--aws-region=us-east-1, --default-size=1]
+
+      - id: testdrive-size-8
+        label: ":racing_car: testdrive with SIZE 8"
+        timeout_in_minutes: 600
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--aws-region=us-east-1, --default-size=8]
+
+      - id: testdrive-in-cloudtest
+        label: Full Testdrive in Cloudtest (K8s)
+        timeout_in_minutes: 300
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/cloudtest:
+              args: [-m=long, --aws-region=us-east-1, test/cloudtest/test_full_testdrive.py]
+
+      - id: persistence-testdrive
+        label: ":racing_car: testdrive with --persistent-user-tables"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/mzcompose:
+              composition: testdrive
+              args: [--aws-region=us-east-1, --persistent-user-tables]
+        skip: Persistence tests disabled
 
   - id: limits
     label: "Product limits"
@@ -117,78 +192,6 @@ steps:
           run: instance-size
     timeout_in_minutes: 50
 
-  - id: testdrive-partitions-5
-    label: ":racing_car: testdrive with --kafka-default-partitions 5"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-1, --kafka-default-partitions=5]
-
-  - id: testdrive-replicas-4
-    label: ":racing_car: testdrive 4 replicas"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-1, --replicas=4]
-
-  - id: testdrive-size-1
-    label: ":racing_car: testdrive with SIZE 1"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-1, --default-size=1]
-
-  - id: testdrive-size-8
-    label: ":racing_car: testdrive with SIZE 8"
-    timeout_in_minutes: 600
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-1, --default-size=8]
-
-  - id: testdrive-in-cloudtest
-    label: Full Testdrive in Cloudtest (K8s)
-    timeout_in_minutes: 300
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/cloudtest:
-          args: [-m=long, --aws-region=us-east-1, test/cloudtest/test_full_testdrive.py]
-
-  - id: persistence-testdrive
-    label: ":racing_car: testdrive with --persistent-user-tables"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/mzcompose:
-          composition: testdrive
-          args: [--aws-region=us-east-1, --persistent-user-tables]
-    skip: Persistence tests disabled
-
   - id: upsert-compaction-enabled
     label: Upsert (compaction enabled)
     timeout_in_minutes: 30
@@ -199,334 +202,346 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: zippy-kafka-sources
-    label: "Zippy Kafka Sources"
-    timeout_in_minutes: 120
-    agents:
-      # Workload takes slightly more than 8Gb, so it OOMs
-      # on the instances from the linux-x86_64 queue
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m]
+  - group: Zippy
+    key: zippy
+    steps:
+      - id: zippy-kafka-sources
+        label: "Zippy Kafka Sources"
+        timeout_in_minutes: 120
+        agents:
+          # Workload takes slightly more than 8Gb, so it OOMs
+          # on the instances from the linux-x86_64 queue
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=KafkaSources, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-kafka-parallel-insert
-    label: "Zippy Kafka Parallel Insert"
-    timeout_in_minutes: 120
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=10000, --max-execution-time=30m]
+      - id: zippy-kafka-parallel-insert
+        label: "Zippy Kafka Parallel Insert"
+        timeout_in_minutes: 120
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=KafkaParallelInsert, --transaction-isolation=serializable, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-user-tables
-    label: "Zippy User Tables"
-    timeout_in_minutes: 180
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=UserTables, --actions=10000, --max-execution-time=30m]
+      - id: zippy-user-tables
+        label: "Zippy User Tables"
+        timeout_in_minutes: 180
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=UserTables, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-postgres-cdc
-    label: "Zippy Postgres CDC"
-    timeout_in_minutes: 120
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=PostgresCdc, --actions=10000, --max-execution-time=30m]
+      - id: zippy-postgres-cdc
+        label: "Zippy Postgres CDC"
+        timeout_in_minutes: 120
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=PostgresCdc, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-debezium-postgres
-    label: "Zippy Debezium Postgres"
-    timeout_in_minutes: 120
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=DebeziumPostgres, --actions=10000, --max-execution-time=30m]
+      - id: zippy-debezium-postgres
+        label: "Zippy Debezium Postgres"
+        timeout_in_minutes: 120
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=DebeziumPostgres, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-cluster-replicas
-    label: "Zippy Cluster Replicas"
-    timeout_in_minutes: 120
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=30m]
+      - id: zippy-cluster-replicas
+        label: "Zippy Cluster Replicas"
+        timeout_in_minutes: 120
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=ClusterReplicas, --actions=10000, --max-execution-time=30m]
 
-  - id: zippy-crdb-latest
-    label: "Zippy w/ latest CRDB"
-    timeout_in_minutes: 120
-    agents:
-      # Workload takes slightly more than 8Gb, so it OOMs
-      # on the instances from the linux-x86_64 queue
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: zippy
-          args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=30m]
+      - id: zippy-crdb-latest
+        label: "Zippy w/ latest CRDB"
+        timeout_in_minutes: 120
+        agents:
+          # Workload takes slightly more than 8Gb, so it OOMs
+          # on the instances from the linux-x86_64 queue
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: zippy
+              args: [--scenario=KafkaSources, --actions=10000, --cockroach-tag=latest, --max-execution-time=30m]
 
-  - id: secrets-aws-secrets-manager
-    label: "Secrets AWS"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: secrets-aws-secrets-manager
+  - group: Secrets
+    key: secrets
+    steps:
+      - id: secrets-aws-secrets-manager
+        label: "Secrets AWS"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: secrets-aws-secrets-manager
 
-  - id: secrets-local-file
-    label: "Secrets Local File"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: secrets-local-file
+      - id: secrets-local-file
+        label: "Secrets Local File"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: secrets-local-file
 
-  - id: checks-restart-cockroach
-    label: "Checks + restart Cockroach"
-    timeout_in_minutes: 60
-    artifact_paths: junit_*.xml
-    agents:
-      # A larger instance is needed due to frequent OOMs
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
+  - group: "Platform checks"
+    key: platform-checks
+    steps:
+      - id: checks-restart-cockroach
+        label: "Checks + restart Cockroach"
+        timeout_in_minutes: 60
+        artifact_paths: junit_*.xml
+        agents:
+          # A larger instance is needed due to frequent OOMs
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartCockroach, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-restart-entire-mz
-    label: "Checks + restart of the entire Mz"
-    timeout_in_minutes: 60
-    artifact_paths: junit_*.xml
-    agents:
-      # A larger instance is needed due to frequent OOMs
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-restart-entire-mz
+        label: "Checks + restart of the entire Mz"
+        timeout_in_minutes: 60
+        artifact_paths: junit_*.xml
+        agents:
+          # A larger instance is needed due to frequent OOMs
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartEntireMz, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-parallel-drop-create-default-replica
-    label: "Checks parallel + DROP/CREATE replica"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel]
+      - id: checks-parallel-drop-create-default-replica
+        label: "Checks parallel + DROP/CREATE replica"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=DropCreateDefaultReplica, --execution-mode=parallel]
 
-  - id: checks-parallel-restart-clusterd-compute
-    label: "Checks parallel + restart compute clusterd"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartClusterdCompute, --execution-mode=parallel]
+      - id: checks-parallel-restart-clusterd-compute
+        label: "Checks parallel + restart compute clusterd"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartClusterdCompute, --execution-mode=parallel]
 
-  - id: checks-parallel-restart-entire-mz
-    label: "Checks parallel + restart of the entire Mz"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEntireMz, --execution-mode=parallel]
+      - id: checks-parallel-restart-entire-mz
+        label: "Checks parallel + restart of the entire Mz"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartEntireMz, --execution-mode=parallel]
 
-  - id: checks-parallel-restart-environmentd-clusterd-storage
-    label: "Checks parallel + restart of environmentd & storage clusterd"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel]
+      - id: checks-parallel-restart-environmentd-clusterd-storage
+        label: "Checks parallel + restart of environmentd & storage clusterd"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartEnvironmentdClusterdStorage, --execution-mode=parallel]
 
-  - id: checks-parallel-kill-clusterd-storage
-    label: "Checks parallel + kill storage clusterd"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=KillClusterdStorage, --execution-mode=parallel]
+      - id: checks-parallel-kill-clusterd-storage
+        label: "Checks parallel + kill storage clusterd"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=KillClusterdStorage, --execution-mode=parallel]
 
-  - id: checks-parallel-restart-redpanda
-    label: "Checks parallel + restart Redpanda & Debezium"
-    skip: "Affected by #21317"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel]
+      - id: checks-parallel-restart-redpanda
+        label: "Checks parallel + restart Redpanda & Debezium"
+        skip: "Affected by #21317"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartRedpandaDebezium, --execution-mode=parallel]
 
-  - id: checks-upgrade-entire-mz
-    label: "Checks upgrade, whole-Mz restart"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeEntireMz]
+      - id: checks-upgrade-entire-mz
+        label: "Checks upgrade, whole-Mz restart"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMz]
 
-  - id: checks-upgrade-entire-mz-previous-version
-    label: "Checks upgrade from previous version, whole-Mz restart"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeEntireMzPreviousVersion]
+      - id: checks-upgrade-entire-mz-previous-version
+        label: "Checks upgrade from previous version, whole-Mz restart"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzPreviousVersion]
 
-  - id: checks-upgrade-entire-mz-two-versions
-    label: "Checks upgrade across two versions"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeEntireMzTwoVersions]
+      - id: checks-upgrade-entire-mz-two-versions
+        label: "Checks upgrade across two versions"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzTwoVersions]
 
-  - id: checks-upgrade-entire-mz-skip-version
-    label: "Checks upgrade from X-2 directly to HEAD"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeEntireMzSkipVersion]
+      - id: checks-upgrade-entire-mz-skip-version
+        label: "Checks upgrade from X-2 directly to HEAD"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzSkipVersion]
 
-  - id: checks-upgrade-entire-mz-four-versions
-    label: "Checks upgrade across four versions"
-    timeout_in_minutes: 60
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeEntireMzFourVersions]
+      - id: checks-upgrade-entire-mz-four-versions
+        label: "Checks upgrade across four versions"
+        timeout_in_minutes: 60
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeEntireMzFourVersions]
 
-  - id: checks-upgrade-clusterd-compute-first
-    label: "Platform checks upgrade, restarting compute clusterd first"
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeClusterdComputeFirst]
+      - id: checks-upgrade-clusterd-compute-first
+        label: "Platform checks upgrade, restarting compute clusterd first"
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeClusterdComputeFirst]
 
-  - id: checks-upgrade-clusterd-compute-last
-    label: "Platform checks upgrade, restarting compute clusterd last"
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=UpgradeClusterdComputeLast]
+      - id: checks-upgrade-clusterd-compute-last
+        label: "Platform checks upgrade, restarting compute clusterd last"
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=UpgradeClusterdComputeLast]
 
-  - id: checks-upgrade-matrix
-    label: "Random upgrades over the entire matrix"
-    timeout_in_minutes: 300
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: upgrade-matrix
-          args: ["--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-upgrade-matrix
+        label: "Random upgrades over the entire matrix"
+        timeout_in_minutes: 300
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: upgrade-matrix
+              args: ["--seed=$BUILDKITE_JOB_ID"]
 
-  - id: cloudtest-upgrade
-    label: "Platform checks upgrade in Cloudtest/K8s"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/scratch-aws-access: ~
-      - ./ci/plugins/cloudtest:
-          args: [-m=long,  --aws-region=us-east-1, test/cloudtest/test_upgrade.py]
+      - id: cloudtest-upgrade
+        label: "Platform checks upgrade in Cloudtest/K8s"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/scratch-aws-access: ~
+          - ./ci/plugins/cloudtest:
+              args: [-m=long,  --aws-region=us-east-1, test/cloudtest/test_upgrade.py]
 
-  - id: persist-maelstrom-single-node
-    label: Long single-node Maelstrom coverage of persist
-    timeout_in_minutes: 20
-    agents:
-      queue: linux-x86_64
-    artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persist
-          args: [--node-count=1, --consensus=mem, --blob=mem, --time-limit=600, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+  - group: Maelstrom
+    key: maelstrom
+    steps:
+      - id: persist-maelstrom-single-node
+        label: Long single-node Maelstrom coverage of persist
+        timeout_in_minutes: 20
+        agents:
+          queue: linux-x86_64
+        artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: persist
+              args: [--node-count=1, --consensus=mem, --blob=mem, --time-limit=600, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
-  - id: persist-maelstrom-multi-node
-    label: Long multi-node Maelstrom coverage of persist with postgres consensus
-    timeout_in_minutes: 20
-    agents:
-      queue: linux-x86_64
-    artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persist
-          args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
+      - id: persist-maelstrom-multi-node
+        label: Long multi-node Maelstrom coverage of persist with postgres consensus
+        timeout_in_minutes: 20
+        agents:
+          queue: linux-x86_64
+        artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: persist
+              args: [--node-count=4, --consensus=cockroach, --blob=maelstrom, --time-limit=300, --concurrency=4, --rate=500, --max-txn-length=16, --unreliability=0.1]
 
-  - id: persist-txn-maelstrom
-    label: Maelstrom coverage of persist-txn
-    timeout_in_minutes: 10
-    agents:
-      queue: linux-x86_64
-    artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persist
-          args: [--consensus=mem, --blob=mem, --persist-txn]
+      - id: persist-txn-maelstrom
+        label: Maelstrom coverage of persist-txn
+        timeout_in_minutes: 10
+        agents:
+          queue: linux-x86_64
+        artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: persist
+              args: [--consensus=mem, --blob=mem, --persist-txn]
 
   - id: persistence-failpoints
     label: Persistence failpoints
@@ -606,93 +621,102 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: mz-e2e
 
-  - id: output-consistency-internal
-    label: "Output consistency (internal)"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: output-consistency
-          args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+  - group: "Output consistency"
+    key: output-consistency
+    steps:
+      - id: output-consistency-internal
+        label: "Output consistency (internal)"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: output-consistency
+              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
 
-  - id: output-consistency-postgres
-    label: "Output consistency (Postgres)"
-    timeout_in_minutes: 58
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: postgres-consistency
-          args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
+      - id: output-consistency-postgres
+        label: "Output consistency (Postgres)"
+        timeout_in_minutes: 58
+        agents:
+          queue: linux-x86_64
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: postgres-consistency
+              args: ["--seed=$BUILDKITE_JOB_ID", "--max-runtime-in-sec=1200"]
 
-  - id: sqlsmith
-    label: "SQLsmith"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlsmith
-          args: [--max-joins=2, --runtime=1500]
+  - group: SQLsmith
+    key: sqlsmith-group
+    steps:
+      - id: sqlsmith
+        label: "SQLsmith"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlsmith
+              args: [--max-joins=2, --runtime=1500]
 
-  - id: sqlsmith-explain
-    label: "SQLsmith explain"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlsmith
-          args: [--max-joins=15, --explain-only, --runtime=1500]
+      - id: sqlsmith-explain
+        label: "SQLsmith explain"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlsmith
+              args: [--max-joins=15, --explain-only, --runtime=1500]
 
-  - id: sqlancer-pqs
-    label: "SQLancer PQS"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=1500, --oracle=PQS, --no-qpg]
+  - group: SQLancer
+    key: sqlancer
+    steps:
+      - id: sqlancer-pqs
+        label: "SQLancer PQS"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlancer
+              args: [--runtime=1500, --oracle=PQS, --no-qpg]
 
-  - id: sqlancer-norec
-    label: "SQLancer NoREC"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=1500, --oracle=NOREC]
+      - id: sqlancer-norec
+        label: "SQLancer NoREC"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlancer
+              args: [--runtime=1500, --oracle=NOREC]
 
-  - id: sqlancer-query-partitioning
-    label: "SQLancer QueryPartitioning"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=1500, --oracle=QUERY_PARTITIONING]
+      - id: sqlancer-query-partitioning
+        label: "SQLancer QueryPartitioning"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlancer
+              args: [--runtime=1500, --oracle=QUERY_PARTITIONING]
 
-  - id: sqlancer-having
-    label: "SQLancer Having"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: sqlancer
-          args: [--runtime=1500, --oracle=HAVING]
+      - id: sqlancer-having
+        label: "SQLancer Having"
+        artifact_paths: junit_*.xml
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: sqlancer
+              args: [--runtime=1500, --oracle=HAVING]
 
   - id: crdb-restarts
     label: "CRDB rolling restarts"
@@ -722,62 +746,65 @@ steps:
       - ./ci/plugins/mzcompose:
           composition: data-ingest
 
-  - id: parallel-workload-dml
-    label: "Parallel Workload (DML)"
-    artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: parallel-workload
-          args: [--runtime=1500, --complexity=dml, --threads=8]
+  - group: "Parallel Workload"
+    key: parallel-workload
+    steps:
+      - id: parallel-workload-dml
+        label: "Parallel Workload (DML)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log]
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --complexity=dml, --threads=8]
 
-  - id: parallel-workload
-    label: "Parallel Workload"
-    artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: parallel-workload
-          args: [--runtime=1500]
+      - id: parallel-workload-ddl
+        label: "Parallel Workload (DDL)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log]
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500]
 
-  # TODO: Reenable when #21954 is fixed
-  #- id: parallel-workload-100-threads
-  #  label: "Parallel Workload (100 threads)"
-  #  artifact_paths: [junit_*.xml, pw-*.log]
-  #  timeout_in_minutes: 30
-  #  agents:
-  #    queue: builder-linux-x86_64
-  #  plugins:
-  #    - ./ci/plugins/mzcompose:
-  #        composition: parallel-workload
-  #        args: [--runtime=1500, --threads=100]
+      # TODO: Reenable when #21954 is fixed
+      # - id: parallel-workload-100-threads
+      #   label: "Parallel Workload (100 threads)"
+      #   artifact_paths: [junit_*.xml, pw-*.log]
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: builder-linux-x86_64
+      #   plugins:
+      #     - ./ci/plugins/mzcompose:
+      #         composition: parallel-workload
+      #         args: [--runtime=1500, --threads=100]
 
-  - id: parallel-workload-cancel
-    label: "Parallel Workload (cancel)"
-    artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: parallel-workload
-          args: [--runtime=1500, --scenario=cancel]
+      - id: parallel-workload-cancel
+        label: "Parallel Workload (cancel)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log]
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --scenario=cancel]
 
-  # TODO(def-) Enable after figuring out restoring catalog
-  #- id: parallel-workload-kill
-  #  label: "Parallel Workload (kill)"
-  #  artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-  #  timeout_in_minutes: 30
-  #  agents:
-  #    queue: builder-linux-x86_64
-  #  plugins:
-  #    - ./ci/plugins/mzcompose:
-  #        composition: parallel-workload
-  #        args: [--runtime=1500, --scenario=kill]
+      # TODO(def-) Enable after figuring out restoring catalog
+      # - id: parallel-workload-kill
+      #   label: "Parallel Workload (kill)"
+      #   artifact_paths: [junit_*.xml, parallel-workload-queries.log]
+      #   timeout_in_minutes: 30
+      #   agents:
+      #     queue: builder-linux-x86_64
+      #   plugins:
+      #     - ./ci/plugins/mzcompose:
+      #         composition: parallel-workload
+      #         args: [--runtime=1500, --scenario=kill]
 
   - id: incident-70
     label: "Test for incident 70"

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -127,14 +127,20 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 ],
                 env=env,
             )
+
             cpu_count = os.cpu_count()
             assert cpu_count
+
+            partition = int(os.environ.get("BUILDKITE_PARALLEL_JOB", 0)) + 1
+            total = int(os.environ.get("BUILDKITE_PARALLEL_JOB_COUNT", 1))
+
             spawn.runv(
                 [
                     "cargo",
                     "nextest",
                     "run",
                     "--profile=ci",
+                    f"--partition=count:{partition}/{total}",
                     # Most tests don't use 100% of a CPU core, so run two tests per CPU.
                     # TODO(def-): Reenable when #19931 is fixed
                     # f"--test-threads={cpu_count * 2}",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -23,138 +23,144 @@ env:
   # CARGO_BUILD_JOBS: "default"
 
 steps:
-  - id: build-x86_64
-    label: Build x86_64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
-    inputs:
-      - "*"
-    timeout_in_minutes: 60
-    priority: 1
-    agents:
-      queue: builder-linux-x86_64
+  - group: Builds
+    key: builds
+    steps:
+      - id: build-x86_64
+        label: Build x86_64
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        timeout_in_minutes: 60
+        priority: 1
+        agents:
+          queue: builder-linux-x86_64
 
-  - id: build-aarch64
-    label: Build aarch64
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
-    inputs:
-      - "*"
-    priority: 1
-    timeout_in_minutes: 60
-    branches: "main v*.*"
-    agents:
-      queue: builder-linux-aarch64
-    coverage: skip
+      - id: build-aarch64
+        label: Build aarch64
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.build
+        inputs:
+          - "*"
+        priority: 1
+        timeout_in_minutes: 60
+        branches: "main v*.*"
+        agents:
+          queue: builder-linux-aarch64
+        coverage: skip
 
-  - id: build-wasm
-    label: Build WASM
-    command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm --no-release
-    inputs:
-      - "*"
-    timeout_in_minutes: 10
-    agents:
-      queue: linux-x86_64
-    coverage: skip
+      - id: build-wasm
+        label: Build WASM
+        command: bin/ci-builder run stable bin/pyactivate -m ci.deploy.npm --no-release
+        inputs:
+          - "*"
+        timeout_in_minutes: 10
+        agents:
+          queue: linux-x86_64
+        coverage: skip
 
-  - id: check-merge-with-target
-    label: Merge skew cargo check
-    command: ci/test/check-merge-with-target.sh
-    inputs:
-      - Cargo.lock
-      - "**/Cargo.toml"
-      - "**/*.rs"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    if: "build.pull_request.id != null"
-    coverage: skip
+      - id: check-merge-with-target
+        label: Merge skew cargo check
+        command: ci/test/check-merge-with-target.sh
+        inputs:
+          - Cargo.lock
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        if: "build.pull_request.id != null"
+        coverage: skip
 
-  - id: devel-docker-tags
-    label: Tag development docker images
-    command: bin/ci-builder run stable bin/pyactivate -m ci.test.dev_tag
-    inputs:
-      - "*"
-    depends_on:
-      - build-x86_64
-      - build-aarch64
-    timeout_in_minutes: 10
-    agents:
-      queue: linux-x86_64
-    coverage: skip
-    # Fortify against intermittent DockerHub issues
-    retry:
-      automatic:
-        - exit_status: 1
-          limit: 2
+      - id: devel-docker-tags
+        label: Tag development docker images
+        command: bin/ci-builder run stable bin/pyactivate -m ci.test.dev_tag
+        inputs:
+          - "*"
+        depends_on:
+          - build-x86_64
+          - build-aarch64
+        timeout_in_minutes: 10
+        agents:
+          queue: linux-x86_64
+        coverage: skip
+        # Fortify against intermittent DockerHub issues
+        retry:
+          automatic:
+            - exit_status: 1
+              limit: 2
 
-  - id: lint-fast
-    label: Lint and rustfmt
-    command: bin/ci-builder run stable ci/test/lint-fast.sh
-    inputs:
-      - "*"
-    timeout_in_minutes: 10
-    agents:
-      queue: linux-x86_64
-    coverage: skip
+  - group: Lints
+    key: lints
+    steps:
+      - id: lint-fast
+        label: Lint and rustfmt
+        command: bin/ci-builder run stable ci/test/lint-fast.sh
+        inputs:
+          - "*"
+        timeout_in_minutes: 10
+        agents:
+          queue: linux-x86_64
+        coverage: skip
 
-  - id: lint-slow
-    label: Clippy and doctests
-    command: bin/ci-builder run stable ci/test/lint-slow.sh
-    inputs:
-      - Cargo.lock
-      - "**/Cargo.toml"
-      - "**/*.rs"
-    timeout_in_minutes: 30
-    agents:
-      queue: builder-linux-x86_64
-    coverage: skip
+      - id: lint-slow
+        label: Clippy and doctests
+        command: bin/ci-builder run stable ci/test/lint-slow.sh
+        inputs:
+          - Cargo.lock
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        timeout_in_minutes: 30
+        agents:
+          queue: builder-linux-x86_64
+        coverage: skip
 
-  - id: lint-macos
-    label: macOS Clippy
-    command: cargo clippy --all-targets -- -D warnings
-    env:
-      CARGO_INCREMENTAL: "0"
-      RUSTUP_TOOLCHAIN: $RUST_VERSION
-    inputs:
-      - Cargo.lock
-      - "**/Cargo.toml"
-      - "**/*.rs"
-    timeout_in_minutes: 30
-    agents:
-      queue: mac
-    coverage: skip
+      - id: lint-macos
+        label: macOS Clippy
+        command: cargo clippy --all-targets -- -D warnings
+        env:
+          CARGO_INCREMENTAL: "0"
+          RUSTUP_TOOLCHAIN: $RUST_VERSION
+        inputs:
+          - Cargo.lock
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        timeout_in_minutes: 30
+        agents:
+          queue: mac
+        coverage: skip
 
-  - id: lint-deps
-    label: Lint dependencies
-    command: bin/ci-builder run stable ci/test/lint-deps.sh
-    inputs:
-      - Cargo.lock
-      - "**/Cargo.toml"
-      - "**/*.rs"
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    coverage: skip
+      - id: lint-deps
+        label: Lint dependencies
+        command: bin/ci-builder run stable ci/test/lint-deps.sh
+        inputs:
+          - Cargo.lock
+          - "**/Cargo.toml"
+          - "**/*.rs"
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        coverage: skip
 
-  - id: lint-docs
-    label: Lint docs
-    command: bin/ci-builder run stable ci/test/lint-docs.sh
-    inputs:
-      - doc/user
-      - src/adapter/src/catalog
-      - test/sqllogictest/autogenerated
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    coverage: skip
+      - id: lint-docs
+        label: Lint docs
+        command: bin/ci-builder run stable ci/test/lint-docs.sh
+        inputs:
+          - doc/user
+          - src/adapter/src/catalog
+          - test/sqllogictest/autogenerated
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        coverage: skip
 
-  - id: preview-docs
-    label: Preview docs
-    command: bin/ci-builder run stable ci/test/preview-docs.sh
-    inputs: [doc/user]
-    timeout_in_minutes: 30
-    agents:
-      queue: linux-x86_64
-    coverage: skip
+      - id: preview-docs
+        label: Preview docs
+        command: bin/ci-builder run stable ci/test/preview-docs.sh
+        inputs: [doc/user]
+        timeout_in_minutes: 30
+        agents:
+          queue: linux-x86_64
+        coverage: skip
 
   - id: cargo-test
     label: Cargo test
@@ -271,68 +277,74 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: debezium-postgres
-    label: Debezium Postgres tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/debezium]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: debezium
-          run: postgres
-    agents:
-      queue: linux-x86_64
+  - group: "Debezium tests"
+    key: debezium-tests
+    steps:
+      - id: debezium-postgres
+        label: Debezium Postgres tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/debezium]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: debezium
+              run: postgres
+        agents:
+          queue: linux-x86_64
 
-  - id: debezium-sql-server
-    label: Debezium SQL Server tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/debezium]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: debezium
-          run: sql-server
-    agents:
-      queue: linux-x86_64
+      - id: debezium-sql-server
+        label: Debezium SQL Server tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/debezium]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: debezium
+              run: sql-server
+        agents:
+          queue: linux-x86_64
 
-  - id: debezium-mysql
-    label: Debezium MySQL tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/debezium]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: debezium
-          run: mysql
-    agents:
-      queue: linux-x86_64
+      - id: debezium-mysql
+        label: Debezium MySQL tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/debezium]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: debezium
+              run: mysql
+        agents:
+          queue: linux-x86_64
 
-  - id: pg-cdc
-    label: Postgres CDC tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/pg-cdc]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: pg-cdc
-    agents:
-      queue: linux-x86_64
+  - group: "Postgres tests"
+    key: postgres-tests
+    steps:
+      - id: pg-cdc
+        label: Postgres CDC tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/pg-cdc]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: pg-cdc
+        agents:
+          queue: linux-x86_64
 
-  - id: pg-cdc-resumption
-    label: Postgres CDC resumption tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/pg-cdc-resumption]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: pg-cdc-resumption
-    agents:
-      queue: linux-x86_64
+      - id: pg-cdc-resumption
+        label: Postgres CDC resumption tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/pg-cdc-resumption]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: pg-cdc-resumption
+        agents:
+          queue: linux-x86_64
 
   - id: ssh-connection
     label: SSH connection tests
@@ -346,16 +358,54 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: kafka-resumption
-    label: Kafka resumption tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-resumption
-    agents:
-      queue: linux-x86_64
+  - group: "Kafka tests"
+    key: kafka-tests
+    steps:
+      - id: kafka-resumption
+        label: Kafka resumption tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: kafka-resumption
+        agents:
+          queue: linux-x86_64
+
+      - id: kafka-ssl
+        label: Kafka SSL smoke test
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/kafka-ssl/smoketest.td]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: kafka-ssl
+        agents:
+          queue: linux-x86_64
+
+      - id: kafka-sasl-plain
+        label: Kafka SASL PLAIN smoke test
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        inputs: [test/kafka-sasl-plain/smoketest.td]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: kafka-sasl-plain
+        agents:
+          queue: linux-x86_64
+
+      - id: kafka-exactly-once
+        label: Kafka exactly-once tests
+        depends_on: build-x86_64
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: kafka-exactly-once
+        agents:
+          queue: linux-x86_64
 
   - id: zippy-kafka-sources-short
     label: "Short Zippy"
@@ -370,83 +420,86 @@ steps:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=200]
 
-  - id: checks-drop-create-default-replica
-    label: "Checks + DROP/CREATE replica"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
+  - group: "Platform checks"
+    key: platform-checks
+    steps:
+      - id: checks-restart-environmentd-clusterd-storage
+        label: "Checks + restart of environmentd & storage clusterd"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartEnvironmentdClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-no-restart-no-upgrade
-    label: "Checks without restart or upgrade"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-drop-create-default-replica
+        label: "Checks + DROP/CREATE replica"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=DropCreateDefaultReplica, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-restart-clusterd-compute
-    label: "Checks + restart clusterd compute"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartClusterdCompute, "--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-no-restart-no-upgrade
+        label: "Checks without restart or upgrade"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=NoRestartNoUpgrade, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-restart-environmentd-clusterd-storage
-    label: "Checks + restart of environmentd & storage clusterd"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartEnvironmentdClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-restart-clusterd-compute
+        label: "Checks + restart clusterd compute"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartClusterdCompute, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-kill-clusterd-storage
-    label: "Checks + kill storage clusterd"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
+      - id: checks-kill-clusterd-storage
+        label: "Checks + kill storage clusterd"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=KillClusterdStorage, "--seed=$BUILDKITE_JOB_ID"]
 
-  - id: checks-restart-source-postgres
-    label: "Checks + restart source Postgres"
-    depends_on: build-x86_64
-    inputs: [misc/python/materialize/checks]
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: platform-checks
-          args: [--scenario=RestartSourcePostgres, --check=PgCdc]
+      - id: checks-restart-source-postgres
+        label: "Checks + restart source Postgres"
+        depends_on: build-x86_64
+        inputs: [misc/python/materialize/checks]
+        timeout_in_minutes: 30
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=RestartSourcePostgres, --check=PgCdc]
 
   - id: cloudtest
     label: Cloudtest %n
@@ -522,30 +575,6 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: kafka-ssl
-    label: Kafka SSL smoke test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/kafka-ssl/smoketest.td]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-ssl
-    agents:
-      queue: linux-x86_64
-
-  - id: kafka-sasl-plain
-    label: Kafka SASL PLAIN smoke test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/kafka-sasl-plain/smoketest.td]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-sasl-plain
-    agents:
-      queue: linux-x86_64
-
   - id: chbench-demo
     label: chbench smoke test
     depends_on: build-x86_64
@@ -577,17 +606,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: dbt-materialize
-    agents:
-      queue: linux-x86_64
-
-  - id: kafka-exactly-once
-    label: Kafka exactly-once tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-exactly-once
     agents:
       queue: linux-x86_64
 
@@ -628,53 +646,56 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: lang-csharp
-    label: ":csharp: tests"
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/lang/csharp]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: csharp
-    agents:
-      queue: linux-x86_64
+  - group: "Language tests"
+    key: language-tests
+    steps:
+      - id: lang-csharp
+        label: ":csharp: tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 10
+        inputs: [test/lang/csharp]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: csharp
+        agents:
+          queue: linux-x86_64
 
-  - id: lang-js
-    label: ":js: tests"
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/lang/js]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: js
-    agents:
-      queue: linux-x86_64
+      - id: lang-js
+        label: ":js: tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 10
+        inputs: [test/lang/js]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: js
+        agents:
+          queue: linux-x86_64
 
-  - id: lang-java
-    label: ":java: tests"
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/lang/java]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: java
-    agents:
-      queue: linux-x86_64
+      - id: lang-java
+        label: ":java: tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 10
+        inputs: [test/lang/java]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: java
+        agents:
+          queue: linux-x86_64
 
-  - id: lang-python
-    label: ":python: tests"
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/lang/python]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: python
-    agents:
-      queue: linux-x86_64
+      - id: lang-python
+        label: ":python: tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 10
+        inputs: [test/lang/python]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: python
+        agents:
+          queue: linux-x86_64
 
   - id: deploy-website
     label: Deploy website

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -164,7 +164,6 @@ steps:
 
   - id: cargo-test
     label: Cargo test
-    parallelism: 2
     timeout_in_minutes: 30
     artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
     inputs:
@@ -187,7 +186,7 @@ steps:
   - id: miri-test
     label: Miri test (fast) %n
     inputs: [src]
-    parallelism: 4
+    parallelism: 2
     timeout_in_minutes: 30
     artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
     plugins:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -158,6 +158,7 @@ steps:
 
   - id: cargo-test
     label: Cargo test
+    parallelism: 2
     timeout_in_minutes: 30
     artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
     inputs:
@@ -180,7 +181,7 @@ steps:
   - id: miri-test
     label: Miri test (fast) %n
     inputs: [src]
-    parallelism: 2
+    parallelism: 4
     timeout_in_minutes: 30
     artifact_paths: [junit_*.xml, target/nextest/ci/junit_cargo-test.xml]
     plugins:
@@ -197,7 +198,7 @@ steps:
     depends_on: build-x86_64
     timeout_in_minutes: 30
     inputs: [test/testdrive]
-    parallelism: 4
+    parallelism: 6
     # Don't need the junit_mzcompose_*.xml for this
     artifact_paths: [junit_testdrive_*.xml, test/testdrive/junit_testdrive_*.xml]
     plugins:
@@ -221,75 +222,16 @@ steps:
     agents:
       queue: linux-x86_64
 
-  - id: persistence
-    label: Persistence tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persistence
-    agents:
-      queue: linux-x86_64
-
   - id: cluster-tests
     label: Cluster tests %n
     depends_on: build-x86_64
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     inputs: [test/cluster]
-    parallelism: 2
+    parallelism: 4
     plugins:
       - ./ci/plugins/mzcompose:
           composition: cluster
-    agents:
-      queue: linux-x86_64
-
-  - id: cluster-isolation
-    label: Cluster isolation test
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/cluster-isolation]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: cluster-isolation
-    agents:
-      queue: linux-x86_64
-
-  - id: replica-isolation
-    label: Replica isolation
-    depends_on: build-x86_64
-    timeout_in_minutes: 20
-    inputs: [test/replica-isolation]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: replica-isolation
-    agents:
-      queue: linux-x86_64
-
-  - id: kafka-ssl
-    label: Kafka SSL smoke test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/kafka-ssl/smoketest.td]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-ssl
-    agents:
-      queue: linux-x86_64
-
-  - id: kafka-sasl-plain
-    label: Kafka SASL PLAIN smoke test
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    inputs: [test/kafka-sasl-plain/smoketest.td]
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-sasl-plain
     agents:
       queue: linux-x86_64
 
@@ -297,24 +239,12 @@ steps:
     label: Fast SQL logic tests %n
     depends_on: build-x86_64
     timeout_in_minutes: 30
-    parallelism: 3
+    parallelism: 5
     inputs: [test/sqllogictest]
     artifact_paths: junit_*.xml
     plugins:
       - ./ci/plugins/mzcompose:
           composition: sqllogictest
-    agents:
-      queue: linux-x86_64
-
-  - id: chbench-demo
-    label: chbench smoke test
-    depends_on: build-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: chbench
-          args: [--run-seconds=10, --wait]
-    timeout_in_minutes: 30
     agents:
       queue: linux-x86_64
 
@@ -338,28 +268,6 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: legacy-upgrade
-    agents:
-      queue: linux-x86_64
-
-  - id: metabase-demo
-    label: Metabase smoke test
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: metabase
-    agents:
-      queue: linux-x86_64
-
-  - id: dbt-materialize
-    label: dbt-materialize tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: dbt-materialize
     agents:
       queue: linux-x86_64
 
@@ -462,31 +370,6 @@ steps:
           composition: zippy
           args: [--scenario=KafkaSources, --actions=200]
 
-  - id: kafka-exactly-once
-    label: Kafka exactly-once tests
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: kafka-exactly-once
-    agents:
-      queue: linux-x86_64
-
-  - id: persist-maelstrom
-    label: Maelstrom coverage of persist
-    depends_on: build-x86_64
-    timeout_in_minutes: 10
-    inputs: [test/persist]
-    artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: persist
-          args: [--consensus=mem, --blob=mem]
-    agents:
-      queue: linux-x86_64
-    coverage: skip # Randomized, shouldn't count for coverage
-
   - id: checks-drop-create-default-replica
     label: "Checks + DROP/CREATE replica"
     depends_on: build-x86_64
@@ -568,7 +451,7 @@ steps:
   - id: cloudtest
     label: Cloudtest %n
     depends_on: build-x86_64
-    parallelism: 3
+    parallelism: 5
     timeout_in_minutes: 30
     artifact_paths: junit_*.xml
     inputs:
@@ -590,6 +473,137 @@ steps:
     plugins:
       - ./ci/plugins/mzcompose:
           composition: source-sink-errors
+
+  - id: feature-benchmark-kafka-only
+    label: "Feature benchmark (Kafka only)"
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: feature-benchmark
+          args: [--scenario=KafkaUpsertUnique]
+    coverage: skip
+
+  # Fast tests closer to the end, doesn't matter as much if they have to wait
+  # for an agent
+  - id: replica-isolation
+    label: Replica isolation
+    depends_on: build-x86_64
+    timeout_in_minutes: 20
+    inputs: [test/replica-isolation]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: replica-isolation
+    agents:
+      queue: linux-x86_64
+
+  - id: persistence
+    label: Persistence tests
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persistence
+    agents:
+      queue: linux-x86_64
+
+  - id: cluster-isolation
+    label: Cluster isolation test
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    inputs: [test/cluster-isolation]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: cluster-isolation
+    agents:
+      queue: linux-x86_64
+
+  - id: kafka-ssl
+    label: Kafka SSL smoke test
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [test/kafka-ssl/smoketest.td]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: kafka-ssl
+    agents:
+      queue: linux-x86_64
+
+  - id: kafka-sasl-plain
+    label: Kafka SASL PLAIN smoke test
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    inputs: [test/kafka-sasl-plain/smoketest.td]
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: kafka-sasl-plain
+    agents:
+      queue: linux-x86_64
+
+  - id: chbench-demo
+    label: chbench smoke test
+    depends_on: build-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: chbench
+          args: [--run-seconds=10, --wait]
+    timeout_in_minutes: 30
+    agents:
+      queue: linux-x86_64
+
+  - id: metabase-demo
+    label: Metabase smoke test
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: metabase
+    agents:
+      queue: linux-x86_64
+
+  - id: dbt-materialize
+    label: dbt-materialize tests
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: dbt-materialize
+    agents:
+      queue: linux-x86_64
+
+  - id: kafka-exactly-once
+    label: Kafka exactly-once tests
+    depends_on: build-x86_64
+    timeout_in_minutes: 30
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: kafka-exactly-once
+    agents:
+      queue: linux-x86_64
+
+  - id: persist-maelstrom
+    label: Maelstrom coverage of persist
+    depends_on: build-x86_64
+    timeout_in_minutes: 10
+    inputs: [test/persist]
+    artifact_paths: [test/persist/maelstrom/**/*.log, junit_*.xml]
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: persist
+          args: [--consensus=mem, --blob=mem]
+    agents:
+      queue: linux-x86_64
+    coverage: skip # Randomized, shouldn't count for coverage
 
   - id: storage-usage
     label: "Storage Usage Table Test"
@@ -661,17 +675,6 @@ steps:
           composition: python
     agents:
       queue: linux-x86_64
-
-  - id: feature-benchmark-kafka-only
-    label: "Feature benchmark (Kafka only)"
-    depends_on: build-x86_64
-    timeout_in_minutes: 30
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: feature-benchmark
-          args: [--scenario=KafkaUpsertUnique]
-    coverage: skip
 
   - id: deploy-website
     label: Deploy website


### PR DESCRIPTION
Old tests pipeline:
![Screenshot 2023-10-16 at 13 12 23](https://github.com/MaterializeInc/materialize/assets/2335377/8845c320-1ad2-4846-a990-9f1d6c8049cb)
New tests pipeline:
![Screenshot 2023-10-16 at 13 12 51](https://github.com/MaterializeInc/materialize/assets/2335377/fdd60f86-72a2-4e9e-b07c-e43a737691ca)

Old nightly pipeline:
![Screenshot 2023-10-16 at 13 19 03](https://github.com/MaterializeInc/materialize/assets/2335377/88f0799a-2f97-4933-b20e-7d21ec31d900)
New nightly pipeline:
![Screenshot 2023-10-16 at 13 19 40](https://github.com/MaterializeInc/materialize/assets/2335377/c828052b-db10-4a8b-a87b-0b7fc851f1ea)
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
