### PR TITLE
test: Deflake test_pg_cancel_dropped_role

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3376,7 +3376,7 @@ fn test_params() {
     client.batch_execute("COMMIT").unwrap();
 }
 
-// Test pg_cancel_backed after the authenticated role is dropped.
+// Test pg_cancel_backend after the authenticated role is dropped.
 #[mz_ore::test]
 fn test_pg_cancel_dropped_role() {
     mz_ore::test::init_logging();
@@ -3392,14 +3392,14 @@ fn test_pg_cancel_dropped_role() {
         .unwrap();
 
     // Start session using role.
-    let _dropped_client = server
+    let dropped_client = server
         .pg_config()
         .user(dropped_role)
         .connect(postgres::NoTls)
         .unwrap();
 
     // Get the connection ID of the new session.
-    let connection_id = query_client
+    let connection_id = dropped_client
         .query_one(
             &format!(
                 "SELECT s.id

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3392,7 +3392,7 @@ fn test_pg_cancel_dropped_role() {
         .unwrap();
 
     // Start session using role.
-    let dropped_client = server
+    let mut dropped_client = server
         .pg_config()
         .user(dropped_role)
         .connect(postgres::NoTls)


### PR DESCRIPTION
The test_pg_cancel_dropped_role test would start a new connection, called dropped_client, and then use another connection, called query_client, to look up dropped_client's session ID in mz_sessions. In CI the lookup would occasionally fail and cause a panic. The reason is that starting a new session and writing the session details to mz_sessions is not linearizable, so we are not guaranteed to see it after a session has been established. However, it does exhibit sequential consistency, so a session will always be able to see its own information in mz_sessions.

This commit updates test_pg_cancel_dropped_role to have dropped_client to look up the session ID instead of query_client, which guarantees that we will always see the ID.

Fixes #22408

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
