### PR TITLE
catalog: Add consistency check for items/objects

### DIFF
--- a/src/adapter/src/coord/consistency.rs
+++ b/src/adapter/src/coord/consistency.rs
@@ -17,7 +17,7 @@ use serde::Serialize;
 #[derive(Debug, Default, Serialize, PartialEq)]
 pub struct CoordinatorInconsistencies {
     /// Inconsistencies found in the catalog.
-    catalog_inconsistencies: CatalogInconsistencies,
+    catalog_inconsistencies: Box<CatalogInconsistencies>,
     /// Inconsistencies found in read capabilities.
     read_capabilities: Vec<ReadCapabilitiesInconsistency>,
 }


### PR DESCRIPTION
This PR spun out of https://github.com/MaterializeInc/materialize/pull/22365. It adds a new consistency check to make sure items and schemas are consistent.


### Motivation

  * This PR adds a feature that has not yet been specified.

It adds a consistency check to make sure our schema entries in `CatalogState` are consistent, and items in the catalog reference an existing schema.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
