### PR TITLE
catalog: Add insta test for initial catalog state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3688,6 +3688,7 @@ dependencies = [
  "async-trait",
  "derivative",
  "futures",
+ "insta",
  "itertools",
  "mz-audit-log",
  "mz-compute-client",

--- a/bin/lint
+++ b/bin/lint
@@ -71,6 +71,7 @@ copyright_files=$(grep -vE \
     -e 'misc/completions/.*' \
     -e 'supply-chain/.*' \
     -e '.devcontainer/.*' \
+    -e 'snapshots/.*\.snap' \
     <<< "$files"
 )
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "materialize",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = "1.0.37"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
+insta = "1.32"
 mz-postgres-util = { path = "../postgres-util" }
 rand = "0.8.5"
 tokio = { version = "1.32.0" }

--- a/src/catalog/src/objects.rs
+++ b/src/catalog/src/objects.rs
@@ -814,7 +814,7 @@ impl DurableType<SystemPrivilegesKey, SystemPrivilegesValue> for MzAclItem {
 // Structs used internally to represent on-disk state.
 
 /// A snapshot of the current on-disk state.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Snapshot {
     pub databases: BTreeMap<proto::DatabaseKey, proto::DatabaseValue>,
     pub schemas: BTreeMap<proto::SchemaKey, proto::SchemaValue>,

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -90,7 +90,7 @@ use mz_catalog::{
     debug_stash_backed_catalog_state, stash_backed_catalog_state, BootstrapArgs, CatalogError,
     DurableCatalogState, OpenableDurableCatalogState, StashConfig,
 };
-use mz_ore::now::SYSTEM_TIME;
+use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
 use mz_repr::role_id::RoleId;
 use mz_stash::DebugStashFactory;
 use std::num::NonZeroI64;
@@ -346,9 +346,10 @@ async fn test_debug_open() {
 }
 
 async fn open<D: DurableCatalogState>(mut openable_state: impl OpenableDurableCatalogState<D>) {
-    {
+    let (snapshot, audit_log) = {
         let mut state = openable_state
-            .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
+            // Use `NOW_ZERO` for consistent timestamps in the snapshots.
+            .open(NOW_ZERO.clone(), &bootstrap_args(), None)
             .await
             .unwrap();
 
@@ -356,11 +357,14 @@ async fn open<D: DurableCatalogState>(mut openable_state: impl OpenableDurableCa
             state.epoch(),
             NonZeroI64::new(2).expect("known to be non-zero")
         );
-        // Check for initial clusters to ensure the catalog was opened properly.
-        let clusters = state.get_clusters().await.unwrap();
-        assert_eq!(clusters.len(), 3);
-    }
-    // Reopening the catalog will increment the epoch.
+        // Check initial snapshot.
+        let snapshot = state.snapshot().await.unwrap();
+        insta::assert_debug_snapshot!(snapshot);
+        let audit_log = state.get_audit_logs().await.unwrap();
+        insta::assert_debug_snapshot!(audit_log);
+        (snapshot, audit_log)
+    };
+    // Reopening the catalog will increment the epoch, but shouldn't change the initial snapshot.
     {
         let mut state = openable_state
             .open(SYSTEM_TIME.clone(), &bootstrap_args(), None)
@@ -371,6 +375,8 @@ async fn open<D: DurableCatalogState>(mut openable_state: impl OpenableDurableCa
             state.epoch(),
             NonZeroI64::new(3).expect("known to be non-zero")
         );
+        assert_eq!(state.snapshot().await.unwrap(), snapshot);
+        assert_eq!(state.get_audit_logs().await.unwrap(), audit_log);
     }
 }
 

--- a/src/catalog/tests/snapshots/open__open-2.snap
+++ b/src/catalog/tests/snapshots/open__open-2.snap
@@ -1,0 +1,200 @@
+---
+source: src/catalog/tests/open.rs
+expression: audit_log
+---
+[
+    V1(
+        EventV1 {
+            id: 1,
+            event_type: Grant,
+            object_type: Cluster,
+            details: AlterDefaultPrivilegeV1(
+                AlterDefaultPrivilegeV1 {
+                    role_id: "p",
+                    database_id: None,
+                    schema_id: None,
+                    grantee_id: "s2",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 2,
+            event_type: Grant,
+            object_type: Database,
+            details: AlterDefaultPrivilegeV1(
+                AlterDefaultPrivilegeV1 {
+                    role_id: "p",
+                    database_id: None,
+                    schema_id: None,
+                    grantee_id: "s2",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 3,
+            event_type: Grant,
+            object_type: Schema,
+            details: AlterDefaultPrivilegeV1(
+                AlterDefaultPrivilegeV1 {
+                    role_id: "p",
+                    database_id: None,
+                    schema_id: None,
+                    grantee_id: "s2",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 4,
+            event_type: Grant,
+            object_type: Type,
+            details: AlterDefaultPrivilegeV1(
+                AlterDefaultPrivilegeV1 {
+                    role_id: "p",
+                    database_id: None,
+                    schema_id: None,
+                    grantee_id: "p",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 5,
+            event_type: Create,
+            object_type: Database,
+            details: IdNameV1(
+                IdNameV1 {
+                    id: "u1",
+                    name: "materialize",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 6,
+            event_type: Grant,
+            object_type: Database,
+            details: UpdatePrivilegeV1(
+                UpdatePrivilegeV1 {
+                    object_id: "Du1",
+                    grantee_id: "p",
+                    grantor_id: "s1",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 7,
+            event_type: Create,
+            object_type: Schema,
+            details: SchemaV2(
+                SchemaV2 {
+                    id: "3",
+                    name: "public",
+                    database_name: Some(
+                        "materialize",
+                    ),
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 8,
+            event_type: Create,
+            object_type: Cluster,
+            details: IdNameV1(
+                IdNameV1 {
+                    id: "u1",
+                    name: "default",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 9,
+            event_type: Grant,
+            object_type: Cluster,
+            details: UpdatePrivilegeV1(
+                UpdatePrivilegeV1 {
+                    object_id: "Cu1",
+                    grantee_id: "p",
+                    grantor_id: "s1",
+                    privileges: "U",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 10,
+            event_type: Create,
+            object_type: ClusterReplica,
+            details: CreateClusterReplicaV1(
+                CreateClusterReplicaV1 {
+                    cluster_id: "u1",
+                    cluster_name: "default",
+                    replica_id: Some(
+                        "u1",
+                    ),
+                    replica_name: "r1",
+                    logical_size: "1",
+                    disk: false,
+                    billed_as: None,
+                    internal: false,
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+    V1(
+        EventV1 {
+            id: 11,
+            event_type: Grant,
+            object_type: System,
+            details: UpdatePrivilegeV1(
+                UpdatePrivilegeV1 {
+                    object_id: "SYSTEM",
+                    grantee_id: "s1",
+                    grantor_id: "s1",
+                    privileges: "RBN",
+                },
+            ),
+            user: None,
+            occurred_at: 0,
+        },
+    ),
+]

--- a/src/catalog/tests/snapshots/open__open.snap
+++ b/src/catalog/tests/snapshots/open__open.snap
@@ -1,0 +1,1432 @@
+---
+source: src/catalog/tests/open.rs
+expression: snapshot
+---
+Snapshot {
+    databases: {
+        DatabaseKey {
+            id: Some(
+                DatabaseId {
+                    value: Some(
+                        User(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: DatabaseValue {
+            name: "materialize",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+    },
+    schemas: {
+        SchemaKey {
+            id: Some(
+                SchemaId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: SchemaValue {
+            database_id: None,
+            name: "mz_catalog",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+        SchemaKey {
+            id: Some(
+                SchemaId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: SchemaValue {
+            database_id: None,
+            name: "pg_catalog",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+        SchemaKey {
+            id: Some(
+                SchemaId {
+                    value: Some(
+                        System(
+                            4,
+                        ),
+                    ),
+                },
+            ),
+        }: SchemaValue {
+            database_id: None,
+            name: "mz_internal",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+        SchemaKey {
+            id: Some(
+                SchemaId {
+                    value: Some(
+                        System(
+                            5,
+                        ),
+                    ),
+                },
+            ),
+        }: SchemaValue {
+            database_id: None,
+            name: "information_schema",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+        SchemaKey {
+            id: Some(
+                SchemaId {
+                    value: Some(
+                        User(
+                            3,
+                        ),
+                    ),
+                },
+            ),
+        }: SchemaValue {
+            database_id: Some(
+                DatabaseId {
+                    value: Some(
+                        User(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            name: "public",
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+        },
+    },
+    roles: {
+        RoleKey {
+            id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: RoleValue {
+            name: "mz_system",
+            attributes: Some(
+                RoleAttributes {
+                    inherit: true,
+                },
+            ),
+            membership: Some(
+                RoleMembership {
+                    map: [],
+                },
+            ),
+            vars: Some(
+                RoleVars {
+                    entries: [],
+                },
+            ),
+        },
+        RoleKey {
+            id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: RoleValue {
+            name: "mz_support",
+            attributes: Some(
+                RoleAttributes {
+                    inherit: true,
+                },
+            ),
+            membership: Some(
+                RoleMembership {
+                    map: [],
+                },
+            ),
+            vars: Some(
+                RoleVars {
+                    entries: [],
+                },
+            ),
+        },
+        RoleKey {
+            id: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+        }: RoleValue {
+            name: "public",
+            attributes: Some(
+                RoleAttributes {
+                    inherit: true,
+                },
+            ),
+            membership: Some(
+                RoleMembership {
+                    map: [],
+                },
+            ),
+            vars: Some(
+                RoleVars {
+                    entries: [],
+                },
+            ),
+        },
+    },
+    items: {},
+    comments: {},
+    clusters: {
+        ClusterKey {
+            id: Some(
+                ClusterId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterValue {
+            name: "mz_system",
+            linked_object_id: None,
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+            config: Some(
+                ClusterConfig {
+                    variant: Some(
+                        Unmanaged(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+        },
+        ClusterKey {
+            id: Some(
+                ClusterId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterValue {
+            name: "mz_introspection",
+            linked_object_id: None,
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+            config: Some(
+                ClusterConfig {
+                    variant: Some(
+                        Unmanaged(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+        },
+        ClusterKey {
+            id: Some(
+                ClusterId {
+                    value: Some(
+                        User(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterValue {
+            name: "default",
+            linked_object_id: None,
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            privileges: [
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                Public(
+                                    Empty,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    2,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 256,
+                        },
+                    ),
+                },
+                MzAclItem {
+                    grantee: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    grantor: Some(
+                        RoleId {
+                            value: Some(
+                                System(
+                                    1,
+                                ),
+                            ),
+                        },
+                    ),
+                    acl_mode: Some(
+                        AclMode {
+                            bitflags: 768,
+                        },
+                    ),
+                },
+            ],
+            config: Some(
+                ClusterConfig {
+                    variant: Some(
+                        Managed(
+                            ManagedCluster {
+                                size: "1",
+                                replication_factor: 1,
+                                availability_zones: [],
+                                logging: Some(
+                                    ReplicaLogging {
+                                        log_logging: false,
+                                        interval: Some(
+                                            Duration {
+                                                secs: 1,
+                                                nanos: 0,
+                                            },
+                                        ),
+                                    },
+                                ),
+                                idle_arrangement_merge_effort: None,
+                                disk: false,
+                            },
+                        ),
+                    ),
+                },
+            ),
+        },
+    },
+    cluster_replicas: {
+        ClusterReplicaKey {
+            id: Some(
+                ReplicaId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterReplicaValue {
+            cluster_id: Some(
+                ClusterId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            name: "r1",
+            config: Some(
+                ReplicaConfig {
+                    logging: Some(
+                        ReplicaLogging {
+                            log_logging: false,
+                            interval: Some(
+                                Duration {
+                                    secs: 1,
+                                    nanos: 0,
+                                },
+                            ),
+                        },
+                    ),
+                    idle_arrangement_merge_effort: None,
+                    location: Some(
+                        Managed(
+                            ManagedLocation {
+                                size: "1",
+                                availability_zone: None,
+                                disk: false,
+                                internal: false,
+                                billed_as: None,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        },
+        ClusterReplicaKey {
+            id: Some(
+                ReplicaId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterReplicaValue {
+            cluster_id: Some(
+                ClusterId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+            name: "r1",
+            config: Some(
+                ReplicaConfig {
+                    logging: Some(
+                        ReplicaLogging {
+                            log_logging: false,
+                            interval: Some(
+                                Duration {
+                                    secs: 1,
+                                    nanos: 0,
+                                },
+                            ),
+                        },
+                    ),
+                    idle_arrangement_merge_effort: None,
+                    location: Some(
+                        Managed(
+                            ManagedLocation {
+                                size: "1",
+                                availability_zone: None,
+                                disk: false,
+                                internal: false,
+                                billed_as: None,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        },
+        ClusterReplicaKey {
+            id: Some(
+                ReplicaId {
+                    value: Some(
+                        User(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: ClusterReplicaValue {
+            cluster_id: Some(
+                ClusterId {
+                    value: Some(
+                        User(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            name: "r1",
+            config: Some(
+                ReplicaConfig {
+                    logging: Some(
+                        ReplicaLogging {
+                            log_logging: false,
+                            interval: Some(
+                                Duration {
+                                    secs: 1,
+                                    nanos: 0,
+                                },
+                            ),
+                        },
+                    ),
+                    idle_arrangement_merge_effort: None,
+                    location: Some(
+                        Managed(
+                            ManagedLocation {
+                                size: "1",
+                                availability_zone: None,
+                                disk: false,
+                                internal: false,
+                                billed_as: None,
+                            },
+                        ),
+                    ),
+                },
+            ),
+            owner_id: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        },
+    },
+    introspection_sources: {},
+    id_allocator: {
+        IdAllocKey {
+            name: "auditlog",
+        }: IdAllocValue {
+            next_id: 12,
+        },
+        IdAllocKey {
+            name: "database",
+        }: IdAllocValue {
+            next_id: 2,
+        },
+        IdAllocKey {
+            name: "replica",
+        }: IdAllocValue {
+            next_id: 2,
+        },
+        IdAllocKey {
+            name: "schema",
+        }: IdAllocValue {
+            next_id: 6,
+        },
+        IdAllocKey {
+            name: "storage_usage",
+        }: IdAllocValue {
+            next_id: 1,
+        },
+        IdAllocKey {
+            name: "system",
+        }: IdAllocValue {
+            next_id: 1,
+        },
+        IdAllocKey {
+            name: "system_compute",
+        }: IdAllocValue {
+            next_id: 3,
+        },
+        IdAllocKey {
+            name: "system_replica",
+        }: IdAllocValue {
+            next_id: 3,
+        },
+        IdAllocKey {
+            name: "user",
+        }: IdAllocValue {
+            next_id: 1,
+        },
+        IdAllocKey {
+            name: "user_compute",
+        }: IdAllocValue {
+            next_id: 2,
+        },
+        IdAllocKey {
+            name: "user_role",
+        }: IdAllocValue {
+            next_id: 1,
+        },
+    },
+    configs: {
+        ConfigKey {
+            key: "deploy_generation",
+        }: ConfigValue {
+            value: 0,
+        },
+        ConfigKey {
+            key: "user_version",
+        }: ConfigValue {
+            value: 40,
+        },
+    },
+    settings: {},
+    timestamps: {
+        TimestampKey {
+            id: "M",
+        }: TimestampValue {
+            ts: Some(
+                Timestamp {
+                    internal: 0,
+                },
+            ),
+        },
+    },
+    system_object_mappings: {},
+    system_configurations: {},
+    default_privileges: {
+        DefaultPrivilegesKey {
+            role_id: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+            database_id: None,
+            schema_id: None,
+            object_type: Type,
+            grantee: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+        }: DefaultPrivilegesValue {
+            privileges: Some(
+                AclMode {
+                    bitflags: 256,
+                },
+            ),
+        },
+        DefaultPrivilegesKey {
+            role_id: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+            database_id: None,
+            schema_id: None,
+            object_type: Cluster,
+            grantee: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: DefaultPrivilegesValue {
+            privileges: Some(
+                AclMode {
+                    bitflags: 256,
+                },
+            ),
+        },
+        DefaultPrivilegesKey {
+            role_id: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+            database_id: None,
+            schema_id: None,
+            object_type: Database,
+            grantee: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: DefaultPrivilegesValue {
+            privileges: Some(
+                AclMode {
+                    bitflags: 256,
+                },
+            ),
+        },
+        DefaultPrivilegesKey {
+            role_id: Some(
+                RoleId {
+                    value: Some(
+                        Public(
+                            Empty,
+                        ),
+                    ),
+                },
+            ),
+            database_id: None,
+            schema_id: None,
+            object_type: Schema,
+            grantee: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            2,
+                        ),
+                    ),
+                },
+            ),
+        }: DefaultPrivilegesValue {
+            privileges: Some(
+                AclMode {
+                    bitflags: 256,
+                },
+            ),
+        },
+    },
+    system_privileges: {
+        SystemPrivilegesKey {
+            grantee: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+            grantor: Some(
+                RoleId {
+                    value: Some(
+                        System(
+                            1,
+                        ),
+                    ),
+                },
+            ),
+        }: SystemPrivilegesValue {
+            acl_mode: Some(
+                AclMode {
+                    bitflags: 3758096384,
+                },
+            ),
+        },
+    },
+}


### PR DESCRIPTION
This tests adds an insta test that tests the initial state of the catalog.

Resolves #22278

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
