### PR TITLE
sql: Add hint to DROP with no CASCADE errors

### DIFF
--- a/misc/python/materialize/checks/cluster_unification.py
+++ b/misc/python/materialize/checks/cluster_unification.py
@@ -91,10 +91,10 @@ class UnifiedCluster(Check):
             > SET cluster = default
 
             ! DROP CLUSTER shared_cluster_compute_first;
-            contains: cannot drop cluster shared_cluster_compute_first because other objects depend on it
+            contains: cannot drop "cluster shared_cluster_compute_first" because other objects depend on it
 
             ! DROP CLUSTER shared_cluster_storage_first;
-            contains: cannot drop cluster shared_cluster_storage_first because other objects depend on it
+            contains: cannot drop cluster "shared_cluster_storage_first" because other objects depend on it
 
             ! ALTER CLUSTER shared_cluster_compute_first SET (REPLICATION FACTOR 2);
             contains: cannot create more than one replica of a cluster containing sources or sinks

--- a/misc/python/materialize/checks/cluster_unification.py
+++ b/misc/python/materialize/checks/cluster_unification.py
@@ -91,7 +91,7 @@ class UnifiedCluster(Check):
             > SET cluster = default
 
             ! DROP CLUSTER shared_cluster_compute_first;
-            contains: cannot drop "cluster shared_cluster_compute_first" because other objects depend on it
+            contains: cannot drop cluster "shared_cluster_compute_first" because other objects depend on it
 
             ! DROP CLUSTER shared_cluster_storage_first;
             contains: cannot drop cluster "shared_cluster_storage_first" because other objects depend on it

--- a/misc/python/materialize/checks/cluster_unification.py
+++ b/misc/python/materialize/checks/cluster_unification.py
@@ -91,10 +91,10 @@ class UnifiedCluster(Check):
             > SET cluster = default
 
             ! DROP CLUSTER shared_cluster_compute_first;
-            contains: cannot drop cluster with active object
+            contains: cannot drop cluster shared_cluster_compute_first because other objects depend on it
 
             ! DROP CLUSTER shared_cluster_storage_first;
-            contains: cannot drop cluster with active object
+            contains: cannot drop cluster shared_cluster_storage_first because other objects depend on it
 
             ! ALTER CLUSTER shared_cluster_compute_first SET (REPLICATION FACTOR 2);
             contains: cannot create more than one replica of a cluster containing sources or sinks

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -240,10 +240,10 @@ mv_f default
 
 # RESTRICT works
 ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e;
-contains:cannot drop source table_e: still depended upon by materialized view mv_e
+contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
 
 ! ALTER SOURCE mz_source DROP SUBSOURCE IF EXISTS table_e RESTRICT;
-contains:cannot drop source table_e: still depended upon by materialized view mv_e
+contains:cannot drop source "table_e": still depended upon by materialized view "mv_e"
 
 # CASCADE works
 > ALTER SOURCE mz_source DROP SUBSOURCE table_e CASCADE;

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -315,7 +315,7 @@ default
 statement error unknown cluster 'baz'
 DROP CLUSTER baz
 
-statement error cannot drop cluster with active objects
+statement error cannot drop cluster bar because other objects depend on it
 DROP CLUSTER bar
 
 query TTTT
@@ -344,7 +344,7 @@ CREATE CLUSTER baz REPLICAS (r1 (SIZE '1'))
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
 
-statement error cannot drop cluster with active objects
+statement error cannot drop cluster baz because other objects depend on it
 DROP CLUSTER baz
 
 statement ok

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -315,7 +315,7 @@ default
 statement error unknown cluster 'baz'
 DROP CLUSTER baz
 
-statement error cannot drop cluster bar because other objects depend on it
+statement error cannot drop cluster "bar" because other objects depend on it
 DROP CLUSTER bar
 
 query TTTT
@@ -344,7 +344,7 @@ CREATE CLUSTER baz REPLICAS (r1 (SIZE '1'))
 statement ok
 CREATE DEFAULT INDEX IN CLUSTER baz ON v
 
-statement error cannot drop cluster baz because other objects depend on it
+statement error cannot drop cluster "baz" because other objects depend on it
 DROP CLUSTER baz
 
 statement ok

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -348,7 +348,7 @@ CREATE CLUSTER to_drop REPLICAS ()
 statement ok
 CREATE MATERIALIZED VIEW to_drop_mv IN CLUSTER to_drop AS SELECT 1
 
-statement error cannot drop cluster with active objects
+statement error cannot drop cluster to_drop because other objects depend on it
 DROP CLUSTER to_drop
 
 

--- a/test/sqllogictest/materialized_views.slt
+++ b/test/sqllogictest/materialized_views.slt
@@ -211,7 +211,7 @@ CREATE MATERIALIZED VIEW mv AS SELECT 1
 statement ok
 CREATE VIEW v AS SELECT * FROM mv
 
-statement error cannot drop materialized view mv: still depended upon by view v
+statement error cannot drop materialized view "mv": still depended upon by view "v"
 DROP MATERIALIZED VIEW mv
 
 
@@ -234,7 +234,7 @@ CREATE VIEW v AS SELECT 1 AS c
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM v WHERE c IS NULL
 
-statement error cannot drop view v: still depended upon by materialized view mv
+statement error cannot drop view "v": still depended upon by materialized view "mv"
 DROP VIEW v
 
 statement ok
@@ -264,7 +264,7 @@ CREATE TABLE t2 (f1 INTEGER NOT NULL PRIMARY KEY);
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE FALSE;
 
-statement error db error: ERROR: cannot drop table t1: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t1": still depended upon by materialized view "mv"
 DROP TABLE t1
 
 statement ok
@@ -274,7 +274,7 @@ DROP MATERIALIZED VIEW mv
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT t1.* FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1);
 
-statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t2": still depended upon by materialized view "mv"
 DROP TABLE t2
 
 statement ok
@@ -283,7 +283,7 @@ DROP MATERIALIZED VIEW mv
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE FALSE AND EXISTS (SELECT * FROM t2);
 
-statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t2": still depended upon by materialized view "mv"
 DROP TABLE t2
 
 statement ok
@@ -292,7 +292,7 @@ DROP MATERIALIZED VIEW mv
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE TRUE OR EXISTS (SELECT * FROM t2);
 
-statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t2": still depended upon by materialized view "mv"
 DROP TABLE t2
 
 statement ok
@@ -301,7 +301,7 @@ DROP MATERIALIZED VIEW mv
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT (SELECT f1 FROM t2 WHERE FALSE) FROM t1;
 
-statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t2": still depended upon by materialized view "mv"
 DROP TABLE t2
 
 statement ok
@@ -311,7 +311,7 @@ DROP MATERIALIZED VIEW mv
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT COALESCE(1, (SELECT * FROM t2 LIMIT 1)) FROM t1;
 
-statement error db error: ERROR: cannot drop table t2: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop table "t2": still depended upon by materialized view "mv"
 DROP TABLE t2
 
 statement ok
@@ -324,7 +324,7 @@ CREATE TYPE int4_list AS LIST (ELEMENT TYPE = int4);
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT * FROM t1 WHERE NULL::int4_list IS NOT NULL;
 
-statement error db error: ERROR: cannot drop type int4_list: still depended upon by materialized view mv
+statement error db error: ERROR: cannot drop type "int4_list": still depended upon by materialized view "mv"
 DROP TYPE int4_list
 
 statement ok
@@ -348,7 +348,7 @@ CREATE CLUSTER to_drop REPLICAS ()
 statement ok
 CREATE MATERIALIZED VIEW to_drop_mv IN CLUSTER to_drop AS SELECT 1
 
-statement error cannot drop cluster to_drop because other objects depend on it
+statement error cannot drop cluster "to_drop" because other objects depend on it
 DROP CLUSTER to_drop
 
 

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2706,14 +2706,25 @@ DROP OWNED BY materialize;
 db error: ERROR: schema "materialize.s" cannot be dropped without CASCADE while it contains non-owned objects
 
 simple conn=mz_system,user=mz_system
-CREATE VIEW v AS SELECT * FROM t;
+CREATE VIEW v1 AS SELECT * FROM t;
 ----
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
 ----
-db error: ERROR: cannot drop table "materialize.public.t": still depended upon by "materialize.public.v"
+db error: ERROR: cannot drop table "materialize.public.t": still depended upon by view "materialize.public.v1"
+HINT: Use DROP ... CASCADE to drop the dependent objects too.
+
+simple conn=mz_system,user=mz_system
+CREATE VIEW v2 AS SELECT * FROM t;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP OWNED BY materialize;
+----
+db error: ERROR: cannot drop table "materialize.public.t": still depended upon by view "materialize.public.v1", view "materialize.public.v2"
 HINT: Use DROP ... CASCADE to drop the dependent objects too.
 
 simple conn=mz_system,user=mz_system
@@ -2724,7 +2735,7 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
 ----
-db error: ERROR: cannot drop cluster "c": still depended upon by "materialize.public.mv"
+db error: ERROR: cannot drop cluster "c": still depended upon by materialized view "materialize.public.mv"
 HINT: Use DROP ... CASCADE to drop the dependent objects too.
 
 simple conn=mz_system,user=mz_system
@@ -2840,7 +2851,7 @@ SELECT name FROM mz_materialized_views WHERE name = 'mv'
 ----
 mv
 
-statement error cannot drop cluster "c": still depended upon by "materialize.public.mv"
+statement error cannot drop cluster "c": still depended upon by materialized view "materialize.public.mv"
 DROP OWNED BY materialize
 
 query T

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -2713,7 +2713,8 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
 ----
-db error: ERROR: cannot drop "materialize.public.t" without CASCADE: still depended upon by non-owned catalog items "materialize.public.v"
+db error: ERROR: cannot drop table "materialize.public.t": still depended upon by "materialize.public.v"
+HINT: Use DROP ... CASCADE to drop the dependent objects too.
 
 simple conn=mz_system,user=mz_system
 CREATE MATERIALIZED VIEW mv IN CLUSTER c AS SELECT 1;
@@ -2723,7 +2724,8 @@ COMPLETE 0
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize;
 ----
-db error: ERROR: cannot drop cluster "c" without CASCADE: still depended upon by non-owned catalog items "materialize.public.mv"
+db error: ERROR: cannot drop cluster "c": still depended upon by "materialize.public.mv"
+HINT: Use DROP ... CASCADE to drop the dependent objects too.
 
 simple conn=mz_system,user=mz_system
 DROP OWNED BY materialize CASCADE;
@@ -2838,7 +2840,7 @@ SELECT name FROM mz_materialized_views WHERE name = 'mv'
 ----
 mv
 
-statement error cannot drop cluster "c" without CASCADE: still depended upon by non-owned catalog items "materialize.public.mv"
+statement error cannot drop cluster "c": still depended upon by "materialize.public.mv"
 DROP OWNED BY materialize
 
 query T

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -222,7 +222,7 @@ CREATE SOURCE webhook_cluster_does_not_exist IN CLUSTER i_do_not_exist FROM WEBH
   BODY FORMAT BYTES;
 
 # Dropping without cascade should fail since there are sources using it.
-statement error cannot drop cluster with active objects
+statement error cannot drop cluster webhook_cluster because other objects depend on it
 DROP CLUSTER webhook_cluster;
 
 # Create a webhook source that uses secrets when validating.

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -222,7 +222,7 @@ CREATE SOURCE webhook_cluster_does_not_exist IN CLUSTER i_do_not_exist FROM WEBH
   BODY FORMAT BYTES;
 
 # Dropping without cascade should fail since there are sources using it.
-statement error cannot drop cluster webhook_cluster because other objects depend on it
+statement error cannot drop cluster "webhook_cluster" because other objects depend on it
 DROP CLUSTER webhook_cluster;
 
 # Create a webhook source that uses secrets when validating.

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -166,7 +166,7 @@ id creature
 1  lizard
 
 ! DROP CONNECTION csr_conn
-contains:depended upon by source csr_source
+contains:depended upon by source "csr_source"
 
 > DROP CONNECTION csr_conn CASCADE
 

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -74,7 +74,7 @@ first second
 
 # Confirm we cannot drop the connection while a source depends upon it
 ! DROP CONNECTION testconn;
-contains:depended upon by source connection_source
+contains:depended upon by source "connection_source"
 
 # Confirm the drop works if we add cascade
 > DROP CONNECTION testconn CASCADE;

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -317,14 +317,14 @@ contains:unknown catalog item 'j2'
 > CREATE VIEW v1 AS SELECT CAST('{2}' AS int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by view v1
+contains:cannot drop type "int4_list": still depended upon by view "v1"
 
 > DROP VIEW v1
 
 > CREATE TABLE t1 (custom int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by table t1
+contains:cannot drop type "int4_list": still depended upon by table "t1"
 
 > DROP TABLE t1
 
@@ -333,28 +333,28 @@ contains:cannot drop type int4_list: still depended upon by table t1
 > CREATE VIEW v1 AS SELECT * FROM ( SELECT CAST('{2}' AS int4_list) )
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by view v1
+contains:cannot drop type "int4_list": still depended upon by view "v1"
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT CAST(CAST('{2}' AS int4_list) AS text)
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by view v1
+contains:cannot drop type "int4_list": still depended upon by view "v1"
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS VALUES (CAST('{2}' AS int4_list))
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by view v1
+contains:cannot drop type "int4_list": still depended upon by view "v1"
 
 > DROP VIEW v1
 
 > CREATE VIEW v1 AS SELECT MIN(CAST(CAST('{1}' AS int4_list) AS string))
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by view v1
+contains:cannot drop type "int4_list": still depended upon by view "v1"
 
 > DROP VIEW v1
 
@@ -365,7 +365,7 @@ contains:cannot drop type int4_list: still depended upon by view v1
 > CREATE TEMPORARY TABLE t1 (f1 int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by table t1
+contains:cannot drop type "int4_list": still depended upon by table "t1"
 
 > DROP TABLE t1
 
@@ -374,14 +374,14 @@ contains:cannot drop type int4_list: still depended upon by table t1
 > CREATE INDEX i1 ON t1 (CAST(f1 AS int4_list))
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by index i1
+contains:cannot drop type "int4_list": still depended upon by index "i1"
 
 > DROP TABLE t1
 
 > CREATE TYPE int4_list_list AS LIST (ELEMENT TYPE = int4_list)
 
 ! DROP TYPE int4_list
-contains:cannot drop type int4_list: still depended upon by type int4_list_list
+contains:cannot drop type "int4_list": still depended upon by type "int4_list_list"
 
 > DROP TYPE int4_list_list
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -50,23 +50,23 @@ contains:source "materialize.public.s" already exists
 > CREATE VIEW test3b AS SELECT * FROM test2;
 
 ! DROP VIEW test1;
-contains:cannot drop view test1: still depended upon by view test2
+contains:cannot drop view "test1": still depended upon by view "test2"
 
 ! DROP VIEW test2;
-contains:cannot drop view test2: still depended upon by view test3a
+contains:cannot drop view "test2": still depended upon by view "test3a"
 
 > DROP VIEW test3a;
 
 ! DROP VIEW test1;
-contains:cannot drop view test1: still depended upon by view test2
+contains:cannot drop view "test1": still depended upon by view "test2"
 
 ! DROP VIEW test2;
-contains:cannot drop view test2: still depended upon by view test3b
+contains:cannot drop view "test2": still depended upon by view "test3b"
 
 > DROP VIEW test3b;
 
 ! DROP VIEW test1;
-contains:cannot drop view test1: still depended upon by view test2
+contains:cannot drop view "test1": still depended upon by view "test2"
 
 > DROP VIEW test2;
 

--- a/test/testdrive/dependencies.td
+++ b/test/testdrive/dependencies.td
@@ -407,7 +407,7 @@ contains:cannot drop type "int4_list": still depended upon by type "int4_list_li
 2
 
 ! CREATE OR REPLACE VIEW v3 AS SELECT 3
-contains:cannot drop view v3: still depended upon by view v4
+contains:cannot drop view "v3": still depended upon by view "v4"
 
 > CREATE OR REPLACE VIEW v4 AS SELECT 3
 > SELECT * FROM v4
@@ -427,7 +427,7 @@ contains:cannot drop view v3: still depended upon by view v4
 > CREATE VIEW test2 AS SELECT * FROM test1;
 
 ! DROP VIEW test1;
-contains:cannot drop view test1: still depended upon by view test2
+contains:cannot drop view "test1": still depended upon by view "test2"
 
 # Succeeds even though it's dependent on.
 > CREATE VIEW IF NOT EXISTS test1 AS SELECT 2 as b;

--- a/test/testdrive/list.td
+++ b/test/testdrive/list.td
@@ -51,7 +51,7 @@ bool
 contains:cannot drop type bool because it is required by the database system
 
 ! DROP TYPE public.bool
-contains:cannot drop type public.bool: still depended upon by type another_custom
+contains:cannot drop type "public.bool": still depended upon by type "another_custom"
 
 > DROP TYPE another_custom
 

--- a/test/testdrive/map.td
+++ b/test/testdrive/map.td
@@ -51,7 +51,7 @@ bool
 contains:cannot drop type bool because it is required by the database system
 
 ! DROP TYPE public.bool
-contains:cannot drop type public.bool: still depended upon by type another_custom
+contains:cannot drop type "public.bool": still depended upon by type "another_custom"
 
 > DROP TYPE another_custom
 

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -93,7 +93,7 @@ contains:cannot create source in cluster with more than one replica
 
 # Test that `DROP CLUSTER` only succeeds with `CASCADE`.
 ! DROP CLUSTER storage
-contains:cannot drop cluster storage because other objects depend on it
+contains:cannot drop cluster "storage" because other objects depend on it
 > DROP CLUSTER storage CASCADE
 
 > SET cluster = default

--- a/test/testdrive/storage-clusters.td
+++ b/test/testdrive/storage-clusters.td
@@ -93,7 +93,7 @@ contains:cannot create source in cluster with more than one replica
 
 # Test that `DROP CLUSTER` only succeeds with `CASCADE`.
 ! DROP CLUSTER storage
-contains:cannot drop cluster with active objects
+contains:cannot drop cluster storage because other objects depend on it
 > DROP CLUSTER storage CASCADE
 
 > SET cluster = default

--- a/test/testdrive/temporary.td
+++ b/test/testdrive/temporary.td
@@ -219,7 +219,7 @@ contains:Expected DATABASE, SCHEMA, ROLE, TYPE, INDEX, SINK, SOURCE, TABLE, SECR
 #####################################################################
 
 ! DROP VIEW temp_v;
-contains:cannot drop view temp_v: still depended upon by view double_temp_v
+contains:cannot drop view "temp_v": still depended upon by view "double_temp_v"
 
 > DROP VIEW double_temp_v;
 


### PR DESCRIPTION
This commit adds a hint to all errors that result from failed DROPs due to dependent objects still existing and not using CASCADE. The hint says to use CASCADE to drop dependent objects.

Resolves #21942

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
