### PR TITLE
lint: Remove clippy allow that's no longer needed

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -7,10 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
-// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
-#![allow(clippy::extra_unused_lifetimes)]
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::future::Future;

--- a/src/avro/src/types.rs
+++ b/src/avro/src/types.rs
@@ -23,10 +23,6 @@
 
 //! Logic handling the intermediate representation of Avro values.
 
-// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
-// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
-#![allow(clippy::extra_unused_lifetimes)]
-
 use std::collections::BTreeMap;
 use std::fmt;
 

--- a/src/repr/src/scalar.rs
+++ b/src/repr/src/scalar.rs
@@ -7,10 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
-// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
-#![allow(clippy::extra_unused_lifetimes)]
-
 use std::fmt::{self, Debug, Write};
 use std::hash::Hash;
 use std::iter;
@@ -2393,7 +2389,7 @@ impl<'a, E> DatumType<'a, E> for CheckedTimestamp<DateTime<Utc>> {
     }
 }
 
-impl<'a> ScalarType {
+impl ScalarType {
     /// Returns the contained numeric maximum scale.
     ///
     /// # Panics

--- a/src/sql-parser/src/ast/defs/statement.rs
+++ b/src/sql-parser/src/ast/defs/statement.rs
@@ -18,10 +18,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
-// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
-#![allow(clippy::extra_unused_lifetimes)]
-
 use std::fmt;
 
 use enum_kinds::EnumKind;

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -26,10 +26,6 @@
 // `plan_root_query` and fanning out based on the contents of the `SELECT`
 // statement.
 
-// `EnumKind` unconditionally introduces a lifetime. TODO: remove this once
-// https://github.com/rust-lang/rust-clippy/pull/9037 makes it into stable
-#![allow(clippy::extra_unused_lifetimes)]
-
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
 use std::time::Duration;


### PR DESCRIPTION
Stumbled on this while reading through some code

### Motivation

Cleans up a lint related TODO

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
