### PR TITLE
persist-txn: prep for forget and compaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4698,6 +4698,7 @@ dependencies = [
  "mz-persist-types",
  "mz-timely-util",
  "prost",
+ "rand",
  "timely",
  "tokio",
  "tracing",

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -115,6 +115,17 @@ impl PersistClientCache {
         &self.cfg
     }
 
+    /// Clears the state cache, allowing for tests with disconnected states.
+    ///
+    /// Only exposed for testing.
+    pub fn clear_state_cache(&mut self) {
+        self.state_cache = Arc::new(StateCache::new(
+            &self.cfg,
+            Arc::clone(&self.metrics),
+            Arc::clone(&self.pubsub_sender),
+        ))
+    }
+
     /// Returns a new [PersistClient] for interfacing with persist shards made
     /// durable to the given [PersistLocation].
     ///

--- a/src/persist-client/src/critical.rs
+++ b/src/persist-client/src/critical.rs
@@ -26,7 +26,7 @@ use uuid::Uuid;
 use crate::internal::machine::Machine;
 use crate::internal::state::Since;
 use crate::stats::SnapshotStats;
-use crate::{parse_id, GarbageCollector};
+use crate::{parse_id, GarbageCollector, ShardId};
 
 /// An opaque identifier for a reader of a persist durable TVC (aka shard).
 #[derive(Arbitrary, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -139,6 +139,11 @@ where
             opaque,
             last_downgrade_since: EpochMillis::default(),
         }
+    }
+
+    /// This handle's shard id.
+    pub fn shard_id(&self) -> ShardId {
+        self.machine.shard_id()
     }
 
     /// This handle's `since` capability.

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -20,6 +20,7 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 crossbeam-channel = "0.5.8"
+rand = { version = "0.8.5", default-features = false, features = ["small_rng"] }
 tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -226,7 +226,7 @@ where
 /// [Subscribe]: mz_persist_client::read::Subscribe
 pub struct DataSubscribe {
     as_of: u64,
-    worker: Worker<timely::communication::allocator::Thread>,
+    pub(crate) worker: Worker<timely::communication::allocator::Thread>,
     data: ProbeHandle<u64>,
     txns: ProbeHandle<u64>,
     capture: mpsc::Receiver<EventCore<u64, Vec<(String, u64, i64)>>>,

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -485,9 +485,22 @@ where
 
 #[cfg(test)]
 mod tests {
-    use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
+    use std::time::UNIX_EPOCH;
 
-    use crate::tests::{writer, CommitLog};
+    use differential_dataflow::Hashable;
+    use futures::future::BoxFuture;
+    use mz_ore::cast::CastFrom;
+    use mz_persist_client::cache::PersistClientCache;
+    use mz_persist_client::PersistLocation;
+    use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
+    use rand::rngs::SmallRng;
+    use rand::{RngCore, SeedableRng};
+    use timely::progress::Antichain;
+    use tokio::sync::oneshot;
+    use tracing::{info, info_span, Instrument};
+
+    use crate::operator::DataSubscribe;
+    use crate::tests::{reader, writer, CommitLog};
 
     use super::*;
 
@@ -641,5 +654,234 @@ mod tests {
         txns.expect_commit_at(10, d0, &[], &log).await;
 
         log.assert_snapshot(d0, 10).await;
+    }
+
+    struct StressWorker {
+        idx: usize,
+        data_ids: Vec<ShardId>,
+        txns: TxnsHandle<String, (), u64, i64>,
+        log: CommitLog,
+        tidy: Tidy,
+        ts: u64,
+        step: usize,
+        rng: SmallRng,
+        reads: Vec<(
+            oneshot::Sender<u64>,
+            ShardId,
+            u64,
+            tokio::task::JoinHandle<Vec<(String, u64, i64)>>,
+        )>,
+    }
+
+    impl StressWorker {
+        pub async fn step(&mut self) {
+            debug!("{} step {} START ts={}", self.idx, self.step, self.ts);
+            let data_id =
+                self.data_ids[usize::cast_from(self.rng.next_u64()) % self.data_ids.len()];
+            match self.rng.next_u64() % 3 {
+                0 => self.write(data_id).await,
+                1 => self.register(data_id).await,
+                2 => self.start_read(data_id),
+                _ => unreachable!(""),
+            }
+            debug!("{} step {} DONE ts={}", self.idx, self.step, self.ts);
+            self.step += 1;
+        }
+
+        fn key(&self) -> String {
+            format!("w{}s{}", self.idx, self.step)
+        }
+
+        async fn registered_at_ts(&mut self, data_id: ShardId) -> bool {
+            self.txns.txns_cache.update_ge(&self.ts).await;
+            self.txns.txns_cache.datas.contains_key(&data_id)
+        }
+
+        // Writes to the given data shard, either via txns if it's registered or
+        // directly if it's not.
+        async fn write(&mut self, data_id: ShardId) {
+            // Make sure to keep the registered_at_ts call _inside_ the retry
+            // loop, because a data shard might switch between registered or not
+            // registered as the loop advances through timestamps.
+            self.retry_ts_err(&mut |w: &mut StressWorker| {
+                Box::pin(async move {
+                    if w.registered_at_ts(data_id).await {
+                        w.write_via_txns(data_id).await
+                    } else {
+                        w.write_direct(data_id).await
+                    }
+                })
+            })
+            .await
+        }
+
+        async fn write_via_txns(&mut self, data_id: ShardId) -> Result<(), u64> {
+            let mut txn = self.txns.begin();
+            txn.tidy(std::mem::take(&mut self.tidy));
+            txn.write(&data_id, self.key(), (), 1).await;
+            let apply = txn.commit_at(&mut self.txns, self.ts).await?;
+            self.log.record_txn(self.ts, &txn);
+            if self.rng.next_u64() % 3 == 0 {
+                self.tidy.merge(apply.apply(&mut self.txns).await);
+            }
+            Ok(())
+        }
+
+        async fn write_direct(&mut self, data_id: ShardId) -> Result<(), u64> {
+            let mut write = writer(&self.txns.datas.client, data_id).await;
+            let mut current = write.shared_upper();
+            loop {
+                if !current.less_equal(&self.ts) {
+                    return Err(current.into_option().unwrap());
+                }
+                let key = self.key();
+                let updates = [((key.clone(), ()), self.ts, 1)];
+                let res = write
+                    .compare_and_append(&updates, current, Antichain::from_elem(self.ts + 1))
+                    .await
+                    .unwrap();
+                match res {
+                    Ok(()) => {
+                        self.log.record((data_id, key, self.ts, 1));
+                        return Ok(());
+                    }
+                    Err(err) => current = err.current,
+                }
+            }
+        }
+
+        async fn register(&mut self, data_id: ShardId) {
+            self.retry_ts_err(&mut |w: &mut StressWorker| {
+                Box::pin(async move {
+                    let data_write = writer(&w.txns.datas.client, data_id).await;
+                    let _ = w.txns.register(w.ts, [data_write]).await?;
+                    Ok(())
+                })
+            })
+            .await
+        }
+
+        fn start_read(&mut self, data_id: ShardId) {
+            let client = self.txns.datas.client.clone();
+            let txns_id = self.txns.txns_id();
+            let as_of = self.ts;
+            debug!("start_read {:.9} as_of {}", data_id.to_string(), as_of);
+            let (tx, mut rx) = oneshot::channel();
+            let subscribe = mz_ore::task::spawn_blocking(
+                || format!("{:.9}-{}", data_id.to_string(), as_of),
+                move || {
+                    let _guard = info_span!("read_worker", %data_id, as_of).entered();
+                    let mut subscribe = DataSubscribe::new("test", client, txns_id, data_id, as_of);
+                    loop {
+                        subscribe.worker.step_or_park(None);
+                        subscribe.capture_output();
+                        let until = match rx.try_recv() {
+                            Ok(ts) => ts,
+                            Err(oneshot::error::TryRecvError::Empty) => {
+                                continue;
+                            }
+                            Err(oneshot::error::TryRecvError::Closed) => 0,
+                        };
+                        while subscribe.progress() < until {
+                            subscribe.worker.step_or_park(None);
+                            subscribe.capture_output();
+                        }
+                        return subscribe.output().clone();
+                    }
+                },
+            );
+            self.reads.push((tx, data_id, as_of, subscribe));
+        }
+
+        async fn retry_ts_err<W>(&mut self, work_fn: &mut W)
+        where
+            W: for<'b> FnMut(&'b mut Self) -> BoxFuture<'b, Result<(), u64>>,
+        {
+            loop {
+                match work_fn(self).await {
+                    Ok(ret) => return ret,
+                    Err(new_ts) => self.ts = new_ts,
+                }
+            }
+        }
+    }
+
+    #[mz_ore::test(tokio::test(flavor = "multi_thread"))]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
+    async fn stress_correctness() {
+        const NUM_DATA_SHARDS: usize = 2;
+        const NUM_WORKERS: usize = 2;
+        const NUM_STEPS_PER_WORKER: usize = 100;
+        let seed = UNIX_EPOCH.elapsed().unwrap().hashed();
+        eprintln!("using seed {}", seed);
+
+        let mut clients = PersistClientCache::new_no_metrics();
+        let client = clients.open(PersistLocation::new_in_mem()).await.unwrap();
+        let mut txns = TxnsHandle::expect_open(client.clone()).await;
+        let log = txns.new_log();
+        let data_ids = (0..NUM_DATA_SHARDS)
+            .map(|_| ShardId::new())
+            .collect::<Vec<_>>();
+        let data_writes = data_ids
+            .iter()
+            .map(|data_id| writer(&client, *data_id))
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>()
+            .await;
+        let _data_sinces = data_ids
+            .iter()
+            .map(|data_id| reader(&client, *data_id))
+            .collect::<FuturesUnordered<_>>()
+            .collect::<Vec<_>>()
+            .await;
+        let register_ts = 1;
+        txns.register(register_ts, data_writes).await.unwrap();
+
+        let mut workers = Vec::new();
+        for idx in 0..NUM_WORKERS {
+            // Clear the state cache between each client to maximally disconnect
+            // them from each other.
+            clients.clear_state_cache();
+            let client = clients.open(PersistLocation::new_in_mem()).await.unwrap();
+            let mut worker = StressWorker {
+                idx,
+                log: log.clone(),
+                txns: TxnsHandle::expect_open_id(client.clone(), txns.txns_id()).await,
+                data_ids: data_ids.clone(),
+                tidy: Tidy::default(),
+                ts: register_ts + 1,
+                step: 0,
+                rng: SmallRng::seed_from_u64(seed.wrapping_add(u64::cast_from(idx))),
+                reads: Vec::new(),
+            };
+            let worker = async move {
+                while worker.step < NUM_STEPS_PER_WORKER {
+                    worker.step().await;
+                }
+                (worker.ts, worker.reads)
+            }
+            .instrument(info_span!("stress_worker", idx));
+            workers.push(mz_ore::task::spawn(|| format!("worker-{}", idx), worker));
+        }
+
+        let mut max_ts = 0;
+        let mut reads = Vec::new();
+        for worker in workers {
+            let (t, mut r) = worker.await.unwrap();
+            max_ts = std::cmp::max(max_ts, t);
+            reads.append(&mut r);
+        }
+
+        info!("finished with max_ts of {}", max_ts);
+        txns.apply_le(&max_ts).await;
+        for data_id in data_ids {
+            log.assert_snapshot(data_id, max_ts).await;
+        }
+        info!("now waiting for reads {}", max_ts);
+        for (tx, data_id, as_of, subscribe) in reads {
+            let _ = tx.send(max_ts + 1);
+            let output = subscribe.await.unwrap();
+            log.assert_eq(data_id, as_of, max_ts + 1, output);
+        }
     }
 }


### PR DESCRIPTION
Pulling out some straightforward, mechanical changes in advance to keep the size of the upcoming tricky PRs smaller. Not a lot of context here, because I think that would roughly amount to just reviewing the big PRs.

Rough outline of what's in here:
- Plumb a (yet unused) SinceHandle into TxnsHandle. This involves a decent amount of plumbing the Opaque type bounds around to things.
- Use the DataSubscribe helper over the dataflow operator to implement reads in the maelstrom tests to get additional coverage on the dataflow stuff. DataSubscribe currently hardcodes String as the K type, we could make it generic but it's just a testing helper, so instead swap the maelstrom stuff from Vec<u8> -> String.
  - Keep track of the original as_of in DataSubscribe.
- Add a couple small persist-client methods used in tests in upcoming PRs.
- Add more tracing instrumentation to persist-txn.
- Add a maybe_cads for more obvious compare_and_downgrade_since calls when the compaction stuff is hooked up.
- Change DataListenNext::ReadDataPast (strictly greater) to ReadDataTo (greater equal). This makes some stuff read more obviously in an upcoming PR.
- Clean up some debug logs in data_subscribe and data_listen_next.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
