### PR TITLE
ci: Catch and ignore sigabort, reduce coredump sizes with zstd

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -93,6 +93,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     gnupg2 \
     jq \
     lcov \
+    libc-dbg \
     libclang-dev \
     libpq-dev \
     lld \
@@ -110,6 +111,7 @@ RUN apt-get update && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get install -y -
     unzip \
     xz-utils \
     yamllint \
+    zstd \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js LTS, for our Python typechecker. This is up here because we don't

--- a/ci/plugins/cloudtest/hooks/post-command
+++ b/ci/plugins/cloudtest/hooks/post-command
@@ -56,8 +56,8 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ]; then
         if [ "${#ARGS[@]}" != 0 ]; then
           bin/ci-builder run stable lcov "${ARGS[@]}" -o coverage/"$BUILDKITE_JOB_ID".lcov
           rm coverage/"$BUILDKITE_JOB_ID"-*.lcov
-          bin/ci-builder run stable xz -0 coverage/"$BUILDKITE_JOB_ID".lcov
-          buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.xz
+          bin/ci-builder run stable zstd coverage/"$BUILDKITE_JOB_ID".lcov
+          buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
         fi
     fi
 fi

--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -13,14 +13,6 @@ set -euo pipefail
 
 . misc/shlib/shlib.bash
 
-cores="$HOME"/cores
-rm -rf "$cores"
-mkdir -m 777 "$cores"
-# Max 128 characters, so don't use $PWD which will make it too long
-sudo sysctl -w kernel.core_pattern="|/usr/bin/env tee $cores/core.%e.%p"
-echo -n "Core pattern: "
-cat /proc/sys/kernel/core_pattern
-
 mzcompose() {
     bin/ci-builder run stable bin/mzcompose --find "$BUILDKITE_PLUGIN_MZCOMPOSE_COMPOSITION" "$@"
 }
@@ -53,6 +45,15 @@ rm -f services.log
 
 ci_collapsed_heading ":docker: Rebuilding non-mzbuild containers"
 mzcompose --mz-quiet build
+
+# Clean up cores here so that just killed processes' core files are ignored
+cores="$HOME"/cores
+rm -rf "$cores"
+mkdir -m 777 "$cores"
+# Max 128 characters, so don't use $PWD which will make it too long
+sudo sysctl -w kernel.core_pattern="|/usr/bin/env tee $cores/core.%E.%t"
+echo -n "Core pattern: "
+cat /proc/sys/kernel/core_pattern
 
 # Start dependencies under a different heading so that the main heading is less
 # noisy. But not if the service is actually a workflow, in which case it will

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -54,8 +54,8 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_
         if [ "${#ARGS[@]}" != 0 ]; then
             bin/ci-builder run stable lcov "${ARGS[@]}" -o coverage/"$BUILDKITE_JOB_ID".lcov
             rm coverage/"$BUILDKITE_JOB_ID"-*.lcov
-            bin/ci-builder run stable xz -0 coverage/"$BUILDKITE_JOB_ID".lcov
-            buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.xz
+            bin/ci-builder run stable zstd coverage/"$BUILDKITE_JOB_ID".lcov
+            buildkite-agent artifact upload coverage/"$BUILDKITE_JOB_ID".lcov.zst
         fi
     fi
 fi
@@ -75,6 +75,9 @@ mv "$HOME"/cores .
 
 if find cores -name 'core.*' | grep -q .; then
     # Best effort attempt to fetch interesting executables to get backtrace of core files
+    bin/ci-builder run stable cp /mnt/build/debug/clusterd cores/ || true
+    bin/ci-builder run stable cp /mnt/build/debug/environmentd cores/ || true
+    bin/ci-builder run stable cp /mnt/build/debug/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/clusterd cores/ || true
     run cp materialized:/usr/local/bin/environmentd cores/ || true
@@ -83,10 +86,15 @@ if find cores -name 'core.*' | grep -q .; then
 fi
 
 find cores -name 'core.*' | while read -r core; do
-    exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9][0-9]*/\1/")
-    bin/ci-builder run stable gdb --batch -ex "bt full" -ex "quit" "$exe" "$core" > "$core".txt || true
-    buildkite-agent artifact upload "$core".txt
-    buildkite-agent artifact upload "$core"
+    exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9]*/\1/" -e "s/.*\!//")
+    bin/ci-builder run stable gdb --batch -ex "bt full" -ex "thread apply all bt" -ex "quit" cores/"$exe" "$core" > "$core".txt || true
+    if grep -q "Program terminated with signal SIGABRT, Aborted." "$core".txt; then
+      echo "SIGABRT found in \"$core.txt\", ignoring core file"
+    else
+      zstd "$core"
+      buildkite-agent artifact upload "$core".txt
+      buildkite-agent artifact upload "$core".zst
+    fi
 done
 # can be huge, clean up
 rm -rf cores

--- a/ci/test/cargo-test/mzcompose.py
+++ b/ci/test/cargo-test/mzcompose.py
@@ -102,9 +102,14 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         try:
             spawn.runv(cmd + args.args, env=env)
         finally:
-            spawn.runv(["xz", "-0", "coverage/cargotest.lcov"])
+            spawn.runv(["zstd", "coverage/cargotest.lcov"])
             spawn.runv(
-                ["buildkite-agent", "artifact", "upload", "coverage/cargotest.lcov.xz"]
+                [
+                    "buildkite-agent",
+                    "artifact",
+                    "upload",
+                    "coverage/cargotest.lcov.zst",
+                ]
             )
     else:
         if args.miri_full:

--- a/ci/test/coverage_report.sh
+++ b/ci/test/coverage_report.sh
@@ -15,8 +15,8 @@ set -euo pipefail
 
 ci_unimportant_heading "Download coverage data from run"
 mkdir -p coverage
-buildkite-agent artifact download 'coverage/*.xz' coverage/
-find coverage -name '*.xz' -exec xz -d {} \;
+buildkite-agent artifact download 'coverage/*.zst' coverage/
+find coverage -name '*.zst' -exec zstd -d {} \;
 
 ci_uncollapsed_heading "Uncovered Lines in Pull Request"
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec bin/ci-coverage-pr-report --unittests=coverage/cargotest.lcov {} +
@@ -28,7 +28,7 @@ REPORT_UNITTESTS=coverage_with_unittests_"$BUILDKITE_BUILD_ID"
 find coverage -name '*.lcov' -exec sed -i "s#SF:/var/lib/buildkite-agent/builds/buildkite-.*/materialize/coverage/#SF:#" {} +
 find coverage -name '*.lcov' -not -name 'cargotest.lcov' -exec genhtml -o "$REPORT" {} +
 find coverage -name '*.lcov' -exec genhtml -o "$REPORT_UNITTESTS" {} +
-tar cfJ "$REPORT".tar.xz "$REPORT"
-tar cfJ "$REPORT_UNITTESTS".tar.xz "$REPORT_UNITTESTS"
-buildkite-agent artifact upload "$REPORT".tar.xz
-buildkite-agent artifact upload "$REPORT_UNITTESTS".tar.xz
+tar -I zstd -cf "$REPORT".tar.zst "$REPORT"
+tar -I zstd -cf "$REPORT_UNITTESTS".tar.zst "$REPORT_UNITTESTS"
+buildkite-agent artifact upload "$REPORT".tar.zst
+buildkite-agent artifact upload "$REPORT_UNITTESTS".tar.zst


### PR DESCRIPTION
Also switch to zstd instead of xz for coverage as it's 10x faster to compress and similar size.

I am hoping that SIGABRT happening so often in our testing is normal? I wasn't sure where it's happening based on our code. `kill -6` or `kill -SIGABRT` would cause this.

Backtrace when a segfault actually happened in Rust code: https://buildkite.com/materialize/tests/builds/66216#018b3ee1-1222-4dde-9af6-34369492beff
```
Program terminated with signal SIGILL, Illegal instruction.
#0  core::ptr::write<i32> (dst=<optimized out>) at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ptr/mod.rs:1376
[Current thread is 1 (LWP 7)]
#0  core::ptr::write<i32> (dst=<optimized out>) at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ptr/mod.rs:1376
        src = <optimized out>
#1  core::ptr::mut_ptr::{impl#0}::write<i32> (self=<optimized out>) at /rustc/8ede3aae28fe6e4d52b38157d7bfe0d3bceef225/library/core/src/ptr/mut_ptr.rs:1467
        val = <optimized out>
#2  environmentd::main () at src/environmentd/src/bin/environmentd/main.rs:594
No locals.
```
Improved backtrace with libc debug symbols:
```
Core was generated by `environmentd --unsafe-mode --environment-id=mzcompose-us-east-1-00000000-0000-0'.
Program terminated with signal SIGABRT, Aborted.
#0  0x00007f85492dca7c in __vfwscanf_internal (s=<optimized out>, format=<optimized out>, argptr=<optimized out>, mode_flags=<optimized out>) at ./stdio-common/vfscanf-internal.c:1973
[Current thread is 1 (LWP 150)]
#0  0x00007f85492dca7c in __vfwscanf_internal (s=<optimized out>, format=<optimized out>, argptr=<optimized out>, mode_flags=<optimized out>) at ./stdio-common/vfscanf-internal.c:1973
        map = <optimized out>
        twend = <optimized out>
        pos = <optimized out>
        arg = <optimized out>
        pos = <optimized out>
        arg = <optimized out>
        pos = <optimized out>
        arg = <optimized out>
        argpos = <optimized out>
        _cleanup_start_doit = true
        _buffer = <error reading variable _buffer (Cannot access memory at address 0xfffffffffffffb96)>
        _cleanup_routine = <optimized out>
        arg = <error reading variable arg (Cannot access memory at address 0xfffffffffffffbbe)>
        f = <optimized out>
        fc = <optimized out>
        done = <optimized out>
        read_in = 6
        c = <optimized out>
        width = 984086080
        flags = <optimized out>
        inchar_errno = <optimized out>
        got_digit = 0 '\000'
        got_dot = 0 '\000'
        got_e = 0 '\000'
        got_sign = <error reading variable got_sign (Cannot access memory at address 0xffffffffffffface)>
        not_in = <optimized out>
        base = <optimized out>
        decimal = <optimized out>
        thousands = <optimized out>
        ptrs_to_free = <optimized out>
        state = <error reading variable state (Cannot access memory at address 0xfffffffffffffbb6)>
        num = <optimized out>
        str = <optimized out>
        wstr = <optimized out>
        strptr = <optimized out>
        strsize = <optimized out>
        skip_space = 0
        tw = <error reading variable tw (Cannot access memory at address 0xfffffffffffffb8e)>
        charbuf = <error reading variable charbuf (Cannot access memory at address 0xfffffffffffffc26)>
        __PRETTY_FUNCTION__ = "D\016(\206\005D\0160\203\006\002Q\n\016(A\016 B\016"
Backtrace stopped: Cannot access memory at address 0x9e
```
Coverage run: https://buildkite.com/materialize/coverage/builds/270
Large coredump in cargo test example: https://buildkite.com/materialize/tests/builds/66196#018b3e94-4b1a-4a36-8eb2-92e6fbc9b3cf

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
