### PR TITLE
Count filled allocations for arrangement allocations

### DIFF
--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -183,10 +183,7 @@ pub trait ArrangementSize {
 #[inline]
 fn vec_size<T>(data: &Vec<T>, mut callback: impl FnMut(usize, usize)) {
     let size_of_t = std::mem::size_of::<T>();
-    // A vector only owns an allocation if the capacity is > 0.
-    if data.capacity() > 0 {
-        callback(data.len() * size_of_t, data.capacity() * size_of_t);
-    }
+    callback(data.len() * size_of_t, data.capacity() * size_of_t);
 }
 
 /// Helper for [`ArrangementSize`] to install a common operator holding on to a trace.
@@ -282,7 +279,7 @@ where
         log_arrangement_size_inner(self, |trace| {
             let (mut size, mut capacity, mut allocations) = (0, 0, 0);
             let mut callback = |siz, cap| {
-                allocations += 1;
+                allocations += usize::from(cap > 0);
                 size += siz;
                 capacity += cap
             };
@@ -310,7 +307,7 @@ where
         log_arrangement_size_inner(self, |trace| {
             let (mut size, mut capacity, mut allocations) = (0, 0, 0);
             let mut callback = |siz, cap| {
-                allocations += 1;
+                allocations += usize::from(cap > 0);
                 size += siz;
                 capacity += cap
             };


### PR DESCRIPTION
Previously, we would count non-allocated data as an allocation, which bloats the number of allocations. This fixes a minor inconsistency.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
