### PR TITLE
Do not enable arrangement specialization with all-features

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1376,6 +1376,13 @@ pub const ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE: ServerVar<bool> = ServerVar {
     internal: false,
 };
 
+pub const ENABLE_SPECIALIZED_ARRANGEMENTS: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_specialized_arrangements"),
+    value: &false,
+    description: "type-specialization for arrangements in compute rendering",
+    internal: true,
+};
+
 pub const MIN_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
     name: UncasedStr::new("min_timestamp_interval"),
     value: &Duration::from_millis(1000),
@@ -1752,11 +1759,6 @@ feature_flags!(
     (
         enable_assert_not_null,
         "ASSERT NOT NULL for materialized views"
-    ),
-    (
-        enable_specialized_arrangements,
-        "type-specialization for arrangements in compute rendering",
-        false
     )
 );
 
@@ -2463,6 +2465,7 @@ impl SystemVars {
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
             .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
+            .with_var(&ENABLE_SPECIALIZED_ARRANGEMENTS)
             .with_var(&ENABLE_DEFAULT_CONNECTION_VALIDATION)
             .with_var(&MIN_TIMESTAMP_INTERVAL)
             .with_var(&MAX_TIMESTAMP_INTERVAL)
@@ -3119,6 +3122,10 @@ impl SystemVars {
 
     pub fn enable_consolidate_after_union_negate(&self) -> bool {
         *self.expect_value(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
+    }
+
+    pub fn enable_specialized_arrangements(&self) -> bool {
+        *self.expect_value(&ENABLE_SPECIALIZED_ARRANGEMENTS)
     }
 
     /// Returns the `enable_default_connection_validation` configuration parameter.


### PR DESCRIPTION
Fixes #22452 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
