### PR TITLE
webhooks: Limit concurrent requests with LaunchDarkly

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -42,8 +42,8 @@ use uuid::Uuid;
 
 use crate::catalog::Catalog;
 use crate::command::{
-    AppendWebhookResponse, Canceled, CatalogDump, CatalogSnapshot, Command, ExecuteResponse,
-    GetVariablesResponse, Response,
+    Canceled, CatalogDump, CatalogSnapshot, Command, ExecuteResponse, GetVariablesResponse,
+    Response,
 };
 use crate::coord::{Coordinator, ExecuteContextExtra};
 use crate::error::AdapterError;
@@ -51,6 +51,7 @@ use crate::metrics::Metrics;
 use crate::session::{EndTransactionAction, PreparedStatement, Session, TransactionId};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::telemetry::{self, SegmentClientExt, StatementFailureType};
+use crate::webhook::AppendWebhookResponse;
 use crate::{AdapterNotice, PeekResponseUnary, StartupResponse};
 
 /// Inner type of a [`ConnectionId`], `u32` for postgres compatibility.

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -8,12 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use std::collections::{BTreeMap, BTreeSet};
-use std::fmt;
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use anyhow::Context;
 use derivative::Derivative;
 use enum_kinds::EnumKind;
 use futures::future::BoxFuture;
@@ -22,18 +20,13 @@ use mz_ore::soft_assert;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::role_id::RoleId;
-use mz_repr::{ColumnType, Datum, GlobalId, Row, RowArena};
-use mz_secrets::cache::CachingSecretsReader;
-use mz_secrets::SecretsReader;
+use mz_repr::{GlobalId, Row};
 use mz_sql::ast::{FetchDirection, Raw, Statement};
 use mz_sql::catalog::ObjectType;
-use mz_sql::plan::{
-    ExecuteTimeout, Plan, PlanKind, WebhookHeaders, WebhookValidation, WebhookValidationSecret,
-};
+use mz_sql::plan::{ExecuteTimeout, Plan, PlanKind};
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{OwnedVarInput, Var};
 use mz_sql_parser::ast::{AlterObjectRenameStatement, AlterOwnerStatement, DropObjectsStatement};
-use mz_storage_client::controller::MonotonicAppender;
 use tokio::sync::{mpsc, oneshot, watch};
 use uuid::Uuid;
 
@@ -46,6 +39,7 @@ use crate::error::AdapterError;
 use crate::session::{EndTransactionAction, RowBatchStream, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::util::Transmittable;
+use crate::webhook::AppendWebhookResponse;
 use crate::AdapterNotice;
 
 #[derive(Debug)]
@@ -258,199 +252,6 @@ impl IntoIterator for GetVariablesResponse {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
-    }
-}
-
-/// Errors returns when running validation of a webhook request.
-#[derive(thiserror::Error, Debug)]
-pub enum AppendWebhookError {
-    // A secret that we need for validation has gone missing.
-    #[error("could not read a required secret")]
-    MissingSecret,
-    #[error("the provided request body is not UTF-8")]
-    NonUtf8Body,
-    // Note: we should _NEVER_ add more detail to this error, including the actual error we got
-    // when running validation. This is because the error messages might contain info about the
-    // arguments provided to the validation expression, we could contains user SECRETs. So by
-    // including any more detail we might accidentally expose SECRETs.
-    #[error("validation failed")]
-    ValidationError,
-    // Note: we should _NEVER_ add more detail to this error, see above as to why.
-    #[error("internal error when validating request")]
-    InternalError,
-}
-
-/// Contains all of the components necessary for running webhook validation.
-///
-/// To actually validate a webhook request call [`AppendWebhookValidator::eval`].
-pub struct AppendWebhookValidator {
-    validation: WebhookValidation,
-    secrets_reader: CachingSecretsReader,
-}
-
-impl AppendWebhookValidator {
-    pub fn new(validation: WebhookValidation, secrets_reader: CachingSecretsReader) -> Self {
-        AppendWebhookValidator {
-            validation,
-            secrets_reader,
-        }
-    }
-
-    pub async fn eval(
-        self,
-        body: bytes::Bytes,
-        headers: Arc<BTreeMap<String, String>>,
-    ) -> Result<bool, AppendWebhookError> {
-        let AppendWebhookValidator {
-            validation,
-            secrets_reader,
-        } = self;
-
-        let WebhookValidation {
-            expression,
-            secrets,
-            bodies: body_columns,
-            headers: header_columns,
-        } = validation;
-
-        // Use the secrets reader to get any secrets.
-        let mut secret_contents = BTreeMap::new();
-        for WebhookValidationSecret {
-            id,
-            column_idx,
-            use_bytes,
-        } in secrets
-        {
-            let secret = secrets_reader
-                .read(id)
-                .await
-                .map_err(|_| AppendWebhookError::MissingSecret)?;
-            secret_contents.insert(column_idx, (secret, use_bytes));
-        }
-
-        // Create a closure to run our validation, this allows lifetimes and unwind boundaries to
-        // work.
-        let validate = move || {
-            // Gather our Datums for evaluation
-            //
-            // TODO(parkmycar): Re-use the RowArena when we implement rate limiting.
-            let temp_storage = RowArena::default();
-            let mut datums = Vec::with_capacity(
-                body_columns.len() + header_columns.len() + secret_contents.len(),
-            );
-
-            // Append all of our body columns.
-            for (column_idx, use_bytes) in body_columns {
-                assert_eq!(column_idx, datums.len(), "body index and datums mismatch!");
-
-                let datum = if use_bytes {
-                    Datum::Bytes(&body[..])
-                } else {
-                    let s = std::str::from_utf8(&body[..])
-                        .map_err(|_| AppendWebhookError::NonUtf8Body)?;
-                    Datum::String(s)
-                };
-                datums.push(datum);
-            }
-
-            // Append all of our header columns, re-using Row packings.
-            //
-            // TODO(parkmycar): Use `std::cell::OnceCell` when #20779 merges.
-            let headers_byte = once_cell::unsync::OnceCell::new();
-            let headers_text = once_cell::unsync::OnceCell::new();
-            for (column_idx, use_bytes) in header_columns {
-                assert_eq!(column_idx, datums.len(), "index and datums mismatch!");
-
-                let row = if use_bytes {
-                    headers_byte.get_or_init(|| {
-                        let mut row = Row::with_capacity(1);
-                        let mut packer = row.packer();
-                        packer.push_dict(
-                            headers
-                                .iter()
-                                .map(|(name, val)| (name.as_str(), Datum::Bytes(val.as_bytes()))),
-                        );
-                        row
-                    })
-                } else {
-                    headers_text.get_or_init(|| {
-                        let mut row = Row::with_capacity(1);
-                        let mut packer = row.packer();
-                        packer.push_dict(
-                            headers
-                                .iter()
-                                .map(|(name, val)| (name.as_str(), Datum::String(val))),
-                        );
-                        row
-                    })
-                };
-                datums.push(row.unpack_first());
-            }
-
-            // Append all of our secrets to our datums, in the correct column order.
-            for column_idx in datums.len()..datums.len() + secret_contents.len() {
-                // Get the secret that corresponds with what is the next "column";
-                let (secret, use_bytes) = secret_contents
-                    .get(&column_idx)
-                    .expect("more secrets to provide, but none for the next column");
-
-                if *use_bytes {
-                    datums.push(Datum::Bytes(secret));
-                } else {
-                    let secret_str = std::str::from_utf8(&secret[..]).expect("valid UTF-8");
-                    datums.push(Datum::String(secret_str));
-                }
-            }
-
-            // Run our validation
-            let valid = expression
-                .eval(&datums[..], &temp_storage)
-                .map_err(|_| AppendWebhookError::ValidationError)?;
-            match valid {
-                Datum::True => Ok::<_, AppendWebhookError>(true),
-                Datum::False | Datum::Null => Ok(false),
-                _ => unreachable!("Creating a webhook source asserts we return a boolean"),
-            }
-        };
-
-        // Then run the validation itself.
-        let valid = mz_ore::task::spawn_blocking(
-            || "webhook-validator-expr",
-            move || {
-                // Since the validation expression is technically a user defined function, we want to
-                // be extra careful and guard against issues taking down the entire process.
-                mz_ore::panic::catch_unwind(validate).map_err(|_| {
-                    tracing::error!("panic while validating webhook request!");
-                    AppendWebhookError::InternalError
-                })
-            },
-        )
-        .await
-        .context("joining on validation")
-        .map_err(|e| {
-            tracing::error!("Failed to run validation for webhook, {e}");
-            AppendWebhookError::InternalError
-        })??;
-
-        valid
-    }
-}
-
-pub struct AppendWebhookResponse {
-    pub tx: MonotonicAppender,
-    pub body_ty: ColumnType,
-    pub header_tys: WebhookHeaders,
-    pub validator: Option<AppendWebhookValidator>,
-}
-
-impl fmt::Debug for AppendWebhookResponse {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("AppendWebhookResponse")
-            .field("tx", &self.tx)
-            .field("body_ty", &self.body_ty)
-            .field("header_tys", &self.header_tys)
-            .field("validate_expr", &"(...)")
-            .finish()
     }
 }
 

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -38,8 +38,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use crate::catalog::{CatalogItem, DataSourceDesc, Source};
 use crate::client::{ConnectionId, ConnectionIdType};
 use crate::command::{
-    AppendWebhookResponse, AppendWebhookValidator, Canceled, CatalogSnapshot, Command,
-    ExecuteResponse, GetVariablesResponse, StartupResponse,
+    Canceled, CatalogSnapshot, Command, ExecuteResponse, GetVariablesResponse, StartupResponse,
 };
 use crate::coord::appends::{Deferred, PendingWriteTxn};
 use crate::coord::peek::PendingPeek;
@@ -48,6 +47,7 @@ use crate::error::AdapterError;
 use crate::notice::AdapterNotice;
 use crate::session::{Session, TransactionOps, TransactionStatus};
 use crate::util::{ClientTransmitter, ResultExt};
+use crate::webhook::{AppendWebhookResponse, AppendWebhookValidator};
 use crate::{catalog, metrics, ExecuteContext};
 
 use super::ExecuteContextExtra;

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -126,6 +126,7 @@ impl Coordinator {
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
         let mut update_jemalloc_profiling_config = false;
+        let mut update_http_config = false;
         let mut log_indexes_to_drop = Vec::new();
 
         for op in &ops {
@@ -224,6 +225,7 @@ impl Coordinator {
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
                     update_jemalloc_profiling_config |=
                         name == vars::ENABLE_JEMALLOC_PROFILING.name();
+                    update_http_config |= vars::is_http_config_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
                     // Assume they all need to be updated.
@@ -236,6 +238,7 @@ impl Coordinator {
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
                     update_jemalloc_profiling_config = true;
+                    update_http_config = true;
                 }
                 _ => (),
             }
@@ -510,6 +513,9 @@ impl Coordinator {
             }
             if update_jemalloc_profiling_config {
                 self.update_jemalloc_profiling_config().await;
+            }
+            if update_http_config {
+                self.update_http_config();
             }
         }
         .await;
@@ -790,6 +796,15 @@ impl Coordinator {
         } else {
             mz_prof::deactivate_jemalloc_profiling().await
         }
+    }
+
+    fn update_http_config(&mut self) {
+        let webhook_request_limit = self
+            .catalog()
+            .system_config()
+            .webhook_concurrent_request_limit();
+        self.webhook_concurrency_limit
+            .set_limit(webhook_request_limit);
     }
 
     async fn create_storage_export(

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -122,11 +122,11 @@ pub mod metrics;
 pub mod session;
 pub mod statement_logging;
 pub mod telemetry;
+pub mod webhook;
 
 pub use crate::client::{Client, Handle, SessionClient};
 pub use crate::command::{
-    AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator, Canceled, ExecuteResponse,
-    ExecuteResponseKind, RowsFuture, StartupResponse,
+    Canceled, ExecuteResponse, ExecuteResponseKind, RowsFuture, StartupResponse,
 };
 pub use crate::coord::id_bundle::CollectionIdBundle;
 pub use crate::coord::peek::PeekResponseUnary;
@@ -139,3 +139,4 @@ pub use crate::coord::ExecuteContextExtra;
 pub use crate::coord::{serve, Config};
 pub use crate::error::AdapterError;
 pub use crate::notice::AdapterNotice;
+pub use crate::webhook::{AppendWebhookError, AppendWebhookResponse, AppendWebhookValidator};

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -1,0 +1,215 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::Arc;
+
+use anyhow::Context;
+use mz_ore::task::RuntimeExt;
+use mz_repr::{ColumnType, Datum, Row, RowArena};
+use mz_secrets::cache::CachingSecretsReader;
+use mz_secrets::SecretsReader;
+use mz_sql::plan::{WebhookHeaders, WebhookValidation, WebhookValidationSecret};
+use mz_storage_client::controller::MonotonicAppender;
+use tokio::sync::Semaphore;
+
+/// Errors returns when running validation of a webhook request.
+#[derive(thiserror::Error, Debug)]
+pub enum AppendWebhookError {
+    // A secret that we need for validation has gone missing.
+    #[error("could not read a required secret")]
+    MissingSecret,
+    #[error("the provided request body is not UTF-8")]
+    NonUtf8Body,
+    // Note: we should _NEVER_ add more detail to this error, including the actual error we got
+    // when running validation. This is because the error messages might contain info about the
+    // arguments provided to the validation expression, we could contains user SECRETs. So by
+    // including any more detail we might accidentally expose SECRETs.
+    #[error("validation failed")]
+    ValidationError,
+    // Note: we should _NEVER_ add more detail to this error, see above as to why.
+    #[error("internal error when validating request")]
+    InternalError,
+}
+
+/// Contains all of the components necessary for running webhook validation.
+///
+/// To actually validate a webhook request call [`AppendWebhookValidator::eval`].
+pub struct AppendWebhookValidator {
+    validation: WebhookValidation,
+    secrets_reader: CachingSecretsReader,
+}
+
+impl AppendWebhookValidator {
+    pub fn new(validation: WebhookValidation, secrets_reader: CachingSecretsReader) -> Self {
+        AppendWebhookValidator {
+            validation,
+            secrets_reader,
+        }
+    }
+
+    pub async fn eval(
+        self,
+        body: bytes::Bytes,
+        headers: Arc<BTreeMap<String, String>>,
+    ) -> Result<bool, AppendWebhookError> {
+        let AppendWebhookValidator {
+            validation,
+            secrets_reader,
+        } = self;
+
+        let WebhookValidation {
+            expression,
+            secrets,
+            bodies: body_columns,
+            headers: header_columns,
+        } = validation;
+
+        // Use the secrets reader to get any secrets.
+        let mut secret_contents = BTreeMap::new();
+        for WebhookValidationSecret {
+            id,
+            column_idx,
+            use_bytes,
+        } in secrets
+        {
+            let secret = secrets_reader
+                .read(id)
+                .await
+                .map_err(|_| AppendWebhookError::MissingSecret)?;
+            secret_contents.insert(column_idx, (secret, use_bytes));
+        }
+
+        // Create a closure to run our validation, this allows lifetimes and unwind boundaries to
+        // work.
+        let validate = move || {
+            // Gather our Datums for evaluation
+            //
+            // TODO(parkmycar): Re-use the RowArena when we implement rate limiting.
+            let temp_storage = RowArena::default();
+            let mut datums = Vec::with_capacity(
+                body_columns.len() + header_columns.len() + secret_contents.len(),
+            );
+
+            // Append all of our body columns.
+            for (column_idx, use_bytes) in body_columns {
+                assert_eq!(column_idx, datums.len(), "body index and datums mismatch!");
+
+                let datum = if use_bytes {
+                    Datum::Bytes(&body[..])
+                } else {
+                    let s = std::str::from_utf8(&body[..])
+                        .map_err(|_| AppendWebhookError::NonUtf8Body)?;
+                    Datum::String(s)
+                };
+                datums.push(datum);
+            }
+
+            // Append all of our header columns, re-using Row packings.
+            //
+            // TODO(parkmycar): Use `std::cell::OnceCell` when #20779 merges.
+            let headers_byte = once_cell::unsync::OnceCell::new();
+            let headers_text = once_cell::unsync::OnceCell::new();
+            for (column_idx, use_bytes) in header_columns {
+                assert_eq!(column_idx, datums.len(), "index and datums mismatch!");
+
+                let row = if use_bytes {
+                    headers_byte.get_or_init(|| {
+                        let mut row = Row::with_capacity(1);
+                        let mut packer = row.packer();
+                        packer.push_dict(
+                            headers
+                                .iter()
+                                .map(|(name, val)| (name.as_str(), Datum::Bytes(val.as_bytes()))),
+                        );
+                        row
+                    })
+                } else {
+                    headers_text.get_or_init(|| {
+                        let mut row = Row::with_capacity(1);
+                        let mut packer = row.packer();
+                        packer.push_dict(
+                            headers
+                                .iter()
+                                .map(|(name, val)| (name.as_str(), Datum::String(val))),
+                        );
+                        row
+                    })
+                };
+                datums.push(row.unpack_first());
+            }
+
+            // Append all of our secrets to our datums, in the correct column order.
+            for column_idx in datums.len()..datums.len() + secret_contents.len() {
+                // Get the secret that corresponds with what is the next "column";
+                let (secret, use_bytes) = secret_contents
+                    .get(&column_idx)
+                    .expect("more secrets to provide, but none for the next column");
+
+                if *use_bytes {
+                    datums.push(Datum::Bytes(secret));
+                } else {
+                    let secret_str = std::str::from_utf8(&secret[..]).expect("valid UTF-8");
+                    datums.push(Datum::String(secret_str));
+                }
+            }
+
+            // Run our validation
+            let valid = expression
+                .eval(&datums[..], &temp_storage)
+                .map_err(|_| AppendWebhookError::ValidationError)?;
+            match valid {
+                Datum::True => Ok::<_, AppendWebhookError>(true),
+                Datum::False | Datum::Null => Ok(false),
+                _ => unreachable!("Creating a webhook source asserts we return a boolean"),
+            }
+        };
+
+        // Then run the validation itself.
+        let valid = mz_ore::task::spawn_blocking(
+            || "webhook-validator-expr",
+            move || {
+                // Since the validation expression is technically a user defined function, we want to
+                // be extra careful and guard against issues taking down the entire process.
+                mz_ore::panic::catch_unwind(validate).map_err(|_| {
+                    tracing::error!("panic while validating webhook request!");
+                    AppendWebhookError::InternalError
+                })
+            },
+        )
+        .await
+        .context("joining on validation")
+        .map_err(|e| {
+            tracing::error!("Failed to run validation for webhook, {e}");
+            AppendWebhookError::InternalError
+        })??;
+
+        valid
+    }
+}
+
+pub struct AppendWebhookResponse {
+    pub tx: MonotonicAppender,
+    pub body_ty: ColumnType,
+    pub header_tys: WebhookHeaders,
+    pub validator: Option<AppendWebhookValidator>,
+}
+
+impl fmt::Debug for AppendWebhookResponse {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AppendWebhookResponse")
+            .field("tx", &self.tx)
+            .field("body_ty", &self.body_ty)
+            .field("header_tys", &self.header_tys)
+            .field("validate_expr", &"(...)")
+            .finish()
+    }
+}
+

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -931,7 +931,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 tls,
                 frontegg,
                 cors_allowed_origin,
-                concurrent_webhook_req_count: None,
                 adapter_stash_url: args.adapter_stash_url,
                 controller,
                 secrets_controller,

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -26,13 +26,6 @@ use bytes::Bytes;
 use http::StatusCode;
 use thiserror::Error;
 
-/// The number of concurrent requests we allow at once for webhook sources.
-///
-/// TODO(parkmycar): Make this configurable via LaunchDarkly and/or as a setting on each webhook
-/// source. The blocker for doing this today is an `axum` layer that allows us to __reduce__ the
-/// concurrency limit, the current one only allows you to increase it.
-pub const CONCURRENCY_LIMIT: usize = 250;
-
 pub async fn handle_webhook(
     State(client): State<mz_adapter::Client>,
     Path((database, schema, name)): Path<(String, String, String)>,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2966,14 +2966,27 @@ fn webhook_concurrent_actions() {
 #[cfg_attr(miri, ignore)] // too slow
 fn webhook_concurrency_limit() {
     let concurrency_limit = 15;
-    let config = util::Config::default().with_concurrent_webhook_req_count(concurrency_limit);
+    let config = util::Config::default();
     let server = util::start_server(config).unwrap();
+
     // Note: we need enable_unstable_dependencies to use mz_sleep.
     server.enable_feature_flags(&[
         "enable_webhook_sources",
         "enable_unstable_dependencies",
         "enable_dangerous_functions",
     ]);
+
+    // Reduce the webhook concurrency limit;
+    let mut mz_client = server
+        .pg_config_internal()
+        .user(&SYSTEM_USER.name)
+        .connect(postgres::NoTls)
+        .unwrap();
+    mz_client
+        .batch_execute(&format!(
+            "ALTER SYSTEM SET webhook_concurrent_request_limit = {concurrency_limit}"
+        ))
+        .unwrap();
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 

--- a/src/environmentd/tests/util.rs
+++ b/src/environmentd/tests/util.rs
@@ -145,7 +145,6 @@ pub struct Config {
     bootstrap_role: Option<String>,
     deploy_generation: Option<u64>,
     system_parameter_defaults: BTreeMap<String, String>,
-    concurrent_webhook_req_count: Option<usize>,
     internal_console_redirect_url: Option<String>,
     metrics_registry: Option<MetricsRegistry>,
 }
@@ -169,7 +168,6 @@ impl Default for Config {
             bootstrap_role: Some("materialize".into()),
             deploy_generation: None,
             system_parameter_defaults: BTreeMap::new(),
-            concurrent_webhook_req_count: None,
             internal_console_redirect_url: None,
             metrics_registry: None,
         }
@@ -264,11 +262,6 @@ impl Config {
 
     pub fn with_system_parameter_default(mut self, param: String, value: String) -> Self {
         self.system_parameter_defaults.insert(param, value);
-        self
-    }
-
-    pub fn with_concurrent_webhook_req_count(mut self, limit: usize) -> Self {
-        self.concurrent_webhook_req_count = Some(limit);
         self
     }
 
@@ -452,7 +445,6 @@ impl Listeners {
                     cloud_resource_controller: None,
                     tls: config.tls,
                     frontegg: config.frontegg,
-                    concurrent_webhook_req_count: config.concurrent_webhook_req_count,
                     unsafe_mode: config.unsafe_mode,
                     all_features: false,
                     metrics_registry: metrics_registry.clone(),

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -191,6 +191,9 @@ macro_rules! sql_err {
 
 pub const DEFAULT_SCHEMA: &str = "public";
 
+/// The number of concurrent requests we allow at once for webhook sources.
+pub const WEBHOOK_CONCURRENCY_LIMIT: usize = 250;
+
 pub mod ast;
 pub mod catalog;
 pub mod func;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -92,7 +92,7 @@ use uncased::UncasedStr;
 
 use crate::ast::Ident;
 use crate::session::user::{User, SYSTEM_USER};
-use crate::DEFAULT_SCHEMA;
+use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
 
 /// The action to take during end_transaction.
 ///
@@ -1390,6 +1390,13 @@ pub const MAX_TIMESTAMP_INTERVAL: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+pub const WEBHOOK_CONCURRENT_REQUEST_LIMIT: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("webhook_concurrent_request_limit"),
+    value: &WEBHOOK_CONCURRENCY_LIMIT,
+    description: "Maximum number of concurrent requests for appending to a webhook source.",
+    internal: true,
+};
+
 /// Configuration for gRPC client connections.
 mod grpc_client {
     use super::*;
@@ -2495,7 +2502,8 @@ impl SystemVars {
             .with_var(&TRUNCATE_STATEMENT_LOG)
             .with_var(&STATEMENT_LOGGING_RETENTION)
             .with_var(&OPTIMIZER_STATS_TIMEOUT)
-            .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT);
+            .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
+            .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT);
 
         for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
@@ -3238,6 +3246,11 @@ impl SystemVars {
     /// Returns the `optimizer_oneshot_stats_timeout` configuration parameter.
     pub fn optimizer_oneshot_stats_timeout(&self) -> Duration {
         *self.expect_value(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
+    }
+
+    /// Returns the `webhook_concurrent_request_limit` configuration parameter.
+    pub fn webhook_concurrent_request_limit(&self) -> usize {
+        *self.expect_value(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
     }
 }
 
@@ -4859,6 +4872,11 @@ pub fn is_cluster_scheduling_var(name: &str) -> bool {
         || name == cluster_scheduling::CLUSTER_TOPOLOGY_SPREAD_SOFT.name()
         || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY.name()
         || name == cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT.name()
+}
+
+/// Returns whether the named variable is an HTTP server related config var.
+pub fn is_http_config_var(name: &str) -> bool {
+    name == WEBHOOK_CONCURRENT_REQUEST_LIMIT.name()
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -996,7 +996,6 @@ impl<'a> RunnerInner<'a> {
             tls: None,
             frontegg: None,
             cors_allowed_origin: AllowOrigin::list([]),
-            concurrent_webhook_req_count: None,
             unsafe_mode: true,
             all_features: false,
             metrics_registry,

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -31,7 +31,7 @@ use tracing::{debug, error, info};
 use crate::{persist_handles, StorageError};
 
 // Note(parkmycar): The capacity here was chosen arbitrarily.
-const CHANNEL_CAPACITY: usize = 255;
+const CHANNEL_CAPACITY: usize = 2048;
 // Default rate at which we append data and advance the uppers of managed collections.
 const DEFAULT_TICK: Duration = Duration::from_secs(1);
 


### PR DESCRIPTION
This PR makes the webhook concurrency limit controllable via LaunchDarkly. We change the concurrency layer we use in `axum` to one that takes a `tokio::sync::Semaphore`. I prioritized this because there is a prospect that might need these limits bumped, [Slack](https://materializeinc.slack.com/archives/C02FWJ94HME/p1697469997098879).

The only tricky thing is there is no API on `Semaphore` to _reduce_ the number of permits you allow, so the [official workaround](https://docs.rs/tokio/latest/tokio/sync/struct.OwnedSemaphorePermit.html#method.forget) is to spawn a task that acquires and then forgets them. Otherwise most of this PR is just plumbing the system var through everywhere.

### Motivation

Closes https://github.com/MaterializeInc/materialize/issues/21240

### Tips for reviewers

There are two commits here:

1. The first commit is entirely just code movement. I moved all webhook related things out of `src/adapter/src/command.rs` into its own `src/adapter/src/webhook.rs` modulde.
2. The second commit actually implements the configurable rate limiting.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
