### PR TITLE
git: Ignore services.log

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,36 +9,38 @@
 #
 # https://github.com/github/gitignore/tree/master/Global
 
-target
-target-ra
-target-xcompile
-miri-target
+/target
+/target-ra
+/target-xcompile
+/miri-target
 .mtrlz.log
-**/*.rs.bk
+*.rs.bk
 mzdata
 __pycache__
 .mypy_cache
 venv
 node_modules
-coverage
-test/feature-benchmark/tmp/*.td
-test/zippy/tmp/*.td
-test/**/tmp_*.toml
+/coverage
+/test/feature-benchmark/tmp/*.td
+/test/zippy/tmp/*.td
+/test/**/tmp_*.toml
 junit_*.xml
+parallel-workload-queries.log
 perf.data*
-**/*.rej
-**/*.orig
-**/*.profraw
-**/*.profdata
-**/*.debug
-scratch
+*.rej
+*.orig
+*.profraw
+*.profdata
+*.debug
+/scratch
+services.log
 *.swp
 
 # This is un-orthodox, but adding it to the repo would "tie" it to each user's
 # local version of nixpkgs. This way, we can all use the flake and have a
 # flake.lock that works well with the rest of the package versions on our
 # system.
-**/flake.lock
+flake.lock
 
 /misc/python/materialize/build/
 /misc/python/materialize/*.egg-info/

--- a/misc/python/materialize/cli/scratch/create.py
+++ b/misc/python/materialize/cli/scratch/create.py
@@ -122,16 +122,16 @@ def run(args: argparse.Namespace) -> None:
     extra_tags["LaunchedBy"] = whoami()
 
     if args.machine:
-        with open(MZ_ROOT / "misc" / "scratch" / "{}.json".format(args.machine)) as f:
+        with open(MZ_ROOT / "misc" / "scratch" / f"{args.machine}.json") as f:
 
-            print("Reading machine configs from {}".format(f.name))
+            print(f"Reading machine configs from {f.name}")
             descs = [MachineDesc.parse_obj(obj) for obj in multi_json(f.read())]
     else:
         print("Reading machine configs from stdin...")
         descs = [MachineDesc.parse_obj(obj) for obj in multi_json(sys.stdin.read())]
 
     if args.ssh and len(descs) != 1:
-        raise RuntimeError("Cannot use `--ssh` with {} instances".format(len(descs)))
+        raise RuntimeError(f"Cannot use `--ssh` with {len(descs)} instances")
 
     if args.max_age_days <= 0:
         raise RuntimeError(f"max_age_days must be positive, got {args.max_age_days}")
@@ -152,5 +152,5 @@ def run(args: argparse.Namespace) -> None:
     print_instances(instances, args.output_format)
 
     if args.ssh:
-        print("ssh-ing into: {}".format(instances[0].instance_id))
+        print(f"ssh-ing into: {instances[0].instance_id}")
         mssh(instances[0], "")


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/22367

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
