### PR TITLE
ci: Increase timeouts for parallel-workload

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -752,7 +752,7 @@ steps:
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -763,7 +763,7 @@ steps:
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -775,7 +775,7 @@ steps:
       # - id: parallel-workload-100-threads
       #   label: "Parallel Workload (100 threads)"
       #   artifact_paths: [junit_*.xml, pw-*.log]
-      #   timeout_in_minutes: 30
+      #   timeout_in_minutes: 40
       #   agents:
       #     queue: builder-linux-x86_64
       #   plugins:
@@ -786,7 +786,7 @@ steps:
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -798,7 +798,7 @@ steps:
       # - id: parallel-workload-kill
       #   label: "Parallel Workload (kill)"
       #   artifact_paths: [junit_*.xml, parallel-workload-queries.log]
-      #   timeout_in_minutes: 30
+      #   timeout_in_minutes: 40
       #   agents:
       #     queue: builder-linux-x86_64
       #   plugins:


### PR DESCRIPTION
Artifact upload can take a while

Seen in https://buildkite.com/materialize/nightlies/builds/4745#018b3ffa-3e21-42a8-b8fa-f269b9dfa82b


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
