### PR TITLE
mzcompose: Make default run all workflows

### DIFF
--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+from copy import copy
+
 from materialize.mzcompose import (
     DEFAULT_CRDB_ENVIRONMENT,
     DEFAULT_MZ_ENVIRONMENT_ID,
@@ -79,7 +81,9 @@ class Materialized(Service):
         ]
 
         if system_parameter_defaults is None:
-            system_parameter_defaults = DEFAULT_SYSTEM_PARAMETERS
+            # Has to be copied so we later don't modify the
+            # DEFAULT_SYSTEM_PARAMETERS dictionary
+            system_parameter_defaults = copy(DEFAULT_SYSTEM_PARAMETERS)
 
         if additional_system_parameter_defaults is not None:
             system_parameter_defaults.update(additional_system_parameter_defaults)

--- a/test/cluster/resources/bootstrapped-system-vars.td
+++ b/test/cluster/resources/bootstrapped-system-vars.td
@@ -8,4 +8,4 @@
 # by the Apache License, Version 2.0.
 
 > SHOW allowed_cluster_replica_sizes
-"'1', '2', 'oops'"
+"\"1\", \"2\", oops"

--- a/test/kafka-resumption/mzcompose.py
+++ b/test/kafka-resumption/mzcompose.py
@@ -30,8 +30,11 @@ SERVICES = [
 
 
 def workflow_default(c: Composition) -> None:
-    c.workflow("sink-networking")
-    c.workflow("source-resumption")
+    for name in c.workflows:
+        if name == "default":
+            continue
+        with c.test_case(name):
+            c.workflow(name)
 
 
 #

--- a/test/kafka-ssl/mzcompose.py
+++ b/test/kafka-ssl/mzcompose.py
@@ -112,8 +112,11 @@ SERVICES = [
 
 def workflow_default(c: Composition) -> None:
     """Run testdrive against an SSL-enabled Confluent Platform."""
-    c.workflow("smoketest")
-    c.workflow("ssh-tunnel")
+    for name in c.workflows:
+        if name == "default":
+            continue
+        with c.test_case(name):
+            c.workflow(name)
 
 
 def workflow_smoketest(c: Composition) -> None:

--- a/test/mzcompose_examples/mzcompose.py
+++ b/test/mzcompose_examples/mzcompose.py
@@ -44,10 +44,11 @@ def workflow_default(c: Composition) -> None:
 
     This workflow just runs all the other ones
     """
-    c.workflow("start-confluents")
-    c.workflow("versioned-mz")
-    c.workflow("two-mz")
-    c.workflow("mz-with-options")
+    for name in c.workflows:
+        if name == "default":
+            continue
+        with c.test_case(name):
+            c.workflow(name)
 
 
 def workflow_start_confluents(c: Composition) -> None:

--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -402,11 +402,8 @@ def workflow_bound_size_mz_status_history(c: Composition) -> None:
 
 
 def workflow_default(c: Composition) -> None:
-    c.workflow("github-17578")
-    c.workflow("github-8021")
-    c.workflow("audit-log")
-    c.workflow("timelines")
-    c.workflow("stash")
-    c.workflow("allowed-cluster-replica-sizes")
-    c.workflow("drop-materialize-database")
-    c.workflow("bound-size-mz-status-history")
+    for name in c.workflows:
+        if name == "default":
+            continue
+        with c.test_case(name):
+            c.workflow(name)

--- a/test/upsert/autospill/bytes.td
+++ b/test/upsert/autospill/bytes.td
@@ -59,7 +59,7 @@ animal:
     SUM(u.envelope_state_count)
   FROM mz_sources s
   JOIN mz_internal.mz_source_statistics u ON s.id = u.id
-  WHERE s.name IN ('autospill')
+  WHERE s.name = 'autospill'
   GROUP BY s.name
   ORDER BY s.name
 0 0

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -57,14 +57,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.compaction_disabled:
         materialized_environment_extra[0] = "MZ_PERSIST_COMPACTION_DISABLED=true"
 
-    for name in [
-        "rehydration",
-        "testdrive",
-        "failpoint",
-        "incident-49",
-        "rocksdb-cleanup",
-        "autospill",
-    ]:
+    for name in c.workflows:
+        if name == "default":
+            continue
         with c.test_case(name):
             c.workflow(name)
 
@@ -168,6 +163,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
+                    "enable_unmanaged_cluster_replicas": "true",
                     "disk_cluster_replicas_default": "true",
                     "enable_disk_cluster_replicas": "true",
                     # Force backpressure to be enabled.
@@ -196,6 +192,7 @@ def workflow_rehydration(c: Composition) -> None:
                     "--orchestrator-process-scratch-directory=/scratch",
                 ],
                 additional_system_parameter_defaults={
+                    "enable_unmanaged_cluster_replicas": "true",
                     # Force backpressure to be enabled.
                     "storage_dataflow_max_inflight_bytes": "1",
                     "storage_dataflow_max_inflight_bytes_to_cluster_size_fraction": "0.01",
@@ -214,6 +211,7 @@ def workflow_rehydration(c: Composition) -> None:
             clusterd,
             Testdrive(no_reset=True, consistent_seed=True),
         ):
+
             print(f"Running rehydration workflow {style}")
             c.down(destroy_volumes=True)
 


### PR DESCRIPTION
Currently a few are missing from the manually maintained list, at least in cluster tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
