### PR TITLE
Worker-local consolidation using Pipeline

### DIFF
--- a/src/compute/src/logging/differential.rs
+++ b/src/compute/src/logging/differential.rs
@@ -24,7 +24,7 @@ use mz_repr::{Datum, Diff, Timestamp};
 use mz_timely_util::buffer::ConsolidateBuffer;
 use mz_timely_util::replay::MzReplay;
 use timely::communication::Allocate;
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Filter, InputCapability};
@@ -117,10 +117,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementBatches);
         let arrangement_batches = batches
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Differential batches",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential batches")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
@@ -130,10 +127,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::ArrangementRecords);
         let arrangement_records = records
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Differential records",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential records")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),
@@ -144,10 +138,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(DifferentialLog::Sharing);
         let sharing = sharing
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Differential sharing",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Differential sharing")
             .as_collection(move |op, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*op)),

--- a/src/compute/src/logging/timely.rs
+++ b/src/compute/src/logging/timely.rs
@@ -24,7 +24,7 @@ use mz_timely_util::replay::MzReplay;
 use serde::{Deserialize, Serialize};
 use timely::communication::Allocate;
 use timely::container::columnation::{Columnation, CopyRegion};
-use timely::dataflow::channels::pact::{Exchange, Pipeline};
+use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::Tee;
 use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
 use timely::dataflow::operators::{Filter, InputCapability};
@@ -151,10 +151,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Operates);
         let operates = operates
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely operates",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
             .as_collection(move |id, name| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*id)),
@@ -165,10 +162,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Channels);
         let channels = channels
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely operates",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely operates")
             .as_collection(move |datum, ()| {
                 let (source_node, source_port) = datum.source;
                 let (target_node, target_port) = datum.target;
@@ -185,10 +179,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Addresses);
         let addresses = addresses
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely addresses",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely addresses")
             .as_collection({
                 move |id, address| {
                     packer.pack_by_index(|packer, index| match index {
@@ -203,10 +194,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Parks);
         let parks = parks
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely parks",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely parks")
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(worker_id)),
@@ -220,10 +208,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::BatchesSent);
         let batches_sent = batches_sent
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely batches sent",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely batches sent")
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
@@ -235,7 +220,7 @@ pub(super) fn construct<A: Allocate>(
         let batches_received = batches_received
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
+                Pipeline,
                 "PreArrange Timely batches received",
             )
             .as_collection(move |datum, ()| {
@@ -248,10 +233,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::MessagesSent);
         let messages_sent = messages_sent
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely messages sent",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely messages sent")
             .as_collection(move |datum, ()| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.channel)),
@@ -263,7 +245,7 @@ pub(super) fn construct<A: Allocate>(
         let messages_received = messages_received
             .as_collection()
             .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
+                Pipeline,
                 "PreArrange Timely messages received",
             )
             .as_collection(move |datum, ()| {
@@ -276,10 +258,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Elapsed);
         let elapsed = schedules_duration
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely duration",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely duration")
             .as_collection(move |operator, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(*operator)),
@@ -289,10 +268,7 @@ pub(super) fn construct<A: Allocate>(
         let mut packer = PermutedRowPacker::new(TimelyLog::Histogram);
         let histogram = schedules_histogram
             .as_collection()
-            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(
-                Exchange::new(move |_| u64::cast_from(worker_id)),
-                "PreArrange Timely histogram",
-            )
+            .mz_arrange_core::<_, RowSpine<_, _, _, _>>(Pipeline, "PreArrange Timely histogram")
             .as_collection(move |datum, _| {
                 packer.pack_slice(&[
                     Datum::UInt64(u64::cast_from(datum.operator)),


### PR DESCRIPTION
Consolidate worker-local data without an exchange. The exchange wasn't useful because it partitioned independently of the data, assigning all data from worker x to worker x. This isn't any better than pipelining the data immediately because we don't have to inspect every record.

This change leaves a defensive assertion in place that checks that we process data for worker x on worker x.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
