### PR TITLE
storage: actually use the new record_namespaced_statuses ld flag

### DIFF
--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -342,6 +342,7 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                 &health_stream,
                 health_configs,
                 crate::healthcheck::DefaultWriter(Rc::clone(&storage_state.internal_cmd_tx)),
+                storage_state.dataflow_parameters.record_namespaced_errors,
             );
             tokens.push(health_token);
 
@@ -408,6 +409,7 @@ pub fn build_export_dataflow<A: Allocate>(
                 &health_stream,
                 health_configs,
                 crate::healthcheck::DefaultWriter(Rc::clone(&storage_state.internal_cmd_tx)),
+                storage_state.dataflow_parameters.record_namespaced_errors,
             );
             tokens.push(health_token);
 


### PR DESCRIPTION
oopsie

### Motivation

   * This PR refactors existing code.

forgot to pipe this through

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
