### PR TITLE
ci: Ignore flaky panics in restart test

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -36,6 +36,10 @@ ERROR_RE = re.compile(
     | timely\ communication\ error:
     # Expected once compute cluster has panicked, only happens in CI
     | aborting\ because\ propagate_crashes\ is\ enabled
+    # Expected when CRDB is corrupted
+    | restart-materialized-1\ .*relation\ \\"fence\\"\ does\ not\ exist
+    # Expected when CRDB is corrupted
+    | restart-materialized-1\ .*relation\ "consensus"\ does\ not\ exist
     ))
     .)*
     # This block contains unexpected failures, report them


### PR DESCRIPTION
Fixes: #22422

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
