### PR TITLE
postgres consistency: less coarse-grained function-does-not-exist ignores

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import re
 from collections.abc import Callable
 from functools import partial
 
@@ -50,6 +51,12 @@ from materialize.output_consistency.operation.operation import (
 from materialize.output_consistency.query.query_result import QueryFailure
 from materialize.output_consistency.query.query_template import QueryTemplate
 from materialize.output_consistency.validation.validation_message import ValidationError
+
+NAME_OF_NON_EXISTING_FUNCTION_PATTERN = re.compile(
+    r"function (\w)\(.*?\) does not exist"
+)
+
+NON_EXISTING_MZ_FUNCTION_DEFINITIONS = ["min(time)", "max(time)"]
 
 
 class PgInconsistencyIgnoreFilter(InconsistencyIgnoreFilter):
@@ -223,7 +230,7 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             # this does not necessarily mean that the function exists in one database but not the other; it could also
             # be a subsequent error when an expression (an argument) is evaluated to another type
             return YesIgnore(
-                "Not supported in Postgres: No function / operator matches the given name and argument types"
+                "Function or operation does not exist for the evaluated input"
             )
 
         if 'syntax error at or near "="' in pg_error_msg:
@@ -252,11 +259,25 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         mz_error_msg = mz_outcome.error_message
 
         if is_unknown_function_or_operation_invocation(mz_error_msg):
-            # this does not necessarily mean that the function exists in one database but not the other; it could also
-            # be a subsequent error when an expression (an argument) is evaluated to another type
-            return YesIgnore(
-                f"#22024: non-existing functions or operation: ({mz_error_msg})"
-            )
+            function_name = extract_unknown_function_from_error_msg(mz_error_msg)
+
+            if (
+                function_name is not None
+                and is_function_invoked_only_with_non_nested_parameters(
+                    query_template, function_name
+                )
+            ):
+                # function does not exist
+                if is_function_known_not_to_exist_in_mz(mz_error_msg):
+                    return YesIgnore(
+                        f"#22024: non-existing function or operation: ({mz_error_msg})"
+                    )
+            else:
+                # this does not necessarily mean that the function exists in one database but not the other; it could
+                # also be a subsequent error when an expression (an argument) is evaluated to another type
+                return YesIgnore(
+                    "Function or operation does not exist for the evaluated input"
+                )
 
         def matches_round_function(expression: Expression) -> bool:
             return (
@@ -487,6 +508,14 @@ def matches_x_or_y(
     return x(expression) or y(expression)
 
 
+def matches_x_and_y(
+    expression: Expression,
+    x: Callable[[Expression], bool],
+    y: Callable[[Expression], bool],
+) -> bool:
+    return x(expression) and y(expression)
+
+
 def matches_fun_by_name(
     expression: Expression, function_name_in_lower_case: str
 ) -> bool:
@@ -508,9 +537,58 @@ def matches_op_by_pattern(expression: Expression, pattern: str) -> bool:
     return False
 
 
+def matches_expression_with_only_plain_arguments(expression: Expression) -> bool:
+    if isinstance(expression, ExpressionWithArgs):
+        for arg in expression.args:
+            if not arg.is_leaf():
+                return False
+
+    return True
+
+
+def matches_nested_expression(expression: Expression) -> bool:
+    return not matches_expression_with_only_plain_arguments(expression)
+
+
 def is_unknown_function_or_operation_invocation(error_msg: str) -> bool:
     return (
         "No function matches the given name and argument types" in error_msg
         or "No operator matches the given name and argument types" in error_msg
         or ("WHERE clause error: " in error_msg and "does not exist" in error_msg)
     )
+
+
+def extract_unknown_function_from_error_msg(error_msg: str) -> str | None:
+    match = NAME_OF_NON_EXISTING_FUNCTION_PATTERN.search(error_msg)
+
+    if match is not None:
+        function_name = match.group(1)
+        return function_name
+
+    # do not parse not existing operators
+    return None
+
+
+def is_function_invoked_only_with_non_nested_parameters(
+    query_template: QueryTemplate, function_name_in_lowercase: str
+) -> bool:
+    at_least_one_invocation_with_nested_args = query_template.matches_any_expression(
+        partial(
+            matches_x_and_y,
+            x=partial(
+                matches_fun_by_name,
+                function_name_in_lower_case=function_name_in_lowercase,
+            ),
+            y=matches_nested_expression,
+        ),
+        True,
+    )
+    return not at_least_one_invocation_with_nested_args
+
+
+def is_function_known_not_to_exist_in_mz(error_msg: str) -> bool:
+    for function_definition in NON_EXISTING_MZ_FUNCTION_DEFINITIONS:
+        if function_definition in error_msg:
+            return True
+
+    return False


### PR DESCRIPTION
Do not automatically ignore all function-does-not-exist errors.

Instead differentiate between a function that exists in Postgres but not in mz and that
* is invoked with only plain arguments (=> it does really not exist in mz)
* is invoked with at least one nested argument (=> it could be a subsequent error of an argument being evaluated to another type than in Postgres)