### PR TITLE
catalog: Improve consistency error message

### DIFF
--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -21,6 +21,7 @@ use mz_sql::names::{
     SchemaSpecifier,
 };
 use mz_sql_parser::ast::{self, Statement};
+use mz_sql_parser::parser::ParserStatementError;
 use serde::Serialize;
 
 use super::CatalogState;
@@ -418,9 +419,10 @@ impl CatalogState {
                             });
                             continue;
                         }
-                        Err(_) => {
+                        Err(e) => {
                             item_inconsistencies.push(ItemInconsistency::StatementParseFailure {
                                 create_sql: entry.create_sql().to_string(),
+                                e,
                             });
                             continue;
                         }
@@ -615,7 +617,10 @@ enum ItemInconsistency {
         entry_name: QualifiedItemName,
     },
     /// Failed to parse the `create_sql` persisted with an item.
-    StatementParseFailure { create_sql: String },
+    StatementParseFailure {
+        create_sql: String,
+        e: ParserStatementError,
+    },
     /// Parsing the `create_sql` returned multiple Statements.
     MultiCreateStatement { create_sql: String },
     /// The name from a parsed `create_sql` statement, is not fully qualified.

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -540,7 +540,11 @@ impl Coordinator {
 
         // Note: It's important that we keep the function call inside macro, this way we only run
         // the consistency checks if sort assertions are enabled.
-        mz_ore::soft_assert_eq!(self.check_consistency(), Ok(()));
+        mz_ore::soft_assert_eq!(
+            self.check_consistency(),
+            Ok(()),
+            "coordinator inconsistency detected"
+        );
 
         Ok(result)
     }


### PR DESCRIPTION
### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
