### PR TITLE
adapter: give INTERNAL replicas system IDs

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -636,6 +636,14 @@ impl Catalog {
             .err_into()
     }
 
+    pub async fn allocate_system_replica_id(&self) -> Result<ReplicaId, Error> {
+        self.storage()
+            .await
+            .allocate_system_replica_id()
+            .await
+            .err_into()
+    }
+
     pub fn allocate_oid(&mut self) -> Result<u32, Error> {
         self.state.allocate_oid()
     }

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -483,7 +483,13 @@ impl Coordinator {
 
         // Replicas have the same owner as their cluster.
         let owner_id = cluster.owner_id();
-        let id = self.catalog_mut().allocate_user_replica_id().await?;
+
+        let id = if config.location.internal() {
+            self.catalog_mut().allocate_system_replica_id().await?
+        } else {
+            self.catalog_mut().allocate_user_replica_id().await?
+        };
+
         let op = catalog::Op::CreateClusterReplica {
             cluster_id,
             id,

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -380,6 +380,13 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
         Ok(ClusterId::System(id))
     }
 
+    /// Allocates and returns a system [`ReplicaId`].
+    async fn allocate_system_replica_id(&mut self) -> Result<ReplicaId, CatalogError> {
+        let id = self.allocate_id(SYSTEM_REPLICA_ID_ALLOC_KEY, 1).await?;
+        let id = id.into_element();
+        Ok(ReplicaId::System(id))
+    }
+
     /// Allocates and returns a user [`ClusterId`].
     async fn allocate_user_cluster_id(&mut self) -> Result<ClusterId, CatalogError> {
         let id = self.allocate_id(USER_CLUSTER_ID_ALLOC_KEY, 1).await?;


### PR DESCRIPTION
This PR makes adapter assign system replica IDs to `INTERNAL` replicas, rather than user IDs.

Draft: This will either fail test or needs new tests to be written.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
