### PR TITLE
fix: panic in renaming schemas

### DIFF
--- a/src/sql/src/ast/transform.rs
+++ b/src/sql/src/ast/transform.rs
@@ -13,6 +13,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use mz_ore::str::StrExt;
 use mz_repr::GlobalId;
+use mz_sql_parser::ast::CreateSubsourceStatement;
 
 use crate::ast::visit::{self, Visit};
 use crate::ast::visit_mut::{self, VisitMut};
@@ -51,7 +52,8 @@ pub fn create_stmt_rename_schema_refs(
         | Statement::CreateConnection(CreateConnectionStatement { name, .. })
         | Statement::CreateWebhookSource(CreateWebhookSourceStatement { name, .. })
         | Statement::CreateType(CreateTypeStatement { name, .. })
-        | Statement::CreateSource(CreateSourceStatement { name, .. }) => {
+        | Statement::CreateSource(CreateSourceStatement { name, .. })
+        | Statement::CreateSubsource(CreateSubsourceStatement { name, .. }) => {
             maybe_update_item_name(name);
         }
         Statement::CreateView(CreateViewStatement {
@@ -64,7 +66,9 @@ pub fn create_stmt_rename_schema_refs(
             maybe_update_item_name(name);
             rewrite_query_schema(cur_schema_name, new_schema_name, query);
         }
-        _ => unreachable!("Internal error: only catalog items need to update item refs"),
+        stmt => {
+            unreachable!("Internal error: only catalog items need to update item refs. {stmt:?}")
+        }
     }
 }
 


### PR DESCRIPTION
### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/22490

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
