### PR TITLE
catalog: Update persist catalog shard IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3717,6 +3717,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "timely",
  "tokio",

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -35,6 +35,7 @@ proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 postgres-openssl = { version = "0.5.0" }
 serde = "1.0.152"
 serde_json = "1.0.89"
+sha2 = "0.10.6"
 timely = { version = "0.12.0", default-features = false }
 tracing = "0.1.37"
 thiserror = "1.0.37"


### PR DESCRIPTION
This commit updates how the persist catalog generates shard IDs. Previously, the persist catalog used the environment ID as the shard ID directly. This may lead to confusion on dashboards and prevents the persist catalog from using multiple shards. This commit updates the shard generation so that it's deterministically generated from the environment ID.

Resolves #22506

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
