### PR TITLE
feature-benchmark: Use devel as ancestor

### DIFF
--- a/misc/python/materialize/benchmark_utils.py
+++ b/misc/python/materialize/benchmark_utils.py
@@ -18,6 +18,6 @@ def resolve_tag_of_common_ancestor(tag_when_on_default_branch: str = "latest") -
         return tag_when_on_default_branch
     else:
         commit_hash = buildkite.get_merge_base()
-        tag = f"unstable-{commit_hash}"
+        tag = f"devel-{commit_hash}"
         print(f"Resolved common-ancestor to {tag} (commit: {commit_hash})")
         return tag


### PR DESCRIPTION
See discussion in  https://materializeinc.slack.com/archives/C01LKF361MZ/p1697734539979959

Broken in https://github.com/MaterializeInc/materialize/pull/22355

Deploy is only run with `unstable` tags if all tests succeeded, but we have flaky tests on main.
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
