### PR TITLE
cluster-test: Extend index-source-stuck to test against source directly

### DIFF
--- a/test/cluster/index-source-stuck/run.td
+++ b/test/cluster/index-source-stuck/run.td
@@ -41,7 +41,16 @@ ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
 # Strict serializable is expected to fail, but serializable isolation should still be able to return (out of date) results
 > SET transaction_isolation = serializable;
 
-# Should return instantly since it only uses the index and we have selected serializable isolation
+# Should return instantly since we have selected serializable isolation
+> SELECT min(counter) FROM src;
+1
+
+# Should return instantly, even inside of a transaction
+# > BEGIN
+# > SELECT * FROM src;
+# > COMMIT
+
+# Should return instantly since it only uses the materialized view and we have selected serializable isolation
 > SELECT min(counter) FROM mv;
 1
 


### PR DESCRIPTION
Didn't expect this to also work, but it does, as suggested in reviews

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
