### PR TITLE
[persist] Restore script followups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4596,6 +4596,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "arrow2",
+ "async-stream",
  "async-trait",
  "aws-config",
  "aws-credential-types",

--- a/src/persist-client/src/cli/admin.rs
+++ b/src/persist-client/src/cli/admin.rs
@@ -16,33 +16,25 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{anyhow, bail};
-use async_trait::async_trait;
-use bytes::Bytes;
 use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use futures_util::{stream, StreamExt, TryStreamExt};
-use mz_ore::bytes::SegmentedBytes;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
-use mz_persist::cfg::{BlobConfig, ConsensusConfig};
-use mz_persist::location::{
-    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo,
-    VersionedData,
-};
+use mz_persist::location::{Blob, Consensus, ExternalError};
 use mz_persist_types::codec_impls::TodoSchema;
 use mz_persist_types::{Codec, Codec64};
 use prometheus::proto::{MetricFamily, MetricType};
 use timely::progress::Timestamp;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cache::StateCache;
-use crate::cli::inspect::{StateArgs, StoreArgs};
+use crate::cli::args::{make_blob, make_consensus, StateArgs, StoreArgs};
 use crate::internal::compact::{CompactConfig, CompactReq, Compactor};
 use crate::internal::encoding::Schemas;
 use crate::internal::gc::{GarbageCollector, GcReq};
 use crate::internal::machine::Machine;
-use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
 use crate::rpc::NoopPubSubSender;
 use crate::write::WriterId;
@@ -340,117 +332,6 @@ where
         info!("expired writer {}", writer_id);
         return Ok(());
     }
-}
-
-/// Wrap a lower-level service (Blob or Consensus) to make it read only.
-/// This is probably not elaborate enough to work in general -- folks may expect to read
-/// their own writes, among other things -- but it should handle the case of GC, where
-/// all reads finish before the writes begin.
-#[derive(Debug)]
-struct ReadOnly<T>(T);
-
-#[async_trait]
-impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
-    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
-        self.0.get(key).await
-    }
-
-    async fn list_keys_and_metadata(
-        &self,
-        key_prefix: &str,
-        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
-    ) -> Result<(), ExternalError> {
-        self.0.list_keys_and_metadata(key_prefix, f).await
-    }
-
-    async fn set(&self, key: &str, _value: Bytes, _atomic: Atomicity) -> Result<(), ExternalError> {
-        warn!("ignoring set({key}) in read-only mode");
-        Ok(())
-    }
-
-    async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
-        warn!("ignoring delete({key}) in read-only mode");
-        Ok(None)
-    }
-
-    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
-        warn!("ignoring restore({key}) in read-only mode");
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Consensus for ReadOnly<Arc<dyn Consensus + Sync + Send>> {
-    fn list_keys(&self) -> ResultStream<String> {
-        self.0.list_keys()
-    }
-
-    async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
-        self.0.head(key).await
-    }
-
-    async fn compare_and_set(
-        &self,
-        key: &str,
-        _expected: Option<SeqNo>,
-        _new: VersionedData,
-    ) -> Result<CaSResult, ExternalError> {
-        warn!("ignoring cas({key}) in read-only mode");
-        Ok(CaSResult::Committed)
-    }
-
-    async fn scan(
-        &self,
-        key: &str,
-        from: SeqNo,
-        limit: usize,
-    ) -> Result<Vec<VersionedData>, ExternalError> {
-        self.0.scan(key, from, limit).await
-    }
-
-    async fn truncate(&self, key: &str, _seqno: SeqNo) -> Result<usize, ExternalError> {
-        warn!("ignoring truncate({key}) in read-only mode");
-        Ok(0)
-    }
-}
-
-pub(super) async fn make_consensus(
-    cfg: &PersistConfig,
-    consensus_uri: &str,
-    commit: bool,
-    metrics: Arc<Metrics>,
-) -> anyhow::Result<Arc<dyn Consensus + Send + Sync>> {
-    let consensus = ConsensusConfig::try_from(
-        consensus_uri,
-        Box::new(cfg.clone()),
-        metrics.postgres_consensus.clone(),
-    )?;
-    let consensus = consensus.clone().open().await?;
-    let consensus = if commit {
-        consensus
-    } else {
-        Arc::new(ReadOnly(consensus))
-    };
-    let consensus = Arc::new(MetricsConsensus::new(consensus, Arc::clone(&metrics)));
-    Ok(consensus)
-}
-
-pub(super) async fn make_blob(
-    cfg: &PersistConfig,
-    blob_uri: &str,
-    commit: bool,
-    metrics: Arc<Metrics>,
-) -> anyhow::Result<Arc<dyn Blob + Send + Sync>> {
-    let blob =
-        BlobConfig::try_from(blob_uri, Box::new(cfg.clone()), metrics.s3_blob.clone()).await?;
-    let blob = blob.clone().open().await?;
-    let blob = if commit {
-        blob
-    } else {
-        Arc::new(ReadOnly(blob))
-    };
-    let blob = Arc::new(MetricsBlob::new(blob, Arc::clone(&metrics)));
-    Ok(blob)
 }
 
 async fn make_machine(

--- a/src/persist-client/src/cli/args.rs
+++ b/src/persist-client/src/cli/args.rs
@@ -1,0 +1,231 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! CLI argument types for persist
+
+use crate::cfg::PersistConfig;
+use crate::internal::metrics::{MetricsBlob, MetricsConsensus};
+use crate::internal::state_versions::StateVersions;
+use crate::metrics::Metrics;
+use crate::ShardId;
+use async_trait::async_trait;
+use bytes::Bytes;
+use mz_build_info::BuildInfo;
+use mz_ore::bytes::SegmentedBytes;
+use mz_ore::metrics::MetricsRegistry;
+use mz_ore::now::SYSTEM_TIME;
+use mz_persist::cfg::{BlobConfig, ConsensusConfig};
+use mz_persist::location::{
+    Atomicity, Blob, BlobMetadata, CaSResult, Consensus, ExternalError, ResultStream, SeqNo,
+    VersionedData,
+};
+use std::str::FromStr;
+use std::sync::Arc;
+use tracing::warn;
+
+/// Arguments for commands that work over both backing stores.
+/// TODO: squish this into `StateArgs`.
+#[derive(Debug, Clone, clap::Parser)]
+pub struct StoreArgs {
+    /// Consensus to use.
+    ///
+    /// When connecting to a deployed environment's consensus table, the Postgres/CRDB connection
+    /// string must contain the database name and `options=--search_path=consensus`.
+    ///
+    /// When connecting to Cockroach Cloud, use the following format:
+    ///
+    /// ```text
+    /// postgresql://<user>:$COCKROACH_PW@<hostname>:<port>/environment_<environment-id>
+    ///   ?sslmode=verify-full
+    ///   &sslrootcert=/path/to/cockroach-cloud/certs/cluster-ca.crt
+    ///   &options=--search_path=consensus
+    /// ```
+    ///
+    #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
+    pub(crate) consensus_uri: String,
+
+    /// Blob to use
+    ///
+    /// When connecting to a deployed environment's blob, the necessary connection glue must be in
+    /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
+    /// URI scoped to the environment's bucket prefix.
+    #[clap(long, env = "BLOB_URI")]
+    pub(crate) blob_uri: String,
+}
+
+/// Arguments for viewing the current state of a given shard
+#[derive(Debug, Clone, clap::Parser)]
+pub struct StateArgs {
+    /// Shard to view
+    #[clap(long)]
+    pub(crate) shard_id: String,
+
+    /// Consensus to use.
+    ///
+    /// When connecting to a deployed environment's consensus table, the Postgres/CRDB connection
+    /// string must contain the database name and `options=--search_path=consensus`.
+    ///
+    /// When connecting to Cockroach Cloud, use the following format:
+    ///
+    /// ```text
+    /// postgresql://<user>:$COCKROACH_PW@<hostname>:<port>/environment_<environment-id>
+    ///   ?sslmode=verify-full
+    ///   &sslrootcert=/path/to/cockroach-cloud/certs/cluster-ca.crt
+    ///   &options=--search_path=consensus
+    /// ```
+    ///
+    #[clap(long, verbatim_doc_comment, env = "CONSENSUS_URI")]
+    pub(crate) consensus_uri: String,
+
+    /// Blob to use
+    ///
+    /// When connecting to a deployed environment's blob, the necessary connection glue must be in
+    /// place. e.g. for S3, sign into SSO, set AWS_PROFILE and AWS_REGION appropriately, with a blob
+    /// URI scoped to the environment's bucket prefix.
+    #[clap(long, env = "BLOB_URI")]
+    pub(crate) blob_uri: String,
+}
+
+// BuildInfo with a larger version than any version we expect to see in prod,
+// to ensure that any data read is from a smaller version and does not trigger
+// alerts.
+pub(crate) const READ_ALL_BUILD_INFO: BuildInfo = BuildInfo {
+    version: "99.999.99+test",
+    sha: "0000000000000000000000000000000000000000",
+    time: "",
+};
+
+// All `inspect` command are read-only.
+pub(crate) const NO_COMMIT: bool = false;
+
+impl StateArgs {
+    pub(crate) fn shard_id(&self) -> ShardId {
+        ShardId::from_str(&self.shard_id).expect("invalid shard id")
+    }
+
+    pub(crate) async fn open(&self) -> Result<StateVersions, anyhow::Error> {
+        let cfg = PersistConfig::new(&READ_ALL_BUILD_INFO, SYSTEM_TIME.clone());
+        let metrics = Arc::new(Metrics::new(&cfg, &MetricsRegistry::new()));
+        let consensus =
+            make_consensus(&cfg, &self.consensus_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
+        let blob = make_blob(&cfg, &self.blob_uri, NO_COMMIT, Arc::clone(&metrics)).await?;
+        Ok(StateVersions::new(cfg, consensus, blob, metrics))
+    }
+}
+
+pub(super) async fn make_consensus(
+    cfg: &PersistConfig,
+    consensus_uri: &str,
+    commit: bool,
+    metrics: Arc<Metrics>,
+) -> anyhow::Result<Arc<dyn Consensus + Send + Sync>> {
+    let consensus = ConsensusConfig::try_from(
+        consensus_uri,
+        Box::new(cfg.clone()),
+        metrics.postgres_consensus.clone(),
+    )?;
+    let consensus = consensus.clone().open().await?;
+    let consensus = if commit {
+        consensus
+    } else {
+        Arc::new(ReadOnly(consensus))
+    };
+    let consensus = Arc::new(MetricsConsensus::new(consensus, Arc::clone(&metrics)));
+    Ok(consensus)
+}
+
+pub(super) async fn make_blob(
+    cfg: &PersistConfig,
+    blob_uri: &str,
+    commit: bool,
+    metrics: Arc<Metrics>,
+) -> anyhow::Result<Arc<dyn Blob + Send + Sync>> {
+    let blob =
+        BlobConfig::try_from(blob_uri, Box::new(cfg.clone()), metrics.s3_blob.clone()).await?;
+    let blob = blob.clone().open().await?;
+    let blob = if commit {
+        blob
+    } else {
+        Arc::new(ReadOnly(blob))
+    };
+    let blob = Arc::new(MetricsBlob::new(blob, Arc::clone(&metrics)));
+    Ok(blob)
+}
+
+/// Wrap a lower-level service (Blob or Consensus) to make it read only.
+/// This is probably not elaborate enough to work in general -- folks may expect to read
+/// their own writes, among other things -- but it should handle the case of GC, where
+/// all reads finish before the writes begin.
+#[derive(Debug)]
+struct ReadOnly<T>(T);
+
+#[async_trait]
+impl Blob for ReadOnly<Arc<dyn Blob + Sync + Send>> {
+    async fn get(&self, key: &str) -> Result<Option<SegmentedBytes>, ExternalError> {
+        self.0.get(key).await
+    }
+
+    async fn list_keys_and_metadata(
+        &self,
+        key_prefix: &str,
+        f: &mut (dyn FnMut(BlobMetadata) + Send + Sync),
+    ) -> Result<(), ExternalError> {
+        self.0.list_keys_and_metadata(key_prefix, f).await
+    }
+
+    async fn set(&self, key: &str, _value: Bytes, _atomic: Atomicity) -> Result<(), ExternalError> {
+        warn!("ignoring set({key}) in read-only mode");
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<Option<usize>, ExternalError> {
+        warn!("ignoring delete({key}) in read-only mode");
+        Ok(None)
+    }
+
+    async fn restore(&self, key: &str) -> Result<(), ExternalError> {
+        warn!("ignoring restore({key}) in read-only mode");
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Consensus for ReadOnly<Arc<dyn Consensus + Sync + Send>> {
+    fn list_keys(&self) -> ResultStream<String> {
+        self.0.list_keys()
+    }
+
+    async fn head(&self, key: &str) -> Result<Option<VersionedData>, ExternalError> {
+        self.0.head(key).await
+    }
+
+    async fn compare_and_set(
+        &self,
+        key: &str,
+        _expected: Option<SeqNo>,
+        _new: VersionedData,
+    ) -> Result<CaSResult, ExternalError> {
+        warn!("ignoring cas({key}) in read-only mode");
+        Ok(CaSResult::Committed)
+    }
+
+    async fn scan(
+        &self,
+        key: &str,
+        from: SeqNo,
+        limit: usize,
+    ) -> Result<Vec<VersionedData>, ExternalError> {
+        self.0.scan(key, from, limit).await
+    }
+
+    async fn truncate(&self, key: &str, _seqno: SeqNo) -> Result<usize, ExternalError> {
+        warn!("ignoring truncate({key}) in read-only mode");
+        Ok(0)
+    }
+}

--- a/src/persist-client/src/internal/restore.rs
+++ b/src/persist-client/src/internal/restore.rs
@@ -17,10 +17,7 @@ use crate::internal::state_versions::StateVersions;
 use crate::ShardId;
 use anyhow::anyhow;
 use mz_persist::location::Blob;
-use std::time::Duration;
-use tracing::{info, warn};
-
-const DIFF_TIMEOUT: Duration = Duration::from_secs(30);
+use tracing::info;
 
 /// Attempt to restore all the blobs referenced by the current state in consensus.
 /// Returns a list of blobs that were not possible to restore.
@@ -30,20 +27,7 @@ pub(crate) async fn restore_blob(
     build_version: &semver::Version,
     shard_id: ShardId,
 ) -> anyhow::Result<Vec<BlobKey>> {
-    // For an as-yet-undetermined reason, we sometimes see this call hang in CI
-    // as this tool starts up. A retry loop should logically live at a lower level
-    // of the stack, but to minimize impact we'll retry at a high level for now.
-    // TODO(bkirwi): move this to the proper location once we've identified the cause of
-    // the timeout.
-    let diffs = loop {
-        let result =
-            tokio::time::timeout(DIFF_TIMEOUT, versions.fetch_all_live_diffs(&shard_id)).await;
-
-        match result {
-            Ok(data) => break data,
-            Err(_) => warn!("Timed out while trying to fetch live diffs; retrying"),
-        }
-    };
+    let diffs = versions.fetch_all_live_diffs(&shard_id).await;
     let Some(first_live_seqno) = diffs.0.first().map(|d| d.seqno) else {
         info!("No diffs for shard {shard_id}.");
         return Ok(vec![]);

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -126,6 +126,7 @@ pub mod cfg;
 pub mod cli {
     //! Persist command-line utilities
     pub mod admin;
+    pub mod args;
     pub mod inspect;
 }
 pub mod critical;

--- a/src/persist/Cargo.toml
+++ b/src/persist/Cargo.toml
@@ -22,6 +22,7 @@ bench = false
 anyhow = { version = "1.0.66", features = ["backtrace"] }
 arrow2 = { version = "0.16.0", features = ["io_ipc", "io_parquet"] }
 async-trait = "0.1.68"
+async-stream = "0.3.3"
 aws-config = { version = "0.55", default-features = false, features = ["native-tls"] }
 aws-credential-types = { version = "0.55", features = ["hardcoded-credentials"] }
 aws-sdk-s3 = { version = "0.26", default-features = false, features = ["native-tls", "rt-tokio"]  }


### PR DESCRIPTION
Various followups to #20482.
- Found the issue causing hangs when querying consensus; eliminate the gross retry loop.
- Add some configurable concurrency for the restore process.
- Adds a new module for shared arg types.

### Motivation

Generally motivated by #17605.

The postgres fix should address #22533.

### Tips for reviewer

The restructuring of the CLI stuff wasn't strictly necessary in retrospect, but I think I still prefer it if you don't mind.

The thing where a long-lived query can hang on to a client even after it's been returned to the pool is a significant footgun. Since I don't think we'll be writing that many other streaming queries for CRDB, I thought a comment might be enough. But let me know if you have other suggestions!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
