### PR TITLE
test: await at least 1 user shard in restart test

### DIFF
--- a/test/restart/mzcompose.py
+++ b/test/restart/mzcompose.py
@@ -189,8 +189,8 @@ def workflow_storage_managed_collections(c: Composition) -> None:
     # Storage collections are eventually consistent, so loop to be sure updates
     # have made it.
 
-    user_shards = None
-    while user_shards == None:
+    user_shards: list[str] = []
+    while len(user_shards) == 0:
         user_shards = c.sql_query(
             "SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id LIKE 'u%';"
         )
@@ -200,8 +200,8 @@ def workflow_storage_managed_collections(c: Composition) -> None:
     c.up("materialized")
 
     # Verify the shard mappings are still present and have not changed.
-    restart_user_shards = None
-    while restart_user_shards == None:
+    restart_user_shards: list[str] = []
+    while len(restart_user_shards) == 0:
         restart_user_shards = c.sql_query(
             "SELECT shard_id FROM mz_internal.mz_storage_shards WHERE object_id LIKE 'u%';"
         )


### PR DESCRIPTION
This test didn't account for getting a valid response from MZ that contained no shards. I don't know why that started happening when we hadn't seen it before, but this is what the test meant to capture.

I ran this for ~30 min without reproing the issue, whereas the current code on main repros in ~5 min.

### Motivation

This PR refactors existing code. Fixes #22495

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
