### PR TITLE
unit tests: Check miri ignores where they are unclear

### DIFF
--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -276,6 +276,7 @@ mod test {
     use super::WebhookConcurrencyLimiter;
 
     #[mz_ore::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn smoke_test_concurrency_limiter() {
         let mut limiter = WebhookConcurrencyLimiter::new(10);
 

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -82,8 +82,8 @@ pub struct ReplicaAllocation {
 }
 
 #[mz_ore::test]
-#[cfg_attr(miri, ignore)]
 // We test this particularly because we deserialize values from strings.
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
 fn test_replica_allocation_deserialization() {
     use bytesize::ByteSize;
 

--- a/src/persist-client/src/usage.rs
+++ b/src/persist-client/src/usage.rs
@@ -848,7 +848,7 @@ mod tests {
     /// This is just a sanity check for the overall flow of computing ShardUsage.
     /// The edge cases are exercised in separate tests.
     #[mz_ore::test(tokio::test)]
-    #[cfg_attr(miri, ignore)] // https://github.com/MaterializeInc/materialize/issues/19981
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     async fn usage_sanity() {
         let data = vec![
             (("1".to_owned(), "one".to_owned()), 1, 1),

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -983,7 +983,6 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
     fn test_backpressure_non_granular() {
         use Step::*;
         backpressure_runner(
@@ -1123,7 +1122,6 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
     fn test_backpressure_granular() {
         use Step::*;
         backpressure_runner(

--- a/src/storage-types/src/errors.rs
+++ b/src/storage-types/src/errors.rs
@@ -907,8 +907,7 @@ mod columnation {
 
         proptest! {
             #[mz_ore::test]
-            // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
-            #[cfg_attr(miri, ignore)]
+            #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `decContextDefault` on OS `linux`
             fn dataflow_error_roundtrip(expect in any::<DataflowError>()) {
                 let actual = columnation_roundtrip(&expect);
                 proptest::prop_assert_eq!(&expect, &actual[0])

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -752,7 +752,7 @@ mod tests {
     // Actual timely tests for `health_operator`.
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     fn test_health_operator_basic() {
         use Step::*;
 
@@ -834,7 +834,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     fn test_health_operator_write_namespaced_map() {
         use Step::*;
 
@@ -876,7 +876,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     fn test_health_operator_namespaces() {
         use Step::*;
 
@@ -953,7 +953,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     fn test_health_operator_namespace_side_channel() {
         use Step::*;
 
@@ -1029,7 +1029,7 @@ mod tests {
     }
 
     #[mz_ore::test]
-    #[cfg_attr(miri, ignore)] // Reports undefined behavior
+    #[cfg_attr(miri, ignore)] // unsupported operation: returning ready events from epoll_wait is not yet implemented
     fn test_health_operator_hints() {
         use Step::*;
 

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -88,7 +88,7 @@ use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::typecheck::TypeErrorHumanizer;
 
 #[mz_ore::test]
-#[cfg_attr(miri, ignore)]
+#[cfg_attr(miri, ignore)] // can't call foreign function `rust_psm_stack_pointer` on OS `linux`
 fn run_tests() {
     // Interpret datadriven tests.
     datadriven::walk("tests/test_transforms", |f| {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
