### PR TITLE
ci: Fix junit_dummy.xml file name for Analyze tests

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -85,15 +85,15 @@ so it is executed.""",
             print(
                 "Repository glue code has changed, so the trimmed pipeline below does not apply"
             )
-            trim_pipeline(copy.deepcopy(pipeline), args.coverage)
+            trim_tests_pipeline(copy.deepcopy(pipeline), args.coverage)
         else:
             print("--- Trimming unchanged steps from pipeline")
-            trim_pipeline(pipeline, args.coverage)
+            trim_tests_pipeline(pipeline, args.coverage)
 
         # Upload a dummy JUnit report so that the "Analyze tests" step doesn't fail
         # if we trim away all the JUnit report-generating steps.
-        Path("junit-dummy.xml").write_text("")
-        spawn.runv(["buildkite-agent", "artifact", "upload", "junit-dummy.xml"])
+        Path("junit_dummy.xml").write_text("")
+        spawn.runv(["buildkite-agent", "artifact", "upload", "junit_dummy.xml"])
 
     if args.coverage:
         pipeline["env"]["CI_BUILDER_SCCACHE"] = 1
@@ -246,7 +246,7 @@ def add_test_selection_block(pipeline: Any, pipeline_name: str) -> None:
     pipeline["steps"].insert(0, selection_step)
 
 
-def trim_pipeline(pipeline: Any, coverage: bool) -> None:
+def trim_tests_pipeline(pipeline: Any, coverage: bool) -> None:
     """Trim pipeline steps whose inputs have not changed in this branch.
 
     Steps are assigned inputs in two ways:

--- a/misc/python/materialize/ci_util/trim_pipeline.py
+++ b/misc/python/materialize/ci_util/trim_pipeline.py
@@ -12,6 +12,7 @@
 import argparse
 import subprocess
 import sys
+from pathlib import Path
 
 import yaml
 
@@ -58,6 +59,11 @@ def main() -> int:
         ["buildkite-agent", "pipeline", "upload", "--replace"],
         stdin=yaml.dump(new_steps).encode(),
     )
+
+    # Upload a dummy JUnit report so that the "Analyze tests" step doesn't fail
+    # if we trim away all the JUnit report-generating steps.
+    Path("junit_dummy.xml").write_text("")
+    spawn.runv(["buildkite-agent", "artifact", "upload", "junit_dummy.xml"])
 
     return 0
 


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/nightlies/builds/4786#018b4cab-ac84-42d2-a443-a4ad6960ebab

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
