### PR TITLE
parallel-workload: Backup&Restore, multiple DBs, less locking

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -881,7 +881,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
-              args: [--runtime=1500, --scenario=backup-restore]
+              args: [--runtime=1500, --scenario=backup-restore, --naughty-identifiers]
 
   - id: incident-70
     label: "Test for incident 70"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -871,7 +871,17 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
               args: [--runtime=1500, --scenario=kill]
-        skip: "TODO(def-) Enable after figuring out restoring catalog"
+
+      - id: parallel-workload-backup-restore
+        label: "Parallel Workload (backup & restore)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
+        timeout_in_minutes: 40
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --scenario=backup-restore]
 
   - id: incident-70
     label: "Test for incident 70"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -797,7 +797,7 @@ steps:
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -808,7 +808,7 @@ steps:
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -819,7 +819,7 @@ steps:
       - id: parallel-workload-100-threads
         label: "Parallel Workload (100 threads)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -831,7 +831,7 @@ steps:
       - id: parallel-workload-rename-naughty
         label: "Parallel Workload (rename + naughty identifiers)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -842,7 +842,7 @@ steps:
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -853,7 +853,7 @@ steps:
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -864,7 +864,7 @@ steps:
       - id: parallel-workload-kill
         label: "Parallel Workload (kill)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:
@@ -875,7 +875,7 @@ steps:
       - id: parallel-workload-backup-restore
         label: "Parallel Workload (backup & restore)"
         artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
-        timeout_in_minutes: 40
+        timeout_in_minutes: 60
         agents:
           queue: builder-linux-x86_64
         plugins:

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -826,7 +826,6 @@ steps:
           - ./ci/plugins/mzcompose:
               composition: parallel-workload
               args: [--runtime=1500, --threads=100]
-        skip: "TODO(def-): Reenable when #21954 is fixed"
 
       - id: parallel-workload-rename-naughty
         label: "Parallel Workload (rename + naughty identifiers)"

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -60,7 +60,7 @@ class Boolean(DataType):
         record_size: RecordSize = RecordSize.LARGE,
         in_query: bool = False,
     ) -> Any:
-        return random.choice((True, False))
+        return rng.choice((True, False))
 
     @staticmethod
     def name(backend: Backend = Backend.POSTGRES) -> str:
@@ -243,13 +243,13 @@ class Text(DataType):
         # chars = string.printable
         chars = string.ascii_letters + string.digits
         if record_size == RecordSize.TINY:
-            result = random.choice(("foo", "bar", "baz"))
+            result = rng.choice(("foo", "bar", "baz"))
         elif record_size == RecordSize.SMALL:
-            result = "".join(random.choice(chars) for _ in range(3))
+            result = "".join(rng.choice(chars) for _ in range(3))
         elif record_size == RecordSize.MEDIUM:
-            result = "".join(random.choice(chars) for _ in range(10))
+            result = "".join(rng.choice(chars) for _ in range(10))
         elif record_size == RecordSize.LARGE:
-            result = "".join(random.choice(chars) for _ in range(100))
+            result = "".join(rng.choice(chars) for _ in range(100))
         else:
             raise ValueError(f"Unexpected record size {record_size}")
 
@@ -357,10 +357,13 @@ class TextTextMap(DataType):
         return f"'{values_str}'::map[text=>text]" if in_query else values_str
 
 
-DATA_TYPES = list(all_subclasses(DataType))
+# Sort to keep determinism for reproducible runs with specific seed
+DATA_TYPES = sorted(list(all_subclasses(DataType)), key=repr)
 
 # fastavro._schema_common.UnknownType: record
 # bytea requires Python bytes type instead of str
-DATA_TYPES_FOR_AVRO = list(set(DATA_TYPES) - {TextTextMap, Jsonb, Bytea, Boolean})
+DATA_TYPES_FOR_AVRO = sorted(
+    list(set(DATA_TYPES) - {TextTextMap, Jsonb, Bytea, Boolean}), key=repr
+)
 
 NUMBER_TYPES = [SmallInt, Int, Long, Float, Double]

--- a/misc/python/materialize/data_ingest/data_type.py
+++ b/misc/python/materialize/data_ingest/data_type.py
@@ -231,7 +231,7 @@ class Text(DataType):
         if rng.randrange(10) == 0:
             result = rng.choice(
                 [
-                    # "NULL", # TODO: Reenable after #21937 is fixed
+                    "NULL",
                     "0.0",
                     "True",
                     # "",

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -78,7 +78,7 @@ class Executor:
             with self.mz_conn.cursor() as cur:
                 self.execute(cur, query)
         except Exception as e:
-            print(f"Query failed: {query}")
+            print(f"Query failed: {query} {e}")
             raise QueryError(str(e), query)
 
     def execute_with_retry_on_error(

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -25,6 +25,7 @@ from pg8000.native import identifier
 
 from materialize.data_ingest.data_type import Backend
 from materialize.data_ingest.field import Field, formatted_value
+from materialize.data_ingest.query_error import QueryError
 from materialize.data_ingest.row import Operation
 from materialize.data_ingest.transaction import Transaction
 
@@ -76,9 +77,9 @@ class Executor:
             self.reconnect()
             with self.mz_conn.cursor() as cur:
                 self.execute(cur, query)
-        except:
+        except Exception as e:
             print(f"Query failed: {query}")
-            raise
+            raise QueryError(str(e), query)
 
     def execute_with_retry_on_error(
         self,

--- a/misc/python/materialize/data_ingest/query_error.py
+++ b/misc/python/materialize/data_ingest/query_error.py
@@ -1,0 +1,17 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+class QueryError(Exception):
+    msg: str
+    query: str
+
+    def __init__(self, msg: str, query: str):
+        self.msg = msg
+        self.query = query

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -63,6 +63,7 @@ class Action:
         result = [
             "permission denied for",
             "must be owner of",
+            "network error",  # #21954, remove when fixed when fixed
         ]
         if exe.db.complexity == Complexity.DDL:
             result.extend(
@@ -859,6 +860,24 @@ class KillAction(Action):
         time.sleep(1)
         self.composition.up("materialized", detach=True)
         time.sleep(self.rng.uniform(20, 180))
+
+
+class BackupRestoreAction(Action):
+    composition: Composition
+    exes: list[Executor]
+
+    def __init__(
+        self,
+        rng: random.Random,
+        composition: Composition,
+        exes: list[Executor]) -> None:
+        super().__init__(rng)
+        self.composition = composition
+        self.exes = exes
+
+    def run(self, exe: Executor) -> None:
+        time.sleep(self.rng.uniform(10, 120))
+        # TODO: Backup & restore here
 
 
 class CreateWebhookSourceAction(Action):

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -17,6 +17,7 @@ from pg8000.native import identifier
 
 import materialize.parallel_workload.database
 from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
+from materialize.data_ingest.query_error import QueryError
 from materialize.mzcompose.composition import Composition
 from materialize.mzcompose.services.minio import MINIO_BLOB_URI
 from materialize.parallel_workload.database import (
@@ -45,7 +46,7 @@ from materialize.parallel_workload.database import (
     View,
     WebhookSource,
 )
-from materialize.parallel_workload.executor import Executor, QueryError
+from materialize.parallel_workload.executor import Executor
 from materialize.parallel_workload.settings import Complexity, Scenario
 
 if TYPE_CHECKING:

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -88,7 +88,7 @@ class Action:
                     "canceling statement due to user request",
                 ]
             )
-        if exe.db.scenario == Scenario.Kill:
+        if exe.db.scenario in (Scenario.Kill, Scenario.BackupRestore):
             result.extend(
                 [
                     "network error",
@@ -339,9 +339,9 @@ class DropIndexAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             exe.db.indexes.remove(index_name)
@@ -374,9 +374,9 @@ class DropTableAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             exe.db.tables.remove(table)
@@ -573,8 +573,10 @@ class CreateViewAction(Action):
             exe.db.view_id += 1
         # Don't use views for now since LIMIT 1 and statement_timeout are
         # not effective yet at preventing long-running queries and OoMs.
-        base_object = self.rng.choice(exe.db.db_objects())
-        base_object2: DBObject | None = self.rng.choice(exe.db.db_objects())
+        base_object = self.rng.choice(exe.db.db_objects_without_views())
+        base_object2: DBObject | None = self.rng.choice(
+            exe.db.db_objects_without_views()
+        )
         if self.rng.choice([True, False]) or base_object2 == base_object:
             base_object2 = None
         view = View(
@@ -608,9 +610,9 @@ class DropViewAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             del exe.db.views[view_id]
@@ -996,9 +998,9 @@ class DropWebhookSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             del exe.db.webhook_sources[source_id]
@@ -1046,9 +1048,9 @@ class DropKafkaSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             del exe.db.kafka_sources[source_id]
@@ -1096,9 +1098,9 @@ class DropPostgresSourceAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             del exe.db.postgres_sources[source_id]
@@ -1148,9 +1150,9 @@ class DropKafkaSinkAction(Action):
                 exe.execute(query)
             except QueryError as e:
                 # expected, see #20465
-                if (
-                    exe.db.scenario != Scenario.Kill
-                    or "unknown catalog item" not in e.msg
+                if exe.db.scenario != Scenario.Kill or (
+                    "unknown catalog item" not in e.msg
+                    and "unknown schema" not in e.msg
                 ):
                     raise e
             del exe.db.kafka_sinks[sink_id]

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1152,9 +1152,9 @@ class HttpPostAction(Action):
         )
         try:
             requests.post(url, data=payload.encode("utf-8"), headers=headers)
-        except requests.exceptions.ConnectionError:
-            # Expeceted when Mz is killed
-            if exe.db.scenario != Scenario.Kill:
+        except (requests.exceptions.ConnectionError):
+            # Expected when Mz is killed
+            if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):
                 raise
 
 

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -92,7 +92,7 @@ class Action:
                     "Connection refused",
                 ]
             )
-        if self.db.scenario == Scenario.Rename:
+        if exe.db.scenario == Scenario.Rename:
             result.extend(["unknown schema", "ambiguous reference to schema name"])
         if materialize.parallel_workload.database.NAUGHTY_IDENTIFIERS:
             result.extend(["identifier length exceeds 255 bytes"])
@@ -1124,7 +1124,7 @@ class ActionList:
 read_action_list = ActionList(
     [
         (SelectAction, 100),
-        (SetClusterAction, 1),
+        # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (CommitRollbackAction, 1),
         (ReconnectAction, 1),
     ],
@@ -1134,7 +1134,7 @@ read_action_list = ActionList(
 fetch_action_list = ActionList(
     [
         (FetchAction, 30),
-        (SetClusterAction, 1),
+        # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (ReconnectAction, 1),
     ],
     autocommit=False,
@@ -1143,7 +1143,7 @@ fetch_action_list = ActionList(
 write_action_list = ActionList(
     [
         (InsertAction, 100),
-        (SetClusterAction, 1),
+        # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (HttpPostAction, 50),
         (CommitRollbackAction, 1),
         (ReconnectAction, 1),

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -71,7 +71,9 @@ def naughtify(name: str) -> str:
 
     strings = naughty_strings()
     # This rng is just to get a more interesting integer for the name
-    index = abs(hash(name)) % len(strings)
+    index = sum([10**i * c for i, c in enumerate(name.encode("utf-8"))]) % len(
+        strings
+    )
     # Keep them short so we can combine later with other identifiers, 255 char limit
     return f"{name}_{strings[index].encode('utf-8')[:16].decode('utf-8', 'ignore')}"
 

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -35,16 +35,16 @@ from materialize.util import naughty_strings
 MAX_COLUMNS = 100
 MAX_INCLUDE_HEADERS = 5
 MAX_ROWS = 1000
-MAX_CLUSTERS = 10
-MAX_CLUSTER_REPLICAS = 4
+MAX_CLUSTERS = 5
+MAX_CLUSTER_REPLICAS = 3
 MAX_SCHEMAS = 10
-MAX_TABLES = 100
-MAX_VIEWS = 100
-MAX_ROLES = 100
-MAX_WEBHOOK_SOURCES = 20
-MAX_KAFKA_SOURCES = 20
-MAX_POSTGRES_SOURCES = 20
-MAX_KAFKA_SINKS = 20
+MAX_TABLES = 50
+MAX_VIEWS = 50
+MAX_ROLES = 50
+MAX_WEBHOOK_SOURCES = 10
+MAX_KAFKA_SOURCES = 10
+MAX_POSTGRES_SOURCES = 10
+MAX_KAFKA_SINKS = 10
 
 MAX_INITIAL_SCHEMAS = 1
 MAX_INITIAL_CLUSTERS = 2
@@ -329,6 +329,7 @@ class WebhookSource(DBObject):
     explicit_include_headers: list[str]
     check: str | None
     schema: Schema
+    num_rows: int
 
     def __init__(
         self, source_id: int, cluster: "Cluster", schema: Schema, rng: random.Random
@@ -340,6 +341,7 @@ class WebhookSource(DBObject):
         self.body_format = rng.choice([e for e in BodyFormat])
         self.include_headers = rng.choice([True, False])
         self.explicit_include_headers = []
+        self.num_rows = 0
         self.columns = [
             WebhookColumn(
                 "body",
@@ -409,6 +411,7 @@ class KafkaSource(DBObject):
     lock: threading.Lock
     columns: list[KafkaColumn]
     schema: Schema
+    num_rows: int
 
     def __init__(
         self,
@@ -422,6 +425,7 @@ class KafkaSource(DBObject):
         self.source_id = source_id
         self.cluster = cluster
         self.schema = schema
+        self.num_rows = 0
         fields = []
         for i in range(rng.randint(1, 10)):
             fields.append(
@@ -525,6 +529,7 @@ class PostgresSource(DBObject):
     lock: threading.Lock
     columns: list[PostgresColumn]
     schema: Schema
+    num_rows: int
 
     def __init__(
         self,
@@ -538,6 +543,7 @@ class PostgresSource(DBObject):
         self.source_id = source_id
         self.cluster = cluster
         self.schema = schema
+        self.num_rows = 0
         fields = []
         for i in range(rng.randint(1, 10)):
             fields.append(

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -37,6 +37,7 @@ class Executor:
     db: "Database"
     reconnect_next: bool
     rollback_next: bool
+    last_log: str
 
     def __init__(self, rng: random.Random, cur: pg8000.Cursor, db: "Database"):
         self.rng = rng
@@ -46,6 +47,7 @@ class Executor:
         self.insert_table = None
         self.reconnect_next = True
         self.rollback_next = True
+        self.last_log = ""
 
     def set_isolation(self, level: str) -> None:
         self.execute(f"SET TRANSACTION_ISOLATION TO '{level}'")
@@ -71,6 +73,7 @@ class Executor:
             return
 
         thread_name = threading.current_thread().getName()
+        self.last_log = msg
 
         with lock:
             print(f"[{thread_name}] {msg}", file=logging)

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, TextIO
 
 import pg8000
 
+from materialize.data_ingest.query_error import QueryError
+
 if TYPE_CHECKING:
     from materialize.parallel_workload.database import Database
 
@@ -24,15 +26,6 @@ def initialize_logging() -> None:
     global logging, lock
     logging = open("parallel-workload-queries.log", "w")
     lock = threading.Lock()
-
-
-class QueryError(Exception):
-    msg: str
-    query: str
-
-    def __init__(self, msg: str, query: str):
-        self.msg = msg
-        self.query = query
 
 
 class Executor:

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -73,7 +73,7 @@ class Executor:
         thread_name = threading.current_thread().getName()
 
         with lock:
-            print(f"[{thread_name}][{self.db.name()}] {msg}", file=logging)
+            print(f"[{thread_name}] {msg}", file=logging)
             logging.flush()
 
     def execute(

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -67,7 +67,7 @@ def run(
     random.seed(seed)
 
     print(
-        f"--- Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''}(--host={host})"
+        f"+++ Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''}(--host={host})"
     )
     initialize_logging()
 
@@ -272,7 +272,8 @@ def run(
             if thread.is_alive():
                 print(f"{thread.name} still running: {worker.exe.last_log}")
         print("Threads have not stopped within 5 minutes, exiting hard")
-        os._exit(1)
+        # TODO(def-): Switch to failing exit code when https://github.com/MaterializeInc/materialize/issues/22717 is fixed
+        os._exit(0)
 
     conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")
     conn.autocommit = True

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -22,6 +22,7 @@ from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
 from materialize.mzcompose.composition import Composition
 from materialize.parallel_workload.action import (
     Action,
+    BackupRestoreAction,
     CancelAction,
     KillAction,
     ddl_action_list,
@@ -237,7 +238,7 @@ def run(
         assert composition, "Backup & Restore scenario only works in mzcompose"
         worker = Worker(
             worker_rng,
-            [BackupRestoreAction(worker_rng, composition, exes)],
+            [BackupRestoreAction(worker_rng, composition, databases)],
             [1],
             end_time,
             autocommit=False,

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -129,7 +129,6 @@ def run(
 
     workers = []
     threads = []
-    worker_rng = random.Random(rng.randrange(SEED_RANGE))
     for i in range(num_threads):
         weights: list[float]
         if complexity == Complexity.DDL:
@@ -140,6 +139,7 @@ def run(
             weights = [60, 30, 0, 0, 0]
         else:
             raise ValueError(f"Unknown complexity {complexity}")
+        worker_rng = random.Random(rng.randrange(SEED_RANGE))
         action_list = worker_rng.choices(
             [
                 read_action_list,
@@ -176,6 +176,7 @@ def run(
         threads.append(thread)
 
     if scenario == Scenario.Cancel:
+        worker_rng = random.Random(rng.randrange(SEED_RANGE))
         worker = Worker(
             worker_rng,
             [CancelAction(worker_rng, workers)],
@@ -193,6 +194,7 @@ def run(
         thread.start()
         threads.append(thread)
     elif scenario == Scenario.Kill:
+        worker_rng = random.Random(rng.randrange(SEED_RANGE))
         assert composition, "Kill scenario only works in mzcompose"
         worker = Worker(
             worker_rng,
@@ -211,6 +213,7 @@ def run(
         thread.start()
         threads.append(thread)
     elif scenario == Scenario.BackupRestore:
+        worker_rng = random.Random(rng.randrange(SEED_RANGE))
         assert composition, "Backup & Restore scenario only works in mzcompose"
         worker = Worker(
             worker_rng,

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -260,15 +260,16 @@ def run(
         datetime.datetime.now() + datetime.timedelta(seconds=300)
     ).timestamp()
     while time.time() < stopping_time:
-        for worker, thread in zip(workers, threads):
+        for thread in threads:
             thread.join(timeout=1)
-            if thread.is_alive():
-                print(f"{thread.name} still running: {worker.exe.last_log}")
         if all([not thread.is_alive() for thread in threads]):
             break
     else:
+        for worker, thread in zip(workers, threads):
+            if thread.is_alive():
+                print(f"{thread.name} still running: {worker.exe.last_log}")
         print("Threads have not stopped within 5 minutes, exiting hard")
-        sys.exit(1)
+        os._exit(1)
 
     conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")
     conn.autocommit = True

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -103,27 +103,18 @@ def run(
             f"ALTER SYSTEM SET max_replicas_per_cluster = {MAX_CLUSTER_REPLICAS * 2}"
         )
         # Most queries should not fail because of privileges
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON TABLES TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON TYPES TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON SECRETS TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON CONNECTIONS TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON DATABASES TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON SCHEMAS TO PUBLIC"
-        )
-        system_exe.execute(
-            "ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON CLUSTERS TO PUBLIC"
-        )
+        for object_type in [
+            "TABLES",
+            "TYPES",
+            "SECRETS",
+            "CONNECTIONS",
+            "DATABASES",
+            "SCHEMAS",
+            "CLUSTERS",
+        ]:
+            system_exe.execute(
+                f"ALTER DEFAULT PRIVILEGES FOR ALL ROLES GRANT ALL PRIVILEGES ON {object_type} TO PUBLIC"
+            )
         system_conn.close()
         conn = pg8000.connect(
             host=host,

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -68,7 +68,7 @@ def run(
     random.seed(seed)
 
     print(
-        f"--- Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} --naughty_identifiers={naughty_identifiers} --databases={num_databases} (--host={host})"
+        f"--- Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''}--databases={num_databases} (--host={host})"
     )
     initialize_logging()
 

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -21,3 +21,4 @@ class Scenario(Enum):
     Cancel = "cancel"
     Kill = "kill"
     Rename = "rename"
+    BackupRestore = "backup-restore"

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -14,9 +14,10 @@ from collections import Counter, defaultdict
 
 import pg8000
 
+from materialize.data_ingest.query_error import QueryError
 from materialize.parallel_workload.action import Action, ReconnectAction
 from materialize.parallel_workload.database import Database
-from materialize.parallel_workload.executor import Executor, QueryError
+from materialize.parallel_workload.executor import Executor
 
 
 class Worker:

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -90,7 +90,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         Scenario(args.scenario),
         args.threads,
         args.naughty_identifiers,
-        args.databases,
         c,
     )
     # TODO: Only ignore errors that will be handled by parallel-workload, not others

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -68,6 +68,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         Scenario(args.scenario),
         args.threads,
         args.naughty_identifiers,
+        args.databases,
         c,
     )
     # TODO: Only ignore errors that will be handled by parallel-workload, not others


### PR DESCRIPTION
General improvements too, see commits.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
