### PR TITLE
Docs: Fix line wrapping in functions list

### DIFF
--- a/doc/user/layouts/shortcodes/fnlist.html
+++ b/doc/user/layouts/shortcodes/fnlist.html
@@ -31,7 +31,7 @@
       {{/*  We use clojure highlighting simply because it looks best with the
       components we want to highlight. In the future, this should be customized
       in some way.  */}}
-      {{ highlight .signature "clojure" "" }}
+      {{ highlight .signature "clojure" "hl_inline=true" }}
     </td>
     <td>
 


### PR DESCRIPTION
This fixes https://github.com/MaterializeInc/materialize/issues/19619: Currently, the function descriptions in the [functions doc page](https://materialize.com/docs/sql/functions/) are hard to read in some of the tables, because lots of line breaks are automatically inserted due to the function signatures taking up almost all the horizontal space. Even worse, in some of the tables a horizontal scrollbar appears.

This PR adjusts the options when we call the ["highlight" Hugo shortcode](https://gohugo.io/functions/transform/highlight/), adding the `hl_inline` option. This causes automatic line breaking to happen in the function signatures, so they don't take up almost all the horizontal space.

I wouldn't say it looks perfect now, because now some function signatures look a bit weird due to the line breaks that are now automatically inserted in them, but I'd say it's definitely an improvement. In the long term, we might want to somehow make the function signatures not auto-linebreaked, but respect manual line breaks instead, and then go through the function signatures and manually insert line breaks in long ones at places where it looks ok.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/19619

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
