### PR TITLE
feature-benchmark: Workaround for running on main

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -129,9 +129,14 @@ def run_one_scenario(
 
         c.up("testdrive", persistent=True)
 
-        additional_system_parameter_defaults = None
+        additional_system_parameter_defaults = {}
+        # TODO(def-) Remove when v0.75 is released, workaround for https://github.com/MaterializeInc/materialize/pull/22472
+        if instance == "other" and tag == "latest":
+            additional_system_parameter_defaults[
+                "enable_specialized_arrangements"
+            ] = "false"
+
         if params is not None:
-            additional_system_parameter_defaults = {}
             for param in params.split(";"):
                 param_name, param_value = param.split("=")
                 additional_system_parameter_defaults[param_name] = param_value


### PR DESCRIPTION
Since enable_specialized_arrangements was broken in v0.74.2, but we still want to enable it in v0.75 and future versions.

Seen in https://buildkite.com/materialize/nightlies/builds/4788#018b4cda-7b24-4d62-afbf-4c43e0a3f0d8

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
