### PR TITLE
Expose rusage utime/stime

### DIFF
--- a/src/metrics/src/rusage.rs
+++ b/src/metrics/src/rusage.rs
@@ -5,9 +5,9 @@
 
 //! Report rusage metrics.
 
-use std::ops::Add;
 use std::time::Duration;
 
+use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use prometheus::{Gauge, IntGauge};
 
@@ -63,9 +63,10 @@ impl Unit for Timeval {
     type To = f64;
     fn from(Self::From { tv_sec, tv_usec }: Self::From) -> Self::To {
         // timeval can capture negative values; it'd be surprising to see a negative values here.
-        Duration::from_secs(tv_sec.abs_diff(0))
-            .add(Duration::from_micros(tv_usec.abs_diff(0)))
-            .as_secs_f64()
+
+        (Duration::from_secs(u64::cast_from(tv_sec.abs_diff(0)))
+            + Duration::from_micros(u64::cast_from(tv_usec.abs_diff(0))))
+        .as_secs_f64()
     }
 }
 

--- a/src/metrics/src/rusage.rs
+++ b/src/metrics/src/rusage.rs
@@ -96,17 +96,10 @@ metrics! {
     (ru_utime, "user CPU time used", "_seconds_total", Timeval),
     (ru_stime, "system CPU time used", "_seconds_total", Timeval),
     (ru_maxrss, "maximum resident set size", "_bytes", KilobytesToBytes),
-    (ru_ixrss, "integral shared memory size (unmaintained)", "", Unitless),
-    (ru_idrss, "integral unshared data size (unmaintained)", "", Unitless),
-    (ru_isrss, "integral unshared stack size (unmaintained)", "", Unitless),
     (ru_minflt, "page reclaims (soft page faults)", "_total", Unitless),
     (ru_majflt, "page faults (hard page faults)", "_total", Unitless),
-    (ru_nswap, "swaps (unmaintained)", "", Unitless),
     (ru_inblock, "block input operations", "_total", Unitless),
     (ru_oublock, "block output operations", "_total", Unitless),
-    (ru_msgsnd, "IPC messages sent (unmaintained)", "", Unitless),
-    (ru_msgrcv, "IPC messages received (unmaintained)", "", Unitless),
-    (ru_nsignals, "signals received (unmaintained)", "", Unitless),
     (ru_nvcsw, "voluntary context switches", "_total", Unitless),
     (ru_nivcsw, "involuntary context switches", "_total", Unitless)
 }

--- a/src/metrics/src/rusage.rs
+++ b/src/metrics/src/rusage.rs
@@ -63,7 +63,6 @@ impl Unit for Timeval {
     type To = f64;
     fn from(Self::From { tv_sec, tv_usec }: Self::From) -> Self::To {
         // timeval can capture negative values; it'd be surprising to see a negative values here.
-
         (Duration::from_secs(u64::cast_from(tv_sec.abs_diff(0)))
             + Duration::from_micros(u64::cast_from(tv_usec.abs_diff(0))))
         .as_secs_f64()
@@ -81,24 +80,35 @@ impl Unit for Unitless {
     }
 }
 
+/// Unit for converting KiB values to bytes expressed i64.
+struct KilobytesToBytes;
+impl Unit for KilobytesToBytes {
+    type Gauge = IntGauge;
+    type From = libc::c_long;
+    type To = i64;
+    fn from(value: Self::From) -> Self::To {
+        value.saturating_mul(1024)
+    }
+}
+
 metrics! {
     mz_metrics_libc
-    (ru_utime, "user CPU time used", "_s", Timeval),
-    (ru_stime, "system CPU time used", "_s", Timeval),
-    (ru_maxrss, "maximum resident set size", "", Unitless),
-    (ru_ixrss, "integral shared memory size", "", Unitless),
-    (ru_idrss, "integral unshared data size", "", Unitless),
-    (ru_isrss, "integral unshared stack size", "", Unitless),
-    (ru_minflt, "page reclaims (soft page faults)", "", Unitless),
-    (ru_majflt, "page faults (hard page faults)", "", Unitless),
-    (ru_nswap, "swaps", "", Unitless),
-    (ru_inblock, "block input operations", "", Unitless),
-    (ru_oublock, "block output operations", "", Unitless),
-    (ru_msgsnd, "IPC messages sent", "", Unitless),
-    (ru_msgrcv, "IPC messages received", "", Unitless),
-    (ru_nsignals, "signals received", "", Unitless),
-    (ru_nvcsw, "voluntary context switches", "", Unitless),
-    (ru_nivcsw, "involuntary context switches", "", Unitless)
+    (ru_utime, "user CPU time used", "_seconds_total", Timeval),
+    (ru_stime, "system CPU time used", "_seconds_total", Timeval),
+    (ru_maxrss, "maximum resident set size", "_bytes", KilobytesToBytes),
+    (ru_ixrss, "integral shared memory size (unmaintained)", "", Unitless),
+    (ru_idrss, "integral unshared data size (unmaintained)", "", Unitless),
+    (ru_isrss, "integral unshared stack size (unmaintained)", "", Unitless),
+    (ru_minflt, "page reclaims (soft page faults)", "_total", Unitless),
+    (ru_majflt, "page faults (hard page faults)", "_total", Unitless),
+    (ru_nswap, "swaps (unmaintained)", "", Unitless),
+    (ru_inblock, "block input operations", "_total", Unitless),
+    (ru_oublock, "block output operations", "_total", Unitless),
+    (ru_msgsnd, "IPC messages sent (unmaintained)", "", Unitless),
+    (ru_msgrcv, "IPC messages received (unmaintained)", "", Unitless),
+    (ru_nsignals, "signals received (unmaintained)", "", Unitless),
+    (ru_nvcsw, "voluntary context switches", "_total", Unitless),
+    (ru_nivcsw, "involuntary context switches", "_total", Unitless)
 }
 
 /// Register a task to read rusage stats.

--- a/src/metrics/src/rusage.rs
+++ b/src/metrics/src/rusage.rs
@@ -5,23 +5,25 @@
 
 //! Report rusage metrics.
 
-use mz_ore::metrics::MetricsRegistry;
-use prometheus::IntGauge;
+use std::ops::Add;
 use std::time::Duration;
 
+use mz_ore::metrics::MetricsRegistry;
+use prometheus::{Gauge, IntGauge};
+
 macro_rules! metrics {
-    ($namespace:ident $(($name:ident, $desc:expr)),*) => {
-        metrics! { @define $namespace $(($name, $desc)),*}
+    ($namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $type:ident)),*) => {
+        metrics! { @define $namespace $(($name, $desc, $suffix, $type)),*}
     };
-    (@define $namespace:ident $(($name:ident, $desc:expr)),*) => {
+    (@define $namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $type:ident)),*) => {
         struct RuMetrics {
-            $($name: IntGauge,)*
+            $($name: <$type as Unit>::Gauge,)*
         }
         impl RuMetrics {
             fn new(registry: &MetricsRegistry) -> Self {
                 Self {
                     $($name: registry.register(mz_ore::metric!(
-                        name: concat!(stringify!($namespace), "_", stringify!($name)),
+                        name: concat!(stringify!($namespace), "_", stringify!($name), $suffix),
                         help: $desc,
                     )),)*
                 }
@@ -29,31 +31,73 @@ macro_rules! metrics {
             fn update(&self) {
                 let rusage = unsafe {
                     let mut rusage = std::mem::zeroed();
-                    libc::getrusage(libc::RUSAGE_SELF, &mut rusage);
+                    let ret = libc::getrusage(libc::RUSAGE_SELF, &mut rusage);
+                    if ret < 0 {
+                        return;
+                    }
                     rusage
                 };
-                $(self.$name.set(rusage.$name);)*
+                $(self.$name.set(<$type as Unit>::from(rusage.$name));)*
             }
         }
     };
 }
 
+/// Type for converting values from POSIX to Prometheus.
+trait Unit {
+    /// Prometheus gauge
+    type Gauge;
+    /// Libc type
+    type From;
+    /// Gauge type.
+    type To;
+    /// Convert an actual value.
+    fn from(value: Self::From) -> Self::To;
+}
+
+/// Unit for converting POSIX timeval.
+struct Timeval;
+impl Unit for Timeval {
+    type Gauge = Gauge;
+    type From = libc::timeval;
+    type To = f64;
+    fn from(Self::From { tv_sec, tv_usec }: Self::From) -> Self::To {
+        // timeval can capture negative values; it'd be surprising to see a negative values here.
+        Duration::from_secs(tv_sec.abs_diff(0))
+            .add(Duration::from_micros(tv_usec.abs_diff(0)))
+            .as_secs_f64()
+    }
+}
+
+/// Unit for direct conversion to i64.
+struct Unitless;
+impl Unit for Unitless {
+    type Gauge = IntGauge;
+    type From = libc::c_long;
+    type To = i64;
+    fn from(value: Self::From) -> Self::To {
+        value
+    }
+}
+
 metrics! {
     mz_metrics_libc
-    (ru_maxrss, "maximum resident set size"),
-    (ru_ixrss, "integral shared memory size"),
-    (ru_idrss, "integral unshared data size"),
-    (ru_isrss, "integral unshared stack size"),
-    (ru_minflt, "page reclaims (soft page faults)"),
-    (ru_majflt, "page faults (hard page faults)"),
-    (ru_nswap, "swaps"),
-    (ru_inblock, "block input operations"),
-    (ru_oublock, "block output operations"),
-    (ru_msgsnd, "IPC messages sent"),
-    (ru_msgrcv, "IPC messages received"),
-    (ru_nsignals, "signals received"),
-    (ru_nvcsw, "voluntary context switches"),
-    (ru_nivcsw, "involuntary context switches")
+    (ru_utime, "user CPU time used", "_s", Timeval),
+    (ru_stime, "system CPU time used", "_s", Timeval),
+    (ru_maxrss, "maximum resident set size", "", Unitless),
+    (ru_ixrss, "integral shared memory size", "", Unitless),
+    (ru_idrss, "integral unshared data size", "", Unitless),
+    (ru_isrss, "integral unshared stack size", "", Unitless),
+    (ru_minflt, "page reclaims (soft page faults)", "", Unitless),
+    (ru_majflt, "page faults (hard page faults)", "", Unitless),
+    (ru_nswap, "swaps", "", Unitless),
+    (ru_inblock, "block input operations", "", Unitless),
+    (ru_oublock, "block output operations", "", Unitless),
+    (ru_msgsnd, "IPC messages sent", "", Unitless),
+    (ru_msgrcv, "IPC messages received", "", Unitless),
+    (ru_nsignals, "signals received", "", Unitless),
+    (ru_nvcsw, "voluntary context switches", "", Unitless),
+    (ru_nivcsw, "involuntary context switches", "", Unitless)
 }
 
 /// Register a task to read rusage stats.

--- a/src/ore/src/cast.rs
+++ b/src/ore/src/cast.rs
@@ -111,6 +111,7 @@ pub mod target64 {
 pub use target64::*;
 
 // TODO(petrosagg): remove these once the std From impls become const
+cast_from!(u8, u8);
 cast_from!(u8, u16);
 cast_from!(u8, i16);
 cast_from!(u8, u32);
@@ -119,27 +120,34 @@ cast_from!(u8, u64);
 cast_from!(u8, i64);
 cast_from!(u8, u128);
 cast_from!(u8, i128);
+cast_from!(u16, u16);
 cast_from!(u16, u32);
 cast_from!(u16, i32);
 cast_from!(u16, u64);
 cast_from!(u16, i64);
 cast_from!(u16, u128);
 cast_from!(u16, i128);
+cast_from!(u32, u32);
 cast_from!(u32, u64);
 cast_from!(u32, i64);
 cast_from!(u32, u128);
 cast_from!(u32, i128);
+cast_from!(u64, u64);
 cast_from!(u64, u128);
 cast_from!(u64, i128);
+cast_from!(i8, i8);
 cast_from!(i8, i16);
 cast_from!(i8, i32);
 cast_from!(i8, i64);
 cast_from!(i8, i128);
+cast_from!(i16, i16);
 cast_from!(i16, i32);
 cast_from!(i16, i64);
 cast_from!(i16, i128);
+cast_from!(i32, i32);
 cast_from!(i32, i64);
 cast_from!(i32, i128);
+cast_from!(i64, i64);
 cast_from!(i64, i128);
 
 /// A trait for reinterpreting casts.


### PR DESCRIPTION
Export rusage utime/stime in addition to other rusage metrics.

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
