### PR TITLE
adapter: reconnect tracing spans

### DIFF
--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -67,6 +67,7 @@ pub(crate) enum BuiltinTableUpdateSource {
 pub(crate) enum PendingWriteTxn {
     /// Write to a user table.
     User {
+        span: Span,
         /// List of all write operations within the transaction.
         writes: Vec<WriteOp>,
         /// Holds the coordinator's write lock.
@@ -294,6 +295,7 @@ impl Coordinator {
         for pending_write_txn in pending_writes {
             match pending_write_txn {
                 PendingWriteTxn::User {
+                    span: _,
                     writes,
                     write_lock_guard: _,
                     pending_txn:

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -28,7 +28,7 @@ use mz_sql::rbac;
 use mz_sql_parser::ast::{Raw, Statement};
 use mz_storage_types::connections::inline::IntoInlineConnection;
 use tokio::sync::oneshot;
-use tracing::{event, Level};
+use tracing::{event, Instrument, Level, Span};
 
 use crate::catalog::{Catalog, ErrorKind};
 use crate::command::{Command, ExecuteResponse, Response};
@@ -646,7 +646,8 @@ impl Coordinator {
                 // We ignore the resp.result because it's not clear what to do if it failed since we
                 // can only send a single ExecuteResponse to tx.
                 tx.send(result, commit_response.session);
-            },
+            }
+            .instrument(Span::current()),
         );
     }
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -80,7 +80,7 @@ use mz_transform::{EmptyStatisticsOracle, Optimizer, StatisticsOracle};
 use timely::progress::{Antichain, Timestamp as TimelyTimestamp};
 use tokio::sync::{mpsc, oneshot, OwnedMutexGuard};
 use tracing::instrument::WithSubscriber;
-use tracing::{event, warn, Level};
+use tracing::{event, warn, Level, Span};
 use tracing_core::callsite::rebuild_interest_cache;
 
 use crate::catalog::{
@@ -1975,6 +1975,7 @@ impl Coordinator {
             }
             Ok((Some(TransactionOps::Writes(writes)), write_lock_guard)) => {
                 self.submit_write(PendingWriteTxn::User {
+                    span: Span::current(),
                     writes,
                     write_lock_guard,
                     pending_txn: PendingTxn {


### PR DESCRIPTION
We got tracing spans for an INSERT hooked up all the way from emit_trace_id_notice down to the underlying storage writes in #20706, but it seems to have rotted (my kingdom for a way to unit test this). Hook it back up again.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
