### PR TITLE
compute: use granular backpressure in persist_source decoding

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -32,7 +32,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
 
     ComputeParameters {
         max_result_size: Some(config.max_result_size()),
-        dataflow_max_inflight_bytes: Some(config.dataflow_max_inflight_bytes()),
+        dataflow_max_inflight_bytes: Some(config.compute_dataflow_max_inflight_bytes()),
         linear_join_yielding: Some(linear_join_yielding),
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -64,11 +64,15 @@ message ProtoPeek {
 message ProtoComputeParameters {
     optional uint32 max_result_size = 1;
     mz_persist_client.cfg.ProtoPersistParameters persist = 2;
-    optional uint64 dataflow_max_inflight_bytes = 3;
+    ProtoComputeMaxInflightBytesConfig dataflow_max_inflight_bytes = 3;
     optional bool enable_mz_join_core = 4;
     mz_tracing.params.ProtoTracingParameters tracing = 5;
     mz_service.params.ProtoGrpcClientParameters grpc_client = 6;
     optional bool enable_jemalloc_profiling = 7;
     optional bool enable_specialized_arrangements = 8;
     mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
+}
+
+message ProtoComputeMaxInflightBytesConfig {
+    optional uint64 dataflow_max_inflight_bytes = 1;
 }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -83,7 +83,7 @@ pub struct ComputeState {
     /// Max size in bytes of any result.
     max_result_size: u32,
     /// Maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
-    pub dataflow_max_inflight_bytes: usize,
+    pub dataflow_max_inflight_bytes: Option<usize>,
     /// Specification for rendering linear joins.
     pub linear_join_spec: LinearJoinSpec,
     /// Metrics for this replica.
@@ -115,7 +115,7 @@ impl ComputeState {
             persist_clients,
             command_history,
             max_result_size: u32::MAX,
-            dataflow_max_inflight_bytes: usize::MAX,
+            dataflow_max_inflight_bytes: None,
             linear_join_spec: Default::default(),
             metrics,
             tracing_handle,

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -216,7 +216,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         dataflow.as_of.clone(),
                         dataflow.until.clone(),
                         mfp.as_mut(),
-                        Some(compute_state.dataflow_max_inflight_bytes),
+                        compute_state.dataflow_max_inflight_bytes,
                     );
 
                     // If `mfp` is non-identity, we need to apply what remains.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -115,6 +115,11 @@ impl PersistClientCache {
         &self.cfg
     }
 
+    /// Returns [ShardMetrics] for the given shard.
+    pub fn shard_metrics(&self, shard_id: &ShardId, name: &str) -> Arc<ShardMetrics> {
+        self.metrics.shards.shard(shard_id, name)
+    }
+
     /// Clears the state cache, allowing for tests with disconnected states.
     ///
     /// Only exposed for testing.

--- a/src/persist-client/src/cache.rs
+++ b/src/persist-client/src/cache.rs
@@ -115,7 +115,7 @@ impl PersistClientCache {
         &self.cfg
     }
 
-    /// Returns [ShardMetrics] for the given shard.
+    /// Returns `ShardMetrics` for the given shard.
     pub fn shard_metrics(&self, shard_id: &ShardId, name: &str) -> Arc<ShardMetrics> {
         self.metrics.shards.shard(shard_id, name)
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -997,12 +997,12 @@ const CRDB_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
-/// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
-const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
-    name: UncasedStr::new("dataflow_max_inflight_bytes"),
+/// The maximum number of in-flight bytes emitted by persist_sources feeding compute dataflows.
+const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
+    name: UncasedStr::new("compute_dataflow_max_inflight_bytes"),
     value: &None,
     description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
-                  dataflows (Materialize).",
+                  compute dataflows (Materialize).",
     internal: true,
 };
 
@@ -2469,7 +2469,7 @@ impl SystemVars {
             .with_var(&PERSIST_READER_LEASE_DURATION)
             .with_var(&CRDB_CONNECT_TIMEOUT)
             .with_var(&CRDB_TCP_USER_TIMEOUT)
-            .with_var(&DATAFLOW_MAX_INFLIGHT_BYTES)
+            .with_var(&COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_TO_CLUSTER_SIZE_FRACTION)
             .with_var(&STORAGE_DATAFLOW_MAX_INFLIGHT_BYTES_DISK_ONLY)
@@ -3036,8 +3036,8 @@ impl SystemVars {
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
-    pub fn dataflow_max_inflight_bytes(&self) -> Option<usize> {
-        *self.expect_value(&DATAFLOW_MAX_INFLIGHT_BYTES)
+    pub fn compute_dataflow_max_inflight_bytes(&self) -> Option<usize> {
+        *self.expect_value(&COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES)
     }
 
     /// Returns the `storage_dataflow_max_inflight_bytes` configuration parameter.
@@ -4859,7 +4859,7 @@ pub fn is_tracing_var(name: &str) -> bool {
 /// Returns whether the named variable is a compute configuration parameter.
 pub fn is_compute_config_var(name: &str) -> bool {
     name == MAX_RESULT_SIZE.name()
-        || name == DATAFLOW_MAX_INFLIGHT_BYTES.name()
+        || name == COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES.name()
         || name == LINEAR_JOIN_YIELDING.name()
         || name == ENABLE_MZ_JOIN_CORE.name()
         || name == ENABLE_JEMALLOC_PROFILING.name()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -998,9 +998,9 @@ const CRDB_TCP_USER_TIMEOUT: ServerVar<Duration> = ServerVar {
 };
 
 /// The maximum number of in-flight bytes emitted by persist_sources feeding dataflows.
-const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<usize> = ServerVar {
+const DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar {
     name: UncasedStr::new("dataflow_max_inflight_bytes"),
-    value: &usize::MAX,
+    value: &None,
     description: "The maximum number of in-flight bytes emitted by persist_sources feeding \
                   dataflows (Materialize).",
     internal: true,
@@ -3036,7 +3036,7 @@ impl SystemVars {
     }
 
     /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
-    pub fn dataflow_max_inflight_bytes(&self) -> usize {
+    pub fn dataflow_max_inflight_bytes(&self) -> Option<usize> {
         *self.expect_value(&DATAFLOW_MAX_INFLIGHT_BYTES)
     }
 

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -145,7 +145,7 @@ where
                 let handle = mz_timely_util::probe::Handle::default();
                 let probe = mz_timely_util::probe::source(
                     scope.clone(),
-                    format!("upsert_probe({source_id})"),
+                    format!("decode_backpressure_probe({source_id})"),
                     handle.clone(),
                 );
                 probe.connect_loop(feedback_handle);


### PR DESCRIPTION
We've seen instances during rehydration in prod of OOMs from what
appears to be a backup of fetched persist parts waiting on decoding. The
recent change to drive s3 work with tokio instead of timely has likely
eliminated any tiny bit of backpressure we were getting from timely
scheduling, and this was already plausible.

In a way, decoding is quite analogous to writing upsert data to rocksdb,
so reuse the recent fine-grained backpressure work from that. I did some
testing on Friday and the results are quite promising. Specifically:

- Turned on the TPCH loadgen source
- Created all 21 TPCH queries as queries in a cluster
- Added and removed replicas of various sizes and watched rehydration

Before, we saw memory spikes during rehydration of 60-70 GiB+, settling
down to 8-9 GiB. With this change and a value of 128 MiB, we saw memory
spikes of 8-13 GiB before settling down to the same 8-9 GiB.

![image](https://github.com/MaterializeInc/materialize/assets/52528/544ed7cf-0a99-4681-a714-10a4c2d8780d)

Note that the recording interval for memory usage here is every 60s, so
the real spikes might be bigger, but the numbers are dramatic enough
that the impact is almost certainly real. I did also try an xsmall (13.5
GiB) and it consistently OOMed, confirming this point.

Ideally, this parameter would be tunable in a more targeted way
(per-cluster/replica/persist_source), but that's much harder. We already
had this LD knob, and the affected customers aren't the most sensitive
to rehydration time, so confirm that this fixes things before investing
more heavily here. This repurposes the `dataflow_max_inflight_bytes`
config from end-to-end compute dataflow backpressure to instead be
granular backpressure purely inside compute's persist_source instances
holding back fetching on decoding. This config isn't even created in LD,
so there aren't any concerns with reusing it.

- Note that this doesn't prevent us from re-introducing the end-to-end dataflow backpressure in the future. Also note that with this PR, the remaining benefit of end-to-end backpressure is really catching up when a computation has been down for a while (the inputs are far ahead of the output). But, this has a nice workaround (temporarily add a larger replica, spin it down when things are caught up) whereas the issue this PR is solving doesn't really have a good workaround (the replica must be oversized just to survive rehydration).

Touches https://github.com/MaterializeInc/cloud/issues/7835

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
