### PR TITLE
Docs: Mention group size hints in TopK patterns page

### DIFF
--- a/doc/user/content/sql/select.md
+++ b/doc/user/content/sql/select.md
@@ -117,8 +117,7 @@ CTEs have the following limitations, which we are working to improve:
 
 ### Query hints
 
-Users can specify any query hints to help Materialize optimize
-query planning more efficiently.
+Users can specify query hints to help Materialize optimize queries.
 
 The following query hints are valid within the `OPTION` clause.
 


### PR DESCRIPTION
This PR adds a mention of the group size hints to the [TopK patterns page](https://materialize.com/docs/transform-data/patterns/top-k/). As it currently is, I'm a bit worried that someone lands on that page coming from the [window functions page](https://materialize.com/docs/transform-data/patterns/window-functions/#top-k-using-row_number), wanting to rewrite a `row_number < k` to a TopK with lateral join, and then ends up with significantly more memory usage after the rewrite. This can happen because using `row_number` is quite ok memory-wise (it has CPU usage problems only), but the TopK pattern has large memory usage without hints.

Additionally, I upgraded a very old example plan, and also simplified a convoluted sentence.

### Motivation

Minor doc enhancement.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
