### PR TITLE
sql: Fix a few issues with `ALTER SCHEMA ... RENAME ...`

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -99,11 +99,7 @@ class Action:
                 ]
             )
         if self.db.scenario == Scenario.Rename:
-            result.extend(
-                [
-                    "unknown schema",
-                ]
-            )
+            result.extend(["unknown schema", "ambiguous reference to schema name"])
         if NAUGHTY_IDENTIFIERS:
             result.extend(["identifier length exceeds 255 bytes"])
         return result

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2850,8 +2850,17 @@ impl Catalog {
                     let conn_id = session
                         .map(|session| session.conn_id())
                         .unwrap_or(&SYSTEM_CONN_ID);
+
                     let schema = state.get_schema(&database_spec, &schema_spec, conn_id);
                     let cur_name = schema.name().schema.clone();
+
+                    let ResolvedDatabaseSpecifier::Id(database_id) = database_spec else {
+                        return Err(AdapterError::Catalog(Error::new(
+                            ErrorKind::AmbientSchemaRename(cur_name),
+                        )));
+                    };
+                    let database = state.get_database(&database_id);
+                    let database_name = &database.name;
 
                     let mut updates = Vec::new();
                     let mut already_updated = HashSet::new();
@@ -2867,8 +2876,16 @@ impl Catalog {
                         let mut new_entry = entry.clone();
                         new_entry.item = entry
                             .item
-                            .rename_schema_refs(&cur_name, new_name.clone())
-                            .expect("no failures");
+                            .rename_schema_refs(database_name, &cur_name, &new_name)
+                            .map_err(|(s, _i)| {
+                                Error::new(ErrorKind::from(AmbiguousRename {
+                                    depender: state
+                                        .resolve_full_name(entry.name(), entry.conn_id())
+                                        .to_string(),
+                                    dependee: format!("{database_name}.{cur_name}"),
+                                    message: format!("ambiguous reference to schema named {s}"),
+                                }))
+                            })?;
 
                         // Update the Stash and Builtin Tables.
                         if !new_entry.item().is_temporary() {

--- a/src/adapter/src/catalog/error.rs
+++ b/src/adapter/src/catalog/error.rs
@@ -58,6 +58,8 @@ pub enum ErrorKind {
     AmbiguousRename(#[from] AmbiguousRename),
     #[error("cannot rename type: {0}")]
     TypeRename(String),
+    #[error("cannot rename schemas in the ambient database: {}", .0.quoted())]
+    AmbientSchemaRename(String),
     #[error("cannot migrate from catalog version {last_seen_version} to version {this_version} (earlier versions might still work): {cause}")]
     FailedMigration {
         last_seen_version: String,

--- a/src/adapter/src/catalog/objects.rs
+++ b/src/adapter/src/catalog/objects.rs
@@ -867,10 +867,11 @@ impl CatalogItem {
 
     pub(crate) fn rename_schema_refs(
         &self,
+        database_name: &str,
         cur_schema_name: &str,
-        new_schema_name: String,
-    ) -> Result<CatalogItem, String> {
-        let do_rewrite = |create_sql: String| -> String {
+        new_schema_name: &str,
+    ) -> Result<CatalogItem, (String, String)> {
+        let do_rewrite = |create_sql: String| -> Result<String, (String, String)> {
             let mut create_stmt = mz_sql::parse::parse(&create_sql)
                 .expect("invalid create sql persisted to catalog")
                 .into_element()
@@ -879,58 +880,59 @@ impl CatalogItem {
             // Rename all references to cur_schema_name.
             mz_sql::ast::transform::create_stmt_rename_schema_refs(
                 &mut create_stmt,
+                database_name,
                 cur_schema_name,
                 new_schema_name,
-            );
+            )?;
 
-            create_stmt.to_ast_string_stable()
+            Ok(create_stmt.to_ast_string_stable())
         };
 
         match self {
             CatalogItem::Table(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Table(i))
             }
             CatalogItem::Log(i) => Ok(CatalogItem::Log(i.clone())),
             CatalogItem::Source(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Source(i))
             }
             CatalogItem::Sink(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Sink(i))
             }
             CatalogItem::View(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::View(i))
             }
             CatalogItem::MaterializedView(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::MaterializedView(i))
             }
             CatalogItem::Index(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Index(i))
             }
             CatalogItem::Secret(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Secret(i))
             }
             CatalogItem::Connection(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Connection(i))
             }
             CatalogItem::Type(i) => {
                 let mut i = i.clone();
-                i.create_sql = do_rewrite(i.create_sql);
+                i.create_sql = do_rewrite(i.create_sql)?;
                 Ok(CatalogItem::Type(i))
             }
             CatalogItem::Func(i) => Ok(CatalogItem::Func(i.clone())),

--- a/test/sqllogictest/rename.slt
+++ b/test/sqllogictest/rename.slt
@@ -262,7 +262,7 @@ statement ok
 CREATE VIEW c1.keys (aux_key) AS VALUES ('apple'), ('orange'), ('banana');
 
 statement ok
-CREATE VIEW c1.v1 AS (SELECT y FROM friend_again.v2 JOIN grand_friend.t1 ON friend_again.v2.y = grand_friend.t1.keys UNION ALL SELECT aux_key FROM c1.keys, b4.t);
+CREATE VIEW c1.v1 AS (SELECT y FROM friend_again.v2 JOIN grand_friend.t1 ON materialize.friend_again.v2.y = materialize.grand_friend.t1.keys UNION ALL SELECT aux_key FROM c1.keys, b4.t);
 
 query T
 SELECT * FROM c1.v1;
@@ -284,7 +284,7 @@ query TT
 SHOW CREATE VIEW c1.v1;
 ----
 materialize.c1.v1
-CREATE VIEW "materialize"."c1"."v1" AS SELECT "y" FROM "materialize"."friend_again"."v2" JOIN "materialize"."grand_friend"."t1" ON "friend_again"."v2"."y" = "grand_friend"."t1"."keys" UNION ALL SELECT "aux_key" FROM "materialize"."c1"."keys", "materialize"."b4"."t"
+CREATE VIEW "materialize"."c1"."v1" AS SELECT "y" FROM "materialize"."friend_again"."v2" JOIN "materialize"."grand_friend"."t1" ON "materialize"."friend_again"."v2"."y" = "materialize"."grand_friend"."t1"."keys" UNION ALL SELECT "aux_key" FROM "materialize"."c1"."keys", "materialize"."b4"."t"
 
 statement ok
 ALTER SCHEMA c1 RENAME TO c2;
@@ -296,7 +296,7 @@ query TT
 SHOW CREATE VIEW c2.v1;
 ----
 materialize.c2.v1
-CREATE VIEW "materialize"."c2"."v1" AS SELECT "y" FROM "materialize"."friend_again"."v2" JOIN "materialize"."grand_acquaintance"."t1" ON "friend_again"."v2"."y" = "grand_acquaintance"."t1"."keys" UNION ALL SELECT "aux_key" FROM "materialize"."c2"."keys", "materialize"."b4"."t"
+CREATE VIEW "materialize"."c2"."v1" AS SELECT "y" FROM "materialize"."friend_again"."v2" JOIN "materialize"."grand_acquaintance"."t1" ON "materialize"."friend_again"."v2"."y" = "materialize"."grand_acquaintance"."t1"."keys" UNION ALL SELECT "aux_key" FROM "materialize"."c2"."keys", "materialize"."b4"."t"
 
 statement ok
 CREATE TABLE c2.c2 (ts int);
@@ -339,13 +339,13 @@ statement ok
 CREATE VIEW d.values (x, y, z) AS VALUES (1, 'foo', 100), (2, 'bar', 200), (3, 'baz', 300);
 
 statement ok
-CREATE VIEW d.qualified_columns AS ( SELECT materialize.d.values.x, d.values.y, z FROM d.values );
+CREATE VIEW d.qualified_columns AS ( SELECT materialize.d.values.x, materialize.d.values.y, z FROM d.values );
 
 query TT
 SHOW CREATE VIEW d.qualified_columns;
 ----
 materialize.d.qualified_columns
-CREATE VIEW "materialize"."d"."qualified_columns" AS SELECT "materialize"."d"."values"."x", "d"."values"."y", "z" FROM "materialize"."d"."values"
+CREATE VIEW "materialize"."d"."qualified_columns" AS SELECT "materialize"."d"."values"."x", "materialize"."d"."values"."y", "z" FROM "materialize"."d"."values"
 
 query ITI
 SELECT * FROM d.qualified_columns;
@@ -367,7 +367,7 @@ query TT
 SHOW CREATE VIEW d_renamed.qualified_columns;
 ----
 materialize.d_renamed.qualified_columns
-CREATE VIEW "materialize"."d_renamed"."qualified_columns" AS SELECT "materialize"."d_renamed"."values"."x", "d_renamed"."values"."y", "z" FROM "materialize"."d_renamed"."values"
+CREATE VIEW "materialize"."d_renamed"."qualified_columns" AS SELECT "materialize"."d_renamed"."values"."x", "materialize"."d_renamed"."values"."y", "z" FROM "materialize"."d_renamed"."values"
 
 query ITI
 SELECT * FROM d_renamed.qualified_columns LIMIT 1;
@@ -471,13 +471,13 @@ SELECT * FROM j_other.l;
 
 # Temporary schemas.
 
-statement error db error: ERROR: system schema 'mz_temp' cannot be modified
+statement error db error: ERROR: cannot rename schemas in the ambient database: "mz_temp"
 ALTER SCHEMA mz_temp RENAME TO mz_temp_renamed;
 
 simple conn=mz_system,user=mz_system
 ALTER SCHEMA mz_temp RENAME TO mz_temp_renamed;
 ----
-db error: ERROR: system schema 'mz_temp' cannot be modified
+db error: ERROR: cannot rename schemas in the ambient database: "mz_temp"
 
 # Schemas that do not exist.
 
@@ -518,3 +518,91 @@ SELECT bar FROM t1;
 100
 200
 300
+
+# Renaming schemas across databases.
+
+statement ok
+CREATE DATABASE a;
+
+statement ok
+CREATE SCHEMA a.foo;
+
+statement ok
+CREATE TABLE a.foo.t1 (x int);
+
+statement ok
+INSERT INTO a.foo.t1 VALUES (4), (5), (6);
+
+statement ok
+CREATE DATABASE b;
+
+statement ok
+CREATE SCHEMA b.foo;
+
+statement ok
+CREATE TABLE b.foo.t1 (y int);
+
+statement ok
+INSERT INTO b.foo.t1 VALUES (1), (2), (3);
+
+statement ok
+CREATE DATABASE c;
+
+statement ok
+CREATE SCHEMA c.foo;
+
+statement ok
+CREATE VIEW c.foo.v1 AS ( SELECT x, y FROM a.foo.t1, b.foo.t1 );
+
+query TT
+SHOW CREATE VIEW c.foo.v1;
+----
+c.foo.v1
+CREATE VIEW "c"."foo"."v1" AS SELECT "x", "y" FROM "a"."foo"."t1", "b"."foo"."t1"
+
+statement ok
+ALTER SCHEMA b.foo RENAME TO bbb;
+
+query TT
+SHOW CREATE VIEW c.foo.v1;
+----
+c.foo.v1
+CREATE VIEW "c"."foo"."v1" AS SELECT "x", "y" FROM "a"."foo"."t1", "b"."bbb"."t1"
+
+statement ok
+ALTER SCHEMA c.foo RENAME TO ccc;
+
+query TT
+SHOW CREATE VIEW c.ccc.v1;
+----
+c.ccc.v1
+CREATE VIEW "c"."ccc"."v1" AS SELECT "x", "y" FROM "a"."foo"."t1", "b"."bbb"."t1"
+
+# Ambiguously refer to a schema.
+
+statement ok
+CREATE SCHEMA amb;
+
+statement ok
+CREATE TABLE amb.t1 (x int);
+
+statement ok
+CREATE DATABASE d;
+
+statement ok
+CREATE SCHEMA d.amb;
+
+statement ok
+CREATE TABLE d.amb.t1 (y int);
+
+statement ok
+CREATE VIEW d.amb.v1 AS SELECT amb.t1.x FROM amb.t1, d.amb.t1;
+
+query TT
+SHOW CREATE VIEW d.amb.v1;
+----
+d.amb.v1
+CREATE VIEW "d"."amb"."v1" AS SELECT "amb"."t1"."x" FROM "materialize"."amb"."t1", "d"."amb"."t1"
+
+statement error db error: ERROR: renaming conflict: in d\.amb\.v1, which uses d\.amb, ambiguous reference to schema named amb
+ALTER SCHEMA d.amb RENAME TO this_rename_will_fail;

--- a/test/testdrive/rename.td
+++ b/test/testdrive/rename.td
@@ -832,3 +832,48 @@ renamed_j
 > ALTER VIEW v_orig RENAME TO v_dontcare
 > CREATE VIEW v_orig AS SELECT 1
 > CREATE DEFAULT INDEX ON v_orig
+
+# Test renaming a schema that contains objects.
+
+> CREATE SCHEMA to_be_renamed;
+
+> SET SCHEMA TO to_be_renamed;
+
+> CREATE SOURCE mz_data
+  FROM KAFKA CONNECTION public.kafka_conn (TOPIC 'testdrive-data-rename-schema-${testdrive.seed}')
+  FORMAT AVRO USING SCHEMA '${writer-schema}'
+
+> CREATE DEFAULT INDEX ON mz_data
+
+> CREATE SINK sink1 FROM mz_data
+  INTO KAFKA CONNECTION public.kafka_conn (TOPIC 'testdrive-snk1-rename-schema-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION public.csr_conn
+  ENVELOPE DEBEZIUM
+
+> SET SCHEMA TO public;
+
+# Check the initial state of the create_sql.
+
+> SHOW CREATE SOURCE to_be_renamed.mz_data;
+name                                create_sql
+---------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.to_be_renamed.mz_data  "CREATE SOURCE \"materialize\".\"to_be_renamed\".\"mz_data\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-data-rename-schema-${testdrive.seed}') FORMAT AVRO USING SCHEMA '{   \"name\": \"row\",   \"type\": \"record\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"string\"}   ] }' EXPOSE PROGRESS AS \"materialize\".\"to_be_renamed\".\"mz_data_progress\""
+
+> SHOW CREATE SINK to_be_renamed.sink1;
+name                                create_sql
+---------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.to_be_renamed.sink1    "CREATE SINK \"materialize\".\"to_be_renamed\".\"sink1\" FROM \"materialize\".\"to_be_renamed\".\"mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-rename-schema-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" ENVELOPE DEBEZIUM"
+
+# Make sure the create_sql got updated.
+
+> ALTER SCHEMA to_be_renamed RENAME TO foo_bar;
+
+> SHOW CREATE SOURCE foo_bar.mz_data;
+name                                create_sql
+---------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.foo_bar.mz_data  "CREATE SOURCE \"materialize\".\"foo_bar\".\"mz_data\" FROM KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-data-rename-schema-${testdrive.seed}') FORMAT AVRO USING SCHEMA '{   \"name\": \"row\",   \"type\": \"record\",   \"fields\": [     {\"name\": \"a\", \"type\": \"long\"},     {\"name\": \"b\", \"type\": \"string\"}   ] }' EXPOSE PROGRESS AS \"materialize\".\"foo_bar\".\"mz_data_progress\""
+
+> SHOW CREATE SINK foo_bar.sink1;
+name                                create_sql
+---------------------------------------------------------------------------------------------------------------------------------------------------
+materialize.foo_bar.sink1    "CREATE SINK \"materialize\".\"foo_bar\".\"sink1\" FROM \"materialize\".\"foo_bar\".\"mz_data\" INTO KAFKA CONNECTION \"materialize\".\"public\".\"kafka_conn\" (TOPIC = 'testdrive-snk1-rename-schema-${testdrive.seed}') FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION \"materialize\".\"public\".\"csr_conn\" ENVELOPE DEBEZIUM"


### PR DESCRIPTION
Randomized testing revealed that we miss another field when renaming schemas (https://github.com/MaterializeInc/materialize/issues/22540), and while working on this I realized that we could improperly rename schemas across databases.

To solve the first issue I refactored the code to always use the rename visitor. Previously we would change the name of statements, and only use the visitor for the `Query`s within a View or Materialized View, but I realized a better approach would be to run the Visitor over the entire statement.

The second issue is the rename visitor did not take database into consideration. Consider the following query:
```
CREATE SCHEMA a.foo; CREATE TABLE a.foo.t1 (x int);
CREATE SCHEMA b.foo; CREATE TABLE b.foo.t1 (y int);
CREATE SCHEMA c.foo;

CREATE VIEW c.foo.v1 AS SELECT x, y FROM a.foo.t1, b.foo.t1;

ALTER SCHEMA b.foo RENAME TO bbb;
```

When doing the schema rename for `b.foo`, we would rename every schema named `foo` within the view definition for `c.foo.v1`, _regardless of the database_ it was in, which is the wrong behavior.

The fix for this introduces a failure mode for renaming schemas. If we encounter a specifier that is not fully qualified, e.g. a column reference to `foo.t1.x`, we bail from the rename because we're not sure what schema `foo` we're referring to. I _think_ with some further work we can lift this restriction because in this case `foo` would refer to the schema in database that this entry lives in, but I'm punting on this for now.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/22540 and the issue described above.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
