### PR TITLE
rbac: Align type USAGE privileges with PostgreSQL

### DIFF
--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -636,7 +636,7 @@ impl Coordinator {
                         ctx.session().role_metadata(),
                         ctx.session().vars(),
                         &resolved_ids,
-                        CREATE_ITEM_USAGE.clone(),
+                        &CREATE_ITEM_USAGE,
                     ) {
                         return ctx.retire(Err(e.into()));
                     }

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -26,6 +26,7 @@ use mz_sql::plan::{
     AbortTransactionPlan, CommitTransactionPlan, CreateRolePlan, Params, Plan, TransactionType,
 };
 use mz_sql::rbac;
+use mz_sql::rbac::CREATE_ITEM_USAGE;
 use mz_sql::session::user::User;
 use mz_sql::session::vars::{
     EndTransactionAction, OwnedVarInput, Var, STATEMENT_LOGGING_SAMPLE_RATE,
@@ -630,11 +631,12 @@ impl Coordinator {
                     // Checks if the session is authorized to purify a statement. Usually
                     // authorization is checked after planning, however purification happens before
                     // planning, which may require the use of some connections and secrets.
-                    if let Err(e) = rbac::check_item_usage(
+                    if let Err(e) = rbac::check_usage(
                         &catalog,
                         ctx.session().role_metadata(),
                         ctx.session().vars(),
                         &resolved_ids,
+                        CREATE_ITEM_USAGE.clone(),
                     ) {
                         return ctx.retire(Err(e.into()));
                     }

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -96,7 +96,7 @@ pub static CREATE_ITEM_USAGE: Lazy<BTreeSet<CatalogItemType>> = Lazy::new(|| {
     items.insert(CatalogItemType::Type);
     items
 });
-pub static EMPTY_ITEM_USAGE: Lazy<BTreeSet<CatalogItemType>> = Lazy::new(|| BTreeSet::new());
+pub static EMPTY_ITEM_USAGE: Lazy<BTreeSet<CatalogItemType>> = Lazy::new(BTreeSet::new);
 
 /// Errors that can occur due to an unauthorized action.
 #[derive(Debug, thiserror::Error)]

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -11,6 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::iter;
 
 use itertools::Itertools;
+use maplit::btreeset;
 use mz_controller_types::ClusterId;
 use mz_expr::{CollectionPlan, MirRelationExpr};
 use mz_ore::str::StrExt;
@@ -18,6 +19,7 @@ use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
 use mz_repr::GlobalId;
 use mz_sql_parser::ast::QualifiedReplica;
+use once_cell::sync::Lazy;
 use tracing::debug;
 
 use crate::catalog::{
@@ -83,6 +85,19 @@ macro_rules! rbac_preamble {
     };
 }
 
+// The default item types that most statements require USAGE privileges for.
+static DEFAULT_ITEM_USAGE: Lazy<BTreeSet<CatalogItemType>> = Lazy::new(|| {
+    btreeset! {CatalogItemType::Secret, CatalogItemType::Connection}
+});
+
+// CREATE statements require USAGE privileges on the default item types and USAGE privileges on
+// Types.
+pub static CREATE_ITEM_USAGE: Lazy<BTreeSet<CatalogItemType>> = Lazy::new(|| {
+    let mut items = DEFAULT_ITEM_USAGE.clone();
+    items.insert(CatalogItemType::Type);
+    items
+});
+
 /// Errors that can occur due to an unauthorized action.
 #[derive(Debug, thiserror::Error)]
 pub enum UnauthorizedError {
@@ -146,11 +161,11 @@ struct RbacRequirements {
     /// The privileges required. The tuples are of the form:
     /// (What object the privilege is on, What privilege is required, Who must possess the privilege).
     privileges: Vec<(SystemObjectId, AclMode, RoleId)>,
-    /// true if the plan requires USAGE privileges on all applicable items, false otherwise.
+    /// The types of catalog items that this plan requires USAGE privileges on.
     ///
-    /// Most plans will be true but some plans, like SHOW CREATE, can reference an item without
-    /// requiring any privileges on that item.
-    item_usage: bool,
+    /// Most plans will require USAGE on secrets and connections but some plans, like SHOW CREATE,
+    /// can reference an item without requiring any privileges on that item.
+    item_usage: BTreeSet<CatalogItemType>,
     /// Some action if superuser is required to perform that action, None otherwise.
     superuser_action: Option<String>,
 }
@@ -166,9 +181,13 @@ impl RbacRequirements {
         // Obtain all roles that the current session is a member of.
         let role_membership = catalog.collect_role_membership(&role_metadata.current_role);
 
-        if self.item_usage {
-            check_item_usage(catalog, role_metadata, session_vars, resolved_ids)?;
-        }
+        check_usage(
+            catalog,
+            role_metadata,
+            session_vars,
+            resolved_ids,
+            self.item_usage,
+        )?;
 
         // Validate that the current session has the required role membership to execute the provided
         // plan.
@@ -217,18 +236,19 @@ impl Default for RbacRequirements {
             role_membership: BTreeSet::new(),
             ownership: Vec::new(),
             privileges: Vec::new(),
-            item_usage: true,
+            item_usage: DEFAULT_ITEM_USAGE.clone(),
             superuser_action: None,
         }
     }
 }
 
 /// Checks if a `session` is authorized to use `resolved_ids`. If not, an error is returned.
-pub fn check_item_usage(
+pub fn check_usage(
     catalog: &impl SessionCatalog,
     role_metadata: &RoleMetadata,
     session_vars: &SessionVars,
     resolved_ids: &ResolvedIds,
+    item_types: BTreeSet<CatalogItemType>,
 ) -> Result<(), UnauthorizedError> {
     rbac_preamble!(catalog, role_metadata, session_vars);
 
@@ -244,10 +264,15 @@ pub fn check_item_usage(
         .cloned()
         .collect();
     let existing_resolved_ids = ResolvedIds(existing_resolved_ids);
-    let required_privileges =
-        generate_item_usage_privileges(catalog, &existing_resolved_ids, role_metadata.current_role)
-            .into_iter()
-            .collect();
+
+    let required_privileges = generate_usage_privileges(
+        catalog,
+        &existing_resolved_ids,
+        role_metadata.current_role,
+        item_types,
+    )
+    .into_iter()
+    .collect();
     check_object_privileges(
         catalog,
         required_privileges,
@@ -315,6 +340,7 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateDatabase(plan::CreateDatabasePlan {
@@ -322,6 +348,7 @@ fn generate_rbac_requirements(
             if_not_exists: _,
         }) => RbacRequirements {
             privileges: vec![(SystemObjectId::System, AclMode::CREATE_DB, role_id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateSchema(plan::CreateSchemaPlan {
@@ -341,6 +368,7 @@ fn generate_rbac_requirements(
             };
             RbacRequirements {
                 privileges,
+                item_usage: CREATE_ITEM_USAGE.clone(),
                 ..Default::default()
             }
         }
@@ -349,6 +377,7 @@ fn generate_rbac_requirements(
             attributes: _,
         }) => RbacRequirements {
             privileges: vec![(SystemObjectId::System, AclMode::CREATE_ROLE, role_id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateCluster(plan::CreateClusterPlan {
@@ -356,6 +385,7 @@ fn generate_rbac_requirements(
             variant: _,
         }) => RbacRequirements {
             privileges: vec![(SystemObjectId::System, AclMode::CREATE_CLUSTER, role_id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateClusterReplica(plan::CreateClusterReplicaPlan {
@@ -364,6 +394,7 @@ fn generate_rbac_requirements(
             config: _,
         }) => RbacRequirements {
             ownership: vec![ObjectId::Cluster(*cluster_id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateSource(plan::CreateSourcePlan {
@@ -379,6 +410,7 @@ fn generate_rbac_requirements(
                 cluster_config,
                 role_id,
             ),
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateSources(plans) => RbacRequirements {
@@ -407,6 +439,7 @@ fn generate_rbac_requirements(
                     },
                 )
                 .collect(),
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateSecret(plan::CreateSecretPlan {
@@ -419,6 +452,7 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateSink(plan::CreateSinkPlan {
@@ -446,6 +480,7 @@ fn generate_rbac_requirements(
             }
             RbacRequirements {
                 privileges,
+                item_usage: CREATE_ITEM_USAGE.clone(),
                 ..Default::default()
             }
         }
@@ -459,6 +494,7 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateView(plan::CreateViewPlan {
@@ -477,6 +513,7 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateMaterializedView(plan::CreateMaterializedViewPlan {
@@ -502,6 +539,7 @@ fn generate_rbac_requirements(
                     role_id,
                 ),
             ],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateIndex(plan::CreateIndexPlan {
@@ -523,6 +561,7 @@ fn generate_rbac_requirements(
                     role_id,
                 ),
             ],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::CreateType(plan::CreateTypePlan { name, typ: _ }) => RbacRequirements {
@@ -531,6 +570,7 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::Comment(plan::CommentPlan {
@@ -611,7 +651,7 @@ fn generate_rbac_requirements(
                 AclMode::USAGE,
                 role_id,
             )],
-            item_usage: false,
+            item_usage: BTreeSet::new(),
             ..Default::default()
         },
         Plan::ShowColumns(plan::ShowColumnsPlan {
@@ -720,8 +760,8 @@ fn generate_rbac_requirements(
                     .collect(),
             },
             item_usage: match explainee {
-                Explainee::MaterializedView(_) | Explainee::Index(_) => false,
-                Explainee::Statement(_) => true,
+                Explainee::MaterializedView(_) | Explainee::Index(_) => BTreeSet::new(),
+                Explainee::Statement(_) => DEFAULT_ITEM_USAGE.clone(),
             },
             ..Default::default()
         },
@@ -799,17 +839,20 @@ fn generate_rbac_requirements(
             options: _,
         }) => RbacRequirements {
             ownership: vec![ObjectId::Cluster(*id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::AlterIndexSetOptions(plan::AlterIndexSetOptionsPlan { id, options: _ }) => {
             RbacRequirements {
                 ownership: vec![ObjectId::Item(*id)],
+                item_usage: CREATE_ITEM_USAGE.clone(),
                 ..Default::default()
             }
         }
         Plan::AlterIndexResetOptions(plan::AlterIndexResetOptionsPlan { id, options: _ }) => {
             RbacRequirements {
                 ownership: vec![ObjectId::Item(*id)],
+                item_usage: CREATE_ITEM_USAGE.clone(),
                 ..Default::default()
             }
         }
@@ -820,14 +863,17 @@ fn generate_rbac_requirements(
                 AclMode::CREATE,
                 role_id,
             )],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::AlterSink(plan::AlterSinkPlan { id, size: _ }) => RbacRequirements {
             ownership: vec![ObjectId::Item(*id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::AlterSource(plan::AlterSourcePlan { id, action: _ }) => RbacRequirements {
             ownership: vec![ObjectId::Item(*id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::PurifiedAlterSource {
@@ -862,6 +908,7 @@ fn generate_rbac_requirements(
                     },
                 )
                 .collect(),
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::AlterClusterRename(plan::AlterClusterRenamePlan {
@@ -930,6 +977,7 @@ fn generate_rbac_requirements(
         }
         Plan::AlterSecret(plan::AlterSecretPlan { id, secret_as: _ }) => RbacRequirements {
             ownership: vec![ObjectId::Item(*id)],
+            item_usage: CREATE_ITEM_USAGE.clone(),
             ..Default::default()
         },
         Plan::AlterRole(plan::AlterRolePlan {
@@ -944,6 +992,7 @@ fn generate_rbac_requirements(
             // Otherwise to ALTER a role, you need to have the CREATE_ROLE privilege.
             _ => RbacRequirements {
                 privileges: vec![(SystemObjectId::System, AclMode::CREATE_ROLE, role_id)],
+                item_usage: CREATE_ITEM_USAGE.clone(),
                 ..Default::default()
             },
         },
@@ -1393,31 +1442,25 @@ fn generate_read_privileges_inner(
     privileges
 }
 
-fn generate_item_usage_privileges(
+fn generate_usage_privileges(
     catalog: &impl SessionCatalog,
     ids: &ResolvedIds,
     role_id: RoleId,
+    item_types: BTreeSet<CatalogItemType>,
 ) -> BTreeSet<(SystemObjectId, AclMode, RoleId)> {
     // Use a `BTreeSet` to remove duplicate privileges.
     ids.0
         .iter()
         .filter_map(move |id| {
             let item = catalog.get_item(id);
-            match item.item_type() {
-                CatalogItemType::Type | CatalogItemType::Secret | CatalogItemType::Connection => {
-                    let schema_id = item.name().qualifiers.clone().into();
-                    Some([
-                        (SystemObjectId::Object(schema_id), AclMode::USAGE, role_id),
-                        (SystemObjectId::Object(id.into()), AclMode::USAGE, role_id),
-                    ])
-                }
-                CatalogItemType::Table
-                | CatalogItemType::Source
-                | CatalogItemType::Sink
-                | CatalogItemType::View
-                | CatalogItemType::MaterializedView
-                | CatalogItemType::Index
-                | CatalogItemType::Func => None,
+            if item_types.contains(&item.item_type()) {
+                let schema_id = item.name().qualifiers.clone().into();
+                Some([
+                    (SystemObjectId::Object(schema_id), AclMode::USAGE, role_id),
+                    (SystemObjectId::Object(id.into()), AclMode::USAGE, role_id),
+                ])
+            } else {
+                None
             }
         })
         .flatten()

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1409,16 +1409,6 @@ GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
 
-simple conn=joe,user=joe
-SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=child,user=child
-SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO joe;
 ----
@@ -1686,16 +1676,6 @@ simple conn=mz_system,user=mz_system
 GRANT USAGE ON SCHEMA materialize.public TO joe;
 ----
 COMPLETE 0
-
-simple conn=joe,user=joe
-EXPLAIN SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
-
-simple conn=child,user=child
-EXPLAIN SELECT a::ty FROM t;
-----
-db error: ERROR: permission denied for TYPE "materialize.public.ty"
 
 simple conn=mz_system,user=mz_system
 GRANT USAGE ON TYPE ty TO joe;


### PR DESCRIPTION
Previously, USAGE privileges are required on types any time the type is mentioned. However, in PostgreSQL USAGE privileges on types are only required when using the type in a CREATE statement. This commit updates Materialize's USAGE privilege semantics to match PostgreSQL.

Fixes #22547

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Remove the requirement that `SELECT` and `EXPLAIN` statements need `USAGE` privileges on types.
