### PR TITLE
WIP: Allow superusers to modify privileges on system objects

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3598,55 +3598,6 @@ impl Catalog {
     pub fn ensure_not_system_role(&self, role_id: &RoleId) -> Result<(), Error> {
         self.state.ensure_not_system_role(role_id)
     }
-
-    pub fn ensure_not_reserved_object(
-        &self,
-        object_id: &ObjectId,
-        conn_id: &ConnectionId,
-    ) -> Result<(), Error> {
-        match object_id {
-            ObjectId::Cluster(cluster_id) | ObjectId::ClusterReplica((cluster_id, _)) => {
-                if cluster_id.is_system() {
-                    let cluster = self.get_cluster(*cluster_id);
-                    Err(Error::new(ErrorKind::ReadOnlyCluster(
-                        cluster.name().to_string(),
-                    )))
-                } else {
-                    Ok(())
-                }
-            }
-            ObjectId::Database(database_id) => {
-                if database_id.is_system() {
-                    let database = self.get_database(database_id);
-                    Err(Error::new(ErrorKind::ReadOnlyDatabase(
-                        database.name().to_string(),
-                    )))
-                } else {
-                    Ok(())
-                }
-            }
-            ObjectId::Schema((database_spec, schema_spec)) => {
-                if schema_spec.is_system() {
-                    let schema = self.get_schema(database_spec, schema_spec, conn_id);
-                    Err(Error::new(ErrorKind::ReadOnlySystemSchema(
-                        schema.name().schema.clone(),
-                    )))
-                } else {
-                    Ok(())
-                }
-            }
-            ObjectId::Role(role_id) => self.ensure_not_reserved_role(role_id),
-            ObjectId::Item(item_id) => {
-                if item_id.is_system() {
-                    let item = self.get_entry(item_id);
-                    let name = self.resolve_full_name(item.name(), Some(conn_id));
-                    Err(Error::new(ErrorKind::ReadOnlyItem(name.to_string())))
-                } else {
-                    Ok(())
-                }
-            }
-        }
-    }
 }
 
 pub fn is_reserved_name(name: &str) -> bool {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5791,11 +5791,6 @@ impl Coordinator {
                 }
             }
 
-            if let SystemObjectId::Object(object_id) = &target_id {
-                self.catalog()
-                    .ensure_not_reserved_object(object_id, session.conn_id())?;
-            }
-
             let privileges = self
                 .catalog()
                 .get_privileges(&target_id, session.conn_id())
@@ -5884,19 +5879,6 @@ impl Coordinator {
         for privilege_object in &privilege_objects {
             self.catalog()
                 .ensure_not_system_role(&privilege_object.role_id)?;
-            if let Some(database_id) = privilege_object.database_id {
-                self.catalog()
-                    .ensure_not_reserved_object(&database_id.into(), session.conn_id())?;
-            }
-            if let Some(schema_id) = privilege_object.schema_id {
-                let database_spec: ResolvedDatabaseSpecifier = privilege_object.database_id.into();
-                let schema_spec: SchemaSpecifier = schema_id.into();
-
-                self.catalog().ensure_not_reserved_object(
-                    &(database_spec, schema_spec).into(),
-                    session.conn_id(),
-                )?;
-            }
             for privilege_acl_item in &privilege_acl_items {
                 self.catalog()
                     .ensure_not_system_role(&privilege_acl_item.grantee)?;

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -5144,9 +5144,6 @@ ALTER DEFAULT PRIVILEGES FOR ROLE mz_support GRANT SELECT ON TABLES TO PUBLIC
 db error: ERROR: role name "mz_support" is reserved
 DETAIL: The role prefixes "mz_" and "pg_" are reserved for system roles.
 
-statement error system schema 'mz_catalog' cannot be modified
-ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO PUBLIC
-
 statement error role name "mz_system" is reserved
 ALTER DEFAULT PRIVILEGES FOR ROLE materialize GRANT INSERT ON TABLES TO mz_system
 
@@ -5195,6 +5192,23 @@ SELECT * FROM default_privileges
 ----
 PUBLIC  NULL  NULL  type  PUBLIC  U
 
+# Test that superusers can alter default privileges of builtin objects
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO materialize
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog REVOKE INSERT ON TABLES FROM materialize
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog GRANT INSERT ON TABLES TO materialize
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+ALTER DEFAULT PRIVILEGES FOR ROLE materialize IN SCHEMA mz_catalog REVOKE INSERT ON TABLES FROM materialize
+----
+COMPLETE 0
 
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -3386,6 +3386,38 @@ DROP ROLE r1, r2, r3;
 ----
 COMPLETE 0
 
+# Test that superusers can alter privileges of builtin objects
+
+simple conn=mz_system,user=mz_system
+CREATE ROLE r1;
+----
+COMPLETE 0
+
+simple conn=joe,user=joe
+GRANT INSERT ON mz_views TO r1
+----
+db error: ERROR: must be owner of TABLE mz_catalog.mz_views
+
+simple conn=child,user=child
+GRANT INSERT ON mz_views TO r1
+----
+db error: ERROR: must be owner of TABLE mz_catalog.mz_views
+
+simple conn=mz_system,user=mz_system
+GRANT INSERT ON mz_views TO r1
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+REVOKE INSERT ON mz_views FROM r1
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP ROLE r1
+----
+COMPLETE 0
+
 # Disable rbac checks.
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
