### PR TITLE
sql: improve lowering strategies for outer joins

### DIFF
--- a/src/expr/src/relation/join_input_mapper.rs
+++ b/src/expr/src/relation/join_input_mapper.rs
@@ -58,9 +58,9 @@ impl JoinInputMapper {
     /// efficient if input arities have been pre-calculated
     pub fn new_from_input_arities<I>(arities: I) -> Self
     where
-        I: Iterator<Item = usize>,
+        I: IntoIterator<Item = usize>,
     {
-        let arities = arities.collect::<Vec<usize>>();
+        let arities = arities.into_iter().collect::<Vec<usize>>();
         let mut offset = 0;
         let mut prior_arities = Vec::new();
         for input in 0..arities.len() {

--- a/src/expr/src/scalar/func/impls/int64.rs
+++ b/src/expr/src/scalar/func/impls/int64.rs
@@ -171,7 +171,7 @@ sqlfunc!(
 
 sqlfunc!(
     #[sqlname = "bigint_to_double"]
-    #[preserves_uniqueness = false]
+    #[preserves_uniqueness = false] // Witness: (1111111111111111111, 1111111111111111112).
     #[inverse = to_unary!(super::CastFloat64ToInt64)]
     #[is_monotone = true]
     fn cast_int64_to_float64(a: i64) -> f64 {

--- a/src/repr/src/explain/tracing.rs
+++ b/src/repr/src/explain/tracing.rs
@@ -117,7 +117,7 @@ pub fn trace_plan<T: Clone + 'static>(plan: &T) {
 ///
 /// [^example]: <https://github.com/MaterializeInc/materialize/commit/2ce93229>
 pub fn dbg_plan<S: Display, T: Clone + 'static>(segment: S, plan: &T) {
-    span!(target: "optimizer", Level::TRACE, "segment", path.segment = %segment).in_scope(|| {
+    span!(target: "optimizer", Level::DEBUG, "segment", path.segment = %segment).in_scope(|| {
         trace_plan(plan);
     });
 }
@@ -129,7 +129,7 @@ pub fn dbg_plan<S: Display, T: Clone + 'static>(segment: S, plan: &T) {
 ///
 /// [^example]: <https://github.com/MaterializeInc/materialize/commit/2ce93229>
 pub fn dbg_misc<S: Display, T: Display>(segment: S, misc: T) {
-    span!(target: "optimizer", Level::TRACE, "segment", path.segment = %segment).in_scope(|| {
+    span!(target: "optimizer", Level::DEBUG, "segment", path.segment = %segment).in_scope(|| {
         trace_plan(&misc.to_string());
     });
 }
@@ -334,7 +334,11 @@ impl field::Visit for ExtractStr {
         }
     }
 
-    fn record_debug(&mut self, _field: &tracing::field::Field, _value: &dyn std::fmt::Debug) {}
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        if field.name() == self.key {
+            self.val = Some(format!("{value:?}"))
+        }
+    }
 }
 
 /// A [`subscriber::Subscriber`] implementation that delegates to the default

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -850,6 +850,7 @@ impl PredicatePushdown {
             // equivalences allow the predicate to be rewritten
             // in terms of only columns from that input.
             for (index, push_down) in push_downs.iter_mut().enumerate() {
+                #[allow(deprecated)] // TODO: use `might_error` if possible.
                 if predicate.is_literal_err() || predicate.contains_error_if_null() {
                     // Do nothing. We don't push down literal errors,
                     // as we can't know the join will be non-empty.

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -83,7 +83,7 @@ Explained Query:
                     Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Distinct group_by=[#1, #0] // { arity: 2 }
+                      Distinct group_by=[#0, #1] // { arity: 2 }
                         Project (#1, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
             Get l1 // { arity: 3 }

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -453,11 +453,10 @@ EXPLAIN WITH(arity, join_impls) SELECT * FROM t4 AS a1 LEFT JOIN t4 AS a2 USING 
 Explained Query:
   Return // { arity: 2 }
     Union // { arity: 2 }
-      Project (#1, #0) // { arity: 2 }
-        Map (234, 123) // { arity: 2 }
-          Negate // { arity: 0 }
-            Project () // { arity: 0 }
-              Get l0 // { arity: 2 }
+      Map (123, 234) // { arity: 2 }
+        Negate // { arity: 0 }
+          Project () // { arity: 0 }
+            Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
       Get l0 // { arity: 2 }
   With

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -754,7 +754,6 @@ ReduceMinsMaxes
 "ArrangeBy[[Column(0)]]-errors"
 "ArrangeBy[[Column(0)]]-errors"
 "ArrangeBy[[Column(0)]]-errors"
-"ArrangeBy[[Column(1), Column(0)]] [val: empty]"
 "ArrangeBy[[Column(1), Column(3)]]"
 "ArrangeBy[[Column(1), Column(3)]]"
 "ArrangeBy[[Column(1)]]"


### PR DESCRIPTION
Expands the class of `OUTER JOIN` queries that are lowered in the HIR ⇒ MIR lowering using an equijoin-based lowering strategy as described in #22347 and #22348.

### Motivation

  * This PR adds a known-desirable feature.

Fixes #22347 and #22348. Closes #22343. 

Some notes on monitoring plans for the rollout phase [in this comment](https://github.com/MaterializeInc/materialize/issues/22343#issuecomment-1775717569).

### Tips for reviewer

[Nightlies runs for this PR](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Aissue_22347).

The commits in the PR can be grouped as follows:

1. Preparation commits with minor fixes
   1. expr: add `MirScalarExpr` helper functions
   1. expr: fix `JoinInputMapper` constructor
   1. repr: fix `mz_repr::explain::tracing:dbg_~` methods
   1. sql: cosmetic changes in lowering.rs
1. Test cases for this PR
   1. test: add tests to `outer_join_lowering.td`
   1. spec: add tests to `predicate_pushdown.spec`
1. Fix the issues marked as resolved in this PR
   1. sql: support complex predicates in equijoin-based outer join lowering
   1. sql: support local predicates in equijoin-based outer join lowering
1. Remove obsolete code
   1. sql: remove obsolete `derive_equijoin_cols` from HIR ⇒ MIR lowering code
1. Fix tests
   1. test: rewrite broken `*.slt` and `*.td` tests

I suggest reviewing commit-by-commit, with a focus on the group which contains the fixes for #22347 and #22348. See commit messages for details.

The key commit is the one that resolves #22347. At a high level, the commit makes the following changes:

1. Introduce a helper `struct` called `OnPredicates` which is used to classify the conditions in an `ON` predicate.
2. Introduce a helper `enum` called `OnPredicate` that lists the recognized `ON` predicate classes.
3. Add some helper methods in `OnPredicates` and to `MirRelationExpr` (the latter through an extension trait `LoweringExt`).
4. Use `OnPredicates::new` instead of `derive_equijoin_cols` in `attempt_outer_equijoin` in order to classify the `on` predicates.
5. Guard the `attempt_outer_equijoin` call by `OnPredicates::is_equijoin`.
6. Call `OnPredicates::join_keys` to get a list of join keys.
6. Use `get_join.restrict(join_keys).distinct()` to define `both_keys` in `derive_equijoin_cols`.
7. Construct `left_present` and `right_present` by calling `MirRelationExpr::join_scalars` and using the equality predicate sides provided by `OnPredicates::eq_rhs` / `OnPredicates::eq_rhs`.

The changes in the commit that resolves #22348 are minimal:

1. Generalize the `OnPredicates::is_equijoin` condition.
1. Push local predicates given by `OnPredicates::rhs()` / `OnPredicates::rhs()` to the first input of `left_present` / `right_present`.

Changes that were deliberately left out of scope are listed in the "Later" tasklist in #22343 and referenced in `TODO(#XXXX)` comments in the code.

Examples of improved queries / behavior:

- Query 13 in `chbench.slt` carries should consume less memory after switching to the equijoin-based outer join lowering. The current version has some `Distinct` operators with long key lists that cannot be simplified because the `LEFT JOIN` inputs do not contain keys.
- The second test in `github-18608.td` is no longer producing results inconsistent with Postgres.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Outer joins with equality predicates are now more likely to be executed efficiently.
