### PR TITLE
*: rework `mz_frontiers`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -23,6 +23,30 @@ reference these objects is not allowed.
 
 ## System Relations
 
+### `mz_cluster_replica_frontiers`
+
+The `mz_cluster_replica_frontiers` table describes the per-replica frontiers of
+sources, sinks, materialized views, indexes, and subscriptions in the system,
+as observed from the coordinator.
+
+[`mz_compute_frontiers`](#mz_compute_frontiers) is similar to
+`mz_cluster_replica_frontiers`, but `mz_compute_frontiers` reports the
+frontiers known to the active compute replica, while
+`mz_cluster_replica_frontiers` reports the frontiers of all replicas. Note also
+that `mz_compute_frontiers` is restricted to compute objects (indexes,
+materialized views, and subscriptions) while `mz_cluster_replica_frontiers`
+contains storage objects that are installed on replicas (sources, sinks) as
+well.
+
+At this time, we do not make any guarantees about the freshness of these numbers.
+
+<!-- RELATION_SPEC mz_internal.mz_cluster_replica_frontiers -->
+| Field            | Type             | Meaning                                                                |
+| -----------------| ---------------- | --------                                                               |
+| `object_id`      | [`text`]         | The ID of the source, sink, index, materialized view, or subscription. |
+| `replica_id`     | [`text`]         | The ID of a cluster replica.                                           |
+| `write_frontier` | [`mz_timestamp`] | The next timestamp at which the output may change.                     |
+
 ### `mz_cluster_replica_metrics`
 
 The `mz_cluster_replica_metrics` table gives the last known CPU and RAM utilization statistics
@@ -178,45 +202,16 @@ The `mz_frontiers` table describes the frontiers of each source, sink, table,
 materialized view, index, and subscription in the system, as observed from the
 coordinator.
 
-For objects that are installed on replicas (e.g., materialized views and
-indexes), the `replica_id` field is always non-`NULL`. If an object is installed
-on multiple replicas, it has multiple entries describing the frontier on each
-individual replica. For objects that are not installed on replicas (e.g.,
-tables), the `replica_id` field is `NULL`.
-
-[`mz_compute_frontiers`](#mz_compute_frontiers) is similar to `mz_frontiers`,
-but `mz_compute_frontiers` reports the frontiers known to the active compute
-replica, while `mz_frontiers` reports the frontiers of all replicas. Note also
-that `mz_compute_frontiers` is restricted to compute objects (indexes,
-materialized views, and subscriptions) while `mz_frontiers` contains storage
-objects (sources, sinks, and tables) as well.
-
 At this time, we do not make any guarantees about the freshness of these numbers.
 
 <!-- RELATION_SPEC mz_internal.mz_frontiers -->
-| Field         | Type             | Meaning                                                                             |
-| ------------- | ------------     | --------                                                                            |
-| `object_id`   | [`text`]         | The ID of the source, sink, table, index, materialized view, or subscription.       |
-| `replica_id`  | [`text`]         | The ID of a cluster replica, or `NULL` if the object is not installed on a replica. |
-| `time`        | [`mz_timestamp`] | The next timestamp at which the output may change.                                  |
+| Field            | Type             | Meaning                                                                             |
+| ---------------- | ------------     | --------                                                                            |
+| `object_id`      | [`text`]         | The ID of the source, sink, table, index, materialized view, or subscription.       |
+| `read_frontier`  | [`mz_timestamp`] | The earliest timestamp at which the output is still readable.                       |
+| `write_frontier` | [`mz_timestamp`] | The next timestamp at which the output may change.                                  |
 
-### `mz_global_frontiers`
-
-The `mz_global_frontiers` view describes the global frontiers of each source,
-sink, table, materialized view, index, and subscription in the system, as
-observed from the coordinator.
-
-For objects that are installed on replicas (e.g., materialized views and
-indexes), the global frontier is the maximum of the per-replica frontiers.
-Objects that are not installed on replicas only have a single, global frontier.
-
-At this time, we do not make any guarantees about the freshness of these numbers.
-
-<!-- RELATION_SPEC mz_internal.mz_global_frontiers -->
-| Field         | Type             | Meaning                                                                       |
-| ------------- | ------------     | --------                                                                      |
-| `object_id`   | [`text`]         | The ID of the source, sink, table, index, materialized view, or subscription. |
-| `time`        | [`mz_timestamp`] | The next timestamp at which the output may change.                            |
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_global_frontiers -->
 
 ### `mz_kafka_sources`
 
@@ -778,6 +773,8 @@ Specifically, reductions can use more memory than we show here.
 | `allocations` | [`numeric`] | The number of separate memory allocations backing the arrangement.                                                        |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_sizes_per_worker -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_records_raw -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_batches_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_heap_allocations_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_heap_capacity_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_heap_size_raw -->
@@ -1122,8 +1119,6 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 [query hints]: /sql/select/#query-hints
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_aggregates -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_batches_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_records_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_dataflow_operator_reachability_raw -->

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2283,49 +2283,38 @@ pub static MZ_CLUSTER_REPLICA_METRICS: Lazy<BuiltinTable> = Lazy::new(|| Builtin
     sensitivity: DataSensitivity::Public,
 });
 
+pub static MZ_CLUSTER_REPLICA_FRONTIERS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
+    name: "mz_cluster_replica_frontiers",
+    schema: MZ_INTERNAL_SCHEMA,
+    data_source: Some(IntrospectionType::ReplicaFrontiers),
+    desc: RelationDesc::empty()
+        .with_column("object_id", ScalarType::String.nullable(false))
+        .with_column("replica_id", ScalarType::String.nullable(false))
+        .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true)),
+    is_retained_metrics_object: false,
+    sensitivity: DataSensitivity::Public,
+});
+
 pub static MZ_FRONTIERS: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
     data_source: Some(IntrospectionType::Frontiers),
     desc: RelationDesc::empty()
         .with_column("object_id", ScalarType::String.nullable(false))
-        .with_column("replica_id", ScalarType::String.nullable(true))
-        .with_column("time", ScalarType::MzTimestamp.nullable(true)),
+        .with_column("read_frontier", ScalarType::MzTimestamp.nullable(true))
+        .with_column("write_frontier", ScalarType::MzTimestamp.nullable(true)),
     is_retained_metrics_object: false,
     sensitivity: DataSensitivity::Public,
 });
 
+/// DEPRECATED and scheduled for removal! Use `mz_frontiers` instead.
 pub const MZ_GLOBAL_FRONTIERS: BuiltinView = BuiltinView {
     name: "mz_global_frontiers",
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_global_frontiers AS
-WITH
-  -- If a collection has reached the empty frontier on one of its replicas,
-  -- the entry for that replica is removed from `mz_frontiers`. In this case,
-  -- it should also be removed from `mz_global_frontiers`, to signal that the
-  -- global frontier is empty as well. The achieve that, we join the replica
-  -- lists from `mz_frontiers` with those in `mz_cluster_replicas`. If a
-  -- replica is missing from `mz_frontiers`, it won't have a match in this
-  -- join and will be omitted from the final output.
-  replica_lists AS (
-    SELECT list_agg(id) AS replicas
-    FROM mz_cluster_replicas
-    GROUP BY cluster_id
-    -- Add a `{NULL}` list to accommodate collections that are not installed
-    -- on a replica.
-    UNION VALUES (LIST[NULL])
-  ),
-  frontiers_with_replicas AS (
-    SELECT
-      object_id,
-      list_agg(replica_id) AS replicas,
-      max(time) AS time
-    FROM mz_internal.mz_frontiers
-    GROUP BY object_id
-  )
-SELECT object_id, time
-FROM frontiers_with_replicas
-JOIN replica_lists USING (replicas)",
+SELECT object_id, write_frontier AS time
+FROM mz_internal.mz_frontiers
+WHERE write_frontier IS NOT NULL",
     sensitivity: DataSensitivity::Public,
 };
 
@@ -5694,6 +5683,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Source(&MZ_COMPUTE_DEPENDENCIES),
         Builtin::View(&MZ_COMPUTE_ERROR_COUNTS_PER_WORKER),
         Builtin::View(&MZ_COMPUTE_ERROR_COUNTS),
+        Builtin::Source(&MZ_CLUSTER_REPLICA_FRONTIERS),
         Builtin::Source(&MZ_CLUSTER_REPLICA_HEARTBEATS),
         Builtin::Index(&MZ_SHOW_DATABASES_IND),
         Builtin::Index(&MZ_SHOW_SCHEMAS_IND),

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -248,6 +248,18 @@ impl<T> ComputeController<T>
 where
     T: Clone,
 {
+    /// Returns the read and write frontiers for each collection.
+    pub fn collection_frontiers(&self) -> BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)> {
+        let collections = self.instances.values().flat_map(|i| i.collections_iter());
+        collections
+            .map(|(id, collection)| {
+                let since = collection.read_frontier().to_owned();
+                let upper = collection.write_frontier().to_owned();
+                (*id, (since, upper))
+            })
+            .collect()
+    }
+
     /// Returns the write frontier for each collection installed on each replica.
     pub fn replica_write_frontiers(&self) -> BTreeMap<(GlobalId, ReplicaId), Antichain<T>> {
         let mut result = BTreeMap::new();

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -326,8 +326,13 @@ where
     }
 
     async fn record_frontiers(&mut self) {
-        let compute_frontiers = self.compute.replica_write_frontiers();
+        let compute_frontiers = self.compute.collection_frontiers();
         self.storage.record_frontiers(compute_frontiers).await;
+
+        let compute_replica_frontiers = self.compute.replica_write_frontiers();
+        self.storage
+            .record_replica_frontiers(compute_replica_frontiers)
+            .await;
     }
 
     /// Produces a timestamp that reflects all data available in

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -333,9 +333,13 @@ pub struct Controller<T: Timestamp + Lattice + Codec64 + From<EpochMillis> + Tim
     /// Note: This is used for finalizing shards of webhook sources, once webhook sources are
     /// installed on a `clusterd` this can likely be refactored away.
     internal_response_sender: tokio::sync::mpsc::UnboundedSender<StorageResponse<T>>,
-    /// Frontiers that have been recorded in the `Frontiers` collection, kept to be able to retract
-    /// old rows.
-    recorded_frontiers: BTreeMap<(GlobalId, Option<ReplicaId>), Antichain<T>>,
+
+    /// `(read, write)` frontiers that have been recorded in the `Frontiers` collection, kept to be
+    /// able to retract old rows.
+    recorded_frontiers: BTreeMap<GlobalId, (Antichain<T>, Antichain<T>)>,
+    /// Write frontiers that have been recorded in the `ReplicaFrontiers` collection, kept to be
+    /// able to retract old rows.
+    recorded_replica_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<T>>,
 }
 
 #[async_trait(?Send)]
@@ -782,7 +786,7 @@ where
                         IntrospectionType::ShardMapping => {
                             self.initialize_shard_mapping().await;
                         }
-                        IntrospectionType::Frontiers => {
+                        IntrospectionType::Frontiers | IntrospectionType::ReplicaFrontiers => {
                             // Set the collection to empty.
                             self.reconcile_managed_collection(id, vec![]).await;
                         }
@@ -1654,68 +1658,58 @@ where
 
     async fn record_frontiers(
         &mut self,
-        external_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<Self::Timestamp>>,
+        external_frontiers: BTreeMap<
+            GlobalId,
+            (Antichain<Self::Timestamp>, Antichain<Self::Timestamp>),
+        >,
     ) {
-        // Make `replica_id` optional, to account for storage objects that are not installed on
-        // replicas.
-        let mut frontiers = BTreeMap::new();
-        let mut external_ids = HashSet::with_capacity(frontiers.len());
-        for ((object_id, replica_id), frontier) in external_frontiers {
-            frontiers.insert((object_id, Some(replica_id)), frontier);
-            external_ids.insert(object_id);
-        }
+        let mut frontiers = external_frontiers;
 
         // Enrich `frontiers` with storage frontiers.
-        // Make sure to not add frontiers for objects already present in `frontiers`
         for (object_id, collection) in self.active_collections() {
-            if !external_ids.contains(&object_id) {
-                let replica_id = collection
-                    .cluster_id()
-                    .and_then(|c| self.replicas.get(&c))
-                    .copied();
-                let frontier = collection.write_frontier.clone();
-                frontiers.insert((object_id, replica_id), frontier);
-            }
+            let since = collection.read_capabilities.frontier().to_owned();
+            let upper = collection.write_frontier.clone();
+            frontiers.insert(object_id, (since, upper));
         }
-        for (object_id, export) in &self.exports {
-            if !external_ids.contains(object_id) {
-                let cluster_id = export.cluster_id();
-                let replica_id = self.replicas.get(&cluster_id).copied();
-                let frontier = export.write_frontier.clone();
-                frontiers.insert((*object_id, replica_id), frontier);
-            }
+        for (object_id, export) in self.active_exports() {
+            // Exports cannot be read from, so their `since` is always the empty frontier.
+            let since = Antichain::new();
+            let upper = export.write_frontier.clone();
+            frontiers.insert(object_id, (since, upper));
         }
 
         let mut updates = Vec::new();
-        let mut push_update = |(object_id, replica_id): (GlobalId, Option<ReplicaId>),
-                               frontier: Antichain<Self::Timestamp>,
-                               diff: Diff| {
-            let time_datum = match frontier.into_option() {
-                Some(ts) => Datum::MzTimestamp(ts.into()),
-                None => return, // don't record empty frontiers
+        let mut push_update =
+            |object_id: GlobalId,
+             (since, upper): (Antichain<Self::Timestamp>, Antichain<Self::Timestamp>),
+             diff: Diff| {
+                let read_frontier = since
+                    .into_option()
+                    .map_or(Datum::Null, |ts| Datum::MzTimestamp(ts.into()));
+                let write_frontier = upper
+                    .into_option()
+                    .map_or(Datum::Null, |ts| Datum::MzTimestamp(ts.into()));
+                let row = Row::pack_slice(&[
+                    Datum::String(&object_id.to_string()),
+                    read_frontier,
+                    write_frontier,
+                ]);
+                updates.push((row, diff));
             };
-            let object_id = object_id.to_string();
-            let object_datum = Datum::String(&object_id);
-            let replica_id = replica_id.map(|id| id.to_string());
-            let replica_datum = replica_id.as_deref().map_or(Datum::Null, Datum::String);
-
-            let row = Row::pack_slice(&[object_datum, replica_datum, time_datum]);
-            updates.push((row, diff));
-        };
 
         let mut old_frontiers = std::mem::replace(&mut self.recorded_frontiers, frontiers);
-        for (&key, new_frontier) in &self.recorded_frontiers {
-            match old_frontiers.remove(&key) {
-                Some(old_frontier) if &old_frontier != new_frontier => {
-                    push_update(key, new_frontier.clone(), 1);
-                    push_update(key, old_frontier, -1);
+        for (&id, new) in &self.recorded_frontiers {
+            match old_frontiers.remove(&id) {
+                Some(old) if &old != new => {
+                    push_update(id, new.clone(), 1);
+                    push_update(id, old, -1);
                 }
                 Some(_) => (),
-                None => push_update(key, new_frontier.clone(), 1),
+                None => push_update(id, new.clone(), 1),
             }
         }
-        for (key, old_frontier) in old_frontiers {
-            push_update(key, old_frontier, -1);
+        for (id, old) in old_frontiers {
+            push_update(id, old, -1);
         }
 
         self.append_to_managed_collection(
@@ -1724,6 +1718,70 @@ where
         )
         .await;
     }
+
+    async fn record_replica_frontiers(
+        &mut self,
+        external_frontiers: BTreeMap<(GlobalId, ReplicaId), Antichain<Self::Timestamp>>,
+    ) {
+        let mut frontiers = external_frontiers;
+
+        // Enrich `frontiers` with storage frontiers.
+        for (object_id, collection) in self.active_collections() {
+            let replica_id = collection
+                .cluster_id()
+                .and_then(|c| self.replicas.get(&c))
+                .copied();
+            if let Some(replica_id) = replica_id {
+                let upper = collection.write_frontier.clone();
+                frontiers.insert((object_id, replica_id), upper);
+            }
+        }
+        for (object_id, export) in self.active_exports() {
+            let cluster_id = export.cluster_id();
+            let replica_id = self.replicas.get(&cluster_id).copied();
+            if let Some(replica_id) = replica_id {
+                let upper = export.write_frontier.clone();
+                frontiers.insert((object_id, replica_id), upper);
+            }
+        }
+
+        let mut updates = Vec::new();
+        let mut push_update = |(object_id, replica_id): (GlobalId, ReplicaId),
+                               upper: Antichain<Self::Timestamp>,
+                               diff: Diff| {
+            let write_frontier = upper
+                .into_option()
+                .map_or(Datum::Null, |ts| Datum::MzTimestamp(ts.into()));
+            let row = Row::pack_slice(&[
+                Datum::String(&object_id.to_string()),
+                Datum::String(&replica_id.to_string()),
+                write_frontier,
+            ]);
+            updates.push((row, diff));
+        };
+
+        let mut old_frontiers = std::mem::replace(&mut self.recorded_replica_frontiers, frontiers);
+        for (&key, new) in &self.recorded_replica_frontiers {
+            match old_frontiers.remove(&key) {
+                Some(old) if &old != new => {
+                    push_update(key, new.clone(), 1);
+                    push_update(key, old, -1);
+                }
+                Some(_) => (),
+                None => push_update(key, new.clone(), 1),
+            }
+        }
+        for (key, old) in old_frontiers {
+            push_update(key, old, -1);
+        }
+
+        self.append_to_managed_collection(
+            self.introspection_ids[&IntrospectionType::ReplicaFrontiers],
+            updates,
+        )
+        .await;
+    }
+
     async fn record_introspection_updates(
         &mut self,
         type_: IntrospectionType,
@@ -1889,6 +1947,7 @@ where
             persist: persist_clients,
             metrics: StorageControllerMetrics::new(metrics_registry),
             recorded_frontiers: BTreeMap::new(),
+            recorded_replica_frontiers: BTreeMap::new(),
         }
     }
 
@@ -1917,6 +1976,14 @@ where
             .iter()
             .filter(|(_id, c)| !c.is_dropped())
             .map(|(id, c)| (*id, c))
+    }
+
+    /// Iterate over exports that have not been dropped.
+    fn active_exports(&self) -> impl Iterator<Item = (GlobalId, &ExportState<T>)> {
+        self.exports
+            .iter()
+            .filter(|(_id, e)| !e.is_dropped())
+            .map(|(id, e)| (*id, e))
     }
 
     /// Return the since frontier at which we can read from all the given

--- a/test/cluster/pg-snapshot-partial-failure/03-verify-good-sub-source.td
+++ b/test/cluster/pg-snapshot-partial-failure/03-verify-good-sub-source.td
@@ -21,5 +21,5 @@
 # snapshot.
 $ sleep-is-probably-flaky-i-have-justified-my-need-with-a-comment duration=5s
 
-> SELECT time FROM mz_internal.mz_frontiers f JOIN mz_objects o ON f.object_id = o.id WHERE o.name = 'two';
+> SELECT write_frontier FROM mz_internal.mz_frontiers f JOIN mz_objects o ON f.object_id = o.id WHERE o.name = 'two';
 0

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -30,6 +30,13 @@ statement ok
 CREATE INDEX objects_idx ON objects(schema, object)
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_frontiers' ORDER BY position
+----
+1  object_id  text
+2  replica_id  text
+3  write_frontier  mz_timestamp
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_cluster_replica_metrics' ORDER BY position
 ----
 1  replica_id  text
@@ -113,14 +120,8 @@ query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_frontiers' ORDER BY position
 ----
 1  object_id  text
-2  replica_id  text
-3  time  mz_timestamp
-
-query ITT
-SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_global_frontiers' ORDER BY position
-----
-1  object_id  text
-2  time  mz_timestamp
+2  read_frontier  mz_timestamp
+3  write_frontier  mz_timestamp
 
 query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_kafka_sources' ORDER BY position
@@ -602,6 +603,7 @@ mz_arrangement_sharing_raw
 mz_arrangement_sizes
 mz_arrangement_sizes_per_worker
 mz_cluster_links
+mz_cluster_replica_frontiers
 mz_cluster_replica_heartbeats
 mz_cluster_replica_history
 mz_cluster_replica_metrics

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -289,6 +289,10 @@ mz_cluster_links
 BASE TABLE
 materialize
 mz_internal
+mz_cluster_replica_frontiers
+SOURCE
+materialize
+mz_internal
 mz_cluster_replica_heartbeats
 SOURCE
 materialize

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -544,7 +544,7 @@ select
            as int2))) # (case when ((cast(null as oid)) < (cast(null as oid)))
           or (((subq_0."c2" is not NULL)
               and ((numrange(0,0)) <= (numrange(0,0))))
-            and ((((select "time" from mz_internal.mz_global_frontiers limit 1 offset 1)
+            and ((((select "write_frontier" from mz_internal.mz_frontiers limit 1 offset 1)
                   ) <> ((select pg_catalog.max("time") from mz_internal.mz_compute_import_frontiers_per_worker)
                   ))
               or (false))) then pg_catalog.abs(

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -522,6 +522,7 @@ mz_arrangement_sharing_raw                   log   <null>   <null>
 mz_arrangement_heap_size_raw                 log   <null>   <null>
 mz_arrangement_heap_capacity_raw             log   <null>   <null>
 mz_arrangement_heap_allocations_raw          log   <null>   <null>
+mz_cluster_replica_frontiers                 source <null>  <null>
 mz_cluster_replica_heartbeats                source <null>  <null>
 mz_compute_delays_histogram_raw              log   <null>   <null>
 mz_compute_dependencies                      source <null>  <null>

--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 
 # Test reporting of controller frontiers through `mz_internal.mz_frontiers` and
-# `mz_internal.mz_global_frontiers`.
+# `mz_internal.mz_cluster_replica_frontiers`.
 #
 # These tests rely on testdrive's retry feature, as they query introspection
 # sources whose data might not be immediately available.
@@ -36,25 +36,26 @@
 > SELECT
     mvs.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_materialized_views mvs
     ON frontiers.object_id = mvs.id
   LEFT JOIN mz_cluster_replicas replicas
     ON frontiers.replica_id = replicas.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.write_frontier > 0
 mv1 r1
 mv1 r2
 
 > SELECT
     mvs.name
-  FROM mz_internal.mz_global_frontiers frontiers
+  FROM mz_internal.mz_frontiers frontiers
   JOIN mz_materialized_views mvs
     ON frontiers.object_id = mvs.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
 mv1
 
 
@@ -65,25 +66,26 @@ mv1
 > SELECT
     indexes.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   LEFT JOIN mz_cluster_replicas replicas
     ON frontiers.replica_id = replicas.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.write_frontier > 0
 idx1 r1
 idx1 r2
 
 > SELECT
     indexes.name
-  FROM mz_internal.mz_global_frontiers frontiers
+  FROM mz_internal.mz_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
 idx1
 
 
@@ -96,25 +98,25 @@ idx1
 > SELECT
     sources.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_sources sources
     ON frontiers.object_id = sources.id
   LEFT JOIN mz_cluster_replicas replicas
     ON frontiers.replica_id = replicas.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.write_frontier > 0
 source1 s1
-source1_progress <null>
 
 > SELECT
     sources.name
-  FROM mz_internal.mz_global_frontiers frontiers
+  FROM mz_internal.mz_frontiers frontiers
   JOIN mz_sources sources
     ON frontiers.object_id = sources.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
 source1
 source1_progress
 
@@ -137,31 +139,32 @@ source1_progress
 > SELECT
     sinks.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_sinks sinks
     ON frontiers.object_id = sinks.id
   LEFT JOIN mz_cluster_replicas replicas
     ON frontiers.replica_id = replicas.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.write_frontier > 0
 sink1 s1
 
 > SELECT
     sinks.name
-  FROM mz_internal.mz_global_frontiers frontiers
+  FROM mz_internal.mz_frontiers frontiers
   JOIN mz_sinks sinks
     ON frontiers.object_id = sinks.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.read_frontier IS NULL AND
+    frontiers.write_frontier > 0
 sink1
 
 # Test that the frontiers of introspection sources are reported.
 
 > SELECT
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   JOIN mz_clusters clusters
@@ -170,72 +173,49 @@ sink1
     ON frontiers.replica_id = replicas.id
   WHERE
     indexes.name LIKE 'mz_active_peeks_per_worker_u%_primary_idx' AND
-    frontiers.time > 0 AND
+    frontiers.write_frontier > 0 AND
     clusters.name = 'test'
 r1
 r2
 
 > SELECT
     count(*)
-  FROM mz_internal.mz_global_frontiers frontiers
+  FROM mz_internal.mz_frontiers frontiers
   JOIN mz_indexes indexes
     ON frontiers.object_id = indexes.id
   JOIN mz_clusters clusters
     ON indexes.cluster_id = clusters.id
   WHERE
     indexes.name LIKE 'mz_active_peeks_per_worker_u%_primary_idx' AND
-    frontiers.time > 0 AND
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0 AND
     clusters.name = 'test'
 1
 
 # Test that the frontiers of tables are reported.
 
 > SELECT
-    tables.name,
-    replicas.name
+    tables.name
   FROM mz_internal.mz_frontiers frontiers
   JOIN mz_tables tables
     ON frontiers.object_id = tables.id
-  LEFT JOIN mz_cluster_replicas replicas
-    ON frontiers.replica_id = replicas.id
   WHERE
     frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
-t1 <null>
-
-> SELECT
-    tables.name
-  FROM mz_internal.mz_global_frontiers frontiers
-  JOIN mz_tables tables
-    ON frontiers.object_id = tables.id
-  WHERE
-    frontiers.object_id LIKE 'u%' AND
-    frontiers.time > 0
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
 t1
 
 # Test that the frontiers of storage-managed collections are reported.
 
 > SELECT
-    sources.name,
-    replicas.name
+    sources.name
   FROM mz_internal.mz_frontiers frontiers
   JOIN mz_sources sources
     ON frontiers.object_id = sources.id
-  LEFT JOIN mz_cluster_replicas replicas
-    ON frontiers.replica_id = replicas.id
   WHERE
     sources.name = 'mz_frontiers' AND
-    frontiers.time > 0
-mz_frontiers <null>
-
-> SELECT
-    sources.name
-  FROM mz_internal.mz_global_frontiers frontiers
-  JOIN mz_sources sources
-    ON frontiers.object_id = sources.id
-  WHERE
-    sources.name = 'mz_frontiers' AND
-    frontiers.time > 0
+    frontiers.read_frontier > 0 AND
+    frontiers.write_frontier > 0
 mz_frontiers
 
 # Test that frontiers are added when replicas are created.
@@ -243,7 +223,7 @@ mz_frontiers
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -252,7 +232,7 @@ mz_frontiers
     ON replicas.cluster_id = clusters.id
   WHERE
     objects.id LIKE 'u%' AND
-    frontiers.time > 0 AND
+    frontiers.write_frontier > 0 AND
     clusters.name = 'test'
 idx1 r1
 idx1 r2
@@ -264,7 +244,7 @@ mv1  r2
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -273,7 +253,7 @@ mv1  r2
     ON replicas.cluster_id = clusters.id
   WHERE
     objects.id LIKE 'u%' AND
-    frontiers.time > 0 AND
+    frontiers.write_frontier > 0 AND
     clusters.name = 'test'
 idx1 r1
 idx1 r2
@@ -289,7 +269,7 @@ mv1  r3
 > SELECT
     objects.name,
     replicas.name
-  FROM mz_internal.mz_frontiers frontiers
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
   JOIN mz_objects objects
     ON frontiers.object_id = objects.id
   JOIN mz_cluster_replicas replicas
@@ -298,38 +278,55 @@ mv1  r3
     ON replicas.cluster_id = clusters.id
   WHERE
     objects.id LIKE 'u%' AND
-    frontiers.time > 0 AND
+    frontiers.write_frontier > 0 AND
     clusters.name = 'test'
 idx1 r2
 idx1 r3
 mv1  r2
 mv1  r3
 
-# Test that collections with empty frontiers are omitted.
+# Test that empty frontiers show up as NULL.
 
 > CREATE MATERIALIZED VIEW mv2 AS SELECT 1
 
 > SELECT
-    count(*)
+    replicas.name,
+    frontiers.write_frontier
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  JOIN mz_materialized_views mvs
+    ON frontiers.object_id = mvs.id
+  JOIN mz_cluster_replicas replicas
+    ON frontiers.replica_id = replicas.id
+  WHERE
+    mvs.name = 'mv2'
+r2 <null>
+r3 <null>
+
+> SELECT
+    frontiers.read_frontier,
+    frontiers.write_frontier
   FROM mz_internal.mz_frontiers frontiers
   JOIN mz_materialized_views mvs
     ON frontiers.object_id = mvs.id
   WHERE
     mvs.name = 'mv2'
-0
+0 <null>
 
 # Test that frontiers are removed when objects are dropped.
 
 > DROP MATERIALIZED VIEW mv1
+> DROP MATERIALIZED VIEW mv2
 > DROP INDEX idx1
 > DROP SOURCE source1
 > DROP SINK sink1
 > DROP TABLE t1
 
 > SELECT *
+  FROM mz_internal.mz_cluster_replica_frontiers frontiers
+  WHERE object_id LIKE 'u%'
+
+> SELECT *
   FROM mz_internal.mz_frontiers frontiers
-  JOIN mz_objects objects
-    ON frontiers.object_id = objects.id
   WHERE object_id LIKE 'u%'
 
 > DROP CLUSTER test CASCADE


### PR DESCRIPTION
This PR changes the way how the controller exposes collection frontiers in the catalog. Previously, this was done through two relatons:

 * `mz_frontiers`: a source that exposes per-replica frontiers
 * `mz_global_frontiers`: a view over `mz_frontiers` that provides the global frontier for each collection by `max` aggregation

There are multiple issues with that approach:

 * `mz_frontiers` has needs special semantics for collections that are not installed on replicas. For these collections, only a single row with a `replica_id` value of NULL is included.
 * `mz_global_frontiers` has a bug: #22561.
 * Both relations only include write frontiers, not read frontiers.

The new approach implemented by this PR attempts to solve all of these issues. Frontiers are still exposed through two relations, but now both of these are sources:

 * `mz_frontiers` exposes global read and write frontiers for all active collections
 * `mz_cluster_replica_frontiers` exposes per-replica write frontiers

`mz_frontiers` looks the same as the old `mz_global_frontiers` relation, just without the above mentioned bug and an additional column for the read frontier. It also gets the prominent name, under the assumption that this relation will be more generally useful, and therefore more frequently used, than `mz_cluster_replica_frontiers`.

`mz_cluster_replica_frontiers` looks mostly like the old `mz_frontiers` relation but doesn't need the special casing for collections that are not associated to replicas anymore, since it omits these.

### Blockers

Users of `mz_frontiers` need to be updated to use the new schema/relations:

* [ ] promsql exporter 

### Motivation

  * This PR fixes a recognized bug.

Fixes #22561 

  * This PR adds a known-desirable feature.

Closes #22100

### Tips for reviewer

Happy to discuss alternatives to solving the issues mentioned above! Ideally we don't have to change these relations every couple months because our design is more robust this time :)

I left in `mz_global_frontiers` as a view on `mz_frontiers`, to simplify the migration of components that use the former (AFAIK that's only the console). Once all users have been migrated, we can remove it.

Note how this PR changes the way empty frontiers are represented. Previously, collections with empty frontiers would be omitted from the frontier relations. Now they are included with a frontier value of `NULL`. This is required for `mz_frontiers`, because a collection might have an empty `upper` but a non-empty `since`, so omitting collections that have an empty frontier might hide useful information. For `mz_cluster_replica_frontiers` the same reasoning doesn't apply but we still represent empty frontiers as `NULL` for consistency.

Handling of (storage) sinks is a bit weird. Those don't have a `since` so we always set the value to `NULL` in `mz_frontiers`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Change the semantics and schema of the `mz_internal.mz_frontiers` relation and add the `mz_internal.mz_cluster_replica_frontiers` relation.