### PR TITLE
Fix Get annotation when it access a GlobalId but inside the same dataflow

### DIFF
--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -425,6 +425,14 @@ impl MirRelationExpr {
                             AccessStrategy::Persist => {
                                 write!(f, "{}ReadStorage {}", ctx.indent, humanize(id))?;
                             }
+                            AccessStrategy::SameDataflow => {
+                                write!(
+                                    f,
+                                    "{}ReadGlobalFromSameDataflow {}",
+                                    ctx.indent,
+                                    humanize(id)
+                                )?;
+                            }
                             AccessStrategy::Index(index_accesses) => {
                                 let mut grouped_index_accesses = BTreeMap::new();
                                 for (idx_id, usage_type) in index_accesses {

--- a/src/expr/src/relation/mod.rs
+++ b/src/expr/src/relation/mod.rs
@@ -104,9 +104,10 @@ pub enum MirRelationExpr {
         /// Schema of the collection.
         typ: RelationType,
         /// If this is a global Get, this will indicate whether we are going to read from Persist or
-        /// from an index. If it's an index, then how downstream dataflow operations will use this
-        /// index is also recorded. This is filled by `prune_and_annotate_dataflow_index_imports`.
-        /// Note that this is not used by the lowering to LIR, but is used only by EXPLAIN.
+        /// from an index, or from a different object in `objects_to_build`. If it's an index, then
+        /// how downstream dataflow operations will use this index is also recorded. This is filled
+        /// by `prune_and_annotate_dataflow_index_imports`. Note that this is not used by the
+        /// lowering to LIR, but is used only by EXPLAIN.
         #[mzreflect(ignore)]
         access_strategy: AccessStrategy,
     },
@@ -3405,6 +3406,9 @@ pub enum AccessStrategy {
     Persist,
     /// The Get will read from an index or indexes: (index id, how the index will be used).
     Index(Vec<(GlobalId, IndexUsageType)>),
+    /// The Get will read a collection that is computed by the same dataflow, but in a different
+    /// `BuildDesc` in `objects_to_build`.
+    SameDataflow,
 }
 
 #[cfg(test)]

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -714,7 +714,7 @@ id: {}, key: {:?}",
         .retain(|id, _index_import| dataflow_metainfo.index_usage_types.contains_key(id));
 
     // A sanity check that all Get annotations indicate indexes that are present in `index_imports`.
-    for build_desc in dataflow.objects_to_build.iter_mut() {
+    for build_desc in dataflow.objects_to_build.iter() {
         build_desc
             .plan
             .as_inner()
@@ -722,17 +722,14 @@ id: {}, key: {:?}",
                 MirRelationExpr::Get {
                     id: Id::Global(_),
                     typ: _,
-                    access_strategy,
-                } => match access_strategy {
-                    AccessStrategy::Index(accesses) => {
-                        for (idx_id, _) in accesses {
-                            soft_assert!(
-                                dataflow.index_imports.contains_key(idx_id),
-                                "Dangling Get index annotation"
-                            );
-                        }
+                    access_strategy: AccessStrategy::Index(accesses),
+                } => {
+                    for (idx_id, _) in accesses {
+                        soft_assert!(
+                            dataflow.index_imports.contains_key(idx_id),
+                            "Dangling Get index annotation"
+                        );
                     }
-                    _ => {}
                 },
                 _ => {}
             })?;

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -17,7 +17,7 @@
 use std::collections::{BTreeMap, BTreeSet};
 
 use itertools::Itertools;
-use mz_compute_types::dataflows::{DataflowDesc, IndexImport};
+use mz_compute_types::dataflows::{BuildDesc, DataflowDesc, IndexImport};
 use mz_expr::visit::Visit;
 use mz_expr::{
     AccessStrategy, CollectionPlan, Id, JoinImplementation, LocalId, MapFilterProject,
@@ -480,6 +480,7 @@ fn prune_and_annotate_dataflow_index_imports(
     indexes: &dyn IndexOracle,
     dataflow_metainfo: &mut DataflowMetainfo,
 ) -> Result<(), TransformError> {
+    // Preparation.
     // Let's save the unique keys of the sources. This will inform which indexes to choose for full
     // scans. (We can't get this info from `source_imports`, because `source_imports` only has those
     // sources that are not getting an indexed read.)
@@ -657,6 +658,10 @@ id: {}, key: {:?}",
                                     // We already know that it's an indexed access.
                                     unreachable!()
                                 }
+                                AccessStrategy::SameDataflow => {
+                                    // We have not added such annotations yet.
+                                    unreachable!()
+                                }
                                 AccessStrategy::Index(accesses) => {
                                     for (idx_id, usage_type) in accesses {
                                         if matches!(usage_type, IndexUsageType::FullScan) {
@@ -713,6 +718,33 @@ id: {}, key: {:?}",
         .index_imports
         .retain(|id, _index_import| dataflow_metainfo.index_usage_types.contains_key(id));
 
+    // Determine AccessStrategy::SameDataflow accesses. These were classified as
+    // AccessStrategy::Persist inside collect_index_reqs, so now we check these, and if the id is of
+    // a collection that we are building ourselves, then we adjust the access strategy.
+    let mut objects_to_build_ids = BTreeSet::new();
+    for BuildDesc { id, plan: _ } in dataflow.objects_to_build.iter() {
+        objects_to_build_ids.insert(id.clone());
+    }
+    for build_desc in dataflow.objects_to_build.iter_mut() {
+        build_desc.plan.as_inner_mut().visit_mut_post(
+            &mut |expr: &mut MirRelationExpr| match expr {
+                MirRelationExpr::Get {
+                    id: Id::Global(global_id),
+                    typ: _,
+                    access_strategy,
+                } => match access_strategy {
+                    AccessStrategy::Persist => {
+                        if objects_to_build_ids.contains(global_id) {
+                            *access_strategy = AccessStrategy::SameDataflow;
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {}
+            },
+        )?;
+    }
+
     // A sanity check that all Get annotations indicate indexes that are present in `index_imports`.
     for build_desc in dataflow.objects_to_build.iter() {
         build_desc
@@ -730,7 +762,7 @@ id: {}, key: {:?}",
                             "Dangling Get index annotation"
                         );
                     }
-                },
+                }
                 _ => {}
             })?;
     }

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -454,7 +454,7 @@ INDEX iv_a_idx;
 ----
 materialize.public.iv_a_idx:
   ArrangeBy keys=[[#0]]
-    ReadStorage materialize.public.iv
+    ReadGlobalFromSameDataflow materialize.public.iv
 
 materialize.public.iv:
   Filter (#0) IS NOT NULL

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -195,7 +195,7 @@ CREATE DEFAULT INDEX ON Q01;
 ----
 materialize.public.q01_primary_idx:
   ArrangeBy keys=[[l_returnflag, l_linestatus]] // { arity: 10 }
-    ReadStorage materialize.public.q01 // { arity: 10 }
+    ReadGlobalFromSameDataflow materialize.public.q01 // { arity: 10 }
 
 materialize.public.q01:
   Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
@@ -257,7 +257,7 @@ CREATE DEFAULT INDEX ON Q02;
 ----
 materialize.public.q02_primary_idx:
   ArrangeBy keys=[[s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment]] // { arity: 8 }
-    ReadStorage materialize.public.q02 // { arity: 8 }
+    ReadGlobalFromSameDataflow materialize.public.q02 // { arity: 8 }
 
 materialize.public.q02:
   Return // { arity: 8 }
@@ -363,7 +363,7 @@ CREATE DEFAULT INDEX ON Q03;
 ----
 materialize.public.q03_primary_idx:
   ArrangeBy keys=[[l_orderkey, o_orderdate, o_shippriority]] // { arity: 4 }
-    ReadStorage materialize.public.q03 // { arity: 4 }
+    ReadGlobalFromSameDataflow materialize.public.q03 // { arity: 4 }
 
 materialize.public.q03:
   Project (#0, #3, #1, #2) // { arity: 4 }
@@ -424,7 +424,7 @@ CREATE DEFAULT INDEX ON Q04;
 ----
 materialize.public.q04_primary_idx:
   ArrangeBy keys=[[o_orderpriority]] // { arity: 2 }
-    ReadStorage materialize.public.q04 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q04 // { arity: 2 }
 
 materialize.public.q04:
   Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
@@ -491,7 +491,7 @@ CREATE DEFAULT INDEX ON Q05;
 ----
 materialize.public.q05_primary_idx:
   ArrangeBy keys=[[n_name]] // { arity: 2 }
-    ReadStorage materialize.public.q05 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q05 // { arity: 2 }
 
 materialize.public.q05:
   Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
@@ -547,7 +547,7 @@ CREATE DEFAULT INDEX ON Q06;
 ----
 materialize.public.q06_primary_idx:
   ArrangeBy keys=[[revenue]] // { arity: 1 }
-    ReadStorage materialize.public.q06 // { arity: 1 }
+    ReadGlobalFromSameDataflow materialize.public.q06 // { arity: 1 }
 
 materialize.public.q06:
   Return // { arity: 1 }
@@ -624,7 +624,7 @@ CREATE DEFAULT INDEX ON Q07;
 ----
 materialize.public.q07_primary_idx:
   ArrangeBy keys=[[supp_nation, cust_nation, l_year]] // { arity: 4 }
-    ReadStorage materialize.public.q07 // { arity: 4 }
+    ReadGlobalFromSameDataflow materialize.public.q07 // { arity: 4 }
 
 materialize.public.q07:
   Return // { arity: 4 }
@@ -718,7 +718,7 @@ CREATE DEFAULT INDEX ON Q08;
 ----
 materialize.public.q08_primary_idx:
   ArrangeBy keys=[[o_year]] // { arity: 2 }
-    ReadStorage materialize.public.q08 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q08 // { arity: 2 }
 
 materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
@@ -815,7 +815,7 @@ CREATE DEFAULT INDEX ON Q09;
 ----
 materialize.public.q09_primary_idx:
   ArrangeBy keys=[[nation, o_year]] // { arity: 3 }
-    ReadStorage materialize.public.q09 // { arity: 3 }
+    ReadGlobalFromSameDataflow materialize.public.q09 // { arity: 3 }
 
 materialize.public.q09:
   Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
@@ -901,7 +901,7 @@ CREATE DEFAULT INDEX ON Q10;
 ----
 materialize.public.q10_primary_idx:
   ArrangeBy keys=[[c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, c_comment]] // { arity: 8 }
-    ReadStorage materialize.public.q10 // { arity: 8 }
+    ReadGlobalFromSameDataflow materialize.public.q10 // { arity: 8 }
 
 materialize.public.q10:
   Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
@@ -973,7 +973,7 @@ CREATE DEFAULT INDEX ON Q11;
 ----
 materialize.public.q11_primary_idx:
   ArrangeBy keys=[[ps_partkey]] // { arity: 2 }
-    ReadStorage materialize.public.q11 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q11 // { arity: 2 }
 
 materialize.public.q11:
   Return // { arity: 2 }
@@ -1054,7 +1054,7 @@ CREATE DEFAULT INDEX ON Q12;
 ----
 materialize.public.q12_primary_idx:
   ArrangeBy keys=[[l_shipmode]] // { arity: 3 }
-    ReadStorage materialize.public.q12 // { arity: 3 }
+    ReadGlobalFromSameDataflow materialize.public.q12 // { arity: 3 }
 
 materialize.public.q12:
   Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
@@ -1107,7 +1107,7 @@ CREATE DEFAULT INDEX ON Q13;
 ----
 materialize.public.q13_primary_idx:
   ArrangeBy keys=[[c_count]] // { arity: 2 }
-    ReadStorage materialize.public.q13 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q13 // { arity: 2 }
 
 materialize.public.q13:
   Return // { arity: 2 }
@@ -1176,7 +1176,7 @@ CREATE DEFAULT INDEX ON Q14;
 ----
 materialize.public.q14_primary_idx:
   ArrangeBy keys=[[promo_revenue]] // { arity: 1 }
-    ReadStorage materialize.public.q14 // { arity: 1 }
+    ReadGlobalFromSameDataflow materialize.public.q14 // { arity: 1 }
 
 materialize.public.q14:
   Return // { arity: 1 }
@@ -1255,7 +1255,7 @@ CREATE DEFAULT INDEX ON Q15;
 ----
 materialize.public.q15_primary_idx:
   ArrangeBy keys=[[s_suppkey, s_name, s_address, s_phone, total_revenue]] // { arity: 5 }
-    ReadStorage materialize.public.q15 // { arity: 5 }
+    ReadGlobalFromSameDataflow materialize.public.q15 // { arity: 5 }
 
 materialize.public.q15:
   Return // { arity: 5 }
@@ -1328,7 +1328,7 @@ CREATE DEFAULT INDEX ON Q16;
 ----
 materialize.public.q16_primary_idx:
   ArrangeBy keys=[[p_brand, p_type, p_size]] // { arity: 4 }
-    ReadStorage materialize.public.q16 // { arity: 4 }
+    ReadGlobalFromSameDataflow materialize.public.q16 // { arity: 4 }
 
 materialize.public.q16:
   Return // { arity: 4 }
@@ -1408,7 +1408,7 @@ CREATE DEFAULT INDEX ON Q17;
 ----
 materialize.public.q17_primary_idx:
   ArrangeBy keys=[[avg_yearly]] // { arity: 1 }
-    ReadStorage materialize.public.q17 // { arity: 1 }
+    ReadGlobalFromSameDataflow materialize.public.q17 // { arity: 1 }
 
 materialize.public.q17:
   Return // { arity: 1 }
@@ -1508,7 +1508,7 @@ CREATE DEFAULT INDEX ON Q18;
 ----
 materialize.public.q18_primary_idx:
   ArrangeBy keys=[[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice]] // { arity: 6 }
-    ReadStorage materialize.public.q18 // { arity: 6 }
+    ReadGlobalFromSameDataflow materialize.public.q18 // { arity: 6 }
 
 materialize.public.q18:
   Return // { arity: 6 }
@@ -1605,7 +1605,7 @@ CREATE DEFAULT INDEX ON Q19;
 ----
 materialize.public.q19_primary_idx:
   ArrangeBy keys=[[revenue]] // { arity: 1 }
-    ReadStorage materialize.public.q19 // { arity: 1 }
+    ReadGlobalFromSameDataflow materialize.public.q19 // { arity: 1 }
 
 materialize.public.q19:
   Return // { arity: 1 }
@@ -1688,7 +1688,7 @@ CREATE DEFAULT INDEX ON Q20;
 ----
 materialize.public.q20_primary_idx:
   ArrangeBy keys=[[s_name, s_address]] // { arity: 2 }
-    ReadStorage materialize.public.q20 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q20 // { arity: 2 }
 
 materialize.public.q20:
   Return // { arity: 2 }
@@ -1813,7 +1813,7 @@ CREATE DEFAULT INDEX ON Q21;
 ----
 materialize.public.q21_primary_idx:
   ArrangeBy keys=[[s_name]] // { arity: 2 }
-    ReadStorage materialize.public.q21 // { arity: 2 }
+    ReadGlobalFromSameDataflow materialize.public.q21 // { arity: 2 }
 
 materialize.public.q21:
   Return // { arity: 2 }
@@ -1952,7 +1952,7 @@ CREATE DEFAULT INDEX ON Q22;
 ----
 materialize.public.q22_primary_idx:
   ArrangeBy keys=[[cntrycode]] // { arity: 3 }
-    ReadStorage materialize.public.q22 // { arity: 3 }
+    ReadGlobalFromSameDataflow materialize.public.q22 // { arity: 3 }
 
 materialize.public.q22:
   Return // { arity: 3 }


### PR DESCRIPTION
This is a straightforward fix for https://github.com/MaterializeInc/materialize/issues/22064.

The first commit is a minor refactoring, the second is the main one.

I thought a bit about how to print the new `AccessStrategy`, and decided in the end for `ReadGlobalFromSameDataflow`. I also considered `ReadMemory`, but the problem with that is that `ReadIndex` is also reading from memory.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/22064

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
