### PR TITLE
ServerVar: `default_idle_arrangment_merge_effort`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1073,14 +1073,17 @@ impl Coordinator {
         info!("coordinator init: beginning bootstrap");
 
         // Inform the controllers about their initial configuration.
-        let compute_config = flags::compute_config(self.catalog().system_config());
+        let system_config = self.catalog().system_config();
+        let compute_config = flags::compute_config(system_config);
+        let storage_config = flags::storage_config(system_config);
+        let scheduling_config = flags::orchestrator_scheduling_config(system_config);
+        let merge_effort = system_config.default_idle_arrangement_merge_effort();
         self.controller.compute.update_configuration(compute_config);
-        let storage_config = flags::storage_config(self.catalog().system_config());
         self.controller.storage.update_configuration(storage_config);
-        let orchestrator_scheduling_config =
-            flags::orchestrator_scheduling_config(self.catalog().system_config());
         self.controller
-            .update_orchestrator_scheduling_config(orchestrator_scheduling_config);
+            .update_orchestrator_scheduling_config(scheduling_config);
+        self.controller
+            .set_default_idle_arrangement_merge_effort(merge_effort);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         //

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -238,6 +238,11 @@ impl<T> Controller<T> {
     pub fn active_compute(&mut self) -> ActiveComputeController<T> {
         self.compute.activate(&mut *self.storage)
     }
+
+    pub fn set_default_idle_arrangement_merge_effort(&mut self, value: u32) {
+        self.compute
+            .set_default_idle_arrangement_merge_effort(value);
+    }
 }
 
 impl<T> Controller<T>

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1315,6 +1315,14 @@ static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
     internal: true,
 });
 
+pub const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("default_idle_arrangement_merge_effort"),
+    value: &1000,
+    description:
+        "The default value to use for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.",
+    internal: true,
+};
+
 pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_default_connection_validation"),
     value: &true,
@@ -2499,6 +2507,7 @@ impl SystemVars {
             .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&LINEAR_JOIN_YIELDING)
+            .with_var(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
             .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
             .with_var(&ENABLE_SPECIALIZED_ARRANGEMENTS)
@@ -3164,6 +3173,11 @@ impl SystemVars {
     /// Returns the `linear_join_yielding` configuration parameter.
     pub fn linear_join_yielding(&self) -> &String {
         self.expect_value(&LINEAR_JOIN_YIELDING)
+    }
+
+    /// Returns the `default_idle_arrangement_merge_effort` configuration parameter.
+    pub fn default_idle_arrangement_merge_effort(&self) -> u32 {
+        *self.expect_value(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
     }
 
     /// Returns the `enable_storage_shard_finalization` configuration parameter.


### PR DESCRIPTION
This commit adds a `ServerVar` called
`default_idle_arrangement_merge_effort` that enables changing the default value for the `IDLE ARRANGEMENT MERGE EFFORT` cluster/replica option.

A changed default applies to newly created replicas, and to all replicas after an environmend restart.

### Motivation

  * This PR adds a known-desirable feature.

Part of #22469

### Tips for reviewers

The default is kept at `1000` for now, pending more tests for the viability of switching off idle merging by default.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A