### PR TITLE
doc/user: correct release window for new aws/us-west-2 region

### DIFF
--- a/ci/deploy_website/website.sh
+++ b/ci/deploy_website/website.sh
@@ -31,6 +31,7 @@ declare -A shortlinks=(
     [non-materialized-error]="https://materialize.com/docs/lts/sql/create-view/#querying-non-materialized-views"
     [sink-key-selection]="https://materialize.com/docs/sql/create-sink/kafka/#upsert-key-selection"
     [chat]="https://join.slack.com/t/materializecommunity/shared_invite/zt-ljdufufo-PTwVPmgzlZtI7RIQLDrAiA"
+    [pricing]="https://materialize.com/pdfs/pricing.pdf"
 )
 
 cd doc/user

--- a/doc/user/content/releases/_index.md
+++ b/doc/user/content/releases/_index.md
@@ -30,7 +30,7 @@ Region        | Day of week | Time
 --------------|-------------|-----------------------------
 aws/eu-west-1 | Wednesday   | 2100-2300 [Europe/Dublin]
 aws/us-east-1 | Thursday    | 0500-0700 [America/New_York]
-aws/us-west-2 | Thursday    | 0200-0400 [America/Los_Angeles]
+aws/us-west-2 | Thursday    | 0500-0700 [America/New_York]
 
 {{< note >}}
 Upgrade windows follow any daylight saving time or summer time rules


### PR DESCRIPTION
The aws/us-west-2 region will be upgraded at 5-7am ET, not 2-4am PT. The difference is relatively pedantic, as it's somewhat inconceivable that ET and PT would have different daylight savings time rules, but nonetheless the table should exactly reflect the calendar events that we have scheduled for the maintenance windows, rather than the region's local time during the maintenance window.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
