### PR TITLE
doc/user: fix errors in CREATE ROLE docs

### DIFF
--- a/doc/user/content/sql/create-role.md
+++ b/doc/user/content/sql/create-role.md
@@ -18,7 +18,7 @@ the system.
 Field               | Use
 --------------------|-------------------------------------------------------------------------
 _role_name_         | A name for the role.
-**INHERIT**         | Grants the role the ability to inheritance of privileges of other roles.
+**INHERIT**         | Grants the role the ability to inherit privileges of other roles.
 
 ## Details
 
@@ -33,7 +33,7 @@ Unlike PostgreSQL, Materialize does not currently support `NOINHERIT`.
 You may not specify redundant or conflicting sets of options. For example,
 Materialize will reject the statement `CREATE ROLE ... INHERIT INHERIT`.
 
-Unlike PostgreSQL, Materialize does not use role attributes to determine a roles ability to create
+Unlike PostgreSQL, Materialize does not use role attributes to determine a role's ability to create
 top level objects such as databases and other roles. Instead, Materialize uses system level
 privileges. See [GRANT PRIVILEGE](../grant-privilege) for more details.
 

--- a/doc/user/layouts/partials/sql-grammar/create-role.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-role.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="533" height="69">
+<svg xmlns="http://www.w3.org/2000/svg" width="573" height="101">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="76" height="32" rx="10"/>
@@ -20,24 +20,24 @@
    <rect x="203" y="3" width="88" height="32"/>
    <rect x="201" y="1" width="88" height="32" class="nonterminal"/>
    <text class="nonterminal" x="211" y="21">role_name</text>
-   <rect x="331" y="35" width="58" height="32" rx="10"/>
-   <rect x="329"
-         y="33"
+   <rect x="351" y="67" width="58" height="32" rx="10"/>
+   <rect x="349"
+         y="65"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="339" y="53">WITH</text>
-   <rect x="429" y="3" width="76" height="32" rx="10"/>
-   <rect x="427"
-         y="1"
+   <text class="terminal" x="359" y="85">WITH</text>
+   <rect x="449" y="35" width="76" height="32" rx="10"/>
+   <rect x="447"
+         y="33"
          width="76"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="437" y="21">INHERIT</text>
+   <text class="terminal" x="457" y="53">INHERIT</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m76 0 h10 m3 0 h-3"/>
-   <polygon points="523 17 531 13 531 21"/>
-   <polygon points="523 17 515 13 515 21"/>
+         d="m17 17 h2 m0 0 h10 m76 0 h10 m0 0 h10 m56 0 h10 m0 0 h10 m88 0 h10 m20 0 h10 m0 0 h204 m-234 0 h20 m214 0 h20 m-254 0 q10 0 10 10 m234 0 q0 -10 10 -10 m-244 10 v12 m234 0 v-12 m-234 12 q0 10 10 10 m214 0 q10 0 10 -10 m-204 10 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m76 0 h10 m23 -32 h-3"/>
+   <polygon points="563 17 571 13 571 21"/>
+   <polygon points="563 17 555 13 555 21"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -116,7 +116,7 @@ create_materialized_view ::=
     ('IN CLUSTER' cluster_name)?
     'AS' select_stmt
 create_role ::=
-    'CREATE' 'ROLE' role_name 'WITH'? 'INHERIT'
+    'CREATE' 'ROLE' role_name ('WITH'? 'INHERIT')?
 create_secret ::=
     'CREATE' 'SECRET' ('IF NOT EXISTS')? name 'AS' value
 create_schema ::=


### PR DESCRIPTION
Noticed by @umanwizard. The `WITH INHERIT` clause is optional and the description of the `INHERIT` option was agrammatical.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a docs bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
