### PR TITLE
compute: mz_dataflow_delayed_time_seconds_total metric

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -376,7 +376,10 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             panic!("dataflow server has already initialized logging");
         }
 
-        let (logger, traces) = logging::initialize(self.timely_worker, config);
+        let worker_id = self.timely_worker.index();
+        let metrics = self.compute_state.metrics.for_logging(worker_id);
+
+        let (logger, traces) = logging::initialize(self.timely_worker, config, metrics);
 
         // Install traces as maintained indexes
         for (log, trace) in traces {

--- a/src/compute/src/logging/compute.rs
+++ b/src/compute/src/logging/compute.rs
@@ -23,6 +23,7 @@ use differential_dataflow::Collection;
 use mz_ore::cast::CastFrom;
 use mz_repr::{Datum, Diff, GlobalId, Timestamp};
 use mz_timely_util::replay::MzReplay;
+use prometheus::core::{AtomicF64, GenericCounter};
 use timely::communication::Allocate;
 use timely::dataflow::channels::pact::Pipeline;
 use timely::dataflow::channels::pushers::buffer::Session;
@@ -39,6 +40,7 @@ use uuid::Uuid;
 
 use crate::extensions::arrange::MzArrange;
 use crate::logging::{ComputeLog, EventQueue, LogVariant, PermutedRowPacker, SharedLoggingState};
+use crate::metrics::LoggingMetrics;
 use crate::typedefs::{KeysValsHandle, RowSpine};
 
 /// Type alias for a logger of compute events.
@@ -150,6 +152,7 @@ impl Peek {
 pub(super) fn construct<A: Allocate + 'static>(
     worker: &mut timely::worker::Worker<A>,
     config: &mz_compute_client::logging::LoggingConfig,
+    metrics: LoggingMetrics,
     event_queue: EventQueue<ComputeEvent>,
     shared_state: Rc<RefCell<SharedLoggingState>>,
 ) -> BTreeMap<LogVariant, (KeysValsHandle, Rc<dyn Any>)> {
@@ -188,7 +191,7 @@ pub(super) fn construct<A: Allocate + 'static>(
             demux.new_output();
         let (mut error_count_out, error_count) = demux.new_output();
 
-        let mut demux_state = DemuxState::new(worker2);
+        let mut demux_state = DemuxState::new(worker2, metrics);
         let mut demux_buffer = Vec::new();
         demux.build(move |_capability| {
             move |_frontiers| {
@@ -412,10 +415,12 @@ struct DemuxState<A: Allocate> {
     peek_stash: BTreeMap<Uuid, Duration>,
     /// Arrangement size stash
     arrangement_size: BTreeMap<usize, ArrangementSizeState>,
+    /// State maintained in support of the `delayed_time_seconds_total` metric.
+    delayed_time: DelayedTimeState,
 }
 
 impl<A: Allocate> DemuxState<A> {
-    fn new(worker: Worker<A>) -> Self {
+    fn new(worker: Worker<A>, metrics: LoggingMetrics) -> Self {
         Self {
             worker,
             exports: Default::default(),
@@ -424,6 +429,7 @@ impl<A: Allocate> DemuxState<A> {
             shutdown_dataflows: Default::default(),
             peek_stash: Default::default(),
             arrangement_size: Default::default(),
+            delayed_time: DelayedTimeState::new(metrics.delayed_time_seconds_total),
         }
     }
 }
@@ -439,6 +445,9 @@ struct ExportState {
     /// This must be a signed integer, since per-worker error counts can be negative, only the
     /// cross-worker total has to sum up to a non-negative value.
     error_count: i64,
+    /// Whether this export is currently delayed, i.e., it's frontier is less than the least of the
+    /// frontiers of its inputs.
+    delayed: bool,
 }
 
 impl ExportState {
@@ -447,6 +456,7 @@ impl ExportState {
             dataflow_id,
             imports: Default::default(),
             error_count: 0,
+            delayed: false,
         }
     }
 }
@@ -468,6 +478,56 @@ struct ArrangementSizeState {
     size: isize,
     capacity: isize,
     count: isize,
+}
+
+/// State maintained in support of the `delayed_time_seconds_total` metric.
+struct DelayedTimeState {
+    /// The `delayed_time_seconds_total` metric.
+    metric: GenericCounter<AtomicF64>,
+    /// The time since when at least one export has been delayed.
+    delayed_since: Option<Duration>,
+    /// The number of exports that are currently delayed.
+    delayed_count: u64,
+}
+
+impl DelayedTimeState {
+    fn new(metric: GenericCounter<AtomicF64>) -> Self {
+        Self {
+            metric,
+            delayed_since: None,
+            delayed_count: 0,
+        }
+    }
+
+    /// Updates the state in response to a delayed export.
+    fn register_delayed_export(&mut self, when: Duration) {
+        self.delayed_count += 1;
+        if self.delayed_since.is_none() {
+            self.delayed_since = Some(when);
+        }
+    }
+
+    /// Updates the state in response to a caught-up export.
+    fn register_caught_up_export(&mut self, when: Duration) {
+        if self.delayed_count > 0 {
+            self.delayed_count -= 1;
+        } else {
+            error!("caught-up export reported even though none was delayed");
+            return;
+        }
+
+        if self.delayed_count > 0 {
+            return; // some exports are still delayed
+        }
+
+        let Some(since) = self.delayed_since.take() else {
+            error!("missing `delayed_since` value");
+            return;
+        };
+
+        let duration = (when - since).as_secs_f64();
+        self.metric.inc_by(duration);
+    }
 }
 
 type Update<D> = (D, Timestamp, Diff);
@@ -652,6 +712,11 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
             };
             self.output.error_count.give((datum, ts, -1));
         }
+
+        // If the export was delayed, we need to remove it from delayed-time tracking.
+        if export.delayed {
+            self.state.delayed_time.register_caught_up_export(self.time);
+        }
     }
 
     fn handle_dataflow_dropped(&mut self, id: usize) {
@@ -787,6 +852,13 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
                         break;
                     }
                 }
+
+                // If any of the imports has no pending frontiers that means the export has caught
+                // up with its inputs.
+                if export.delayed && time_deque.is_empty() {
+                    export.delayed = false;
+                    self.state.delayed_time.register_caught_up_export(self.time);
+                }
             }
         }
     }
@@ -818,6 +890,16 @@ impl<A: Allocate> DemuxHandler<'_, '_, A> {
         if let Some(export) = self.state.exports.get_mut(&export_id) {
             let delay_state = export.imports.entry(import_id).or_default();
             delay_state.time_deque.push_back((frontier, self.time));
+
+            // If all of the imports have pending frontiers that means the export has become
+            // delayed.
+            if !export.delayed
+                && delay_state.time_deque.len() == 1
+                && export.imports.values().all(|i| !i.time_deque.is_empty())
+            {
+                export.delayed = true;
+                self.state.delayed_time.register_delayed_export(self.time);
+            }
         }
     }
 

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -47,6 +47,8 @@ pub struct ComputeMetrics {
     // yielding, but it should hopefully alert us when there is something to
     // look at.
     pub(crate) timely_step_duration_seconds: Histogram,
+
+    pub(crate) delayed_time_seconds_total: raw::CounterVec,
 }
 
 impl ComputeMetrics {
@@ -87,7 +89,13 @@ impl ComputeMetrics {
                 help: "The time spent in each compute step_or_park call",
                 const_labels: {"cluster" => "compute"},
                 buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 32.0),
-            ))
+            )),
+            delayed_time_seconds_total: registry.register(metric!(
+                name: "mz_dataflow_delayed_time_seconds_total",
+                help: "The total time dataflow outputs were delayed relative to their inputs.",
+                const_labels: {"cluster" => "compute"},
+                var_labels: ["worker_id"],
+            )),
         }
     }
 
@@ -117,6 +125,17 @@ impl ComputeMetrics {
         TraceMetrics {
             maintenance_seconds_total,
             maintenance_active_info,
+        }
+    }
+
+    pub fn for_logging(&self, worker_id: usize) -> LoggingMetrics {
+        let worker = worker_id.to_string();
+        let delayed_time_seconds_total = self
+            .delayed_time_seconds_total
+            .with_label_values(&[&worker]);
+
+        LoggingMetrics {
+            delayed_time_seconds_total,
         }
     }
 
@@ -162,4 +181,10 @@ pub struct TraceMetrics {
     /// to gain a sense that Materialize is stuck on maintenance before the
     /// maintenance completes
     pub maintenance_active_info: UIntGauge,
+}
+
+/// Metrics maintained by the logging dataflows.
+#[derive(Clone)]
+pub struct LoggingMetrics {
+    pub delayed_time_seconds_total: GenericCounter<AtomicF64>,
 }

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2242,6 +2242,8 @@ def workflow_test_replica_metrics(c: Composition) -> None:
 
     maintenance = metrics.get_value("mz_arrangement_maintenance_seconds_total")
     assert maintenance > 0, f"unexpected arrangement maintanence time: {maintenance}"
+    delayed_time = metrics.get_value("mz_dataflow_delayed_time_seconds_total")
+    assert delayed_time < 1, f"unexpected delayed time: {delayed_time}"
 
 
 def workflow_test_compute_controller_metrics(c: Composition) -> None:


### PR DESCRIPTION
This PR adds a metric tracking a replica's "delayed time", i.e. the time during which at least one of the dataflows installed on the replica hasn't been fully caught up. Our hope is that this will be a useful metric to estimate replica utilization, even in the face of idle merging.

The metric is calculated based on dataflow import and export frontiers. The compute logging dataflow has access to both, so it is made responsible for maintaining the metric.

The main wrinkle with this new metric is that it is based on import frontiers, which means it doesn't account for:

 * the time between dataflow creation and when the first import frontier is logged
 * logging dataflows that have no imports and therefore no import frontiers

### Motivation

  * This PR adds a known-desirable feature.

Part of https://github.com/MaterializeInc/materialize/issues/21743

### Tips for reviewer

This metric has been called "replica busy time" before. I'm preferring "delayed time" for this internal metric as I think it makes clearer how this metric is computed.

There are two reasons for exposing this as a metric:

 * Doing so allows us to internally evaluate whether this metric is a useful replacement for CPU usage. If we go ahead with #22469 we probably won't need a replacement.
 * It is potentially useful for debugging/monitoring. For example, if we see low CPU usage, low worker skew, but high delayed time that would point to a bug in Mz. So having this metric seems worthwhile regardless of whether CPU usage is usable or not.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
