### PR TITLE
parallel-workload: Don't reconnect forever

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -676,7 +676,8 @@ class ReconnectAction(Action):
         except:
             pass
 
-        while True:
+        NUM_ATTEMPTS = 20
+        for i in range(NUM_ATTEMPTS):
             try:
                 conn = pg8000.connect(
                     host=host, port=port, user=user, database=self.db.name()
@@ -688,7 +689,7 @@ class ReconnectAction(Action):
                 cur.execute("SELECT pg_backend_pid()")
                 exe.pg_pid = cur.fetchall()[0][0]
             except Exception as e:
-                if (
+                if i < NUM_ATTEMPTS - 1 and (
                     "network error" in str(e)
                     or "Can't create a connection to host" in str(e)
                     or "Connection refused" in str(e)

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -77,8 +77,3 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     #     # Don't fail the entire run. We ran into a crash,
     #     # ci-logged-errors-detect will handle this if it's an unknown failure.
     #     return
-    # Restart mz
-    c.kill("materialized")
-    c.up("materialized")
-    # Verify that things haven't blown up
-    c.sql("SELECT 1")


### PR DESCRIPTION
Will fail if Mz can never start up because it is corrupted. As seen in https://buildkite.com/materialize/nightlies/builds/4818

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
