### PR TITLE
scalability framework: enable in CI

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -56,7 +56,6 @@ steps:
                - common-ancestor
     - id: scalability-benchmark
       label: "Scalability benchmark against merge base or 'latest'"
-      skip: "Results not yet stable enough"
       timeout_in_minutes: 120
       agents:
         queue: linux-x86_64-large


### PR DESCRIPTION
### Nightlies (before introducing the [retry functionality](https://github.com/MaterializeInc/materialize/pull/22612))
* https://buildkite.com/materialize/nightlies/builds/4827 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4828 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4829 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4830 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4831 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4836 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4837 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4838 ✅ 
* https://buildkite.com/materialize/nightlies/builds/4839 🔴 SelectUnionAllWorkload @ concurr 2 with 11.3%
* https://buildkite.com/materialize/nightlies/builds/4840 🔴 SelectOneWorkload @ concurr 4 with 11.1%