### PR TITLE
catalog: Fix persist epoch fencing

### DIFF
--- a/src/catalog/src/persist.rs
+++ b/src/catalog/src/persist.rs
@@ -943,7 +943,7 @@ impl DurableCatalogState for PersistCatalogState {
                     .expect("invalid usage");
             }
             // If we haven't fenced the previous catalog state, do that now.
-            if let Some(Fence { prev_epoch }) = self.fence {
+            if let Some(Fence { prev_epoch }) = self.fence.take() {
                 if let Some(prev_epoch) = prev_epoch {
                     batch_builder
                         .add(

--- a/src/catalog/src/persist.rs
+++ b/src/catalog/src/persist.rs
@@ -959,7 +959,6 @@ impl DurableCatalogState for PersistCatalogState {
                     .add(&StateUpdateKind::Epoch(self.epoch), &(), &current_upper, &1)
                     .await
                     .expect("invalid usage");
-                self.fence = None;
             }
             let mut batch = batch_builder
                 .finish(Antichain::from_elem(next_upper))


### PR DESCRIPTION
Previously, when a new persist catalog would open, it would insert a
new epoch to fence out the previous catalog. However, it would never
retract the previous epoch, leaving +1s for all epoch values that ever
existed. This commit updates the fencing process to retract the
previous epoch if one exists.

Works towards resolving #22392

### Motivation
 This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
