### PR TITLE
Allow join yielding by work and time simultaneously

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -44,19 +44,30 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
 }
 
 fn parse_yield_spec(s: &str) -> Option<YieldSpec> {
-    let parts: Vec<_> = s.split(':').collect();
-    match &parts[..] {
-        ["work", amount] => {
-            let amount = amount.parse().ok()?;
-            Some(YieldSpec::ByWork(amount))
+    let mut after_work = None;
+    let mut after_time = None;
+
+    let options = s.split(',').map(|o| o.trim());
+    for option in options {
+        let parts: Vec<_> = option.split(':').map(|p| p.trim()).collect();
+        match &parts[..] {
+            ["work", amount] => {
+                let amount = amount.parse().ok()?;
+                after_work = Some(amount);
+            }
+            ["time", millis] => {
+                let millis = millis.parse().ok()?;
+                let duration = Duration::from_millis(millis);
+                after_time = Some(duration);
+            }
+            _ => return None,
         }
-        ["time", millis] => {
-            let millis = millis.parse().ok()?;
-            let duration = Duration::from_millis(millis);
-            Some(YieldSpec::ByTime(duration))
-        }
-        _ => None,
     }
+
+    Some(YieldSpec {
+        after_work,
+        after_time,
+    })
 }
 
 /// Return the current storage configuration, derived from the system configuration.

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -25,6 +25,8 @@ breaking:
     - compute-client/src/protocol/response.proto
     # reason: does currently not require backward-compatibility
     - compute-client/src/service.proto
+    # reason: does currently not require backward-compatibility
+    - compute-types/src/dataflows.proto
     # reason: Ignore because plans are currently not persisted.
     - expr/src/relation.proto
     # reason: still under active development

--- a/src/compute-types/src/dataflows.proto
+++ b/src/compute-types/src/dataflows.proto
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// buf breaking: ignore (does currently not require backward-compatibility)
+
 syntax = "proto3";
 
 import "compute-types/src/plan.proto";
@@ -66,8 +68,6 @@ message ProtoBuildDesc {
 }
 
 message ProtoYieldSpec {
-    oneof kind {
-        uint64 by_work = 1;
-        mz_proto.ProtoDuration by_time = 2;
-    }
+    optional uint64 after_work = 1;
+    optional mz_proto.ProtoDuration after_time = 2;
 }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1311,7 +1311,9 @@ static LINEAR_JOIN_YIELDING: Lazy<ServerVar<String>> = Lazy::new(|| ServerVar {
     value: &DEFAULT_LINEAR_JOIN_YIELDING,
     description:
         "The yielding behavior compute rendering should apply for linear join operators. Either \
-         'work:<amount>' or 'time:<milliseconds>'.",
+         'work:<amount>' or 'time:<milliseconds>' or 'work:<amount>,time:<milliseconds>'. Note \
+         that omitting one of 'work' or 'time' will entirely disable join yielding by time or \
+         work, respectively, rather than falling back to some default.",
     internal: true,
 });
 


### PR DESCRIPTION
This PR extends the `YieldSpec` type and the syntax allowed for the `linear_join_yielding` system var to enable specifying yield strategies that consider both the performed work and the elapsed time.

This will allow us to make sure that (a) join operators don't keep around huge amounts of output records and (b) join operators don't regress interactivity.

### Motivation

  * This PR fixes a recognized bug.

Part of #22390 

Follow-up to #22391, in which we discussed that we still want a way to ensure join outputs won't produce an OOM when time-based yielding is used.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
