### PR TITLE
doc/developer: document CLA check self-service fix

### DIFF
--- a/doc/developer/guide-changes.md
+++ b/doc/developer/guide-changes.md
@@ -909,6 +909,19 @@ submit a PR to fix it!
 * Accept PRs that improve the overall health of the codebase, even if they
   are not perfect.
 
+## Common Issues
+
+### Stuck CLA check
+
+Taken from the [cla-assistant `README.md`](https://github.com/cla-assistant/cla-assistant/blob/main/COMMON_ISSUES.md#cla-assistant-status-or-comment-not-updated-1).
+
+Sometimes it happens that while you signed the CLA the status doesn't get updated.
+Might be a technical issue or some other problem. Most temporary issues can be solved by manually triggering a new check with navigating to
+```
+https://cla-assistant.io/check/<orgname>/<reponame>?pullRequest=<pr_number>
+```
+replacing `<orgname>`, `<reponame>` and `<pr_number>` with your respective values.
+
 [`29f8f46b9`]: https://github.com/MaterializeInc/materialize/commit/29f8f46b92280071c96b294d414675aa626f9403
 [#3808]: https://github.com/MaterializeInc/materialize/pull/3808
 [#3982]: https://github.com/MaterializeInc/materialize/pull/3982


### PR DESCRIPTION
Document a recently found self-service fix for stuck CLA assistant check.

### Motivation

   * This PR refactors existing code.

Documentation improvements.

### Tips for reviewer

N/A

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
