### PR TITLE
scalability framework: upload workload results

### DIFF
--- a/misc/python/materialize/scalability/df/paths.py
+++ b/misc/python/materialize/scalability/df/paths.py
@@ -37,3 +37,11 @@ def regressions_csv_name() -> str:
 
 def regressions_csv() -> Path:
     return RESULTS_DIR / regressions_csv_name()
+
+
+def results_csv_rel_path(endpoint_name: str) -> Path:
+    return Path(endpoint_name) / "results.csv"
+
+
+def results_csv(endpoint_name: str) -> Path:
+    return RESULTS_DIR / results_csv_rel_path(endpoint_name)

--- a/misc/python/materialize/scalability/workload_executor.py
+++ b/misc/python/materialize/scalability/workload_executor.py
@@ -45,6 +45,7 @@ class WorkloadExecutor:
         self.baseline_endpoint = baseline_endpoint
         self.other_endpoints = other_endpoints
         self.result_analyzer = result_analyzer
+        self.df_total_by_endpoint_name: dict[str, pd.DataFrame] = dict()
 
     def run_workloads(
         self,
@@ -140,6 +141,7 @@ class WorkloadExecutor:
             df_totals.to_csv(paths.df_totals_csv(endpoint_name, workload))
             df_details.to_csv(paths.df_details_csv(endpoint_name, workload))
 
+        self._record_results(endpoint, df_totals)
         return WorkloadResult(workload, df_totals, df_details)
 
     def run_workload_for_endpoint_with_concurrency(
@@ -283,3 +285,15 @@ class WorkloadExecutor:
             cursor_pool.append(cursor)
 
         return cursor_pool
+
+    def _record_results(self, endpoint: Endpoint, df_totals: pd.DataFrame) -> None:
+        endpoint_name = endpoint.name()
+        print(f"Collecting results of endpoint {endpoint} with name {endpoint_name}")
+
+        if endpoint_name not in self.df_total_by_endpoint_name:
+            self.df_total_by_endpoint_name[endpoint_name] = df_totals
+        else:
+            self.df_total_by_endpoint_name[endpoint_name] = pd.concat(
+                [self.df_total_by_endpoint_name[endpoint_name], df_totals],
+                ignore_index=True,
+            )

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -157,9 +157,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         count=args.count,
     )
 
-    overall_regression_outcome = WorkloadExecutor(
+    executor = WorkloadExecutor(
         config, schema, baseline_endpoint, other_endpoints, result_analyzer
-    ).run_workloads()
+    )
+
+    overall_regression_outcome = executor.run_workloads()
+    store_and_upload_results_to_buildkite(executor.df_total_by_endpoint_name)
 
     report_regression_result(baseline_endpoint, overall_regression_outcome)
 
@@ -264,6 +267,27 @@ def upload_regressions_to_buildkite(outcome: RegressionOutcome) -> None:
         ["buildkite-agent", "artifact", "upload", paths.regressions_csv_name()],
         cwd=paths.RESULTS_DIR,
     )
+
+
+def store_and_upload_results_to_buildkite(
+    df_total_by_endpoint_name: dict[str, pd.DataFrame]
+) -> None:
+    for (endpoint_name, results) in df_total_by_endpoint_name.items():
+        print(
+            f"Writing results of {endpoint_name} to {paths.results_csv(endpoint_name)}"
+        )
+        results.to_csv(paths.results_csv(endpoint_name))
+
+        if buildkite.is_in_buildkite():
+            spawn.runv(
+                [
+                    "buildkite-agent",
+                    "artifact",
+                    "upload",
+                    paths.results_csv_rel_path(endpoint_name),
+                ],
+                cwd=paths.RESULTS_DIR,
+            )
 
 
 def workflow_lab(c: Composition) -> None:


### PR DESCRIPTION
Based on https://github.com/MaterializeInc/materialize/pull/22612, which shall be reviewed and merged first. ✅ 

Tested with https://buildkite.com/materialize/nightlies/builds/4879#018b6709-1e27-4ad8-bded-73e4342c8a52. Only one file is uploaded, but this is another issue (actually not an issue, `HEAD` and `common-ancestor` resolve to the same because no database code is changed).