### PR TITLE
tests: parallel workload: adapt error message to ignore

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -540,7 +540,8 @@ class CreateClusterAction(Action):
 class DropClusterAction(Action):
     def errors_to_ignore(self) -> list[str]:
         return [
-            "cannot drop cluster with active objects",
+            # cannot drop cluster "..." because other objects depend on it
+            "because other objects depend on it",
         ] + super().errors_to_ignore()
 
     def run(self, exe: Executor) -> None:


### PR DESCRIPTION
This should fix [nightly](https://buildkite.com/materialize/nightlies/builds/4848#018b6173-b4bf-4f5f-8b73-9d1b21e00736), which presumably broke in https://github.com/MaterializeInc/materialize/pull/22418/files.

Nightly: https://buildkite.com/materialize/nightlies/builds/4858