### PR TITLE
bump up the default timeout for waiting for environments

### DIFF
--- a/misc/python/materialize/cloudtest/util/environment.py
+++ b/misc/python/materialize/cloudtest/util/environment.py
@@ -63,7 +63,7 @@ class Environment:
             environment_assignment,
         )
 
-    def wait_for_environmentd(self, max_attempts: int = 300) -> dict[str, Any]:
+    def wait_for_environmentd(self, max_attempts: int = 600) -> dict[str, Any]:
         def get_environment() -> Response:
             response = self.region_api_requests.get(
                 "/api/region",


### PR DESCRIPTION
### Motivation

it's taking longer than 5 minutes a bunch these days

### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user facing changes