### PR TITLE
transaction ID in statement log

### DIFF
--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -495,6 +495,7 @@ impl SessionClient {
         outer_ctx_extra: Option<ExecuteContextExtra>,
     ) -> Result<(ExecuteResponse, Instant), AdapterError> {
         let execute_started = Instant::now();
+        let tid = self.session().transaction().inner().map(|t| t.id);
         let response = self
             .send_with_cancel(
                 |tx, session| Command::Execute {

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -495,7 +495,6 @@ impl SessionClient {
         outer_ctx_extra: Option<ExecuteContextExtra>,
     ) -> Result<(ExecuteResponse, Instant), AdapterError> {
         let execute_started = Instant::now();
-        let tid = self.session().transaction().inner().map(|t| t.id);
         let response = self
             .send_with_cancel(
                 |tx, session| Command::Execute {

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -508,7 +508,11 @@ impl Coordinator {
             execution_timestamp: None,
             application_name: session.application_name().to_string(),
             transaction_isolation: session.vars().transaction_isolation().to_string(),
-            transaction_id: session.transaction().inner().expect("Every statement runs in an explicit or implicit transaction").id,
+            transaction_id: session
+                .transaction()
+                .inner()
+                .expect("Every statement runs in an explicit or implicit transaction")
+                .id,
         };
         let mseh_update = Self::pack_statement_began_execution_update(&record);
         self.statement_logging

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -249,6 +249,7 @@ impl Coordinator {
             application_name,
             transaction_isolation,
             execution_timestamp,
+            transaction_id,
         } = record;
 
         let cluster = cluster_id.map(|id| id.to_string());
@@ -264,6 +265,7 @@ impl Coordinator {
             cluster_name.as_ref().map(String::as_str).into(),
             Datum::String(&*transaction_isolation),
             (*execution_timestamp).into(),
+            Datum::UInt64(*transaction_id),
         ]);
         packer
             .push_array(
@@ -506,6 +508,7 @@ impl Coordinator {
             execution_timestamp: None,
             application_name: session.application_name().to_string(),
             transaction_isolation: session.vars().transaction_isolation().to_string(),
+            transaction_id: session.transaction().inner().expect("Every statement runs in an explicit or implicit transaction").id,
         };
         let mseh_update = Self::pack_statement_began_execution_update(&record);
         self.statement_logging

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -12,6 +12,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
 use uuid::Uuid;
 
+use crate::session::TransactionId;
 use crate::{AdapterError, ExecuteResponse};
 /// Contains all the information necessary to generate the initial
 /// entry in `mz_statement_execution_history`. We need to keep this
@@ -28,6 +29,7 @@ pub struct StatementBeganExecutionRecord {
     pub application_name: String,
     pub transaction_isolation: String,
     pub execution_timestamp: Option<EpochMillis>,
+    pub transaction_id: TransactionId,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2138,7 +2138,8 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY_REDACTED: BuiltinView = BuiltinView {
     // everything but `params`
     sql: "CREATE VIEW mz_internal.mz_statement_execution_history_redacted AS
 SELECT id, prepared_statement_id, sample_rate, cluster_id, application_name,
-cluster_name, transaction_isolation, execution_timestamp, began_at, finished_at, finished_status,
+cluster_name, transaction_isolation, execution_timestamp, transaction_id,
+began_at, finished_at, finished_status,
 error_message, rows_returned, execution_strategy
 FROM mz_internal.mz_statement_execution_history",
     sensitivity: DataSensitivity::SuperuserAndSupport,

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -123,6 +123,7 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|
         // Note that this can't be a timestamp, as it might be u64::max,
         // which is out of range.
         .with_column("execution_timestamp", ScalarType::UInt64.nullable(true))
+        .with_column("transaction_id", ScalarType::UInt64.nullable(false))
         .with_column(
             "params",
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),

--- a/test/testdrive/statement-logging.td
+++ b/test/testdrive/statement-logging.td
@@ -142,3 +142,27 @@ default default my_app 1 {} success <null> <null> <null> true "SET cluster TO c"
 mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'beginning real test!'" "strict serializable"
 mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'serializable'" serializable
 mz_introspection mz_introspection my_app 1 {} success <null> 1 standard true "SELECT count(*) > 0 FROM mz_internal.mz_cluster_replica_metrics" "strict serializable"
+
+# Test that everything in a transaction has the same transaction ID
+
+> BEGIN --hello
+
+> SELECT 'transaction statement 1'
+"transaction statement 1"
+
+> SELECT 'transaction statement 2'
+"transaction statement 2"
+
+> ROLLBACK
+
+> WITH begin_tid AS
+  (SELECT transaction_id FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh
+   WHERE mseh.prepared_statement_id = mpsh.id
+   AND mpsh.sql = 'BEGIN --hello')
+  SELECT sql FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, begin_tid
+  WHERE mseh.prepared_statement_id = mpsh.id
+  AND mseh.transaction_id = begin_tid.transaction_id
+"BEGIN --hello"
+"SELECT 'transaction statement 1'"
+"SELECT 'transaction statement 2'"
+ROLLBACK

--- a/test/testdrive/statement-logging.td
+++ b/test/testdrive/statement-logging.td
@@ -162,6 +162,7 @@ mz_introspection mz_introspection my_app 1 {} success <null> 1 standard true "SE
   SELECT sql FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh, begin_tid
   WHERE mseh.prepared_statement_id = mpsh.id
   AND mseh.transaction_id = begin_tid.transaction_id
+  AND mseh.application_name = 'my_app'
 "BEGIN --hello"
 "SELECT 'transaction statement 1'"
 "SELECT 'transaction statement 2'"


### PR DESCRIPTION
Add the ID of the current transaction to the statement log.

This fixes an unreported feature request: we would like to be able to see whether multiple statements are from the same transaction.

Note that transaction IDs are per-session, so joining against mz_sessions might be necessary to disambiguate.