### PR TITLE
fix and re-enable statement_logging.py check

### DIFF
--- a/misc/python/materialize/checks/all_checks/statement_logging.py
+++ b/misc/python/materialize/checks/all_checks/statement_logging.py
@@ -15,7 +15,7 @@ from materialize.util import MzVersion
 
 
 class StatementLogging(Check):
-    def _can_run(self, e: Executor) -> bool:
+    def _can_run(self, _e: Executor) -> bool:
         return self.base_version >= MzVersion(0, 69, 0)
 
     def initialize(self) -> Testdrive:
@@ -50,16 +50,31 @@ class StatementLogging(Check):
         ]
 
     def validate(self) -> Testdrive:
-        return Testdrive(
-            dedent(
-                """
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
-                ALTER SYSTEM SET enable_rbac_checks TO false
-                > SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
-                "SELECT 'hello' /* Btv was here */" success
-                "SELECT 'goodbye' /* Btv was here */" success
-                $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
-                ALTER SYSTEM SET enable_rbac_checks TO true
-                """
+        if self.base_version == self.current_version:
+            return Testdrive(
+                dedent(
+                    """
+                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    ALTER SYSTEM SET enable_rbac_checks TO false
+                    > SELECT sql, finished_status FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */' ORDER BY mseh.began_at;
+                    "SELECT 'hello' /* Btv was here */" success
+                    "SELECT 'goodbye' /* Btv was here */" success
+                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    ALTER SYSTEM SET enable_rbac_checks TO true
+                    """
+                )
             )
-        )
+        else:
+            # Rows are expected to maybe disappear across versions
+            return Testdrive(
+                dedent(
+                    """
+                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    ALTER SYSTEM SET enable_rbac_checks TO false
+                    > SELECT count(*) <= 2 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh WHERE mseh.prepared_statement_id = mpsh.id AND sql LIKE '%/* Btv was here */'
+                    true
+                    $ postgres-execute connection=postgres://mz_system@materialized:6877/materialize
+                    ALTER SYSTEM SET enable_rbac_checks TO true
+                    """
+                )
+            )


### PR DESCRIPTION
The statement log can lose updates across versions, which was causing the check to expectedly fail.

### Motivation


  * This PR fixes #22448 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None