### PR TITLE
add --default-timeout option to testdrive mzcompose

### DIFF
--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -32,7 +32,7 @@ class Testdrive(Service):
         kafka_args: str | None = None,
         schema_registry_url: str = "http://schema-registry:8081",
         no_reset: bool = False,
-        default_timeout: str = "120s",
+        default_timeout: str | None = None,
         seed: int | None = None,
         consistent_seed: bool = False,
         validate_postgres_stash: str | None = None,
@@ -101,6 +101,8 @@ class Testdrive(Service):
         for k, v in materialize_params.items():
             entrypoint.append(f"--materialize-param={k}={v}")
 
+        if default_timeout is None:
+            default_timeout = "120s"
         entrypoint.append(f"--default-timeout={default_timeout}")
 
         if kafka_default_partitions:

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -79,17 +79,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.aws_region is None:
         dependencies += ["localstack"]
 
-    if args.default_timeout is None:
-        timeout_arg = {}
-    else:
-        timeout_arg = {"default_timeout": f"{args.default_timeout}s"}
-
     testdrive = Testdrive(
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
         validate_postgres_stash="materialized",
-        **timeout_arg,
+        default_timeout=args.default_timeout,
     )
 
     materialized = Materialized(

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -57,6 +57,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument("--replicas", type=int, default=1, help="use multiple replicas")
 
     parser.add_argument(
+        "--default-timeout",
+        type=int,
+        help="set the default timeout for Testdrive, in seconds",
+    )
+
+    parser.add_argument(
         "files",
         nargs="*",
         default=["*.td"],
@@ -73,11 +79,17 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if args.aws_region is None:
         dependencies += ["localstack"]
 
+    if args.default_timeout is None:
+        timeout_arg = {}
+    else:
+        timeout_arg = {"default_timeout": f"{args.default_timeout}s"}
+
     testdrive = Testdrive(
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
         validate_postgres_stash="materialized",
+        **timeout_arg,
     )
 
     materialized = Materialized(


### PR DESCRIPTION
This is occasionally useful during local development.