### PR TITLE
"Activity log" pre-joined views

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -1121,6 +1121,8 @@ The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow] wor
 [Top K]: /transform-data/patterns/top-k
 [query hints]: /sql/select/#query-hints
 
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_activity_log -->
+<!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_activity_log_redacted -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_aggregates -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_batches_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_arrangement_records_raw -->

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2179,8 +2179,9 @@ pub static MZ_ACTIVITY_LOG: BuiltinView = BuiltinView {
     sql: "CREATE VIEW mz_internal.mz_activity_log AS
 SELECT mseh.id AS execution_id, sample_rate, cluster_id, application_name, cluster_name,
 transaction_isolation, execution_timestamp, params, began_at, finished_at, finished_status,
-error_message, rows_returned, execution_strategy,
-sql, session_id, redacted_sql, prepared_at
+error_message, rows_returned, execution_strategy, transaction_id,
+mpsh.id AS prepared_statement_id, sql, mpsh.name AS prepared_statement_name,
+session_id, redacted_sql, prepared_at
 FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh
 WHERE mseh.prepared_statement_id = mpsh.id",
     sensitivity: DataSensitivity::Superuser,
@@ -2192,8 +2193,8 @@ pub static MZ_ACTIVITY_LOG_REDACTED: BuiltinView = BuiltinView {
     sql: "CREATE VIEW mz_internal.mz_activity_log_redacted AS
 SELECT execution_id, sample_rate, cluster_id, application_name, cluster_name,
 transaction_isolation, execution_timestamp, began_at, finished_at, finished_status,
-error_message, rows_returned, execution_strategy,
-session_id, redacted_sql, prepared_at
+error_message, rows_returned, execution_strategy, transaction_id, prepared_statement_id,
+prepared_statement_name, session_id, redacted_sql, prepared_at
 FROM mz_internal.mz_activity_log",
     sensitivity: DataSensitivity::SuperuserAndSupport,
 };

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2173,6 +2173,31 @@ pub static MZ_SESSION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource 
     sensitivity: DataSensitivity::SuperuserAndSupport,
 });
 
+pub static MZ_ACTIVITY_LOG: BuiltinView = BuiltinView {
+    name: "mz_activity_log",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_activity_log AS
+SELECT mseh.id AS execution_id, sample_rate, cluster_id, application_name, cluster_name,
+transaction_isolation, execution_timestamp, params, began_at, finished_at, finished_status,
+error_message, rows_returned, execution_strategy,
+sql, session_id, redacted_sql, prepared_at
+FROM mz_internal.mz_statement_execution_history mseh, mz_internal.mz_prepared_statement_history mpsh
+WHERE mseh.prepared_statement_id = mpsh.id",
+    sensitivity: DataSensitivity::Superuser,
+};
+
+pub static MZ_ACTIVITY_LOG_REDACTED: BuiltinView = BuiltinView {
+    name: "mz_activity_log_redacted",
+    schema: MZ_INTERNAL_SCHEMA,
+    sql: "CREATE VIEW mz_internal.mz_activity_log_redacted AS
+SELECT execution_id, sample_rate, cluster_id, application_name, cluster_name,
+transaction_isolation, execution_timestamp, began_at, finished_at, finished_status,
+error_message, rows_returned, execution_strategy,
+session_id, redacted_sql, prepared_at
+FROM mz_internal.mz_activity_log",
+    sensitivity: DataSensitivity::SuperuserAndSupport,
+};
+
 pub const MZ_SOURCE_STATUSES: BuiltinView = BuiltinView {
     name: "mz_source_statuses",
     schema: MZ_INTERNAL_SCHEMA,
@@ -5694,6 +5719,8 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Source(&MZ_PREPARED_STATEMENT_HISTORY),
         Builtin::View(&MZ_PREPARED_STATEMENT_HISTORY_REDACTED),
         Builtin::Source(&MZ_SESSION_HISTORY),
+        Builtin::View(&MZ_ACTIVITY_LOG),
+        Builtin::View(&MZ_ACTIVITY_LOG_REDACTED),
         Builtin::View(&MZ_SOURCE_STATUSES),
         Builtin::Source(&MZ_STORAGE_SHARDS),
         Builtin::Source(&MZ_SOURCE_STATISTICS),

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -80,8 +80,12 @@ pub static MZ_SINK_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
         .with_column("details", ScalarType::Jsonb.nullable(true))
 });
 
-// NOTE: Update the view `mz_statement_execution_history_redacted` whenever this is updated,
-// to include the new columns if and only if they're allowed to be queried by mz_support.
+// NOTE: Update the views `mz_statement_execution_history_redacted`
+// and `mz_activity_log`, and `mz_activity_log_redacted` whenever this
+// is updated, to include the new columns where appropriate.
+//
+// The `redacted` views should contain only those columns that should
+// be queryable by support.
 pub static MZ_PREPARED_STATEMENT_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
     RelationDesc::empty()
         .with_column("id", ScalarType::Uuid.nullable(false))
@@ -109,8 +113,12 @@ pub static MZ_SESSION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
         .with_column("authenticated_user", ScalarType::String.nullable(false))
 });
 
-// NOTE: Update the view `mz_statement_execution_history_redacted` whenever this is updated,
-// to include the new columns if and only if they're allowed to be queried by mz_support.
+// NOTE: Update the views `mz_statement_execution_history_redacted`
+// and `mz_activity_log`, and `mz_activity_log_redacted` whenever this
+// is updated, to include the new columns where appropriate.
+//
+// The `redacted` views should contain only those columns that should
+// be queryable by support.
 pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
     RelationDesc::empty()
         .with_column("id", ScalarType::Uuid.nullable(false))

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -590,6 +590,8 @@ SELECT DISTINCT object FROM objects WHERE schema IN ('mz_internal') ORDER BY obj
 ----
 mz_active_peeks
 mz_active_peeks_per_worker
+mz_activity_log
+mz_activity_log_redacted
 mz_aggregates
 mz_arrangement_batches_raw
 mz_arrangement_heap_allocations_raw

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -240,6 +240,14 @@ mz_internal
 mz_active_peeks_per_worker
 SOURCE
 materialize
+mv_internal
+mz_activity_log
+VIEW
+materialize
+mz_internal
+mz_activity_log_redacted
+VIEW
+materialize
 mz_internal
 mz_aggregates
 BASE TABLE

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -240,7 +240,7 @@ mz_internal
 mz_active_peeks_per_worker
 SOURCE
 materialize
-mv_internal
+mz_internal
 mz_activity_log
 VIEW
 materialize

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -4715,9 +4715,10 @@ materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
+mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 16
+COMPLETE 17
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.table_privileges WHERE grantee = 'PUBLIC'
@@ -4760,9 +4761,10 @@ materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
+mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 16
+COMPLETE 17
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.role_table_grants WHERE grantee = 'PUBLIC'

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -575,6 +575,8 @@ mz_webhook_sources
 name
 -------------------------------------
 mz_active_peeks
+mz_activity_log
+mz_activity_log_redacted
 mz_arrangement_sharing
 mz_arrangement_sharing_per_worker
 mz_arrangement_sizes


### PR DESCRIPTION
Create two views, `mz_activity_log` and `mz_activity_log_redacted`, which join mz_statement_execution_history and mz_prepared_statement_history (as desired 99% of the time when people are querying those tables).

### Motivation

Discussed on Slack: https://materializeinc.slack.com/archives/C056M3001Q9/p1697648680898179

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
