### PR TITLE
persist: wrap shard_source open_leased_reader call in a tokio task

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -97,7 +97,7 @@ where
         Stream<Child<'g, G, T>, (usize, SerdeLeasedBatchPart)>,
         Rc<dyn Any>,
     ),
-    C: Future<Output = PersistClient> + 'static,
+    C: Future<Output = PersistClient> + Send + 'static,
 {
     // WARNING! If emulating any of this code, you should read the doc string on
     // [`LeasedBatchPart`] and [`Subscribe`] or will likely run into intentional
@@ -169,7 +169,7 @@ impl Drop for ActivateOnDrop {
 pub(crate) fn shard_source_descs<K, V, D, F, G>(
     scope: &G,
     name: &str,
-    client: impl Future<Output = PersistClient> + 'static,
+    client: impl Future<Output = PersistClient> + Send + 'static,
     shard_id: ShardId,
     as_of: Option<Antichain<G::Timestamp>>,
     until: Antichain<G::Timestamp>,
@@ -241,22 +241,31 @@ where
         let token_is_dropped = token_tx.closed();
         tokio::pin!(token_is_dropped);
 
-        let create_read_handle = async {
-            let read = client.await
-                .open_leased_reader::<K, V, G::Timestamp, D>(
-                    shard_id,
-                    key_schema,
-                    val_schema,
-                    Diagnostics {
-                        shard_name: name_owned.clone(),
-                        handle_purpose: format!("shard_source({})", name_owned),
-                    }
-                )
-                .await
-                .expect("could not open persist shard");
-
-            read
-        };
+        // Internally, the `open_leased_reader` call registers a new LeasedReaderId and then fires
+        // up a background tokio task to heartbeat it. It is possible that we might get a
+        // particularly adversarial scheduling where the CRDB query to register the id is sent and
+        // then our Future is not polled again for a long time, resulting is us never spawning the
+        // heartbeat task. Run reader creation in a task to attempt to defend against this.
+        //
+        // TODO: Really we likely need to swap the inners of all persist operators to be
+        // communicating with a tokio task over a channel, but that's much much harder, so for now
+        // we whack the moles as we see them.
+        let create_read_handle = mz_ore::task::spawn(|| format!("shard_source_reader({})", name_owned), {
+            let diagnostics = Diagnostics {
+                handle_purpose: format!("shard_source({})", name_owned),
+                shard_name: name_owned.clone(),
+            };
+            async move {
+                client.await
+                    .open_leased_reader::<K, V, G::Timestamp, D>(
+                        shard_id,
+                        key_schema,
+                        val_schema,
+                        diagnostics,
+                    )
+                    .await
+            }
+        });
 
         tokio::pin!(create_read_handle);
 
@@ -275,6 +284,8 @@ where
             }
             Either::Right((read, _)) => {
                 read
+                    .expect("reader creation shouldn't panic")
+                    .expect("could not open persist shard")
             }
         };
         let cfg = read.cfg.clone();


### PR DESCRIPTION
Internally, the `open_leased_reader` call registers a new LeasedReaderId and then fires up a background tokio task to heartbeat it. It is possible that we might get a particularly adversarial scheduling where the CRDB query to register the id is sent and then our Future is not polled again for a long time, resulting is us never spawning the heartbeat task. Run reader creation in a task to attempt to defend against this.

h/t Nikhil for the theory

Touches #https://github.com/MaterializeInc/cloud/issues/7602

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
