### PR TITLE
fix: Change panic! to warn!

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -627,7 +627,14 @@ where
                 for (id, new_shard_upper) in list {
                     let (frontier, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => panic!("Reference to absent collection: {id}"),
+                        None => {
+                            // This can occur if a running clusterd gets
+                            // connected to a new environmentd; the clusterd
+                            // might not yet know that its new envd doesn't have
+                            // this collection.
+                            tracing::warn!("Reference to absent collection: {id}");
+                            return None;
+                        }
                     };
                     let old_upper = frontier.frontier().to_owned();
                     let shard_upper = match &mut shard_frontiers[shard_id] {
@@ -656,7 +663,14 @@ where
                 for id in dropped_ids {
                     let (_, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => panic!("Reference to absent collection: {id}"),
+                        None => {
+                            // This can occur if a running clusterd gets
+                            // connected to a new environmentd; the clusterd
+                            // might not yet know that its new envd doesn't have
+                            // this collection.
+                            tracing::warn!("Reference to absent collection: {id}");
+                            return None;
+                        }
                     };
                     let prev = shard_frontiers[shard_id].take();
                     assert!(


### PR DESCRIPTION
A test in CI is broken, this is the suggested fix from @sploiselle, [Slack](https://materializeinc.slack.com/archives/CM7ATT65S/p1698173941914379)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
