### PR TITLE
test: Speed up test_subscribe_progress

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -663,11 +663,12 @@ fn test_subscribe_basic() {
 fn test_subscribe_progress() {
     mz_ore::test::init_logging();
 
+    let config = test_util::Config::default().workers(2);
+    let server = test_util::start_server(config).unwrap();
+
     for has_initial_data in [false, true] {
         for has_index in [false, true] {
             for has_snapshot in [false, true] {
-                let config = test_util::Config::default().workers(2);
-                let server = test_util::start_server(config).unwrap();
                 let mut client_writes = server.connect(postgres::NoTls).unwrap();
                 let mut client_reads = server.connect(postgres::NoTls).unwrap();
 
@@ -767,6 +768,10 @@ fn test_subscribe_progress() {
                     let data_ts = await_data(&mut client_reads, &mut last_seen_ts, &data);
                     await_progress(&mut client_reads, &mut last_seen_ts, data_ts + 1);
                 }
+
+                client_writes
+                    .batch_execute("DROP TABLE t1 CASCADE")
+                    .unwrap();
             }
         }
     }


### PR DESCRIPTION
test_subscribe_progress iterates on a couple of different parameters and executes roughly the same test for each variant of each parameter. Previously, each iteration would stop and start a new Materialize server. Considering that starting a new server is fairly expensive, this cause test_subscribe_progress to be very slow. Roughly 94.158s in CI and 160s locally on my machine. There's no correctness reason for each iteration to start with a fresh server.

This commit updates test_subscribe_progress so that it only starts a single server and uses it for each iteration. Locally this caused the test to speed up to 37s.

### Motivation
Speedup tests

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
