### PR TITLE
storage: refactor reconciliation errors

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -627,14 +627,7 @@ where
                 for (id, new_shard_upper) in list {
                     let (frontier, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => {
-                            // This can occur if a running clusterd gets
-                            // connected to a new environmentd; the clusterd
-                            // might not yet know that its new envd doesn't have
-                            // this collection.
-                            tracing::warn!("Reference to absent collection: {id}");
-                            return None;
-                        }
+                        None => panic!("Reference to absent collection: {id}"),
                     };
                     let old_upper = frontier.frontier().to_owned();
                     let shard_upper = match &mut shard_frontiers[shard_id] {
@@ -663,14 +656,7 @@ where
                 for id in dropped_ids {
                     let (_, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => {
-                            // This can occur if a running clusterd gets
-                            // connected to a new environmentd; the clusterd
-                            // might not yet know that its new envd doesn't have
-                            // this collection.
-                            tracing::warn!("Reference to absent collection: {id}");
-                            return None;
-                        }
+                        None => panic!("Reference to absent collection: {id}"),
                     };
                     let prev = shard_frontiers[shard_id].take();
                     assert!(


### PR DESCRIPTION
@MaterializeInc/storage wdyt? this is a little more principled than #22632, though I worry that it's a little fiddly.

### Motivation

This PR refactors existing code. supersedes #22632 if merged

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
