### PR TITLE
persist-client: warn if heartbeat task exits with live read handle

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1074,6 +1074,19 @@ where
             }
 
             if !existed {
+                // If the read handle was intentionally expired, this task
+                // *should* be aborted before it observes the expiration. So if
+                // we get here, this task somehow failed to keep the read lease
+                // alive. Warn loudly, because there's now a live read handle to
+                // an expired shard that will panic if used, but don't panic,
+                // just in case there is some edge case that results in this
+                // task observing the intentional expiration of a read handle.
+                warn!(
+                    "heartbeat task for reader ({}) of shard ({}) exiting due to expired lease \
+                     while read handle is live",
+                    reader_id,
+                    machine.shard_id(),
+                );
                 return;
             }
         }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -783,6 +783,7 @@ impl Schema<ShardId> for ShardIdSchema {
 #[cfg(test)]
 mod tests {
     use std::future::Future;
+    use std::mem;
     use std::pin::Pin;
     use std::str::FromStr;
     use std::task::Context;
@@ -1985,12 +1986,12 @@ mod tests {
             .expect("client construction failed")
             .expect_open::<(), (), u64, i64>(ShardId::new())
             .await;
-        let read_heartbeat_tasks = read
-            .heartbeat_tasks
+        let mut read_unexpired_state = read
+            .unexpired_state
             .take()
-            .expect("handle should have heartbeat task");
+            .expect("handle should have unexpired state");
         read.expire().await;
-        for read_heartbeat_task in read_heartbeat_tasks {
+        for read_heartbeat_task in mem::take(&mut read_unexpired_state.heartbeat_tasks) {
             let () = read_heartbeat_task
                 .await
                 .expect("task should shutdown cleanly");


### PR DESCRIPTION
We suspect that slow timely polls could result in a live read handle whose heartbeat task has exited because the lease has expired. Warn loudly when this occurs, to hopefully make the root cause easier to track down.

Related to #22630.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improves logging in the hopes of tracking down reader lease timeouts in production.

### Tips for reviewer

I was worried about `explicitly_expired` getting out of sync with `heartbeat_tasks`, so I merged the state into one optional field called `UnexpiredReadHandleState`. When this field is `None`, the handle has been explicitly expired. If you feel like the separate fields were clearer, happy to defer to that opinion. Feel free also to just take over this PR if that will be faster than iterating via code review.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
