### PR TITLE
*: remove deprecated log-filter arguments

### DIFF
--- a/doc/developer/guide-testing.md
+++ b/doc/developer/guide-testing.md
@@ -75,6 +75,9 @@ might be familiar with it from other command-line tools.)
 Without `--nocapture`, `println!()` and `dbg!()`, output from tests can go
 missing, making debugging a very frustrating experience.
 
+Most tests execute with the tracing log filter `info`.
+This can be changed by setting the environment variable `MZ_TEST_LOG_FILTER`.
+
 The second argument worth special mention is the filter argument, which only
 runs the tests that match the specified pattern. For example, to only run tests
 with `avro` in their name:

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -91,7 +91,6 @@ use mz_http_util::DynamicFilterTarget;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
-use mz_ore::halt;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::netio::{Listener, SocketAddr};
 use mz_ore::now::SYSTEM_TIME;
@@ -211,22 +210,6 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             metrics_registry.clone(),
         )
         .await?;
-
-    if args.tracing.log_filter.is_some() {
-        halt!(
-            "`MZ_LOG_FILTER` / `--log-filter` has been removed. The filter is now configured by the \
-             `log_filter` system variable. In the rare case the filter is needed before the \
-             process has access to the system variable, use `MZ_STARTUP_LOG_FILTER` / `--startup-log-filter`."
-        )
-    }
-    if args.tracing.opentelemetry_filter.is_some() {
-        halt!(
-            "`MZ_OPENTELEMETRY_FILTER` / `--opentelemetry-filter` has been removed. The filter is now \
-            configured by the `opentelemetry_filter` system variable. In the rare case the filter \
-            is needed before the process has access to the system variable, use \
-            `MZ_STARTUP_OPENTELEMETRY_FILTER` / `--startup-opentelemetry-filter`."
-        )
-    }
 
     let tracing_handle = Arc::new(tracing_handle);
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -110,10 +110,10 @@ use mz_orchestrator_process::{
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs, TracingOrchestrator};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::error::ErrorExt;
+use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::task::RuntimeExt;
-use mz_ore::{halt, metric};
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::PersistConfig;
 use mz_persist_client::rpc::{
@@ -658,22 +658,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
         },
         metrics_registry.clone(),
     ))?;
-
-    if args.tracing.log_filter.is_some() {
-        halt!(
-            "`MZ_LOG_FILTER` / `--log-filter` has been removed. The filter is now configured by the \
-             `log_filter` system variable. In the rare case the filter is needed before the \
-             process has access to the system variable, use `MZ_STARTUP_LOG_FILTER` / `--startup-log-filter`."
-        )
-    }
-    if args.tracing.opentelemetry_filter.is_some() {
-        halt!(
-            "`MZ_OPENTELEMETRY_FILTER` / `--opentelemetry-filter` has been removed. The filter is now \
-            configured by the `opentelemetry_filter` system variable. In the rare case the filter \
-            is needed before the process has access to the system variable, use \
-            `MZ_STARTUP_OPENTELEMETRY_FILTER` / `--startup-opentelemetry-filter`."
-        )
-    }
 
     let span = tracing::info_span!("environmentd::run").entered();
 

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -120,10 +120,6 @@ use opentelemetry::KeyValue;
 /// orchestrators and does not belong in a foundational crate like `mz_ore`.
 #[derive(Debug, Clone, clap::Parser)]
 pub struct TracingCliArgs {
-    /// This arg has been replaced. Use the `log_filter` system variable or
-    /// `--startup-log-filter` arg instead.
-    #[clap(long, env = "LOG_FILTER", value_name = "FILTER")]
-    pub log_filter: Option<CloneableEnvFilter>,
     /// Which tracing events to log to stderr.
     ///
     /// This value is a comma-separated list of filter directives. Each filter
@@ -185,10 +181,6 @@ pub struct TracingCliArgs {
         use_value_delimiter = true
     )]
     pub opentelemetry_header: Vec<KeyValueArg<HeaderName, HeaderValue>>,
-    /// This arg has been replaced. Use the `opentelemetry_filter` system
-    /// variable or `--startup-opentelemetry-filter` arg instead.
-    #[clap(long, env = "OPENTELEMETRY_FILTER")]
-    pub opentelemetry_filter: Option<CloneableEnvFilter>,
     /// Which tracing events to export to the OpenTelemetry endpoint specified
     /// by `--opentelemetry-endpoint`.
     ///
@@ -398,13 +390,11 @@ impl NamespacedOrchestrator for NamespacedTracingOrchestrator {
             let tokio_console_listen_addr = listen_addrs.get("tokio-console");
             let mut args = (service_config.args)(listen_addrs);
             let TracingCliArgs {
-                log_filter: _,
                 startup_log_filter,
                 log_prefix,
                 log_format,
                 opentelemetry_endpoint,
                 opentelemetry_header,
-                opentelemetry_filter: _,
                 startup_opentelemetry_filter: _,
                 opentelemetry_resource,
                 #[cfg(feature = "tokio-console")]

--- a/src/ore/src/test.rs
+++ b/src/ore/src/test.rs
@@ -42,7 +42,7 @@ pub fn init_logging() {
 /// not run tests in any particular order, each must call `init_logging`.
 pub fn init_logging_default(level: &str) {
     LOG_INIT.call_once(|| {
-        let filter = EnvFilter::try_from_env("MZ_LOG_FILTER")
+        let filter = EnvFilter::try_from_env("MZ_TEST_LOG_FILTER")
             .or_else(|_| EnvFilter::try_new(level))
             .unwrap();
         FmtSubscriber::builder()


### PR DESCRIPTION
These have been unused and erroring for long enough that no one should be using them anymore.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a