### PR TITLE
ci: run SQLsmith as mz_system

### DIFF
--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -240,6 +240,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             f"--max-joins={args.max_joins}",
             f"--seed={seed + i}",
             "--log-json",
+            # we use mz_system to have access to all tables, including ones with restricted permissions
             f"--target=host={MZ_SERVERS[i % len(MZ_SERVERS)]} port=6877 dbname=materialize user=mz_system",
         ]
         if args.exclude_catalog:

--- a/test/sqlsmith/mzcompose.py
+++ b/test/sqlsmith/mzcompose.py
@@ -240,7 +240,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             f"--max-joins={args.max_joins}",
             f"--seed={seed + i}",
             "--log-json",
-            f"--target=host={MZ_SERVERS[i % len(MZ_SERVERS)]} port=6875 dbname=materialize user=materialize",
+            f"--target=host={MZ_SERVERS[i % len(MZ_SERVERS)]} port=6877 dbname=materialize user=mz_system",
         ]
         if args.exclude_catalog:
             cmd.append("--exclude-catalog")


### PR DESCRIPTION
As discussed with @def- to circumvent issues like `permission denied for SOURCE "mz_internal.mz_statement_execution_history"` in https://buildkite.com/materialize/nightlies/builds/4860.

Nightly: https://buildkite.com/materialize/nightlies/builds/4867