### PR TITLE
compute: remove unused flow control plumbing

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -31,7 +31,6 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_repr::fixed_length::{FromRowByTypes, IntoRowByTypes};
 use mz_repr::{ColumnType, Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
-use mz_timely_util::probe;
 use timely::communication::Allocate;
 use timely::container::columnation::Columnation;
 use timely::order::PartialOrder;
@@ -938,14 +937,6 @@ pub struct CollectionState {
     ///
     /// Only `Some` if the collection is a sink and *not* a subscribe.
     pub sink_write_frontier: Option<Rc<RefCell<Antichain<Timestamp>>>>,
-    /// Probe handles for regulating the output of dataflow sources that (transitively) feed this
-    /// collection.
-    ///
-    /// Only populated if the collection is an index.
-    ///
-    /// New dataflows that depend on this index are expected to report their output frontiers
-    /// through these probe handles.
-    pub index_flow_control_probes: Vec<probe::Handle<Timestamp>>,
 }
 
 impl CollectionState {
@@ -954,7 +945,6 @@ impl CollectionState {
             reported_frontier: ReportedFrontier::new(),
             sink_token: None,
             sink_write_frontier: None,
-            index_flow_control_probes: Default::default(),
         }
     }
 

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -27,8 +27,6 @@ use mz_repr::{ColumnType, DatumVec, DatumVecBorrow, Diff, GlobalId, Row, RowAren
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
-use mz_timely_util::probe;
-use mz_timely_util::probe::ProbeNotify;
 use timely::communication::message::RefOrMut;
 use timely::container::columnation::Columnation;
 use timely::dataflow::channels::pact::Pipeline;
@@ -345,19 +343,6 @@ impl<S: Scope> SpecializedArrangement<S>
 where
     S: ScopeParent<Timestamp = mz_repr::Timestamp>,
 {
-    /// Attaches probes to the stream of the underlying arrangement
-    /// to notify on index frontier advancement.
-    pub fn probe_notify_with(&self, probes: Vec<probe::Handle<mz_repr::Timestamp>>) {
-        match self {
-            SpecializedArrangement::RowUnit(inner) => {
-                inner.stream.probe_notify_with(probes);
-            }
-            SpecializedArrangement::RowRow(inner) => {
-                inner.stream.probe_notify_with(probes);
-            }
-        }
-    }
-
     /// Obtains a `SpecializedTraceHandle` for the underlying arrangement.
     pub fn trace_handle(&self) -> SpecializedTraceHandle {
         match self {

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -22,7 +22,6 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_timely_util::operator::CollectionExt;
-use mz_timely_util::probe;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::Scope;
 use timely::progress::Antichain;
@@ -45,7 +44,6 @@ where
         dependency_ids: BTreeSet<GlobalId>,
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
-        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) {
         soft_assert!(sink.non_null_assertions.is_strictly_sorted());
         // put together tokens that belong to the export
@@ -126,7 +124,6 @@ where
                     self.as_of_frontier.clone(),
                     ok_collection.enter_region(inner),
                     err_collection.enter_region(inner),
-                    probes,
                 );
 
                 if let Some(sink_token) = sink_token {
@@ -152,7 +149,6 @@ where
         as_of: Antichain<mz_repr::Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-        probes: Vec<probe::Handle<mz_repr::Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = mz_repr::Timestamp>;

--- a/src/compute/src/sink/subscribe.rs
+++ b/src/compute/src/sink/subscribe.rs
@@ -9,7 +9,6 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::convert::Infallible;
 use std::ops::DerefMut;
 use std::rc::Rc;
 
@@ -20,10 +19,9 @@ use mz_compute_types::sinks::{ComputeSinkDesc, SubscribeSinkConnection};
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
-use mz_timely_util::probe::{self, ProbeNotify};
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::Operator;
-use timely::dataflow::{Scope, Stream};
+use timely::dataflow::operators::generic::builder_rc::OperatorBuilder;
+use timely::dataflow::Scope;
 use timely::progress::timestamp::Timestamp as TimelyTimestamp;
 use timely::progress::Antichain;
 use timely::PartialOrder;
@@ -42,7 +40,6 @@ where
         as_of: Antichain<Timestamp>,
         sinked_collection: Collection<G, Row, Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-        probes: Vec<probe::Handle<Timestamp>>,
     ) -> Option<Rc<dyn Any>>
     where
         G: Scope<Timestamp = Timestamp>,
@@ -67,7 +64,6 @@ where
             as_of,
             sink.up_to.clone(),
             subscribe_protocol_handle,
-            probes,
         );
 
         // Inform the coordinator that we have been dropped,
@@ -89,92 +85,84 @@ fn subscribe<G>(
     as_of: Antichain<G::Timestamp>,
     up_to: Antichain<G::Timestamp>,
     subscribe_protocol_handle: Rc<RefCell<Option<SubscribeProtocol>>>,
-    probes: Vec<probe::Handle<Timestamp>>,
 ) where
     G: Scope<Timestamp = Timestamp>,
 {
-    // Let the subscribe sink emit a progress stream, so we can attach the flow control probes.
-    // The `Infallible` type signals that this steam never transports data updates.
-    // TODO: Replace `Infallible` with `!` once the latter is stabilized.
-    let progress_stream: Stream<G, Infallible>;
+    let name = format!("subscribe-{}", sink_id);
+    let mut op = OperatorBuilder::new(name, sinked_collection.scope());
+    let mut ok_input = op.new_input(&sinked_collection.inner, Pipeline);
+    let mut err_input = op.new_input(&err_collection.inner, Pipeline);
 
-    let mut rows_to_emit = Vec::new();
-    let mut errors_to_emit = Vec::new();
-    let mut finished = false;
-    let mut ok_buf = Default::default();
-    let mut err_buf = Default::default();
-    progress_stream = sinked_collection.inner.binary_frontier(
-        &err_collection.inner,
-        Pipeline,
-        Pipeline,
-        &format!("subscribe-{}", sink_id),
-        move |_cap, _info| {
-            move |ok_input, err_input, _output| {
-                if finished {
-                    // Drain the inputs, to avoid the operator being constantly rescheduled
-                    ok_input.for_each(|_, _| {});
-                    err_input.for_each(|_, _| {});
-                    return;
-                }
+    op.build(|_cap| {
+        let mut rows_to_emit = Vec::new();
+        let mut errors_to_emit = Vec::new();
+        let mut finished = false;
+        let mut ok_buf = Default::default();
+        let mut err_buf = Default::default();
 
-                let mut frontier = ok_input.frontier().frontier().to_owned();
-                frontier.extend(err_input.frontier().frontier().iter().copied());
+        move |frontiers| {
+            if finished {
+                // Drain the inputs, to avoid the operator being constantly rescheduled
+                ok_input.for_each(|_, _| {});
+                err_input.for_each(|_, _| {});
+                return;
+            }
 
-                let should_emit = |time: &Timestamp| {
-                    let beyond_as_of = if with_snapshot {
-                        as_of.less_equal(time)
-                    } else {
-                        as_of.less_than(time)
-                    };
-                    let before_up_to = !up_to.less_equal(time);
-                    beyond_as_of && before_up_to
+            let mut frontier = Antichain::new();
+            for input_frontier in frontiers {
+                frontier.extend(input_frontier.frontier().iter().copied());
+            }
+
+            let should_emit = |time: &Timestamp| {
+                let beyond_as_of = if with_snapshot {
+                    as_of.less_equal(time)
+                } else {
+                    as_of.less_than(time)
                 };
+                let before_up_to = !up_to.less_equal(time);
+                beyond_as_of && before_up_to
+            };
 
-                ok_input.for_each(|_, data| {
-                    data.swap(&mut ok_buf);
-                    for (row, time, diff) in ok_buf.drain(..) {
-                        if should_emit(&time) {
-                            rows_to_emit.push((time, row, diff));
-                        }
+            ok_input.for_each(|_, data| {
+                data.swap(&mut ok_buf);
+                for (row, time, diff) in ok_buf.drain(..) {
+                    if should_emit(&time) {
+                        rows_to_emit.push((time, row, diff));
                     }
-                });
-                err_input.for_each(|_, data| {
-                    data.swap(&mut err_buf);
-                    for (error, time, diff) in err_buf.drain(..) {
-                        if should_emit(&time) {
-                            errors_to_emit.push((time, error, diff));
-                        }
+                }
+            });
+            err_input.for_each(|_, data| {
+                data.swap(&mut err_buf);
+                for (error, time, diff) in err_buf.drain(..) {
+                    if should_emit(&time) {
+                        errors_to_emit.push((time, error, diff));
                     }
-                });
+                }
+            });
 
+            if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut() {
+                subscribe_protocol.send_batch(
+                    frontier.clone(),
+                    &mut rows_to_emit,
+                    &mut errors_to_emit,
+                );
+            }
+
+            if PartialOrder::less_equal(&up_to, &frontier) {
+                finished = true;
+                // We are done; indicate this by sending a batch at the
+                // empty frontier.
                 if let Some(subscribe_protocol) = subscribe_protocol_handle.borrow_mut().deref_mut()
                 {
                     subscribe_protocol.send_batch(
-                        frontier.clone(),
-                        &mut rows_to_emit,
-                        &mut errors_to_emit,
+                        Antichain::default(),
+                        &mut Vec::new(),
+                        &mut Vec::new(),
                     );
                 }
-
-                if PartialOrder::less_equal(&up_to, &frontier) {
-                    finished = true;
-                    // We are done; indicate this by sending a batch at the
-                    // empty frontier.
-                    if let Some(subscribe_protocol) =
-                        subscribe_protocol_handle.borrow_mut().deref_mut()
-                    {
-                        subscribe_protocol.send_batch(
-                            Antichain::default(),
-                            &mut Vec::new(),
-                            &mut Vec::new(),
-                        );
-                    }
-                }
             }
-        },
-    );
-
-    progress_stream.probe_notify_with(probes);
+        }
+    });
 }
 
 /// A type that guides the transmission of rows back to the coordinator.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1007,8 +1007,7 @@ const COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES: ServerVar<Option<usize>> = ServerVar 
 };
 
 /// The maximum number of in-flight bytes emitted by persist_sources feeding _storage
-/// dataflows_. This is distinct from `DATAFLOW_MAX_INFLIGHT_BYTES`, as this will
-/// supports more granular control (within a single timestamp).
+/// dataflows_.
 /// Currently defaults to 256MiB = 268435456 bytes
 /// Note: Backpressure will only be turned on if disk is enabled based on
 /// `storage_dataflow_max_inflight_bytes_disk_only` flag
@@ -3037,7 +3036,7 @@ impl SystemVars {
         *self.expect_value(&CRDB_TCP_USER_TIMEOUT)
     }
 
-    /// Returns the `dataflow_max_inflight_bytes` configuration parameter.
+    /// Returns the `compute_dataflow_max_inflight_bytes` configuration parameter.
     pub fn compute_dataflow_max_inflight_bytes(&self) -> Option<usize> {
         *self.expect_value(&COMPUTE_DATAFLOW_MAX_INFLIGHT_BYTES)
     }


### PR DESCRIPTION
As of #22549, which made flow control in compute local to the `persist_source`, the plumbing required for dataflow-wide flow control is dead code which this PR removes.

The intention is to free the rendering code from some needless complexity, not to give up on dataflow-wide flow control entirely. If we decide to pursue dataflow-wide flow control in the future, we can add the code removed here back in again. 

### Motivation

   * This PR refactors existing code.

Follow-up to #22549.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A