### PR TITLE
parallel-workload: 2 fixes for too long identifiers

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -15,6 +15,7 @@ import pg8000
 import requests
 from pg8000.native import identifier
 
+import materialize.parallel_workload.database
 from materialize.data_ingest.data_type import NUMBER_TYPES, Text, TextTextMap
 from materialize.mzcompose.composition import Composition
 from materialize.parallel_workload.database import (
@@ -29,7 +30,6 @@ from materialize.parallel_workload.database import (
     MAX_TABLES,
     MAX_VIEWS,
     MAX_WEBHOOK_SOURCES,
-    NAUGHTY_IDENTIFIERS,
     Cluster,
     ClusterReplica,
     Database,
@@ -100,7 +100,7 @@ class Action:
             )
         if self.db.scenario == Scenario.Rename:
             result.extend(["unknown schema", "ambiguous reference to schema name"])
-        if NAUGHTY_IDENTIFIERS:
+        if materialize.parallel_workload.database.NAUGHTY_IDENTIFIERS:
             result.extend(["identifier length exceeds 255 bytes"])
         return result
 

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -73,13 +73,7 @@ def naughtify(name: str) -> str:
     # This rng is just to get a more interesting integer for the name
     index = abs(hash(name)) % len(strings)
     # Keep them short so we can combine later with other identifiers, 255 char limit
-    naughty_suffix = strings[index].encode("utf-8")[:8].decode("utf-8", "ignore")
-
-    naughty_identifier = f"{name}_{naughty_suffix}"
-    assert (
-        len(naughty_identifier.encode("utf-8")) <= MAX_IDENTIFIER_LENGTH
-    ), f"Naughty identifier exceeds length limit of {MAX_IDENTIFIER_LENGTH} chars (name={name}, naughty_suffix={naughty_suffix})"
-    return naughty_identifier
+    return f"{name}_{strings[index].encode('utf-8')[:16].decode('utf-8', 'ignore')}"
 
 
 class BodyFormat(Enum):
@@ -103,7 +97,7 @@ class Column:
     db_object: "DBObject"
     nullable: bool
     default: str | None
-    _name: str
+    raw_name: str
 
     def __init__(
         self,
@@ -119,16 +113,17 @@ class Column:
         self.default = rng.choice(
             [None, str(data_type.random_value(rng, in_query=True))]
         )
-        self._name = f"c-{self.column_id}-{self.data_type.name()}"
+        self.raw_name = f"c-{self.column_id}-{self.data_type.name()}"
+
+    def name(self, in_query: bool = False) -> str:
+        return (
+            identifier(naughtify(self.raw_name))
+            if in_query
+            else naughtify(self.raw_name)
+        )
 
     def __str__(self) -> str:
         return f"{self.db_object}.{self.name(True)}"
-
-    def name(self, in_query: bool = False) -> str:
-        return identifier(naughtify(self._name)) if in_query else naughtify(self._name)
-
-    def set_name(self, new_name: str) -> None:
-        self._name = new_name
 
     def value(self, rng: random.Random, in_query: bool = False) -> str:
         return str(self.data_type.random_value(rng, in_query=in_query))
@@ -238,7 +233,7 @@ class View(DBObject):
         ]
         self.columns = [copy(column) for column in self.source_columns]
         for column in self.columns:
-            column.set_name(f"{column.name()}-{column.db_object}")
+            column.raw_name = f"{column.raw_name}-{column.db_object}"
             column.db_object = self
 
         self.materialized = rng.choice([True, False])
@@ -312,13 +307,13 @@ class WebhookColumn(Column):
     def __init__(
         self, name: str, data_type: type[DataType], nullable: bool, db_object: DBObject
     ):
-        self._name = name
+        self.raw_name = name
         self.data_type = data_type
         self.nullable = nullable
         self.db_object = db_object
 
     def name(self, in_query: bool = False) -> str:
-        return identifier(self._name) if in_query else self._name
+        return identifier(self.raw_name) if in_query else self.raw_name
 
 
 class WebhookSource(DBObject):
@@ -393,13 +388,13 @@ class KafkaColumn(Column):
     def __init__(
         self, name: str, data_type: type[DataType], nullable: bool, db_object: DBObject
     ):
-        self._name = name
+        self.raw_name = name
         self.data_type = data_type
         self.nullable = nullable
         self.db_object = db_object
 
     def name(self, in_query: bool = False) -> str:
-        return identifier(self._name) if in_query else self._name
+        return identifier(self.raw_name) if in_query else self.raw_name
 
 
 class KafkaSource(DBObject):
@@ -509,13 +504,13 @@ class PostgresColumn(Column):
     def __init__(
         self, name: str, data_type: type[DataType], nullable: bool, db_object: DBObject
     ):
-        self._name = name
+        self.raw_name = name
         self.data_type = data_type
         self.nullable = nullable
         self.db_object = db_object
 
     def name(self, in_query: bool = False) -> str:
-        return identifier(self._name) if in_query else self._name
+        return identifier(self.raw_name) if in_query else self.raw_name
 
 
 class PostgresSource(DBObject):


### PR DESCRIPTION
Fixes:  #22607 

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
