### PR TITLE
ci: upgrade-matrix: fix

### DIFF
--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -15,6 +15,8 @@ from collections.abc import Generator
 
 import networkx as nx
 
+from materialize.mzcompose.services.minio import Minio
+
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
 sys.path.append(os.path.dirname(__file__))
@@ -52,7 +54,8 @@ SERVICES = [
     Postgres(),
     Redpanda(auto_create_topics=True),
     Debezium(redpanda=True),
-    Materialized(),  # Overriden inside Platform Checks
+    Minio(setup_materialize=True),
+    Materialized(external_minio=True),  # Overriden inside Platform Checks
     TestdriveService(
         default_timeout="300s",
         no_reset=True,


### PR DESCRIPTION
This should fix the failure https://buildkite.com/materialize/nightlies/builds/4860#018b6609-f7a0-480a-ba3a-4a40738a1c6d (tested locally with this seed). (I assume that the platform checks, which override mz according to the comment, use minio?)

The error message was:
```
Starting Mz using image materialize/materialized:v0.44.3
service "materialized" depends on undefined service minio: invalid compose project
```

Does this fix make sense?

Triggered nightly: https://buildkite.com/materialize/nightlies/builds/4873 (with a new seed)