### PR TITLE
ci: Fix coverage post-command hook

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -797,7 +797,7 @@ steps:
     steps:
       - id: parallel-workload-dml
         label: "Parallel Workload (DML)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -808,7 +808,7 @@ steps:
 
       - id: parallel-workload-ddl
         label: "Parallel Workload (DDL)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -819,7 +819,7 @@ steps:
 
       - id: parallel-workload-100-threads
         label: "Parallel Workload (100 threads)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -831,7 +831,7 @@ steps:
 
       - id: parallel-workload-rename-naughty
         label: "Parallel Workload (rename + naughty identifiers)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -842,7 +842,7 @@ steps:
 
       - id: parallel-workload-rename
         label: "Parallel Workload (rename)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -853,7 +853,7 @@ steps:
 
       - id: parallel-workload-cancel
         label: "Parallel Workload (cancel)"
-        artifact_paths: junit_*.xml
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
         timeout_in_minutes: 40
         agents:
           queue: builder-linux-x86_64
@@ -862,17 +862,17 @@ steps:
               composition: parallel-workload
               args: [--runtime=1500, --scenario=cancel]
 
-  - id: parallel-workload-kill
-    label: "Parallel Workload (kill)"
-    artifact_paths: junit_*.xml
-    timeout_in_minutes: 40
-    agents:
-      queue: builder-linux-x86_64
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: parallel-workload
-          args: [--runtime=1500, --scenario=kill]
-    skip: "TODO(def-) Enable after figuring out restoring catalog"
+      - id: parallel-workload-kill
+        label: "Parallel Workload (kill)"
+        artifact_paths: [junit_*.xml, parallel-workload-queries.log.zst]
+        timeout_in_minutes: 40
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: parallel-workload
+              args: [--runtime=1500, --scenario=kill]
+        skip: "TODO(def-) Enable after figuring out restoring catalog"
 
   - id: incident-70
     label: "Test for incident 70"

--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -91,7 +91,7 @@ find cores -name 'core.*' | while read -r core; do
     if grep -q "Program terminated with signal SIGABRT, Aborted." "$core".txt; then
       echo "SIGABRT found in \"$core.txt\", ignoring core file"
     else
-      bin/ci-builder run stable zstd --rm "$core"
+      zstd --rm "$core"
       buildkite-agent artifact upload "$core".txt
       buildkite-agent artifact upload "$core".zst
     fi
@@ -103,5 +103,5 @@ bin/ci-builder run stable zstd --rm parallel-workload-queries.log || true
 
 artifacts=(run.log services.log journalctl-merge.log netstat-ant.log netstat-panelot.log ps-aux.log docker-ps-a.log docker-inspect.log)
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
-buildkite-agent artifact upload "$artifacts_str;parallel-workload-queries.log.zst"
+buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-logged-errors-detect "${artifacts[@]}"


### PR DESCRIPTION
Seen to work in https://buildkite.com/materialize/coverage/builds/289#_
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
