### PR TITLE
sql: Fix panic when casting string to map

### DIFF
--- a/src/expr/src/scalar/func/impls/string.rs
+++ b/src/expr/src/scalar/func/impls/string.rs
@@ -478,11 +478,11 @@ impl LazyUnaryFunc for CastStringToMap {
             ),
             |value_text| -> Result<Datum, EvalError> {
                 let value_text = match value_text {
-                    Cow::Owned(s) => temp_storage.push_string(s),
-                    Cow::Borrowed(s) => s,
+                    Some(Cow::Owned(s)) => Datum::String(temp_storage.push_string(s)),
+                    Some(Cow::Borrowed(s)) => Datum::String(s),
+                    None => Datum::Null,
                 };
-                self.cast_expr
-                    .eval(&[Datum::String(value_text)], temp_storage)
+                self.cast_expr.eval(&[value_text], temp_storage)
             },
         )?;
         let mut pairs: Vec<(String, Datum)> = parsed_map.into_iter().map(|(k, v)| (k, v)).collect();

--- a/src/pgrepr/src/value.rs
+++ b/src/pgrepr/src/value.rs
@@ -599,7 +599,11 @@ impl Value {
             Type::Map { value_type } => Value::Map(strconv::parse_map(
                 s,
                 matches!(**value_type, Type::Map { .. }),
-                |elem_text| Value::decode_text(value_type, elem_text.as_bytes()).map(Some),
+                |elem_text| {
+                    elem_text
+                        .map(|t| Value::decode_text(value_type, t.as_bytes()))
+                        .transpose()
+                },
             )?),
             Type::Name => Value::Name(strconv::parse_pg_legacy_name(s)),
             Type::Numeric { .. } => Value::Numeric(Numeric(strconv::parse_numeric(s)?)),

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -1301,7 +1301,7 @@ fn lex_unquoted_element<'a>(
 pub fn parse_map<'a, V, E>(
     s: &'a str,
     is_value_type_map: bool,
-    gen_elem: impl FnMut(Cow<'a, str>) -> Result<V, E>,
+    gen_elem: impl FnMut(Option<Cow<'a, str>>) -> Result<V, E>,
 ) -> Result<BTreeMap<String, V>, ParseError>
 where
     E: ToString,
@@ -1313,7 +1313,7 @@ where
 fn parse_map_inner<'a, V, E>(
     s: &'a str,
     is_value_type_map: bool,
-    mut gen_elem: impl FnMut(Cow<'a, str>) -> Result<V, E>,
+    mut gen_elem: impl FnMut(Option<Cow<'a, str>>) -> Result<V, E>,
 ) -> Result<BTreeMap<String, V>, String>
 where
     E: ToString,
@@ -1388,7 +1388,7 @@ where
             Some(_) => lex_unquoted_element(buf, is_special_char, is_end_of_literal)?,
             None => bail!("unexpected end of input"),
         };
-        let value = gen_value(value.unwrap())?;
+        let value = gen_value(value)?;
 
         // Insert elements.
         map.insert(key, value);

--- a/test/sqllogictest/map.slt
+++ b/test/sqllogictest/map.slt
@@ -175,6 +175,11 @@ SELECT '{""=>1}'::map[text=>int] ? ''
 true
 
 query T
+SELECT '{"1" => NULL}'::map[text=>text] ? ''
+----
+false
+
+query T
 SELECT '{hello=>{world=>false}}'::map[text=>map[text=>bool]] -> 'hello'::text ? 'world'::text
 ----
 true


### PR DESCRIPTION
This PR fixes a panic that occurs when casting a string literal to a map, if the resulting map contained `NULL` for any values. For example:

```
SELECT '{1 => NULL}'::map[text=>text];
```

The code paths for handling NULL values already existed, we just needed to plumb things through.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/21937

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
