### PR TITLE
ci: annotate more information when SLT test fails

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -72,6 +72,7 @@ ERROR_RE = re.compile(
     | clusterd:\ fatal: # startup failure
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
     | unrecognized\ configuration\ parameter
+    | OutputFailure:
     )
     """,
     re.VERBOSE,


### PR DESCRIPTION
Addressing https://materializeinc.slack.com/archives/C01LKF361MZ/p1698148877662499.

The log contains stuff like

```
_bk;t=1698093503667    SELECT DISTINCT(privilege) FROM item_privileges WHERE type = 'view' OR type = 'materialized view' OR type = 'source'
_bk;t=1698093503667    OutputFailure:test/sqllogictest/privilege_grants.slt:99
_bk;t=1698093503667            expected: Values(["=r/mz_system", "mz_system=r/mz_system", "materialize=r/materialize"])
_bk;t=1698093503667            actually: Values(["=r/mz_system", "mz_system=r/mz_system", "mz_support=r/mz_system", "materialize=r/materialize"])
_bk;t=1698093503667            actual raw: [Row { columns: [Column { name: "privilege", type: Text }] }, Row { columns: [Column { name: "privilege", type: Text }] }, Row { columns: [Column { name: "privilege", type: Text }] }, Row { columns: [Column { name: "privilege", type: Text }] }]
```

We could also include `        expected: ` and `        actually:` if we want.

Testing with https://buildkite.com/materialize/tests/builds/66890.