### PR TITLE
ci: fix data-ingest

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -80,6 +80,29 @@ class Executor:
             print(f"Query failed: {query}")
             raise
 
+    def execute_with_retry_on_error(
+        self,
+        cur: pg8000.Cursor,
+        query: str,
+        max_tries: int,
+        wait_time_in_sec: int,
+        required_error_message_substr: str | None,
+    ) -> None:
+        for try_count in range(1, max_tries + 1):
+            try:
+                self.execute(cur, query)
+                return
+            except Exception as e:
+                if (
+                    required_error_message_substr is not None
+                    and required_error_message_substr not in e.__str__()
+                ):
+                    raise
+                elif try_count == max_tries:
+                    raise
+                else:
+                    time.sleep(wait_time_in_sec)
+
 
 class PrintExecutor(Executor):
     def create(self) -> None:
@@ -398,7 +421,7 @@ class KafkaRoundtripExecutor(Executor):
         keys = [field.name for field in self.fields if field.is_key]
 
         self.mz_conn.autocommit = True
-        with self.mz_conn.cursor() as cur:
+        with (self.mz_conn.cursor() as cur):
             self.execute(cur, f"DROP TABLE IF EXISTS {identifier(self.table_original)}")
             self.execute(
                 cur,
@@ -415,13 +438,16 @@ class KafkaRoundtripExecutor(Executor):
                     USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                     ENVELOPE DEBEZIUM""",
             )
-            self.execute(
+            self.execute_with_retry_on_error(
                 cur,
                 f"""CREATE SOURCE {identifier(self.schema)}.{identifier(self.table)}
                     FROM KAFKA CONNECTION kafka_conn (TOPIC '{self.topic}')
                     FORMAT AVRO
                     USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                     ENVELOPE DEBEZIUM""",
+                wait_time_in_sec=1,
+                max_tries=15,
+                required_error_message_substr="No value schema found",
             )
         self.mz_conn.autocommit = False
 

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -84,9 +84,9 @@ class Executor:
         self,
         cur: pg8000.Cursor,
         query: str,
-        max_tries: int,
-        wait_time_in_sec: int,
         required_error_message_substr: str | None,
+        max_tries: int = 5,
+        wait_time_in_sec: int = 1,
     ) -> None:
         for try_count in range(1, max_tries + 1):
             try:


### PR DESCRIPTION
This is the proposed solution to fix https://buildkite.com/materialize/nightlies/builds/4875#018b669a-0249-44f8-b910-710dc093bb7c if we don't want to use testdrive in data-ingest.

I haven't found a way to realize the wait using introspection tables; `mz_sinks` and `mz_kafka_sinks` won't provide us the information we need. The testdrive command `kafka-verify-topic` reaches out to kafka to do its job.