### PR TITLE
adapter: rework `feature_flags` macro

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3484,13 +3484,16 @@ impl Catalog {
     ) -> Result<CatalogItem, AdapterError> {
         let mut session_catalog = self.for_system_session();
         // Enable catalog features that might be required during planning in
-        // [Catalog::open]. Existing catalog items might have been created while a
-        // specific feature flag turned on, so we need to ensure that this is also the
-        // case during catalog rehydration in order to avoid panics.
-        // WARNING / CONTRACT: The session catalog with all features enabled should be used
-        // exclusively for parsing and obtaining an mz_sql::plan::Plan. After this step,
-        // feature flag configuration must not be overridden.
-        session_catalog.system_vars_mut().enable_all_feature_flags();
+        // [Catalog::open]. Existing catalog items might have been created while
+        // a specific feature flag was turned on, so we need to ensure that this
+        // is also the case during catalog rehydration in order to avoid panics.
+        //
+        // WARNING / CONTRACT:
+        // 1. Features used in this method that related to parsing / planning
+        //    should be `enable_for_item_parsing` set to `true`.
+        // 2. After this step, feature flag configuration must not be
+        //    overridden.
+        session_catalog.system_vars_mut().enable_for_item_parsing();
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -688,13 +688,16 @@ impl CatalogState {
         let mut session_catalog = Catalog::for_system_session_state(self);
 
         // Enable catalog features that might be required during planning in
-        // [Catalog::open]. Existing catalog items might have been created while a
-        // specific feature flag turned on, so we need to ensure that this is also the
-        // case during catalog rehydration in order to avoid panics.
-        // WARNING / CONTRACT: The session catalog with all features enabled should be used
-        // exclusively for parsing and obtaining an an mz_sql::plan::Plan. After this step,
-        // feature flag configuration must not be overridden.
-        session_catalog.system_vars_mut().enable_all_feature_flags();
+        // [Catalog::open]. Existing catalog items might have been created while
+        // a specific feature flag was turned on, so we need to ensure that this
+        // is also the case during catalog rehydration in order to avoid panics.
+        //
+        // WARNING / CONTRACT:
+        // 1. Features used in this method that related to parsing / planning
+        //    should be `enable_for_item_parsing` set to `true`.
+        // 2. After this step, feature flag configuration must not be
+        //    overridden.
+        session_catalog.system_vars_mut().enable_for_item_parsing();
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;


### PR DESCRIPTION
Rework the `feature_flags` to make it both (a) more transparent (less implicit magic), and (b) useful for compute folks that might need flags turned off in catalog item parsing methods.

### Motivation

   * This PR refactors existing code.

Addressing some readability and utility limitations with the current `feature_flags` macro.

### Tips for reviewer

Rework the macro as follows:

- Prohibit implicit default values. I think people are often confused by the default, so it's better for every feature flag to explicitly state all its property values.
- Use syntax with explicit naming `{key1: val1, key2: val2}` instead of syntax with anonymous tuples `(val1, val2)`.
- Rename `enable_all_feature_flags` to `enable_in_item_parsing`. This better indicates the scope in which this method should be called.
- Add an extra property called `enable_in_item_parsing` to determine which flags are turned on by the `enable_in_item_parsing()` call. This allows us to explicitly exclude flags from having this behavior (which is desirable for feature flags influencing the HIR ⇒ MIR lowering code).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
