### PR TITLE
zippy: Only create sources on source-capable clusters

### DIFF
--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -20,6 +20,7 @@ from materialize.zippy.debezium_capabilities import (
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.kafka_capabilities import KafkaRunning
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.storaged_capabilities import StoragedRunning
 
 
@@ -57,7 +58,7 @@ class CreateDebeziumSource(Action):
     def __init__(self, capabilities: Capabilities) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
-        cluster_name = random.choice(["storage", "default"])
+        cluster_name = random.choice(source_capable_clusters(capabilities))
         debezium_source_name = f"debezium_source_{postgres_table.name}"
         this_debezium_source = DebeziumSourceExists(name=debezium_source_name)
 

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -16,6 +16,7 @@ from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
 from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
+from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.storaged_capabilities import StoragedRunning
 
 
@@ -30,7 +31,7 @@ class CreatePostgresCdcTable(Action):
         postgres_table = random.choice(capabilities.get(PostgresTableExists))
         postgres_pg_cdc_name = f"postgres_{postgres_table.name}"
         this_postgres_cdc_table = PostgresCdcTableExists(name=postgres_pg_cdc_name)
-        cluster_name = random.choice(["storage", "default"])
+        cluster_name = random.choice(source_capable_clusters(capabilities))
 
         existing_postgres_cdc_tables = [
             s

--- a/misc/python/materialize/zippy/replica_capabilities.py
+++ b/misc/python/materialize/zippy/replica_capabilities.py
@@ -9,7 +9,7 @@
 
 from enum import Enum
 
-from materialize.zippy.framework import Capability
+from materialize.zippy.framework import Capabilities, Capability
 
 
 class ReplicaSizeType(Enum):
@@ -27,3 +27,11 @@ class ReplicaExists(Capability):
 
     def __init__(self, name: str) -> None:
         self.name = name
+
+
+def source_capable_clusters(capabilities: Capabilities) -> list[str]:
+    if len(capabilities.get(ReplicaExists)) > 0:
+        # Default cluster may have multiple replicas, can not be used for sources
+        return ["storage"]
+    else:
+        return ["storage", "default"]

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -13,6 +13,7 @@ from textwrap import dedent
 from materialize.mzcompose.composition import Composition
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.sink_capabilities import SinkExists
 from materialize.zippy.storaged_capabilities import StoragedRunning
 from materialize.zippy.view_capabilities import ViewExists
@@ -35,8 +36,8 @@ class CreateSinkParameterized(ActionFactory):
 
         if new_sink_name:
             source_view = random.choice(capabilities.get(ViewExists))
-            cluster_name_out = random.choice(["storage", "default"])
-            cluster_name_in = random.choice(["storage", "default"])
+            cluster_name_out = random.choice(source_capable_clusters(capabilities))
+            cluster_name_in = random.choice(source_capable_clusters(capabilities))
 
             dest_view = ViewExists(
                 name=f"{new_sink_name}_view",

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -14,6 +14,7 @@ from materialize.mzcompose.composition import Composition
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
 from materialize.zippy.mz_capabilities import MzIsRunning
+from materialize.zippy.replica_capabilities import source_capable_clusters
 from materialize.zippy.source_capabilities import SourceExists
 from materialize.zippy.storaged_capabilities import StoragedRunning
 
@@ -40,7 +41,9 @@ class CreateSourceParameterized(ActionFactory):
                     source=SourceExists(
                         name=new_source_name,
                         topic=random.choice(capabilities.get(TopicExists)),
-                        cluster_name=random.choice(["storage", "default"]),
+                        cluster_name=random.choice(
+                            source_capable_clusters(capabilities)
+                        ),
                     ),
                 )
             ]


### PR DESCRIPTION
If a workload is messing up with the replicas of the default cluster, that cluster can not be used to host sources.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Nightly was failing after an incomplete test was pushed prematurely.