### PR TITLE
Fix merge skew in scalability framework

### DIFF
--- a/misc/python/materialize/scalability/workload_executor.py
+++ b/misc/python/materialize/scalability/workload_executor.py
@@ -289,13 +289,15 @@ class WorkloadExecutor:
         return cursor_pool
 
     def _record_results(self, endpoint: Endpoint, df_totals: pd.DataFrame) -> None:
-        endpoint_name = endpoint.name()
-        print(f"Collecting results of endpoint {endpoint} with name {endpoint_name}")
+        endpoint_version_name = endpoint.try_load_version()
+        print(
+            f"Collecting results of endpoint {endpoint} with name {endpoint_version_name}"
+        )
 
-        if endpoint_name not in self.df_total_by_endpoint_name:
-            self.df_total_by_endpoint_name[endpoint_name] = df_totals
+        if endpoint_version_name not in self.df_total_by_endpoint_name:
+            self.df_total_by_endpoint_name[endpoint_version_name] = df_totals
         else:
-            self.df_total_by_endpoint_name[endpoint_name] = pd.concat(
-                [self.df_total_by_endpoint_name[endpoint_name], df_totals],
+            self.df_total_by_endpoint_name[endpoint_version_name] = pd.concat(
+                [self.df_total_by_endpoint_name[endpoint_version_name], df_totals],
                 ignore_index=True,
             )


### PR DESCRIPTION
Merge skew between https://github.com/MaterializeInc/materialize/pull/22672 and https://github.com/MaterializeInc/materialize/pull/22614

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
