### PR TITLE
cleanup: Remove enable_webhook_sources LD flag

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -86,7 +86,6 @@ def run(
     system_conn.autocommit = True
     with system_conn.cursor() as system_cur:
         system_exe = Executor(rng, system_cur, database)
-        system_exe.execute("ALTER SYSTEM SET enable_webhook_sources TO true")
         system_exe.execute(
             f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 2}"
         )

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -810,13 +810,6 @@ impl Coordinator {
         conn_id: ConnectionId,
         tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
     ) {
-        // Make sure the feature is enabled before doing anything else.
-        if !self.catalog().system_config().enable_webhook_sources() {
-            // We don't care if the listener went away.
-            let _ = tx.send(Err(AdapterError::Unsupported("enable_webhook_sources")));
-            return;
-        }
-
         /// Attempts to resolve a Webhook source from a provided `database.schema.name` path.
         ///
         /// Returns a struct that can be used to append data to the underlying storate collection, and the

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2446,7 +2446,6 @@ fn test_cancel_ws() {
 #[cfg_attr(miri, ignore)] // too slow
 fn smoketest_webhook_source() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -2559,7 +2558,6 @@ fn smoketest_webhook_source() {
 #[cfg_attr(miri, ignore)] // too slow
 fn test_invalid_webhook_body() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     let http_client = Client::new();
@@ -2643,7 +2641,6 @@ fn test_invalid_webhook_body() {
 #[cfg_attr(miri, ignore)] // too slow
 fn test_webhook_duplicate_headers() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     let http_client = Client::new();
@@ -2870,7 +2867,6 @@ fn test_http_metrics() {
 #[cfg_attr(miri, ignore)] // too slow
 fn webhook_concurrent_actions() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -3030,11 +3026,7 @@ fn webhook_concurrency_limit() {
     let server = test_util::start_server(config).unwrap();
 
     // Note: we need enable_unstable_dependencies to use mz_sleep.
-    server.enable_feature_flags(&[
-        "enable_webhook_sources",
-        "enable_unstable_dependencies",
-        "enable_dangerous_functions",
-    ]);
+    server.enable_feature_flags(&["enable_unstable_dependencies", "enable_dangerous_functions"]);
 
     // Reduce the webhook concurrency limit;
     let mut mz_client = server
@@ -3117,7 +3109,6 @@ fn webhook_concurrency_limit() {
 #[cfg_attr(miri, ignore)] // too slow
 fn webhook_too_large_request() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
 
@@ -3167,7 +3158,6 @@ fn webhook_too_large_request() {
 #[cfg_attr(miri, ignore)] // too slow
 fn test_webhook_url_notice() {
     let server = test_util::start_server(test_util::Config::default()).unwrap();
-    server.enable_feature_flags(&["enable_webhook_sources"]);
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
 
     let mut client = server

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -401,9 +401,6 @@ pub fn plan_create_webhook_source(
     scx: &StatementContext,
     stmt: CreateWebhookSourceStatement<Aug>,
 ) -> Result<Plan, PlanError> {
-    // Make sure the LaunchDarkly flag is enabled.
-    scx.require_feature_flag(&vars::ENABLE_WEBHOOK_SOURCES)?;
-
     let create_sql =
         normalize::create_statement(scx, Statement::CreateWebhookSource(stmt.clone()))?;
 

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1873,13 +1873,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_webhook_sources,
-        desc: "creating or pushing data to webhook sources",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_try_parse_monotonic_iso8601_timestamp,
         desc: "the try_parse_monotonic_iso8601_timestamp function",
         default: false,

--- a/src/testdrive/src/error.rs
+++ b/src/testdrive/src/error.rs
@@ -129,7 +129,7 @@ impl ErrorLocation {
                     &mut snippet,
                     "{:4} | {} ... [rest of line truncated for security]",
                     i + 1,
-                    l.get(0..20).unwrap()
+                    l.get(0..20).unwrap_or(l)
                 )
                 .unwrap();
             } else if i + 2 >= line {

--- a/test/legacy-upgrade/create-in-v0.76.0-webhook-source.td
+++ b/test/legacy-upgrade/create-in-v0.76.0-webhook-source.td
@@ -8,10 +8,7 @@
 # by the Apache License, Version 2.0.
 
 $ skip-if
-SELECT mz_version_num() >= 7600;
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_webhook_sources = true
+SELECT mz_version_num() < 7600;
 
 > CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
 

--- a/test/sqllogictest/comment.slt
+++ b/test/sqllogictest/comment.slt
@@ -18,11 +18,6 @@ ALTER SYSTEM SET enable_comment TO true;
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_webhook_sources = true
-----
-COMPLETE 0
-
 statement ok
 CREATE TABLE a ( x int8, y text, z jsonb );
 

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -23,13 +23,6 @@ ALTER SYSTEM SET enable_ld_rbac_checks TO true;
 ----
 COMPLETE 0
 
-# Enable webhook sources.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_webhook_sources TO true;
-----
-COMPLETE 0
-
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_connection_validation_syntax TO true;
 ----
@@ -3275,12 +3268,5 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
-
-# Disable webhook sources.
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_webhook_sources TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -16,16 +16,6 @@ reset-server
 statement ok
 CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
 
-# We shouldn't be able to create a webhook source unless the feature is enabled.
-statement error creating or pushing data to webhook sources is not supported
-CREATE SOURCE webhook_bytes IN CLUSTER webhook_cluster FROM WEBHOOK
-    BODY FORMAT BYTES
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_webhook_sources = true
-----
-COMPLETE 0
-
 #
 # Happy Path, valid WEBHOOK sources
 #

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -9,9 +9,6 @@
 
 # Exercies Webhook sources.
 
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_webhook_sources = true
-
 > CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
 
 > CREATE SOURCE webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK
@@ -333,16 +330,8 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 > SELECT COUNT(*) FROM mz_internal.mz_storage_shards WHERE object_id = '${webhook-source-id}';
 0
 
-# Turn off the feature.
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_webhook_sources = false
-
-# Appending should now fail because the feature isn't enabled.
-$ webhook-append database=materialize schema=public name=webhook_text status=400
-d
-
 # Cleanup.
-DROP CLUSTER webhook_cluster CASCADE;
+> DROP CLUSTER webhook_cluster CASCADE;
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_unstable_dependencies = false;


### PR DESCRIPTION
Webhook sources have been released and have been created by users, so we have no intention of turning them off. This PR does some cleanup and removes the LaunchDarkly flag `enable_webhook_sources`.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/20218

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Removes a LaunchDarkly flag that was released to 100% of environments.
