### PR TITLE
catalog: Make transient_revision shared among all Clone's of a Catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4727,7 +4727,14 @@ mod tests {
                 Catalog::open_debug_stash_catalog_factory(&debug_stash_factory, NOW_ZERO.clone())
                     .await
                     .expect("unable to open debug catalog");
+            let catalog_clone = catalog.clone();
+
             assert_eq!(catalog.transient_revision(), 1);
+            assert_eq!(
+                catalog.transient_revision(),
+                catalog_clone.transient_revision()
+            );
+
             catalog
                 .transact(
                     mz_repr::Timestamp::MIN,
@@ -4743,7 +4750,15 @@ mod tests {
                 .await
                 .expect("failed to transact");
             assert_eq!(catalog.transient_revision(), 2);
+
+            // Make sure all clones of the catalog observe the change in transient revision.
+            assert_eq!(
+                catalog.transient_revision(),
+                catalog_clone.transient_revision()
+            );
+
             catalog.expire().await;
+            catalog_clone.expire().await;
         }
         {
             let catalog =

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -256,7 +256,7 @@ impl Catalog {
                 physical_plan_by_id: Default::default(),
                 dataflow_metainfos: BTreeMap::new(),
             },
-            transient_revision: 0,
+            transient_revision: Arc::new(atomic::AtomicU64::new(0)),
             storage: Arc::new(tokio::sync::Mutex::new(config.storage)),
         };
 
@@ -1697,7 +1697,7 @@ impl Catalog {
             }));
         }
 
-        c.transient_revision = 1;
+        c.transient_revision.store(1, atomic::Ordering::SeqCst);
         Ok(c)
     }
 


### PR DESCRIPTION
This PR changes the `transient_revision` field on the `Catalog` struct from being a `u64` to an `Arc<AtomicU64>`. Currently when a `Catalog` is `Clone`-d, each clone maintains it's own `transient_revision`, which means the `Catalog` could change, but the clones would not observe this change.

I could be misunderstanding how `transient_revision` intends to be used, but it seems to be intended to track when any version of the Catalog is changed at all.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
