### PR TITLE
platform-checks: Rework all_checks to use import_module

### DIFF
--- a/misc/python/materialize/checks/all_checks/__init__.py
+++ b/misc/python/materialize/checks/all_checks/__init__.py
@@ -8,13 +8,11 @@
 # by the Apache License, Version 2.0.
 
 import glob
+from importlib import import_module
 from os.path import basename, dirname, isfile, join
 
 # Automatically find all python files in this directory and import them when
 # using "from materialize.checks.all_checks import *"
-modules = glob.glob(join(dirname(__file__), "*.py"))
-__all__ = [  # pyright: ignore
-    basename(f).removesuffix(".py")
-    for f in modules
-    if isfile(f) and basename(f) != "__init__.py"
-]
+for f in glob.glob(join(dirname(__file__), "*.py")):
+    if isfile(f) and basename(f) != "__init__.py":
+        import_module(f".{basename(f).removesuffix('.py')}", __package__)


### PR DESCRIPTION
Was failing in https://buildkite.com/materialize/deploy/builds/11493#018b6bab-ae4e-4be7-bc14-c7cfb312d3ff

More modern solution and works with pdoc, see https://dev.materialize.com/api/python/materialize/checks/

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
