### PR TITLE
storage: refactor dropping + reconciling in storage_state

### DIFF
--- a/src/storage-client/src/client.rs
+++ b/src/storage-client/src/client.rs
@@ -627,14 +627,7 @@ where
                 for (id, new_shard_upper) in list {
                     let (frontier, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => {
-                            // This can occur if a running clusterd gets
-                            // connected to a new environmentd; the clusterd
-                            // might not yet know that its new envd doesn't have
-                            // this collection.
-                            tracing::warn!("Reference to absent collection: {id}");
-                            return None;
-                        }
+                        None => panic!("Reference to absent collection: {id}"),
                     };
                     let old_upper = frontier.frontier().to_owned();
                     let shard_upper = match &mut shard_frontiers[shard_id] {
@@ -663,14 +656,7 @@ where
                 for id in dropped_ids {
                     let (_, shard_frontiers) = match self.uppers.get_mut(&id) {
                         Some(value) => value,
-                        None => {
-                            // This can occur if a running clusterd gets
-                            // connected to a new environmentd; the clusterd
-                            // might not yet know that its new envd doesn't have
-                            // this collection.
-                            tracing::warn!("Reference to absent collection: {id}");
-                            return None;
-                        }
+                        None => panic!("Reference to absent collection: {id}"),
                     };
                     let prev = shard_frontiers[shard_id].take();
                     assert!(

--- a/src/storage/src/internal_control.rs
+++ b/src/storage/src/internal_control.rs
@@ -127,8 +127,11 @@ pub enum InternalStorageCommand {
         GlobalId,
         StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
     ),
-    /// Drop all state and operators for a dataflow.
-    DropDataflow(GlobalId),
+    /// Drop all state and operators for a dataflow. This is a vec because some
+    /// dataflows have their state spread over multiple IDs (i.e. sources that
+    /// spawn subsources); this means that actions taken in response to this
+    /// command should be permissive about missing state.
+    DropDataflow(Vec<GlobalId>),
 
     /// Update the configuration for rendering dataflows.
     UpdateConfiguration {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1122,6 +1122,12 @@ impl<'w, A: Allocate> Worker<'w, A> {
 
         commands.push(StorageCommand::AllowCompaction(stale_objects));
 
+        // Do not report dropping any objects that do not belong to expected
+        // objects.
+        self.storage_state
+            .dropped_ids
+            .retain(|id| expected_objects.contains(id));
+
         // Do not report any frontiers that do not belong to expected objects.
         // Note that this set of objects can differ from th set of sources and
         // sinks.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -1118,7 +1118,13 @@ impl<'w, A: Allocate> Worker<'w, A> {
             .filter(|id| !expected_objects.contains(id))
             // Synthesize the drop command
             .map(|id| (*id, Antichain::new()))
-            .collect();
+            .collect::<Vec<_>>();
+
+        trace!(
+            "reconciliation expected objects\n{:?}\ndropping stale objects\n{:?}",
+            expected_objects,
+            stale_objects.iter().map(|(id, _)| id).collect::<Vec<_>>(),
+        );
 
         commands.push(StorageCommand::AllowCompaction(stale_objects));
 


### PR DESCRIPTION
This is the actual fix for the bug that https://github.com/MaterializeInc/materialize/pull/22632 papers over.

### Motivation

This PR fixes a previously undiscovered bug.

During reconciliation, we did not reconcile the frontiers we were allowed to report back to the client, which could put us in a situation where reporting frontier progress could include collections that we know that the new envd did not have.

Sufficiently refactoring this also slightly changes the semantics of dropping an object, in that we now report it dropped when we receive an `AllowCompaction` command to the empty antichain and not  when we receive the `DropDataflow` command. I detailed why this must be done this way in an inline comment. Working around this requires adding a provisional drop state to signal that we do want to clean up the worker's state but should not send a response to the client--that felt more brittle than it was worth so I went with this approach.

Overall, I believe this state management should be refactored but it's a larger task than I think anyone has bandwidth for immediately.

### Tips for reviewer

Glad to walk through this with you as I have touched this code and gotten it wrong at least once.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
