### PR TITLE
fix: Don't double panic in Drop for DebugStashFactory

### DIFF
--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -1464,10 +1464,17 @@ impl DebugStashFactory {
 
 impl Drop for DebugStashFactory {
     fn drop(&mut self) {
-        assert!(
-            self.dropped,
-            "You forgot to call `drop()` on a `DebugStashFactory` before dropping it! You may also \
-            see this if a test panicked before calling `drop()`."
-        );
+        let message =
+            "You forgot to call `drop()` on a `DebugStashFactory` before dropping it! You \
+        may also see this if a test panicked before calling `drop()`.";
+
+        if !self.dropped {
+            // Don't double panic so we keep the stack trace relatively small.
+            if std::thread::panicking() {
+                tracing::error!("{message}");
+            } else {
+                panic!("{message}");
+            }
+        }
     }
 }


### PR DESCRIPTION
Just a small thing I noticed today while working on a test. If a test uses a `DebugStashFactory` and it fails an assert, we're almost guaranteed to double panic because we'll also panic in the `Drop` impl of `DebugStashFactory`. Nothing is inherently wrong with this, but it at least doubles the size of the backtrace, which makes debugging harder.

This PR checks if we're already panicking, and if so, emits a `tracing::error` instead of a panic.

### Motivation

Refactor

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
