### PR TITLE
mz: add envd extra args to enable region

### DIFF
--- a/src/mz/src/bin/mz/command/region.rs
+++ b/src/mz/src/bin/mz/command/region.rs
@@ -30,6 +30,8 @@ pub enum RegionSubcommand {
     Enable {
         #[clap(hide = true, short, long)]
         version: Option<String>,
+        #[clap(hide = true, short, long)]
+        environmentd_extra_args: Option<Vec<String>>,
     },
     /// Disable a region.
     #[clap(hide = true)]
@@ -44,7 +46,10 @@ pub enum RegionSubcommand {
 pub async fn run(cx: Context, cmd: RegionCommand) -> Result<(), Error> {
     let cx = cx.activate_profile()?.activate_region()?;
     match cmd.subcommand {
-        RegionSubcommand::Enable { version } => mz::command::region::enable(cx, version).await,
+        RegionSubcommand::Enable {
+            version,
+            environmentd_extra_args,
+        } => mz::command::region::enable(cx, version, environmentd_extra_args).await,
         RegionSubcommand::Disable => mz::command::region::disable(cx).await,
         RegionSubcommand::List => mz::command::region::list(cx).await,
         RegionSubcommand::Show => mz::command::region::show(cx).await,

--- a/src/mz/src/bin/mz/command/region.rs
+++ b/src/mz/src/bin/mz/command/region.rs
@@ -31,7 +31,7 @@ pub enum RegionSubcommand {
         #[clap(hide = true, short, long)]
         version: Option<String>,
         #[clap(hide = true, short, long)]
-        environmentd_extra_args: Option<Vec<String>>,
+        environmentd_extra_arg: Option<Vec<String>>,
     },
     /// Disable a region.
     #[clap(hide = true)]
@@ -48,8 +48,8 @@ pub async fn run(cx: Context, cmd: RegionCommand) -> Result<(), Error> {
     match cmd.subcommand {
         RegionSubcommand::Enable {
             version,
-            environmentd_extra_args,
-        } => mz::command::region::enable(cx, version, environmentd_extra_args).await,
+            environmentd_extra_arg,
+        } => mz::command::region::enable(cx, version, environmentd_extra_arg).await,
         RegionSubcommand::Disable => mz::command::region::disable(cx).await,
         RegionSubcommand::List => mz::command::region::list(cx).await,
         RegionSubcommand::Show => mz::command::region::show(cx).await,

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -31,13 +31,19 @@ use tabled::Tabled;
 /// In cases where the organization has already enabled the region
 /// the command will try to run a version update. Resulting
 /// in a downtime for a short period.
-pub async fn enable(cx: RegionContext, version: Option<String>) -> Result<(), Error> {
+pub async fn enable(
+    cx: RegionContext,
+    version: Option<String>,
+    environmentd_extra_args: Option<Vec<String>>,
+) -> Result<(), Error> {
     let loading_spinner = cx
         .output_formatter()
         .loading_spinner("Retrieving information...");
     let cloud_provider = cx.get_cloud_provider().await?;
 
     loading_spinner.set_message("Enabling the region...");
+
+    let environmentd_extra_args: Vec<String> = environmentd_extra_args.unwrap_or_else(Vec::new);
 
     // Loop region creation.
     // After 6 minutes it will timeout.
@@ -47,7 +53,11 @@ pub async fn enable(cx: RegionContext, version: Option<String>) -> Result<(), Er
         .retry_async(|_| async {
             let _ = cx
                 .cloud_client()
-                .create_region(version.clone(), vec![], cloud_provider.clone())
+                .create_region(
+                    version.clone(),
+                    environmentd_extra_args.clone(),
+                    cloud_provider.clone(),
+                )
                 .await?;
             Ok(())
         })

--- a/src/mz/src/command/region.rs
+++ b/src/mz/src/command/region.rs
@@ -34,7 +34,7 @@ use tabled::Tabled;
 pub async fn enable(
     cx: RegionContext,
     version: Option<String>,
-    environmentd_extra_args: Option<Vec<String>>,
+    environmentd_extra_arg: Option<Vec<String>>,
 ) -> Result<(), Error> {
     let loading_spinner = cx
         .output_formatter()
@@ -43,7 +43,7 @@ pub async fn enable(
 
     loading_spinner.set_message("Enabling the region...");
 
-    let environmentd_extra_args: Vec<String> = environmentd_extra_args.unwrap_or_else(Vec::new);
+    let environmentd_extra_arg: Vec<String> = environmentd_extra_arg.unwrap_or_else(Vec::new);
 
     // Loop region creation.
     // After 6 minutes it will timeout.
@@ -55,7 +55,7 @@ pub async fn enable(
                 .cloud_client()
                 .create_region(
                     version.clone(),
-                    environmentd_extra_args.clone(),
+                    environmentd_extra_arg.clone(),
                     cloud_provider.clone(),
                 )
                 .await?;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds back an old feature `environmentd-extra-flags` options for `mz region enable`.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
