### PR TITLE
[persist] Estimate mz_now dynamically

### DIFF
--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -287,7 +287,7 @@ impl DataSubscribe {
                     false.then_some(|_, _: &_, _| unreachable!()),
                     Arc::new(StringSchema),
                     Arc::new(UnitSchema),
-                    |_| true,
+                    |_, _| true,
                 );
                 (data_stream.leave(), token)
             });


### PR DESCRIPTION
Previously, we'd choose a range of possible values for mz_now based on the as_of of the query. Drawbacks of this:
- As time passes, the range of possible values for mz_now diminishes; narrowing our estimate might let us filter more parts.
- ~~Not all calls to persist source specify an as-of. In those cases, temporal filters get way less pushdown than you might hope.~~ The only calls that don't specify an as-of appear to be in the `persist_sink`, where pushdown doesn't happen. That's good in general but makes this change less exciting.

Now we calculate the range of possible values dynamically, by passing in the current timestamp in the _descs source.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This fixes a TODO in the code. (Less important than I thought it might be, but still nice!)

### Tips for reviewer

The existing tests should do a pretty good job of finding bugs. I don't have good ideas for ways to capture the performance difference in CI, though I should be able to construct something meaningful in staging.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
