### PR TITLE
*: pull out a batch of prep for integrating persist-txn

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5646,6 +5646,7 @@ dependencies = [
  "mz-kafka-util",
  "mz-ore",
  "mz-persist-client",
+ "mz-persist-txn",
  "mz-persist-types",
  "mz-postgres-util",
  "mz-proto",

--- a/src/adapter/src/coord/timestamp_oracle/catalog_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/catalog_oracle.rs
@@ -65,13 +65,13 @@ impl<T: TimestampManipulation> InMemoryTimestampOracle<T> {
     fn write_ts(&mut self) -> WriteTimestamp<T> {
         let mut next = (self.next)();
         if next.less_equal(&self.write_ts) {
-            next = self.write_ts.step_forward();
+            next = TimestampManipulation::step_forward(&self.write_ts);
         }
         assert!(self.read_ts.less_than(&next));
         assert!(self.write_ts.less_than(&next));
         self.write_ts = next.clone();
         assert!(self.read_ts.less_equal(&self.write_ts));
-        let advance_to = next.step_forward();
+        let advance_to = TimestampManipulation::step_forward(&next);
         WriteTimestamp {
             timestamp: next,
             advance_to,

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -109,17 +109,7 @@ where
     let shutdown_button = builder.build(move |capabilities| async move {
         let [mut cap]: [_; 1] = capabilities.try_into().expect("one capability per output");
         let client = client.await;
-        let (txns_key_schema, txns_val_schema) = C::schemas();
-        let txns_read = client
-            .open_leased_reader::<C::Key, C::Val, _, _>(
-                txns_id,
-                Arc::new(txns_key_schema),
-                Arc::new(txns_val_schema),
-                Diagnostics::from_purpose("txns_progress"),
-            )
-            .await
-            .expect("schema shouldn't change");
-        let mut txns_cache = TxnsCache::<T, C>::open(txns_read).await;
+        let mut txns_cache = TxnsCache::<T, C>::open(&client, txns_id).await;
 
         txns_cache.update_gt(&as_of).await;
         let snap = txns_cache.data_snapshot(data_id, as_of.clone());

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -40,6 +40,7 @@ pub trait TimestampManipulation:
     + timely::order::TotalOrder
     + differential_dataflow::lattice::Lattice
     + std::fmt::Debug
+    + mz_persist_types::StepForward
 {
     /// Advance a timestamp by the least amount possible such that
     /// `ts.less_than(ts.step_forward())` is true. Panic if unable to do so.
@@ -72,6 +73,12 @@ impl TimestampManipulation for Timestamp {
 
     fn maximum() -> Self {
         Self::MAX
+    }
+}
+
+impl mz_persist_types::StepForward for Timestamp {
+    fn step_forward(&self) -> Self {
+        self.step_forward()
     }
 }
 

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -637,7 +637,7 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> PersistMonotonicW
                                         .expect("cannot append data to closed collection")
                                 };
 
-                                let upper = lower.step_forward();
+                                let upper = TimestampManipulation::step_forward(&lower);
                                 let update = update
                                     .into_iter()
                                     .map(|TimestamplessUpdate { row, diff }| Update {

--- a/src/storage-types/Cargo.toml
+++ b/src/storage-types/Cargo.toml
@@ -23,6 +23,7 @@ mz-interchange = { path = "../interchange" }
 mz-kafka-util = { path = "../kafka-util" }
 mz-ore = { path = "../ore", features = ["async", "tracing_"] }
 mz-persist-client = { path = "../persist-client" }
+mz-persist-txn = { path = "../persist-txn" }
 mz-persist-types = { path = "../persist-types" }
 mz-postgres-util = { path = "../postgres-util" }
 mz-proto = { path = "../proto", features = ["tokio-postgres"] }


### PR DESCRIPTION
Trying to keep the size of the actual integration PR down by pulling out what I can here. See individual commits for details.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

Definitely look at this commit by commit.

Probably sane for Joe to sign off on everything except the "storage: register tables in bulk" commit. We might want a storage reviewer in on that one.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
