### PR TITLE
storage: report ssh tunnel statuses for sources

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,6 +4351,7 @@ dependencies = [
  "clap",
  "crossbeam",
  "fancy-regex",
+ "futures",
  "mz-avro",
  "mz-ccsr",
  "mz-ore",
@@ -5365,6 +5366,7 @@ name = "mz-ssh-util"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "futures",
  "mz-ore",
  "openssh",
  "openssh-mux-client",
@@ -5375,7 +5377,9 @@ dependencies = [
  "serde_json",
  "ssh-key",
  "tempfile",
+ "thiserror",
  "tokio",
+ "tokio-stream",
  "tracing",
  "workspace-hack",
  "zeroize",

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -351,7 +351,7 @@ steps:
   - id: ssh-connection
     label: SSH connection tests
     depends_on: build-x86_64
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     inputs: [test/ssh-connection]
     artifact_paths: junit_*.xml
     plugins:

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -12,6 +12,7 @@ chrono = { version = "0.4.23", default-features = false, features = ["std"] }
 clap = { version = "3.2.24", features = ["derive"] }
 crossbeam = "0.8.2"
 fancy-regex = "0.11.0"
+futures = "0.3.25"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["cli", "network", "async"] }

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -111,10 +111,10 @@ pub enum PostgresError {
     Generic(#[from] anyhow::Error),
     /// Error using ssh.
     #[cfg(feature = "tunnel")]
-    #[error(transparent)]
-    Ssh(#[from] openssh::Error),
+    #[error("error setting up ssh: {0}")]
+    Ssh(#[source] anyhow::Error),
     /// Error doing io to setup an ssh connection.
-    #[error(transparent)]
+    #[error("error communicating with ssh tunnel: {0}")]
     SshIo(#[from] std::io::Error),
     /// A postgres error.
     #[error(transparent)]

--- a/src/ssh-util/Cargo.toml
+++ b/src/ssh-util/Cargo.toml
@@ -13,12 +13,15 @@ openssh = { version = "0.9.8", default-features = false, features = ["native-mux
 openssh-mux-client = "0.15.5"
 openssl = { version = "0.10.48", features = ["vendored"] }
 rand = "0.8.5"
+futures = "0.3.25"
 scopeguard = "1.1.0"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89" }
 ssh-key = { version = "0.4.3" }
 tempfile = "3.3.0"
+thiserror = { version = "1.0.37" }
 tokio = "1.32.0"
+tokio-stream = "0.1.11"
 tracing = "0.1.37"
 zeroize = { version = "1.5.7", features = ["serde"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/ssh-util/src/keys.rs
+++ b/src/ssh-util/src/keys.rs
@@ -11,6 +11,7 @@
 
 use std::cmp::Ordering;
 use std::fmt;
+use std::hash::{Hash, Hasher};
 
 use openssl::pkey::{PKey, Private};
 use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
@@ -73,6 +74,18 @@ impl SshKeyPair {
         self.key_pair
             .to_openssh(LineEnding::LF)
             .expect("encoding as OpenSSH cannot fail")
+    }
+}
+
+impl Hash for SshKeyPair {
+    fn hash<H>(&self, state: &mut H)
+    where
+        H: Hasher,
+    {
+        self.key_pair
+            .fingerprint(HashAlg::default())
+            .as_ref()
+            .hash(state)
     }
 }
 

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -253,7 +253,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let task_name = format!("timely-{worker_id} PG snapshotter");
 
             let client = if is_snapshot_leader {
-                let client = connection_config.connect_replication(&context.ssh_tunnel_manager).await?;
+                let client = connection_config.connect_replication(
+                    &context.ssh_tunnel_manager,
+                ).await?;
                 // The main slot must be created *before* we start snapshotting so that we can be
                 // certain that the temporarly slot created for the snapshot start at an LSN that
                 // is greater than or equal to that of the main slot.
@@ -267,7 +269,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 client
             } else {
                 // Only the snapshot leader needs a replication connection.
-                connection_config.connect(&task_name, &context.ssh_tunnel_manager).await?
+                connection_config.connect(
+                    &task_name,
+                    &context.ssh_tunnel_manager,
+                ).await?
             };
 
             // Configure statement_timeout based on param. We want to be able to

--- a/test/ssh-connection/kafka-source-after-ssh-failure-restart-replica.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure-restart-replica.td
@@ -1,0 +1,34 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test script runs after the SSH bastion host has been terminated.
+
+> DROP CLUSTER REPLICA sc.r1
+> CREATE CLUSTER REPLICA sc.r1 SIZE '32'
+
+# TODO(guswynn): these should be correctly namespaced as ssh errors
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE error LIKE 'kafka:%'
+  AND s.name in ('fixed_text')
+stalled
+
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE error LIKE 'decode:%'
+  AND s.name in ('fixed_plus_csr', 'dynamic_plus_csr')
+stalled
+stalled
+
+# top-level ssh sources that don't use ssh in decoding work correctly already
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE error LIKE 'ssh:%'
+  AND s.name in ('dynamic_text')
+stalled

--- a/test/ssh-connection/kafka-source-after-ssh-failure.td
+++ b/test/ssh-connection/kafka-source-after-ssh-failure.td
@@ -9,21 +9,12 @@
 
 # This test script runs after the SSH bastion host has been terminated.
 
-# Ensure that the source status reflects the error before the source restarts.
-# This error comes from the Kafka source's metadata fetch loop.
+# Ensure they all are marked as broken for ssh reasons
 > SELECT status FROM mz_internal.mz_source_statuses st
   JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source' AND error LIKE '%Meta data fetch error%'
+  WHERE error LIKE 'ssh:%'
+  AND s.name in ('fixed_text', 'dynamic_text', 'fixed_plus_csr', 'dynamic_plus_csr')
 stalled
-
-# Drop and recreate the source cluster's replica so we can test behavior after
-# a restart.
-> DROP CLUSTER REPLICA sc.r1;
-> CREATE CLUSTER REPLICA sc.r1 SIZE '1';
-
-# Verify that the, after restart, the source reports that the SSH tunnel was
-# unable to connect.
-> SELECT status FROM mz_internal.mz_source_statuses st
-  JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source' AND error LIKE '%failed creating kafka consumer: creating ssh tunnel: failed to connect to the remote host%'
+stalled
+stalled
 stalled

--- a/test/ssh-connection/kafka-source-after-ssh-restart.td
+++ b/test/ssh-connection/kafka-source-after-ssh-restart.td
@@ -15,14 +15,35 @@
 $ kafka-ingest topic=thetopic format=bytes
 three
 
-> SELECT * FROM mz_source
+> SELECT * FROM fixed_text
 text
 ----
 one
 two
 three
 
+> SELECT * FROM dynamic_text
+text
+----
+one
+two
+three
+
+> SELECT * FROM fixed_plus_csr
+f1    f2
+----------
+fish  1000
+
+> SELECT * FROM dynamic_plus_csr
+f1    f2
+----------
+fish  1000
+
+# ensure they all were marked as running correctly
 > SELECT status FROM mz_internal.mz_source_statuses st
   JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source'
+  WHERE s.name in ('fixed_text', 'dynamic_text', 'fixed_plus_csr', 'dynamic_plus_csr')
+running
+running
+running
 running

--- a/test/ssh-connection/kafka-source.td
+++ b/test/ssh-connection/kafka-source.td
@@ -18,8 +18,8 @@ $ kafka-create-topic topic=thetopic
 $ kafka-ingest topic=thetopic format=bytes
 one
 
-# Create a dedicated cluster for the source, so we can easily restart the
-# source by dropping and recreating the cluster's replica.
+# Create a dedicated cluster for the sources, so we can easily restart the
+# sources by dropping and recreating the cluster's replica.
 #
 # We also use a large number of worker threads to protect against past behavior
 # in which we opened one SSH tunnel per worker thread per broker, which
@@ -27,43 +27,39 @@ one
 > DROP CLUSTER IF EXISTS sc;
 > CREATE CLUSTER sc REPLICAS (r1 (SIZE '32'))
 
-> CREATE CONNECTION kafka_conn
+# Test the various types of tunnels
+
+> CREATE CONNECTION kafka_conn_using
   TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
 
-# Test that we can create, validate, and use a dynamic kafka connection
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_default_kafka_ssh_tunnel = true
-
-> CREATE CONNECTION kafka_conn_top_level
+> CREATE CONNECTION kafka_conn_dynamic
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SSH TUNNEL thancred);
 
-> CREATE SOURCE mz_source_top_level IN CLUSTER sc
-  FROM KAFKA CONNECTION kafka_conn_top_level (
-    TOPIC 'testdrive-thetopic-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS 1000
-  )
-  FORMAT TEXT
-  ENVELOPE NONE
+# TODO(guswynn): this should be correctly namespaced as an ssh error
+! CREATE CONNECTION kafka_conn_keyless
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SSH TUNNEL keyless);
+contains:Failed to resolve hostname
 
-> SELECT * FROM mz_source_top_level
-text
-----
-one
 
 # Create source with a faster metadata refresh interval so
 # errors are detected every second instead of every minute.
-> CREATE SOURCE mz_source IN CLUSTER sc
-  FROM KAFKA CONNECTION kafka_conn (
+> CREATE SOURCE fixed_text IN CLUSTER sc
+  FROM KAFKA CONNECTION kafka_conn_using (
     TOPIC 'testdrive-thetopic-${testdrive.seed}',
     TOPIC METADATA REFRESH INTERVAL MS 1000
   )
   FORMAT TEXT
   ENVELOPE NONE
 
-> SHOW SUBSOURCES ON mz_source
-mz_source_progress progress
+> CREATE SOURCE dynamic_text  IN CLUSTER sc
+  FROM KAFKA CONNECTION kafka_conn_dynamic (
+    TOPIC 'testdrive-thetopic-${testdrive.seed}',
+    TOPIC METADATA REFRESH INTERVAL MS 1000
+  )
+  FORMAT TEXT
+  ENVELOPE NONE
 
-> SELECT * FROM mz_source
+> SELECT * FROM fixed_text
 text
 ----
 one
@@ -71,7 +67,14 @@ one
 $ kafka-ingest topic=thetopic format=bytes
 two
 
-> SELECT * FROM mz_source
+# Ensure both types of tunnels work
+> SELECT * FROM fixed_text
+text
+----
+one
+two
+
+> SELECT * FROM dynamic_text
 text
 ----
 one
@@ -96,13 +99,34 @@ $ kafka-create-topic topic=avroavro
 $ kafka-ingest format=avro topic=avroavro schema=${schema}
 {"f1": "fish", "f2": 1000}
 
-> CREATE SOURCE csr_source
+> CREATE SOURCE fixed_plus_csr
   IN CLUSTER sc
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FROM KAFKA CONNECTION kafka_conn_using (TOPIC 'testdrive-avroavro-${testdrive.seed}')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
 
-> SELECT * FROM csr_source
+> SELECT * FROM fixed_plus_csr
 f1    f2
 ----------
 fish  1000
+
+# Test csr sources for dynamic connections as well.
+> CREATE SOURCE dynamic_plus_csr
+  IN CLUSTER sc
+  FROM KAFKA CONNECTION kafka_conn_dynamic (TOPIC 'testdrive-avroavro-${testdrive.seed}')
+  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  ENVELOPE NONE
+
+> SELECT * FROM dynamic_plus_csr
+f1    f2
+----------
+fish  1000
+
+# ensure they all were marked as running correctly
+> SELECT status FROM mz_internal.mz_source_statuses st
+  JOIN mz_sources s ON st.id = s.id
+  WHERE s.name in ('fixed_text', 'dynamic_text', 'fixed_plus_csr', 'dynamic_plus_csr')
+running
+running
+running
+running

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -64,9 +64,13 @@ def workflow_validate_connection(c: Composition) -> None:
 
     c.run("testdrive", "setup.td")
 
-    public_key = c.sql_query("select public_key_1 from mz_ssh_tunnel_connections;")[0][
-        0
-    ]
+    public_key = c.sql_query(
+        """
+        select public_key_1 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
+    )[0][0]
 
     c.run("testdrive", "--no-reset", "validate-failures.td")
 
@@ -149,6 +153,52 @@ def workflow_kafka(c: Composition, redpanda: bool = False) -> None:
         c.run("testdrive", "--no-reset", "kafka-source-after-ssh-restart.td")
 
 
+def workflow_kafka_restart_replica(c: Composition, redpanda: bool = False) -> None:
+    c.down()
+    # Configure the SSH bastion host to allow only two connections to be
+    # initiated simultaneously. This is enough to establish *one* Kafka SSH
+    # tunnel and *one* Confluent Schema Registry tunnel simultaneously.
+    # Combined with using a large cluster in kafka-source.td, this ensures that
+    # we only create one SSH tunnel per Kafka broker, rather than one SSH tunnel
+    # per Kafka broker per worker.
+    with c.override(SshBastionHost(max_startups="2")):
+
+        dependencies = ["materialized", "ssh-bastion-host"]
+        if redpanda:
+            dependencies += ["redpanda"]
+        else:
+            dependencies += ["zookeeper", "kafka", "schema-registry"]
+        c.up(*dependencies)
+
+        c.run("testdrive", "setup.td")
+
+        public_key = c.sql_query(
+            """
+            select public_key_1 from mz_ssh_tunnel_connections ssh \
+            join mz_connections c on c.id = ssh.id
+            where c.name = 'thancred';
+            """
+        )[0][0]
+
+        c.exec(
+            "ssh-bastion-host",
+            "bash",
+            "-c",
+            f"echo '{public_key}' > /etc/authorized_keys/mz",
+        )
+
+        c.run("testdrive", "--no-reset", "kafka-source.td")
+        c.kill("ssh-bastion-host")
+        c.run(
+            "testdrive",
+            "--no-reset",
+            "kafka-source-after-ssh-failure-restart-replica.td",
+        )
+
+        c.up("ssh-bastion-host")
+        c.run("testdrive", "--no-reset", "kafka-source-after-ssh-restart.td")
+
+
 def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
     c.down()
     dependencies = ["materialized", "ssh-bastion-host"]
@@ -160,9 +210,13 @@ def workflow_hidden_hosts(c: Composition, redpanda: bool = False) -> None:
 
     c.run("testdrive", "setup.td")
 
-    public_key = c.sql_query("select public_key_1 from mz_ssh_tunnel_connections;")[0][
-        0
-    ]
+    public_key = c.sql_query(
+        """
+        select public_key_1 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
+    )[0][0]
 
     c.exec(
         "ssh-bastion-host",
@@ -195,9 +249,13 @@ def workflow_pg_restart_bastion(c: Composition) -> None:
 
     c.run("testdrive", "setup.td")
 
-    public_key = c.sql_query("select public_key_1 from mz_ssh_tunnel_connections;")[0][
-        0
-    ]
+    public_key = c.sql_query(
+        """
+        select public_key_1 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
+    )[0][0]
     c.exec(
         "ssh-bastion-host",
         "bash",
@@ -245,9 +303,13 @@ def workflow_pg_via_ssh_tunnel_with_ssl(c: Composition) -> None:
 
     c.run("testdrive", "setup.td")
 
-    public_key = c.sql_query("SELECT public_key_1 FROM mz_ssh_tunnel_connections;")[0][
-        0
-    ]
+    public_key = c.sql_query(
+        """
+        select public_key_1 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
+    )[0][0]
 
     c.exec(
         "ssh-bastion-host",
@@ -283,7 +345,7 @@ def workflow_ssh_key_after_restart(c: Composition) -> None:
     num_connections = c.sql_query("SELECT count(*) FROM mz_ssh_tunnel_connections;")[0][
         0
     ]
-    if num_connections != 0:
+    if num_connections != 1:
         connections = c.sql_query("SELECT * FROM mz_ssh_tunnel_connections;")
         print("Found connections in mz_ssh_tunnel_connections: ", connections)
         raise Exception(
@@ -297,7 +359,11 @@ def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
     c.run("testdrive", "setup.td")
 
     secondary_public_key = c.sql_query(
-        "SELECT public_key_2 FROM mz_ssh_tunnel_connections;"
+        """
+        select public_key_2 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
     )[0][0]
 
     c.sql("ALTER CONNECTION thancred ROTATE KEYS;")
@@ -305,7 +371,11 @@ def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
     restart_mz(c)
 
     primary_public_key_after_restart = c.sql_query(
-        "SELECT public_key_1 FROM mz_ssh_tunnel_connections;"
+        """
+        select public_key_1 from mz_ssh_tunnel_connections ssh \
+        join mz_connections c on c.id = ssh.id
+        where c.name = 'thancred';
+        """
     )[0][0]
 
     if secondary_public_key != primary_public_key_after_restart:
@@ -320,7 +390,7 @@ def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
     num_connections = c.sql_query("SELECT count(*) FROM mz_ssh_tunnel_connections;")[0][
         0
     ]
-    if num_connections != 0:
+    if num_connections != 1:
         connections = c.sql_query("SELECT * FROM mz_ssh_tunnel_connections;")
         print("Found connections in mz_ssh_tunnel_connections: ", connections)
         raise Exception(
@@ -331,9 +401,12 @@ def workflow_rotated_ssh_key_after_restart(c: Composition) -> None:
 def workflow_default(c: Composition) -> None:
     # Test against both standard schema registry
     # and kafka implementations.
+    #
+    # These tests core functionality related to kafka with ssh and error reporting.
     for workflow in [
         workflow_basic_ssh_features,
         workflow_kafka,
+        workflow_kafka_restart_replica,
         workflow_hidden_hosts,
     ]:
         workflow(c, redpanda=False)
@@ -341,11 +414,18 @@ def workflow_default(c: Composition) -> None:
         workflow(c, redpanda=True)
         c.sanity_restart_mz()
 
+    # These tests core functionality related to pg with ssh and error reporting.
+    for workflow in [
+        workflow_pg,
+    ]:
+        workflow(c)
+        c.sanity_restart_mz()
+
+    # Various special cases related to ssh
     for workflow in [
         workflow_validate_connection,
         workflow_ssh_key_after_restart,
         workflow_rotated_ssh_key_after_restart,
-        workflow_pg,
         workflow_pg_via_ssh_tunnel_with_ssl,
         workflow_pg_restart_bastion,
     ]:

--- a/test/ssh-connection/pg-source-after-ssh-failure.td
+++ b/test/ssh-connection/pg-source-after-ssh-failure.td
@@ -11,5 +11,5 @@
 
 > SELECT status FROM mz_internal.mz_source_statuses st
   JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source' AND error LIKE '%connection closed%'
+  WHERE s.name = 'mz_source' AND error LIKE 'ssh:%'
 stalled

--- a/test/ssh-connection/setup.td
+++ b/test/ssh-connection/setup.td
@@ -12,8 +12,17 @@
 
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_connection_validation_syntax = true
+ALTER SYSTEM SET enable_default_kafka_ssh_tunnel = true
 
 > CREATE CONNECTION IF NOT EXISTS thancred TO SSH TUNNEL (
+    HOST 'ssh-bastion-host',
+    USER 'mz',
+    PORT 22
+  );
+
+# We don't authorize this connection's keys, so we
+# can test error handling.
+> CREATE CONNECTION IF NOT EXISTS keyless TO SSH TUNNEL (
     HOST 'ssh-bastion-host',
     USER 'mz',
     PORT 22


### PR DESCRIPTION
(this was originally a much larger pr; it is not stacked on top of #22799 and #22795 and only the top commit should be reviewed)

Closes https://github.com/MaterializeInc/materialize/issues/18375

This ended up being fairly complex, but I think what I ended up with is reasonably considering the intrinsic complexities

  - ssh tunnels and their users are 1-to-many (many being multiple sources, across multiple workers), which means they distribute their status using `tokio` _broadcast_ channels
  - ssh tunnels and their subscriptions cannot be pre-created during rendering (because of dynamic broker lists and the fact that ssh tunnel creation is async), which means we need an `ssh_health_operator` that receives subscriptions on a channel (well, channel-per-worker)
  - 1 source may have many ssh tunnels (kafka sources can do this; we can remove that feature once this feature is released, and simplify some code), which means the `ssh_health_operator` must handle this
  - Postgres source errors always restart the source, which interacts poorly with `ssh_health_operator`. See the `N.B.` for how this is handled

Note also that their are 2 scenarios as of this pr that do not yet report `ssh` namespaced statuses:
- sinks
- kafka sources on startup

Both of these require we carefully categorize errors that are currently just `anyhow::Error`'s, which is left as a followup, as this pr is already too complex. Note that I added a test the latter in the 4th commit.

### Motivation
  * This PR adds a known-desirable feature.
### Tips for reviewer


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
