### PR TITLE
Fix assert not null check

### DIFF
--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -71,8 +71,8 @@ class MaterializedViews(Check):
 
 class MaterializedViewsAssertNotNull(Check):
     def _can_run(self, e: Executor) -> bool:
-        # CREATE ROLE not compatible with older releases
-        return self.base_version >= MzVersion.parse("0.73.0-dev")
+        # ASSERT NOT NULL known broken in earlier releases
+        return self.base_version >= MzVersion.parse("0.74.0")
 
     def initialize(self) -> Testdrive:
         return Testdrive(


### PR DESCRIPTION
This feature was known broken in v0.73, so the upgrade test failing between v0.73 and v0.74 is a known issue. Update the `_can_run` function accordingly.

### Motivation

  * This PR fixes https://github.com/MaterializeInc/materialize/issues/22715

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None