### PR TITLE
Soften language in private preview warning box

### DIFF
--- a/doc/user/layouts/shortcodes/private-preview.html
+++ b/doc/user/layouts/shortcodes/private-preview.html
@@ -1,7 +1,7 @@
 <div class="private-preview">
   <strong class="gutter">PREVIEW</strong>
   {{ with .Inner}}{{.|$.Page.RenderString}}{{else}}This feature{{ end }} is in
-  <strong>private preview</strong>. It has known performance or stability
+  <strong>private preview</strong>. It may have performance or stability
   issues and is under active development. It isn't subject to our backwards
   compatibility guarantees.
   {{if not (.Get "enabled-by-default")}}


### PR DESCRIPTION
It's not necessarily true that there are known bugs in every private preview feature, so I think we can be less assertive here. Open to bikeshedding/discussion; let me know if you disagree.

Slack discussion: https://materializeinc.slack.com/archives/CPNFV9CVB/p1698361921652779