### PR TITLE
Integrate lgalloc for Row allocations in Columnation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,9 +848,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.3.3"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
 
 [[package]]
 name = "bitvec"
@@ -1428,9 +1428,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -3076,6 +3076,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "lgalloc"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22763659eca028d9bf872e5cdf978c87dfaa4a379ba50abb8e94b48c9869e18e"
+dependencies = [
+ "crossbeam-deque",
+ "libc",
+ "memmap2",
+ "tempfile",
+ "thiserror",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3406,7 +3419,7 @@ checksum = "57349d5a326b437989b6ee4dc8f2f34b0cc131202748414712a8e7d98952fc8c"
 dependencies = [
  "base64 0.21.0",
  "bindgen",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "bitvec",
  "byteorder",
  "bytes",
@@ -3951,6 +3964,7 @@ dependencies = [
  "dogsdogsdogs",
  "futures",
  "itertools",
+ "lgalloc",
  "mz-build-info",
  "mz-cluster",
  "mz-cluster-client",
@@ -4500,8 +4514,10 @@ dependencies = [
 name = "mz-metrics"
 version = "0.0.0"
 dependencies = [
+ "lgalloc",
  "libc",
  "mz-ore",
+ "paste",
  "prometheus",
  "tokio",
  "workspace-hack",
@@ -4633,6 +4649,7 @@ dependencies = [
  "http",
  "hyper",
  "hyper-tls",
+ "lgalloc",
  "mz-test-macro",
  "native-tls",
  "once_cell",
@@ -8855,7 +8872,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55ae70283aba8d2a8b411c695c437fe25b8b5e44e23e780662002fc72fb47a82"
 dependencies = [
  "base64 0.21.0",
- "bitflags 2.3.3",
+ "bitflags 2.4.1",
  "bytes",
  "futures-core",
  "futures-util",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -50,6 +50,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_pubsub_client_enabled": "true",
     "persist_stats_audit_percent": "100",
     "persist_batch_delete_enabled": "true",
+    "enable_columnation_lgalloc": "true",
     "enable_rbac_checks": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -37,6 +37,7 @@ pub fn compute_config(config: &SystemVars) -> ComputeParameters {
         enable_mz_join_core: Some(config.enable_mz_join_core()),
         enable_jemalloc_profiling: Some(config.enable_jemalloc_profiling()),
         enable_specialized_arrangements: Some(config.enable_specialized_arrangements()),
+        enable_columnation_lgalloc: Some(config.enable_columnation_lgalloc()),
         persist: persist_config(config),
         tracing: tracing_config(config),
         grpc_client: grpc_client_config(config),

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -71,6 +71,7 @@ message ProtoComputeParameters {
     optional bool enable_jemalloc_profiling = 7;
     optional bool enable_specialized_arrangements = 8;
     mz_compute_types.dataflows.ProtoYieldSpec linear_join_yielding = 9;
+    optional bool enable_columnation_lgalloc = 10;
 }
 
 message ProtoComputeMaxInflightBytesConfig {

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -371,6 +371,8 @@ pub struct ComputeParameters {
     pub enable_jemalloc_profiling: Option<bool>,
     /// Enable arrangement type specialization.
     pub enable_specialized_arrangements: Option<bool>,
+    /// Enable lgalloc for columnation.
+    pub enable_columnation_lgalloc: Option<bool>,
     /// Persist client configuration.
     pub persist: PersistParameters,
     /// Tracing configuration.
@@ -389,6 +391,7 @@ impl ComputeParameters {
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_specialized_arrangements,
+            enable_columnation_lgalloc,
             persist,
             tracing,
             grpc_client,
@@ -412,6 +415,10 @@ impl ComputeParameters {
 
         if enable_specialized_arrangements.is_some() {
             self.enable_specialized_arrangements = enable_specialized_arrangements;
+        }
+
+        if enable_columnation_lgalloc.is_some() {
+            self.enable_columnation_lgalloc = enable_columnation_lgalloc;
         }
 
         self.persist.update(persist);
@@ -438,6 +445,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: self.enable_mz_join_core.into_proto(),
             enable_jemalloc_profiling: self.enable_jemalloc_profiling.into_proto(),
             enable_specialized_arrangements: self.enable_specialized_arrangements.into_proto(),
+            enable_columnation_lgalloc: self.enable_columnation_lgalloc.into_proto(),
             persist: Some(self.persist.into_proto()),
             tracing: Some(self.tracing.into_proto()),
             grpc_client: Some(self.grpc_client.into_proto()),
@@ -455,6 +463,7 @@ impl RustType<ProtoComputeParameters> for ComputeParameters {
             enable_mz_join_core: proto.enable_mz_join_core.into_rust()?,
             enable_jemalloc_profiling: proto.enable_jemalloc_profiling.into_rust()?,
             enable_specialized_arrangements: proto.enable_specialized_arrangements.into_rust()?,
+            enable_columnation_lgalloc: proto.enable_columnation_lgalloc.into_rust()?,
             persist: proto
                 .persist
                 .into_rust_if_some("ProtoComputeParameters::persist")?,

--- a/src/compute/Cargo.toml
+++ b/src/compute/Cargo.toml
@@ -17,6 +17,7 @@ differential-dataflow = "0.12.0"
 dogsdogsdogs = "0.1.0"
 futures = "0.3.25"
 itertools = "0.10.5"
+lgalloc = "0.1"
 mz-build-info = { path = "../build-info" }
 mz-cluster = { path = "../cluster" }
 mz-cluster-client = { path = "../cluster-client" }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -12,6 +12,7 @@ use std::num::NonZeroUsize;
 use std::ops::DerefMut;
 use std::rc::Rc;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bytesize::ByteSize;
 use differential_dataflow::trace::{Cursor, TraceReader};
@@ -36,7 +37,7 @@ use timely::container::columnation::Columnation;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::worker::Worker as TimelyWorker;
-use tracing::{error, info, span, Level};
+use tracing::{error, info, span, warn, Level};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
@@ -44,7 +45,7 @@ use crate::logging;
 use crate::logging::compute::ComputeEvent;
 use crate::metrics::ComputeMetrics;
 use crate::render::{LinearJoinImpl, LinearJoinSpec};
-use crate::server::ResponseSender;
+use crate::server::{ComputeInstanceContext, ResponseSender};
 use crate::typedefs::TraceRowHandle;
 
 /// Worker-local state that is maintained across dataflows.
@@ -91,6 +92,8 @@ pub struct ComputeState {
     tracing_handle: Arc<TracingHandle>,
     /// Enable arrangement type specialization.
     pub enable_specialized_arrangements: bool,
+    /// Other configuration for compute
+    pub context: ComputeInstanceContext,
 }
 
 impl ComputeState {
@@ -100,6 +103,7 @@ impl ComputeState {
         persist_clients: Arc<PersistClientCache>,
         metrics: ComputeMetrics,
         tracing_handle: Arc<TracingHandle>,
+        context: ComputeInstanceContext,
     ) -> Self {
         let traces = TraceManager::new(metrics.for_traces(worker_id));
         let command_history = ComputeCommandHistory::new(metrics.for_history(worker_id));
@@ -119,6 +123,7 @@ impl ComputeState {
             metrics,
             tracing_handle,
             enable_specialized_arrangements: Default::default(),
+            context,
         }
     }
 
@@ -201,6 +206,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
             enable_mz_join_core,
             enable_jemalloc_profiling,
             enable_specialized_arrangements,
+            enable_columnation_lgalloc,
             persist,
             tracing,
             grpc_client: _grpc_client,
@@ -238,6 +244,29 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                 );
             }
             None => (),
+        }
+        match enable_columnation_lgalloc {
+            Some(true) => {
+                if let Some(path) = self.compute_state.context.scratch_directory.as_ref() {
+                    info!(path = ?path, "Enabling lgalloc");
+                    lgalloc::lgalloc_set_config(
+                        lgalloc::LgAlloc::new()
+                            .enable()
+                            .with_path(path.clone())
+                            .with_background_config(lgalloc::BackgroundWorkerConfig {
+                                interval: Duration::from_secs(1),
+                                batch: 32,
+                            }),
+                    );
+                } else {
+                    warn!("Not enabling lgalloc, scratch directory not specified");
+                }
+            }
+            Some(false) => {
+                info!("Disabling lgalloc");
+                lgalloc::lgalloc_set_config(&lgalloc::LgAlloc::new())
+            }
+            None => {}
         }
 
         persist.apply(self.compute_state.persist_clients.cfg());

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -12,6 +12,7 @@
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
+use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
@@ -43,6 +44,13 @@ use crate::compute_state::{ActiveComputeState, ComputeState, ReportedFrontier};
 use crate::logging::compute::ComputeEvent;
 use crate::metrics::ComputeMetrics;
 
+/// Caller-provided configuration for compute.
+#[derive(Clone, Debug)]
+pub struct ComputeInstanceContext {
+    /// A directory that can be used for scratch work.
+    pub scratch_directory: Option<PathBuf>,
+}
+
 /// Configures the server with compute-specific metrics.
 #[derive(Debug, Clone)]
 pub struct Config {
@@ -50,11 +58,14 @@ pub struct Config {
     // TODO(guswynn): cluster-unification: ensure these stats
     // also work for storage when merging.
     pub metrics: ComputeMetrics,
+    /// Other configuration for compute.
+    pub context: ComputeInstanceContext,
 }
 
 /// Initiates a timely dataflow computation, processing compute commands.
 pub fn serve(
     config: mz_cluster::server::ClusterConfig,
+    context: ComputeInstanceContext,
 ) -> Result<
     (
         TimelyContainerRef<ComputeCommand, ComputeResponse, SyncActivator>,
@@ -63,7 +74,7 @@ pub fn serve(
     Error,
 > {
     let metrics = ComputeMetrics::register_with(&config.metrics_registry);
-    let compute_config = Config { metrics };
+    let compute_config = Config { metrics, context };
 
     let (timely_container, client_builder) = mz_cluster::server::serve::<
         Config,
@@ -177,6 +188,7 @@ struct Worker<'w, A: Allocate> {
     persist_clients: Arc<PersistClientCache>,
     /// A process-global handle to tracing configuration.
     tracing_handle: Arc<TracingHandle>,
+    context: ComputeInstanceContext,
 }
 
 impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Config {
@@ -196,6 +208,7 @@ impl mz_cluster::types::AsRunnableWorker<ComputeCommand, ComputeResponse> for Co
             timely_worker,
             client_rx,
             metrics: config.metrics,
+            context: config.context,
             persist_clients,
             compute_state: None,
             tracing_handle,
@@ -417,6 +430,7 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                     Arc::clone(&self.persist_clients),
                     self.metrics.clone(),
                     Arc::clone(&self.tracing_handle),
+                    self.context.clone(),
                 ));
             }
             _ => (),

--- a/src/metrics/Cargo.toml
+++ b/src/metrics/Cargo.toml
@@ -7,8 +7,10 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
+lgalloc = "0.1"
 libc = "0.2.138"
 mz-ore = { path = "../ore", features = ["metrics"] }
+paste = "1.0"
 prometheus = { version = "0.13.3", default-features = false }
 tokio = { version = "1.32.0", features = ["time"]}
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }

--- a/src/metrics/src/lgalloc.rs
+++ b/src/metrics/src/lgalloc.rs
@@ -1,0 +1,98 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+
+//! Report lgalloc metrics.
+
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+use lgalloc::SizeClassStats;
+use mz_ore::cast::CastFrom;
+use mz_ore::metrics::{raw, MetricsRegistry};
+use paste::paste;
+use prometheus::core::{AtomicU64, GenericGauge};
+
+macro_rules! metrics {
+    ($namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*) => {
+        metrics! { @define $namespace $(($name, $desc, $suffix, $conv)),*}
+    };
+    (@define $namespace:ident $(($name:ident, $desc:expr, $suffix:expr, $conv:expr)),*) => {
+        paste! {
+            struct LgMetrics {
+                stats: lgalloc::LgAllocStats,
+                size_class: BTreeMap<usize, LgMetricsSC>,
+                $([<$name $suffix>]: raw::UIntGaugeVec,)*
+            }
+            struct LgMetricsSC {
+                $([<$name $suffix>]: GenericGauge<AtomicU64>,)*
+            }
+            impl LgMetrics {
+                fn new(registry: &MetricsRegistry) -> Self {
+                    Self {
+                        size_class: BTreeMap::default(),
+                        stats: lgalloc::LgAllocStats::default(),
+                        $([<$name $suffix>]: registry.register(mz_ore::metric!(
+                            name: concat!(stringify!($namespace), "_", stringify!($name), $suffix),
+                            help: $desc,
+                            var_labels: ["size_class"],
+                        )),)*
+                    }
+                }
+                fn update(&mut self) {
+                    lgalloc::lgalloc_stats(&mut self.stats);
+                    for sc in &self.stats.size_class {
+                        let sc_stats = self.size_class.entry(sc.size_class).or_insert_with(|| {
+                            LgMetricsSC {
+                                $([<$name $suffix>]: self.[<$name $suffix>].with_label_values(&[&sc.size_class.to_string()]),)*
+                            }
+                        });
+                        $(sc_stats.[<$name $suffix>].set(($conv)(u64::cast_from(sc.$name), sc));)*
+                    }
+                }
+            }
+        }
+    };
+}
+
+fn normalize_by_size_class(value: u64, stats: &SizeClassStats) -> u64 {
+    value * u64::cast_from(stats.size_class)
+}
+
+fn id(value: u64, _stats: &SizeClassStats) -> u64 {
+    value
+}
+
+metrics! {
+    mz_metrics_lgalloc
+    (allocations, "Number of region allocations in size class", "_total", id),
+    (area_total_bytes, "Number of bytes in all areas in size class", "", id),
+    (areas, "Number of areas backing size class", "_total", id),
+    (clean_regions, "Number of clean regions in size class", "_total", id),
+    (clean_regions, "Number of clean regions in size class", "_bytes_total", normalize_by_size_class),
+    (deallocations, "Number of region deallocations for size class", "_total", id),
+    (free_regions, "Number of free regions in size class", "_total", id),
+    (free_regions, "Number of free regions in size class", "_bytes_total", normalize_by_size_class),
+    (global_regions, "Number of global regions in size class", "_total", id),
+    (global_regions, "Number of global regions in size class", "_bytes_total", normalize_by_size_class),
+    (refill, "Number of area refills for size class", "_total", id),
+    (slow_path, "Number of slow path region allocations for size class", "_total", id),
+    (thread_regions, "Number of thread regions in size class", "_total", id),
+    (thread_regions, "Number of thread regions in size class", "_bytes_total", normalize_by_size_class)
+}
+
+/// Register a task to read lgalloc stats.
+#[allow(clippy::unused_async)]
+pub async fn register_metrics_into(metrics_registry: &MetricsRegistry) {
+    let mut lgmetrics = LgMetrics::new(metrics_registry);
+
+    mz_ore::task::spawn(|| "lgalloc_stats_update", async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(10));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            lgmetrics.update();
+        }
+    });
+}

--- a/src/metrics/src/lib.rs
+++ b/src/metrics/src/lib.rs
@@ -85,4 +85,13 @@
 
 #![warn(missing_docs, missing_debug_implementations)]
 
+use mz_ore::metrics::MetricsRegistry;
+
+pub mod lgalloc;
 pub mod rusage;
+
+/// Register all metrics into the provided registry.
+pub async fn register_metrics_into(metrics_registry: &MetricsRegistry) {
+    lgalloc::register_metrics_into(metrics_registry).await;
+    rusage::register_metrics_into(metrics_registry).await;
+}

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -24,6 +24,7 @@ clap = { version = "3.2.24", features = ["env"], optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
+lgalloc =  { version = "0.1", optional = true }
 mz-test-macro = { path = "../test-macro", default-features = false }
 once_cell = "1.16.0"
 # The vendored feature is transitively depended upon by tokio-openssl.
@@ -96,6 +97,7 @@ async = [
 ]
 bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
+region = ["lgalloc"]
 tracing_ = [
   "anyhow",
   "atty",

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -131,6 +131,8 @@ pub mod panic;
 pub mod path;
 pub mod permutations;
 pub mod process;
+#[cfg(feature = "region")]
+pub mod region;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "process")))]
 pub mod result;
 #[cfg_attr(nightly_doc_features, doc(cfg(feature = "async")))]

--- a/src/ore/src/region.rs
+++ b/src/ore/src/region.rs
@@ -1,0 +1,150 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Region-allocated data utilities.
+
+use std::fmt::{Debug, Formatter};
+
+/// A region allocator which holds items at stable memory locations.
+///
+/// Items once inserted will not be moved, and their locations in memory
+/// can be relied on by others, until the region is cleared.
+///
+/// This type accepts owned data, rather than references, and does not
+/// itself intend to implement `Region`. Rather, it is a useful building
+/// block for other less-safe code that wants allocated data to remain at
+/// fixed memory locations.
+pub struct LgAllocRegion<T> {
+    /// The active allocation into which we are writing.
+    local: lgalloc::Region<T>,
+    /// All previously active allocations.
+    stash: Vec<lgalloc::Region<T>>,
+    /// The maximum allocation size
+    limit: usize,
+}
+
+// Manually implement `Default` as `T` may not implement it.
+impl<T> Default for LgAllocRegion<T> {
+    fn default() -> Self {
+        Self {
+            local: Default::default(),
+            stash: Vec::new(),
+            limit: usize::MAX,
+        }
+    }
+}
+
+impl<T> Debug for LgAllocRegion<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LgAllocRegion")
+            .field("limit", &self.limit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T> LgAllocRegion<T> {
+    /// Construct a [LgAllocRegion] with a allocation size limit.
+    pub fn with_limit(limit: usize) -> Self {
+        Self {
+            local: Default::default(),
+            stash: Default::default(),
+            limit,
+        }
+    }
+
+    /// Clears the contents without dropping any elements.
+    #[inline]
+    pub fn clear(&mut self) {
+        unsafe {
+            // Unsafety justified in that setting the length to zero exposes
+            // no invalid data.
+            self.local.clear();
+            // Release allocations in `stash` without dropping their elements.
+            self.stash.clear()
+        }
+    }
+    /// Copies an iterator of items into the region.
+    #[inline]
+    pub fn copy_iter<I>(&mut self, items: I) -> &mut [T]
+    where
+        I: Iterator<Item = T> + std::iter::ExactSizeIterator,
+    {
+        self.reserve(items.len());
+        let initial_len = self.local.len();
+        self.local.extend(items);
+        &mut self.local[initial_len..]
+    }
+    /// Copies a slice of cloneable items into the region.
+    #[inline]
+    pub fn copy_slice(&mut self, items: &[T]) -> &mut [T]
+    where
+        T: Clone,
+    {
+        self.reserve(items.len());
+        let initial_len = self.local.len();
+        self.local.extend_from_slice(items);
+        &mut self.local[initial_len..]
+    }
+
+    /// Ensures that there is space in `self.local` to copy at least `count` items.
+    #[inline(always)]
+    pub fn reserve(&mut self, count: usize) {
+        // Check if `item` fits into `self.local` without reallocation.
+        // If not, stash `self.local` and increase the allocation.
+        if count > self.local.capacity() - self.local.len() {
+            // Increase allocated capacity in powers of two.
+            // We could choose a different rule here if we wanted to be
+            // more conservative with memory (e.g. page size allocations).
+            let mut next_len = (self.local.capacity() + 1).next_power_of_two();
+            next_len = std::cmp::min(next_len, self.limit);
+            next_len = std::cmp::max(count, next_len);
+            let new_local = lgalloc::Region::new_auto(next_len);
+            if !self.local.is_empty() {
+                self.stash.push(std::mem::take(&mut self.local));
+            }
+            self.local = new_local;
+        }
+    }
+
+    /// Allocates a new `Self` that can accept `count` items without reallocation.
+    pub fn with_capacity(count: usize) -> Self {
+        let mut region = Self::default();
+        region.reserve(count);
+        region
+    }
+
+    /// The number of items current held in the region.
+    pub fn len(&self) -> usize {
+        self.local.len() + self.stash.iter().map(|r| r.len()).sum::<usize>()
+    }
+
+    /// Visit contained allocations to determine their size and capacity.
+    #[inline]
+    pub fn heap_size(&self, mut callback: impl FnMut(usize, usize)) {
+        // Calculate heap size for local, stash, and stash entries
+        let size_of_t = std::mem::size_of::<T>();
+        callback(
+            self.local.len() * size_of_t,
+            self.local.capacity() * size_of_t,
+        );
+        callback(
+            self.stash.len() * std::mem::size_of::<Vec<T>>(),
+            self.stash.capacity() * std::mem::size_of::<Vec<T>>(),
+        );
+        for stash in &self.stash {
+            callback(stash.len() * size_of_t, stash.capacity() * size_of_t);
+        }
+    }
+}

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -31,7 +31,7 @@ hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes", "smallvec", "stack", "test", "serde"] }
+mz-ore = { path = "../ore", features = ["bytes", "smallvec", "region", "stack", "test", "serde"] }
 mz-persist-types = { path = "../persist-types" }
 mz-pgtz = { path = "../pgtz" }
 mz-proto = { path = "../proto", features = ["chrono"] }

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -169,8 +169,8 @@ impl Ord for Row {
 
 #[allow(missing_debug_implementations)]
 mod columnation {
-
-    use columnation::{Columnation, Region, StableRegion};
+    use columnation::{Columnation, Region};
+    use mz_ore::region::LgAllocRegion;
 
     use crate::Row;
 
@@ -179,7 +179,7 @@ mod columnation {
     /// Content bytes are stored in stable contiguous memory locations,
     /// and then a `Row` referencing them is falsified.
     pub struct RowStack {
-        region: StableRegion<u8>,
+        region: LgAllocRegion<u8>,
     }
 
     impl RowStack {
@@ -191,7 +191,7 @@ mod columnation {
         fn default() -> Self {
             Self {
                 // Limit the region size to 2MiB.
-                region: StableRegion::with_limit(Self::LIMIT),
+                region: LgAllocRegion::with_limit(Self::LIMIT),
             }
         }
     }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1482,6 +1482,13 @@ pub const WEBHOOK_CONCURRENT_REQUEST_LIMIT: ServerVar<usize> = ServerVar {
     internal: true,
 };
 
+pub const ENABLE_COLUMNATION_LGALLOC: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("enable_columnation_lgalloc"),
+    value: &false,
+    description: "Enable allocating regions from lgalloc",
+    internal: true,
+};
+
 /// Configuration for gRPC client connections.
 mod grpc_client {
     use super::*;
@@ -2816,7 +2823,8 @@ impl SystemVars {
             .with_var(&STATEMENT_LOGGING_RETENTION)
             .with_var(&OPTIMIZER_STATS_TIMEOUT)
             .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
-            .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT);
+            .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
+            .with_var(&ENABLE_COLUMNATION_LGALLOC);
 
         for flag in PersistFeatureFlag::ALL {
             vars = vars.with_var(&flag.into())
@@ -3602,6 +3610,11 @@ impl SystemVars {
     /// Returns the `webhook_concurrent_request_limit` configuration parameter.
     pub fn webhook_concurrent_request_limit(&self) -> usize {
         *self.expect_value(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
+    }
+
+    /// Returns the `enable_columnation_lgalloc` configuration parameter.
+    pub fn enable_columnation_lgalloc(&self) -> bool {
+        *self.expect_value(&ENABLE_COLUMNATION_LGALLOC)
     }
 }
 
@@ -5168,6 +5181,7 @@ pub fn is_compute_config_var(name: &str) -> bool {
         || name == ENABLE_MZ_JOIN_CORE.name()
         || name == ENABLE_JEMALLOC_PROFILING.name()
         || name == ENABLE_SPECIALIZED_ARRANGEMENTS.name()
+        || name == ENABLE_COLUMNATION_LGALLOC.name()
         || is_persist_config_var(name)
         || is_tracing_var(name)
 }

--- a/src/workspace-hack/Cargo.toml
+++ b/src/workspace-hack/Cargo.toml
@@ -30,7 +30,7 @@ chrono = { version = "0.4.25", default-features = false, features = ["alloc", "c
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-deque = { version = "0.8.2" }
+crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }
@@ -136,7 +136,7 @@ chrono = { version = "0.4.25", default-features = false, features = ["alloc", "c
 clap = { version = "3.2.24", features = ["derive", "env", "wrap_help"] }
 console = { version = "0.15.5", default-features = false, features = ["ansi-parsing", "unicode-width"] }
 criterion = { version = "0.4.0", features = ["async_tokio", "html_reports"] }
-crossbeam-deque = { version = "0.8.2" }
+crossbeam-deque = { version = "0.8.3" }
 crossbeam-epoch = { version = "0.9.13" }
 crossbeam-utils = { version = "0.8.7" }
 crypto-common = { version = "0.1.3", default-features = false, features = ["std"] }


### PR DESCRIPTION
Use [`lgalloc`](https://github.com/antiguru/rust-lgalloc) as a backend for region-allocated rows.

Enable using:
```
ALTER SYSTEM SET enable_disk_cluster_replicas = true;
ALTER SYSTEM SET enable_columnation_lgalloc = true;
```

The PR comes with the following changes:
* It adds a `LgAllocRegion` in `mz-ore` that uses `lgalloc` to allocate regions. This is behind feature flag `region`, which is not enabled by default. This is required because `lgalloc` isn't compatible with wasm, but we compile the sql parser to wasm, and it depends on mz-ore.
* It switches `RowStack` to use `LgAllocRegion` instead of `StableRegion` from Columnation.
* It adds metrics for `lgalloc`.
* It adds a feature flag `enable_columnation_lgalloc`. This only enables `lgalloc` for rows, but we might want to extend it to other parts of region-allocated data later, hence the name.
* Compute enables `lgalloc` based on the following conditions:
  1. The cluster/replica has access to a local disk (`DISK`).
  2. The `enable_columnation_lgalloc` feature flag is set. (`lgalloc` by default forwards requests to the system allocator, unless it's configured.)

Note that `lgalloc` does not play nicely with arrangement idle merge effort. To test this, create a cluster as follows:

```
CREATE CLUSTER lgalloc_test SIZE '8-16G', DISK, IDLE ARRANGEMENT MERGE EFFORT 0;
```

To compare lgalloc vs. regular heap allocations in the same cluster, do something like this:

```
CREATE CLUSTER c REPLICAS (
	lgalloc (SIZE '8-32G', IDLE ARRANGEMENT MERGE EFFORT 0, INTROSPECTION DEBUGGING true, DISK),
	heap (SIZE '8-32G', IDLE ARRANGEMENT MERGE EFFORT 0, INTROSPECTION DEBUGGING true)
);
```


### Motivation

* This PR implements a known-desirable feature: Part of #22678.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
