### PR TITLE
Remove flag `enable_monotonic_oneshot_selects`

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -51,7 +51,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_stats_audit_percent": "100",
     "enable_ld_rbac_checks": "true",
     "enable_rbac_checks": "true",
-    "enable_monotonic_oneshot_selects": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",
     "enable_disk_cluster_replicas": "true",

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -296,9 +296,6 @@ impl Coordinator {
                 .enable_consolidate_after_union_negate(),
             self.catalog()
                 .system_config()
-                .enable_monotonic_oneshot_selects(),
-            self.catalog()
-                .system_config()
                 .enable_specialized_arrangements(),
         )
         .map_err(AdapterError::Internal)

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -236,7 +236,6 @@ impl<'ctx> Optimize<'ctx, GlobalMirPlan<Resolved>> for OptimizeIndex {
         let df_desc = Plan::finalize_dataflow(
             df_desc,
             self.config.enable_consolidate_after_union_negate,
-            false, // we are not in a monotonic context here
             self.config.enable_specialized_arrangements,
         )
         .map_err(OptimizerError::Internal)?;

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -280,7 +280,6 @@ impl<'ctx> Optimize<'ctx, GlobalMirPlan<Resolved>> for OptimizeMaterializedView 
         let df_desc = Plan::finalize_dataflow(
             df_desc,
             self.config.enable_consolidate_after_union_negate,
-            false, // we are not in a monotonic context here
             self.config.enable_specialized_arrangements,
         )
         .map_err(OptimizerError::Internal)?;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -109,12 +109,6 @@ pub struct OptimizerConfig {
     ///
     /// The refinement happens in the LIR ⇒ LIR phase.
     pub enable_consolidate_after_union_negate: bool,
-    /// Enable relaxing of consolidation enforcers for optimization pipelines
-    /// that produce dataflows that run a computation for a single timestamp
-    /// (such as SELECTs).
-    ///
-    /// The refinement happens in the LIR ⇒ LIR phase.
-    pub enable_monotonic_oneshot_selects: bool,
     /// Enable collecting type information so that rendering can type-specialize
     /// arrangements.
     ///
@@ -129,7 +123,6 @@ impl From<&SystemVars> for OptimizerConfig {
     fn from(vars: &SystemVars) -> Self {
         Self {
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
-            enable_monotonic_oneshot_selects: vars.enable_monotonic_oneshot_selects(),
             enable_specialized_arrangements: vars.enable_specialized_arrangements(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
         }

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1761,13 +1761,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_monotonic_oneshot_selects,
-        desc: "monotonic evaluation of one-shot SELECT queries",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_primary_key_not_enforced,
         desc: "PRIMARY KEY NOT ENFORCED",
         default: false,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1112,18 +1112,9 @@ impl<'a> RunnerInner<'a> {
     /// Set features that should be enabled regardless of whether reset-server was
     /// called. These features may be set conditionally depending on the run configuration.
     async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
-        // We turn on enable_monotonic_oneshot_selects,
-        // as that feature has reached enough maturity to do so.
-        // We also turn on enable_specialized_arrangements, as we wish to get
+        // We turn on enable_specialized_arrangements, as we wish to get
         // as much coverage of this feature as we can.
         // TODO(vmarcos): Remove this code when we retire these feature flags.
-        self.system_client
-            .execute(
-                "ALTER SYSTEM SET enable_monotonic_oneshot_selects = on",
-                &[],
-            )
-            .await?;
-
         self.system_client
             .execute("ALTER SYSTEM SET enable_specialized_arrangements = on", &[])
             .await?;


### PR DESCRIPTION
This PR removes the `enable_monotonic_oneshot_selects` feature flag, as this feature has been in GA for more than three months without any reported issues.

The original design document for the feature is #19250.

### Motivation

   * This PR refactors existing code. Fixes https://github.com/MaterializeInc/materialize/issues/20946

### Tips for reviewer

You probably want to omit whitespace when visualizing the diff here.

There were some hard-coded values being passed instead of the feature flag at some points in the code. I replace those with explicit `assert!`s on the `DataflowDescription` not being a single-time one. @aalexandrov: Hope this is an acceptable fix!

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
