### PR TITLE
Remove `DatumVec::borrow_with_many`

### DIFF
--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -276,7 +276,9 @@ where
                 logic(&datums_borrow)
             }),
             SpecializedArrangement::RowRow(inner) => inner.as_collection(move |k, v| {
-                let datums_borrow = datums.borrow_with_many(&[k, v]);
+                let mut datums_borrow = datums.borrow();
+                datums_borrow.extend(&**k);
+                datums_borrow.extend(&**v);
                 logic(&datums_borrow)
             }),
         }
@@ -313,7 +315,9 @@ where
                 inner,
                 key,
                 move |k, v, t, d| {
-                    let mut datums_borrow = datums.borrow_with_many(&[&k, &v]);
+                    let mut datums_borrow = datums.borrow();
+                    datums_borrow.extend(&**k);
+                    datums_borrow.extend(&**v);
                     logic(&mut datums_borrow, t, d)
                 },
                 refuel,
@@ -410,7 +414,9 @@ where
                 logic(&datums_borrow)
             }),
             SpecializedArrangementImport::RowRow(inner) => inner.as_collection(move |k, v| {
-                let datums_borrow = datums.borrow_with_many(&[k, v]);
+                let mut datums_borrow = datums.borrow();
+                datums_borrow.extend(&**k);
+                datums_borrow.extend(&**v);
                 logic(&datums_borrow)
             }),
         }
@@ -447,7 +453,9 @@ where
                 inner,
                 key,
                 move |k, v, t, d| {
-                    let mut datums_borrow = datums.borrow_with_many(&[&k, &v]);
+                    let mut datums_borrow = datums.borrow();
+                    datums_borrow.extend(&**k);
+                    datums_borrow.extend(&**v);
                     logic(&mut datums_borrow, t, d)
                 },
                 refuel,

--- a/src/repr/src/datum_vec.rs
+++ b/src/repr/src/datum_vec.rs
@@ -45,19 +45,6 @@ impl DatumVec {
         borrow.extend(row.iter());
         borrow
     }
-
-    /// Borrow an instance with a specific lifetime, and pre-populate with `Row`s, for example
-    /// first adding a key followed by its values.
-    pub fn borrow_with_many<'a, 'b, D: ::std::borrow::Borrow<Row> + 'a>(
-        &'a mut self,
-        rows: &'b [&'a D],
-    ) -> DatumVecBorrow<'a> {
-        let mut borrow = self.borrow();
-        for row in rows {
-            borrow.extend(row.borrow().iter());
-        }
-        borrow
-    }
 }
 
 /// A borrowed allocation of `Datum` with a specific lifetime.
@@ -110,7 +97,9 @@ mod test {
         {
             // different lifetime, so that rust is happy with the reference lifetimes
             let r2 = Row::pack_slice(&[Datum::String("second")]);
-            let borrow = d.borrow_with_many(&[&r, &r2]);
+            let mut borrow = d.borrow();
+            borrow.extend(&*r);
+            borrow.extend(&*r2);
             assert_eq!(borrow.len(), 3);
             assert_eq!(borrow[2], Datum::String("second"));
         }


### PR DESCRIPTION
This PR removes the function `borrow_with_many` from `DatumVec`, adjusting the call sites accordingly. The function was intended as a variadic borrowing API for `DatumVec`, but type specialization made its use awkward. This is because borrowing no longer happens exclusively with `Row`.

This PR builds on the design introduced by #21968.

### Motivation

   * This PR refactors existing code. Fixes #22522.

### Tips for reviewer

Would @antiguru be OK with this PR fixing instead of just advancing #22522? I looked at the uses of the function `borrow_with`, which takes a single `Row` as a parameter. It is used widely across several layers (adapter, compute, storage) and not only in rendering. It seems to me that `borrow_with` is an acceptable shorthand for `borrow` followed by a single `extend`, and makes a lot of code more readable.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
