### PR TITLE
stash: Optimize TableTransaction set and set_many

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -798,11 +798,15 @@ where
         let restore = self.pending.get(&k).cloned();
 
         let prev = match self.pending.entry(k.clone()) {
-            // key hasn't been set in this txn yet. Set it and return the
-            // initial txn's value of k.
+            // key hasn't been set in this txn yet.
             Entry::Vacant(e) => {
-                e.insert(v);
-                self.initial.get(&k).cloned()
+                let initial = self.initial.get(&k);
+                if initial != v.as_ref() {
+                    // Provided value and initial value are different. Set key.
+                    e.insert(v);
+                }
+                // Return the initial txn's value of k.
+                initial.cloned()
             }
             // key has been set in this txn. Set it and return the previous
             // pending value.
@@ -845,11 +849,15 @@ where
             restores.insert(k.clone(), restore);
 
             let prev = match self.pending.entry(k.clone()) {
-                // key hasn't been set in this txn yet. Set it and return the
-                // initial txn's value of k.
+                // key hasn't been set in this txn yet.
                 Entry::Vacant(e) => {
-                    e.insert(v);
-                    self.initial.get(&k).cloned()
+                    let initial = self.initial.get(&k);
+                    if initial != v.as_ref() {
+                        // Provided value and initial value are different. Set key.
+                        e.insert(v);
+                    }
+                    // Return the initial txn's value of k.
+                    initial.cloned()
                 }
                 // key has been set in this txn. Set it and return the previous
                 // pending value.

--- a/src/stash/src/tests.rs
+++ b/src/stash/src/tests.rs
@@ -1029,6 +1029,15 @@ async fn test_stash_table(stash: &mut Stash) {
         BTreeMap::from([(3i64.to_le_bytes().to_vec(), "v6".to_string())])
     );
 
+    // Duplicate `set`.
+    let items = TABLE.peek_one(stash).await.unwrap();
+    let mut table = TableTransaction::new(items, uniqueness_violation).unwrap();
+    table
+        .set(3i64.to_le_bytes().to_vec(), Some("v6".to_string()))
+        .unwrap();
+    let pending = table.pending::<Vec<u8>, String>();
+    assert!(pending.is_empty());
+
     // Test `set_many`.
     let items = TABLE.peek_one(stash).await.unwrap();
     let mut table = TableTransaction::new(items, uniqueness_violation).unwrap();
@@ -1069,6 +1078,18 @@ async fn test_stash_table(stash: &mut Stash) {
             (42i64.to_le_bytes().to_vec(), "v7".to_string())
         ])
     );
+
+    // Duplicate `set_many`.
+    let items = TABLE.peek_one(stash).await.unwrap();
+    let mut table = TableTransaction::new(items, uniqueness_violation).unwrap();
+    table
+        .set_many(BTreeMap::from([
+            (1i64.to_le_bytes().to_vec(), Some("v6".to_string())),
+            (42i64.to_le_bytes().to_vec(), Some("v7".to_string())),
+        ]))
+        .unwrap();
+    let pending = table.pending::<Vec<u8>, String>();
+    assert!(pending.is_empty());
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
This commit optimizes the `set` and `set_many` methods in `TableTransaction` so that no action is taken if the provided values are equal to the existing values.

This has the added benefit that if `set` or `set_many` are called in a read-only context, and they make no changes, then they will not cause a read-only error. This matches the semantics of other stash methods such as `TypedCollection::upsert_key`.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
