### PR TITLE
ci: Allow rerunning after trimming pipeline too

### DIFF
--- a/ci/mkpipeline.py
+++ b/ci/mkpipeline.py
@@ -32,6 +32,7 @@ from typing import Any
 import yaml
 
 from materialize import mzbuild, spawn
+from materialize.ci_util.trim_pipeline import permit_rerunning_successful_steps
 from materialize.mzcompose.composition import Composition
 
 from .deploy.deploy_util import rust_version
@@ -192,22 +193,6 @@ def prioritize_pipeline(pipeline: Any) -> None:
                     visit(inner_config)
                 continue
             visit(config)
-
-
-def permit_rerunning_successful_steps(pipeline: Any) -> None:
-    def visit(step: Any) -> None:
-        step.setdefault("retry", {}).setdefault("manual", {}).setdefault(
-            "permit_on_passed", True
-        )
-
-    for config in pipeline["steps"]:
-        if "trigger" in config or "wait" in config or "block" in config:
-            continue
-        if "group" in config:
-            for inner_config in config.get("steps", []):
-                visit(inner_config)
-            continue
-        visit(config)
 
 
 def add_test_selection_block(pipeline: Any, pipeline_name: str) -> None:


### PR DESCRIPTION
Reads the pipeline.template.yaml file again, so has to be applied too

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
