### PR TITLE
explain: control outer join lowering via `ExplainConfig`

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3569,11 +3569,12 @@ impl Catalog {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
                 let raw_expr = view.expr;
-                let decorrelated_expr = raw_expr.lower(session_catalog.system_vars())?;
+                let decorrelated_expr = raw_expr.clone().lower(session_catalog.system_vars())?;
                 let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
+                    raw_expr,
                     optimized_expr,
                     desc,
                     conn_id: None,
@@ -3586,7 +3587,7 @@ impl Catalog {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
                 let raw_expr = materialized_view.expr;
-                let decorrelated_expr = raw_expr.lower(session_catalog.system_vars())?;
+                let decorrelated_expr = raw_expr.clone().lower(session_catalog.system_vars())?;
                 let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let mut typ = optimized_expr.typ();
                 for &i in &materialized_view.non_null_assertions {
@@ -3595,6 +3596,7 @@ impl Catalog {
                 let desc = RelationDesc::new(typ, materialized_view.column_names);
                 CatalogItem::MaterializedView(MaterializedView {
                     create_sql: materialized_view.create_sql,
+                    raw_expr,
                     optimized_expr,
                     desc,
                     resolved_ids,

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1943,6 +1943,13 @@ mod builtin_migration_tests {
                         create_sql: format!(
                             "CREATE MATERIALIZED VIEW mv AS SELECT * FROM {table_list}"
                         ),
+                        raw_expr: mz_sql::plan::HirRelationExpr::Constant {
+                            rows: Vec::new(),
+                            typ: RelationType {
+                                column_types: Vec::new(),
+                                keys: Vec::new(),
+                            },
+                        },
                         optimized_expr: OptimizedMirRelationExpr(MirRelationExpr::Constant {
                             rows: Ok(Vec::new()),
                             typ: RelationType {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -713,11 +713,12 @@ impl CatalogState {
                 let optimizer =
                     Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
                 let raw_expr = view.expr;
-                let decorrelated_expr = raw_expr.lower(session_catalog.system_vars())?;
+                let decorrelated_expr = raw_expr.clone().lower(session_catalog.system_vars())?;
                 let optimized_expr = optimizer.optimize(decorrelated_expr)?;
                 let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
                 CatalogItem::View(View {
                     create_sql: view.create_sql,
+                    raw_expr,
                     optimized_expr,
                     desc,
                     conn_id: None,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -111,7 +111,7 @@ use crate::error::AdapterError;
 use crate::explain::explain_dataflow;
 use crate::explain::optimizer_trace::OptimizerTrace;
 use crate::notice::{AdapterNotice, DroppedInUseIndex};
-use crate::optimize::{self, Optimize};
+use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session, TransactionOps, TransactionStatus, WriteOp};
 use crate::subscribe::ActiveSubscribe;
 use crate::util::{viewable_variables, ClientTransmitter, ComputeSinkId, ResultExt};
@@ -3136,6 +3136,7 @@ impl Coordinator {
                     target_cluster,
                     ctx.session_mut(),
                     &row_set_finishing,
+                    &config,
                     root_dispatch,
                 )
                 .with_subscriber(&optimizer_trace)
@@ -3157,6 +3158,7 @@ impl Coordinator {
                     cluster_id,
                     broken,
                     non_null_assertions,
+                    &config,
                     root_dispatch,
                 )
                 .with_subscriber(&optimizer_trace)
@@ -3169,9 +3171,15 @@ impl Coordinator {
             } => {
                 if enable_unified_optimizer_api {
                     // Please see the docs on `explain_query_optimizer_pipeline` above.
-                    self.explain_create_index_optimizer_pipeline(name, index, broken, root_dispatch)
-                        .with_subscriber(&optimizer_trace)
-                        .await
+                    self.explain_create_index_optimizer_pipeline(
+                        name,
+                        index,
+                        broken,
+                        &config,
+                        root_dispatch,
+                    )
+                    .with_subscriber(&optimizer_trace)
+                    .await
                 } else {
                     // Allow while the introduction of the new optimizer API in
                     // #20569 is in progress.
@@ -3181,6 +3189,7 @@ impl Coordinator {
                         name,
                         index,
                         broken,
+                        &config,
                         root_dispatch,
                     )
                     .with_subscriber(&optimizer_trace)
@@ -3299,6 +3308,7 @@ impl Coordinator {
         target_cluster: TargetCluster,
         session: &mut Session,
         finishing: &Option<RowSetFinishing>,
+        explain_config: &mz_repr::explain::ExplainConfig,
         root_dispatch: tracing::Dispatch,
     ) -> Result<
         (
@@ -3317,6 +3327,8 @@ impl Coordinator {
 
         let catalog = self.catalog();
         let target_cluster_id = catalog.resolve_target_cluster(target_cluster, session)?.id;
+        let system_config = catalog.system_config();
+        let optimizer_config = OptimizerConfig::from((system_config, explain_config));
 
         // Execute the various stages of the optimization pipeline
         // -------------------------------------------------------
@@ -3328,7 +3340,7 @@ impl Coordinator {
 
         // Execute the `optimize/hir_to_mir` stage.
         let decorrelated_plan = catch_unwind(broken, "hir_to_mir", || {
-            raw_plan.lower(catalog.system_config())
+            raw_plan.lower((system_config, explain_config))
         })?;
 
         let mut timeline_context =
@@ -3383,6 +3395,7 @@ impl Coordinator {
 
             let mut df = DataflowDesc::new("explanation".to_string());
             df_builder.import_view_into_dataflow(&GlobalId::Explain, &optimized_plan, &mut df)?;
+            df_builder.reoptimize_imported_views(&mut df, &optimizer_config)?;
 
             // Resolve all unmaterializable function calls except mz_now(),
             // because in line with the `sequence_~` method we pretend that we
@@ -3485,6 +3498,7 @@ impl Coordinator {
         target_cluster_id: ClusterId,
         broken: bool,
         non_null_assertions: Vec<usize>,
+        explain_config: &mz_repr::explain::ExplainConfig,
         _root_dispatch: tracing::Dispatch,
     ) -> Result<
         (
@@ -3513,7 +3527,8 @@ impl Coordinator {
         let exported_sink_id = self.allocate_transient_id()?;
         let internal_view_id = self.allocate_transient_id()?;
         let debug_name = full_name.to_string();
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+        let system_config = self.catalog().system_config();
+        let optimizer_config = optimize::OptimizerConfig::from((system_config, explain_config));
 
         // Build a MATERIALIZED VIEW optimizer for this view.
         let mut optimizer = optimize::OptimizeMaterializedView::new(
@@ -3604,6 +3619,7 @@ impl Coordinator {
         name: QualifiedItemName,
         index: Index,
         broken: bool,
+        explain_config: &mz_repr::explain::ExplainConfig,
         _root_dispatch: tracing::Dispatch,
     ) -> Result<
         (
@@ -3622,14 +3638,14 @@ impl Coordinator {
 
         // Initialize optimizer context
         // ----------------------------
-
         let compute_instance = self
             .instance_snapshot(index.cluster_id)
             .expect("compute instance does not exist");
         let exported_index_id = self.allocate_transient_id()?;
-        let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
+        let system_config = self.catalog().system_config();
+        let optimizer_config = optimize::OptimizerConfig::from((system_config, explain_config));
 
-        // Build a MATERIALIZED VIEW optimizer for this view.
+        // Build an INDEX optimizer for this index.
         let mut optimizer = optimize::OptimizeIndex::new(
             self.owned_catalog(),
             compute_instance,

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -133,6 +133,7 @@ impl<'ctx> Optimize<'ctx, Index> for OptimizeIndex {
         let mut df_desc = MirDataflowDescription::new(full_name.to_string());
 
         df_builder.import_into_dataflow(&index.on, &mut df_desc)?;
+        df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;
 
         for desc in df_desc.objects_to_build.iter_mut() {
             prep_relation_expr(state, &mut desc.plan, ExprPrepStyle::Index)?;

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -187,6 +187,7 @@ impl<'ctx> Optimize<'ctx, LocalMirPlan> for OptimizeMaterializedView {
         let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
 
         df_builder.import_view_into_dataflow(&self.internal_view_id, &expr, &mut df_desc)?;
+        df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;
 
         for BuildDesc { plan, .. } in &mut df_desc.objects_to_build {
             prep_relation_expr(self.catalog.state(), plan, ExprPrepStyle::Index)?;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -52,10 +52,12 @@
 
 mod index;
 mod materialized_view;
+mod view;
 
 // Re-export optimzier structs
 pub use index::{Index, OptimizeIndex};
 pub use materialized_view::OptimizeMaterializedView;
+pub use view::OptimizeView;
 
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -62,6 +62,7 @@ pub use view::OptimizeView;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
 use mz_expr::OptimizedMirRelationExpr;
+use mz_repr::explain::ExplainConfig;
 use mz_sql::plan::PlanError;
 use mz_sql::session::vars::SystemVars;
 use mz_transform::TransformError;
@@ -106,7 +107,10 @@ where
 }
 
 // Feature flags for the optimizer.
+#[derive(Clone)]
 pub struct OptimizerConfig {
+    /// The mode in which the optimizer runs.
+    pub mode: OptimizeMode,
     /// Enable consolidation of unions that happen immediately after negate.
     ///
     /// The refinement happens in the LIR ⇒ LIR phase.
@@ -123,14 +127,36 @@ pub struct OptimizerConfig {
     pub enable_new_outer_join_lowering: bool,
 }
 
+#[derive(Clone, PartialEq, Eq)]
+pub enum OptimizeMode {
+    /// A mode where the optimized statement is executed.
+    Execute,
+    /// A mode where the optimized statement is explained.
+    Explain,
+}
+
 impl From<&SystemVars> for OptimizerConfig {
     fn from(vars: &SystemVars) -> Self {
         Self {
+            mode: OptimizeMode::Execute,
             enable_consolidate_after_union_negate: vars.enable_consolidate_after_union_negate(),
             enable_specialized_arrangements: vars.enable_specialized_arrangements(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
         }
+    }
+}
+
+impl From<(&SystemVars, &ExplainConfig)> for OptimizerConfig {
+    fn from((vars, explain_config): (&SystemVars, &ExplainConfig)) -> Self {
+        // Construct base config from vars.
+        let mut config = Self::from(vars);
+        // We are calling this constructor from an 'Explain' mode context.
+        config.mode = OptimizeMode::Explain;
+        // Override feature flags that can be enabled in the EXPLAIN config.
+        config.enable_new_outer_join_lowering |= explain_config.enable_new_outer_join_lowering;
+        // Return final result.
+        config
     }
 }
 

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -1,0 +1,59 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Optimizer implementation for `CREATE VIEW` statements.
+
+use mz_expr::OptimizedMirRelationExpr;
+use mz_repr::explain::trace_plan;
+use mz_sql::plan::HirRelationExpr;
+use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
+use mz_transform::Optimizer as TransformOptimizer;
+use tracing::{span, Level};
+
+use crate::optimize::{Optimize, OptimizerConfig, OptimizerError};
+
+pub struct OptimizeView {
+    /// A typechecking context to use throughout the optimizer pipeline.
+    typecheck_ctx: TypecheckContext,
+    // Optimizer config.
+    config: OptimizerConfig,
+}
+
+impl OptimizeView {
+    #[allow(unused)]
+    pub fn new(config: OptimizerConfig) -> Self {
+        Self {
+            typecheck_ctx: empty_context(),
+            config,
+        }
+    }
+}
+
+impl<'ctx> Optimize<'ctx, HirRelationExpr> for OptimizeView {
+    type To = OptimizedMirRelationExpr;
+
+    fn optimize<'a: 'ctx>(&'a mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+        // HIR ⇒ MIR lowering and decorrelation
+        let expr = expr.lower(&self.config)?;
+
+        // MIR ⇒ MIR optimization (local)
+        let expr = span!(target: "optimizer", Level::TRACE, "local").in_scope(|| {
+            let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
+            let expr = optimizer.optimize(expr)?;
+
+            // Trace the result of this phase.
+            trace_plan(expr.as_inner());
+
+            Ok::<_, OptimizerError>(expr)
+        })?;
+
+        // Return the resulting OptimizedMirRelationExpr.
+        Ok(expr)
+    }
+}

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -44,7 +44,8 @@ use mz_sql::names::{
     ResolvedDatabaseSpecifier, ResolvedIds, SchemaId, SchemaSpecifier,
 };
 use mz_sql::plan::{
-    CreateSourcePlan, Ingestion as PlanIngestion, WebhookHeaders, WebhookValidation,
+    CreateSourcePlan, HirRelationExpr, Ingestion as PlanIngestion, WebhookHeaders,
+    WebhookValidation,
 };
 use mz_sql::rbac;
 use mz_sql::session::vars::OwnedVarInput;
@@ -667,6 +668,7 @@ pub enum StorageSinkConnectionState {
 #[derive(Debug, Clone, Serialize)]
 pub struct View {
     pub create_sql: String,
+    pub raw_expr: HirRelationExpr,
     pub optimized_expr: OptimizedMirRelationExpr,
     pub desc: RelationDesc,
     pub conn_id: Option<ConnectionId>,
@@ -676,6 +678,7 @@ pub struct View {
 #[derive(Debug, Clone, Serialize)]
 pub struct MaterializedView {
     pub create_sql: String,
+    pub raw_expr: HirRelationExpr,
     pub optimized_expr: OptimizedMirRelationExpr,
     pub desc: RelationDesc,
     pub resolved_ids: ResolvedIds,

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -183,6 +183,8 @@ pub struct ExplainConfig {
     pub column_names: bool,
     /// Use inferred column names when rendering scalar and aggregate expressions.
     pub humanized_exprs: bool,
+    /// Enable outer join lowering implemented in #22343.
+    pub enable_new_outer_join_lowering: bool,
 }
 
 impl Default for ExplainConfig {
@@ -203,6 +205,7 @@ impl Default for ExplainConfig {
             cardinality: false,
             column_names: false,
             humanized_exprs: false,
+            enable_new_outer_join_lowering: false,
         }
     }
 }
@@ -244,6 +247,7 @@ impl TryFrom<BTreeSet<String>> for ExplainConfig {
             cardinality: flags.remove("cardinality"),
             column_names: flags.remove("column_names"),
             humanized_exprs: flags.remove("humanized_exprs") && !flags.contains("raw_plans"),
+            enable_new_outer_join_lowering: flags.remove("enable_new_outer_join_lowering"),
         };
         if flags.is_empty() {
             Ok(result)
@@ -887,6 +891,7 @@ mod tests {
             cardinality: false,
             column_names: false,
             humanized_exprs: false,
+            enable_new_outer_join_lowering: false,
         };
         let context = ExplainContext {
             env,

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -635,7 +635,7 @@ COMPLETE 0
 
 # EXPLAIN a SELECT with the feature turned in the EXPLAIN config.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+EXPLAIN OPTIMIZED PLAN WITH(enable_new_outer_join_lowering, humanized_exprs, arity) FOR
 SELECT
   facts.facts_k01,
   facts.facts_d01,
@@ -653,31 +653,33 @@ FROM
 Explained Query:
   Return // { arity: 6 }
     Union // { arity: 6 }
-      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
-        Get l0 // { arity: 12 }
-      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
-        Map (null, null, null) // { arity: 21 }
-          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              Union // { arity: 9 }
-                Negate // { arity: 9 }
-                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                    Project (#0..=#8) // { arity: 9 }
-                      Get l0 // { arity: 12 }
-                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-  With
-    cte l0 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+      Map (null, null, null) // { arity: 6 }
+        Union // { arity: 3 }
+          Negate // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l1 // { arity: 7 }
+          Project (#0, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+      Project (#0, #2..=#6) // { arity: 6 }
+        Get l1 // { arity: 7 }
+  With
+    cte l1 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Filter (dim01_d02 < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+        Project (#0, #1, #4, #5) // { arity: 4 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
   filter=((dim01_d02 < 24))
@@ -703,37 +705,39 @@ FROM
 
 # EXPLAIN a SELECT * FROM <view> with the feature turned in the EXPLAIN config.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+EXPLAIN OPTIMIZED PLAN WITH(enable_new_outer_join_lowering, humanized_exprs, arity) FOR
 SELECT * FROM v;
 ----
 Explained Query:
   Return // { arity: 6 }
     Union // { arity: 6 }
-      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
-        Get l0 // { arity: 12 }
-      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
-        Map (null, null, null) // { arity: 21 }
-          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              Union // { arity: 9 }
-                Negate // { arity: 9 }
-                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                    Project (#0..=#8) // { arity: 9 }
-                      Get l0 // { arity: 12 }
-                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-  With
-    cte l0 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+      Map (null, null, null) // { arity: 6 }
+        Union // { arity: 3 }
+          Negate // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l1 // { arity: 7 }
+          Project (#0, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+      Project (#0, #2..=#6) // { arity: 6 }
+        Get l1 // { arity: 7 }
+  With
+    cte l1 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Filter (dim01_d02 < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+        Project (#0, #1, #4, #5) // { arity: 4 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
   filter=((dim01_d02 < 24))
@@ -742,7 +746,7 @@ EOF
 
 # EXPLAIN a CREATE INDEX with the feature turned in the EXPLAIN config.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+EXPLAIN OPTIMIZED PLAN WITH(enable_new_outer_join_lowering, humanized_exprs, arity) FOR
 CREATE INDEX ON v(facts_k01);
 ----
 materialize.public.v_facts_k01_idx:
@@ -752,31 +756,33 @@ materialize.public.v_facts_k01_idx:
 materialize.public.v:
   Return // { arity: 6 }
     Union // { arity: 6 }
-      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
-        Get l0 // { arity: 12 }
-      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
-        Map (null, null, null) // { arity: 21 }
-          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              Union // { arity: 9 }
-                Negate // { arity: 9 }
-                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                    Project (#0..=#8) // { arity: 9 }
-                      Get l0 // { arity: 12 }
-                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-  With
-    cte l0 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+      Map (null, null, null) // { arity: 6 }
+        Union // { arity: 3 }
+          Negate // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l1 // { arity: 7 }
+          Project (#0, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+      Project (#0, #2..=#6) // { arity: 6 }
+        Get l1 // { arity: 7 }
+  With
+    cte l1 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Filter (dim01_d02 < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+        Project (#0, #1, #4, #5) // { arity: 4 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
   filter=((dim01_d02 < 24))
@@ -785,7 +791,7 @@ EOF
 
 # EXPLAIN a CREATE MATERIALIZED VIEW with the feature turned in the EXPLAIN config.
 query T multiline
-EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+EXPLAIN OPTIMIZED PLAN WITH(enable_new_outer_join_lowering, humanized_exprs, arity) FOR
 CREATE MATERIALIZED VIEW mv AS
 SELECT
   facts.facts_k01,
@@ -804,31 +810,33 @@ FROM
 materialize.public.mv:
   Return // { arity: 6 }
     Union // { arity: 6 }
-      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
-        Get l0 // { arity: 12 }
-      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
-        Map (null, null, null) // { arity: 21 }
-          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              Union // { arity: 9 }
-                Negate // { arity: 9 }
-                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                    Project (#0..=#8) // { arity: 9 }
-                      Get l0 // { arity: 12 }
-                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
-                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
-              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
-  With
-    cte l0 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+      Map (null, null, null) // { arity: 6 }
+        Union // { arity: 3 }
+          Negate // { arity: 3 }
+            Project (#0, #2, #3) // { arity: 3 }
+              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+                Get l0 // { arity: 4 }
+                ArrangeBy keys=[[#0]] // { arity: 1 }
+                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                    Project (#1) // { arity: 1 }
+                      Get l1 // { arity: 7 }
+          Project (#0, #4, #5) // { arity: 3 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+      Project (#0, #2..=#6) // { arity: 6 }
+        Get l1 // { arity: 7 }
+  With
+    cte l1 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+        Get l0 // { arity: 4 }
         ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Filter (dim01_d02 < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+    cte l0 =
+      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+        Project (#0, #1, #4, #5) // { arity: 4 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
   filter=((dim01_d02 < 24))

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -625,3 +625,212 @@ With
       Get materialize.left_joins.outer // { arity: 2 }
 
 EOF
+
+# The following tests are for the EXPLAIN override of this
+# feature flag, so we want to disable it.
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_new_outer_join_lowering TO false;
+----
+COMPLETE 0
+
+# EXPLAIN a SELECT with the feature turned in the EXPLAIN config.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+SELECT
+  facts.facts_k01,
+  facts.facts_d01,
+  facts.facts_d02,
+  dim01.dim01_k01,
+  dim01.dim01_d01,
+  dim01.dim01_d02
+FROM
+  left_joins_raw.facts LEFT JOIN
+  left_joins_raw.dim01 ON(
+    coalesce(facts.dim01_k01, 5) = coalesce(dim01.dim01_k01, 5) AND
+    facts_d01 > 42 AND dim01_d02 < 24
+  );
+----
+Explained Query:
+  Return // { arity: 6 }
+    Union // { arity: 6 }
+      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
+        Get l0 // { arity: 12 }
+      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
+        Map (null, null, null) // { arity: 21 }
+          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              Union // { arity: 9 }
+                Negate // { arity: 9 }
+                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                    Project (#0..=#8) // { arity: 9 }
+                      Get l0 // { arity: 12 }
+                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+  With
+    cte l0 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (dim01_d02 < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+
+Source materialize.left_joins_raw.dim01
+  filter=((dim01_d02 < 24))
+
+EOF
+
+# Define the above statement as a view.
+statement ok
+CREATE VIEW v AS
+SELECT
+  facts.facts_k01,
+  facts.facts_d01,
+  facts.facts_d02,
+  dim01.dim01_k01,
+  dim01.dim01_d01,
+  dim01.dim01_d02
+FROM
+  left_joins_raw.facts LEFT JOIN
+  left_joins_raw.dim01 ON(
+    coalesce(facts.dim01_k01, 5) = coalesce(dim01.dim01_k01, 5) AND
+    facts_d01 > 42 AND dim01_d02 < 24
+  );
+
+# EXPLAIN a SELECT * FROM <view> with the feature turned in the EXPLAIN config.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+SELECT * FROM v;
+----
+Explained Query:
+  Return // { arity: 6 }
+    Union // { arity: 6 }
+      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
+        Get l0 // { arity: 12 }
+      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
+        Map (null, null, null) // { arity: 21 }
+          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              Union // { arity: 9 }
+                Negate // { arity: 9 }
+                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                    Project (#0..=#8) // { arity: 9 }
+                      Get l0 // { arity: 12 }
+                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+  With
+    cte l0 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (dim01_d02 < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+
+Source materialize.left_joins_raw.dim01
+  filter=((dim01_d02 < 24))
+
+EOF
+
+# EXPLAIN a CREATE INDEX with the feature turned in the EXPLAIN config.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+CREATE INDEX ON v(facts_k01);
+----
+materialize.public.v_facts_k01_idx:
+  ArrangeBy keys=[[facts_k01]] // { arity: 6 }
+    ReadGlobalFromSameDataflow materialize.public.v // { arity: 6 }
+
+materialize.public.v:
+  Return // { arity: 6 }
+    Union // { arity: 6 }
+      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
+        Get l0 // { arity: 12 }
+      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
+        Map (null, null, null) // { arity: 21 }
+          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              Union // { arity: 9 }
+                Negate // { arity: 9 }
+                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                    Project (#0..=#8) // { arity: 9 }
+                      Get l0 // { arity: 12 }
+                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+  With
+    cte l0 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (dim01_d02 < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+
+Source materialize.left_joins_raw.dim01
+  filter=((dim01_d02 < 24))
+
+EOF
+
+# EXPLAIN a CREATE MATERIALIZED VIEW with the feature turned in the EXPLAIN config.
+query T multiline
+EXPLAIN OPTIMIZED PLAN WITH(humanized_exprs, arity) FOR
+CREATE MATERIALIZED VIEW mv AS
+SELECT
+  facts.facts_k01,
+  facts.facts_d01,
+  facts.facts_d02,
+  dim01.dim01_k01,
+  dim01.dim01_d01,
+  dim01.dim01_d02
+FROM
+  left_joins_raw.facts LEFT JOIN
+  left_joins_raw.dim01 ON(
+    coalesce(facts.dim01_k01, 5) = coalesce(dim01.dim01_k01, 5) AND
+    facts_d01 > 42 AND dim01_d02 < 24
+  );
+----
+materialize.public.mv:
+  Return // { arity: 6 }
+    Union // { arity: 6 }
+      Project (#0, #4, #5, #9..=#11) // { arity: 6 }
+        Get l0 // { arity: 12 }
+      Project (#0, #4, #5, #18..=#20) // { arity: 6 }
+        Map (null, null, null) // { arity: 21 }
+          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) type=differential // { arity: 18 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              Union // { arity: 9 }
+                Negate // { arity: 9 }
+                  Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                    Project (#0..=#8) // { arity: 9 }
+                      Get l0 // { arity: 12 }
+                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                  ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+            ArrangeBy keys=[[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05]] // { arity: 9 }
+              ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+  With
+    cte l0 =
+      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 12 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 9 }
+          Filter (facts_d01 > 42) // { arity: 9 }
+            ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
+        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+          Project (#0..=#2) // { arity: 3 }
+            Filter (dim01_d02 < 24) // { arity: 6 }
+              ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
+
+Source materialize.left_joins_raw.dim01
+  filter=((dim01_d02 < 24))
+
+EOF


### PR DESCRIPTION
Implements the `EXPLAIN`-based mechanism for inspecting plans with the new `OUTER JOIN` lowering without enabling the feature in production.

### Motivation

  * This PR adds a known-desirable feature.

Closes #22729.

### Tips for reviewer

The first commits are part of #22745 and will be reviewed there. For the rest, see the commit messages for details.

@mjibson note one of the commits is introducing a `row_expr: HirRelationExpr` to the `View` and `MaterializedView` catalog items. I plan to pick up other code #21709 and try to implement the changes from that PR when I'm working on putting `CREATE VIEW` behind the `OptimizeView` API (also introduced by this PR) next week.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
