### PR TITLE
adapter: cleanup `CREATE MATERIALIZED VIEW` code paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -23,6 +23,7 @@
 /src/adapter                        @MaterializeInc/adapter
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
+/src/adapter/src/coord/dataflows.rs @MaterializeInc/compute
 /src/adapter/src/flags.rs
 /src/alloc                          @benesch
 /src/audit-log                      @MaterializeInc/adapter

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1515,95 +1515,56 @@ impl Coordinator {
                         .storage_ids
                         .insert(entry.id());
 
-                    if enable_unified_optimizer_api {
-                        // Collect optimizer parameters
-                        let compute_instance = self
-                            .instance_snapshot(mview.cluster_id)
-                            .expect("compute instance does not exist");
-                        let internal_view_id = self.allocate_transient_id()?;
-                        let debug_name = self
-                            .catalog()
-                            .resolve_full_name(entry.name(), None)
-                            .to_string();
-                        let optimizer_config =
-                            OptimizerConfig::from(self.catalog().system_config());
+                    // Collect optimizer parameters
+                    let compute_instance = self
+                        .instance_snapshot(mview.cluster_id)
+                        .expect("compute instance does not exist");
+                    let internal_view_id = self.allocate_transient_id()?;
+                    let debug_name = self
+                        .catalog()
+                        .resolve_full_name(entry.name(), None)
+                        .to_string();
+                    let optimizer_config = OptimizerConfig::from(self.catalog().system_config());
 
-                        // Build a MATERIALIZED VIEW optimizer for this view.
-                        let mut optimizer = OptimizeMaterializedView::new(
-                            self.owned_catalog(),
-                            compute_instance,
-                            entry.id(),
-                            internal_view_id,
-                            mview.desc.iter_names().cloned().collect(),
-                            mview.non_null_assertions.clone(),
-                            debug_name,
-                            optimizer_config,
-                        );
+                    // Build a MATERIALIZED VIEW optimizer for this view.
+                    let mut optimizer = OptimizeMaterializedView::new(
+                        self.owned_catalog(),
+                        compute_instance,
+                        entry.id(),
+                        internal_view_id,
+                        mview.desc.iter_names().cloned().collect(),
+                        mview.non_null_assertions.clone(),
+                        debug_name,
+                        optimizer_config,
+                    );
 
-                        // MIR ⇒ MIR optimization (global)
-                        let global_mir_plan = optimizer.optimize(mview.optimized_expr.clone())?;
-                        // Timestamp selection
-                        let as_of = self.bootstrap_materialized_view_as_of(
-                            global_mir_plan.df_desc(),
-                            global_mir_plan.compute_instance_id(),
-                        );
-                        let global_mir_plan = global_mir_plan.resolve(as_of);
-                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
+                    // MIR ⇒ MIR optimization (global)
+                    let global_mir_plan = optimizer.optimize(mview.optimized_expr.clone())?;
+                    // Timestamp selection
+                    let as_of = self.bootstrap_materialized_view_as_of(
+                        global_mir_plan.df_desc(),
+                        global_mir_plan.compute_instance_id(),
+                    );
+                    let global_mir_plan = global_mir_plan.resolve(as_of);
+                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                    let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
 
-                        // Note: ideally, the optimized_plan should be computed
-                        // and set when the CatalogItem is re-constructed (in
-                        // parse_item).
-                        //
-                        // However, it's not clear how exactly to change
-                        // `load_catalog_items` in order to accommodate for the
-                        // optimizer pipeline executed above.
-                        self.catalog_mut()
-                            .set_optimized_plan(entry.id(), global_mir_plan.df_desc().clone());
-                        self.catalog_mut()
-                            .set_physical_plan(entry.id(), global_lir_plan.df_desc().clone());
-                        self.catalog_mut()
-                            .set_dataflow_metainfo(entry.id(), global_lir_plan.df_meta().clone());
+                    // Note: ideally, the optimized_plan should be computed
+                    // and set when the CatalogItem is re-constructed (in
+                    // parse_item).
+                    //
+                    // However, it's not clear how exactly to change
+                    // `load_catalog_items` in order to accommodate for the
+                    // optimizer pipeline executed above.
+                    self.catalog_mut()
+                        .set_optimized_plan(entry.id(), global_mir_plan.df_desc().clone());
+                    self.catalog_mut()
+                        .set_physical_plan(entry.id(), global_lir_plan.df_desc().clone());
+                    self.catalog_mut()
+                        .set_dataflow_metainfo(entry.id(), global_lir_plan.df_meta().clone());
 
-                        let df_desc = global_lir_plan.unapply().0;
-                        self.ship_dataflow_new(df_desc, mview.cluster_id).await;
-                    } else {
-                        // Re-create the sink on the compute instance.
-                        let internal_view_id = self.allocate_transient_id()?;
-                        let debug_name = self
-                            .catalog()
-                            .resolve_full_name(entry.name(), entry.conn_id())
-                            .to_string();
-
-                        let mut builder = self.dataflow_builder(mview.cluster_id);
-                        let (mut df, df_metainfo) = builder.build_materialized_view(
-                            entry.id(),
-                            internal_view_id,
-                            debug_name,
-                            &mview.optimized_expr,
-                            &mview.desc,
-                            &mview.non_null_assertions,
-                        )?;
-
-                        // Note: ideally, the optimized_plan should be computed and
-                        // set when the CatalogItem is re-constructed (in
-                        // parse_item).
-                        //
-                        // However, it's not clear how exactly to change
-                        // `load_catalog_items` to accommodate for the
-                        // `build_materialized_view` call above.
-                        self.catalog_mut()
-                            .set_optimized_plan(entry.id(), df.clone());
-                        self.catalog_mut()
-                            .set_dataflow_metainfo(entry.id(), df_metainfo);
-
-                        // The 'as_of' field of the dataflow changes after restart
-                        let as_of = self.bootstrap_materialized_view_as_of(&df, mview.cluster_id);
-                        df.set_as_of(as_of);
-
-                        let df = self.must_ship_dataflow(df, mview.cluster_id).await;
-                        self.catalog_mut().set_physical_plan(entry.id(), df);
-                    }
+                    let df_desc = global_lir_plan.unapply().0;
+                    self.ship_dataflow_new(df_desc, mview.cluster_id).await;
                 }
                 CatalogItem::Sink(sink) => {
                     let id = entry.id();

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -22,7 +22,7 @@ use mz_adapter_types::compaction::DEFAULT_LOGICAL_COMPACTION_WINDOW_TS;
 use mz_compute_client::controller::error::InstanceMissing;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::plan::Plan;
-use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection};
+use mz_compute_types::sinks::ComputeSinkDesc;
 use mz_compute_types::ComputeInstanceId;
 use mz_controller::Controller;
 use mz_expr::visit::Visit;
@@ -34,7 +34,7 @@ use mz_ore::cast::ReinterpretCast;
 use mz_ore::stack::{maybe_grow, CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::adt::array::ArrayDimension;
 use mz_repr::role_id::RoleId;
-use mz_repr::{Datum, GlobalId, RelationDesc, Row, Timestamp};
+use mz_repr::{Datum, GlobalId, Row, Timestamp};
 use mz_sql::catalog::{CatalogRole, SessionCatalog};
 use mz_sql::rbac;
 use mz_transform::dataflow::DataflowMetainfo;
@@ -505,47 +505,6 @@ impl<'a> DataflowBuilder<'a> {
             mz_transform::optimize_dataflow(dataflow, self, &mz_transform::EmptyStatisticsOracle)?;
 
         Ok(dataflow_metainfo)
-    }
-
-    /// Builds a dataflow description for a materialized view.
-    ///
-    /// For this, we first build a dataflow for the view expression, then we add
-    /// a sink that writes that dataflow's output to storage. `internal_view_id`
-    /// is the ID we assign to the view dataflow internally, so we can connect
-    /// the sink to it.
-    pub fn build_materialized_view(
-        &mut self,
-        exported_sink_id: GlobalId,
-        internal_view_id: GlobalId,
-        debug_name: String,
-        optimized_expr: &OptimizedMirRelationExpr,
-        desc: &RelationDesc,
-        non_null_assertions: &[usize],
-    ) -> Result<(DataflowDesc, DataflowMetainfo), AdapterError> {
-        let mut dataflow = DataflowDesc::new(debug_name);
-
-        self.import_view_into_dataflow(&internal_view_id, optimized_expr, &mut dataflow)?;
-
-        for BuildDesc { plan, .. } in &mut dataflow.objects_to_build {
-            prep_relation_expr(self.catalog, plan, ExprPrepStyle::Index)?;
-        }
-
-        let sink_description = ComputeSinkDesc {
-            from: internal_view_id,
-            from_desc: desc.clone(),
-            connection: ComputeSinkConnection::Persist(PersistSinkConnection {
-                value_desc: desc.clone(),
-                storage_metadata: (),
-            }),
-            with_snapshot: true,
-            up_to: Antichain::default(),
-            non_null_assertions: non_null_assertions.to_vec(),
-        };
-
-        let dataflow_metainfo =
-            self.build_sink_dataflow_into(&mut dataflow, exported_sink_id, sink_description)?;
-
-        Ok((dataflow, dataflow_metainfo))
     }
 
     /// Determine the given source's monotonicity.

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -911,8 +911,6 @@ impl Coordinator {
         Ok(ops)
     }
 
-    /// This should mirror the operational semantics of
-    /// `Coordinator::sequence_create_materialized_view_deprecated`.
     #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn sequence_create_materialized_view(
         &mut self,
@@ -3468,9 +3466,6 @@ impl Coordinator {
     /// Run the MV optimization explanation pipeline. This function must be called with
     /// an `OptimizerTrace` `tracing` subscriber, using `.with_subscriber(...)`.
     /// The `root_dispatch` should be the global `tracing::Dispatch`.
-    ///
-    /// This should mirror the operational semantics of
-    /// `Coordinator::explain_create_materialized_view_optimizer_pipeline_deprecated`.
     ///
     /// WARNING, ENTERING SPOOKY ZONE 3.0
     ///

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -13,7 +13,9 @@ use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
 use maplit::btreemap;
+use mz_compute_types::dataflows::BuildDesc;
 use mz_compute_types::plan::Plan;
+use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_ore::soft_assert_or_log;
@@ -28,7 +30,9 @@ use timely::progress::Antichain;
 use tracing::{span, Level};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
+use crate::coord::dataflows::{
+    prep_relation_expr, ComputeInstanceSnapshot, DataflowBuilder, ExprPrepStyle,
+};
 use crate::optimize::{
     LirDataflowDescription, MirDataflowDescription, Optimize, OptimizerConfig, OptimizerError,
 };
@@ -170,7 +174,7 @@ impl<'ctx> Optimize<'ctx, LocalMirPlan> for OptimizeMaterializedView {
     type To = GlobalMirPlan<Unresolved>;
 
     fn optimize<'s: 'ctx>(&'s mut self, plan: LocalMirPlan) -> Result<Self::To, OptimizerError> {
-        let LocalMirPlan { expr } = plan;
+        let expr = OptimizedMirRelationExpr(plan.expr);
 
         let mut rel_typ = expr.typ();
         for &i in self.non_null_assertions.iter() {
@@ -180,14 +184,30 @@ impl<'ctx> Optimize<'ctx, LocalMirPlan> for OptimizeMaterializedView {
 
         let mut df_builder =
             DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+        let mut df_desc = MirDataflowDescription::new(self.debug_name.clone());
 
-        let (df_desc, df_meta) = df_builder.build_materialized_view(
+        df_builder.import_view_into_dataflow(&self.internal_view_id, &expr, &mut df_desc)?;
+
+        for BuildDesc { plan, .. } in &mut df_desc.objects_to_build {
+            prep_relation_expr(self.catalog.state(), plan, ExprPrepStyle::Index)?;
+        }
+
+        let sink_description = ComputeSinkDesc {
+            from: self.internal_view_id,
+            from_desc: rel_desc.clone(),
+            connection: ComputeSinkConnection::Persist(PersistSinkConnection {
+                value_desc: rel_desc,
+                storage_metadata: (),
+            }),
+            with_snapshot: true,
+            up_to: Antichain::default(),
+            non_null_assertions: self.non_null_assertions.clone(),
+        };
+
+        let df_meta = df_builder.build_sink_dataflow_into(
+            &mut df_desc,
             self.exported_sink_id,
-            self.internal_view_id,
-            self.debug_name.clone(),
-            &OptimizedMirRelationExpr(expr),
-            &rel_desc,
-            &self.non_null_assertions,
+            sink_description,
         )?;
 
         // Return the (sealed) plan at the end of this optimization step.


### PR DESCRIPTION
Some leftovers from #22701.

In addition, I tagged @MaterializeInc/compute as CODEOWNER of the `dataflows.rs` code in `mz_adapter`, since it is mostly convenience syntax for the global MIR optimization step when we build the MIR-backed `DataflowDescription`.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

See commit messages for details.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
