### PR TITLE
catalog: Add debug logs to persist implementation

### DIFF
--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -338,7 +338,7 @@ impl PersistHandle {
         let current_epoch = Epoch::new(current_epoch).expect("known to be non-zero");
 
         debug!(
-            "open_inner is_initialized={:?} upper={:?} user_version={:?} prev_epoch={:?} current_epoch={:?}", 
+            "open_inner is_initialized={:?} upper={:?} user_version={:?} prev_epoch={:?} current_epoch={:?}",
             is_initialized,
             upper,
             user_version,

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -261,7 +261,7 @@ impl PersistHandle {
     pub(crate) async fn new(persist_client: PersistClient, organization_id: Uuid) -> PersistHandle {
         const SEED: usize = 1;
         let shard_id = Self::shard_id(organization_id, SEED);
-        debug!("new shard_id={shard_id:?}");
+        debug!(?shard_id, "new persist backed catalog state");
         let (write_handle, read_handle) = persist_client
             .open(
                 shard_id,
@@ -338,12 +338,12 @@ impl PersistHandle {
         let current_epoch = Epoch::new(current_epoch).expect("known to be non-zero");
 
         debug!(
-            "open_inner is_initialized={:?} upper={:?} user_version={:?} prev_epoch={:?} current_epoch={:?}",
-            is_initialized,
-            upper,
-            user_version,
-            prev_epoch,
-            current_epoch,
+            ?is_initialized,
+            ?upper,
+            ?user_version,
+            ?prev_epoch,
+            ?current_epoch,
+            "open inner"
         );
 
         let mut catalog = PersistCatalogState {


### PR DESCRIPTION
This commit adds debug logs to the persist implementation of
DurableCatalogState.

Resolves #22750

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
