### PR TITLE
Collapse `generate_series` when output columns are projected away

### DIFF
--- a/src/transform/src/fold_constants.rs
+++ b/src/transform/src/fold_constants.rs
@@ -451,10 +451,10 @@ impl FoldConstants {
                 ))));
             }
 
-            if limit_remaining < *diff as usize {
+            if limit_remaining < 1 as usize {
                 return None;
             }
-            limit_remaining -= *diff as usize;
+            limit_remaining -= 1 as usize;
 
             let datums = row.unpack();
             let temp_storage = RowArena::new();


### PR DESCRIPTION
This PR updates projection pushdown for `FlatMap` nodes to notice example cases where output columns are unused, and the number of records can be determined from the data. This is essentially only in support of optimizing `generate_series`, which has historically forced complete unpacking for something like
```sql
select count(*) from generate_series(1, 1000000);
```
This now optimizes to the constant `1000000` rather than a dataflow that deploys to build one million rows and count them.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
