### PR TITLE
stash-debug: Make stash-debug aware of comments

### DIFF
--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -267,7 +267,7 @@ macro_rules! for_collections {
                 $macro!(catalog::CLUSTER_COLLECTION);
                 $macro!(catalog::CLUSTER_INTROSPECTION_SOURCE_INDEX_COLLECTION);
                 $macro!(catalog::CLUSTER_REPLICA_COLLECTION);
-                $macro!(catalog::CONFIG_COLLECTION);
+                $macro!(catalog::COMMENTS_COLLECTION);
                 $macro!(catalog::CONFIG_COLLECTION);
                 $macro!(catalog::DATABASES_COLLECTION);
                 $macro!(catalog::DEFAULT_PRIVILEGES_COLLECTION);


### PR DESCRIPTION
### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
