### PR TITLE
sql: correctly check enable_disk_cluster_replicas for alter cluster

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4711,6 +4711,9 @@ pub fn plan_alter_cluster(
                 options.introspection_interval = AlterOptionParameter::Set(introspection_interval);
             }
             if let Some(disk) = disk {
+                if disk {
+                    scx.require_feature_flag(&vars::ENABLE_DISK_CLUSTER_REPLICAS)?;
+                }
                 options.disk = AlterOptionParameter::Set(disk);
             }
             if !replicas.is_empty() {

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -7,12 +7,24 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_disk_cluster_replicas = false
+ALTER SYSTEM SET disk_cluster_replicas_default = false
+
+! CREATE CLUSTER no SIZE = '1', REPLICATION FACTOR 0, DISK;
+exact:`WITH (DISK)` for cluster replicas is not supported
+
+> CREATE CLUSTER no SIZE = '1', REPLICATION FACTOR 0;
+
+! ALTER CLUSTER no SET (REPLICATION FACTOR 1, DISK);
+exact:`WITH (DISK)` for cluster replicas is not supported
+
+
 # Test that with `enable_create_source_denylist_with_options` off, if
 # `enable_disk_cluster_replicas` is on, we can use `WITH(DISK)`.
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_create_source_denylist_with_options = false
 ALTER SYSTEM SET enable_disk_cluster_replicas = true
-ALTER SYSTEM SET disk_cluster_replicas_default = false
 
 > DROP CLUSTER IF EXISTS c;
 


### PR DESCRIPTION
Fixes https://github.com/MaterializeInc/materialize/issues/22755

I believe that alter cluster commands are never written into the catalog? so this should be backward compatible; if anyone did this in prod, they would probably panic on restart as we have adjusted the `CREATE CLUSTER` command, which means no one has done this!

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
