### PR TITLE
[skunkworks] row: Use CompactBytes as backing store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "compact_bytes"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2396576e22796b9f74443e7d70900052ab718791d9800ec487f6ff78fe1cced"
+checksum = "de71a0422a777179ab4baef92325e56396443df4a680bc443b11f63d644ca019"
 dependencies = [
  "serde",
  "static_assertions",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,6 +1199,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_bytes"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2396576e22796b9f74443e7d70900052ab718791d9800ec487f6ff78fe1cced"
+dependencies = [
+ "serde",
+ "static_assertions",
+]
+
+[[package]]
 name = "compile-time-run"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4642,6 +4652,7 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
+ "compact_bytes",
  "console-subscriber",
  "ctor",
  "either",
@@ -5095,6 +5106,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "columnation",
+ "compact_bytes",
  "criterion",
  "dec",
  "differential-dataflow",
@@ -5125,6 +5137,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
+ "static_assertions",
  "thiserror",
  "timely",
  "tokio-postgres",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
   "std",
 ], optional = true }
 clap = { version = "3.2.24", features = ["env"], optional = true }
-compact_bytes = { version = "0.1", optional = true }
+compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { version = "0.4.23", default-features = false, features = [
   "std",
 ], optional = true }
 clap = { version = "3.2.24", features = ["env"], optional = true }
+compact_bytes = { version = "0.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
@@ -95,7 +96,7 @@ async = [
   "tokio",
   "tracing",
 ]
-bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
+bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 region = ["lgalloc"]
 tracing_ = [

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -78,6 +78,17 @@ where
     }
 }
 
+#[cfg(feature = "compact_bytes")]
+impl Vector<u8> for compact_bytes::CompactBytes {
+    fn push(&mut self, value: u8) {
+        self.push(value)
+    }
+
+    fn extend_from_slice(&mut self, other: &[u8]) {
+        self.extend_from_slice(other)
+    }
+}
+
 /// Extension methods for `std::vec::Vec`
 pub trait VecExt<T> {
     /// Creates an iterator which uses a closure to determine if an element should be removed.

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -22,7 +22,7 @@ cfg-if = "1.0.0"
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
-compact_bytes = "0.1"
+compact_bytes = "0.1.1"
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
 enum_dispatch = "0.3.11"
@@ -53,7 +53,7 @@ tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
+proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 thiserror = "1.0.37"
 
 # for the tracing_ feature

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -22,6 +22,7 @@ cfg-if = "1.0.0"
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
+compact_bytes = "0.1"
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
 enum_dispatch = "0.3.11"
@@ -31,7 +32,7 @@ hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes", "smallvec", "region", "stack", "test", "serde"] }
+mz-ore = { path = "../ore", features = ["bytes_", "smallvec", "region", "stack", "test", "serde"] }
 mz-persist-types = { path = "../persist-types" }
 mz-pgtz = { path = "../pgtz" }
 mz-proto = { path = "../proto", features = ["chrono"] }
@@ -45,6 +46,7 @@ ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
+static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -110,13 +110,25 @@ pub static VARIABLE_LENGTH_ENCODING: AtomicBool = AtomicBool::new(false);
 /// Rows are dynamically sized, but up to a fixed size their data is stored in-line.
 /// It is best to re-use a `Row` across multiple `Row` creation calls, as this
 /// avoids the allocations involved in `Row::new()`.
-#[derive(Clone, Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
     data: CompactBytes,
 }
 
 // Nothing depends on Row being exactly 24, we just want to add visibility to the size.
 static_assertions::const_assert_eq!(std::mem::size_of::<Row>(), 24);
+
+impl Clone for Row {
+    fn clone(&self) -> Self {
+        Row {
+            data: self.data.clone(),
+        }
+    }
+
+    fn clone_from(&mut self, source: &Self) {
+        self.data.clone_from(&source.data);
+    }
+}
 
 impl Arbitrary for Row {
     type Parameters = prop::collection::SizeRange;

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1549,13 +1549,24 @@ NULL
 query III
 SELECT mz_row_size((1, 2)), mz_row_size((1, 2, 3, 4)), mz_row_size((1, 2, 3, 4, 5))
 ----
-32  32  32
+24  24  24
+
+statement ok
+CREATE TABLE ts_size (t TEXT)
+
+statement ok
+INSERT INTO ts_size VALUES ('2023-10-30T13:47:11Z')
+
+query I
+SELECT mz_row_size(ts_size.*) FROM ts_size
+----
+24
 
 query III
 SELECT a, b, mz_row_size(col_size.*) FROM col_size ORDER BY a
 ----
-1  2  71
-NULL  NULL  32
+1  2  63
+NULL  NULL  24
 
 query error mz_errored
 SELECT mz_internal.mz_error_if_null(NULL, 'mz_errored')

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -265,8 +265,8 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
 # Under arrangement specialization of only empty values, a single-column relation
-# should demand 56 bytes per tuple instead of 88.
-> SELECT records >= 300, size >= 300*56, capacity >= 300*56 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+# should demand 48 bytes per tuple instead of 96.
+> SELECT records >= 300, size >= 300*48, capacity >= 300*48 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
 true true true
 true true true
 
@@ -295,7 +295,7 @@ true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 56*1000 AND size < 2*56*1000, capacity > 56*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 48*1000 AND size < 2*48*1000, capacity > 48*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 true true true true true
 
 > DROP INDEX ii_t4

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -14,23 +14,23 @@ $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdri
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = 128
 
-# Each inline row takes 32 bytes of memory. 24 bytes for the inline array and 8 bytes
-# for the capacity.
+# Each inline row takes 24 bytes of memory, 23 for the inline array and 1 for the length.
 
-> SELECT 1::int4 FROM generate_series(1, 4);
+> SELECT 1::int4 FROM generate_series(1, 5);
+1
 1
 1
 1
 1
 
-! SELECT 1::int4 FROM generate_series(1, 5);
+! SELECT 1::int4 FROM generate_series(1, 6);
 contains:result exceeds max size of 128 B
 
 > CREATE TABLE t1 (a int4)
 
-> INSERT INTO t1 SELECT 1::int4 FROM generate_series(1, 4);
+> INSERT INTO t1 SELECT 1::int4 FROM generate_series(1, 5);
 
-> INSERT INTO t1 VALUES (5);
+> INSERT INTO t1 VALUES (6);
 
 ! SELECT * FROM t1
 contains:result exceeds max size of 128 B
@@ -54,7 +54,7 @@ contains:result exceeds max size of 128 B
 # be sent to computed to be executed. Therefore, we need to set the size high enough such that it will be evaluated by
 # computed to test the computed side of things.
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 320000;
+ALTER SYSTEM SET max_result_size = 240000;
 
 > SELECT generate_series::int4 FROM generate_series(1, 4);
 1
@@ -63,35 +63,35 @@ ALTER SYSTEM SET max_result_size = 320000;
 4
 
 ! SELECT generate_series::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 320.0 KB
+contains:result exceeds max size of 240.0 KB
 
 ! SELECT 1::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 320.0 KB
+contains:result exceeds max size of 240.0 KB
 
 > CREATE TABLE t2 (a int4)
 
 ! INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10001);
-contains:result exceeds max size of 320.0 KB
+contains:result exceeds max size of 240.0 KB
 
 > INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10000);
 
 > INSERT INTO t2 VALUES (10000);
 
 ! SELECT * FROM t2
-contains:result exceeds max size of 320.0 KB
+contains:result exceeds max size of 240.0 KB
 
 ! INSERT INTO t2 SELECT * FROM t2;
-contains:result exceeds max size of 320.0 KB
+contains:result exceeds max size of 240.0 KB
 
-# Rows keep 24 bytes inline, after that the row is spilled to the heap. int4 takes 5 bytes,
+# Rows keep 23 bytes inline, after that the row is spilled to the heap. int4 takes 5 bytes,
 # 4 for the int and 1 for the tag. A row of 5 int4's will spill to the heap, but any less will
-# be kept inline. A row of 5 int4's should then take 25 + 32 = 57 bytes.
+# be kept inline. A row of 5 int4's should then take 25 + 24 = 49 bytes.
 #
 # Large numbers are used to avoid this test being defeated
 # by the optimization in https://github.com/MaterializeInc/materialize/pull/21016
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 57
+ALTER SYSTEM SET max_result_size = 49
 
 > SELECT 17000000, 17000001, 17000002, 17000003;
 17000000 17000001 17000002 17000003
@@ -100,10 +100,10 @@ ALTER SYSTEM SET max_result_size = 57
 17000000 17000001 17000002 17000003 17000004
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 56
+ALTER SYSTEM SET max_result_size = 48
 
 ! SELECT 17000000, 17000001, 17000002, 17000003, 17000004;
-contains:result exceeds max size of 56 B
+contains:result exceeds max size of 48 B
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET max_result_size


### PR DESCRIPTION
This PR changes the backing store of a `Row` from a `SmallVec<[u8; 24]>` to `CompactBytes`.

The two key distinctions between `CompactBytes` and the existing `SmallVec<[u8; 24]>` are:
1. `CompactBytes` only stores 23 bytes inline vs `SmallVec<...>` stores 24
2. `CompactBytes` is only 24 bytes on the stack vs `SmallVec<...>` is 32

The goal here is that we save 8 bytes for each `Row`, albeit with storing 1 byte less inline. I believe this tradeoff is worth it because as far as I can tell, only storing 23 bytes vs 24 shouldn't cause us to spill to the heap much more often. The scenarios I considered were:

* ISO8601 encoded timestamps, 20 bytes of ASCII text + 1 byte for tag + 1 byte for length = 22 bytes total
* 3 8-byte integers, (8 bytes + 1 byte for tag) * 3 = 27
* 5 4-byte integers, (4 bytes + 1 byte for tag) * 5 = 25

`CompactBytes` is a type that I originally implemented in https://github.com/MaterializeInc/materialize/pull/22759, but we decided to spin out into its own crate.

### Motivation

Should reduce our memory usage, came up from a [Slack](https://materializeinc.slack.com/archives/CMH6PG4CW/p1698175409219429) convo.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
