### PR TITLE
doc/user: handle multiple sources with same name in postgres guide

### DIFF
--- a/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/check-the-ingestion-status.html
@@ -6,8 +6,8 @@ In this step, you'll first verify that the source is running and then check the 
 
     ```sql
     WITH
-      source_id AS
-      (SELECT id FROM mz_objects WHERE name = 'mz_source')
+      source_ids AS
+      (SELECT id FROM mz_sources WHERE name = 'mz_source')
     SELECT *
     FROM
       mz_internal.mz_source_statuses
@@ -16,8 +16,8 @@ In this step, you'll first verify that the source is running and then check the 
             SELECT referenced_object_id
             FROM mz_internal.mz_object_dependencies
             WHERE
-              object_id = (SELECT id FROM source_id)
-            UNION SELECT id FROM source_id
+              object_id IN (SELECT id FROM source_ids)
+            UNION SELECT id FROM source_ids
           )
           AS sources
         ON mz_source_statuses.id = sources.referenced_object_id;
@@ -29,28 +29,29 @@ In this step, you'll first verify that the source is running and then check the 
 
     ```sql
     WITH
-      source_id AS
-      (SELECT id FROM mz_objects WHERE name = 'mz_source')
-    SELECT bool_and(snapshot_committed) AS snapshot_committed
+      source_ids AS
+      (SELECT id FROM mz_sources WHERE name = 'mz_source')
+    SELECT sources.object_id, bool_and(snapshot_committed) AS snapshot_committed
     FROM
       mz_internal.mz_source_statistics
         JOIN
           (
-            SELECT referenced_object_id
+            SELECT object_id, referenced_object_id
             FROM mz_internal.mz_object_dependencies
             WHERE
-              object_id = (SELECT id FROM source_id)
-            UNION SELECT id FROM source_id
+              object_id IN (SELECT id FROM source_ids)
+            UNION SELECT id, id FROM source_ids
           )
           AS sources
-        ON mz_source_statistics.id = sources.referenced_object_id;
+        ON mz_source_statistics.id = sources.referenced_object_id
+      GROUP BY sources.object_id;
     ```
     <p></p>
 
     ```nofmt
-     snapshot_committed
-    --------------------
-     t
+    object_id | snapshot_committed
+    ----------|------------------
+     u144     | t
     (1 row)
     ```
 


### PR DESCRIPTION
These queries broke when multiple sources had the same name. The new queries aren't perfect--ideally they'd select the one source from the correct database/schema--but they at least render multiple rows, one for each source named `mz_source`, with whatever IDs are necessary to distinguish the sources.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a docs bug encountered by a customer.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
