### PR TITLE
pgrepr-constants,sql: fix builtin OIDs for a few functions

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4629,7 +4629,7 @@ mod tests {
     use mz_ore::collections::CollectionExt;
     use mz_ore::now::{to_datetime, NOW_ZERO, SYSTEM_TIME};
     use mz_ore::task;
-    use mz_pgrepr::oid::{FIRST_MATERIALIZE_OID, FIRST_UNPINNED_OID};
+    use mz_pgrepr::oid::{FIRST_MATERIALIZE_OID, FIRST_UNPINNED_OID, FIRST_USER_OID};
     use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
     use mz_repr::namespaces::{INFORMATION_SCHEMA, PG_CATALOG_SCHEMA};
     use mz_repr::role_id::RoleId;
@@ -5422,6 +5422,13 @@ mod tests {
                                 "{} reused oid {}",
                                 func.name,
                                 imp.oid
+                            );
+
+                            assert!(
+                                imp.oid < FIRST_USER_OID,
+                                "built-in function {} erroneously has OID in user space ({})",
+                                func.name,
+                                imp.oid,
                             );
 
                             // For functions that have a postgres counterpart, verify that the name and

--- a/src/pgrepr-consts/src/oid.rs
+++ b/src/pgrepr-consts/src/oid.rs
@@ -102,6 +102,10 @@ pub const FIRST_USER_OID: u32 = 20_000;
 // Postgres builtins in the "unpinned" OID range. We get to choose whatever OIDs
 // we like for these builtins.
 pub const FUNC_PG_EXPAND_ARRAY: u32 = 12000;
+pub const FUNC_PG_DIGEST_STRING: u32 = 12001;
+pub const FUNC_PG_DIGEST_BYTES: u32 = 12002;
+pub const FUNC_PG_HMAC_STRING: u32 = 12003;
+pub const FUNC_PG_HMAC_BYTES: u32 = 12004;
 
 // Materialize-specific builtin OIDs.
 pub const TYPE_LIST_OID: u32 = 16_384;
@@ -305,7 +309,7 @@ pub const FUNC_DATABASE_OID_OID: u32 = 16_585;
 pub const FUNC_SCHEMA_OID_OID: u32 = 16_586;
 pub const FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_TEXT_OID: u32 = 16_587;
 pub const FUNC_HAS_CLUSTER_PRIVILEGE_OID_TEXT_TEXT_OID: u32 = 16_588;
-pub const FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_OID: u32 = 16_5890;
+pub const FUNC_HAS_CLUSTER_PRIVILEGE_TEXT_TEXT_OID: u32 = 16_589;
 pub const FUNC_HAS_CONNECTION_PRIVILEGE_TEXT_TEXT_TEXT_OID: u32 = 16_591;
 pub const FUNC_HAS_CONNECTION_PRIVILEGE_TEXT_OID_TEXT_OID: u32 = 16_592;
 pub const FUNC_HAS_CONNECTION_PRIVILEGE_OID_TEXT_TEXT_OID: u32 = 16_593;

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -2019,8 +2019,8 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(Float64) => UnaryFunc::Degrees(func::Degrees) => Float64, 1608;
         },
         "digest" => Scalar {
-            params!(String, String) => BinaryFunc::DigestString => Bytes, 44154;
-            params!(Bytes, String) => BinaryFunc::DigestBytes => Bytes, 44155;
+            params!(String, String) => BinaryFunc::DigestString => Bytes, oid::FUNC_PG_DIGEST_STRING;
+            params!(Bytes, String) => BinaryFunc::DigestBytes => Bytes, oid::FUNC_PG_DIGEST_BYTES;
         },
         "exp" => Scalar {
             params!(Float64) => UnaryFunc::Exp(func::Exp) => Float64, 1347;
@@ -2076,8 +2076,8 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
             params!(Oid, String) => sql_impl_func("has_table_privilege(current_user, $1, $2)") => Bool, 1927;
         },
         "hmac" => Scalar {
-            params!(String, String, String) => VariadicFunc::HmacString => Bytes, 44156;
-            params!(Bytes, Bytes, String) => VariadicFunc::HmacBytes => Bytes, 44157;
+            params!(String, String, String) => VariadicFunc::HmacString => Bytes, oid::FUNC_PG_HMAC_STRING;
+            params!(Bytes, Bytes, String) => VariadicFunc::HmacBytes => Bytes, oid::FUNC_PG_HMAC_BYTES;
         },
         "int4range" => Scalar {
             params!(Int32, Int32) => Operation::variadic(|_ecx, mut exprs| {


### PR DESCRIPTION
We were choosing inappropriate OIDs for a few built-in functions that could have conflicted with OIDs for user objects. Add a test to protect against that, and fix the few incorrect OIDs that slipped through:

  * hmac and digest are part of pgcrypto, so they belong in the unpinned but non-Materialize OID space.

  * The OID for has_cluster_privilege just had a typo.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a previously unreported bug.

Happened to notice this while talking to @matthewarthur about what these OIDs meant.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
