### PR TITLE
adapter: allow intervals in AS OF

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2801,9 +2801,18 @@ impl Coordinator {
             self.set_statement_execution_timestamp(id, as_of);
         }
 
-        let up_to = up_to
-            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr, ctx.session_mut()))
-            .transpose()?;
+        let up_to = match up_to {
+            Some(expr) => Some(
+                self.evaluate_when(
+                    self.catalog().state(),
+                    expr,
+                    ctx.session_mut(),
+                    timeline.timeline(),
+                )
+                .await?,
+            ),
+            None => None,
+        };
         if let Some(up_to) = up_to {
             if as_of == up_to {
                 ctx.session_mut()

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -194,8 +194,9 @@ impl TimestampProvider for Frontiers {
         &self.storage.get(&id).unwrap().write
     }
 
-    async fn oracle_read_ts(&self, timeline: &Timeline) -> Option<Timestamp> {
-        matches!(timeline, Timeline::EpochMilliseconds).then(|| self.oracle)
+    async fn oracle_read_ts(&self, timeline: &Timeline) -> Timestamp {
+        assert_eq!(timeline, &Timeline::EpochMilliseconds);
+        self.oracle
     }
 }
 


### PR DESCRIPTION
When an interval is used with AS OF, compute a timestamp relative to the current oracle read ts.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add support for intervals in `AS OF` and `UP TO`.