### PR TITLE
ci: Add 'Coordinator is stuck' to ci-logged-errors-detect

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -72,6 +72,7 @@ ERROR_RE = re.compile(
     | clusterd:\ fatal: # startup failure
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
     | unrecognized\ configuration\ parameter
+    | Coordinator is stuck
     )
     """,
     re.VERBOSE,


### PR DESCRIPTION
### Motivation

I wanted to make the "coordinator is stuck" an explicit error so that I can attach it to the right ticket using `ci-regexp`.