### PR TITLE
version consistency: allow running output consistency check against different mz versions

### DIFF
--- a/bin/version-consistency-test
+++ b/bin/version-consistency-test
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 # Copyright Materialize, Inc. and contributors. All rights reserved.
 #
 # Use of this software is governed by the Business Source License
@@ -6,14 +8,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
+#
+# version-consistency-test - Test the output consistency on different versions of mz.
 
-from enum import Enum
-
-
-class EvaluationScenario(Enum):
-    OUTPUT_CONSISTENCY = 1
-    """Data-flow rendering vs. constant folding"""
-    POSTGRES_CONSISTENCY = 2
-    """Materialize vs. Postgres"""
-    VERSION_CONSISTENCY = 3
-    """Two different versions of mz"""
+exec "$(dirname "$0")"/pyactivate -m materialize.version_consistency.version_consistency_test "$@"

--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -35,6 +35,8 @@ class EvaluationStrategyKey(Enum):
     MZ_DATAFLOW_RENDERING = 2
     MZ_CONSTANT_FOLDING = 3
     POSTGRES = 4
+    MZ_DATAFLOW_RENDERING_DB_2 = 5
+    MZ_CONSTANT_FOLDING_DB_2 = 6
 
 
 class EvaluationStrategy:

--- a/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
+++ b/misc/python/materialize/output_consistency/execution/evaluation_strategy.py
@@ -35,8 +35,8 @@ class EvaluationStrategyKey(Enum):
     MZ_DATAFLOW_RENDERING = 2
     MZ_CONSTANT_FOLDING = 3
     POSTGRES = 4
-    MZ_DATAFLOW_RENDERING_DB_2 = 5
-    MZ_CONSTANT_FOLDING_DB_2 = 6
+    MZ_DATAFLOW_RENDERING_OTHER_DB = 5
+    MZ_CONSTANT_FOLDING_OTHER_DB = 6
 
 
 class EvaluationStrategy:

--- a/misc/python/materialize/output_consistency/execution/sql_executor.py
+++ b/misc/python/materialize/output_consistency/execution/sql_executor.py
@@ -56,11 +56,13 @@ class PgWireDatabaseSqlExecutor(SqlExecutor):
         connection: Connection,
         use_autocommit: bool,
         output_printer: OutputPrinter,
+        name: str,
     ):
         connection.autocommit = use_autocommit
         self.cursor = connection.cursor()
         self.output_printer = output_printer
         self.last_statements = deque[str](maxlen=5)
+        self.name = name
 
     def ddl(self, sql: str) -> None:
         self._execute_with_cursor(sql)
@@ -150,10 +152,11 @@ def create_sql_executor(
     config: ConsistencyTestConfiguration,
     connection: Connection,
     output_printer: OutputPrinter,
+    name: str,
 ) -> SqlExecutor:
     if config.dry_run:
         return DryRunSqlExecutor(output_printer)
     else:
         return PgWireDatabaseSqlExecutor(
-            connection, config.use_autocommit, output_printer
+            connection, config.use_autocommit, output_printer, name
         )

--- a/misc/python/materialize/output_consistency/execution/sql_executors.py
+++ b/misc/python/materialize/output_consistency/execution/sql_executors.py
@@ -19,3 +19,8 @@ class SqlExecutors:
 
     def get_executor(self, strategy: EvaluationStrategy) -> SqlExecutor:
         return self.executor
+
+    def get_database_infos(self) -> str:
+        return (
+            f"Using {self.executor.name} in version '{self.executor.query_version()}'."
+        )

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -141,7 +141,9 @@ class OutputConsistencyTest:
 
         randomized_picker = RandomizedPicker(config)
 
-        ignore_filter = self.create_inconsistency_ignore_filter()
+        sql_executors = self.create_sql_executors(config, connection, output_printer)
+
+        ignore_filter = self.create_inconsistency_ignore_filter(sql_executors)
 
         expression_generator = ExpressionGenerator(
             config, randomized_picker, input_data
@@ -150,7 +152,6 @@ class OutputConsistencyTest:
             config, randomized_picker, input_data, ignore_filter
         )
         output_comparator = self.create_result_comparator(ignore_filter)
-        sql_executors = self.create_sql_executors(config, connection, output_printer)
 
         output_printer.print_info(sql_executors.get_database_infos())
         output_printer.print_empty_line()
@@ -201,7 +202,9 @@ class OutputConsistencyTest:
     ) -> ResultComparator:
         return ResultComparator(ignore_filter)
 
-    def create_inconsistency_ignore_filter(self) -> InconsistencyIgnoreFilter:
+    def create_inconsistency_ignore_filter(
+        self, sql_executors: SqlExecutors
+    ) -> InconsistencyIgnoreFilter:
         return InconsistencyIgnoreFilter()
 
     def create_evaluation_strategies(self) -> list[EvaluationStrategy]:

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -152,6 +152,9 @@ class OutputConsistencyTest:
         output_comparator = self.create_result_comparator(ignore_filter)
         sql_executors = self.create_sql_executors(config, connection, output_printer)
 
+        output_printer.print_info(sql_executors.get_database_infos())
+        output_printer.print_empty_line()
+
         test_runner = ConsistencyTestRunner(
             config,
             input_data,

--- a/misc/python/materialize/output_consistency/output_consistency_test.py
+++ b/misc/python/materialize/output_consistency/output_consistency_test.py
@@ -186,7 +186,9 @@ class OutputConsistencyTest:
         connection: Connection,
         output_printer: OutputPrinter,
     ) -> SqlExecutors:
-        return SqlExecutors(create_sql_executor(config, connection, output_printer))
+        return SqlExecutors(
+            create_sql_executor(config, connection, output_printer, "mz")
+        )
 
     def get_scenario(self) -> EvaluationScenario:
         return EvaluationScenario.OUTPUT_CONSISTENCY

--- a/misc/python/materialize/postgres_consistency/execution/pg_sql_executors.py
+++ b/misc/python/materialize/postgres_consistency/execution/pg_sql_executors.py
@@ -25,3 +25,9 @@ class PgSqlExecutors(SqlExecutors):
             return self.pg_executor
 
         return super().get_executor(strategy)
+
+    def get_database_infos(self) -> str:
+        return (
+            f"Using {self.executor.name} in version '{self.executor.query_version()}'."
+            f"Using {self.pg_executor.name} in version '{self.pg_executor.query_version()}'."
+        )

--- a/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
+++ b/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
@@ -61,8 +61,8 @@ class PostgresConsistencyTest(OutputConsistencyTest):
             raise RuntimeError("Postgres connection is not initialized")
 
         return PgSqlExecutors(
-            create_sql_executor(config, connection, output_printer),
-            create_sql_executor(config, self.pg_connection, output_printer),
+            create_sql_executor(config, connection, output_printer, "mz"),
+            create_sql_executor(config, self.pg_connection, output_printer, "pg"),
         )
 
     def create_result_comparator(

--- a/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
+++ b/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
@@ -72,7 +72,9 @@ class PostgresConsistencyTest(OutputConsistencyTest):
     ) -> ResultComparator:
         return PostgresResultComparator(ignore_filter)
 
-    def create_inconsistency_ignore_filter(self) -> InconsistencyIgnoreFilter:
+    def create_inconsistency_ignore_filter(
+        self, sql_executors: SqlExecutors
+    ) -> InconsistencyIgnoreFilter:
         return PgInconsistencyIgnoreFilter()
 
     def create_evaluation_strategies(self) -> list[EvaluationStrategy]:

--- a/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
+++ b/misc/python/materialize/postgres_consistency/postgres_consistency_test.py
@@ -62,7 +62,9 @@ class PostgresConsistencyTest(OutputConsistencyTest):
 
         return PgSqlExecutors(
             create_sql_executor(config, connection, output_printer, "mz"),
-            create_sql_executor(config, self.pg_connection, output_printer, "pg"),
+            create_sql_executor(
+                config, self.pg_connection, output_printer, "pg", is_mz=False
+            ),
         )
 
     def create_result_comparator(

--- a/misc/python/materialize/version_consistency/execution/multi_version_executors.py
+++ b/misc/python/materialize/version_consistency/execution/multi_version_executors.py
@@ -28,3 +28,9 @@ class MultiVersionSqlExecutors(SqlExecutors):
             return self.executor2
 
         return super().get_executor(strategy)
+
+    def get_database_infos(self) -> str:
+        return (
+            f"Using {self.executor.name} in version '{self.executor.query_version()}'."
+            f"Using {self.executor2.name} in version '{self.executor2.query_version()}'."
+        )

--- a/misc/python/materialize/version_consistency/execution/multi_version_executors.py
+++ b/misc/python/materialize/version_consistency/execution/multi_version_executors.py
@@ -22,8 +22,8 @@ class MultiVersionSqlExecutors(SqlExecutors):
 
     def get_executor(self, strategy: EvaluationStrategy) -> SqlExecutor:
         if strategy.identifier in [
-            EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_DB_2,
-            EvaluationStrategyKey.MZ_CONSTANT_FOLDING_DB_2,
+            EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB,
+            EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB,
         ]:
             return self.executor2
 

--- a/misc/python/materialize/version_consistency/execution/multi_version_executors.py
+++ b/misc/python/materialize/version_consistency/execution/multi_version_executors.py
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.output_consistency.execution.evaluation_strategy import (
+    EvaluationStrategy,
+    EvaluationStrategyKey,
+)
+from materialize.output_consistency.execution.sql_executor import SqlExecutor
+from materialize.output_consistency.execution.sql_executors import SqlExecutors
+
+
+class MultiVersionSqlExecutors(SqlExecutors):
+    def __init__(self, executor1: SqlExecutor, executor2: SqlExecutor):
+        super().__init__(executor1)
+        self.executor2 = executor2
+
+    def get_executor(self, strategy: EvaluationStrategy) -> SqlExecutor:
+        if strategy.identifier in [
+            EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_DB_2,
+            EvaluationStrategyKey.MZ_CONSTANT_FOLDING_DB_2,
+        ]:
+            return self.executor2
+
+        return super().get_executor(strategy)

--- a/misc/python/materialize/version_consistency/ignore_filter/none_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/none_ignore_filter.py
@@ -1,0 +1,30 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
+    IgnoreVerdict,
+    InconsistencyIgnoreFilter,
+    NoIgnore,
+)
+from materialize.output_consistency.selection.selection import DataRowSelection
+from materialize.output_consistency.validation.validation_message import (
+    ValidationError,
+)
+
+
+class NoneIgnoreFilter(InconsistencyIgnoreFilter):
+    def shall_ignore_expression(
+        self, expression: Expression, row_selection: DataRowSelection
+    ) -> IgnoreVerdict:
+        return NoIgnore()
+
+    def shall_ignore_error(self, error: ValidationError) -> IgnoreVerdict:
+        return NoIgnore()

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -20,7 +20,7 @@ from materialize.output_consistency.validation.validation_message import (
 )
 
 
-class NoneIgnoreFilter(InconsistencyIgnoreFilter):
+class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
     def shall_ignore_expression(
         self, expression: Expression, row_selection: DataRowSelection
     ) -> IgnoreVerdict:

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -21,6 +21,11 @@ from materialize.output_consistency.validation.validation_message import (
 
 
 class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
+    def __init__(self, mz1_version: str, mz2_version: str):
+        super().__init__()
+        self.mz1_version = mz1_version
+        self.mz2_version = mz2_version
+
     def shall_ignore_expression(
         self, expression: Expression, row_selection: DataRowSelection
     ) -> IgnoreVerdict:

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+import argparse
+
+from pg8000 import Connection
+from pg8000.exceptions import InterfaceError
+
+from materialize.output_consistency.common.configuration import (
+    ConsistencyTestConfiguration,
+)
+from materialize.output_consistency.execution.evaluation_strategy import (
+    ConstantFoldingEvaluation,
+    DataFlowRenderingEvaluation,
+    EvaluationStrategy,
+    EvaluationStrategyKey,
+)
+from materialize.output_consistency.execution.sql_executor import create_sql_executor
+from materialize.output_consistency.execution.sql_executors import SqlExecutors
+from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
+    InconsistencyIgnoreFilter,
+)
+from materialize.output_consistency.input_data.scenarios.evaluation_scenario import (
+    EvaluationScenario,
+)
+from materialize.output_consistency.output.output_printer import OutputPrinter
+from materialize.output_consistency.output_consistency_test import (
+    OutputConsistencyTest,
+    connect,
+)
+from materialize.output_consistency.validation.result_comparator import ResultComparator
+from materialize.version_consistency.execution.multi_version_executors import (
+    MultiVersionSqlExecutors,
+)
+from materialize.version_consistency.ignore_filter.none_ignore_filter import (
+    NoneIgnoreFilter,
+)
+
+
+class VersionConsistencyTest(OutputConsistencyTest):
+    def __init__(self) -> None:
+        self.mz2_connection: Connection | None = None
+        self.evaluation_strategy_name: str | None = None
+
+    def get_scenario(self) -> EvaluationScenario:
+        return EvaluationScenario.VERSION_CONSISTENCY
+
+    def create_sql_executors(
+        self,
+        config: ConsistencyTestConfiguration,
+        connection: Connection,
+        output_printer: OutputPrinter,
+    ) -> SqlExecutors:
+        assert self.mz2_connection is not None, "Second connection is not initialized"
+
+        return MultiVersionSqlExecutors(
+            create_sql_executor(config, connection, output_printer),
+            create_sql_executor(config, self.mz2_connection, output_printer),
+        )
+
+    def create_result_comparator(
+        self, ignore_filter: InconsistencyIgnoreFilter
+    ) -> ResultComparator:
+        return ResultComparator(ignore_filter)
+
+    def create_inconsistency_ignore_filter(self) -> InconsistencyIgnoreFilter:
+        return NoneIgnoreFilter()
+
+    def create_evaluation_strategies(self) -> list[EvaluationStrategy]:
+        assert (
+            self.evaluation_strategy_name is not None
+        ), "Evaluation strategy name is not initialized"
+
+        strategies: list[EvaluationStrategy]
+
+        if self.evaluation_strategy_name == "dataflow_rendering":
+            strategies = [DataFlowRenderingEvaluation(), DataFlowRenderingEvaluation()]
+            strategies[1].identifier = EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_DB_2
+        elif self.evaluation_strategy_name == "constant_folding":
+            strategies = [ConstantFoldingEvaluation(), ConstantFoldingEvaluation()]
+            strategies[1].identifier = EvaluationStrategyKey.MZ_CONSTANT_FOLDING_DB_2
+        else:
+            raise RuntimeError(f"Unexpected name: {self.evaluation_strategy_name}")
+
+        for i, strategy in enumerate(strategies):
+            number = i + 1
+            strategy.name = f"{strategy.name} {number}"
+            strategy.object_name_base = f"{strategy.object_name_base}_{number}"
+            strategy.simple_db_object_name = (
+                f"{strategy.simple_db_object_name}_{number}"
+            )
+
+        return strategies
+
+
+def main() -> int:
+    test = VersionConsistencyTest()
+    parser = argparse.ArgumentParser(
+        prog="postgres-consistency-test",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="Test the consistency of Materialize and Postgres",
+    )
+
+    parser.add_argument("--mz-host", default="localhost", type=str)
+    parser.add_argument("--mz-port", default=6875, type=int)
+    parser.add_argument("--mz-host-2", default="localhost", type=str)
+    parser.add_argument("--mz-port-2", default=6975, type=int)
+    parser.add_argument(
+        "--evaluation-strategy",
+        default="dataflow_rendering",
+        type=str,
+        choices=["dataflow_rendering", "constant_folding"],
+    )
+
+    args = test.parse_output_consistency_input_args(parser)
+
+    try:
+        mz_db_user = "materialize"
+        mz_connection = connect(args.mz_host, args.mz_port, mz_db_user)
+        test.mz2_connection = connect(args.mz_host_2, args.mz_port_2, mz_db_user)
+        test.evaluation_strategy_name = args.evaluation_strategy
+    except InterfaceError:
+        return 1
+
+    result = test.run_output_consistency_tests(mz_connection, args)
+    return 0 if result.all_passed() else 1
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -59,8 +59,8 @@ class VersionConsistencyTest(OutputConsistencyTest):
         assert self.mz2_connection is not None, "Second connection is not initialized"
 
         return MultiVersionSqlExecutors(
-            create_sql_executor(config, connection, output_printer),
-            create_sql_executor(config, self.mz2_connection, output_printer),
+            create_sql_executor(config, connection, output_printer, "mz1"),
+            create_sql_executor(config, self.mz2_connection, output_printer, "mz2"),
         )
 
     def create_result_comparator(

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -86,10 +86,14 @@ class VersionConsistencyTest(OutputConsistencyTest):
 
         if self.evaluation_strategy_name == "dataflow_rendering":
             strategies = [DataFlowRenderingEvaluation(), DataFlowRenderingEvaluation()]
-            strategies[1].identifier = EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_DB_2
+            strategies[
+                1
+            ].identifier = EvaluationStrategyKey.MZ_DATAFLOW_RENDERING_OTHER_DB
         elif self.evaluation_strategy_name == "constant_folding":
             strategies = [ConstantFoldingEvaluation(), ConstantFoldingEvaluation()]
-            strategies[1].identifier = EvaluationStrategyKey.MZ_CONSTANT_FOLDING_DB_2
+            strategies[
+                1
+            ].identifier = EvaluationStrategyKey.MZ_CONSTANT_FOLDING_OTHER_DB
         else:
             raise RuntimeError(f"Unexpected name: {self.evaluation_strategy_name}")
 

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -68,8 +68,14 @@ class VersionConsistencyTest(OutputConsistencyTest):
     ) -> ResultComparator:
         return ResultComparator(ignore_filter)
 
-    def create_inconsistency_ignore_filter(self) -> InconsistencyIgnoreFilter:
-        return VersionConsistencyIgnoreFilter()
+    def create_inconsistency_ignore_filter(
+        self, sql_executors: SqlExecutors
+    ) -> InconsistencyIgnoreFilter:
+        assert isinstance(sql_executors, MultiVersionSqlExecutors)
+        return VersionConsistencyIgnoreFilter(
+            sql_executors.executor.query_version(),
+            sql_executors.executor2.query_version(),
+        )
 
     def create_evaluation_strategies(self) -> list[EvaluationStrategy]:
         assert (

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -113,7 +113,7 @@ def main() -> int:
     parser = argparse.ArgumentParser(
         prog="postgres-consistency-test",
         formatter_class=argparse.RawDescriptionHelpFormatter,
-        description="Test the consistency of Materialize and Postgres",
+        description="Test the consistency of different versions of mz",
     )
 
     parser.add_argument("--mz-host", default="localhost", type=str)

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -37,8 +37,8 @@ from materialize.output_consistency.validation.result_comparator import ResultCo
 from materialize.version_consistency.execution.multi_version_executors import (
     MultiVersionSqlExecutors,
 )
-from materialize.version_consistency.ignore_filter.none_ignore_filter import (
-    NoneIgnoreFilter,
+from materialize.version_consistency.ignore_filter.version_consistency_ignore_filter import (
+    VersionConsistencyIgnoreFilter,
 )
 
 
@@ -69,7 +69,7 @@ class VersionConsistencyTest(OutputConsistencyTest):
         return ResultComparator(ignore_filter)
 
     def create_inconsistency_ignore_filter(self) -> InconsistencyIgnoreFilter:
-        return NoneIgnoreFilter()
+        return VersionConsistencyIgnoreFilter()
 
     def create_evaluation_strategies(self) -> list[EvaluationStrategy]:
         assert (


### PR DESCRIPTION
This version-consistency test compares the output consistency of two running mz instances (with different versions). I created this last week when I couldn't reproduce an output inconsistency issue locally with a slightly different mz version. As of now, this is designed to be run manually. Let me know if you think that we should integrate this into CI as well.

## Commits
cfa891425c version consistency: allow running output consistency check against different mz versions
f6b65aea2f output consistency: assign name to SqlExecutor
19ffc263e8 output consistency: provide db version in SqlExecutor
762a1f7aa1 output consistency: use name in all types of SqlExecutors
2006f89a50 output consistency: print infos about used database version
27f51607e3 version consistency: rename VersionConsistencyIgnoreFilter
60c01e5ee3 output consistency: provide SqlExecutors to ignore filter


## Execute with second mz running on port 6975

```
bin/version-consistency-test --mz-port-2=6975 --evaluation-strategy=dataflow_rendering
```

or

```
bin/version-consistency-test --mz-port-2=6975 --evaluation-strategy=constant_folding
```

## Open tasks
* Include in CI or not?
* ✅ Problem with pgwire cursor after error, see https://materializeinc.slack.com/archives/C057X0NG91B/p1698660257239749 => https://github.com/tlocke/pg8000/issues/144