### PR TITLE
platform-checks: Fix @disabled

### DIFF
--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -18,10 +18,13 @@ TESTDRIVE_NOP = "$ nop"
 
 
 class Check:
+    # Has to be set for the class already, not just in the constructor, so that
+    # we can change the value for the entire class in the decorator
+    enabled: bool = True
+
     def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
         self.base_version = base_version
         self.rng = rng
-        self.enabled = True
 
     def _can_run(self, e: Executor) -> bool:
         return True
@@ -74,10 +77,10 @@ def disabled(ignore_reason: str):
         def __init__(self, cls: type[Check]):
             assert issubclass(cls, Check)
             self.check_class = cls
+            self.check_class.enabled = False
 
         def __call__(self, *cls_ars: Any):
             check = self.check_class(*cls_ars)
-            check.enabled = False
             return check
 
     return ClassWrapper


### PR DESCRIPTION
Alternative to https://github.com/MaterializeInc/materialize/pull/22773, not sure if it's preferred

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
