### PR TITLE
parallel-workload: Handle bad cluster state in kill scenario

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -967,6 +967,14 @@ class BackupRestoreAction(Action):
 
 
 class CreateWebhookSourceAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        if exe.db.scenario == Scenario.Kill:
+            result.extend(
+                ["cannot create source in cluster with more than one replica"]
+            )
+        return result
+
     def run(self, exe: Executor) -> None:
         with exe.db.lock:
             if len(exe.db.webhook_sources) > MAX_WEBHOOK_SOURCES:
@@ -1007,6 +1015,14 @@ class DropWebhookSourceAction(Action):
 
 
 class CreateKafkaSourceAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        if exe.db.scenario == Scenario.Kill:
+            result.extend(
+                ["cannot create source in cluster with more than one replica"]
+            )
+        return result
+
     def run(self, exe: Executor) -> None:
         with exe.db.lock:
             if len(exe.db.kafka_sources) > MAX_KAFKA_SOURCES:
@@ -1057,6 +1073,14 @@ class DropKafkaSourceAction(Action):
 
 
 class CreatePostgresSourceAction(Action):
+    def errors_to_ignore(self, exe: Executor) -> list[str]:
+        result = super().errors_to_ignore(exe)
+        if exe.db.scenario == Scenario.Kill:
+            result.extend(
+                ["cannot create source in cluster with more than one replica"]
+            )
+        return result
+
     def run(self, exe: Executor) -> None:
         with exe.db.lock:
             if len(exe.db.postgres_sources) > MAX_POSTGRES_SOURCES:


### PR DESCRIPTION
What happens is that we dropped a cluster replica just before killing Mz, thus the state is wrong after restarting Mz. Ignore this in kill scenario.

Seen in https://buildkite.com/materialize/nightlies/builds/4939#018b8059-d8bc-4714-b0f6-bda58e4d141d

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
