### PR TITLE
ci: Detect references to closed issues to prevent regressions

### DIFF
--- a/bin/ci-closed-issues-detect
+++ b/bin/ci-closed-issues-detect
@@ -9,19 +9,6 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# lint-slow.sh — slow linters that require building code.
+# ci-closed-issues-detect - Detect references to already closed issues.
 
-set -euo pipefail
-
-. misc/shlib/shlib.bash
-
-try cargo clippy --all-targets -- -D warnings
-
-try bin/doc
-try bin/doc --document-private-items
-
-try bin/xcompile cargo test --locked --doc
-
-try bin/ci-closed-issues-detect --changed-lines-only
-
-try_status_report
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.ci_closed_issues_detect "$@"

--- a/bin/ci-logged-errors-detect
+++ b/bin/ci-logged-errors-detect
@@ -10,6 +10,6 @@
 # by the Apache License, Version 2.0.
 #
 # ci-logged-errors-detect - Detect errors in log files during CI and find
-# associated open Github issues in Materialize repository.
+# associated open GitHub issues in Materialize repository.
 
 exec "$(dirname "$0")"/pyactivate -m materialize.cli.ci_logged_errors_detect "$@"

--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -26,6 +26,12 @@ steps:
 
   - wait: ~
 
+  - id: closed-issues-detect
+    label: Detect references to already closed issues
+    command: bin/ci-builder run stable bin/ci-closed-issues-detect
+    agents:
+      queue: linux-x86_64
+
   - id: miri-test
     label: Miri test (full)
     timeout_in_minutes: 600

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -805,9 +805,6 @@ steps:
     priority: 1
     agents:
       queue: builder-linux-x86_64
-    retry:
-      manual:
-        permit_on_passed: true
     coverage: only
 
   - wait: ~

--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -1,0 +1,190 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# ci_closed_issues_detect.py - Detect references to already closed issues.
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass
+
+import requests
+
+from materialize import buildkite, spawn
+
+ISSUE_RE = re.compile(r"\#([0-9]+) | materialize/issues/([0-9]+)", re.VERBOSE)
+
+FILE_ENDINGS = [".py", ".rs", ".yml", ".td", ".slt", ".md"]
+
+REFERENCE_RE = re.compile(
+    r"""
+    # This block contains expected references, don't report them
+    ^((?!.*
+    # Only track issues in Materialize repo
+    ( timely-dataflow\#
+    ))
+    .)*
+    # This block contains unexpected references to issues, report them
+    ( reenable
+    | TODO
+    # Used in Buildkite pipeline config files
+    | skip:
+    # Used in platform-checks
+    | @disabled
+    # Used in pytest
+    | @pytest.mark.skip
+    )
+    """,
+    re.VERBOSE | re.IGNORECASE,
+)
+
+
+@dataclass
+class IssueRef:
+    issue_id: int
+    filename: str
+    line_number: int
+    line: str
+
+
+def detect_closed_issues(filename: str) -> list[IssueRef]:
+    issue_refs: list[IssueRef] = []
+
+    with open(filename) as file:
+        for line_number, line in enumerate(file):
+            if REFERENCE_RE.search(line):
+                if issue_match := ISSUE_RE.search(line):
+                    issue_refs.append(
+                        IssueRef(
+                            int(issue_match.group(1) or issue_match.group(2)),
+                            filename,
+                            line_number + 1,
+                            line.strip(),
+                        )
+                    )
+
+    return issue_refs
+
+
+def is_issue_closed_on_github(issue_id: int) -> bool:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token := os.getenv("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = requests.get(
+        f"https://api.github.com/repos/MaterializeInc/materialize/issues/{issue_id}",
+        headers=headers,
+    )
+
+    if response.status_code != 200:
+        raise ValueError(
+            f"Bad return code from GitHub: {response.status_code}: {response.text}"
+        )
+
+    issue_json = response.json()
+    assert (
+        issue_json["number"] == issue_id
+    ), f"Returned issue number {issue_json['number']} is not the expected issue number {issue_id}"
+    return issue_json["state"] == "closed"
+
+
+def filter_changed(issue_refs: list[IssueRef]) -> list[IssueRef]:
+    merge_base = buildkite.get_merge_base()
+    print(f"Merge base: {merge_base}")
+    result = spawn.capture(["git", "diff", "-U0", merge_base])
+    file_path = None
+    changed_lines = set()
+
+    for line in result.splitlines():
+        # +++ b/src/adapter/src/coord/command_handler.rs
+        if line.startswith("+++"):
+            file_path = line.removeprefix("+++ b/")
+        # @@ -641,7 +640,6 @@ impl Coordinator {
+        elif line.startswith("@@ "):
+            # We only care about the second value ("+640,6" in the example),
+            # which contains the line number and length of the modified block
+            # in new code state.
+            parts = line.split(" ")[2]
+            if "," in parts:
+                start, length = map(int, parts.split(","))
+            else:
+                start = int(parts)
+                length = 1
+            for line_nr in range(start, start + length):
+                changed_lines.add((file_path, line_nr))
+
+    return [
+        issue_ref
+        for issue_ref in issue_refs
+        if (issue_ref.filename, issue_ref.line_number) in changed_lines
+    ]
+
+
+def filter_closed(issue_refs: list[IssueRef]) -> list[IssueRef]:
+    issues = {issue_ref.issue_id for issue_ref in issue_refs}
+    closed_issues = {issue for issue in issues if is_issue_closed_on_github(issue)}
+    return [
+        issue_ref for issue_ref in issue_refs if issue_ref.issue_id in closed_issues
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="ci-closed-issues-detect",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description="ci-closed-issues-detect detects references to already closed GitHub issues.",
+    )
+
+    parser.add_argument(
+        "--changed-lines-only",
+        action="store_true",
+        help="only report issues in changed files/lines",
+    )
+
+    args = parser.parse_args()
+
+    filenames = spawn.capture(
+        ["git", "ls-tree", "--full-tree", "-r", "--name-only", "HEAD"]
+    )
+
+    issue_refs: list[IssueRef] = []
+    for filename in filenames.splitlines():
+        # Files without any ending can be interesting datadriven test files
+        if (
+            any([filename.endswith(ending) for ending in FILE_ENDINGS])
+            or "." not in filename
+        ) and os.path.isfile(filename):
+            try:
+                issue_refs.extend(detect_closed_issues(filename))
+            except UnicodeDecodeError:
+                # Not all files are source code
+                pass
+
+    if args.changed_lines_only:
+        issue_refs = filter_changed(issue_refs)
+
+    issue_refs = filter_closed(issue_refs)
+
+    for issue_ref in issue_refs:
+        url = buildkite.inline_link(
+            f"https://github.com/MaterializeInc/materialize/issues/{issue_ref.issue_id}",
+            f"#{issue_ref.issue_id}",
+        )
+        print(f"--- Issue is referenced in comment but already closed: {url}")
+        print(f"{issue_ref.filename}:{issue_ref.line_number}: {issue_ref.line}")
+
+    return 1 if len(issue_refs) else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -8,7 +8,7 @@
 # by the Apache License, Version 2.0.
 #
 # ci_logged_errors_detect.py - Detect errors in log files during CI and find
-# associated open Github issues in Materialize repository.
+# associated open GitHub issues in Materialize repository.
 
 import argparse
 import os
@@ -98,7 +98,7 @@ def main() -> int:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         description="""
 ci-logged-errors-detect detects errors in log files during CI and finds
-associated open Github issues in Materialize repository.""",
+associated open GitHub issues in Materialize repository.""",
     )
 
     parser.add_argument("log_files", nargs="+", help="log files to search in")
@@ -248,8 +248,7 @@ def get_known_issues_from_github_page(page: int = 1) -> Any:
         "Accept": "application/vnd.github+json",
         "X-GitHub-Api-Version": "2022-11-28",
     }
-    token = os.getenv("GITHUB_TOKEN")
-    if token:
+    if token := os.getenv("GITHUB_TOKEN"):
         headers["Authorization"] = f"Bearer {token}"
 
     response = requests.get(
@@ -258,7 +257,7 @@ def get_known_issues_from_github_page(page: int = 1) -> Any:
     )
 
     if response.status_code != 200:
-        raise ValueError(f"Bad return code from Github: {response.status_code}")
+        raise ValueError(f"Bad return code from GitHub: {response.status_code}")
 
     issues_json = response.json()
     assert issues_json["incomplete_results"] == False

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4175,7 +4175,7 @@ impl Coordinator {
                     future: batch,
                     span: _,
                 } => {
-                    // TODO: This timeout should be removed once #11782 lands;
+                    // TODO(jkosh44): This timeout should be removed;
                     // we should instead periodically ensure clusters are
                     // healthy and actively cancel any work waiting on unhealthy
                     // clusters.

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -113,9 +113,8 @@ impl AppendWebhookValidator {
 
             // Append all of our header columns, re-using Row packings.
             //
-            // TODO(parkmycar): Use `std::cell::OnceCell` when #20779 merges.
-            let headers_byte = once_cell::unsync::OnceCell::new();
-            let headers_text = once_cell::unsync::OnceCell::new();
+            let headers_byte = std::cell::OnceCell::new();
+            let headers_text = std::cell::OnceCell::new();
             for (column_idx, use_bytes) in header_columns {
                 assert_eq!(column_idx, datums.len(), "index and datums mismatch!");
 

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -769,7 +769,19 @@ where
 
         let existed = self.leased_readers.remove(reader_id).is_some();
         if existed {
-            self.update_since();
+            // TODO(#22789): Re-enable this
+            //
+            // Temporarily disabling this because we think it might be the cause
+            // of the remap since bug. Specifically, a clusterd process has a
+            // ReadHandle for maintaining the once and one inside a Listen. If
+            // we crash and stay down for longer than the read lease duration,
+            // it's possible that an expiry of them both in quick succession
+            // jumps the since forward to the Listen one.
+            //
+            // Don't forget to update the downgrade_since when this gets
+            // switched back on.
+            //
+            // self.update_since();
         }
         // No-op if existed is false, but still commit the state change so that
         // this gets linearized.
@@ -790,7 +802,19 @@ where
 
         let existed = self.critical_readers.remove(reader_id).is_some();
         if existed {
-            self.update_since();
+            // TODO(#22789): Re-enable this
+            //
+            // Temporarily disabling this because we think it might be the cause
+            // of the remap since bug. Specifically, a clusterd process has a
+            // ReadHandle for maintaining the once and one inside a Listen. If
+            // we crash and stay down for longer than the read lease duration,
+            // it's possible that an expiry of them both in quick succession
+            // jumps the since forward to the Listen one.
+            //
+            // Don't forget to update the downgrade_since when this gets
+            // switched back on.
+            //
+            // self.update_since();
         }
         // This state transition is a no-op if existed is false, but we still
         // commit the state change so that this gets linearized (maybe we're
@@ -1746,14 +1770,22 @@ pub(crate) mod tests {
             state.collections.expire_leased_reader(&reader2),
             Continue(true)
         );
-        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
+        // TODO(#22789): expiry temporarily doesn't advance since
+        // Switch this assertion back when we re-enable this.
+        //
+        // assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
 
         // Shard since unaffected when all readers are expired.
         assert_eq!(
             state.collections.expire_leased_reader(&reader3),
             Continue(true)
         );
-        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
+        // TODO(#22789): expiry temporarily doesn't advance since
+        // Switch this assertion back when we re-enable this.
+        //
+        // assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
     }
 
     #[mz_ore::test]

--- a/src/persist-client/src/internal/state.rs
+++ b/src/persist-client/src/internal/state.rs
@@ -769,19 +769,7 @@ where
 
         let existed = self.leased_readers.remove(reader_id).is_some();
         if existed {
-            // TODO: Re-enable this once we have #15511.
-            //
-            // Temporarily disabling this because we think it might be the cause
-            // of the remap since bug. Specifically, a clusterd process has a
-            // ReadHandle for maintaining the once and one inside a Listen. If
-            // we crash and stay down for longer than the read lease duration,
-            // it's possible that an expiry of them both in quick succession
-            // jumps the since forward to the Listen one.
-            //
-            // Don't forget to update the downgrade_since when this gets
-            // switched back on.
-            //
-            // self.update_since();
+            self.update_since();
         }
         // No-op if existed is false, but still commit the state change so that
         // this gets linearized.
@@ -802,19 +790,7 @@ where
 
         let existed = self.critical_readers.remove(reader_id).is_some();
         if existed {
-            // TODO: Re-enable this once we have #15511.
-            //
-            // Temporarily disabling this because we think it might be the cause
-            // of the remap since bug. Specifically, a clusterd process has a
-            // ReadHandle for maintaining the once and one inside a Listen. If
-            // we crash and stay down for longer than the read lease duration,
-            // it's possible that an expiry of them both in quick succession
-            // jumps the since forward to the Listen one.
-            //
-            // Don't forget to update the downgrade_since when this gets
-            // switched back on.
-            //
-            // self.update_since();
+            self.update_since();
         }
         // This state transition is a no-op if existed is false, but we still
         // commit the state change so that this gets linearized (maybe we're
@@ -1770,22 +1746,14 @@ pub(crate) mod tests {
             state.collections.expire_leased_reader(&reader2),
             Continue(true)
         );
-        // TODO: expiry temporarily doesn't advance since until we have #15511.
-        // Switch this assertion back when we re-enable this.
-        //
-        // assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
-        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
 
         // Shard since unaffected when all readers are expired.
         assert_eq!(
             state.collections.expire_leased_reader(&reader3),
             Continue(true)
         );
-        // TODO: expiry temporarily doesn't advance since until we have #15511.
-        // Switch this assertion back when we re-enable this.
-        //
-        // assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
-        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(3));
+        assert_eq!(state.collections.trace.since(), &Antichain::from_elem(10));
     }
 
     #[mz_ore::test]

--- a/src/persist-client/tests/machine/since_downgrade_critical
+++ b/src/persist-client/tests/machine/since_downgrade_critical
@@ -111,23 +111,29 @@ shard-desc
 since=[3] upper=[0]
 
 # Shard since advances when handle with the minimal since expires.
+#
+# TODO(#22789): expiry temporarily doesn't advance since
+# Switch this assertion back when we re-enable this.
 expire-critical-reader reader_id=c11111111-1111-1111-1111-111111111111
 ----
 v16 ok
 
 shard-desc
 ----
-since=[10] upper=[0]
+since=[3] upper=[0]
 
 # Shard since unaffected when all handle are expired.
+#
+# TODO(#22789): expiry temporarily doesn't advance since
+# Switch this assertion back when we re-enable this.
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
 v17 ok
 
 shard-desc
 ----
-since=[10] upper=[0]
+since=[3] upper=[0]
 
 register-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
 ----
-v18 [10]
+v18 [3]

--- a/src/persist-client/tests/machine/since_downgrade_critical
+++ b/src/persist-client/tests/machine/since_downgrade_critical
@@ -111,29 +111,23 @@ shard-desc
 since=[3] upper=[0]
 
 # Shard since advances when handle with the minimal since expires.
-#
-# TODO: expiry temporarily doesn't advance since until we have #15511.
-# Switch this assertion back when we re-enable this.
 expire-critical-reader reader_id=c11111111-1111-1111-1111-111111111111
 ----
 v16 ok
 
 shard-desc
 ----
-since=[3] upper=[0]
+since=[10] upper=[0]
 
 # Shard since unaffected when all handle are expired.
-#
-# TODO: expiry temporarily doesn't advance since until we have #15511.
-# Switch this assertion back when we re-enable this.
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
 v17 ok
 
 shard-desc
 ----
-since=[3] upper=[0]
+since=[10] upper=[0]
 
 register-critical-reader reader_id=c33333333-3333-3333-3333-333333333333
 ----
-v18 [3]
+v18 [10]

--- a/src/persist-client/tests/machine/since_downgrade_leased
+++ b/src/persist-client/tests/machine/since_downgrade_leased
@@ -85,25 +85,19 @@ shard-desc
 since=[3] upper=[0]
 
 # Shard since advances when reader with the minimal since expires.
-#
-# TODO: expiry temporarily doesn't advance since until we have #15511.
-# Switch this assertion back when we re-enable this.
 expire-leased-reader reader_id=r11111111-1111-1111-1111-111111111111
 ----
 v12 ok
 
 shard-desc
 ----
-since=[3] upper=[0]
+since=[10] upper=[0]
 
 # Shard since unaffected when all readers are expired.
-#
-# TODO: expiry temporarily doesn't advance since until we have #15511.
-# Switch this assertion back when we re-enable this.
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
 v13 ok
 
 shard-desc
 ----
-since=[3] upper=[0]
+since=[10] upper=[0]

--- a/src/persist-client/tests/machine/since_downgrade_leased
+++ b/src/persist-client/tests/machine/since_downgrade_leased
@@ -85,19 +85,25 @@ shard-desc
 since=[3] upper=[0]
 
 # Shard since advances when reader with the minimal since expires.
+#
+# TODO(#22789): expiry temporarily doesn't advance since
+# Switch this assertion back when we re-enable this.
 expire-leased-reader reader_id=r11111111-1111-1111-1111-111111111111
 ----
 v12 ok
 
 shard-desc
 ----
-since=[10] upper=[0]
+since=[3] upper=[0]
 
 # Shard since unaffected when all readers are expired.
+#
+# TODO(#22789): expiry temporarily doesn't advance since
+# Switch this assertion back when we re-enable this.
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
 v13 ok
 
 shard-desc
 ----
-since=[10] upper=[0]
+since=[3] upper=[0]

--- a/src/sql-parser/tests/testdata/explain
+++ b/src/sql-parser/tests/testdata/explain
@@ -138,7 +138,7 @@ EXPLAIN OPTIMIZER TRACE WITH(est_cost) AS TEXT FOR BROKEN SELECT 1 + 1
 =>
 ExplainPlan(ExplainPlanStatement { stage: Trace, config_flags: [Ident("est_cost")], format: Text, explainee: Query(Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("1")), expr2: Some(Value(Number("1"))) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, true) })
 
-# TODO (#13299): Add negative tests for new explain API.
+# TODO (aalexandrov): Add negative tests for new explain API.
 
 parse-statement
 EXPLAIN WITH (humanized_exprs) CREATE MATERIALIZED VIEW mv AS SELECT 665

--- a/src/sql/src/plan/explain/mod.rs
+++ b/src/sql/src/plan/explain/mod.rs
@@ -99,7 +99,7 @@ pub fn normalize_subqueries<'a>(expr: &'a mut HirRelationExpr) -> Result<(), Rec
                         // generate a `Get(local_id)` to be used as a subquery replacement
                         let mut subquery = Get {
                             id: Id::Local(local_id.clone()),
-                            typ: RelationType::empty(), // TODO (#13732)
+                            typ: RelationType::empty(), // TODO (aalexandrov)
                         };
                         // swap the current subquery with the replacement
                         std::mem::swap(expr, &mut subquery);

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -387,11 +387,6 @@ impl Default for FuseAndCollapse {
                 // Removes redundant inputs from joins.
                 // Note that this eliminates one redundant input per join,
                 // so it is necessary to run this section in a loop.
-                // TODO: (#6748) Predicate pushdown unlocks the ability to
-                // remove some redundant joins but also prevents other
-                // redundant joins from being removed. When predicate pushdown
-                // no longer works against redundant join, check if it is still
-                // necessary to run RedundantJoin here.
                 Box::new(crate::redundant_join::RedundantJoin::default()),
                 // As a final logical action, convert any constant expression to a constant.
                 // Some optimizations fight against this, and we want to be sure to end as a

--- a/test/kafka-ssl/multi.td
+++ b/test/kafka-ssl/multi.td
@@ -70,14 +70,14 @@ $ kafka-verify-data format=avro sink=materialize.public.snk sort-messages=true
 {"before": null, "after": {"row":{"a": 1}}}
 {"before": null, "after": {"row":{"a": 2}}}
 
-# todo: re-enable this as part of #13453
 # Ensure that our test infra correctly sets up certs by failing when CSR is not
 # specifically configured, AND we are specifically setting certs
-# > CREATE CONNECTION unknown_cert
-#   FOR CONFLUENT SCHEMA REGISTRY
-#     URL '${testdrive.schema-registry-url}',
-#     SSL KEY = SECRET ssl_key_kafka,
-#     SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
-#     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}',
-#     USERNAME = 'materialize',
-#     PASSWORD = SECRET password_csr;
+! CREATE CONNECTION unknown_cert
+  FOR CONFLUENT SCHEMA REGISTRY
+    URL '${testdrive.schema-registry-url}',
+    SSL KEY = SECRET ssl_key_kafka,
+    SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
+    SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}',
+    USERNAME = 'materialize',
+    PASSWORD = SECRET password_csr;
+contains: X509_check_private_key:key values mismatch

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -526,8 +526,7 @@ true
 2 two_two
 5 five
 
-# TODO: should only be 'running' w/ resolution of #20666
-> SELECT status = 'starting' OR status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_pk_table';
+> SELECT status = 'running' FROM mz_internal.mz_source_statuses WHERE name = 'large_cluster_pk_table';
 true
 
 > DROP SOURCE large_cluster;

--- a/test/sqllogictest/arrays.slt
+++ b/test/sqllogictest/arrays.slt
@@ -464,11 +464,10 @@ SELECT ARRAY[2] > ARRAY[1, 2], ARRAY[2] >= ARRAY[1, 2]
 ----
 true true
 
-# todo(uce): uncomment after #5982
-#query BB
-#SELECT ARRAY[1] > ARRAY[NULL]::int[], ARRAY[1] >= ARRAY[NULL]::int[]
-#----
-#false false
+query BB
+SELECT ARRAY[1] > ARRAY[NULL]::int[], ARRAY[1] >= ARRAY[NULL]::int[]
+----
+false false
 
 query error operator does not exist: integer\[\] = text\[\]
 SELECT ARRAY[1,2,3] = ARRAY['1','2','3']

--- a/test/sqllogictest/cockroach/alter_table.slt
+++ b/test/sqllogictest/cockroach/alter_table.slt
@@ -341,7 +341,7 @@ ALTER TABLE t DROP COLUMN y
 statement error cannot drop column "e" because view "v" depends on it
 ALTER TABLE t DROP COLUMN e
 
-# TODO(knz): this statement should succeed after #17269 is fixed.
+# TODO(knz): this statement should succeed after cockroach#17269 is fixed.
 statement error cannot drop column "d" because view "v" depends on it
 ALTER TABLE t DROP COLUMN d
 

--- a/test/sqllogictest/cockroach/array.slt
+++ b/test/sqllogictest/cockroach/array.slt
@@ -71,7 +71,7 @@ SELECT ARRAY['1}'::BYTES]
 ----
 {"\\x317d"}
 
-# TODO(jordan): #16487
+# TODO(jordan): cockroach#16487
 # query T
 # SELECT ARRAY[e'g\x10h']
 # ----
@@ -152,7 +152,7 @@ SELECT ARRAY(VALUES ('a'),('b'),('c'))
 {a,b,c}
 
 
-# TODO(justin): uncomment when #32715 is fixed.
+# TODO(justin): uncomment when cockroach#32715 is fixed.
 # query T
 # SELECT ARRAY(SELECT (1,2))
 # ----

--- a/test/sqllogictest/cockroach/computed.slt
+++ b/test/sqllogictest/cockroach/computed.slt
@@ -260,7 +260,7 @@ SELECT a, b, c, d FROM x
 statement ok
 DROP TABLE x
 
-# TODO(justin): #22434
+# TODO(justin): cockroach#22434
 # statement ok
 # CREATE TABLE x (
 #   b INT AS a STORED,

--- a/test/sqllogictest/cockroach/insert.slt
+++ b/test/sqllogictest/cockroach/insert.slt
@@ -308,7 +308,7 @@ a  b  c
 statement ok
 INSERT INTO return AS r VALUES (5, 6)
 
-# TODO(knz) after #6092 is fixed
+# TODO(knz) after cockroach#6092 is fixed
 # statement ok
 # INSERT INTO return AS r VALUES (5, 6) RETURNING r.a
 

--- a/test/sqllogictest/cockroach/json.slt
+++ b/test/sqllogictest/cockroach/json.slt
@@ -194,7 +194,7 @@ SELECT bar FROM foo WHERE bar ?| ARRAY['a',null]
 ----
 {"a":"b"}
 
-# TODO(justin):#29355
+# TODO(justin):cockroach#29355
 # query T
 # SELECT bar FROM foo WHERE bar ?| ARRAY[null,null]::STRING[]
 # ----

--- a/test/sqllogictest/cockroach/pg_catalog.slt
+++ b/test/sqllogictest/cockroach/pg_catalog.slt
@@ -1802,7 +1802,7 @@ SELECT unnest((SELECT proargtypes FROM pg_proc WHERE proname='split_part'));
 25
 20
 
-## TODO(masha): #16769
+## TODO(masha): cockroach#16769
 #statement ok
 #CREATE TABLE types(a int8, b int2);
 

--- a/test/sqllogictest/cockroach/rename_column.slt
+++ b/test/sqllogictest/cockroach/rename_column.slt
@@ -114,7 +114,7 @@ ALTER TABLE users RENAME COLUMN id TO uid
 statement error cannot rename column "username" because view "v1" depends on it
 ALTER TABLE users RENAME COLUMN username TO name
 
-# TODO(knz): restore test after #17269 / #10083 is fixed.
+# TODO(knz): restore test after cockroach#17269 / cockroach#10083 is fixed.
 #statement ok
 #ALTER TABLE users RENAME COLUMN species TO title
 
@@ -127,7 +127,7 @@ DROP VIEW v1
 statement error cannot rename column "id" because view "v2" depends on it
 ALTER TABLE users RENAME COLUMN id TO uid
 
-# TODO(knz): restore test after #17269 / #10083 is fixed.
+# TODO(knz): restore test after cockroach#17269 / cockroach#10083 is fixed.
 # statement ok
 # ALTER TABLE users RENAME COLUMN username TO name
 

--- a/test/sqllogictest/cockroach/tuple.slt
+++ b/test/sqllogictest/cockroach/tuple.slt
@@ -52,7 +52,7 @@ false
 
 subtest unlabeled_tuple
 
-# TODO(bram): We don't pretty print tuples the same way as postgres. See #25522.
+# TODO(bram): We don't pretty print tuples the same way as postgres. See cockroach#25522.
 query TT colnames
 SELECT (1, 2, 'hello', NULL, NULL) AS t, (true, NULL, (false, 6.6, false)) AS u FROM tb
 ----

--- a/test/sqllogictest/cockroach/update.slt
+++ b/test/sqllogictest/cockroach/update.slt
@@ -291,7 +291,7 @@ statement count 1
 INSERT INTO xyz VALUES (111, 222, 333)
 
 
-# TODO(jordan): re-enable post #28716
+# TODO(jordan): re-enable post cockroach#28716
 # statement count 1
 # UPDATE xyz SET (z, y) = (SELECT 666, 777), x = (SELECT 2)
 #

--- a/test/sqllogictest/cockroach/upsert.slt
+++ b/test/sqllogictest/cockroach/upsert.slt
@@ -206,7 +206,7 @@ SELECT * FROM kv ORDER BY (k, v)
 140 14
 150 17
 
-# TODO(knz): Enable the 1st statement and remove the 2nd once #33313 is fixed.
+# TODO(knz): Enable the 1st statement and remove the 2nd once cockroach#33313 is fixed.
 #query II rowsort
 #UPSERT INTO kv(k) VALUES (6), (8) RETURNING k,v
 #----

--- a/test/sqllogictest/cockroach/window.slt
+++ b/test/sqllogictest/cockroach/window.slt
@@ -3036,7 +3036,7 @@ SELECT sum(a) OVER (PARTITION BY count(a) OVER () + 1) FROM x
 statement error window function calls cannot be nested
 SELECT sum(a) OVER (ORDER BY count(a) OVER () + 1) FROM x
 
-# TODO(justin): blocked by #37134.
+# TODO(justin): blocked by cockroach#37134.
 # statement error more than one row returned by a subquery used as an expression
 # SELECT sum(a) OVER (PARTITION BY (SELECT count(*) FROM x GROUP BY a)) FROM x
 

--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -31,7 +31,7 @@ column1
 statement ok
 CREATE TABLE asciitest (strcol CHAR(15), vccol VARCHAR(15))
 
-# TODO: materialize#589 Add two tests:
+# TODO: Add two tests:
 # 1: empty string to each column
 # 2: single space in each column
 statement ok
@@ -120,7 +120,17 @@ SELECT substr('hello', 0/0, 3)
 
 # standard tests
 
-# TODO: materialize#589 SELECT strcol FROM substrtest
+query T colnames
+SELECT to_jsonb(strcol) as strcol FROM substrtest
+----
+strcol
+null
+"               "
+"24.31          "
+"Mg             "
+"magnesium      "
+"长久不见           "
+
 query T colnames
 SELECT substr(vccol, 1, 3) AS vcres FROM substrtest ORDER BY vcres
 ----
@@ -1064,7 +1074,16 @@ SELECT position('str' IN 42, 172)
 
 # standard tests
 
-#TODO: materialize#589 select position(strcol1 IN strcol2) from positiontest
+query I rowsort
+select position(strcol1 IN strcol2) from positiontest;
+----
+0
+0
+1
+3
+3
+NULL
+NULL
 
 query I rowsort
 SELECT position(vccol1 IN vccol2) FROM positiontest
@@ -1125,7 +1144,15 @@ SELECT left('str', 42, 17)
 
 # standard tests
 
-#TODO: materialize#589 select left(strcol, foo) from lefttest
+query T rowsort
+select left(strcol, 3) from lefttest
+----
+(empty)
+24.
+Mg
+NULL
+mag
+长久不
 
 # edge case
 query T rowsort
@@ -1247,7 +1274,15 @@ SELECT right('str', 42, 17)
 
 # standard tests
 
-#TODO: materialize#589 select right(strcol, foo) from righttest
+query T rowsort
+select right(strcol, 3) from righttest
+----
+(empty)
+.31
+Mg
+NULL
+ium
+久不见
 
 # edge case
 query T rowsort

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -66,8 +66,7 @@ EOF
 
 # Outer joins
 
-# TODO (#6748): the second join should be removed as redundant and replaced with
-# `Get(l1)`.
+# TODO the second join should be removed as redundant and replaced with `Get(l1)`.
 query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT * FROM t1 LEFT JOIN t2 ON (t1.f1 = t2.f1) WHERE t1.f1 = 123;
 ----

--- a/test/sqllogictest/transform/filter_index.slt
+++ b/test/sqllogictest/transform/filter_index.slt
@@ -103,19 +103,17 @@ is
 statement ok
 create index foo_idx on foo(a);
 
-#TODO (wangandi) (materialize#616): uncomment these tests when FilterEqualLiteral is enabled
+query T multiline
+explain with(arity, join_impls) select b, c from foo where a = 5
+----
+Explained Query (fast path):
+  Project (#1, #2)
+    ReadIndex on=materialize.public.foo foo_idx=[lookup value=(5)]
 
-#query T multiline
-#explain with(arity, join_impls) select b, c from foo where a = 5
-#----
-#Project {
-#  outputs: [1, 2],
-#  Join {
-#    variables: [[(0, 0), (1, 0)]],
-#    ArrangeBy { keys: [[#0]], Get { foo (u1) } },
-#    Constant [[5]]
-#  }
-#}
+Used Indexes:
+  - materialize.public.foo_idx (lookup)
+
+EOF
 
 query TR
 select b, c from foo where a = 5
@@ -123,20 +121,18 @@ select b, c from foo where a = 5
 this
 -4.4
 
-#query T multiline
-#explain with(arity, join_impls) select b, c from foo where a = 5 and b = 'this'
-#----
-#Project {
-#  outputs: [1, 2],
-#  Filter {
-#    predicates: [#1 = "this"],
-#    Join {
-#      variables: [[(0, 0), (1, 0)]],
-#      ArrangeBy { keys: [[#0]], Get { foo (u1) } },
-#      Constant [[5]],
-#    }
-#  }
-#}
+query T multiline
+explain with(arity, join_impls) select b, c from foo where a = 5 and b = 'this'
+----
+Explained Query (fast path):
+  Project (#1, #2)
+    Filter ("this" = varchar_to_text(#1))
+      ReadIndex on=materialize.public.foo foo_idx=[lookup value=(5)]
+
+Used Indexes:
+  - materialize.public.foo_idx (lookup)
+
+EOF
 
 query TR
 select b, c from foo where a = 5
@@ -150,26 +146,39 @@ create index foo_idx2 on foo(b, a);
 statement ok
 create index foo_idx3 on foo(b);
 
-#query T multiline
-#explain with(arity, join_impls) select b, c from foo where a = 5 and b = 'this'
-#----
-#Project {
-#  outputs: [1, 2],
-#  Join {
-#    variables: [[(0, 1), (1, 0)], [(0, 0), (1, 1)]],
-#    ArrangeBy { keys: [[#1, #0]], Get { foo (u1) } },
-#    Constant [["this", 5]],
-#  }
-#}
+query T multiline
+explain with(arity, join_impls) select b, c from foo where a = 5 and b = 'this'
+----
+Explained Query (fast path):
+  Project (#0, #2)
+    ReadIndex on=materialize.public.foo foo_idx2=[lookup value=("this", 5)]
 
-#TODO (wangandi) (materialize#616): uncomment these tests when FilterEqualLiteral is enabled
-#think about what the desired plan is when
-#statement ok
-#create index bar_idx on bar(a)
-#
-#query T multiline
-#explain with(arity, join_impls) select foo.a, b, c, d, e from foo, bar where foo.a = bar.a and b = 'this'
-#----
+Used Indexes:
+  - materialize.public.foo_idx2 (lookup)
+
+EOF
+
+statement ok
+create index bar_idx on bar(a)
+
+query T multiline
+explain with(arity, join_impls) select foo.a, b, c, d, e from foo, bar where foo.a = bar.a and b = 'this'
+----
+Explained Query:
+  Project (#0..=#2, #5, #6) // { arity: 5 }
+    Join on=(#0 = #4) type=differential // { arity: 7 }
+      implementation
+        %0:foo[#0]KAe » %1:bar[#0]KAe
+      ArrangeBy keys=[[#0]] // { arity: 4 }
+        ReadIndex on=materialize.public.foo foo_idx3=[lookup value=("this")] // { arity: 4 }
+      ArrangeBy keys=[[#0]] // { arity: 3 }
+        ReadIndex on=bar bar_idx=[differential join] // { arity: 3 }
+
+Used Indexes:
+  - materialize.public.foo_idx3 (lookup)
+  - materialize.public.bar_idx (differential join)
+
+EOF
 
 query ITRTR
 select foo.a, b, c, d, e from foo, bar where foo.a = bar.a and b = 'this'


### PR DESCRIPTION
The motivation is to notice quickly when an issue has been closed, but there is still associated work/reenabling to be done in the source code. We warn in nightly, so as not to block normal CI runs, but additionally warn when a PR touches or adds a comment referencing a closed issue.

Fixes: #20549

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
