### PR TITLE
storage: use the CSR client during validation

### DIFF
--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -817,7 +817,8 @@ impl CsrConnection {
         _id: GlobalId,
         connection_context: &ConnectionContext,
     ) -> Result<(), anyhow::Error> {
-        self.connect(connection_context).await?;
+        let client = self.connect(connection_context).await?;
+        client.list_subjects().await?;
         Ok(())
     }
 }

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -100,33 +100,21 @@ $ kafka-verify-data format=avro sink=materialize.public.snk sort-messages=true
 {"before": null, "after": {"row":{"a": 1}}}
 {"before": null, "after": {"row":{"a": 2}}}
 
-> CREATE CONNECTION no_basic_auth_conn
+! CREATE CONNECTION no_basic_auth_conn
   FOR CONFLUENT SCHEMA REGISTRY
     URL '${testdrive.schema-registry-url}',
     SSL KEY = SECRET ssl_key_csr,
     SSL CERTIFICATE = '${arg.materialized-schema-registry-crt}',
     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}';
+contains:server error 401: Unauthorized
 
-# not basic_auth
-! CREATE SINK no_basic_auth FROM data
-  INTO KAFKA CONNECTION kafka_ssl (TOPIC 'snk')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION no_basic_auth_conn
-  ENVELOPE DEBEZIUM
-contains:CONFLUENT SCHEMA REGISTRY validation: client errored
-detail:server error 401: Unauthorized
-
-> CREATE CONNECTION csr_without_ssl
+# Ensure that we get an ssl error if we forget to set certs
+! CREATE CONNECTION csr_without_ssl
   FOR CONFLUENT SCHEMA REGISTRY
     URL '${testdrive.schema-registry-url}',
     USERNAME = 'materialize',
     PASSWORD = SECRET password_csr;
-
-# Ensure that we get an ssl error if we forget to set certs
-! CREATE SOURCE data
-  FROM KAFKA CONNECTION kafka_ssl (TOPIC 'testdrive-data-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_without_ssl
-contains:failed to fetch schema subject
-detail:self signed certificate in certificate chain
+contains:self signed certificate in certificate chain
 
 # missing config
 ! CREATE CONNECTION m TO KAFKA (

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1334,7 +1334,7 @@ DROP TABLE t;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL 'https://google.com');
+CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL 'https://google.com') WITH (VALIDATE = false);
 ----
 COMPLETE 0
 
@@ -1356,13 +1356,13 @@ COMPLETE 0
 simple conn=joe,user=joe
 SHOW CREATE CONNECTION csr_conn;
 ----
-materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com') WITH (VALIDATE = false)
 COMPLETE 1
 
 simple conn=child,user=child
 SHOW CREATE CONNECTION csr_conn;
 ----
-materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com') WITH (VALIDATE = false)
 COMPLETE 1
 
 simple conn=mz_system,user=mz_system

--- a/test/testdrive/kafka-source-errors.td
+++ b/test/testdrive/kafka-source-errors.td
@@ -28,14 +28,10 @@ contains:Failed to resolve hostname
     URL '${testdrive.schema-registry-url}'
   );
 
-> CREATE CONNECTION IF NOT EXISTS fawlty_csr_conn TO CONFLUENT SCHEMA REGISTRY (
+! CREATE CONNECTION IF NOT EXISTS fawlty_csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL 'http://non-existent-csr:8081'
   );
-
-! CREATE SOURCE fawlty_csr_source
-  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-fawlty-csr-source-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION fawlty_csr_conn
-contains: failed to fetch schema subject
+contains:failed to lookup address information
 
 # Check that for all tables clause is rejected
 ! CREATE SOURCE bad_definition1


### PR DESCRIPTION
The original implementation of validating a CSR connection only ensured that the client could be built but didn't make an attempt to actually _use_ the connection. The other validation implementations do reach out to the external service, so this seems like a desirable property.

Secondly, once we support `ALTER CONNECTION`, testing that the altered connection details do allow you to connect to the CSR is very desirable. For example, without this change, you can `ALTER CONNECTION` and remove all of the authentication from the connection, and the `ALTER` succeeds even though any source using the connection will cease working.

### Motivation

This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - When creating a Confluent Schema Registry connection, attempt to connect to the identified service using connection validation. Previously, Materialize only built the client during validation but never attempted to use it.
