### PR TITLE
Strengthen type capture for specialization

### DIFF
--- a/src/compute-types/src/plan/reduce.rs
+++ b/src/compute-types/src/plan/reduce.rs
@@ -755,7 +755,7 @@ impl ReducePlan {
             .map(mz_expr::MirScalarExpr::Column)
             .collect::<Vec<_>>();
         let (permutation, thinning) = permutation_for_arrangement(&key, arity);
-        AvailableCollections::new_arranged(vec![(key, permutation, thinning)])
+        AvailableCollections::new_arranged(vec![(key, permutation, thinning)], None)
     }
 }
 

--- a/src/compute-types/src/plan/threshold.rs
+++ b/src/compute-types/src/plan/threshold.rs
@@ -27,6 +27,7 @@ use std::collections::BTreeMap;
 
 use mz_expr::{permutation_for_arrangement, MirScalarExpr};
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use mz_repr::ColumnType;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
@@ -103,15 +104,17 @@ impl RustType<ProtoArrangement> for (Vec<MirScalarExpr>, BTreeMap<usize, usize>,
 }
 
 impl ThresholdPlan {
-    /// Reports all keys of produced arrangements.
+    /// Reports all keys of produced arrangements, with optionally
+    /// given types describing the rows that would be in the raw
+    /// form of the collection.
     ///
     /// This is likely either an empty vector, for no arrangement,
     /// or a singleton vector containing the list of expressions
     /// that key a single arrangement.
-    pub fn keys(&self) -> AvailableCollections {
+    pub fn keys(&self, types: Option<Vec<ColumnType>>) -> AvailableCollections {
         match self {
             ThresholdPlan::Basic(plan) => {
-                AvailableCollections::new_arranged(vec![plan.ensure_arrangement.clone()])
+                AvailableCollections::new_arranged(vec![plan.ensure_arrangement.clone()], types)
             }
         }
     }

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -658,7 +658,12 @@ SELECT a FROM t EXCEPT ALL SELECT b FROM mv
                     []
                   ]
                 ],
-                "types": null
+                "types": [
+                  {
+                    "scalar_type": "Int32",
+                    "nullable": true
+                  }
+                ]
               },
               "input_key": null,
               "input_mfp": {
@@ -931,7 +936,12 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                         []
                       ]
                     ],
-                    "types": null
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": true
+                      }
+                    ]
                   },
                   "input_key": null,
                   "input_mfp": {
@@ -984,7 +994,12 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                           []
                         ]
                       ],
-                      "types": null
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ]
                     },
                     "plan": {
                       "Arrangement": [
@@ -1051,7 +1066,12 @@ WITH cte(x) as (SELECT a FROM t EXCEPT ALL SELECT b FROM mv)
                           []
                         ]
                       ],
-                      "types": null
+                      "types": [
+                        {
+                          "scalar_type": "Int32",
+                          "nullable": true
+                        }
+                      ]
                     },
                     "plan": {
                       "Arrangement": [
@@ -1329,7 +1349,12 @@ SELECT x * 5 FROM cte WHERE x = 5
                         []
                       ]
                     ],
-                    "types": null
+                    "types": [
+                      {
+                        "scalar_type": "Int32",
+                        "nullable": false
+                      }
+                    ]
                   },
                   "input_key": null,
                   "input_mfp": {

--- a/test/sqllogictest/explain/physical_plan_as_text.slt
+++ b/test/sqllogictest/explain/physical_plan_as_text.slt
@@ -246,6 +246,7 @@ Explained Query:
     ArrangeBy
       raw=false
       arrangements[0]={ key=[#0], permutation=id, thinning=() }
+      types=[integer?]
       Union consolidate_output=true
         Get::Arrangement materialize.public.t
           project=(#0)
@@ -280,18 +281,21 @@ Explained Query:
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
       Get::Arrangement l0
         project=(#1)
         map=((#0 - 1))
         key=#0
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer?]
   With
     cte l0 =
       Threshold::Basic ensure_arrangement={ key=[#0], permutation=id, thinning=() }
         ArrangeBy
           raw=false
           arrangements[0]={ key=[#0], permutation=id, thinning=() }
+          types=[integer?]
           Union consolidate_output=true
             Get::Arrangement materialize.public.t
               project=(#0)
@@ -326,6 +330,7 @@ Explained Query:
       ArrangeBy
         raw=false
         arrangements[0]={ key=[#0], permutation=id, thinning=() }
+        types=[integer]
         Union consolidate_output=true
           Join::Linear
             linear_stage[0]

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -332,6 +332,7 @@ Explained Query:
           ArrangeBy
             raw=false
             arrangements[0]={ key=[#0, #1], permutation=id, thinning=() }
+            types=[integer, integer?]
             Union consolidate_output=true
               Get::Collection materialize.public.t
                 filter=((1 = (#0 % 2)))


### PR DESCRIPTION
This PR strengthens the type capture step for arrangement specialization to ensure that input `types` in `ArrangeBy` are only set to `Some` if the `enable_specialized_arrangements` flag is turned on. Additionally, the PR strengthens the checks when using type information to only proceed with specialization when the type capture is not out-of-sync with the flag.

This PR builds on the design introduced by #21968.

### Motivation

  * This PR fixes a recognized bug. Fixes https://github.com/MaterializeInc/materialize/issues/22778

### Tips for reviewer

In addition to strengthening the checks, a regression test is provided as part of the `cluster` tests. Moreover, the strengthening of type capture was carried through to planning of `ArrangeBy` in `Threshold` lowering, as a special case is handled there to plan a required arrangement when necessary.

The diff is easier to read if you hide whitespace.

[Slack ref](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1698666467029299)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
