### PR TITLE
Use the new `Optimize` API for `CREATE VIEW`

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -75,6 +75,7 @@ use crate::catalog::{
     LINKED_CLUSTER_REPLICA_NAME, SYSTEM_CONN_ID,
 };
 use crate::coord::ConnMeta;
+use crate::optimize::{self, Optimize};
 use crate::session::Session;
 use crate::util::{index_sql, ResultExt};
 use crate::AdapterError;
@@ -767,18 +768,22 @@ impl CatalogState {
         Ok(match plan {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 if enable_unified_optimizer_api {
-                    let optimizer =
-                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    // Collect optimizer parameters
+                    let optimizer_config =
+                        optimize::OptimizerConfig::from(session_catalog.system_vars());
+
+                    // Build a VIEW optimizer for this view.
+                    let mut optimizer = optimize::OptimizeView::new(optimizer_config);
+
+                    // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
                     let raw_expr = view.expr;
-                    let decorrelated_expr =
-                        raw_expr.clone().lower(session_catalog.system_vars())?;
-                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
-                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    let optimized_expr = optimizer.optimize(raw_expr.clone())?;
+
                     CatalogItem::View(View {
                         create_sql: view.create_sql,
                         raw_expr,
+                        desc: RelationDesc::new(optimized_expr.typ(), view.column_names),
                         optimized_expr,
-                        desc,
                         conn_id: None,
                         resolved_ids,
                     })
@@ -899,18 +904,22 @@ impl CatalogState {
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 if enable_unified_optimizer_api {
-                    let optimizer =
-                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    // Collect optimizer parameters
+                    let optimizer_config =
+                        optimize::OptimizerConfig::from(session_catalog.system_vars());
+
+                    // Build a VIEW optimizer for this view.
+                    let mut optimizer = optimize::OptimizeView::new(optimizer_config);
+
+                    // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
                     let raw_expr = view.expr;
-                    let decorrelated_expr =
-                        raw_expr.clone().lower(session_catalog.system_vars())?;
-                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
-                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    let optimized_expr = optimizer.optimize(raw_expr.clone())?;
+
                     CatalogItem::View(View {
                         create_sql: view.create_sql,
                         raw_expr,
+                        desc: RelationDesc::new(optimized_expr.typ(), view.column_names),
                         optimized_expr,
-                        desc,
                         conn_id: None,
                         resolved_ids,
                     })

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -752,6 +752,9 @@ impl CatalogState {
         //    overridden.
         session_catalog.system_vars_mut().enable_for_item_parsing();
 
+        let enable_unified_optimizer_api =
+            session_catalog.system_vars().enable_unified_optimizer_api();
+
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
         let plan = mz_sql::plan::plan(
@@ -763,20 +766,39 @@ impl CatalogState {
         )?;
         Ok(match plan {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let optimizer =
-                    Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
-                let raw_expr = view.expr;
-                let decorrelated_expr = raw_expr.clone().lower(session_catalog.system_vars())?;
-                let optimized_expr = optimizer.optimize(decorrelated_expr)?;
-                let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
-                CatalogItem::View(View {
-                    create_sql: view.create_sql,
-                    raw_expr,
-                    optimized_expr,
-                    desc,
-                    conn_id: None,
-                    resolved_ids,
-                })
+                if enable_unified_optimizer_api {
+                    let optimizer =
+                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    let raw_expr = view.expr;
+                    let decorrelated_expr =
+                        raw_expr.clone().lower(session_catalog.system_vars())?;
+                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
+                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    CatalogItem::View(View {
+                        create_sql: view.create_sql,
+                        raw_expr,
+                        optimized_expr,
+                        desc,
+                        conn_id: None,
+                        resolved_ids,
+                    })
+                } else {
+                    let optimizer =
+                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    let raw_expr = view.expr;
+                    let decorrelated_expr =
+                        raw_expr.clone().lower(session_catalog.system_vars())?;
+                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
+                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    CatalogItem::View(View {
+                        create_sql: view.create_sql,
+                        raw_expr,
+                        optimized_expr,
+                        desc,
+                        conn_id: None,
+                        resolved_ids,
+                    })
+                }
             }
             _ => bail!("Expected valid CREATE VIEW statement"),
         })
@@ -814,6 +836,9 @@ impl CatalogState {
         // 2. After this step, feature flag configuration must not be
         //    overridden.
         session_catalog.system_vars_mut().enable_for_item_parsing();
+
+        let enable_unified_optimizer_api =
+            session_catalog.system_vars().enable_unified_optimizer_api();
 
         let stmt = mz_sql::parse::parse(&create_sql)?.into_element().ast;
         let (stmt, resolved_ids) = mz_sql::names::resolve(&session_catalog, stmt)?;
@@ -873,20 +898,39 @@ impl CatalogState {
                 is_retained_metrics_object,
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {
-                let optimizer =
-                    Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
-                let raw_expr = view.expr;
-                let decorrelated_expr = raw_expr.clone().lower(session_catalog.system_vars())?;
-                let optimized_expr = optimizer.optimize(decorrelated_expr)?;
-                let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
-                CatalogItem::View(View {
-                    create_sql: view.create_sql,
-                    raw_expr,
-                    optimized_expr,
-                    desc,
-                    conn_id: None,
-                    resolved_ids,
-                })
+                if enable_unified_optimizer_api {
+                    let optimizer =
+                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    let raw_expr = view.expr;
+                    let decorrelated_expr =
+                        raw_expr.clone().lower(session_catalog.system_vars())?;
+                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
+                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    CatalogItem::View(View {
+                        create_sql: view.create_sql,
+                        raw_expr,
+                        optimized_expr,
+                        desc,
+                        conn_id: None,
+                        resolved_ids,
+                    })
+                } else {
+                    let optimizer =
+                        Optimizer::logical_optimizer(&mz_transform::typecheck::empty_context());
+                    let raw_expr = view.expr;
+                    let decorrelated_expr =
+                        raw_expr.clone().lower(session_catalog.system_vars())?;
+                    let optimized_expr = optimizer.optimize(decorrelated_expr)?;
+                    let desc = RelationDesc::new(optimized_expr.typ(), view.column_names);
+                    CatalogItem::View(View {
+                        create_sql: view.create_sql,
+                        raw_expr,
+                        optimized_expr,
+                        desc,
+                        conn_id: None,
+                        resolved_ids,
+                    })
+                }
             }
             Plan::CreateMaterializedView(CreateMaterializedViewPlan {
                 materialized_view, ..

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3919,9 +3919,11 @@ impl Coordinator {
         let optimized_mir = if let Some(..) = &plan.values.as_const() {
             // We don't perform any optimizations on an expression that is already
             // a constant for writes, as we want to maximize bulk-insert throughput.
-            OptimizedMirRelationExpr(plan.values)
+            let expr = return_if_err!(plan.values.lower(self.catalog().system_config()), ctx);
+            OptimizedMirRelationExpr(expr)
         } else {
-            return_if_err!(self.view_optimizer.optimize(plan.values), ctx)
+            let expr = return_if_err!(plan.values.lower(self.catalog().system_config()), ctx);
+            return_if_err!(self.view_optimizer.optimize(expr), ctx)
         };
 
         match optimized_mir.into_inner() {

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -26,7 +26,6 @@ pub struct OptimizeView {
 }
 
 impl OptimizeView {
-    #[allow(unused)]
     pub fn new(config: OptimizerConfig) -> Self {
         Self {
             typecheck_ctx: empty_context(),

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -953,7 +953,7 @@ pub struct SendDiffsPlan {
 #[derive(Debug)]
 pub struct InsertPlan {
     pub id: GlobalId,
-    pub values: mz_expr::MirRelationExpr,
+    pub values: HirRelationExpr,
     pub returning: Vec<mz_expr::MirScalarExpr>,
 }
 

--- a/src/sql/src/plan/expr.rs
+++ b/src/sql/src/plan/expr.rs
@@ -1269,6 +1269,14 @@ impl HirRelationExpr {
         }
     }
 
+    /// If self is a constant, return the value and the type, otherwise `None`.
+    pub fn as_const(&self) -> Option<(&Vec<Row>, &RelationType)> {
+        match self {
+            Self::Constant { rows, typ } => Some((rows, typ)),
+            _ => None,
+        }
+    }
+
     /// Reports whether this expression contains a column reference to its
     /// direct parent scope.
     pub fn is_correlated(&self) -> bool {

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -83,7 +83,6 @@ pub fn plan_insert(
     let (id, mut expr, returning) =
         query::plan_insert_query(scx, table_name, columns, source, returning)?;
     expr.bind_parameters(params)?;
-    let expr = expr.lower(scx.catalog.system_vars())?;
     let returning = returning
         .expr
         .into_iter()

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1968,7 +1968,7 @@ feature_flags!(
         desc: "use the new unified optimizer API in bootstrap() and coordinator methods",
         default: true,
         internal: true,
-        enable_for_item_parsing: true,
+        enable_for_item_parsing: false,
     },
     {
         name: enable_assert_not_null,


### PR DESCRIPTION
Integrate `OptimizeView` in the `CREATE VIEW` and `INSERT` code paths.

### Motivation

  * This PR adds a known-desirable feature.

Part of the integration process of the `Optimize` API proposed in #20569 according to the rollout plan from the design doc.

### Tips for reviewer

The first PR fixes a minor issue [discussed here](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1698686153397869).

The second commit moves HIR ⇒ MIR lowering for `InsertPlan` from `mz_sql::plan` to the the `Coordinator`.

For the remaining commits see commit messages for details. This follows the rollout plan from #20569 and are similar to the PR structure from #22381 and #22263, except for the fact that `OptimizeView` already landed as part of #22744.

- Old code paths are still available behind a feature flag.
- The new code paths are selected by default.
- Some due diligence is needed to not allow the two paths to diverge in the brief period while they co-exist in `main`. The current plan is to remove them one week after a successful deployment.

@MaterializeInc/testing we should be worried if we see failures in CI / Nightlies runs for the PR branch that can be attributed to index creation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
