### PR TITLE
persist: set compute_dataflow_max_inflight_bytes in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -68,6 +68,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_streaming_compaction_enabled": "true",
     "persist_streaming_snapshot_and_fetch_enabled": "true",
     "storage_source_decode_fuel": "100000",
+    # 128 MiB,
+    "compute_dataflow_max_inflight_bytes": "134217728",
     "enable_unified_clusters": "true",
     "enable_jemalloc_profiling": "true",
     "enable_comment": "true",

--- a/test/limits/mzcompose.py
+++ b/test/limits/mzcompose.py
@@ -1239,8 +1239,14 @@ class FilterSubqueries(Generator):
 
             > INSERT INTO t1 VALUES (1);
 
-            #Increase SQL timeout to 10 minutes (~5 should be enough).
-            $ set-sql-timeout duration=600s
+            # Increase SQL timeout to 10 minutes (~5 should be enough).
+            #
+            # Update: Now 15 minutes, not 10. This query appears to scale
+            # super-linear with COUNT. Here are timings for the first few
+            # multiples of 10 on a fresh staging env.
+            #
+            # 10: 200ms, 20: 375ms, 30: 1.5s, 40: 5.5s, 50: 16s, 60: 45s
+            $ set-sql-timeout duration=900s
 
             > SELECT * FROM t1 AS a1 WHERE {
                 " AND ".join(


### PR DESCRIPTION
We're intending to turn this on for a few customers when it goes out in the deploy this week, so get CI coverage on it.

Touches https://github.com/MaterializeInc/cloud/issues/7835

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
