### PR TITLE
Adding 'Transactions' and 'Client-side latency' sections to the troubleshooting docs

### DIFF
--- a/doc/user/content/manage/troubleshooting.md
+++ b/doc/user/content/manage/troubleshooting.md
@@ -199,7 +199,7 @@ What this means for latency: Materialize may delay queries against "slow" tables
 
 What you can do:
 
-- Avoid using transactions where you don’t need them, if you’re only executing single statements at a time, for example.
+- Avoid using transactions where you don’t need them. For example, if you’re only executing single statements at a time.
 - Double check whether your SQL library or ORM is wrapping all queries in transactions on your behalf, and disable that setting, only using transactions explicitly when you want them.
 
 ### Client-side latency


### PR DESCRIPTION
Following up from Incident-78, adding documentation to the "Why is Materialize unresponsive or slow?" troubleshooting docs to mention transactions, since these are pretty straightforward. I also put in a section on "client side latency" that I had written up previously for a customer but never put in the docs.

I also included a brief mention of indexes and isolation level, linking folks to do the docs, rather than add complete docs for those sections now, because adding guides for those are a much more involved project that we should tackle outside of this PR.

This is a very small piece of the ask in https://github.com/MaterializeInc/materialize/issues/20719