### PR TITLE
Add github action to publish sql parser changes to the sql council slack

### DIFF
--- a/.github/workflows/slack_notify_sql_parser.yml
+++ b/.github/workflows/slack_notify_sql_parser.yml
@@ -1,0 +1,85 @@
+# Copyright 2020 The Actions Ecosystem Authors
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the Action
+# Slack Notifier project. The original source code was retrieved on
+# January 5, 2022 from:
+#
+#     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
+
+# Send a notification to the #epd-sql-council Slack channel when a change
+# to the SQL parser is made.
+#
+# A notification is sent when all of these conditions are true:
+#   * A ready-to-review PR is (re-)opened, or a PR is moved from draft
+#     to ready-to-review.
+#   * The PR modifies the 'src/sql-parser/src/parser.rs' file.
+
+name: Slack SQL Parser Notifications
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    paths:
+      - "src/sql-parser/src/parser.rs"
+
+jobs:
+  notify:
+    name: "Notify about changes to the SQL parser"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: "Path filter"
+        id: filter
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            parser-change:
+              - 'src/sql-parser/src/parser.rs'
+      - name: "Push to Slack"
+        if: steps.filter.outputs.parser-change == 'true'
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: epd-sql-council
+          custom_payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new SQL parser change is ready for review!"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *PR:* <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *Author:* <${{ github.event.pull_request.user.html_url }}|${{ github.event.pull_request.user.login }}>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that pushes a notification to the #epd-sql-council Slack channel when the SQL parser is changed in a PR.
PRs touch this file ~10-15 times/month and the volume is declining, so I'm hoping the notifications are useful and manageable, but I can turn this off if they're not.

Part of https://github.com/MaterializeInc/eng-org/issues/19.

### Motivation

* This PR adds new automation.

### Tips for reviewer

GitHub does not allow actions invoked through the `pull_request` event to access secrets, like the Slack token. This workflow uses `pull_request_target`, which unfortunately means that we have to merge it to main before we can actually test it. Are there any ways I can partially test before merging?
