### PR TITLE
storage: add basic top-level ssh-tunnel support for kafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4354,6 +4354,7 @@ dependencies = [
  "mz-avro",
  "mz-ccsr",
  "mz-ore",
+ "mz-ssh-util",
  "num_cpus",
  "prost",
  "prost-build",

--- a/src/kafka-util/Cargo.toml
+++ b/src/kafka-util/Cargo.toml
@@ -15,13 +15,14 @@ fancy-regex = "0.11.0"
 mz-avro = { path = "../avro" }
 mz-ccsr = { path = "../ccsr" }
 mz-ore = { path = "../ore", features = ["cli", "network", "async"] }
+mz-ssh-util = { path = "../ssh-util" }
 num_cpus = "1.14.0"
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 rand = "0.8.5"
 rdkafka = { version = "0.29.0", features = ["cmake-build", "ssl-vendored", "libz-static", "zstd"] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
-tokio = { version = "1.32.0", features = ["macros", "sync"] }
+tokio = { version = "1.32.0", features = ["macros", "rt", "sync"] }
 thiserror = "1.0.37"
 tracing = "0.1.37"
 url = "2.3.1"

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -3590,8 +3590,12 @@ impl KafkaConnectionOptionExtracted {
         scx: &StatementContext,
     ) -> Result<mz_storage_types::connections::KafkaConnection<ReferencedConnection>, PlanError>
     {
+        if self.ssh_tunnel.is_some() {
+            scx.require_feature_flag(&vars::ENABLE_DEFAULT_KAFKA_SSH_TUNNEL)?;
+        }
         Ok(KafkaConnection {
             brokers: self.get_brokers(scx)?,
+            default_tunnel: scx.build_tunnel_definition(self.ssh_tunnel, None)?,
             security: Option::<KafkaSecurity>::try_from(&self)?,
             progress_topic: self.progress_topic,
             options: BTreeMap::new(),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1991,6 +1991,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: false,
     },
+    {
+        name: enable_default_kafka_ssh_tunnel,
+        desc: "the top-level SSH TUNNEL feature for kafka connections",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: true,
+    },
 );
 
 /// Represents the input to a variable.

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use maplit::btreemap;
 use mz_kafka_util::client::{
-    BrokerRewritingClientContext, MzClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
+    MzClientContext, TunnelingClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
@@ -372,7 +372,7 @@ pub async fn determine_latest_progress_record(
     name: String,
     progress_topic: String,
     progress_key: String,
-    progress_client: Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>,
+    progress_client: Arc<BaseConsumer<TunnelingClientContext<MzClientContext>>>,
 ) -> Result<Option<Timestamp>, anyhow::Error> {
     // Polls a message from a Kafka Source.  Blocking so should always be called on background
     // thread.

--- a/src/storage-types/src/connections.proto
+++ b/src/storage-types/src/connections.proto
@@ -58,6 +58,7 @@ message ProtoKafkaConnection {
     reserved 1, 2;
     reserved "broker";
     repeated ProtoKafkaBroker brokers = 3;
+    ProtoTunnel default_tunnel = 7;
     optional ProtoKafkaConnectionSecurity security = 4;
     optional string progress_topic = 5;
     map<string, mz_storage_types.connections.ProtoStringOrSecret> options = 6;

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -24,7 +24,7 @@ use maplit::btreemap;
 use mz_interchange::avro::{AvroEncoder, AvroSchemaGenerator, AvroSchemaOptions};
 use mz_interchange::encode::Encode;
 use mz_interchange::json::JsonEncoder;
-use mz_kafka_util::client::{BrokerRewritingClientContext, MzClientContext};
+use mz_kafka_util::client::{MzClientContext, TunnelingClientContext};
 use mz_ore::cast::CastFrom;
 use mz_ore::error::ErrorExt;
 use mz_ore::metrics::{CounterVecExt, DeleteOnDropCounter, DeleteOnDropGauge, GaugeVecExt};
@@ -252,7 +252,7 @@ impl ProducerContext for SinkProducerContext {
 #[derive(Clone)]
 struct KafkaTxProducer {
     name: String,
-    inner: Arc<ThreadedProducer<BrokerRewritingClientContext<SinkProducerContext>>>,
+    inner: Arc<ThreadedProducer<TunnelingClientContext<SinkProducerContext>>>,
     timeout: Duration,
 }
 
@@ -384,7 +384,7 @@ struct KafkaSinkState {
 
     progress_topic: String,
     progress_key: String,
-    progress_client: Option<Arc<BaseConsumer<BrokerRewritingClientContext<MzClientContext>>>>,
+    progress_client: Option<Arc<BaseConsumer<TunnelingClientContext<MzClientContext>>>>,
 
     healthchecker: HealthOutputHandle,
     gate_ts: Rc<Cell<Option<Timestamp>>>,

--- a/test/ssh-connection/kafka-source.td
+++ b/test/ssh-connection/kafka-source.td
@@ -30,6 +30,26 @@ one
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
 
+# Test that we can create, validate, and use a dynamic kafka connection
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_default_kafka_ssh_tunnel = true
+
+> CREATE CONNECTION kafka_conn_top_level
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SSH TUNNEL thancred);
+
+> CREATE SOURCE mz_source_top_level IN CLUSTER sc
+  FROM KAFKA CONNECTION kafka_conn_top_level (
+    TOPIC 'testdrive-thetopic-${testdrive.seed}',
+    TOPIC METADATA REFRESH INTERVAL MS 1000
+  )
+  FORMAT TEXT
+  ENVELOPE NONE
+
+> SELECT * FROM mz_source_top_level
+text
+----
+one
+
 # Create source with a faster metadata refresh interval so
 # errors are detected every second instead of every minute.
 > CREATE SOURCE mz_source IN CLUSTER sc


### PR DESCRIPTION
(this was originally broken out #22718. it is stacked on top of #22795, and only the top commit should be reviewed until that pr merges)

This pr implements https://github.com/MaterializeInc/materialize/issues/18375, and adds a basic test. It does NOT implement comprehensive error reporting for this, as that is extremely complicated (that is covered in #22718). Because of this, the feature if left behind a feature flag.

### Motivation
  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
