### PR TITLE
cli: Make `pyactivate` work properly on Debian

### DIFF
--- a/bin/pyactivate
+++ b/bin/pyactivate
@@ -95,6 +95,15 @@ def activate_venv(py_dir: Path) -> Path:
         # `symlinks=False` is broken with the system Python.
         # See: https://bugs.python.org/issue38705
         symlinks = os.name != "nt"
+        # Work around Debian's packaging of Python, which doesn't include the
+        # `ensurepip` module that `venv` uses under the hood.
+        try:
+            import ensurepip
+        except ImportError:
+            raise AssertionError(
+                "It appears you're on a Debian-derived system. Please install `python3-venv`, otherwise this will fail annoyingly."
+            )
+
         venv.create(venv_dir, with_pip=True, clear=True, symlinks=symlinks)
         # Work around a Debian bug which incorrectly makes pip think that we've
         # installed wheel in the virtual environment when we haven't. This is
@@ -165,10 +174,10 @@ def acquire_deps(venv_dir: Path, variant: Optional[str] = None, use_pep517: bool
     if stamp_mtime <= requirements_mtime:
         print(f"==> Updating {variant + ' ' if variant else ''}dependencies with pip", file=sys.stderr)
         subprocess.check_call([
-            venv_dir / "bin" / "pip", "install", "-r", requirements_path,
-            "--disable-pip-version-check",
-            *(["--use-pep517"] if use_pep517 else [])
-        ],
+                venv_dir / "bin" / "pip", "install", "-r", requirements_path,
+                "--disable-pip-version-check",
+                *(["--use-pep517"] if use_pep517 else []),
+            ],
             stdout=sys.stderr
         )
         stamp_path.touch()


### PR DESCRIPTION
Work around Debian's unusual packing of Python, where we can't rely on
the standard library's `ensurepip` module and have to manually install
`pip` into the virtual environment.


### Motivation

  * This PR adds a feature that has not yet been specified.

    See https://github.com/MaterializeInc/cloud/pull/7982 . No reason to think that same issue doesn't exist in this repo!