### PR TITLE
catalog: Set connect timeout during transactions

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -187,9 +187,6 @@ pub trait DurableCatalogState: ReadOnlyDurableCatalogState {
     /// NB: We may remove this in later iterations of Pv2.
     async fn confirm_leadership(&mut self) -> Result<(), CatalogError>;
 
-    /// Set's the connection timeout for the underlying durable store.
-    async fn set_connect_timeout(&mut self, connect_timeout: Duration);
-
     /// Gets all storage usage events and permanently deletes from the catalog those
     /// that happened more than the retention period ago from boot_ts.
     async fn get_and_prune_storage_usage(

--- a/src/catalog/src/durable/persist.rs
+++ b/src/catalog/src/durable/persist.rs
@@ -104,6 +104,8 @@ impl StateUpdate {
             system_privileges,
             audit_log_updates,
             storage_usage_updates,
+            // Persist implementation does not use the connection timeout.
+            connection_timeout: _,
         } = txn_batch;
         let databases = from_batch(databases, ts, StateUpdateKind::Database);
         let schemas = from_batch(schemas, ts, StateUpdateKind::Schema);
@@ -800,12 +802,6 @@ impl DurableCatalogState for PersistCatalogState {
             ))
             .into())
         }
-    }
-
-    async fn set_connect_timeout(&mut self, _connect_timeout: Duration) {
-        // Persist is able to set this timeout internally so this is a no-op. The connect timeout
-        // passed to this function in production and the timeout Persist uses are both derived
-        // from the "crdb_connect_timeout" system variable.
     }
 
     // TODO(jkosh44) For most modifications we delegate to transactions to avoid duplicate code.

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -25,6 +25,7 @@ use mz_stash::TableTransaction;
 use mz_stash_types::objects::proto;
 use mz_storage_types::sources::Timeline;
 use std::collections::{BTreeMap, BTreeSet};
+use std::time::Duration;
 
 use crate::builtin::BuiltinLog;
 use crate::durable::objects::ClusterConfig;
@@ -68,6 +69,7 @@ pub struct Transaction<'a> {
     // memory cache.
     audit_log_updates: Vec<(proto::AuditLogKey, (), i64)>,
     storage_usage_updates: Vec<(proto::StorageUsageKey, (), i64)>,
+    connection_timeout: Option<Duration>,
 }
 
 impl<'a> Transaction<'a> {
@@ -119,6 +121,7 @@ impl<'a> Transaction<'a> {
             system_privileges: TableTransaction::new(system_privileges, |_a, _b| false)?,
             audit_log_updates: Vec::new(),
             storage_usage_updates: Vec::new(),
+            connection_timeout: None,
         })
     }
 
@@ -1203,6 +1206,10 @@ impl<'a> Transaction<'a> {
             .map(|value| value.value.clone())
     }
 
+    pub fn set_connection_timeout(&mut self, timeout: Duration) {
+        self.connection_timeout = Some(timeout);
+    }
+
     pub(crate) fn into_parts(self) -> (TransactionBatch, &'a mut dyn DurableCatalogState) {
         let txn_batch = TransactionBatch {
             databases: self.databases.pending(),
@@ -1223,6 +1230,7 @@ impl<'a> Transaction<'a> {
             system_privileges: self.system_privileges.pending(),
             audit_log_updates: self.audit_log_updates,
             storage_usage_updates: self.storage_usage_updates,
+            connection_timeout: self.connection_timeout,
         };
         (txn_batch, self.durable_catalog)
     }
@@ -1275,4 +1283,5 @@ pub struct TransactionBatch {
     )>,
     pub(crate) audit_log_updates: Vec<(proto::AuditLogKey, (), Diff)>,
     pub(crate) storage_usage_updates: Vec<(proto::StorageUsageKey, (), Diff)>,
+    pub(crate) connection_timeout: Option<Duration>,
 }


### PR DESCRIPTION
This commit allows setting the catalog connect timeout during a transaction. This allows you to set the connect timeout that will be used for the transaction itself during commit. This is especially helpful when opening the catalog, where we want to use the connect timeout, but we need to start a transaction to fetch it.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
