### PR TITLE
testdrive: Fortify disk-feature-flag.td

### DIFF
--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -19,6 +19,7 @@ exact:`WITH (DISK)` for cluster replicas is not supported
 ! ALTER CLUSTER no SET (REPLICATION FACTOR 1, DISK);
 exact:`WITH (DISK)` for cluster replicas is not supported
 
+> DROP CLUSTER no;
 
 # Test that with `enable_create_source_denylist_with_options` off, if
 # `enable_disk_cluster_replicas` is on, we can use `WITH(DISK)`.


### PR DESCRIPTION
DROP a cluster after the test is done using it

### Motivation

Nightly CI was failing because the .td file in question was leaving behind a cluster that was then showing up when other tests did `SHOW CLUSTERS`