### PR TITLE
sql: make internal `SystemVars` visible to `mz_support`

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -91,7 +91,7 @@ use serde::Serialize;
 use uncased::UncasedStr;
 
 use crate::ast::Ident;
-use crate::session::user::{User, SYSTEM_USER};
+use crate::session::user::{User, SUPPORT_USER, SYSTEM_USER};
 use crate::{DEFAULT_SCHEMA, WEBHOOK_CONCURRENCY_LIMIT};
 
 /// The action to take during end_transaction.
@@ -3608,7 +3608,7 @@ where
     }
 
     fn visible(&self, user: &User, system_vars: Option<&SystemVars>) -> Result<(), VarError> {
-        if self.internal && user != &*SYSTEM_USER {
+        if self.internal && user != &*SYSTEM_USER && user != &*SUPPORT_USER {
             Err(VarError::UnknownParameter(self.name().to_string()))
         } else if self.name().starts_with("unsafe")
             && match system_vars {

--- a/test/sqllogictest/mz-support-privileges.slt
+++ b/test/sqllogictest/mz-support-privileges.slt
@@ -48,6 +48,48 @@ CREATE VIEW vv AS SELECT 66
 ----
 db error: ERROR: permission denied for SCHEMA "materialize.public"
 
+# The mz_support user can SHOW public system vars.
+simple conn=mz_support,user=mz_support
+SHOW max_tables;
+----
+100
+COMPLETE 1
+
+# The mz_support user can SHOW internal system vars.
+simple conn=mz_support,user=mz_support
+SHOW log_filter;
+----
+warn
+COMPLETE 1
+
+# The mz_support user cannot ALTER SYSTEM SET public system vars.
+simple conn=mz_support,user=mz_support
+ALTER SYSTEM SET max_tables = 1234;
+----
+db error: ERROR: permission denied to alter system
+DETAIL: You must be the 'mz_system' role
+
+# The mz_support user cannot ALTER SYSTEM SET internal system vars.
+simple conn=mz_support,user=mz_support
+ALTER SYSTEM SET log_filter = 'error';
+----
+db error: ERROR: permission denied to alter system
+DETAIL: You must be the 'mz_system' role
+
+# The mz_support user cannot ALTER SYSTEM RESET public system vars.
+simple conn=mz_support,user=mz_support
+ALTER SYSTEM RESET max_tables;
+----
+db error: ERROR: permission denied to alter system
+DETAIL: You must be the 'mz_system' role
+
+# The mz_support user cannot ALTER SYSTEM RESET internal system vars.
+simple conn=mz_support,user=mz_support
+ALTER SYSTEM RESET log_filter;
+----
+db error: ERROR: permission denied to alter system
+DETAIL: You must be the 'mz_system' role
+
 # The mz_support user cannot query the un-redacted statement log tables
 simple conn=mz_support,user=mz_support
 SELECT count(*) >= 0 FROM mz_internal.mz_statement_execution_history


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

We want to allow the `mz_support` user access to `SystemVar` entries marked as internal.

### Tips for reviewer

N/A

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
