### PR TITLE
explain: print empty key on `Distinct` in MIR plans

### DIFF
--- a/src/expr-parser/src/parser.rs
+++ b/src/expr-parser/src/parser.rs
@@ -386,7 +386,7 @@ mod relation {
     fn parse_distinct(ctx: CtxRef, input: ParseStream) -> Result {
         let reduce = input.parse::<kw::Distinct>()?;
 
-        let group_key = if input.eat(kw::group_by) {
+        let group_key = if input.eat(kw::project) {
             input.parse::<syn::Token![=]>()?;
             let inner;
             syn::bracketed!(inner in input);
@@ -1491,6 +1491,7 @@ mod kw {
     syn::custom_keyword!(on);
     syn::custom_keyword!(OR);
     syn::custom_keyword!(order_by);
+    syn::custom_keyword!(project);
     syn::custom_keyword!(Project);
     syn::custom_keyword!(Recursive);
     syn::custom_keyword!(Reduce);

--- a/src/expr-parser/tests/test_mir_parser/reduce.spec
+++ b/src/expr-parser/tests/test_mir_parser/reduce.spec
@@ -27,7 +27,7 @@ roundtrip OK
 
 # Distinct without key
 roundtrip
-Distinct monotonic
+Distinct project=[] monotonic
   Constant // { types: "(text, bigint)" }
     - ("a", 2)
     - ("a", 4)
@@ -36,7 +36,7 @@ roundtrip OK
 
 # Distinct with key
 roundtrip
-Distinct group_by=[#0, #1] exp_group_size=4
+Distinct project=[#0, #1] exp_group_size=4
   Constant // { types: "(text, bigint)" }
     - ("a", 2)
     - ("a", 4)

--- a/src/expr-test-util/tests/testdata/rel
+++ b/src/expr-test-util/tests/testdata/rel
@@ -158,7 +158,7 @@ build
 (reduce (get y) [#2] [])
 ----
 ----
-Distinct group_by=[#2]
+Distinct project=[#2]
   Get u1
 
 ----

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -728,18 +728,27 @@ impl MirRelationExpr {
             } => {
                 FmtNode {
                     fmt_root: |f, ctx: &mut PlanRenderingContext<'_, MirRelationExpr>| {
-                        if aggregates.len() > 0 {
-                            write!(f, "{}Reduce", ctx.indent)?;
-                        } else {
+                        if aggregates.len() == 0 && !ctx.config.raw_syntax {
                             write!(f, "{}Distinct", ctx.indent)?;
-                        }
-                        if group_key.len() > 0 {
+
                             if let Some(cols) = input.column_names(ctx) {
                                 let group_key = HumanizedExpr::seq(group_key, Some(cols));
-                                write!(f, " group_by=[{}]", separated(", ", group_key))?;
+                                write!(f, " project=[{}]", separated(", ", group_key))?;
                             } else {
                                 let group_key = CompactScalarSeq(group_key);
-                                write!(f, " group_by=[{}]", group_key)?;
+                                write!(f, " project=[{}]", group_key)?;
+                            }
+                        } else {
+                            write!(f, "{}Reduce", ctx.indent)?;
+
+                            if group_key.len() > 0 {
+                                if let Some(cols) = input.column_names(ctx) {
+                                    let group_key = HumanizedExpr::seq(group_key, Some(cols));
+                                    write!(f, " group_by=[{}]", separated(", ", group_key))?;
+                                } else {
+                                    let group_key = CompactScalarSeq(group_key);
+                                    write!(f, " group_by=[{}]", group_key)?;
+                                }
                             }
                         }
                         if aggregates.len() > 0 {

--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -197,7 +197,7 @@ impl Default for ExplainConfig {
             non_negative: false,
             no_fast_path: true,
             raw_plans: true,
-            raw_syntax: true,
+            raw_syntax: false,
             subtree_size: false,
             timing: false,
             types: false,

--- a/src/transform/tests/test_transforms/anf.spec
+++ b/src/transform/tests/test_transforms/anf.spec
@@ -126,7 +126,7 @@ With
           Get l1
     With Mutually Recursive
       cte l2 = // { types: "(bigint, bigint?)" }
-        Distinct group_by=[#0, #1]
+        Distinct project=[#0, #1]
           Union
             Filter #1 > 7
               Get l0
@@ -139,7 +139,7 @@ With
             Filter #1 > 7
               Get l2
       cte l1 = // { types: "(bigint, bigint?)" }
-        Distinct group_by=[#0, #1]
+        Distinct project=[#0, #1]
           Union
             Filter #1 > 7
               Get l0
@@ -188,7 +188,7 @@ With
           Get l14
         With
           cte l14 =
-            Distinct group_by=[#0, #1]
+            Distinct project=[#0, #1]
               Get l13
           cte l13 =
             Union
@@ -211,7 +211,7 @@ With
           Get l9
         With
           cte l9 =
-            Distinct group_by=[#0, #1]
+            Distinct project=[#0, #1]
               Get l8
           cte l8 =
             Union

--- a/src/transform/tests/test_transforms/column_knowledge.spec
+++ b/src/transform/tests/test_transforms/column_knowledge.spec
@@ -176,7 +176,7 @@ Return
               Negate
                 Join on=(#0 = #2)
                   Get t2
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Get l0
             Get t2
         Get l0
@@ -198,7 +198,7 @@ Return
               Negate
                 Join on=(#0 = #2)
                   Get t2
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Get l0
             Get t2
         Get l0
@@ -223,7 +223,7 @@ Return
 With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint?)" }
     Filter #0 = 3 AND #1 = 5
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Get t0
           Get l0
@@ -234,7 +234,7 @@ Return
 With Mutually Recursive
   cte l0 =
     Filter (#0 = 3) AND (#1 = 5)
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Get t0
           Get l0
@@ -248,7 +248,7 @@ Return
 With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint?)" }
     Filter #1 IS NOT NULL
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Get t0
           Get l0
@@ -259,7 +259,7 @@ Return
 With Mutually Recursive
   cte l0 =
     Filter (#1) IS NOT NULL
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Get t0
           Get l0
@@ -271,7 +271,7 @@ Return
   Get l1
 With Mutually Recursive
   cte l1 = // { types: "(bigint, bigint, bigint)" }
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         Project (#3, #1, #2)
           Map (#0 * 2)
@@ -280,7 +280,7 @@ With Mutually Recursive
               Get t0
         Get l1
   cte l0 = // { types: "(bigint)" }
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Union
         Constant // { types: "(bigint)" }
           - (1)
@@ -291,7 +291,7 @@ Return
   Get l1
 With Mutually Recursive
   cte l1 =
-    Distinct group_by=[2, #1, #2]
+    Distinct project=[2, #1, #2]
       Union
         Project (#3, #1, #2)
           Map (2)
@@ -300,7 +300,7 @@ With Mutually Recursive
               Get t0
         Get l1
   cte l0 =
-    Distinct group_by=[1]
+    Distinct project=[1]
       Union
         Constant
           - (1)
@@ -318,7 +318,7 @@ Return
   Get l1
 With Mutually Recursive
   cte l1 = // { types: "(boolean, bigint, bigint)" }
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         Project (#3, #1, #2)
           Map (#0 IS NULL)
@@ -327,7 +327,7 @@ With Mutually Recursive
               Get t0
         Get l1
   cte l0 = // { types: "(bigint)" }
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Union
         Constant // { types: "(bigint)" }
           - (1)
@@ -338,7 +338,7 @@ Return
   Get l1
 With Mutually Recursive
   cte l1 =
-    Distinct group_by=[false, #1, #2]
+    Distinct project=[false, #1, #2]
       Union
         Project (#3, #1, #2)
           Map (false)
@@ -347,7 +347,7 @@ With Mutually Recursive
               Get t0
         Get l1
   cte l0 =
-    Distinct group_by=[1]
+    Distinct project=[1]
       Union
         Constant
           - (1)

--- a/src/transform/tests/test_transforms/literal_lifting.spec
+++ b/src/transform/tests/test_transforms/literal_lifting.spec
@@ -115,7 +115,7 @@ Return
     Get l0
 With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint)" }
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Map (42)
           Project (#0)
@@ -130,7 +130,7 @@ Return
       Get l0
 With Mutually Recursive
   cte l0 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Union
         Project (#0)
           Get t0
@@ -147,7 +147,7 @@ Return
   Get l1
 With Mutually Recursive
   cte l1 = // { types: "(bigint, bigint, bigint)" }
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         CrossJoin
           Get t0
@@ -156,7 +156,7 @@ With Mutually Recursive
           Project (#0, #1)
             Get l1
   cte l0 = // { types: "(bigint)" }
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Union
         Constant // { types: "(bigint)" }
           - (17)
@@ -168,7 +168,7 @@ Return
 With Mutually Recursive
   cte l1 =
     Map (17)
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           CrossJoin
             Get t0
@@ -176,7 +176,7 @@ With Mutually Recursive
           Project (#0, #1)
             Get l1
   cte l0 =
-    Distinct
+    Distinct project=[]
       Union
         Constant
           - ()

--- a/src/transform/tests/test_transforms/non_null_requirements.spec
+++ b/src/transform/tests/test_transforms/non_null_requirements.spec
@@ -137,7 +137,7 @@ With Mutually Recursive
       Threshold
         Get l0
   cte l1 = // { types: "(bigint, bigint, bigint?)" }
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         Get l1
         Filter #2 > 0
@@ -157,7 +157,7 @@ With Mutually Recursive
       Threshold
         Get l0
   cte l1 =
-    Distinct group_by=[#0..=#2]
+    Distinct project=[#0..=#2]
       Union
         Get l1
         Filter (#2 > 0)

--- a/src/transform/tests/test_transforms/predicate_pushdown.spec
+++ b/src/transform/tests/test_transforms/predicate_pushdown.spec
@@ -35,7 +35,7 @@ Return
     Get l1
 With
   cte l1 =
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         Project (#0, #1, #5)
           Join on=(#0 = #3 AND #2 = #4)
@@ -52,7 +52,7 @@ Return
     Get l1
 With
   cte l1 =
-    Distinct group_by=[#0..=#2]
+    Distinct project=[#0..=#2]
       Union
         Project (#0, #1, #5)
           Join on=(#0 = #3 AND #2 = #4)
@@ -79,7 +79,7 @@ Return
     Get l0
 With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint)" }
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Get t0
         Get l0
@@ -93,7 +93,7 @@ Return
     Get l0
 With Mutually Recursive
   cte l0 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Get t0
         Get l0

--- a/src/transform/tests/test_transforms/projection_lifting.spec
+++ b/src/transform/tests/test_transforms/projection_lifting.spec
@@ -153,7 +153,7 @@ With Mutually Recursive
       Project (#1, #1)
         Get t1
   cte l1 = // { types: "(bigint, bigint?)" }
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Get t0
         Get l0
@@ -173,7 +173,7 @@ With Mutually Recursive
     Filter (#1) IS NOT NULL
       Get t1
   cte l1 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Get t0
         Project (#1, #1)

--- a/src/transform/tests/test_transforms/projection_pushdown.spec
+++ b/src/transform/tests/test_transforms/projection_pushdown.spec
@@ -275,11 +275,11 @@ Project (#1, #0)
 # Project around a Reduce (1)
 apply pipeline=projection_pushdown
 Project ()
-  Distinct group_by=[(#0 + #2)]
+  Distinct project=[(#0 + #2)]
     Get x
 ----
 Project ()
-  Distinct group_by=[(#0 + #1)]
+  Distinct project=[(#0 + #1)]
     Project (#0, #2)
       Get x
 
@@ -528,7 +528,7 @@ With Mutually Recursive
     Get l0
   cte l1 = // { types: "(bigint, bigint, bigint)" }
     Project (#0, #0, #0)
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Union
           Project (#0)
             Get l1
@@ -547,7 +547,7 @@ With Mutually Recursive
     Get l0
   cte l1 =
     Project (#0, #0, #0)
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Union
           Project (#0)
             Get l1

--- a/src/transform/tests/test_transforms/redundant_join.spec
+++ b/src/transform/tests/test_transforms/redundant_join.spec
@@ -123,7 +123,7 @@ With
 apply pipeline=redundant_join
 Join on=(#0 = #2)
   Get x
-  Distinct group_by=[#0]
+  Distinct project=[#0]
     Get x
 ----
 Project (#0..=#2)
@@ -139,7 +139,7 @@ Return
     Get l0
 With
   cte l0 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get x
 ----
 Return
@@ -149,7 +149,7 @@ Return
         Get x
 With
   cte l0 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get x
 
 
@@ -184,12 +184,12 @@ Return
   Get l0
 With Mutually Recursive
   cte l0 = // { types: "(bigint, bigint, bigint)" }
-    Distinct group_by=[#0, #1, #2]
+    Distinct project=[#0, #1, #2]
       Union
         Get l0
         Join on=(#2 = (#0 % 2))
           Get x
-          Distinct group_by=[(#0 % 2)]
+          Distinct project=[(#0 % 2)]
             Project (#0)
               Get x
 ----
@@ -197,7 +197,7 @@ Return
   Get l0
 With Mutually Recursive
   cte l0 =
-    Distinct group_by=[#0..=#2]
+    Distinct project=[#0..=#2]
       Union
         Get l0
         Project (#0..=#2)

--- a/src/transform/tests/test_transforms/relation_cse.spec
+++ b/src/transform/tests/test_transforms/relation_cse.spec
@@ -58,7 +58,7 @@ Return
         Get l1
   With Mutually Recursive
     cte l2 = // { types: "(bigint, bigint?)" }
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Filter #1 > 7
             Get l0
@@ -71,7 +71,7 @@ Return
           Filter #1 > 7
             Get l2
     cte l1 = // { types: "(bigint, bigint?)" }
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Filter #1 > 7
             Get l0
@@ -101,7 +101,7 @@ Return
       Get l4
 With Mutually Recursive
   cte l7 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Filter (#1 > 7)
           Get l1
@@ -116,7 +116,7 @@ With Mutually Recursive
     Filter (#1 > 7)
       Get l4
   cte l4 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Filter (#1 > 7)
           Get l1

--- a/src/transform/tests/test_transforms/semijoin_idempotence.spec
+++ b/src/transform/tests/test_transforms/semijoin_idempotence.spec
@@ -38,7 +38,7 @@ Return
           Negate
             Join on=(#0 = #3)
               Get t0
-              Distinct group_by=[#0]
+              Distinct project=[#0]
                 Get l0
         Get t0
     Project (#0, #1, #2, #0, #4)

--- a/src/transform/tests/test_transforms/typecheck.spec
+++ b/src/transform/tests/test_transforms/typecheck.spec
@@ -425,7 +425,7 @@ Distinct monotonic
 ()
 
 typecheck
-Distinct group_by=[#0, #1] exp_group_size=4
+Distinct project=[#0, #1] exp_group_size=4
   Constant // { types: "(text, bigint)" }
     - ("a", 2)
     - ("a", 4)

--- a/src/transform/tests/testdata/partial-reduction-pushdown
+++ b/src/transform/tests/testdata/partial-reduction-pushdown
@@ -33,9 +33,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
 
 ## distinct(<multiple columns from same input>)
@@ -45,9 +45,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #1)
   Join on=(#1 = #2)
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 ## distinct(<multiple columns from differing inputs>)
@@ -57,9 +57,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #1, #3)
   Join on=(#1 = #2)
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Get x
-    Distinct group_by=[#1, #0]
+    Distinct project=[#1, #0]
       Constant <empty>
 
 ## Negative test: Perform a full reduction pushdown
@@ -73,9 +73,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
 
 ## Expressions in join equivalence classes
@@ -88,9 +88,9 @@ build apply=ReductionPushdown
 ----
 Project (#1)
   Join on=(#0 = #1)
-    Distinct group_by=[substr(#1, 5)]
+    Distinct project=[substr(#1, 5)]
       Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 build apply=ReductionPushdown
@@ -102,9 +102,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(#0 = #1)
-    Distinct group_by=[substr(#1, 5)]
+    Distinct project=[substr(#1, 5)]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
 
 ### Negative test: Do not do reduction pushdown
@@ -117,7 +117,7 @@ build apply=ReductionPushdown
     [(call_variadic substr [#1 5])]
     [])
 ----
-Distinct group_by=[substr(#1, 5)]
+Distinct project=[substr(#1, 5)]
   Join on=(substr(#1, 5) = (#1 || #3))
     Get x
     Constant <empty>
@@ -130,7 +130,7 @@ build apply=ReductionPushdown
     [(call_variadic substr [#1 5])]
     [])
 ----
-Distinct group_by=[substr(#1, 5)]
+Distinct project=[substr(#1, 5)]
   Join on=(substr(#1, 5) = #3 AND (#1 || #3) = "hello")
     Constant <empty>
     Get y
@@ -144,7 +144,7 @@ build apply=ReductionPushdown
     [(call_binary text_concat #1 #3)]
     [])
 ----
-Distinct group_by=[(#1 || #3)]
+Distinct project=[(#1 || #3)]
   Join on=((#1 || #3) = "hello")
     Get x
     Constant <empty>
@@ -160,11 +160,11 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(eq(#0, #1, #2))
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
 
 build apply=ReductionPushdown
@@ -177,9 +177,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #2)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1, #3]
+    Distinct project=[#1, #3]
       Join on=(#0 = #2)
         Constant <empty>
         Constant <empty>
@@ -195,11 +195,11 @@ build apply=ReductionPushdown
 ----
 Project (#0, #2)
   Join on=(#1 = #2)
-    Distinct group_by=[#3, #1]
+    Distinct project=[#3, #1]
       Join on=(#0 = #2)
         Get x
         Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 ## Cross join tests
@@ -209,11 +209,11 @@ build apply=ReductionPushdown
 ----
 Project (#1)
   Join on=(#0 = #1)
-    Distinct
+    Distinct project=[]
       Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 build apply=ReductionPushdown
@@ -221,9 +221,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   CrossJoin
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Constant <empty>
-    Distinct
+    Distinct project=[]
       Join on=(#1 = #3)
         Get y
         Get z
@@ -240,7 +240,7 @@ Project (#0, #1)
   Join on=(#0 = #2)
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Constant <empty>
 
 build apply=ReductionPushdown
@@ -251,11 +251,11 @@ build apply=ReductionPushdown
 ----
 Project (#1, #2)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Constant <empty>
-    Distinct
+    Distinct project=[]
       Get z
 
 build apply=ReductionPushdown
@@ -272,7 +272,7 @@ Project (#2, #1, #3)
       Constant <empty>
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Constant <empty>
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 # Pushdown agg(distinct <single-component multi-input expression>)
@@ -296,5 +296,5 @@ Project (#3, #1, #2)
         Constant <empty>
         Constant <empty>
         Constant <empty>
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get w

--- a/src/transform/tests/testdata/projection-pushdown
+++ b/src/transform/tests/testdata/projection-pushdown
@@ -259,7 +259,7 @@ build apply=ProjectionPushdown
     [])
 ----
 Project ()
-  Distinct group_by=[(#0 + #1)]
+  Distinct project=[(#0 + #1)]
     Project (#0, #2)
       Get x
 

--- a/src/transform/tests/testdata/reduction-pushdown
+++ b/src/transform/tests/testdata/reduction-pushdown
@@ -24,9 +24,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 ## distinct(<multiple columns from same input>)
@@ -36,9 +36,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #1)
   Join on=(#1 = #2)
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 ## distinct(<multiple columns from differing inputs>)
@@ -48,9 +48,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #1, #3)
   Join on=(#1 = #2)
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Get x
-    Distinct group_by=[#1, #0]
+    Distinct project=[#1, #0]
       Get y
 
 ## Expressions in join equivalence classes
@@ -60,9 +60,9 @@ build apply=ReductionPushdown
 ----
 Project (#1)
   Join on=(#0 = #1)
-    Distinct group_by=[substr(#1, 5)]
+    Distinct project=[substr(#1, 5)]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 build apply=ReductionPushdown
@@ -74,9 +74,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(#0 = #1)
-    Distinct group_by=[substr(#1, 5)]
+    Distinct project=[substr(#1, 5)]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 ### Negative test: Do not do reduction pushdown
@@ -89,7 +89,7 @@ build apply=ReductionPushdown
     [(call_variadic substr [#1 5])]
     [])
 ----
-Distinct group_by=[substr(#1, 5)]
+Distinct project=[substr(#1, 5)]
   Join on=(substr(#1, 5) = (#1 || #3))
     Get x
     Get y
@@ -102,7 +102,7 @@ build apply=ReductionPushdown
     [(call_variadic substr [#1 5])]
     [])
 ----
-Distinct group_by=[substr(#1, 5)]
+Distinct project=[substr(#1, 5)]
   Join on=(substr(#1, 5) = #3 AND (#1 || #3) = "hello")
     Get x
     Get y
@@ -116,7 +116,7 @@ build apply=ReductionPushdown
     [(call_binary text_concat #1 #3)]
     [])
 ----
-Distinct group_by=[(#1 || #3)]
+Distinct project=[(#1 || #3)]
   Join on=((#1 || #3) = "hello")
     Get x
     Get y
@@ -129,11 +129,11 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   Join on=(eq(#0, #1, #2))
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 build apply=ReductionPushdown
@@ -141,9 +141,9 @@ build apply=ReductionPushdown
 ----
 Project (#0, #2)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
-    Distinct group_by=[#1, #3]
+    Distinct project=[#1, #3]
       Join on=(#0 = #2)
         Get y
         Get z
@@ -155,11 +155,11 @@ build apply=ReductionPushdown
 ----
 Project (#0, #2)
   Join on=(#1 = #2)
-    Distinct group_by=[#3, #1]
+    Distinct project=[#3, #1]
       Join on=(#0 = #2)
         Get x
         Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 ### Push down reductions on join(x, y) and join(z, w)
@@ -169,11 +169,11 @@ build apply=ReductionPushdown
 ----
 Project (#0, #3)
   Join on=(#0 = #2 AND #1 = #3)
-    Distinct group_by=[#3, #3]
+    Distinct project=[#3, #3]
       Join on=(#0 = #2)
         Get x
         Get y
-    Distinct group_by=[#1, #1]
+    Distinct project=[#1, #1]
       Join on=(#0 = #2)
         Get z
         Get w
@@ -187,7 +187,7 @@ Project (#0, #0)
     implementation
       %0[#0]UKA » %1[#0]UKA
     ArrangeBy keys=[[#0]]
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Project (#2)
           Join on=(#0 = #1) type=differential
             implementation
@@ -198,7 +198,7 @@ Project (#0, #0)
             ArrangeBy keys=[[#0]]
               Get y
     ArrangeBy keys=[[#0]]
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Project (#1)
           Join on=(#0 = #2) type=differential
             implementation
@@ -219,7 +219,7 @@ build apply=ReductionPushdown
     [(call_binary text_concat #1 #3)]
     [])
 ----
-Distinct group_by=[(#1 || #3)]
+Distinct project=[(#1 || #3)]
   Join on=((#1 || #3) = "hello" AND #1 = #5)
     Get x
     Get y
@@ -232,11 +232,11 @@ build apply=ReductionPushdown
 ----
 Project (#1)
   Join on=(#0 = #1)
-    Distinct
+    Distinct project=[]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 build apply=ReductionPushdown
@@ -244,9 +244,9 @@ build apply=ReductionPushdown
 ----
 Project (#0)
   CrossJoin
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get x
-    Distinct
+    Distinct project=[]
       Join on=(#1 = #3)
         Get y
         Get z
@@ -260,7 +260,7 @@ Project (#0, #1)
   Join on=(#0 = #2)
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Get x
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get y
 
 build apply=ReductionPushdown
@@ -268,11 +268,11 @@ build apply=ReductionPushdown
 ----
 Project (#1, #2)
   Join on=(#0 = #1)
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get x
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Get y
-    Distinct
+    Distinct project=[]
       Get z
 
 build apply=ReductionPushdown
@@ -287,7 +287,7 @@ Project (#2, #1, #3)
       Get x
     Reduce group_by=[#1] aggregates=[sum(distinct #0)]
       Get y
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get z
 
 # Pushdown agg(distinct <single-component multi-input expression>)
@@ -306,7 +306,7 @@ Project (#3, #1, #2)
         Get x
         Get y
         Get z
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get w
 
 # Empty group by key tests
@@ -318,7 +318,7 @@ Project (#0)
   CrossJoin
     Reduce aggregates=[sum(distinct #0)]
       Get x
-    Distinct
+    Distinct project=[]
       Get y
 
 build apply=ReductionPushdown

--- a/src/transform/tests/testdata/redundant_join
+++ b/src/transform/tests/testdata/redundant_join
@@ -143,7 +143,7 @@ Join on=(#0 = #1)
     Project (#2)
       Map ((#0 + 2))
         Get x
-  Distinct group_by=[(#0 + 1)]
+  Distinct project=[(#0 + 1)]
     Get x
 
 # We can't remove the join unless the literal is lifted
@@ -156,7 +156,7 @@ build apply=RedundantJoin
 ----
 Join on=(#0 = #2)
   Map (1)
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get x
   Get x
 

--- a/src/transform/tests/testdata/threshold_elision
+++ b/src/transform/tests/testdata/threshold_elision
@@ -70,10 +70,10 @@ build apply=ThresholdElision
       (reduce (filter (get x) [(call_binary lt #0 (7 Int64))]) [#1 #2] [])) ]))
 ----
 Union
-  Distinct group_by=[#1, #2]
+  Distinct project=[#1, #2]
     Get x
   Negate
-    Distinct group_by=[#1, #2]
+    Distinct project=[#1, #2]
       Filter (#0 < 7)
         Get x
 
@@ -118,10 +118,10 @@ build apply=ThresholdElision
 ----
 Threshold
   Union
-    Distinct group_by=[#1, #2]
+    Distinct project=[#1, #2]
       Get x
     Negate
-      Distinct group_by=[#1, #2]
+      Distinct project=[#1, #2]
         Filter (#0 < 7)
           Get y
 

--- a/src/transform/tests/testdata/typ
+++ b/src/transform/tests/testdata/typ
@@ -75,7 +75,7 @@ build format=types
 (filter (reduce (get x) [#0 #2] []) [(call_binary eq #0 #1)])
 ----
 Filter (#0 = #1) // { types: "(Int32, Int32)", keys: "([0], [1])" }
-  Distinct group_by=[#0, #2] // { types: "(Int32?, Int32?)", keys: "([0, 1])" }
+  Distinct project=[#0, #2] // { types: "(Int32?, Int32?)", keys: "([0, 1])" }
     Get x // { types: "(Int32?, Int64?, Int32?)", keys: "()" }
 
 cat

--- a/test/pg-cdc/constraints.td
+++ b/test/pg-cdc/constraints.td
@@ -81,4 +81,4 @@ ALTER TABLE unique_nullable REPLICA IDENTITY FULL;
 #
 # Unique NOT converted to keys because values are nullable
 > EXPLAIN SELECT DISTINCT f1, f2 FROM unique_nullable
-"Explained Query:\n  Distinct group_by=[#0, #1]\n    Project (#0, #1)\n      ReadIndex on=unique_nullable unique_nullable_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.public.unique_nullable_primary_idx (*** full scan ***)\n"
+"Explained Query:\n  Distinct project=[#0, #1]\n    Project (#0, #1)\n      ReadIndex on=unique_nullable unique_nullable_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.public.unique_nullable_primary_idx (*** full scan ***)\n"

--- a/test/sqllogictest/attributes/mir_arity.slt
+++ b/test/sqllogictest/attributes/mir_arity.slt
@@ -47,7 +47,7 @@ Explained Query:
     Threshold // { arity: 4 }
       Union // { arity: 4 }
         Negate // { arity: 4 }
-          Distinct group_by=[#0..=#3] // { arity: 4 }
+          Distinct project=[#0..=#3] // { arity: 4 }
             TopK order_by=[#1 asc nulls_last] limit=10 offset=1 // { arity: 4 }
               Project (#0..=#2, #4) // { arity: 4 }
                 Map ((#3 + 1)) // { arity: 5 }
@@ -60,7 +60,7 @@ Explained Query:
                               ArrangeBy keys=[[#0]] // { arity: 3 }
                                 Get l0 // { arity: 3 }
                               ArrangeBy keys=[[#0]] // { arity: 1 }
-                                Distinct group_by=[#0] // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
                                   Project (#0) // { arity: 1 }
                                     Get l1 // { arity: 4 }
                         Get l0 // { arity: 3 }
@@ -153,7 +153,7 @@ Explained Query:
       Project (#0, #2) // { arity: 2 }
         Join on=(#0 = #1) type=differential // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Filter (#1) IS NOT NULL // { arity: 2 }
                   ReadIndex on=u u_d_idx=[*** full scan ***] // { arity: 2 }

--- a/test/sqllogictest/attributes/mir_column_types.slt
+++ b/test/sqllogictest/attributes/mir_column_types.slt
@@ -90,7 +90,7 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { types: "(integer?)" }
                   ReadStorage materialize.public.u // { types: "(integer?)" }
                 ArrangeBy keys=[[#0]] // { types: "(integer)" }
-                  Distinct group_by=[#0] // { types: "(integer)" }
+                  Distinct project=[#0] // { types: "(integer)" }
                     Project (#0) // { types: "(integer)" }
                       Get l0 // { types: "(integer, text?, date?)" }
           Project () // { types: "()" }

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -113,7 +113,7 @@ Explained Query:
             Project (#0, #1) // { keys: "()" }
               Join on=(#0 = #2) type=differential // { keys: "()" }
                 ArrangeBy keys=[[#0]] // { keys: "([0])" }
-                  Distinct group_by=[#0] // { keys: "([0])" }
+                  Distinct project=[#0] // { keys: "([0])" }
                     Project (#0) // { keys: "()" }
                       Filter (#0) IS NOT NULL // { keys: "()" }
                         ReadStorage materialize.public.u // { keys: "()" }
@@ -153,7 +153,7 @@ Explained Query:
           Map (null) // { keys: "()" }
             Union // { keys: "()" }
               Negate // { keys: "()" }
-                Distinct // { keys: "([])" }
+                Distinct project=[] // { keys: "([])" }
                   Project () // { keys: "()" }
                     Get l1 // { keys: "()" }
               Constant // { keys: "([])" }

--- a/test/sqllogictest/autogenerated/all_parts_essential.slt
+++ b/test/sqllogictest/autogenerated/all_parts_essential.slt
@@ -422,7 +422,7 @@ Explained Query:
                     Project (#4, #11) // { arity: 2 }
                       Get l1 // { arity: 16 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#2) // { arity: 1 }
                         Get l0 // { arity: 5 }
             Project (#4) // { arity: 1 }

--- a/test/sqllogictest/cardinality.slt
+++ b/test/sqllogictest/cardinality.slt
@@ -46,7 +46,7 @@ query T multiline
 EXPLAIN WITH(cardinality) SELECT DISTINCT x FROM t
 ----
 Explained Query:
-  Distinct group_by=[#0] // { cardinality: "materialize.public.t" }
+  Distinct project=[#0] // { cardinality: "materialize.public.t" }
     Project (#0) // { cardinality: "materialize.public.t" }
       ReadIndex on=t t_x=[*** full scan ***] // { cardinality: "materialize.public.t" }
 
@@ -253,9 +253,9 @@ Explained Query:
     Get l4
   With Mutually Recursive
     cte l4 =
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
-          Distinct group_by=[#0, #1]
+          Distinct project=[#0, #1]
             Union
               Project (#1, #0)
                 CrossJoin type=differential
@@ -274,7 +274,7 @@ Explained Query:
             - (1, true)
             - (2, false)
     cte l3 =
-      Distinct
+      Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
@@ -304,9 +304,9 @@ Explained Query:
                   ArrangeBy keys=[[#0..=#2]]
                     Union
                       Negate
-                        Distinct group_by=[#0..=#2]
+                        Distinct project=[#0..=#2]
                           Get l0
-                      Distinct group_by=[#0..=#2]
+                      Distinct project=[#0..=#2]
                         ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
                   ArrangeBy keys=[[#0..=#2]]
                     ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
@@ -366,9 +366,9 @@ Explained Query:
     Get l4
   With Mutually Recursive
     cte l4 =
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
-          Distinct group_by=[#0, #1]
+          Distinct project=[#0, #1]
             Union
               Project (#1, #0)
                 CrossJoin type=differential
@@ -387,7 +387,7 @@ Explained Query:
             - (1, true)
             - (2, false)
     cte l3 =
-      Distinct
+      Distinct project=[]
         Project ()
           Join on=(#0 = #1) type=differential
             ArrangeBy keys=[[#0]]
@@ -417,9 +417,9 @@ Explained Query:
                   ArrangeBy keys=[[#0..=#2]]
                     Union
                       Negate
-                        Distinct group_by=[#0..=#2]
+                        Distinct project=[#0..=#2]
                           Get l0
-                      Distinct group_by=[#0..=#2]
+                      Distinct project=[#0..=#2]
                         ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]
                   ArrangeBy keys=[[#0..=#2]]
                     ReadIndex on=person_knows_person person_knows_person_person1id_person2id=[*** full scan ***]

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -434,7 +434,7 @@ Explained Query:
               Project (#0..=#2, #4, #6) // { arity: 5 }
                 Get l0 // { arity: 9 }
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
-              Distinct group_by=[#0..=#3] // { arity: 4 }
+              Distinct project=[#0..=#3] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
                   Filter (#10 >= #3) // { arity: 14 }
                     Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
@@ -949,7 +949,7 @@ Explained Query:
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Distinct group_by=[#0..=#21] // { arity: 22 }
+                      Distinct project=[#0..=#21] // { arity: 22 }
                         Project (#0..=#21) // { arity: 22 }
                           Get l0 // { arity: 23 }
                   Project (#0) // { arity: 1 }
@@ -1129,7 +1129,7 @@ Explained Query:
                 Get l1 // { arity: 1 }
     With
       cte l1 =
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 4 }
       cte l0 =
@@ -1353,7 +1353,7 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (integer_to_bigint((2 * #3)) > #4) // { arity: 5 }
                   Reduce group_by=[#0..=#3] aggregates=[sum(#4)] // { arity: 5 }
@@ -1437,7 +1437,7 @@ Explained Query:
             ArrangeBy keys=[[#0..=#3]] // { arity: 4 }
               Union // { arity: 4 }
                 Negate // { arity: 4 }
-                  Distinct group_by=[#0..=#3] // { arity: 4 }
+                  Distinct project=[#0..=#3] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
                       Filter (#10 > #3) // { arity: 14 }
                         Join on=(#0 = #4 AND #1 = #5 AND #2 = #6) type=differential // { arity: 14 }
@@ -1449,7 +1449,7 @@ Explained Query:
                 Get l2 // { arity: 4 }
     With
       cte l2 =
-        Distinct group_by=[#0..=#3] // { arity: 4 }
+        Distinct project=[#0..=#3] // { arity: 4 }
           Project (#1..=#4) // { arity: 4 }
             Get l1 // { arity: 5 }
       cte l1 =
@@ -1528,7 +1528,7 @@ Explained Query:
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
                         Get l2 // { arity: 3 }
                       ArrangeBy keys=[[#0..=#2]] // { arity: 3 }
-                        Distinct group_by=[#2, #0, #1] // { arity: 3 }
+                        Distinct project=[#2, #0, #1] // { arity: 3 }
                           Project (#1..=#3) // { arity: 3 }
                             Filter (#3) IS NOT NULL // { arity: 8 }
                               ReadIndex on=order fk_order_customer=[*** full scan ***] // { arity: 8 }

--- a/test/sqllogictest/cte_lowering.slt
+++ b/test/sqllogictest/cte_lowering.slt
@@ -100,9 +100,9 @@ Return // { arity: 2 }
               Join on=(#0 = #1) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Get l2 // { arity: 2 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Get l1 // { arity: 1 }
                 Get l1 // { arity: 1 }
             Constant // { arity: 1 }
@@ -115,7 +115,7 @@ With
           Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 1 }
   cte l0 =
     CrossJoin // { arity: 1 }
@@ -166,9 +166,9 @@ Return // { arity: 2 }
                           Join on=(#0 = #1) // { arity: 2 }
                             Union // { arity: 1 }
                               Negate // { arity: 1 }
-                                Distinct group_by=[#0] // { arity: 1 }
+                                Distinct project=[#0] // { arity: 1 }
                                   Get l7 // { arity: 2 }
-                              Distinct group_by=[#0] // { arity: 1 }
+                              Distinct project=[#0] // { arity: 1 }
                                 Get l5 // { arity: 1 }
                             Get l5 // { arity: 1 }
                         Constant // { arity: 1 }
@@ -193,18 +193,18 @@ With
               Join on=(#0 = #1) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Get l2 // { arity: 2 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Get l1 // { arity: 1 }
                 Get l1 // { arity: 1 }
             Constant // { arity: 1 }
               - (null)
   cte l5 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l4 // { arity: 2 }
   cte l4 =
-    Distinct group_by=[#0, #1] // { arity: 2 }
+    Distinct project=[#0, #1] // { arity: 2 }
       Get l3 // { arity: 2 }
   cte l3 =
     CrossJoin // { arity: 2 }
@@ -217,7 +217,7 @@ With
           Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 1 }
   cte l0 =
     CrossJoin // { arity: 1 }
@@ -255,9 +255,9 @@ With
           Join on=(#0 = #1) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+                Distinct project=[#0] // { arity: 1 }
                   Get l2 // { arity: 2 }
-              Distinct group_by=[#0] // { arity: 1 }
+              Distinct project=[#0] // { arity: 1 }
                 Get l1 // { arity: 1 }
             Get l1 // { arity: 1 }
         Constant // { arity: 1 }
@@ -269,7 +269,7 @@ With
           Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 1 }
   cte l0 =
     CrossJoin // { arity: 1 }
@@ -329,9 +329,9 @@ Return // { arity: 3 }
                               Join on=(#0 = #1) // { arity: 2 }
                                 Union // { arity: 1 }
                                   Negate // { arity: 1 }
-                                    Distinct group_by=[#0] // { arity: 1 }
+                                    Distinct project=[#0] // { arity: 1 }
                                       Get l8 // { arity: 2 }
-                                  Distinct group_by=[#0] // { arity: 1 }
+                                  Distinct project=[#0] // { arity: 1 }
                                     Get l6 // { arity: 1 }
                                 Get l6 // { arity: 1 }
                             Constant // { arity: 1 }
@@ -351,10 +351,10 @@ With
         Get l6 // { arity: 1 }
         Get l3 // { arity: 2 }
   cte l6 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l5 // { arity: 2 }
   cte l5 =
-    Distinct group_by=[#0, #1] // { arity: 2 }
+    Distinct project=[#0, #1] // { arity: 2 }
       Get l4 // { arity: 2 }
   cte l4 =
     CrossJoin // { arity: 2 }
@@ -368,9 +368,9 @@ With
           Join on=(#0 = #1) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct group_by=[#0] // { arity: 1 }
+                Distinct project=[#0] // { arity: 1 }
                   Get l2 // { arity: 2 }
-              Distinct group_by=[#0] // { arity: 1 }
+              Distinct project=[#0] // { arity: 1 }
                 Get l1 // { arity: 1 }
             Get l1 // { arity: 1 }
         Constant // { arity: 1 }
@@ -382,7 +382,7 @@ With
           Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 1 }
   cte l0 =
     CrossJoin // { arity: 1 }
@@ -440,9 +440,9 @@ Return // { arity: 3 }
                                 Join on=(#0 = #1) // { arity: 2 }
                                   Union // { arity: 1 }
                                     Negate // { arity: 1 }
-                                      Distinct group_by=[#0] // { arity: 1 }
+                                      Distinct project=[#0] // { arity: 1 }
                                         Get l7 // { arity: 2 }
-                                    Distinct group_by=[#0] // { arity: 1 }
+                                    Distinct project=[#0] // { arity: 1 }
                                       Get l5 // { arity: 1 }
                                   Get l5 // { arity: 1 }
                               Constant // { arity: 1 }
@@ -467,20 +467,20 @@ With
               Join on=(#0 = #1) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Get l2 // { arity: 2 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Get l1 // { arity: 1 }
                 Get l1 // { arity: 1 }
             Constant // { arity: 1 }
               - (null)
   cte l5 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l4 // { arity: 2 }
   cte l4 =
     Filter true // { arity: 2 }
       CrossJoin // { arity: 2 }
-        Distinct group_by=[#1] // { arity: 1 }
+        Distinct project=[#1] // { arity: 1 }
           Get l3 // { arity: 2 }
         Get materialize.public.x // { arity: 1 }
   cte l3 =
@@ -494,7 +494,7 @@ With
           Get l1 // { arity: 1 }
           Get materialize.public.y // { arity: 1 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 1 }
   cte l0 =
     CrossJoin // { arity: 1 }

--- a/test/sqllogictest/explain/decorrelated_plan_as_text.slt
+++ b/test/sqllogictest/explain/decorrelated_plan_as_text.slt
@@ -110,14 +110,14 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 ----
 Threshold
   Union
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Project (#0)
         CrossJoin
           Constant
             - ()
           Get materialize.public.t
     Negate
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Project (#1)
           CrossJoin
             Constant
@@ -175,9 +175,9 @@ Return
             CrossJoin
               Union
                 Negate
-                  Distinct
+                  Distinct project=[]
                     Get l0
-                Distinct
+                Distinct project=[]
                   Constant
                     - ()
               Constant
@@ -229,9 +229,9 @@ Return
                 Join on=(#0 = #1)
                   Union
                     Negate
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l5
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Get l4
                   Get l4
               Constant
@@ -239,13 +239,13 @@ Return
 With
   cte l5 =
     Map (true)
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Filter (#0 > #2)
           CrossJoin
             Get l4
             Get materialize.public.mv
   cte l4 =
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get l3
   cte l3 =
     Project (#0, #1)
@@ -260,22 +260,22 @@ With
                   Join on=(#0 = #1)
                     Union
                       Negate
-                        Distinct group_by=[#0]
+                        Distinct project=[#0]
                           Get l2
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l1
                     Get l1
                 Constant
                   - (false)
   cte l2 =
     Map (true)
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Filter (#0 < #1)
           CrossJoin
             Get l1
             Get materialize.public.mv
   cte l1 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get l0
   cte l0 =
     Filter (true AND true)
@@ -306,9 +306,9 @@ Return
                   Join on=(#0 = #1)
                     Union
                       Negate
-                        Distinct group_by=[#0]
+                        Distinct project=[#0]
                           Get l4
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l2
                     Get l2
                 Constant
@@ -323,9 +323,9 @@ Return
                   Join on=(#0 = #1)
                     Union
                       Negate
-                        Distinct group_by=[#0]
+                        Distinct project=[#0]
                           Get l8
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l6
                     Get l6
                 Constant
@@ -347,10 +347,10 @@ With
             Get l6
             Get materialize.public.mv
   cte l6 =
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get l5
   cte l5 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Get l0
   cte l4 =
     Union
@@ -368,10 +368,10 @@ With
             Get l2
             Get materialize.public.v
   cte l2 =
-    Distinct group_by=[#1]
+    Distinct project=[#1]
       Get l1
   cte l1 =
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Get l0
   cte l0 =
     CrossJoin
@@ -502,7 +502,7 @@ Return
               Project (#0, #1)
                 Join on=(#1 = #2)
                   Get l2
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Project (#3)
                       Get l3
             Get l2
@@ -519,7 +519,7 @@ With
                   Project (#0, #1)
                     Join on=(#1 = #2)
                       Get l0
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Project (#1)
                           Get l1
                 Get l0
@@ -608,9 +608,9 @@ Return
                 Join on=(#0 = #1)
                   Union
                     Negate
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l5
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Get l4
                   Get l4
               Constant
@@ -622,7 +622,7 @@ With
         Get l4
         Get materialize.public.t
   cte l4 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get l3
   cte l3 =
     Filter true
@@ -637,9 +637,9 @@ With
                   Join on=(#0 = #1)
                     Union
                       Negate
-                        Distinct group_by=[#0]
+                        Distinct project=[#0]
                           Get l2
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Get l1
                     Get l1
                 Constant
@@ -650,7 +650,7 @@ With
         Get l1
         Get materialize.public.t
   cte l1 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get l0
   cte l0 =
     CrossJoin
@@ -704,9 +704,9 @@ Return
                       Join on=(#0 = #2 AND #1 = #3)
                         Union
                           Negate
-                            Distinct group_by=[#0, #1]
+                            Distinct project=[#0, #1]
                               Get l5
-                          Distinct group_by=[#0, #1]
+                          Distinct project=[#0, #1]
                             Get l4
                         Get l4
                     Constant
@@ -718,7 +718,7 @@ With
         Get l4
         Get materialize.public.t
   cte l4 =
-    Distinct group_by=[#1, #0]
+    Distinct project=[#1, #0]
       Get l3
   cte l3 =
     Union
@@ -728,9 +728,9 @@ With
           Join on=(#0 = #1)
             Union
               Negate
-                Distinct group_by=[#0]
+                Distinct project=[#0]
                   Get l2
-              Distinct group_by=[#0]
+              Distinct project=[#0]
                 Get l1
             Get l1
         Constant
@@ -741,7 +741,7 @@ With
         Get l1
         Get materialize.public.t
   cte l1 =
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Get l0
   cte l0 =
     CrossJoin
@@ -762,9 +762,9 @@ Return
         CrossJoin
           Union
             Negate
-              Distinct
+              Distinct project=[]
                 Get l0
-            Distinct
+            Distinct project=[]
               Constant
                 - ()
           Constant

--- a/test/sqllogictest/explain/optimized_plan_as_text.slt
+++ b/test/sqllogictest/explain/optimized_plan_as_text.slt
@@ -146,11 +146,11 @@ SELECT a FROM t EXCEPT SELECT b FROM mv
 Explained Query:
   Threshold
     Union
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Project (#0)
           ReadIndex on=t t_a_idx=[*** full scan ***]
       Negate
-        Distinct group_by=[#0]
+        Distinct project=[#0]
           Project (#1)
             ReadStorage materialize.public.mv
 
@@ -263,12 +263,12 @@ Explained Query:
         ArrangeBy keys=[[#1]]
           Get l0
         ArrangeBy keys=[[#0]]
-          Distinct group_by=[#0]
+          Distinct project=[#0]
             Project (#0)
               Filter (#0 > #1)
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Project (#1)
                         Get l0
                   ArrangeBy keys=[[]]
@@ -281,12 +281,12 @@ Explained Query:
           ArrangeBy keys=[[#0]]
             ReadIndex on=t t_a_idx=[differential join]
           ArrangeBy keys=[[#0]]
-            Distinct group_by=[#0]
+            Distinct project=[#0]
               Project (#0)
                 Filter (#0 < #1)
                   CrossJoin type=differential
                     ArrangeBy keys=[[]]
-                      Distinct group_by=[#0]
+                      Distinct project=[#0]
                         Project (#0)
                           ReadIndex on=t t_a_idx=[*** full scan ***]
                     ArrangeBy keys=[[]]
@@ -349,7 +349,7 @@ Explained Query:
       ArrangeBy keys=[[#0]]
         Get l1
     cte l1 =
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Get l0
     cte l0 =
       Project (#1)
@@ -384,7 +384,7 @@ Explained Query:
                   Project (#1)
                     ReadIndex on=t t_a_idx=[*** full scan ***]
                 ArrangeBy keys=[[#0]]
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Project (#1)
                       Get l2
           Project ()
@@ -527,7 +527,7 @@ Explained Query:
             Reduce group_by=[#0] aggregates=[max((#0 * #1))]
               CrossJoin type=differential
                 ArrangeBy keys=[[]]
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Project (#0)
                       Get l2
                 Get l1
@@ -542,7 +542,7 @@ Explained Query:
               Reduce group_by=[#0] aggregates=[max((#0 * #1))]
                 CrossJoin type=differential
                   ArrangeBy keys=[[]]
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Get l0
                   Get l1
     cte l1 =
@@ -1063,7 +1063,7 @@ UNION
 ----
 Explained Query:
   Return
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Project (#4, #5)
           Filter (#0) IS NOT NULL
@@ -1096,7 +1096,7 @@ UNION
 ----
 Explained Query:
   Return
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Project (#4, #5)
           Map ((#0 + #2), (#1 + #1))
@@ -1140,7 +1140,7 @@ UNION
 ----
 Explained Query:
   Return
-    Distinct group_by=[#0, #1]
+    Distinct project=[#0, #1]
       Union
         Project (#4, #5)
           Map ((#0 + #2), (#1 + #1))
@@ -1172,7 +1172,7 @@ UNION
  WHERE b > 5)
 ----
 Explained Query:
-  Distinct group_by=[#0, #1]
+  Distinct project=[#0, #1]
     Union
       Project (#4, #5)
         Map ((#0 + #2), (#1 + #3))
@@ -1197,7 +1197,7 @@ UNION
 SELECT * FROM t WHERE a = 5;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1]
+  Distinct project=[#0, #1]
     Union
       ReadIndex on=t t_a_idx_2=[*** full scan ***]
       Project (#0, #1)

--- a/test/sqllogictest/github-14116.slt
+++ b/test/sqllogictest/github-14116.slt
@@ -43,7 +43,7 @@ Explained Query:
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
-                Distinct // { arity: 0 }
+                Distinct project=[] // { arity: 0 }
                   Project () // { arity: 0 }
                     Get l1 // { arity: 1 }
               Constant // { arity: 0 }

--- a/test/sqllogictest/github-17616.slt
+++ b/test/sqllogictest/github-17616.slt
@@ -66,9 +66,9 @@ Return // { arity: 3 }
                           Join on=(#0 = #3 AND #1 = #4 AND #2 = #5) // { arity: 6 }
                             Union // { arity: 3 }
                               Negate // { arity: 3 }
-                                Distinct group_by=[#0..=#2] // { arity: 3 }
+                                Distinct project=[#0..=#2] // { arity: 3 }
                                   Get l4 // { arity: 4 }
-                              Distinct group_by=[#0..=#2] // { arity: 3 }
+                              Distinct project=[#0..=#2] // { arity: 3 }
                                 Get l2 // { arity: 3 }
                             Get l2 // { arity: 3 }
                         Constant // { arity: 1 }
@@ -87,11 +87,11 @@ With
       Map (3) // { arity: 4 }
         Get l2 // { arity: 3 }
   cte l2 =
-    Distinct group_by=[#0..=#2] // { arity: 3 }
+    Distinct project=[#0..=#2] // { arity: 3 }
       Get l1 // { arity: 3 }
   cte l1 =
     CrossJoin // { arity: 3 }
-      Distinct group_by=[#1] // { arity: 1 }
+      Distinct project=[#1] // { arity: 1 }
         Get l0 // { arity: 3 }
       Get materialize.public.t2 // { arity: 2 }
   cte l0 =

--- a/test/sqllogictest/github-9147.slt
+++ b/test/sqllogictest/github-9147.slt
@@ -24,7 +24,7 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadStorage materialize.public.t1 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Filter (#0 > 1) // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }

--- a/test/sqllogictest/github-9782.slt
+++ b/test/sqllogictest/github-9782.slt
@@ -83,7 +83,7 @@ Explained Query:
                     Get l1 // { arity: 3 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Distinct group_by=[#0, #1] // { arity: 2 }
+                      Distinct project=[#0, #1] // { arity: 2 }
                         Project (#1, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
             Get l1 // { arity: 3 }

--- a/test/sqllogictest/group_size_hints.slt
+++ b/test/sqllogictest/group_size_hints.slt
@@ -235,7 +235,7 @@ materialize.public.sections_of_top_3_courses_per_teacher:
             Project (#0, #1, #3)
               Join on=(#0 = #2) type=differential
                 ArrangeBy keys=[[#0]]
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Project (#0)
                       Filter (#0) IS NOT NULL
                         ReadStorage materialize.public.teachers
@@ -282,7 +282,7 @@ materialize.public.max_sections_of_top_3_courses_per_teacher:
               Project (#0, #1, #3)
                 Join on=(#0 = #2) type=differential
                   ArrangeBy keys=[[#0]]
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Project (#0)
                         Filter (#0) IS NOT NULL
                           ReadStorage materialize.public.teachers

--- a/test/sqllogictest/joins.slt
+++ b/test/sqllogictest/joins.slt
@@ -167,7 +167,7 @@ Explained Query:
         ArrangeBy keys=[[#0]] // { arity: 2 }
           ReadStorage materialize.public.l // { arity: 2 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct group_by=[#0] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Join on=(eq(#1, #2, #3)) type=delta // { arity: 4 }
                 implementation
@@ -178,12 +178,12 @@ Explained Query:
                   Filter (#0 = (#1 + 1)) // { arity: 2 }
                     Get l1 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Filter (#1) IS NOT NULL // { arity: 2 }
                         Get l1 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[(#0 + 1)] // { arity: 1 }
+                  Distinct project=[(#0 + 1)] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Filter (#0) IS NOT NULL // { arity: 2 }
                         ReadStorage materialize.public.l // { arity: 2 }
@@ -193,7 +193,7 @@ Explained Query:
         implementation
           %0[×] » %1:l0[×]
         ArrangeBy keys=[[]] // { arity: 1 }
-          Distinct group_by=[#0] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
             Get l0 // { arity: 1 }
         ArrangeBy keys=[[]] // { arity: 1 }
           Get l0 // { arity: 1 }
@@ -333,7 +333,7 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { arity: 2 }
                   ReadStorage materialize.public.l // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l0 // { arity: 3 }
           ReadStorage materialize.public.l // { arity: 2 }
@@ -375,7 +375,7 @@ Explained Query:
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     ReadStorage materialize.public.r // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l0 // { arity: 3 }
             ReadStorage materialize.public.r // { arity: 2 }
@@ -434,7 +434,7 @@ Explained Query:
   With
     cte l1 =
       ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 3 }
     cte l0 =
@@ -1137,7 +1137,7 @@ Explained Query:
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
-                  Distinct // { arity: 0 }
+                  Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
                       Get l1 // { arity: 1 }
                 Constant // { arity: 0 }
@@ -1155,7 +1155,7 @@ Explained Query:
                 Project () // { arity: 0 }
                   ReadStorage materialize.public.a // { arity: 2 }
     cte l0 =
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.c // { arity: 1 }
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -620,7 +620,7 @@ Explained Query:
             ArrangeBy keys=[[id]] // { arity: 4 }
               ReadIndex on=country country_id=[differential join] // { arity: 4 }
             ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct group_by=[messageid] // { arity: 1 }
+              Distinct project=[messageid] // { arity: 1 }
                 Project (#10) // { arity: 1 }
                   Filter (id) IS NOT NULL AND (id) IS NOT NULL // { arity: 12 }
                     Join on=(id = typetagclassid AND id = tagid) type=delta // { arity: 12 }
@@ -731,7 +731,7 @@ Explained Query:
                       %1[#0]UKA » %0:l2[#1]K
                     Get l2 // { arity: 4 }
                     ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct group_by=[id] // { arity: 1 }
+                      Distinct project=[id] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           Get l3 // { arity: 5 }
               Get l1 // { arity: 4 }
@@ -746,12 +746,12 @@ Explained Query:
             ArrangeBy keys=[[creatorpersonid]] // { arity: 13 }
               ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
             ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-              Distinct group_by=[containerforumid] // { arity: 1 }
+              Distinct project=[containerforumid] // { arity: 1 }
                 Project (#10) // { arity: 1 }
                   Filter (containerforumid) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Get l0 // { arity: 1 }
       cte l2 =
         ArrangeBy keys=[[id]] // { arity: 4 }
@@ -766,12 +766,12 @@ Explained Query:
             ArrangeBy keys=[[id]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (id) IS NOT NULL // { arity: 11 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
             ArrangeBy keys=[[personid]] // { arity: 1 }
-              Distinct group_by=[personid] // { arity: 1 }
+              Distinct project=[personid] // { arity: 1 }
                 Project (#3) // { arity: 1 }
                   Join on=(id = forumid) type=differential // { arity: 4 }
                     implementation
@@ -974,7 +974,7 @@ Explained Query:
             ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
@@ -985,7 +985,7 @@ Explained Query:
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct group_by=[messageid] // { arity: 1 }
+                        Distinct project=[messageid] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -1079,7 +1079,7 @@ Explained Query:
             ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
@@ -1090,7 +1090,7 @@ Explained Query:
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
                       ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct group_by=[messageid] // { arity: 1 }
+                        Distinct project=[messageid] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -1185,7 +1185,7 @@ Explained Query:
             ArrangeBy keys=[[person2id]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct group_by=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[creatorpersonid, personid] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
@@ -1198,7 +1198,7 @@ Explained Query:
                         Project (#1, #2) // { arity: 2 }
                           Get l2 // { arity: 3 }
                       ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct group_by=[messageid] // { arity: 1 }
+                        Distinct project=[messageid] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             Get l1 // { arity: 4 }
                 Project (#2) // { arity: 1 }
@@ -1296,12 +1296,12 @@ Explained Query:
                       ArrangeBy keys=[[messageid]] // { arity: 1 }
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct group_by=[messageid] // { arity: 1 }
+                        Distinct project=[messageid] // { arity: 1 }
                           Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct group_by=[messageid] // { arity: 1 }
+        Distinct project=[messageid] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 2 }
       cte l1 =
@@ -1411,7 +1411,7 @@ Explained Query:
                       ArrangeBy keys=[[person2id]] // { arity: 3 }
                         Get l10 // { arity: 3 }
                       ArrangeBy keys=[[person2id]] // { arity: 1 }
-                        Distinct group_by=[person2id] // { arity: 1 }
+                        Distinct project=[person2id] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l11 // { arity: 4 }
                 Project (#0, #1) // { arity: 2 }
@@ -1440,7 +1440,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get l7 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l9 // { arity: 3 }
               Get l7 // { arity: 2 }
@@ -1471,7 +1471,7 @@ Explained Query:
                             %0:l4[#0]UKA » %1[#0]UKA
                           Get l4 // { arity: 2 }
                           ArrangeBy keys=[[id]] // { arity: 1 }
-                            Distinct group_by=[id] // { arity: 1 }
+                            Distinct project=[id] // { arity: 1 }
                               Get l6 // { arity: 1 }
                     Get l3 // { arity: 2 }
               Map (null, null) // { arity: 3 }
@@ -1683,10 +1683,10 @@ Explained Query:
               implementation
                 %0[#0]UKA » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
               ArrangeBy keys=[[person2id]] // { arity: 1 }
-                Distinct group_by=[person2id] // { arity: 1 }
+                Distinct project=[person2id] // { arity: 1 }
                   Threshold // { arity: 1 }
                     Union // { arity: 1 }
-                      Distinct group_by=[person2id] // { arity: 1 }
+                      Distinct project=[person2id] // { arity: 1 }
                         Project (#6) // { arity: 1 }
                           Join on=(person2id = person1id AND person2id = person1id) type=differential // { arity: 7 }
                             implementation
@@ -1698,7 +1698,7 @@ Explained Query:
                       Negate // { arity: 1 }
                         Get l2 // { arity: 1 }
               ArrangeBy keys=[[id]] // { arity: 1 }
-                Distinct group_by=[id] // { arity: 1 }
+                Distinct project=[id] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Filter (name = "Italy") AND (id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 19 }
                       Join on=(locationcityid = id AND partofcountryid = id) type=delta // { arity: 19 }
@@ -1713,11 +1713,11 @@ Explained Query:
                         ArrangeBy keys=[[id]] // { arity: 4 }
                           ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
               ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-                Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
+                Distinct project=[creatorpersonid, messageid] // { arity: 2 }
                   Project (#1, #9) // { arity: 2 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[messageid]] // { arity: 1 }
-                Distinct group_by=[messageid] // { arity: 1 }
+                Distinct project=[messageid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Filter (tagid) IS NOT NULL AND (typetagclassid) IS NOT NULL // { arity: 12 }
                       Join on=(tagid = id AND typetagclassid = id) type=delta // { arity: 12 }
@@ -1737,7 +1737,7 @@ Explained Query:
                 ReadIndex on=tag tag_id=[differential join] // { arity: 4 }
     With
       cte l2 =
-        Distinct group_by=[person2id] // { arity: 1 }
+        Distinct project=[person2id] // { arity: 1 }
           Union // { arity: 1 }
             Get l1 // { arity: 1 }
             Project (#3) // { arity: 1 }
@@ -1914,7 +1914,7 @@ Explained Query:
                           %1[#0]UKA » %0:l0[#1]KA
                         Get l0 // { arity: 11 }
                         ArrangeBy keys=[[id]] // { arity: 1 }
-                          Distinct group_by=[id] // { arity: 1 }
+                          Distinct project=[id] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
@@ -1981,10 +1981,10 @@ Explained Query:
                     ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
-                          Distinct group_by=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
+                          Distinct project=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
                             Project (#0..=#10) // { arity: 11 }
                               Get l1 // { arity: 12 }
-                        Distinct group_by=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
+                        Distinct project=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
                     ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
@@ -1999,11 +1999,11 @@ Explained Query:
                 Filter (length < 120) AND (creationdate > 2012-06-03 00:00:00 UTC) AND (content) IS NOT NULL AND (id = creatorpersonid) // { arity: 17 }
                   Get l0 // { arity: 17 }
             ArrangeBy keys=[[rootpostlanguage]] // { arity: 1 }
-              Distinct group_by=[rootpostlanguage] // { arity: 1 }
+              Distinct project=[rootpostlanguage] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (rootpostlanguage = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct group_by=[rootpostlanguage] // { arity: 1 }
+                      Distinct project=[rootpostlanguage] // { arity: 1 }
                         Project (#13) // { arity: 1 }
                           Get l0 // { arity: 17 }
       cte l0 =
@@ -2107,10 +2107,10 @@ Explained Query:
             ArrangeBy keys=[[id]] // { arity: 1 }
               Get l6 // { arity: 1 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Get l3 // { arity: 1 }
       cte l6 =
-        Distinct group_by=[id] // { arity: 1 }
+        Distinct project=[id] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l5 // { arity: 2 }
       cte l5 =
@@ -2150,11 +2150,11 @@ Explained Query:
                       ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
-                            Distinct group_by=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
+                            Distinct project=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
                               Project (#0..=#15) // { arity: 16 }
                                 Filter (id = id) AND (id = id) // { arity: 17 }
                                   Get l1 // { arity: 17 }
-                          Distinct group_by=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
+                          Distinct project=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
                             Filter (id = id) AND (id = id) // { arity: 16 }
                               Get l0 // { arity: 16 }
                       ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
@@ -2312,7 +2312,7 @@ Explained Query:
             ArrangeBy keys=[[id, person2id]] // { arity: 2 }
               Get l7 // { arity: 2 }
             ArrangeBy keys=[[personid, creatorpersonid]] // { arity: 2 }
-              Distinct group_by=[personid, creatorpersonid] // { arity: 2 }
+              Distinct project=[personid, creatorpersonid] // { arity: 2 }
                 Project (#9, #14) // { arity: 2 }
                   Join on=(messageid = messageid) type=differential // { arity: 16 }
                     implementation
@@ -2321,7 +2321,7 @@ Explained Query:
                     ArrangeBy keys=[[messageid]] // { arity: 3 }
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l7 =
-        Distinct group_by=[id, person2id] // { arity: 2 }
+        Distinct project=[id, person2id] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l6 // { arity: 6 }
       cte l6 =
@@ -2348,7 +2348,7 @@ Explained Query:
             ArrangeBy keys=[[id, person2id]] // { arity: 2 }
               Get l3 // { arity: 2 }
             ArrangeBy keys=[[creatorpersonid, creatorpersonid]] // { arity: 2 }
-              Distinct group_by=[creatorpersonid, creatorpersonid] // { arity: 2 }
+              Distinct project=[creatorpersonid, creatorpersonid] // { arity: 2 }
                 Project (#9, #22) // { arity: 2 }
                   Filter (messageid) IS NOT NULL // { arity: 26 }
                     Join on=(messageid = parentmessageid) type=differential // { arity: 26 }
@@ -2361,7 +2361,7 @@ Explained Query:
         ArrangeBy keys=[[messageid]] // { arity: 13 }
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
       cte l3 =
-        Distinct group_by=[id, person2id] // { arity: 2 }
+        Distinct project=[id, person2id] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l2 // { arity: 5 }
       cte l2 =
@@ -2483,7 +2483,7 @@ Explained Query:
         Project (#2, #0, #1) // { arity: 3 }
           Map (1450) // { arity: 3 }
             Reduce group_by=[person2id] aggregates=[min(#1)] // { arity: 2 }
-              Distinct group_by=[person2id, #1] // { arity: 2 }
+              Distinct project=[person2id, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
                     Map ((#1 + #4)) // { arity: 6 }
@@ -2507,10 +2507,10 @@ Explained Query:
                                       ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                                         Union // { arity: 3 }
                                           Negate // { arity: 3 }
-                                            Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
+                                            Distinct project=[creationdate, person1id, person2id] // { arity: 3 }
                                               Project (#0..=#2) // { arity: 3 }
                                                 Get l2 // { arity: 4 }
-                                          Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
+                                          Distinct project=[creationdate, person1id, person2id] // { arity: 3 }
                                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                                       ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                                         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2534,12 +2534,12 @@ Explained Query:
                     ArrangeBy keys=[[containerforumid]] // { arity: 4 }
                       Get l1 // { arity: 4 }
                     ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-                      Distinct group_by=[containerforumid] // { arity: 1 }
+                      Distinct project=[containerforumid] // { arity: 1 }
                         Project (#3) // { arity: 1 }
                           Filter (containerforumid) IS NOT NULL // { arity: 4 }
                             Get l1 // { arity: 4 }
                     ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct group_by=[id] // { arity: 1 }
+                      Distinct project=[id] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                             ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
@@ -2553,12 +2553,12 @@ Explained Query:
             ArrangeBy keys=[[containerforumid]] // { arity: 5 }
               Get l0 // { arity: 5 }
             ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-              Distinct group_by=[containerforumid] // { arity: 1 }
+              Distinct project=[containerforumid] // { arity: 1 }
                 Project (#2) // { arity: 1 }
                   Filter (containerforumid) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                     ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
@@ -2740,7 +2740,7 @@ Explained Query:
                     Get l16 // { arity: 6 }
   With Mutually Recursive
     cte l16 =
-      Distinct group_by=[#0, #1, person2id, #3, #4, #5] // { arity: 6 }
+      Distinct project=[#0, #1, person2id, #3, #4, #5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
@@ -2774,7 +2774,7 @@ Explained Query:
                         Constant // { arity: 0 }
                           - ()
     cte l15 =
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter #1 AND (person2id = -1) // { arity: 2 }
             Get l7 // { arity: 2 }
@@ -2850,15 +2850,15 @@ Explained Query:
           ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
             Get l10 // { arity: 3 }
           ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-            Distinct group_by=[#0, #1, #2] // { arity: 3 }
+            Distinct project=[#0, #1, #2] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
                 Get l8 // { arity: 5 }
     cte l10 =
-      Distinct group_by=[#0, #1, #2] // { arity: 3 }
+      Distinct project=[#0, #1, #2] // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
           Get l9 // { arity: 6 }
     cte l9 =
-      Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+      Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
         Get l16 // { arity: 6 }
     cte l8 =
       TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -2866,9 +2866,9 @@ Explained Query:
           Filter (#4 = false) // { arity: 6 }
             Get l16 // { arity: 6 }
     cte l7 =
-      Distinct group_by=[person2id, #1] // { arity: 2 }
+      Distinct project=[person2id, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Distinct group_by=[person2id, #1] // { arity: 2 }
+          Distinct project=[person2id, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#1, #0) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
@@ -2889,7 +2889,7 @@ Explained Query:
             - (1450, true)
             - (15393162796819, false)
     cte l6 =
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Join on=(person2id = person2id) type=differential // { arity: 2 }
             implementation
@@ -2931,10 +2931,10 @@ Explained Query:
                   ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                     Union // { arity: 3 }
                       Negate // { arity: 3 }
-                        Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
+                        Distinct project=[creationdate, person1id, person2id] // { arity: 3 }
                           Project (#0..=#2) // { arity: 3 }
                             Get l2 // { arity: 4 }
-                      Distinct group_by=[creationdate, person1id, person2id] // { arity: 3 }
+                      Distinct project=[creationdate, person1id, person2id] // { arity: 3 }
                         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                   ArrangeBy keys=[[creationdate, person1id, person2id]] // { arity: 3 }
                     ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
@@ -2956,12 +2956,12 @@ Explained Query:
                   ArrangeBy keys=[[containerforumid]] // { arity: 4 }
                     Get l1 // { arity: 4 }
                   ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-                    Distinct group_by=[containerforumid] // { arity: 1 }
+                    Distinct project=[containerforumid] // { arity: 1 }
                       Project (#3) // { arity: 1 }
                         Filter (containerforumid) IS NOT NULL // { arity: 4 }
                           Get l1 // { arity: 4 }
                   ArrangeBy keys=[[id]] // { arity: 1 }
-                    Distinct group_by=[id] // { arity: 1 }
+                    Distinct project=[id] // { arity: 1 }
                       Project (#1) // { arity: 1 }
                         Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                           ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
@@ -2975,12 +2975,12 @@ Explained Query:
           ArrangeBy keys=[[containerforumid]] // { arity: 5 }
             Get l0 // { arity: 5 }
           ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-            Distinct group_by=[containerforumid] // { arity: 1 }
+            Distinct project=[containerforumid] // { arity: 1 }
               Project (#2) // { arity: 1 }
                 Filter (containerforumid) IS NOT NULL // { arity: 5 }
                   Get l0 // { arity: 5 }
           ArrangeBy keys=[[id]] // { arity: 1 }
-            Distinct group_by=[id] // { arity: 1 }
+            Distinct project=[id] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
                   ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
@@ -3099,7 +3099,7 @@ Explained Query:
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct group_by=[id, messageid] // { arity: 2 }
+                          Distinct project=[id, messageid] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l5 // { arity: 3 }
                         Get l3 // { arity: 2 }
@@ -3110,7 +3110,7 @@ Explained Query:
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct group_by=[id, messageid] // { arity: 2 }
+                          Distinct project=[id, messageid] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
@@ -3124,7 +3124,7 @@ Explained Query:
               Get l6 // { arity: 2 }
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l6 // { arity: 2 }
       cte l6 =
@@ -3134,12 +3134,12 @@ Explained Query:
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-              Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
+              Distinct project=[creatorpersonid, messageid] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
                   Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct group_by=[messageid] // { arity: 1 }
+              Distinct project=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (tagid) IS NOT NULL // { arity: 8 }
                     Join on=(tagid = id) type=differential // { arity: 8 }
@@ -3157,7 +3157,7 @@ Explained Query:
               Get l3 // { arity: 2 }
             Get l4 // { arity: 3 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l4 =
@@ -3170,12 +3170,12 @@ Explained Query:
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
             ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-              Distinct group_by=[creatorpersonid, messageid] // { arity: 2 }
+              Distinct project=[creatorpersonid, messageid] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
                   Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
             ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct group_by=[messageid] // { arity: 1 }
+              Distinct project=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (tagid) IS NOT NULL // { arity: 8 }
                     Join on=(tagid = id) type=differential // { arity: 8 }
@@ -3192,7 +3192,7 @@ Explained Query:
           ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
       cte l0 =
         ArrangeBy keys=[[id]] // { arity: 1 }
-          Distinct group_by=[id] // { arity: 1 }
+          Distinct project=[id] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Filter (id) IS NOT NULL // { arity: 11 }
                 ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
@@ -3269,13 +3269,13 @@ Explained Query:
                       ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 2 }
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[personid, forumid]] // { arity: 2 }
-                        Distinct group_by=[personid, forumid] // { arity: 2 }
+                        Distinct project=[personid, forumid] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct group_by=[creatorpersonid, containerforumid] // { arity: 2 }
+        Distinct project=[creatorpersonid, containerforumid] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
@@ -3308,7 +3308,7 @@ Explained Query:
             ArrangeBy keys=[[messageid]] // { arity: 13 }
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
             ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct group_by=[messageid] // { arity: 1 }
+              Distinct project=[messageid] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Join on=(tagid = id) type=differential // { arity: 4 }
                     implementation
@@ -3316,7 +3316,7 @@ Explained Query:
                     ArrangeBy keys=[[tagid]] // { arity: 3 }
                       ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct group_by=[id] // { arity: 1 }
+                      Distinct project=[id] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Filter (id) IS NOT NULL // { arity: 5 }
                             ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
@@ -3382,13 +3382,13 @@ Explained Query:
                       ArrangeBy keys=[[personid, personid]] // { arity: 2 }
                         Get l2 // { arity: 2 }
                       ArrangeBy keys=[[person2id, person1id]] // { arity: 2 }
-                        Distinct group_by=[person2id, person1id] // { arity: 2 }
+                        Distinct project=[person2id, person1id] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
     With
       cte l2 =
-        Distinct group_by=[personid, personid] // { arity: 2 }
+        Distinct project=[personid, personid] // { arity: 2 }
           Get l1 // { arity: 2 }
       cte l1 =
         Project (#0, #2) // { arity: 2 }
@@ -3516,19 +3516,19 @@ Explained Query:
             ArrangeBy keys=[[id]] // { arity: 3 }
               Get l0 // { arity: 3 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (id) IS NOT NULL // { arity: 3 }
                     Get l0 // { arity: 3 }
             ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct group_by=[id] // { arity: 1 }
+              Distinct project=[id] // { arity: 1 }
                 Project (#1) // { arity: 1 }
                   Filter (id) IS NOT NULL // { arity: 12 }
                     ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
   With Mutually Recursive
     cte l0 =
       Reduce group_by=[id, id] aggregates=[min(#2)] // { arity: 3 }
-        Distinct group_by=[id, id, #2] // { arity: 3 }
+        Distinct project=[id, id, #2] // { arity: 3 }
           Union // { arity: 3 }
             Project (#1, #1, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
@@ -3667,7 +3667,7 @@ Explained Query:
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
-                            Distinct // { arity: 0 }
+                            Distinct project=[] // { arity: 0 }
                               Project () // { arity: 0 }
                                 Get l2 // { arity: 1 }
                           Constant // { arity: 0 }
@@ -3706,7 +3706,7 @@ Explained Query:
                       Map (null) // { arity: 1 }
                         Union // { arity: 0 }
                           Negate // { arity: 0 }
-                            Distinct // { arity: 0 }
+                            Distinct project=[] // { arity: 0 }
                               Project () // { arity: 0 }
                                 Get l0 // { arity: 1 }
                           Constant // { arity: 0 }
@@ -3831,7 +3831,7 @@ Explained Query:
                       Get l8 // { arity: 6 }
     With Mutually Recursive
       cte l8 =
-        Distinct group_by=[#0, id, id, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, id, id, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Map (0) // { arity: 6 }
               Union // { arity: 5 }
@@ -3895,7 +3895,7 @@ Explained Query:
                     Get l4 // { arity: 5 }
       cte l4 =
         TopK group_by=[#0, #1, dst] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct group_by=[#0, #1, dst, #3, #4] // { arity: 5 }
+          Distinct project=[#0, #1, dst, #3, #4] // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1, #7, #8) // { arity: 5 }
                 Map ((#6 + bigint_to_double(w)), false) // { arity: 9 }
@@ -3942,16 +3942,16 @@ Explained Query:
               Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 3 }
                 Get l2 // { arity: 3 }
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-              Distinct group_by=[#0, #1, #2] // { arity: 3 }
+              Distinct project=[#0, #1, #2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Filter (#1) IS NOT NULL AND (#2) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
       cte l2 =
-        Distinct group_by=[#0, #1, #2] // { arity: 3 }
+        Distinct project=[#0, #1, #2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l1 // { arity: 6 }
       cte l1 =
-        Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
           Get l8 // { arity: 6 }
       cte l0 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -4035,7 +4035,7 @@ Explained Query:
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4052,7 +4052,7 @@ Explained Query:
                 Project (#1, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
               ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct group_by=[personid] // { arity: 1 }
+                Distinct project=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
                       Join on=(companyid = id) type=differential // { arity: 8 }
@@ -4067,7 +4067,7 @@ Explained Query:
         Project (#2, #0, #1) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
             Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
-              Distinct group_by=[dst, #1] // { arity: 2 }
+              Distinct project=[dst, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
                     Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
@@ -4141,7 +4141,7 @@ Explained Query:
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4157,7 +4157,7 @@ Explained Query:
               ArrangeBy keys=[[dst]] // { arity: 2 }
                 Get l0 // { arity: 2 }
               ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct group_by=[personid] // { arity: 1 }
+                Distinct project=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
                       Join on=(companyid = id) type=differential // { arity: 8 }
@@ -4170,7 +4170,7 @@ Explained Query:
     With Mutually Recursive
       cte l0 =
         Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
-          Distinct group_by=[dst, #1] // { arity: 2 }
+          Distinct project=[dst, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#3, #5) // { arity: 2 }
                 Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
@@ -4248,7 +4248,7 @@ Explained Query:
                     implementation
                       %0[×] » %1:l2[×]
                     ArrangeBy keys=[[]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l2 // { arity: 1 }
                     ArrangeBy keys=[[]] // { arity: 1 }
                       Get l2 // { arity: 1 }
@@ -4265,7 +4265,7 @@ Explained Query:
                 Project (#1..=#3) // { arity: 3 }
                   Get l0 // { arity: 4 }
               ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct group_by=[personid] // { arity: 1 }
+                Distinct project=[personid] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
                       Join on=(companyid = id) type=differential // { arity: 8 }
@@ -4281,7 +4281,7 @@ Explained Query:
           Map (10995116285979) // { arity: 4 }
             Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
               Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
-                Distinct group_by=[dst, #1, #2] // { arity: 3 }
+                Distinct project=[dst, #1, #2] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#4, #6, #7) // { arity: 3 }
                       Map ((#1 + integer_to_bigint(w)), (#2 + 1)) // { arity: 8 }
@@ -4428,11 +4428,11 @@ Explained Query:
                       Get l11 // { arity: 6 }
     With Mutually Recursive
       cte l11 =
-        Distinct group_by=[#0, personid, personid, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, personid, personid, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
-                Distinct group_by=[#0, personid, personid] // { arity: 3 }
+                Distinct project=[#0, personid, personid] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
@@ -4470,7 +4470,7 @@ Explained Query:
                           Constant // { arity: 0 }
                             - ()
       cte l10 =
-        Distinct // { arity: 0 }
+        Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
             Join on=(dst = personid) type=differential // { arity: 2 }
               implementation
@@ -4551,15 +4551,15 @@ Explained Query:
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
               Get l5 // { arity: 3 }
             ArrangeBy keys=[[#0, #1, #2]] // { arity: 3 }
-              Distinct group_by=[#0, #1, #2] // { arity: 3 }
+              Distinct project=[#0, #1, #2] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
                   Get l3 // { arity: 5 }
       cte l5 =
-        Distinct group_by=[#0, #1, #2] // { arity: 3 }
+        Distinct project=[#0, #1, #2] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Get l4 // { arity: 6 }
       cte l4 =
-        Distinct group_by=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, #1, #2, #3, #4, #5] // { arity: 6 }
           Get l11 // { arity: 6 }
       cte l3 =
         TopK order_by=[#3 asc nulls_last] limit=1000 // { arity: 5 }
@@ -4567,7 +4567,7 @@ Explained Query:
             Filter (#4 = false) // { arity: 6 }
               Get l11 // { arity: 6 }
       cte l2 =
-        Distinct group_by=[dst] // { arity: 1 }
+        Distinct project=[dst] // { arity: 1 }
           Union // { arity: 1 }
             Project (#2) // { arity: 1 }
               Join on=(#0 = src) type=differential // { arity: 4 }
@@ -4579,7 +4579,7 @@ Explained Query:
                 ArrangeBy keys=[[]] // { arity: 0 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
-                      Distinct // { arity: 0 }
+                      Distinct project=[] // { arity: 0 }
                         Project () // { arity: 0 }
                           Join on=(#0 = personid) type=differential // { arity: 2 }
                             implementation

--- a/test/sqllogictest/not-null-propagation.slt
+++ b/test/sqllogictest/not-null-propagation.slt
@@ -422,7 +422,7 @@ Explained Query:
                   Get l0 // { types: "(integer?, integer)" }
   With
     cte l0 =
-      Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
@@ -451,7 +451,7 @@ Explained Query:
                   Get l0 // { types: "(integer?, integer)" }
   With
     cte l0 =
-      Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
@@ -479,7 +479,7 @@ Explained Query:
                   Get l0 // { types: "(integer?, integer)" }
   With
     cte l0 =
-      Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
 
 EOF
@@ -558,7 +558,7 @@ Explained Query:
       FlatMap wrap1(#0, null) // { types: "(integer, integer?)" }
         Get l1 // { types: "(integer)" }
     cte l1 =
-      Distinct group_by=[#0] // { types: "(integer)" }
+      Distinct project=[#0] // { types: "(integer)" }
         Get l0 // { types: "(integer)" }
     cte l0 =
       Project (#1) // { types: "(integer)" }
@@ -584,7 +584,7 @@ Explained Query:
           Map (null) // { types: "(integer?)" }
             Union // { types: "()" }
               Negate // { types: "()" }
-                Distinct // { types: "()" }
+                Distinct project=[] // { types: "()" }
                   Project () // { types: "()" }
                     Get l1 // { types: "(integer)" }
               Constant // { types: "()" }
@@ -635,7 +635,7 @@ Explained Query:
               Constant // { types: "()" }
                 - ()
     cte l0 =
-      Distinct // { types: "()" }
+      Distinct project=[] // { types: "()" }
         Project () // { types: "()" }
           Filter (#1 = 1) // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
@@ -663,7 +663,7 @@ Explained Query:
                   - ()
   With
     cte l1 =
-      Distinct // { types: "()" }
+      Distinct project=[] // { types: "()" }
         Get l0 // { types: "()" }
     cte l0 =
       Project () // { types: "()" }
@@ -732,14 +732,14 @@ Explained Query:
             Project (#1) // { types: "(integer)" }
               ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l2 =
-      Distinct group_by=[#0] // { types: "(integer?)" }
+      Distinct project=[#0] // { types: "(integer?)" }
         Project (#0) // { types: "(integer?)" }
           ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l1 =
-      Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l0 =
-      Distinct // { types: "()" }
+      Distinct project=[] // { types: "()" }
         Project () // { types: "()" }
           Filter (#1 = 1) // { types: "(integer?, integer)" }
             ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
@@ -808,10 +808,10 @@ Explained Query:
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
-                  Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                  Distinct project=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#0, #1) // { types: "(integer?, integer)" }
                       Get l0 // { types: "(integer?, integer, integer)" }
-                Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                Distinct project=[#0, #1] // { types: "(integer?, integer)" }
                   ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
@@ -840,7 +840,7 @@ Explained Query:
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
-                  Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                  Distinct project=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#0, #1) // { types: "(integer?, integer)" }
                       Get l1 // { types: "(integer?, integer, integer?, integer)" }
                 Get l2 // { types: "(integer?, integer)" }
@@ -851,7 +851,7 @@ Explained Query:
             ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
               Union // { types: "(integer?, integer)" }
                 Negate // { types: "(integer?, integer)" }
-                  Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+                  Distinct project=[#0, #1] // { types: "(integer?, integer)" }
                     Project (#2, #3) // { types: "(integer?, integer)" }
                       Get l1 // { types: "(integer?, integer, integer?, integer)" }
                 Get l2 // { types: "(integer?, integer)" }
@@ -861,7 +861,7 @@ Explained Query:
       ArrangeBy keys=[[#0, #1]] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l2 =
-      Distinct group_by=[#0, #1] // { types: "(integer?, integer)" }
+      Distinct project=[#0, #1] // { types: "(integer?, integer)" }
         ReadStorage materialize.public.int_table // { types: "(integer?, integer)" }
     cte l1 =
       CrossJoin type=differential // { types: "(integer?, integer, integer?, integer)" }

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -114,9 +114,9 @@ Return // { arity: 4 }
           Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) // { arity: 18 }
             Union // { arity: 9 }
               Negate // { arity: 9 }
-                Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                Distinct project=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
                   Get l1 // { arity: 15 }
-              Distinct group_by=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+              Distinct project=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
                 Get l0 // { arity: 9 }
             Get l0 // { arity: 9 }
         Constant // { arity: 6 }
@@ -171,7 +171,7 @@ Return // { arity: 4 }
             Project (#0..=#8) // { arity: 9 }
               Join on=(dim01_k01 = dim01_k01) // { arity: 10 }
                 Get l0 // { arity: 9 }
-                Distinct group_by=[dim01_k01] // { arity: 1 }
+                Distinct project=[dim01_k01] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l1 // { arity: 15 }
           Get l0 // { arity: 9 }
@@ -222,7 +222,7 @@ Return // { arity: 6 }
                   Project (#0..=#10) // { arity: 11 }
                     Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
                       Get l2 // { arity: 11 }
-                      Distinct group_by=[x, y, #2] // { arity: 3 }
+                      Distinct project=[x, y, #2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
                           Map (x, y, (dim01_k01 + x)) // { arity: 20 }
                             Get l3 // { arity: 17 }
@@ -242,7 +242,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -281,7 +281,7 @@ Return // { arity: 6 }
                     Project (#0..=#10) // { arity: 11 }
                       Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
                         Get l2 // { arity: 11 }
-                        Distinct group_by=[x, y, #2] // { arity: 3 }
+                        Distinct project=[x, y, #2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
                             Map (x, y, (dim01_k01 + y)) // { arity: 20 }
                               Get l3 // { arity: 17 }
@@ -301,7 +301,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -344,7 +344,7 @@ Return // { arity: 6 }
                     Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
                       Filter (facts_d02 = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
-                      Distinct group_by=[x, y, #2] // { arity: 3 }
+                      Distinct project=[x, y, #2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
                           Map (x, y, (dim01_k01 + x)) // { arity: 20 }
                             Get l3 // { arity: 17 }
@@ -364,7 +364,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -408,7 +408,7 @@ Return // { arity: 6 }
                       Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
                         Filter (facts_d02 = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
-                        Distinct group_by=[x, y, #2] // { arity: 3 }
+                        Distinct project=[x, y, #2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
                             Map (x, y, (dim01_k01 + y)) // { arity: 20 }
                               Get l3 // { arity: 17 }
@@ -428,7 +428,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -485,7 +485,7 @@ Return // { arity: 6 }
             Get l4 // { arity: 14 }
 With
   cte l5 =
-    Distinct group_by=[x, y, #2] // { arity: 3 }
+    Distinct project=[x, y, #2] // { arity: 3 }
       Project (#14..=#16) // { arity: 3 }
         Map (x, y, coalesce(dim01_k01, x)) // { arity: 17 }
           Get l4 // { arity: 14 }
@@ -504,7 +504,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.dim01 // { arity: 6 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -546,9 +546,9 @@ Return // { arity: 6 }
                 Join on=(x = x AND y = y AND facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
-                      Distinct group_by=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
+                      Distinct project=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
                         Get l8 // { arity: 17 }
-                    Distinct group_by=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
+                    Distinct project=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
                       Get l2 // { arity: 11 }
                   Get l2 // { arity: 11 }
               Constant // { arity: 6 }
@@ -567,9 +567,9 @@ With
                   Join on=(dim01_d01 = dim01_d01) // { arity: 2 }
                     Union // { arity: 1 }
                       Negate // { arity: 1 }
-                        Distinct group_by=[dim01_d01] // { arity: 1 }
+                        Distinct project=[dim01_d01] // { arity: 1 }
                           Get l7 // { arity: 2 }
-                      Distinct group_by=[dim01_d01] // { arity: 1 }
+                      Distinct project=[dim01_d01] // { arity: 1 }
                         Get l4 // { arity: 1 }
                     Get l4 // { arity: 1 }
                 Constant // { arity: 1 }
@@ -590,9 +590,9 @@ With
           Join on=(dim01_d01 = dim01_d01) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct group_by=[dim01_d01] // { arity: 1 }
+                Distinct project=[dim01_d01] // { arity: 1 }
                   Get l5 // { arity: 2 }
-              Distinct group_by=[dim01_d01] // { arity: 1 }
+              Distinct project=[dim01_d01] // { arity: 1 }
                 Get l4 // { arity: 1 }
             Get l4 // { arity: 1 }
         Constant // { arity: 1 }
@@ -602,7 +602,7 @@ With
       FlatMap unnest_array(strtoarray("{24, 42}")) // { arity: 2 }
         Get l4 // { arity: 1 }
   cte l4 =
-    Distinct group_by=[dim01_d01] // { arity: 1 }
+    Distinct project=[dim01_d01] // { arity: 1 }
       Get l3 // { arity: 17 }
   cte l3 =
     Project (#0..=#10, #13..=#18) // { arity: 17 }
@@ -616,7 +616,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct group_by=[x, y] // { arity: 2 }
+    Distinct project=[x, y] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -660,7 +660,7 @@ Explained Query:
               Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -718,7 +718,7 @@ Explained Query:
               Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -763,7 +763,7 @@ materialize.public.v:
               Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -817,7 +817,7 @@ materialize.public.mv:
               Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }

--- a/test/sqllogictest/outer_join_simplification.slt
+++ b/test/sqllogictest/outer_join_simplification.slt
@@ -329,7 +329,7 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3]
+      Distinct project=[#0..=#3]
         Union
           Project (#0..=#2, #0)
             Join on=(#0 = #3) type=differential
@@ -372,14 +372,14 @@ Explained Query:
     Get l0 // { keys: "([0, 1, 2, 3])" }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
+      Distinct project=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
         Union // { keys: "()" }
           Project (#0..=#2, #0) // { keys: "()" }
             Join on=(#0 = #3) type=differential // { keys: "()" }
               ArrangeBy keys=[[#0]] // { keys: "()" }
                 ReadStorage materialize.public.foo // { keys: "()" }
               ArrangeBy keys=[[#0]] // { keys: "([0])" }
-                Distinct group_by=[#0] // { keys: "([0])" }
+                Distinct project=[#0] // { keys: "([0])" }
                   Project (#0) // { keys: "()" }
                     Get l0 // { keys: "()" }
           Get l0 // { keys: "()" }
@@ -410,7 +410,7 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3]
+      Distinct project=[#0..=#3]
         Union
           Project (#0..=#3)
             Join on=(#0 = #4) type=differential
@@ -448,7 +448,7 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3]
+      Distinct project=[#0..=#3]
         Union
           Project (#0..=#3)
             Join on=(#0 = #4) type=differential
@@ -492,7 +492,7 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3]
+      Distinct project=[#0..=#3]
         Union
           Project (#0..=#3)
             Join on=(#0 = #4) type=differential
@@ -501,7 +501,7 @@ Explained Query:
               ArrangeBy keys=[[#0]]
                 TopK group_by=[#0] limit=1
                   Project (#0)
-                    Distinct group_by=[#0, #1]
+                    Distinct project=[#0, #1]
                       Union
                         Filter (#0) IS NOT NULL
                           ReadStorage materialize.public.bar
@@ -542,7 +542,7 @@ Explained Query:
     Get l2 // { keys: "([0, 1, 2, 3])" }
   With Mutually Recursive
     cte l2 =
-      Distinct group_by=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
+      Distinct project=[#0..=#3] // { keys: "([0, 1, 2, 3])" }
         Union // { keys: "()" }
           Project (#0..=#3) // { keys: "()" }
             Join on=(#0 = #4) type=differential // { keys: "()" }
@@ -552,7 +552,7 @@ Explained Query:
                 Get l0 // { keys: "([0])" }
           Get l2 // { keys: "()" }
     cte l1 =
-      Distinct group_by=[#0, #1] // { keys: "([0, 1])" }
+      Distinct project=[#0, #1] // { keys: "([0, 1])" }
         Union // { keys: "()" }
           ReadStorage materialize.public.bar // { keys: "([0])" }
           Project (#0, #2) // { keys: "()" }
@@ -561,7 +561,7 @@ Explained Query:
       Project (#0) // { keys: "([0])" }
         Join on=(#0 = #1) type=differential // { keys: "([0])" }
           ArrangeBy keys=[[#0]] // { keys: "([0])" }
-            Distinct group_by=[#0] // { keys: "([0])" }
+            Distinct project=[#0] // { keys: "([0])" }
               Project (#0) // { keys: "()" }
                 Get l2 // { keys: "()" }
           ArrangeBy keys=[[#0]] // { keys: "([0])" }
@@ -610,7 +610,7 @@ Explained Query:
           Get l1
   With Mutually Recursive
     cte l2 =
-      Distinct group_by=[#0..=#3]
+      Distinct project=[#0..=#3]
         Union
           Project (#0..=#3)
             Join on=(#0 = #4) type=differential
@@ -626,7 +626,7 @@ Explained Query:
       Project (#0)
         Join on=(#0 = #1) type=differential
           ArrangeBy keys=[[#0]]
-            Distinct group_by=[#0]
+            Distinct project=[#0]
               Project (#0)
                 Get l2
           ArrangeBy keys=[[#0]]
@@ -635,7 +635,7 @@ Explained Query:
                 Filter (#0) IS NOT NULL
                   Get l0
     cte l0 =
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           ReadStorage materialize.public.bar
           Project (#0, #2)
@@ -662,7 +662,7 @@ Explained Query:
     Get l1 // { keys: "([0, 1, 2, 3, 4])" }
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#4] // { keys: "([0, 1, 2, 3, 4])" }
+      Distinct project=[#0..=#4] // { keys: "([0, 1, 2, 3, 4])" }
         Union // { keys: "()" }
           Map (null, null) // { keys: "()" }
             Union // { keys: "()" }
@@ -672,7 +672,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { keys: "()" }
                       ReadStorage materialize.public.foo_raw // { keys: "()" }
                     ArrangeBy keys=[[#0]] // { keys: "([0])" }
-                      Distinct group_by=[#0] // { keys: "([0])" }
+                      Distinct project=[#0] // { keys: "([0])" }
                         Project (#0) // { keys: "()" }
                           Get l0 // { keys: "()" }
               ReadStorage materialize.public.foo_raw // { keys: "()" }
@@ -714,7 +714,7 @@ Explained Query:
     Get l1
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#4]
+      Distinct project=[#0..=#4]
         Union
           Map (null, null)
             Union
@@ -763,7 +763,7 @@ Explained Query:
     Get l1
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#4]
+      Distinct project=[#0..=#4]
         Union
           Map (null, null)
             Union
@@ -810,7 +810,7 @@ Explained Query:
     Get l5
   With Mutually Recursive
     cte l5 =
-      Distinct group_by=[#0..=#2]
+      Distinct project=[#0..=#2]
         Union
           Project (#7..=#9)
             Map ((#0 + #3), (#1 + #4), (#2 || smallint_to_text((#5 + #6))))
@@ -899,7 +899,7 @@ Explained Query:
     Get l1 // { arity: 3 }
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#2] // { arity: 3 }
+      Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
             Union // { arity: 4 }

--- a/test/sqllogictest/recursive_type_unioning.slt
+++ b/test/sqllogictest/recursive_type_unioning.slt
@@ -23,7 +23,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT row(a,b) as record from t1 union select row(a,b) as record from t2
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Union // { arity: 1 }
       Project (#2) // { arity: 1 }
         Map (row(#0, #1)) // { arity: 3 }

--- a/test/sqllogictest/scalar_subqueries_select_list.slt
+++ b/test/sqllogictest/scalar_subqueries_select_list.slt
@@ -63,7 +63,7 @@ Explained Query:
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
-                  Distinct // { arity: 0 }
+                  Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
                       Get l0 // { arity: 1 }
                 Constant // { arity: 0 }
@@ -102,7 +102,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -128,7 +128,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 1 }
                 ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -165,7 +165,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -201,7 +201,7 @@ Explained Query:
       Filter (#0) IS NOT NULL // { arity: 1 }
         Get l0 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -232,7 +232,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -242,7 +242,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l6 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -287,7 +287,7 @@ Explained Query:
       Filter (#0) IS NOT NULL // { arity: 1 }
         Get l0 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -325,7 +325,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l3 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -335,7 +335,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l4 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -368,7 +368,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 1 }
                 ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -451,7 +451,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 1 }
                 ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -487,7 +487,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l6 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -514,7 +514,7 @@ Explained Query:
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 2 }
                   Get l2 // { arity: 1 }
@@ -538,7 +538,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 1 }
     cte l2 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Get l1 // { arity: 1 }
     cte l1 =
       Project (#0) // { arity: 1 }
@@ -552,7 +552,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 1 }
                 ReadStorage materialize.public.t2 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t3 // { arity: 1 }
 
 Source materialize.public.t1
@@ -602,7 +602,7 @@ Explained Query:
                 Map (null) // { arity: 2 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l7 // { arity: 2 }
                     Get l5 // { arity: 1 }
@@ -625,7 +625,7 @@ Explained Query:
               Get l5 // { arity: 1 }
             Get l1 // { arity: 1 }
     cte l5 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l4 // { arity: 2 }
     cte l4 =
@@ -641,7 +641,7 @@ Explained Query:
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l3 // { arity: 2 }
                   Get l0 // { arity: 1 }
@@ -668,7 +668,7 @@ Explained Query:
         Filter (#0) IS NOT NULL // { arity: 1 }
           ReadStorage materialize.public.t1 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t2 // { arity: 1 }
 
 Source materialize.public.t1
@@ -706,7 +706,7 @@ Explained Query:
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l2 // { arity: 2 }
                 Get l0 // { arity: 1 }
@@ -737,7 +737,7 @@ Explained Query:
               Filter (#0) IS NOT NULL // { arity: 1 }
                 ReadStorage materialize.public.t2 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.t3 // { arity: 1 }
 
 Source materialize.public.t1
@@ -782,7 +782,7 @@ Explained Query:
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Distinct group_by=[#0, #1] // { arity: 2 }
+                  Distinct project=[#0, #1] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
                       Get l3 // { arity: 3 }
                 Get l1 // { arity: 2 }
@@ -808,7 +808,7 @@ Explained Query:
             Filter (#0) IS NOT NULL // { arity: 1 }
               ReadStorage materialize.public.t1 // { arity: 1 }
     cte l1 =
-      Distinct group_by=[#0, #1] // { arity: 2 }
+      Distinct project=[#0, #1] // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
       CrossJoin type=differential // { arity: 2 }
@@ -872,9 +872,9 @@ Return // { arity: 2, types: "(integer, text)" }
                 CrossJoin // { arity: 0, types: "()" }
                   Union // { arity: 0, types: "()" }
                     Negate // { arity: 0, types: "()" }
-                      Distinct // { arity: 0, types: "()" }
+                      Distinct project=[] // { arity: 0, types: "()" }
                         Get l1 // { arity: 1, types: "(integer)" }
-                    Distinct // { arity: 0, types: "()" }
+                    Distinct project=[] // { arity: 0, types: "()" }
                       Constant // { arity: 0, types: "()" }
                         - ()
                   Constant // { arity: 0, types: "()" }

--- a/test/sqllogictest/subquery.slt
+++ b/test/sqllogictest/subquery.slt
@@ -258,7 +258,7 @@ Explained Query:
     ArrangeBy keys=[[]] // { arity: 1 }
       ReadStorage materialize.public.t1 // { arity: 1 }
     ArrangeBy keys=[[]] // { arity: 0 }
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.t2 // { arity: 1 }
 
@@ -277,7 +277,7 @@ Explained Query:
       ArrangeBy keys=[[#0]] // { arity: 2 }
         ReadStorage materialize.public.t3 // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 0 }
-        Distinct // { arity: 0 }
+        Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
             ReadStorage materialize.public.t2 // { arity: 1 }
 
@@ -296,7 +296,7 @@ Explained Query:
       ArrangeBy keys=[[#1]] // { arity: 2 }
         ReadStorage materialize.public.t3 // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 1 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           ReadStorage materialize.public.t2 // { arity: 1 }
 
 EOF
@@ -466,10 +466,10 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               ReadStorage materialize.public.x // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
 
 EOF
@@ -504,10 +504,10 @@ Explained Query:
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Get l0 // { arity: 1 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               ReadStorage materialize.public.x // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
 
 EOF
@@ -536,7 +536,7 @@ Explained Query:
                   Get l0 // { arity: 1 }
   With
     cte l1 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Filter (#0 <= #1) // { arity: 2 }
             CrossJoin type=differential // { arity: 2 }
@@ -547,7 +547,7 @@ Explained Query:
               ArrangeBy keys=[[]] // { arity: 1 }
                 ReadStorage materialize.public.x // { arity: 1 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         ReadStorage materialize.public.y // { arity: 1 }
 
 EOF
@@ -650,7 +650,7 @@ WHERE a IN (9, 0)
 ----
 Explained Query:
   Map (1) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.y // { arity: 1 }
 

--- a/test/sqllogictest/system-cluster.slt
+++ b/test/sqllogictest/system-cluster.slt
@@ -417,7 +417,7 @@ Explained Query:
                 Join on=(#0 = #11) type=differential
                   Get l0
                   ArrangeBy keys=[[#0]]
-                    Distinct group_by=[#0]
+                    Distinct project=[#0]
                       Project (#0)
                         Get l1
           Project (#0, #1, #3, #4, #6)

--- a/test/sqllogictest/topk.slt
+++ b/test/sqllogictest/topk.slt
@@ -105,10 +105,10 @@ Explained Query:
       Map (null) // { arity: 2 }
         Union // { arity: 1 }
           Negate // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               Project (#1) // { arity: 1 }
                 Get l0 // { arity: 2 }
-          Distinct group_by=[#0] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
             Project (#1) // { arity: 1 }
               ReadStorage materialize.public.cities // { arity: 3 }
   With

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -279,7 +279,7 @@ materialize.public.q02:
                     %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                    Distinct group_by=[p_partkey] // { arity: 1 }
+                    Distinct project=[p_partkey] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
@@ -438,12 +438,12 @@ materialize.public.q04:
           ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
           ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-            Distinct group_by=[o_orderkey] // { arity: 1 }
+            Distinct project=[o_orderkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-            Distinct group_by=[l_orderkey] // { arity: 1 }
+            Distinct project=[l_orderkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (l_commitdate < l_receiptdate) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
@@ -1125,10 +1125,10 @@ materialize.public.q13:
                   ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                     Union // { arity: 8 }
                       Negate // { arity: 8 }
-                        Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                        Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                           Project (#0..=#7) // { arity: 8 }
                             Get l0 // { arity: 9 }
-                      Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                      Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
                   ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
@@ -1342,7 +1342,7 @@ materialize.public.q16:
           ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct group_by=[ps_suppkey] // { arity: 1 }
+                Distinct project=[ps_suppkey] // { arity: 1 }
                   Project (#0) // { arity: 1 }
                     Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
@@ -1357,7 +1357,7 @@ materialize.public.q16:
               Get l1 // { arity: 1 }
   With
     cte l1 =
-      Distinct group_by=[ps_suppkey] // { arity: 1 }
+      Distinct project=[ps_suppkey] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
@@ -1440,7 +1440,7 @@ materialize.public.q17:
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct group_by=[l_partkey] // { arity: 1 }
+                        Distinct project=[l_partkey] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
@@ -1527,7 +1527,7 @@ materialize.public.q18:
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
                     ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                      Distinct group_by=[o_orderkey] // { arity: 1 }
+                      Distinct project=[o_orderkey] // { arity: 1 }
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
@@ -1699,7 +1699,7 @@ materialize.public.q20:
         ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
           Get l0 // { arity: 3 }
         ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-          Distinct group_by=[s_suppkey] // { arity: 1 }
+          Distinct project=[s_suppkey] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
                 Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
@@ -1719,7 +1719,7 @@ materialize.public.q20:
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                  Distinct group_by=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                  Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
                                     Project (#1, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
@@ -1731,13 +1731,13 @@ materialize.public.q20:
           implementation
             %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct group_by=[s_suppkey] // { arity: 1 }
+            Distinct project=[s_suppkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get l0 // { arity: 3 }
           ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
             ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
           ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-            Distinct group_by=[p_partkey] // { arity: 1 }
+            Distinct project=[p_partkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
@@ -1827,7 +1827,7 @@ materialize.public.q21:
           ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
             Union // { arity: 2 }
               Negate // { arity: 2 }
-                Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
                     Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
                       Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
@@ -1839,7 +1839,7 @@ materialize.public.q21:
               Get l3 // { arity: 2 }
   With
     cte l3 =
-      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
         Project (#0, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
@@ -1850,14 +1850,14 @@ materialize.public.q21:
           ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-            Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+            Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Filter (s_suppkey != l_suppkey) // { arity: 18 }
                   Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                         Project (#0, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
@@ -1974,13 +1974,13 @@ materialize.public.q22:
                       ArrangeBy keys=[[c_custkey]] // { arity: 1 }
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                        Distinct group_by=[o_custkey] // { arity: 1 }
+                        Distinct project=[o_custkey] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =
-      Distinct group_by=[c_custkey] // { arity: 1 }
+      Distinct project=[c_custkey] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -263,7 +263,7 @@ materialize.public.q02:
                     %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                   ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                    Distinct group_by=[p_partkey] // { arity: 1 }
+                    Distinct project=[p_partkey] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
@@ -404,12 +404,12 @@ materialize.public.q04:
           ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
           ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-            Distinct group_by=[o_orderkey] // { arity: 1 }
+            Distinct project=[o_orderkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
           ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-            Distinct group_by=[l_orderkey] // { arity: 1 }
+            Distinct project=[l_orderkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (l_commitdate < l_receiptdate) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
@@ -1010,10 +1010,10 @@ materialize.public.q13:
                   ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                     Union // { arity: 8 }
                       Negate // { arity: 8 }
-                        Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                        Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                           Project (#0..=#7) // { arity: 8 }
                             Get l0 // { arity: 9 }
-                      Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                      Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
                   ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                     ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
@@ -1203,7 +1203,7 @@ materialize.public.q16:
           ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct group_by=[ps_suppkey] // { arity: 1 }
+                Distinct project=[ps_suppkey] // { arity: 1 }
                   Project (#0) // { arity: 1 }
                     Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
@@ -1218,7 +1218,7 @@ materialize.public.q16:
               Get l1 // { arity: 1 }
   With
     cte l1 =
-      Distinct group_by=[ps_suppkey] // { arity: 1 }
+      Distinct project=[ps_suppkey] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
@@ -1292,7 +1292,7 @@ materialize.public.q17:
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct group_by=[l_partkey] // { arity: 1 }
+                        Distinct project=[l_partkey] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
@@ -1370,7 +1370,7 @@ materialize.public.q18:
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
                     ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                      Distinct group_by=[o_orderkey] // { arity: 1 }
+                      Distinct project=[o_orderkey] // { arity: 1 }
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
@@ -1524,7 +1524,7 @@ materialize.public.q20:
         ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
           Get l0 // { arity: 3 }
         ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-          Distinct group_by=[s_suppkey] // { arity: 1 }
+          Distinct project=[s_suppkey] // { arity: 1 }
             Project (#0) // { arity: 1 }
               Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
                 Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
@@ -1544,7 +1544,7 @@ materialize.public.q20:
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                 ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                  Distinct group_by=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                  Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
                                     Project (#1, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
                                 ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
@@ -1556,13 +1556,13 @@ materialize.public.q20:
           implementation
             %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct group_by=[s_suppkey] // { arity: 1 }
+            Distinct project=[s_suppkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get l0 // { arity: 3 }
           ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
             ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
           ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-            Distinct group_by=[p_partkey] // { arity: 1 }
+            Distinct project=[p_partkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
@@ -1643,7 +1643,7 @@ materialize.public.q21:
           ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
             Union // { arity: 2 }
               Negate // { arity: 2 }
-                Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
                     Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
                       Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
@@ -1655,7 +1655,7 @@ materialize.public.q21:
               Get l3 // { arity: 2 }
   With
     cte l3 =
-      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
         Project (#0, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
@@ -1666,14 +1666,14 @@ materialize.public.q21:
           ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-            Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+            Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
                 Filter (s_suppkey != l_suppkey) // { arity: 18 }
                   Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
                     ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                      Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                         Project (#0, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
@@ -1781,13 +1781,13 @@ materialize.public.q22:
                       ArrangeBy keys=[[c_custkey]] // { arity: 1 }
                         Get l2 // { arity: 1 }
                       ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                        Distinct group_by=[o_custkey] // { arity: 1 }
+                        Distinct project=[o_custkey] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =
-      Distinct group_by=[c_custkey] // { arity: 1 }
+      Distinct project=[c_custkey] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -262,7 +262,7 @@ Explained Query:
                       %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                       %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                      Distinct group_by=[p_partkey] // { arity: 1 }
+                      Distinct project=[p_partkey] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l4 // { arity: 9 }
                     Get l1 // { arity: 5 }
@@ -403,12 +403,12 @@ Explained Query:
             ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
             ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-              Distinct group_by=[o_orderkey] // { arity: 1 }
+              Distinct project=[o_orderkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
                     ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
             ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-              Distinct group_by=[l_orderkey] // { arity: 1 }
+              Distinct project=[l_orderkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (l_commitdate < l_receiptdate) // { arity: 16 }
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
@@ -1008,10 +1008,10 @@ Explained Query:
                     ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                       Union // { arity: 8 }
                         Negate // { arity: 8 }
-                          Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                          Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                             Project (#0..=#7) // { arity: 8 }
                               Get l0 // { arity: 9 }
-                        Distinct group_by=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
+                        Distinct project=[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment] // { arity: 8 }
                           ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
                     ArrangeBy keys=[[c_custkey, c_name, c_address, c_nationkey, c_phone, c_acctbal, c_mktsegment, c_comment]] // { arity: 8 }
                       ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
@@ -1200,7 +1200,7 @@ Explained Query:
             ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct group_by=[ps_suppkey] // { arity: 1 }
+                  Distinct project=[ps_suppkey] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
@@ -1215,7 +1215,7 @@ Explained Query:
                 Get l1 // { arity: 1 }
     With
       cte l1 =
-        Distinct group_by=[ps_suppkey] // { arity: 1 }
+        Distinct project=[ps_suppkey] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 4 }
       cte l0 =
@@ -1288,7 +1288,7 @@ Explained Query:
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
                       ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct group_by=[l_partkey] // { arity: 1 }
+                        Distinct project=[l_partkey] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
@@ -1366,7 +1366,7 @@ Explained Query:
                       implementation
                         %0[#0]UKA » %1:l0[#0]KA
                       ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                        Distinct group_by=[o_orderkey] // { arity: 1 }
+                        Distinct project=[o_orderkey] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l1 // { arity: 6 }
                       Get l0 // { arity: 16 }
@@ -1519,7 +1519,7 @@ Explained Query:
           ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
             Get l0 // { arity: 3 }
           ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-            Distinct group_by=[s_suppkey] // { arity: 1 }
+            Distinct project=[s_suppkey] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
                   Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
@@ -1539,7 +1539,7 @@ Explained Query:
                                   implementation
                                     %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
                                   ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                    Distinct group_by=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                    Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
                                       Project (#1, #2) // { arity: 2 }
                                         Get l1 // { arity: 4 }
                                   ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
@@ -1551,13 +1551,13 @@ Explained Query:
             implementation
               %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
             ArrangeBy keys=[[]] // { arity: 1 }
-              Distinct group_by=[s_suppkey] // { arity: 1 }
+              Distinct project=[s_suppkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 3 }
             ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
             ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-              Distinct group_by=[p_partkey] // { arity: 1 }
+              Distinct project=[p_partkey] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
@@ -1638,7 +1638,7 @@ Explained Query:
             ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                  Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
                       Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
                         Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
@@ -1650,7 +1650,7 @@ Explained Query:
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+        Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
@@ -1661,14 +1661,14 @@ Explained Query:
             ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
               Get l0 // { arity: 3 }
             ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-              Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+              Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
                   Filter (s_suppkey != l_suppkey) // { arity: 18 }
                     Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
                       implementation
                         %1:l1[#0]KA » %0[#0]K
                       ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                        Distinct group_by=[l_orderkey, s_suppkey] // { arity: 2 }
+                        Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
                           Project (#0, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                       Get l1 // { arity: 16 }
@@ -1776,13 +1776,13 @@ Explained Query:
                         ArrangeBy keys=[[c_custkey]] // { arity: 1 }
                           Get l2 // { arity: 1 }
                         ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                          Distinct group_by=[o_custkey] // { arity: 1 }
+                          Distinct project=[o_custkey] // { arity: 1 }
                             Project (#1) // { arity: 1 }
                               ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct group_by=[c_custkey] // { arity: 1 }
+        Distinct project=[c_custkey] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 3 }
       cte l1 =

--- a/test/sqllogictest/transform/aggregation_nullability.slt
+++ b/test/sqllogictest/transform/aggregation_nullability.slt
@@ -37,7 +37,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l0 // { arity: 1 }
               Get l1 // { arity: 1 }
           Project (#0, #0) // { arity: 2 }
@@ -120,7 +120,7 @@ Explained Query:
                   ArrangeBy keys=[[#0]] // { arity: 2 }
                     ReadStorage materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l0 // { arity: 2 }
             ReadStorage materialize.public.t1 // { arity: 2 }
@@ -163,7 +163,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       ReadStorage materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l0 // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }
@@ -206,7 +206,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       ReadStorage materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l0 // { arity: 2 }
               ReadStorage materialize.public.t1 // { arity: 2 }
@@ -324,7 +324,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l0 // { arity: 2 }
               Get l1 // { arity: 1 }
@@ -424,7 +424,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Get l1 // { arity: 1 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l0 // { arity: 1 }
               Get l1 // { arity: 1 }
           Project (#0, #0) // { arity: 2 }
@@ -470,7 +470,7 @@ Explained Query:
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l0 // { arity: 2 }
             Get l1 // { arity: 1 }
@@ -515,7 +515,7 @@ Explained Query:
                   ArrangeBy keys=[[#0]] // { arity: 1 }
                     Get l1 // { arity: 1 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l0 // { arity: 2 }
             Get l1 // { arity: 1 }
@@ -639,7 +639,7 @@ Explained Query:
                   ArrangeBy keys=[[#1]] // { arity: 2 }
                     ReadStorage materialize.public.t1 // { arity: 2 }
                   ArrangeBy keys=[[#0]] // { arity: 1 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Project (#1) // { arity: 1 }
                         Get l0 // { arity: 3 }
             ReadStorage materialize.public.t1 // { arity: 2 }
@@ -680,7 +680,7 @@ Explained Query:
                     ArrangeBy keys=[[#1]] // { arity: 2 }
                       ReadStorage materialize.public.t1 // { arity: 2 }
                     ArrangeBy keys=[[#0]] // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           Get l0 // { arity: 3 }
               ReadStorage materialize.public.t1 // { arity: 2 }
@@ -829,10 +829,10 @@ Explained Query:
                         Union // { arity: 2 }
                           Map (6) // { arity: 2 }
                             Negate // { arity: 1 }
-                              Distinct group_by=[#0] // { arity: 1 }
+                              Distinct project=[#0] // { arity: 1 }
                                 Project (#1) // { arity: 1 }
                                   Get l0 // { arity: 2 }
-                          Distinct group_by=[#0, #1] // { arity: 2 }
+                          Distinct project=[#0, #1] // { arity: 2 }
                             ReadStorage materialize.public.t3 // { arity: 2 }
                       ArrangeBy keys=[[#0, #1]] // { arity: 2 }
                         ReadStorage materialize.public.t3 // { arity: 2 }
@@ -894,10 +894,10 @@ Explained Query:
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l0 // { arity: 2 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       ReadStorage materialize.public.t2 // { arity: 1 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
                   ReadStorage materialize.public.t2 // { arity: 1 }

--- a/test/sqllogictest/transform/column_knowledge.slt
+++ b/test/sqllogictest/transform/column_knowledge.slt
@@ -281,7 +281,7 @@ Explained Query:
               Map (null) // { arity: 1 }
                 Union // { arity: 0 }
                   Negate // { arity: 0 }
-                    Distinct // { arity: 0 }
+                    Distinct project=[] // { arity: 0 }
                       Project () // { arity: 0 }
                         Get l0 // { arity: 1 }
                   Constant // { arity: 0 }
@@ -595,7 +595,7 @@ Explained Query:
   With Mutually Recursive
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
-        Distinct // { arity: 0, types: "()" }
+        Distinct project=[] // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
@@ -629,7 +629,7 @@ Explained Query:
   With Mutually Recursive [recursion_limit=1]
     cte l0 =
       Map (3, 5) // { arity: 2, types: "(integer, integer)" }
-        Distinct // { arity: 0, types: "()" }
+        Distinct project=[] // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Filter (#0 = 3) AND (#1 = 5) // { arity: 2, types: "(integer, integer)" }
@@ -662,7 +662,7 @@ Explained Query:
       Get l0 // { arity: 2, types: "(integer?, integer?)" }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+      Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
         Union // { arity: 2, types: "(integer?, integer?)" }
           Filter (#1) IS NOT NULL // { arity: 2, types: "(integer, integer)" }
             ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
@@ -693,7 +693,7 @@ Explained Query:
         Get l0 // { arity: 2, types: "(integer?, integer?)" }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+      Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
         Union // { arity: 2, types: "(integer?, integer?)" }
           ReadStorage materialize.public.t1 // { arity: 2, types: "(integer, integer?)" }
           Filter (#1) IS NOT NULL // { arity: 2, types: "(integer?, integer)" }
@@ -724,7 +724,7 @@ Explained Query:
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(integer, integer?, integer?)" }
         Map (2) // { arity: 3, types: "(integer?, integer?, integer)" }
-          Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+          Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
             Union // { arity: 2, types: "(integer?, integer?)" }
               CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
                 ArrangeBy keys=[[]] // { arity: 0, types: "()" }
@@ -736,7 +736,7 @@ Explained Query:
                 Get l1 // { arity: 3, types: "(integer?, integer?, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
-        Distinct monotonic // { arity: 0, types: "()" }
+        Distinct project=[] monotonic // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Get l0 // { arity: 1, types: "(integer?)" }
@@ -773,7 +773,7 @@ Explained Query:
     cte l1 =
       Project (#2, #0, #1) // { arity: 3, types: "(boolean, integer?, integer?)" }
         Map (false) // { arity: 3, types: "(integer?, integer?, boolean)" }
-          Distinct group_by=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
+          Distinct project=[#0, #1] // { arity: 2, types: "(integer?, integer?)" }
             Union // { arity: 2, types: "(integer?, integer?)" }
               CrossJoin type=differential // { arity: 2, types: "(integer, integer?)" }
                 ArrangeBy keys=[[]] // { arity: 0, types: "()" }
@@ -785,7 +785,7 @@ Explained Query:
                 Get l1 // { arity: 3, types: "(boolean?, integer?, integer?)" }
     cte l0 =
       Map (1) // { arity: 1, types: "(integer)" }
-        Distinct monotonic // { arity: 0, types: "()" }
+        Distinct project=[] monotonic // { arity: 0, types: "()" }
           Union // { arity: 0, types: "()" }
             Project () // { arity: 0, types: "()" }
               Get l0 // { arity: 1, types: "(integer?)" }

--- a/test/sqllogictest/transform/demand.slt
+++ b/test/sqllogictest/transform/demand.slt
@@ -65,7 +65,7 @@ Explained Query:
                 Map ((#0 + 1), -(#1)) // { arity: 4 }
                   Get l0 // { arity: 2 }
     cte l0 =
-      Distinct group_by=[#0, #1] // { arity: 2 }
+      Distinct project=[#0, #1] // { arity: 2 }
         Union // { arity: 2 }
           Filter (#0) IS NOT NULL // { arity: 2 }
             Get l1 // { arity: 2 }

--- a/test/sqllogictest/transform/fold_constants.slt
+++ b/test/sqllogictest/transform/fold_constants.slt
@@ -96,11 +96,11 @@ Explained Query:
     Get l0 // { arity: 2 }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] monotonic // { arity: 2 }
+      Distinct project=[#0, #1] monotonic // { arity: 2 }
         Union // { arity: 2 }
-          Distinct group_by=[#0, #1] monotonic // { arity: 2 }
+          Distinct project=[#0, #1] monotonic // { arity: 2 }
             Union // { arity: 2 }
-              Distinct group_by=[#0, #1] monotonic // { arity: 2 }
+              Distinct project=[#0, #1] monotonic // { arity: 2 }
                 Union // { arity: 2 }
                   Get l0 // { arity: 2 }
                   Constant // { arity: 2 }
@@ -136,7 +136,7 @@ Explained Query:
     Get l0 // { arity: 1 }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Union // { arity: 1 }
           Project (#1) // { arity: 1 }
             ReadStorage materialize.public.edges // { arity: 2 }

--- a/test/sqllogictest/transform/is_null_propagation.slt
+++ b/test/sqllogictest/transform/is_null_propagation.slt
@@ -56,7 +56,7 @@ Explained Query:
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct group_by=[#0] // { arity: 1 }
+          Distinct project=[#0] // { arity: 1 }
             Union // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter (#0 = bigint_to_double(#1)) // { arity: 2 }
@@ -92,7 +92,7 @@ Explained Query:
               ArrangeBy keys=[[]] // { arity: 1 }
                 Get l0 // { arity: 1 }
     cte l1 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Get l0 // { arity: 1 }
     cte l0 =
       Project (#1) // { arity: 1 }

--- a/test/sqllogictest/transform/lifting.slt
+++ b/test/sqllogictest/transform/lifting.slt
@@ -81,7 +81,7 @@ select a, b from t where a = 1 group by a, b
 Explained Query:
   Project (#1, #0) // { arity: 2 }
     Map (1) // { arity: 2 }
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Project (#1) // { arity: 1 }
           Filter (#0 = 1) // { arity: 2 }
             ReadStorage materialize.public.t // { arity: 2 }
@@ -97,7 +97,7 @@ select a, b from t where b = 1 group by a, b
 ----
 Explained Query:
   Map (1) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         Filter (#1 = 1) // { arity: 2 }
           ReadStorage materialize.public.t // { arity: 2 }
@@ -297,7 +297,7 @@ explain with(arity, join_impls) select 123 from (select distinct 234 from t);
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -308,7 +308,7 @@ explain with(arity, join_impls) select distinct 123 from (select 234 from t);
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -319,7 +319,7 @@ explain with(arity, join_impls) select distinct 123 from (select distinct 234 fr
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -332,7 +332,7 @@ explain with(arity, join_impls) select * from (select distinct 123 from t);
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -343,7 +343,7 @@ explain with(arity, join_impls) select distinct * from (select 123 from t);
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -367,7 +367,7 @@ explain with(arity, join_impls) select 123 from (select distinct a from t);
 Explained Query:
   Project (#1) // { arity: 1 }
     Map (123) // { arity: 2 }
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
           ReadStorage materialize.public.t // { arity: 2 }
 
@@ -378,7 +378,7 @@ explain with(arity, join_impls) select distinct 123 from (select a from t);
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -389,7 +389,7 @@ explain with(arity, join_impls) select distinct 123 from (select distinct a from
 ----
 Explained Query:
   Map (123) // { arity: 1 }
-    Distinct // { arity: 0 }
+    Distinct project=[] // { arity: 0 }
       Project () // { arity: 0 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -402,7 +402,7 @@ explain with(arity, join_impls) select distinct a1.a, a1.literal from (select a,
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -413,7 +413,7 @@ explain with(arity, join_impls) select a1.a, a1.literal from (select distinct a,
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -424,7 +424,7 @@ explain with(arity, join_impls) select a1.a, a1.literal from (select distinct a,
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -435,7 +435,7 @@ explain with(arity, join_impls) select distinct a1.a, a1.literal from (select di
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -448,7 +448,7 @@ explain with(arity, join_impls) select distinct a1.a, 123 from (select a from t)
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -459,7 +459,7 @@ explain with(arity, join_impls) select distinct a1.a, 123 from (select distinct 
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -470,7 +470,7 @@ query T multiline
 explain with(arity, join_impls) select distinct a1.a+2 from (select distinct a+1 as a, 123 as literal from t) as a1;
 ----
 Explained Query:
-  Distinct group_by=[((#0 + 1) + 2)] // { arity: 1 }
+  Distinct project=[((#0 + 1) + 2)] // { arity: 1 }
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 2 }
 
@@ -481,7 +481,7 @@ explain with(arity, join_impls) select distinct a1.a, 123 from (select distinct 
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[(#0 + 1)] // { arity: 1 }
+    Distinct project=[(#0 + 1)] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -492,7 +492,7 @@ explain with(arity, join_impls) select distinct a1.a+2, a1.literal from (select 
 ----
 Explained Query:
   Map (123) // { arity: 2 }
-    Distinct group_by=[((#0 + 1) + 2)] // { arity: 1 }
+    Distinct project=[((#0 + 1) + 2)] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -504,7 +504,7 @@ explain with(arity, join_impls) select distinct a1.a, a1.literal + 1 from (selec
 ----
 Explained Query:
   Map (124) // { arity: 2 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         ReadStorage materialize.public.t // { arity: 2 }
 
@@ -577,7 +577,7 @@ select a, b, min(2), max(3) from t where b = 1 group by a, b;
 ----
 Explained Query:
   Map (1, 2, 3) // { arity: 4 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         Filter (#1 = 1) // { arity: 2 }
           ReadStorage materialize.public.t // { arity: 2 }
@@ -604,7 +604,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.t // { arity: 2 }
 
@@ -626,7 +626,7 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           ReadStorage materialize.public.t // { arity: 2 }
 

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -1232,7 +1232,7 @@ Explained Query:
     Get l0
   With Mutually Recursive [recursion_limit=3, return_at_limit]
     cte l0 =
-      Distinct group_by=[#0]
+      Distinct project=[#0]
         Union
           ReadIndex on=t5 idx_t5_f1=[*** full scan ***]
           Project (#2)

--- a/test/sqllogictest/transform/literal_lifting.slt
+++ b/test/sqllogictest/transform/literal_lifting.slt
@@ -38,9 +38,9 @@ Explained Query:
   With Mutually Recursive
     cte l0 =
       Map (42) // { arity: 2 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Union // { arity: 1 }
-            Distinct group_by=[#0] // { arity: 1 }
+            Distinct project=[#0] // { arity: 1 }
               Union // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 2 }
@@ -76,13 +76,13 @@ Explained Query:
   With Mutually Recursive
     cte l1 =
       Map (42) // { arity: 2 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Union // { arity: 1 }
             Get l0 // { arity: 1 }
             Project (#0) // { arity: 1 }
               Get l1 // { arity: 2 }
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Union // { arity: 1 }
           Project (#0) // { arity: 1 }
             ReadStorage materialize.public.t1 // { arity: 2 }

--- a/test/sqllogictest/transform/monotonic.slt
+++ b/test/sqllogictest/transform/monotonic.slt
@@ -82,14 +82,14 @@ SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
 Explained Query:
   Return
     Reduce group_by=[#0] aggregates=[max(#1)] monotonic
-      Distinct group_by=[#0, #1] monotonic
+      Distinct project=[#0, #1] monotonic
         Union
           Get l0
           Get l1
   With Mutually Recursive
     cte l1 =
       Union
-        Distinct group_by=[#0, (#0 + 1)] monotonic
+        Distinct project=[#0, (#0 + 1)] monotonic
           Project (#0)
             Filter (#0 >= 1)
               Get l0
@@ -99,7 +99,7 @@ Explained Query:
           - (5, 6)
     cte l0 =
       Union
-        Distinct group_by=[#0, (#0 - 1)] monotonic
+        Distinct project=[#0, (#0 - 1)] monotonic
           Project (#1)
             Filter (#0 < 1)
               Get l1
@@ -133,7 +133,7 @@ SELECT x, MAX(y) FROM (SELECT * FROM c1 UNION SELECT * FROM c2) GROUP BY x
 Explained Query:
   Return
     Reduce group_by=[#0] aggregates=[max(#1)]
-      Distinct group_by=[#0, #1]
+      Distinct project=[#0, #1]
         Union
           Get l0
           Get l1
@@ -141,7 +141,7 @@ Explained Query:
     cte l1 =
       TopK limit=2
         Union
-          Distinct group_by=[#0, (#0 + 1)]
+          Distinct project=[#0, (#0 + 1)]
             Project (#0)
               Filter (#0 >= 1)
                 Get l0
@@ -151,7 +151,7 @@ Explained Query:
             - (5, 6)
     cte l0 =
       Union
-        Distinct group_by=[#0, (#0 - 1)]
+        Distinct project=[#0, (#0 - 1)]
           Project (#1)
             Filter (#0 < 1)
               Get l1

--- a/test/sqllogictest/transform/non_null_requirements.slt
+++ b/test/sqllogictest/transform/non_null_requirements.slt
@@ -41,7 +41,7 @@ Explained Query:
   With Mutually Recursive
     cte l0 =
       Map (42) // { arity: 3 }
-        Distinct group_by=[#0, #1] monotonic // { arity: 2 }
+        Distinct project=[#0, #1] monotonic // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l0 // { arity: 3 }
 

--- a/test/sqllogictest/transform/normalize_lets.slt
+++ b/test/sqllogictest/transform/normalize_lets.slt
@@ -23,7 +23,7 @@ Explained Query:
     cte l0 =
       Project (#1)
         Map (1)
-          Distinct group_by=[#0] monotonic
+          Distinct project=[#0] monotonic
             Union
               Project (#1)
                 Map (7)
@@ -128,7 +128,7 @@ Explained Query:
     Get l0
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0]
+      Reduce group_by=[#0]
         Union
           Filter (#0 < 27)
             ReadStorage materialize.public.t1
@@ -185,10 +185,10 @@ Explained Query:
       Get l1
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Get l1
     cte l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Get l0
 
 EOF
@@ -282,7 +282,7 @@ Explained Query:
     Get l0
   With Mutually Recursive [recursion_limit=10]
     cte l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Union
           Project (#1)
             Map ((#0 + 1))
@@ -307,7 +307,7 @@ Explained Query:
     Get l0
   With Mutually Recursive [recursion_limit=10, return_at_limit]
     cte l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Union
           Project (#1)
             Map ((#0 + 1))
@@ -332,7 +332,7 @@ Explained Query:
     Get l0
   With Mutually Recursive [recursion_limit=10]
     cte l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Union
           Project (#1)
             Map ((#0 + 1))
@@ -364,10 +364,10 @@ Explained Query:
       Get l1
   With Mutually Recursive
     cte [recursion_limit=7] l1 =
-      Distinct group_by=[(#0 - 2)] monotonic
+      Distinct project=[(#0 - 2)] monotonic
         Get l1
     cte [recursion_limit=5] l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Get l0
 
 EOF
@@ -395,10 +395,10 @@ Explained Query:
       Get l1
   With Mutually Recursive [recursion_limit=27]
     cte l1 =
-      Distinct group_by=[(#0 - 2)] monotonic
+      Distinct project=[(#0 - 2)] monotonic
         Get l1
     cte l0 =
-      Distinct group_by=[#0] monotonic
+      Distinct project=[#0] monotonic
         Get l0
 
 EOF

--- a/test/sqllogictest/transform/predicate_pushdown.slt
+++ b/test/sqllogictest/transform/predicate_pushdown.slt
@@ -106,7 +106,7 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 ----
 Filter (#0 = 3) // { arity: 1 }
   Union // { arity: 1 }
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Project (#0) // { arity: 1 }
         CrossJoin // { arity: 3 }
           Constant // { arity: 0 }
@@ -126,7 +126,7 @@ SELECT a FROM (SELECT DISTINCT a FROM x UNION ALL SELECT a FROM y) WHERE a = 3
 Explained Query:
   Union // { arity: 1 }
     Map (3) // { arity: 1 }
-      Distinct // { arity: 0 }
+      Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
           Filter (#0 = 3) // { arity: 3 }
             ReadStorage materialize.public.x // { arity: 3 }
@@ -445,7 +445,7 @@ Explained Query:
             Project (#0)
               Join on=(#0 = #1) type=differential
                 ArrangeBy keys=[[#0]]
-                  Distinct group_by=[#0]
+                  Distinct project=[#0]
                     Get l0
                 ArrangeBy keys=[[#0]]
                   Project (#0)
@@ -681,7 +681,7 @@ SELECT * FROM ((SELECT * FROM c2) UNION (SELECT * FROM c0));
 ----
 Explained Query:
   Return
-    Distinct group_by=[#0]
+    Distinct project=[#0]
       Union
         Get l2
         Get l0

--- a/test/sqllogictest/transform/projection_lifting.slt
+++ b/test/sqllogictest/transform/projection_lifting.slt
@@ -94,7 +94,7 @@ Explained Query:
     Get l1
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#2]
+      Distinct project=[#0..=#2]
         Union
           Project (#1, #3, #0)
             Join on=(#0 = #5 AND #1 = #2 AND #3 = #4) type=differential

--- a/test/sqllogictest/transform/reduce_elision.slt
+++ b/test/sqllogictest/transform/reduce_elision.slt
@@ -42,7 +42,7 @@ Explained Query:
       implementation
         %1:y[#1]UK » %0[#1]K
       ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
-        Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+        Distinct project=[#0, #1] // { arity: 2, keys: "([0, 1])" }
           Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
             ReadStorage materialize.public.x // { arity: 2, keys: "()" }
       ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
@@ -81,7 +81,7 @@ Explained Query:
             implementation
               %1:y[#1]UK » %0[#1]K
             ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
-              Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+              Distinct project=[#0, #1] // { arity: 2, keys: "([0, 1])" }
                 Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
                   ReadStorage materialize.public.x // { arity: 2, keys: "()" }
             ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
@@ -115,19 +115,19 @@ Explained Query:
     Get l0 // { arity: 4, keys: "([0, 1, 2, 3])" }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
+      Distinct project=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
         Union // { arity: 4, keys: "()" }
           Project (#0..=#2, #1) // { arity: 4, keys: "([0, 1])" }
             Join on=(#1 = #3) type=differential // { arity: 4, keys: "([0, 1])" }
               implementation
                 %1:y[#1]UK » %0[#1]K
               ArrangeBy keys=[[#1]] // { arity: 2, keys: "([0, 1])" }
-                Distinct group_by=[#0, #1] // { arity: 2, keys: "([0, 1])" }
+                Distinct project=[#0, #1] // { arity: 2, keys: "([0, 1])" }
                   Filter (#1) IS NOT NULL // { arity: 2, keys: "()" }
                     ReadStorage materialize.public.x // { arity: 2, keys: "()" }
               ArrangeBy keys=[[#1]] // { arity: 2, keys: "([1])" }
                 ReadStorage materialize.public.y // { arity: 2, keys: "([1])" }
-          Distinct group_by=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
+          Distinct project=[#0..=#3] // { arity: 4, keys: "([0, 1, 2, 3])" }
             Get l0 // { arity: 4, keys: "()" }
 
 Source materialize.public.x

--- a/test/sqllogictest/transform/reduce_fusion.slt
+++ b/test/sqllogictest/transform/reduce_fusion.slt
@@ -14,7 +14,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT * FROM t GROUP BY f1, f2, f0
 ----
 Explained Query:
-  Distinct group_by=[#0..=#2] // { arity: 3 }
+  Distinct project=[#0..=#2] // { arity: 3 }
     ReadStorage materialize.public.t // { arity: 3 }
 
 EOF
@@ -23,7 +23,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT r0 FROM (SELECT DISTINCT f1 + 1 as r0, f0 FROM t)
 ----
 Explained Query:
-  Distinct group_by=[(#0 + 1)] // { arity: 1 }
+  Distinct project=[(#0 + 1)] // { arity: 1 }
     Project (#1) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 
@@ -33,7 +33,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1 FROM (SELECT DISTINCT f0, f1 FROM t)
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#1) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 
@@ -43,7 +43,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT FROM (SELECT DISTINCT f0, f1 FROM t)
 ----
 Explained Query:
-  Distinct // { arity: 0 }
+  Distinct project=[] // { arity: 0 }
     Project () // { arity: 0 }
       ReadStorage materialize.public.t // { arity: 3 }
 
@@ -53,7 +53,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT FROM (SELECT DISTINCT f0 FROM (SELECT DISTINCT f0, f1 FROM t));
 ----
 Explained Query:
-  Distinct // { arity: 0 }
+  Distinct project=[] // { arity: 0 }
     Project () // { arity: 0 }
       ReadStorage materialize.public.t // { arity: 3 }
 
@@ -63,7 +63,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT f0 FROM (SELECT f0 FROM t GROUP BY f1 / 10, f0) GROUP BY f0;
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 
@@ -73,7 +73,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT f0 / 20 FROM (SELECT f0 / 10 AS f0 FROM t GROUP BY f0 / 10) GROUP BY f0 / 20;
 ----
 Explained Query:
-  Distinct group_by=[((#0 / 10) / 20)] // { arity: 1 }
+  Distinct project=[((#0 / 10) / 20)] // { arity: 1 }
     Project (#0) // { arity: 1 }
       ReadStorage materialize.public.t // { arity: 3 }
 

--- a/test/sqllogictest/transform/reduction_pushdown.slt
+++ b/test/sqllogictest/transform/reduction_pushdown.slt
@@ -26,11 +26,11 @@ Explained Query:
       implementation
         %0[#1]K » %1[#0]K
       ArrangeBy keys=[[#1]] // { arity: 2 }
-        Distinct group_by=[#0, #1] // { arity: 2 }
+        Distinct project=[#0, #1] // { arity: 2 }
           Filter (#1) IS NOT NULL // { arity: 2 }
             ReadStorage materialize.public.x // { arity: 2 }
       ArrangeBy keys=[[#0]] // { arity: 2 }
-        Distinct group_by=[#1, #0] // { arity: 2 }
+        Distinct project=[#1, #0] // { arity: 2 }
           Filter (#1) IS NOT NULL // { arity: 2 }
             ReadStorage materialize.public.y // { arity: 2 }
 
@@ -68,11 +68,11 @@ Explained Query:
             implementation
               %0[#1]K » %1[#0]K
             ArrangeBy keys=[[#1]] // { arity: 2 }
-              Distinct group_by=[#0, #1] // { arity: 2 }
+              Distinct project=[#0, #1] // { arity: 2 }
                 Filter (#1) IS NOT NULL // { arity: 2 }
                   ReadStorage materialize.public.x // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 2 }
-              Distinct group_by=[#1, #0] // { arity: 2 }
+              Distinct project=[#1, #0] // { arity: 2 }
                 Filter (#1) IS NOT NULL // { arity: 2 }
                   ReadStorage materialize.public.y // { arity: 2 }
         Get l0 // { arity: 4 }

--- a/test/sqllogictest/transform/redundant_join.slt
+++ b/test/sqllogictest/transform/redundant_join.slt
@@ -67,7 +67,7 @@ Explained Query:
     Get l0 // { arity: 3 }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#2] // { arity: 3 }
+      Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
           Get l0 // { arity: 3 }
           Map ((#0 % 2)) // { arity: 3 }
@@ -94,7 +94,7 @@ Explained Query:
     Get l0 // { arity: 3 }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0..=#2] // { arity: 3 }
+      Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
           Get l0 // { arity: 3 }
           Filter (#0) IS NOT NULL // { arity: 3 }
@@ -139,9 +139,9 @@ Explained Query:
           Get l0 // { arity: 1 }
   With Mutually Recursive
     cte l1 =
-      Distinct group_by=[#0..=#2] // { arity: 3 }
+      Distinct project=[#0..=#2] // { arity: 3 }
         Union // { arity: 3 }
-          Distinct group_by=[#0..=#2] // { arity: 3 }
+          Distinct project=[#0..=#2] // { arity: 3 }
             Union // { arity: 3 }
               Get l1 // { arity: 3 }
               Project (#0, #0, #0) // { arity: 3 }
@@ -154,7 +154,7 @@ Explained Query:
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Get l0 // { arity: 1 }
     cte l0 =
-      Distinct group_by=[(#0 % 2)] // { arity: 1 }
+      Distinct project=[(#0 % 2)] // { arity: 1 }
         Project (#0) // { arity: 1 }
           ReadStorage materialize.public.t2 // { arity: 2 }
 

--- a/test/sqllogictest/transform/relation_cse.slt
+++ b/test/sqllogictest/transform/relation_cse.slt
@@ -270,7 +270,7 @@ Explained Query:
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
-                Distinct // { arity: 0 }
+                Distinct project=[] // { arity: 0 }
                   Project () // { arity: 0 }
                     Get l0 // { arity: 1 }
               Constant // { arity: 0 }
@@ -405,7 +405,7 @@ Explained Query:
   Return // { arity: 2 }
     Project (#1, #0) // { arity: 2 }
       Map (1) // { arity: 2 }
-        Distinct group_by=[#0] // { arity: 1 }
+        Distinct project=[#0] // { arity: 1 }
           Union // { arity: 1 }
             Get l0 // { arity: 1 }
             Get l0 // { arity: 1 }
@@ -442,7 +442,7 @@ Explained Query:
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
-                  Distinct // { arity: 0 }
+                  Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
                       Get l1 // { arity: 1 }
                 Constant // { arity: 0 }
@@ -500,7 +500,7 @@ Explained Query:
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
-                Distinct // { arity: 0 }
+                Distinct project=[] // { arity: 0 }
                   Project () // { arity: 0 }
                     Get l1 // { arity: 1 }
               Constant // { arity: 0 }
@@ -541,7 +541,7 @@ Explained Query:
         Project () // { arity: 0 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
       ArrangeBy keys=[[]] // { arity: 0 }
-        Distinct // { arity: 0 }
+        Distinct project=[] // { arity: 0 }
           Get l1 // { arity: 0 }
       ArrangeBy keys=[[]] // { arity: 1 }
         Union // { arity: 1 }
@@ -549,7 +549,7 @@ Explained Query:
           Map (null) // { arity: 1 }
             Union // { arity: 0 }
               Negate // { arity: 0 }
-                Distinct // { arity: 0 }
+                Distinct project=[] // { arity: 0 }
                   Project () // { arity: 0 }
                     Get l2 // { arity: 1 }
               Constant // { arity: 0 }
@@ -595,7 +595,7 @@ Explained Query:
             Map (null) // { arity: 1 }
               Union // { arity: 0 }
                 Negate // { arity: 0 }
-                  Distinct // { arity: 0 }
+                  Distinct project=[] // { arity: 0 }
                     Project () // { arity: 0 }
                       Get l2 // { arity: 1 }
                 Constant // { arity: 0 }
@@ -681,7 +681,7 @@ Explained Query:
                   %1[#0]UKA » %0:l0[#0]KA
                 Get l0 // { arity: 2 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct group_by=[#0] // { arity: 1 }
+                  Distinct project=[#0] // { arity: 1 }
                     Project (#0) // { arity: 1 }
                       Get l1 // { arity: 3 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
@@ -894,7 +894,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
-          Distinct // { arity: 0 }
+          Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -1018,7 +1018,7 @@ Explained Query:
       Get l0 // { arity: 1 }
   With
     cte l0 =
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Project (#0) // { arity: 1 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
 
@@ -1142,7 +1142,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
-          Distinct // { arity: 0 }
+          Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -1176,7 +1176,7 @@ Explained Query:
         ArrangeBy keys=[[]] // { arity: 2 }
           ReadIndex on=t1 i1=[*** full scan ***] // { arity: 2 }
         ArrangeBy keys=[[]] // { arity: 0 }
-          Distinct // { arity: 0 }
+          Distinct project=[] // { arity: 0 }
             Project () // { arity: 0 }
               ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -1209,7 +1209,7 @@ Explained Query:
   With
     cte l0 =
       ArrangeBy keys=[[]] // { arity: 0 }
-        Distinct // { arity: 0 }
+        Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
             ReadIndex on=materialize.public.t1 i1=[lookup value=(1)] // { arity: 3 }
 
@@ -1593,7 +1593,7 @@ Explained Query:
                     ArrangeBy keys=[[#0]] // { arity: 1 }
                       Union // { arity: 1 }
                         Negate // { arity: 1 }
-                          Distinct group_by=[#0] // { arity: 1 }
+                          Distinct project=[#0] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l5 // { arity: 2 }
                         Constant // { arity: 1 }
@@ -1663,7 +1663,7 @@ Explained Query:
   With Mutually Recursive
     cte l1 =
       Union // { arity: 2 }
-        Distinct group_by=[#0, (#1 + #2)] monotonic // { arity: 2 }
+        Distinct project=[#0, (#1 + #2)] monotonic // { arity: 2 }
           Project (#0, #1, #3) // { arity: 3 }
             Join on=(#0 = #2) type=differential // { arity: 4 }
               implementation

--- a/test/sqllogictest/transform/threshold_elision.slt
+++ b/test/sqllogictest/transform/threshold_elision.slt
@@ -115,11 +115,11 @@ SELECT name FROM people WHERE id > 1
 ----
 Explained Query:
   Union // { non_negative: false }
-    Distinct group_by=[#0] // { non_negative: true }
+    Distinct project=[#0] // { non_negative: true }
       Project (#1) // { non_negative: true }
         ReadStorage materialize.public.people // { non_negative: true }
     Negate // { non_negative: false }
-      Distinct group_by=[#0] // { non_negative: true }
+      Distinct project=[#0] // { non_negative: true }
         Project (#1) // { non_negative: true }
           Filter (#0 > 1) // { non_negative: true }
             ReadStorage materialize.public.people // { non_negative: true }
@@ -268,7 +268,7 @@ Explained Query:
           Get l0 // { non_negative: true }
   With
     cte l0 =
-      Distinct group_by=[#0] // { non_negative: true }
+      Distinct project=[#0] // { non_negative: true }
         Project (#1) // { non_negative: true }
           ReadStorage materialize.public.people // { non_negative: true }
 
@@ -328,7 +328,7 @@ Explained Query:
           Get l0 // { non_negative: false }
   With
     cte l0 =
-      Distinct group_by=[#0..=#3] // { non_negative: false }
+      Distinct project=[#0..=#3] // { non_negative: false }
         Union // { non_negative: false }
           ReadStorage materialize.public.people // { non_negative: true }
           Negate // { non_negative: false }
@@ -391,7 +391,7 @@ Explained Query:
     Get l0 // { non_negative: false }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] // { non_negative: false }
+      Distinct project=[#0, #1] // { non_negative: false }
         Union // { non_negative: false }
           Project (#0, #2) // { non_negative: false }
             Map ((#1 || "_init")) // { non_negative: false }
@@ -441,17 +441,17 @@ Explained Query:
           Filter (#0 > 2) // { non_negative: true }
             Get l0 // { non_negative: true }
     cte l0 =
-      Distinct group_by=[#0, #1] // { non_negative: true }
+      Distinct project=[#0, #1] // { non_negative: true }
         Union // { non_negative: true }
           Project (#0, #4) // { non_negative: true }
             Map ((#1 || "_init")) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
           Threshold // { non_negative: true }
             Union // { non_negative: false }
-              Distinct group_by=[#0, (#1 || "_iter")] // { non_negative: false }
+              Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
                 Get l1 // { non_negative: false }
               Negate // { non_negative: false }
-                Distinct group_by=[#0, (#1 || "_iter")] // { non_negative: false }
+                Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
                   Filter (#0 > 1) // { non_negative: false }
                     Get l1 // { non_negative: false }
 
@@ -480,17 +480,17 @@ Explained Query:
     Get l0 // { non_negative: true }
   With Mutually Recursive
     cte l0 =
-      Distinct group_by=[#0, #1] // { non_negative: true }
+      Distinct project=[#0, #1] // { non_negative: true }
         Union // { non_negative: true }
           Project (#0, #4) // { non_negative: true }
             Map ((#1 || "_init")) // { non_negative: true }
               ReadStorage materialize.public.people // { non_negative: true }
           Threshold // { non_negative: true }
             Union // { non_negative: false }
-              Distinct group_by=[#0, (#1 || "_iter")] // { non_negative: false }
+              Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
                 Get l0 // { non_negative: false }
               Negate // { non_negative: false }
-                Distinct group_by=[#0, (#1 || "_iter")] // { non_negative: false }
+                Distinct project=[#0, (#1 || "_iter")] // { non_negative: false }
                   Filter (#0 > 1) // { non_negative: false }
                     Get l0 // { non_negative: false }
 

--- a/test/sqllogictest/transform/union.slt
+++ b/test/sqllogictest/transform/union.slt
@@ -147,7 +147,7 @@ Explained Query:
             ArrangeBy keys=[[#0]] // { arity: 2 }
               ReadStorage materialize.public.t3 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
-              Distinct group_by=[#0] // { arity: 1 }
+              Distinct project=[#0] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 2 }
       ReadStorage materialize.public.t3 // { arity: 2 }

--- a/test/sqllogictest/uniqueness_propagation_filter.slt
+++ b/test/sqllogictest/uniqueness_propagation_filter.slt
@@ -142,7 +142,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1 FROM v1 WHERE f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#0) // { arity: 1 }
       Filter (#0 = #2) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -156,7 +156,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1, f2 FROM v1 WHERE f1 + 1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1] // { arity: 2 }
+  Distinct project=[#0, #1] // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Filter (#2 = (#0 + 1)) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -170,7 +170,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1, f2 FROM v1 WHERE f1 > f3;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1] // { arity: 2 }
+  Distinct project=[#0, #1] // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Filter (#0 > #2) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -184,7 +184,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1 + 1, f2 FROM v1 WHERE f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[(#0 + 1), #1] // { arity: 2 }
+  Distinct project=[(#0 + 1), #1] // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Filter (#0 = #2) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -198,7 +198,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f2, f3 FROM v1 WHERE f1 = f2 OR f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1] // { arity: 2 }
+  Distinct project=[#0, #1] // { arity: 2 }
     Project (#1, #2) // { arity: 2 }
       Filter ((#0 = #1) OR (#0 = #2)) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -212,7 +212,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1 + 1 , f2 FROM v1 WHERE f1 + 1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[(#0 + 1), #1] // { arity: 2 }
+  Distinct project=[(#0 + 1), #1] // { arity: 2 }
     Project (#0, #1) // { arity: 2 }
       Filter (#2 = (#0 + 1)) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -226,7 +226,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f1 FROM v1 WHERE f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#0) // { arity: 1 }
       Filter (#0 = #2) // { arity: 3 }
         ReadIndex on=v1 v1_primary_idx=[*** full scan ***] // { arity: 3 }
@@ -316,7 +316,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f2, f3 FROM t2 WHERE f3 = f4;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1] // { arity: 2 }
+  Distinct project=[#0, #1] // { arity: 2 }
     Project (#1, #2) // { arity: 2 }
       Filter (#2 = #3) // { arity: 4 }
         ReadStorage materialize.public.t2 // { arity: 4 }
@@ -330,7 +330,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f2 FROM t2 WHERE f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#1) // { arity: 1 }
       Filter (#0 = #2) // { arity: 4 }
         ReadStorage materialize.public.t2 // { arity: 4 }
@@ -344,7 +344,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f3, f4 FROM t2 WHERE f1 = f3;
 ----
 Explained Query:
-  Distinct group_by=[#0, #1] // { arity: 2 }
+  Distinct project=[#0, #1] // { arity: 2 }
     Project (#2, #3) // { arity: 2 }
       Filter (#0 = #2) // { arity: 4 }
         ReadStorage materialize.public.t2 // { arity: 4 }
@@ -358,7 +358,7 @@ query T multiline
 EXPLAIN WITH(arity, join_impls) SELECT DISTINCT f3 FROM t2 WHERE f1 = f2;
 ----
 Explained Query:
-  Distinct group_by=[#0] // { arity: 1 }
+  Distinct project=[#0] // { arity: 1 }
     Project (#2) // { arity: 1 }
       Filter (#0 = #1) // { arity: 4 }
         ReadStorage materialize.public.t2 // { arity: 4 }

--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -184,9 +184,9 @@ Return // { arity: 1 }
                 Join on=(#0 = #1) // { arity: 2 }
                   Union // { arity: 1 }
                     Negate // { arity: 1 }
-                      Distinct group_by=[#0] // { arity: 1 }
+                      Distinct project=[#0] // { arity: 1 }
                         Get l2 // { arity: 2 }
-                    Distinct group_by=[#0] // { arity: 1 }
+                    Distinct project=[#0] // { arity: 1 }
                       Get l1 // { arity: 1 }
                   Get l1 // { arity: 1 }
               Constant // { arity: 1 }
@@ -194,7 +194,7 @@ Return // { arity: 1 }
 With
   cte l2 =
     Map (true) // { arity: 2 }
-      Distinct group_by=[#0] // { arity: 1 }
+      Distinct project=[#0] // { arity: 1 }
         Filter (integer_to_bigint(#0) = #1) // { arity: 2 }
           Project (#0, #4) // { arity: 2 }
             Map (#3) // { arity: 5 }
@@ -206,7 +206,7 @@ With
                         Get l1 // { arity: 1 }
                         Get materialize.public.t2 // { arity: 2 }
   cte l1 =
-    Distinct group_by=[#0] // { arity: 1 }
+    Distinct project=[#0] // { arity: 1 }
       Get l0 // { arity: 2 }
   cte l0 =
     Filter true // { arity: 2 }
@@ -230,7 +230,7 @@ Explained Query:
         ArrangeBy keys=[[#0]] // { arity: 1 }
           Get l0 // { arity: 1 }
         ArrangeBy keys=[[#0]] // { arity: 1 }
-          Distinct group_by=[record_get[0](record_get[1](#0))] // { arity: 1 }
+          Distinct project=[record_get[0](record_get[1](#0))] // { arity: 1 }
             Project (#1) // { arity: 1 }
               Filter (integer_to_bigint(record_get[0](record_get[1](#1))) = record_get[0](#1)) // { arity: 2 }
                 FlatMap unnest_list(#0) // { arity: 2 }
@@ -240,7 +240,7 @@ Explained Query:
                         implementation
                           %0[×] » %1:t2[×]
                         ArrangeBy keys=[[]] // { arity: 1 }
-                          Distinct group_by=[#0] // { arity: 1 }
+                          Distinct project=[#0] // { arity: 1 }
                             Get l0 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 2 }
                           ReadStorage materialize.public.t2 // { arity: 2 }
@@ -309,7 +309,7 @@ Return // { arity: 5 }
                   Reduce group_by=[#0] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 2 }
                     Filter (#2 = #0) // { arity: 3 }
                       CrossJoin // { arity: 3 }
-                        Distinct group_by=[#1] // { arity: 1 }
+                        Distinct project=[#1] // { arity: 1 }
                           Get l0 // { arity: 2 }
                         Get materialize.public.t1 // { arity: 2 }
 With
@@ -337,7 +337,7 @@ Return // { arity: 5 }
                   Reduce group_by=[#0, #1] aggregates=[row_number[order_by=[]](row(list[row(#0, #1, #2)]))] // { arity: 3 }
                     Filter (#2 = #0) // { arity: 3 }
                       CrossJoin // { arity: 3 }
-                        Distinct group_by=[#1] // { arity: 1 }
+                        Distinct project=[#1] // { arity: 1 }
                           Get l0 // { arity: 2 }
                         Get materialize.public.t1 // { arity: 2 }
 With

--- a/test/testdrive/kafka-include-key-sources.td
+++ b/test/testdrive/kafka-include-key-sources.td
@@ -323,11 +323,11 @@ Used Indexes:
   ENVELOPE NONE
 
 # For ENVELOPE NONE with INCLUDE KEY, uniqueness is not guaranteed,
-# so we expect that query plans will contain an explicit Distinct group_by
+# so we expect that query plans will contain an explicit Distinct on
 
 ? EXPLAIN SELECT DISTINCT named FROM envelope_none_with_key;
 Explained Query:
-  Distinct group_by=[#0] monotonic
+  Distinct project=[#0] monotonic
     Project (#0)
       ReadStorage materialize.public.envelope_none_with_key
 
@@ -335,7 +335,7 @@ Explained Query:
 
 ? EXPLAIN SELECT DISTINCT named FROM envelope_none_with_key;
 Explained Query:
-  Distinct group_by=[#0] monotonic
+  Distinct project=[#0] monotonic
     Project (#0)
       ReadIndex on=envelope_none_with_key envelope_none_with_key_primary_idx=[*** full scan ***]
 

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -84,22 +84,22 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 # Optimization not possible - explicit distinct is present in planFor certain types of tests the 
 
 > EXPLAIN SELECT DISTINCT key1 FROM t1;
-"Explained Query:  Distinct group_by=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key2 FROM t1;
-"Explained Query:  Distinct group_by=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1;
-"Explained Query:  Distinct group_by=[#0, upper(#1)]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0, upper(#1)]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1;
-"Explained Query:  Distinct group_by=[#0, (#1 || \"a\")]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0, (#1 || \"a\")]    Project (#0, #1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key1 FROM t1 GROUP BY key1;
-"Explained Query:  Distinct group_by=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0]    Project (#0)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key2 FROM t1 GROUP BY key2;
-"Explained Query:  Distinct group_by=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0]    Project (#1)      ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1;
 "Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)]        Project (#0)          ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
@@ -195,22 +195,22 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 # Optimization not possible - explicit distinct is present in plan
 
 > EXPLAIN SELECT DISTINCT key1 FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key2 FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key1, upper(key2) FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0, upper(#1)] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0, upper(#1)] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT DISTINCT key1, key2 || 'a' FROM t1_pkne;
-"Explained Query:  Distinct group_by=[#0, (#1 || \"a\")] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0, (#1 || \"a\")] monotonic    Project (#0, #1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key1 FROM t1_pkne GROUP BY key1;
-"Explained Query:  Distinct group_by=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0] monotonic    Project (#0)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key2 FROM t1_pkne GROUP BY key2;
-"Explained Query:  Distinct group_by=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
+"Explained Query:  Distinct project=[#0] monotonic    Project (#1)      ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT COUNT(DISTINCT key1) FROM t1_pkne;
 "Explained Query:  Return    Union      Get l0      Map (0)        Union          Negate            Project ()              Get l0          Constant            - ()  With    cte l0 =      Reduce aggregates=[count(distinct #0)] monotonic        Project (#0)          ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"


### PR DESCRIPTION
### Motivation

   * This PR refactors existing code.

This fixes a source a cause for confusion. Currently `HirRelationExpr` actually has a dedicated `Distinct` variant which means "distinct on all keys", whereas in the `EXPLAIN AS TEXT` output for MIR nodes the `Distinct` node means "distinct on the empty key".

This PR changes the `MirRelationExpr` handling of `Reduce` so we print:

```text
Distinct project=[]
```

for "distinct on the empty key" and 

```text
Distinct project=[#0, #2, #3]
```

for a `Distinct` with a key.

### Tips for reviewer

Most of the PR is rewriting failing tests. The `*.rs*` changes are almost trivial.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Distinct with an empty key is now printed with an empty `on` list in the `EXPLAIN` output.