### PR TITLE
compute,adapter: add logging of selected dataflow `as_of`s

### DIFF
--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -837,6 +837,26 @@ where
             debug_name: dataflow.debug_name,
         };
 
+        if augmented_dataflow.is_transient() {
+            tracing::debug!(
+                name = %augmented_dataflow.debug_name,
+                import_ids = %augmented_dataflow.format_import_ids(),
+                export_ids = %augmented_dataflow.format_export_ids(),
+                as_of = ?augmented_dataflow.as_of.as_ref().unwrap().elements(),
+                until = ?augmented_dataflow.until.elements(),
+                "creating dataflow",
+            );
+        } else {
+            tracing::info!(
+                name = %augmented_dataflow.debug_name,
+                import_ids = %augmented_dataflow.format_import_ids(),
+                export_ids = %augmented_dataflow.format_export_ids(),
+                as_of = ?augmented_dataflow.as_of.as_ref().unwrap().elements(),
+                until = ?augmented_dataflow.until.elements(),
+                "creating dataflow",
+            );
+        }
+
         self.compute
             .send(ComputeCommand::CreateDataflow(augmented_dataflow));
 


### PR DESCRIPTION
To help us better debug timestamp selection bugs in the future, this PR adds more logging around dataflow creation, and especially selected `as_of` frontiers.

The following events are now logged:
* dataflow creation in the controller
* dataflow creation on the replica
* selection of index and MV `as_of`s during bootstrapping

### Motivation

  * This PR fixes a recognized bug.

Helps with https://github.com/MaterializeInc/cloud/issues/7998

### Tips for reviewer

I'm not particularly happy about the boilerplate introduced by the `is_transient` check, but I think we need to somehow make sure dataflow logging doesn't get too noisy when users run large amounts of slow-path SELECTs. Discussion [in Slack](https://materializeinc.slack.com/archives/C03TDG8L76V/p1698757303251359).

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A