### PR TITLE
Ignore mz-prof-http unused dependency in mz-alloc

### DIFF
--- a/src/alloc/Cargo.toml
+++ b/src/alloc/Cargo.toml
@@ -38,4 +38,9 @@ default = ["workspace-hack"]
 jemalloc = ["tikv-jemallocator", "mz-prof/jemalloc", "mz-prof-http/jemalloc"]
 
 [package.metadata.cargo-udeps.ignore]
-normal = ["workspace-hack"]
+# The only reason we depend on mz-prof-http
+# from this package is so that we can force its `jemalloc`
+# option to be enabled when this package's is, which
+# makes all the Materialize binaries correctly
+# serve heap profiling tools at the `/prof` endpoints.
+normal = ["workspace-hack", "mz-prof-http"]


### PR DESCRIPTION
In #22786 we introduced an unused dependency, which is causing the unused dependency checker to fail.

This unused dependency is actually desired (for controlling feature selection), so add it to the ignore list.

### Motivation

  * This PR fixes a recognized bug.

    Reported by Philip in Slack: https://materializeinc.slack.com/archives/C02FWJ94HME/p1698741565850579 .

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
@philip-stoev I don't know how to run the unused deps check; can you verify that this fixes the issue?

- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None