### PR TITLE
CODEOWNERS: add QA for feature flags

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,9 @@
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
 /src/adapter/src/coord/dataflows.rs @MaterializeInc/compute
+# to track changes to feature flags
 /src/adapter/src/coord/ddl.rs       @MaterializeInc/testing
+# to track changes to feature flags
 /src/adapter/src/flags.rs           @MaterializeInc/testing
 /src/alloc                          @benesch
 /src/audit-log                      @MaterializeInc/adapter

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,6 +24,7 @@
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
 /src/adapter/src/coord/dataflows.rs @MaterializeInc/compute
+/src/adapter/src/coord/ddl.rs       @MaterializeInc/testing
 /src/adapter/src/flags.rs           @MaterializeInc/testing
 /src/alloc                          @benesch
 /src/audit-log                      @MaterializeInc/adapter

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,7 @@
 /src/adapter-types                  @MaterializeInc/adapter
 /src/adapter/src/optimizer          @MaterializeInc/compute
 /src/adapter/src/coord/dataflows.rs @MaterializeInc/compute
-/src/adapter/src/flags.rs
+/src/adapter/src/flags.rs           @MaterializeInc/testing
 /src/alloc                          @benesch
 /src/audit-log                      @MaterializeInc/adapter
 /src/avro                           @umanwizard


### PR DESCRIPTION
Adding QA as code owners for
* `./src/adapter/src/flags.rs` (as discussed)
* `./src/adapter/src/coord/ddl.rs` (contains also some references to `SystemVars` and validates values; however, it also contains lots of other stuff...)

Let me know if there are any further files of interest.