### PR TITLE
persist: plumb down an override for the next_listen_batch sleep params

### DIFF
--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -197,6 +197,11 @@ fn persist_config(config: &SystemVars) -> PersistParameters {
             multiplier: config.persist_next_listen_batch_retryer_multiplier(),
             clamp: config.persist_next_listen_batch_retryer_clamp(),
         }),
+        txns_data_shard_retryer: Some(RetryParameters {
+            initial_backoff: config.persist_txns_data_shard_retryer_initial_backoff(),
+            multiplier: config.persist_txns_data_shard_retryer_multiplier(),
+            clamp: config.persist_txns_data_shard_retryer_clamp(),
+        }),
         reader_lease_duration: Some(config.persist_reader_lease_duration()),
         stats_audit_percent: Some(config.persist_stats_audit_percent()),
         stats_collection_enabled: Some(config.persist_stats_collection_enabled()),

--- a/src/persist-client/src/cfg.proto
+++ b/src/persist-client/src/cfg.proto
@@ -21,6 +21,7 @@ message ProtoPersistParameters {
     optional uint64 storage_sink_minimum_batch_updates = 8;
     optional uint64 storage_source_decode_fuel = 21;
     optional ProtoRetryParameters next_listen_batch_retryer = 5;
+    optional ProtoRetryParameters txns_data_shard_retryer = 22;
     optional uint64 stats_audit_percent = 9;
     optional bool stats_collection_enabled = 6;
     optional bool stats_filter_enabled = 7;

--- a/src/persist-client/src/cfg.rs
+++ b/src/persist-client/src/cfg.rs
@@ -205,6 +205,7 @@ impl PersistConfig {
                 pubsub_client_enabled: AtomicBool::new(Self::DEFAULT_PUBSUB_CLIENT_ENABLED),
                 pubsub_push_diff_enabled: AtomicBool::new(Self::DEFAULT_PUBSUB_PUSH_DIFF_ENABLED),
                 rollup_threshold: AtomicUsize::new(Self::DEFAULT_ROLLUP_THRESHOLD),
+                txns_data_shard_retryer: RwLock::new(Self::DEFAULT_TXNS_DATA_SHARD_RETRYER),
                 feature_flags: {
                     // NB: initialized with the full set of feature flags, so the map never needs updating.
                     PersistFeatureFlag::ALL
@@ -340,6 +341,13 @@ impl PersistConfig {
         clamp: Duration::from_secs(16),
     };
 
+    /// Default value for [`DynamicConfig::txns_data_shard_retry_params`].
+    pub const DEFAULT_TXNS_DATA_SHARD_RETRYER: RetryParameters = RetryParameters {
+        initial_backoff: Duration::from_millis(1024),
+        multiplier: 2,
+        clamp: Duration::from_secs(16),
+    };
+
     pub(crate) const DEFAULT_FALLBACK_ROLLUP_THRESHOLD_MULTIPLIER: usize = 3;
 
     /// Default value for [`DynamicConfig::blob_cache_mem_limit_bytes`].
@@ -455,6 +463,7 @@ pub struct DynamicConfig {
     // We put them under a single RwLock to reduce the cost of reads
     // and to logically group them together.
     next_listen_batch_retryer: RwLock<RetryParameters>,
+    txns_data_shard_retryer: RwLock<RetryParameters>,
 }
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Arbitrary, Serialize, Deserialize)]
@@ -723,6 +732,12 @@ impl DynamicConfig {
             .expect("lock poisoned")
     }
 
+    /// Retry configuration for persist-txns data shard override of
+    /// `next_listen_batch`.
+    pub fn txns_data_shard_retry_params(&self) -> RetryParameters {
+        *self.txns_data_shard_retryer.read().expect("lock poisoned")
+    }
+
     // TODO: Get rid of these in favor of using PersistParameters at the
     // relevant callsites.
     #[cfg(test)]
@@ -789,6 +804,8 @@ pub struct PersistParameters {
     pub consensus_connection_pool_ttl_stagger: Option<Duration>,
     /// Configures [`DynamicConfig::next_listen_batch_retry_params`].
     pub next_listen_batch_retryer: Option<RetryParameters>,
+    /// Configures [`DynamicConfig::txns_data_shard_retry_params`].
+    pub txns_data_shard_retryer: Option<RetryParameters>,
     /// Configures [`DynamicConfig::reader_lease_duration`].
     pub reader_lease_duration: Option<Duration>,
     /// Configures [`PersistConfig::sink_minimum_batch_updates`].
@@ -835,6 +852,7 @@ impl PersistParameters {
             storage_sink_minimum_batch_updates: self_storage_sink_minimum_batch_updates,
             storage_source_decode_fuel: self_storage_source_decode_fuel,
             next_listen_batch_retryer: self_next_listen_batch_retryer,
+            txns_data_shard_retryer: self_txns_data_shard_retryer,
             stats_audit_percent: self_stats_audit_percent,
             stats_collection_enabled: self_stats_collection_enabled,
             stats_filter_enabled: self_stats_filter_enabled,
@@ -858,6 +876,7 @@ impl PersistParameters {
             storage_sink_minimum_batch_updates: other_storage_sink_minimum_batch_updates,
             storage_source_decode_fuel: other_storage_source_decode_fuel,
             next_listen_batch_retryer: other_next_listen_batch_retryer,
+            txns_data_shard_retryer: other_txns_data_shard_retryer,
             stats_audit_percent: other_stats_audit_percent,
             stats_collection_enabled: other_stats_collection_enabled,
             stats_filter_enabled: other_stats_filter_enabled,
@@ -903,6 +922,9 @@ impl PersistParameters {
         }
         if let Some(v) = other_next_listen_batch_retryer {
             *self_next_listen_batch_retryer = Some(v);
+        }
+        if let Some(v) = other_txns_data_shard_retryer {
+            *self_txns_data_shard_retryer = Some(v);
         }
         if let Some(v) = other_stats_audit_percent {
             *self_stats_audit_percent = Some(v)
@@ -950,6 +972,7 @@ impl PersistParameters {
             storage_sink_minimum_batch_updates,
             storage_source_decode_fuel,
             next_listen_batch_retryer,
+            txns_data_shard_retryer,
             stats_audit_percent,
             stats_collection_enabled,
             stats_filter_enabled,
@@ -972,6 +995,7 @@ impl PersistParameters {
             && storage_sink_minimum_batch_updates.is_none()
             && storage_source_decode_fuel.is_none()
             && next_listen_batch_retryer.is_none()
+            && txns_data_shard_retryer.is_none()
             && stats_audit_percent.is_none()
             && stats_collection_enabled.is_none()
             && stats_filter_enabled.is_none()
@@ -1003,6 +1027,7 @@ impl PersistParameters {
             storage_sink_minimum_batch_updates,
             storage_source_decode_fuel,
             next_listen_batch_retryer,
+            txns_data_shard_retryer,
             stats_audit_percent,
             stats_collection_enabled,
             stats_filter_enabled,
@@ -1091,6 +1116,14 @@ impl PersistParameters {
                 .expect("lock poisoned");
             *retry = *retry_params;
         }
+        if let Some(retry_params) = txns_data_shard_retryer {
+            let mut retry = cfg
+                .dynamic
+                .txns_data_shard_retryer
+                .write()
+                .expect("lock poisoned");
+            *retry = *retry_params;
+        }
         if let Some(stats_audit_percent) = stats_audit_percent {
             cfg.dynamic
                 .stats_audit_percent
@@ -1161,6 +1194,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
                 .into_proto(),
             storage_source_decode_fuel: self.storage_source_decode_fuel.into_proto(),
             next_listen_batch_retryer: self.next_listen_batch_retryer.into_proto(),
+            txns_data_shard_retryer: self.txns_data_shard_retryer.into_proto(),
             stats_audit_percent: self.stats_audit_percent.into_proto(),
             stats_collection_enabled: self.stats_collection_enabled.into_proto(),
             stats_filter_enabled: self.stats_filter_enabled.into_proto(),
@@ -1192,6 +1226,7 @@ impl RustType<ProtoPersistParameters> for PersistParameters {
                 .into_rust()?,
             storage_source_decode_fuel: proto.storage_source_decode_fuel.into_rust()?,
             next_listen_batch_retryer: proto.next_listen_batch_retryer.into_rust()?,
+            txns_data_shard_retryer: proto.txns_data_shard_retryer.into_rust()?,
             stats_audit_percent: proto.stats_audit_percent.into_rust()?,
             stats_collection_enabled: proto.stats_collection_enabled.into_rust()?,
             stats_filter_enabled: proto.stats_filter_enabled.into_rust()?,

--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -32,6 +32,7 @@ use tracing::{debug, info, trace_span, warn, Instrument};
 
 use crate::async_runtime::IsolatedRuntime;
 use crate::cache::StateCache;
+use crate::cfg::RetryParameters;
 use crate::critical::CriticalReaderId;
 use crate::error::{CodecMismatch, InvalidUsage};
 use crate::internal::apply::Applier;
@@ -834,6 +835,8 @@ where
         frontier: &Antichain<T>,
         watch: &mut StateWatch<K, V, T, D>,
         reader_id: Option<&LeasedReaderId>,
+        // If Some, an override for the default listen sleep retry parameters.
+        retry: Option<RetryParameters>,
     ) -> HollowBatch<T> {
         let mut seqno = match self.applier.next_listen_batch(frontier) {
             Ok(b) => return b,
@@ -842,14 +845,14 @@ where
 
         // The latest state still doesn't have a new frontier for us:
         // watch+sleep in a loop until it does.
-        let sleeps = self.applier.metrics.retries.next_listen_batch.stream(
-            self.applier
-                .cfg
-                .dynamic
-                .next_listen_batch_retry_params()
-                .into_retry(SystemTime::now())
-                .into_retry_stream(),
-        );
+        let retry =
+            retry.unwrap_or_else(|| self.applier.cfg.dynamic.next_listen_batch_retry_params());
+        let sleeps = self
+            .applier
+            .metrics
+            .retries
+            .next_listen_batch
+            .stream(retry.into_retry(SystemTime::now()).into_retry_stream());
 
         enum Wake<'a, K, V, T, D> {
             Watch(&'a mut StateWatch<K, V, T, D>),

--- a/src/persist-client/src/internal/watch.rs
+++ b/src/persist-client/src/internal/watch.rs
@@ -304,7 +304,7 @@ mod tests {
             .unwrap();
         let mut snapshot = Box::pin(read.snapshot(Antichain::from_elem(0)));
         assert!(Pin::new(&mut snapshot).poll(&mut cx).is_pending());
-        let mut listen_next_batch = Box::pin(listen.next());
+        let mut listen_next_batch = Box::pin(listen.next(None));
         assert!(Pin::new(&mut listen_next_batch).poll(&mut cx).is_pending());
 
         // Now update the frontier, which should allow the snapshot to resolve

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -33,7 +33,7 @@ use tokio::task::JoinHandle;
 use tracing::{debug_span, instrument, warn, Instrument};
 use uuid::Uuid;
 
-use crate::cfg::PersistFeatureFlag;
+use crate::cfg::{PersistFeatureFlag, RetryParameters};
 use crate::fetch::{
     fetch_leased_part, BatchFetcher, FetchBatchFilter, FetchedPart, LeasedBatchPart,
     SerdeLeasedBatchPart, SerdeLeasedBatchPartMetadata,
@@ -132,14 +132,18 @@ where
     /// The returned `Antichain` represents the subscription progress as it will
     /// be _after_ the returned parts are fetched.
     #[instrument(level = "debug", skip_all, fields(shard = %self.listen.handle.machine.shard_id()))]
-    pub async fn next(&mut self) -> Vec<ListenEvent<T, LeasedBatchPart<T>>> {
+    pub async fn next(
+        &mut self,
+        // If Some, an override for the default listen sleep retry parameters.
+        listen_retry: Option<RetryParameters>,
+    ) -> Vec<ListenEvent<T, LeasedBatchPart<T>>> {
         // This is odd, but we move our handle into a `Listen`.
         self.listen.handle.maybe_heartbeat_reader().await;
 
         match self.snapshot.take() {
             Some(parts) => vec![ListenEvent::Updates(parts)],
             None => {
-                let (parts, upper) = self.listen.next().await;
+                let (parts, upper) = self.listen.next(listen_retry).await;
                 vec![ListenEvent::Updates(parts), ListenEvent::Progress(upper)]
             }
         }
@@ -151,7 +155,7 @@ where
     pub async fn fetch_next(
         &mut self,
     ) -> Vec<ListenEvent<T, ((Result<K, String>, Result<V, String>), T, D)>> {
-        let events = self.next().await;
+        let events = self.next(None).await;
         let new_len = events
             .iter()
             .map(|event| match event {
@@ -298,7 +302,11 @@ where
     ///
     /// The returned `Antichain` represents the subscription progress as it will
     /// be _after_ the returned parts are fetched.
-    pub async fn next(&mut self) -> (Vec<LeasedBatchPart<T>>, Antichain<T>) {
+    pub async fn next(
+        &mut self,
+        // If Some, an override for the default listen sleep retry parameters.
+        retry: Option<RetryParameters>,
+    ) -> (Vec<LeasedBatchPart<T>>, Antichain<T>) {
         let batch = self
             .handle
             .machine
@@ -306,6 +314,7 @@ where
                 &self.frontier,
                 &mut self.watch,
                 Some(&self.handle.reader_id),
+                retry,
             )
             .await;
 
@@ -397,7 +406,7 @@ where
     pub async fn fetch_next(
         &mut self,
     ) -> Vec<ListenEvent<T, ((Result<K, String>, Result<V, String>), T, D)>> {
-        let (parts, progress) = self.next().await;
+        let (parts, progress) = self.next(None).await;
         let mut ret = Vec::with_capacity(parts.len() + 1);
         for part in parts {
             let fetched_part = self.fetch_batch_part(part).await;
@@ -1436,7 +1445,7 @@ mod tests {
         width = 4;
         // Collect parts while continuing to write values
         for i in offset..offset + width {
-            for event in subscribe.next().await {
+            for event in subscribe.next(None).await {
                 if let ListenEvent::Updates(mut new_parts) = event {
                     parts.append(&mut new_parts);
                     // Here and elsewhere we "cheat" and immediately downgrade the since
@@ -1492,7 +1501,7 @@ mod tests {
             subscribe.return_leased_part(part);
 
             // Simulates an exchange
-            for event in subscribe.next().await {
+            for event in subscribe.next(None).await {
                 if let ListenEvent::Updates(parts) = event {
                     for part in parts {
                         subsequent_parts.push(part.into_exchangeable_part());

--- a/src/persist-client/src/write.rs
+++ b/src/persist-client/src/write.rs
@@ -623,7 +623,7 @@ where
         let mut watch = self.machine.applier.watch();
         let batch = self
             .machine
-            .next_listen_batch(frontier, &mut watch, None)
+            .next_listen_batch(frontier, &mut watch, None, None)
             .await;
         if PartialOrder::less_than(&self.upper, batch.desc.upper()) {
             self.upper.clone_from(batch.desc.upper());

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -388,7 +388,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
 
     async fn update<F: Fn(&T) -> bool>(&mut self, done: F) {
         while !done(&self.progress_exclusive) {
-            let events = self.txns_subscribe.next().await;
+            let events = self.txns_subscribe.next(None).await;
             for event in events {
                 let parts = match event {
                     ListenEvent::Progress(frontier) => {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -646,6 +646,33 @@ const PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+/// Controls initial backoff of [`mz_persist_client::cfg::DynamicConfig::txns_data_shard_retry_params`].
+const PERSIST_TXNS_DATA_SHARD_RETRYER_INITIAL_BACKOFF: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_txns_data_shard_retryer_initial_backoff"),
+    value: &PersistConfig::DEFAULT_TXNS_DATA_SHARD_RETRYER.initial_backoff,
+    description:
+        "The initial backoff when polling for new batches from a txns data shard persist_source.",
+    internal: true,
+};
+
+/// Controls backoff multiplier of [`mz_persist_client::cfg::DynamicConfig::txns_data_shard_retry_params`].
+const PERSIST_TXNS_DATA_SHARD_RETRYER_MULTIPLIER: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("persist_txns_data_shard_retryer_multiplier"),
+    value: &PersistConfig::DEFAULT_TXNS_DATA_SHARD_RETRYER.multiplier,
+    description:
+        "The backoff multiplier when polling for new batches from a txns data shard persist_source.",
+    internal: true,
+};
+
+/// Controls backoff clamp of [`mz_persist_client::cfg::DynamicConfig::txns_data_shard_retry_params`].
+const PERSIST_TXNS_DATA_SHARD_RETRYER_CLAMP: ServerVar<Duration> = ServerVar {
+    name: UncasedStr::new("persist_txns_data_shard_retryer_clamp"),
+    value: &PersistConfig::DEFAULT_TXNS_DATA_SHARD_RETRYER.clamp,
+    description:
+        "The backoff clamp duration when polling for new batches from a txns data shard persist_source.",
+    internal: true,
+};
+
 const PERSIST_FAST_PATH_LIMIT: ServerVar<usize> = ServerVar {
     name: UncasedStr::new("persist_fast_path_limit"),
     value: &0,
@@ -2679,6 +2706,9 @@ impl SystemVars {
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER)
             .with_var(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+            .with_var(&PERSIST_TXNS_DATA_SHARD_RETRYER_INITIAL_BACKOFF)
+            .with_var(&PERSIST_TXNS_DATA_SHARD_RETRYER_MULTIPLIER)
+            .with_var(&PERSIST_TXNS_DATA_SHARD_RETRYER_CLAMP)
             .with_var(&PERSIST_FAST_PATH_LIMIT)
             .with_var(&PERSIST_STATS_AUDIT_PERCENT)
             .with_var(&PERSIST_STATS_COLLECTION_ENABLED)
@@ -3166,6 +3196,21 @@ impl SystemVars {
     /// Returns the `persist_next_listen_batch_retryer_clamp` configuration parameter.
     pub fn persist_next_listen_batch_retryer_clamp(&self) -> Duration {
         *self.expect_value(&PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP)
+    }
+
+    /// Returns the `persist_txns_data_shard_retryer_initial_backoff` configuration parameter.
+    pub fn persist_txns_data_shard_retryer_initial_backoff(&self) -> Duration {
+        *self.expect_value(&PERSIST_TXNS_DATA_SHARD_RETRYER_INITIAL_BACKOFF)
+    }
+
+    /// Returns the `persist_txns_data_shard_retryer_multiplier` configuration parameter.
+    pub fn persist_txns_data_shard_retryer_multiplier(&self) -> u32 {
+        *self.expect_value(&PERSIST_TXNS_DATA_SHARD_RETRYER_MULTIPLIER)
+    }
+
+    /// Returns the `persist_txns_data_shard_retryer_clamp` configuration parameter.
+    pub fn persist_txns_data_shard_retryer_clamp(&self) -> Duration {
+        *self.expect_value(&PERSIST_TXNS_DATA_SHARD_RETRYER_CLAMP)
     }
 
     pub fn persist_fast_path_limit(&self) -> usize {
@@ -5115,6 +5160,9 @@ fn is_persist_config_var(name: &str) -> bool {
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_INITIAL_BACKOFF.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_MULTIPLIER.name()
         || name == PERSIST_NEXT_LISTEN_BATCH_RETRYER_CLAMP.name()
+        || name == PERSIST_TXNS_DATA_SHARD_RETRYER_INITIAL_BACKOFF.name()
+        || name == PERSIST_TXNS_DATA_SHARD_RETRYER_MULTIPLIER.name()
+        || name == PERSIST_TXNS_DATA_SHARD_RETRYER_CLAMP.name()
         || name == PERSIST_FAST_PATH_LIMIT.name()
         || name == PERSIST_STATS_AUDIT_PERCENT.name()
         || name == PERSIST_STATS_COLLECTION_ENABLED.name()

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -481,6 +481,7 @@ where
                                         Antichain::new(),
                                         None,
                                         flow_control,
+                                        false.then_some(|| unreachable!()),
                                     );
                                     (
                                         stream.as_collection(),


### PR DESCRIPTION
The next_listen_batch sleeps are now only a fallback for pubsub edge
cases (crashes, full buffers etc). We've also got them tuned quite
directly for the current write pattern of the upper advancing once per
second. In particular, an initial sleep of just over a second (so most
times it's preempted by a pubsub wakeup and we never get to the crdb
state scan) and then every 100ms after (if pubsub didn't wake it up
within a second, it probably won't and we want to stay responsive).

Shards managed by persist-txn break this "upper advances every second"
assumption by allowing the "logical" upper to advance past the
"physical" upper when the shard is not being written to. However, this
plays poorly with the above listen tunings: after just over a second,
they start polling every 100ms until the next time the shard is written,
which for most system tables is only on restart.

This PR plumbs an override for the listen sleep retry parameters all the
way from persist_source_core down to next_listen_batch, so that we can
override the behavior for ones paired with a txns_progress operator.

To get a sense for the impact of this issue, here's the current pattern of an
empty env flipping from main to txns before this PR:

<img width="950" alt="image" src="https://github.com/MaterializeInc/materialize/assets/52528/fc2b1ed5-edd2-4bc6-91d8-8f3f4fa14db7">

Touches #22173
Touches #22801

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
