### PR TITLE
ccsr: error if X509::stack_from_pem returns 0 X509s

### DIFF
--- a/src/ccsr/Cargo.toml
+++ b/src/ccsr/Cargo.toml
@@ -10,7 +10,11 @@ publish = false
 anyhow = "1.0.66"
 native-tls = "0.2.11"
 openssl = { version = "0.10.48", features = ["vendored"] }
-reqwest = { version = "0.11.13", features = ["blocking", "json", "native-tls-vendored"] }
+reqwest = { version = "0.11.13", features = [
+    "blocking",
+    "json",
+    "native-tls-vendored",
+] }
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.89"
 url = { version = "2.3.1", features = ["serde"] }

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -79,6 +79,7 @@ use std::env;
 
 use hyper::server::conn::AddrIncoming;
 use hyper::{service, Body, Response, Server, StatusCode};
+use mz_ccsr::tls::Identity;
 use mz_ccsr::{
     Client, DeleteError, GetByIdError, GetBySubjectError, PublishError, SchemaReference, SchemaType,
 };
@@ -479,4 +480,42 @@ async fn count_schemas(client: &Client, subject_prefix: &str) -> Result<usize, a
         .iter()
         .filter(|s| s.starts_with(subject_prefix))
         .count())
+}
+
+#[mz_ore::test]
+#[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `TLS_method` on OS `linux`
+fn test_stack_from_pem_error() {
+    // Note that this file has file has a malformed certificate after the end of
+    // the private key. This is also not a private key in use anywhere to our
+    // knowledge.
+    let certs = r#"-----BEGIN PRIVATE KEY-----
+MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDC5MP3v1BHOgI
+5SsmrW8mjxzQGOz0IlC5jp1muW/kpEoE9TG317TEnO5Uye6zZudkFCP8YGEiN3Mc
+FbTM7eX6PjAPdnGU7khuUt/20ZM+NX5kWZPrmPTh4WQaDCL7ah1LqzBaUAMaSXq8
+iuy7LGJNF8wdx8L5BjDiGTTxZXOg0Haxknc7Mbiwc9z8eb7omvzQzsOwyqocrF2u
+z86TzX1jtHP48i5CxoRHKxE94De3tNxjT/Y3OZlS4QS7iekAOQ04DVV3GIHvRUXN
+2H8ayy4+yOdhHn6ER5Jn3lti1Q5XSrxkrYn7L1Vcj6IwZQhhF5vc+ovxOYb+8ert
+Eo97tIkLAgMBAAECggEAQteHHRPKz9Mzs8Sxvo4GPv0hnzFDl0DhUE4PJCKdtYoV
+8dADq2DJiu3LAZS4cJPt7Y63bGitMRg2oyPPM8G9pD5Goy3wq9zjRqexKDlXUCTt
+/T7zofRny7c94m1RWb7ablGq/vBXt90BqnajvVtvDsN+iKAqccQM4ZdI3QdrEmt1
+cHex924itzG/mqbFTAfAmVj1ZsRnJp55Txy2gqq7jX00xDM8+H49SRvUu49N64LQ
+6BUWCgWCJePRtgjSHjboAzPqSkMdaTE/WDY2zgGF3Qfq4f6JCHKfm4QylCH4gYUU
+1Kf7ttmhu9NoZO+hczobKkxP9RtXfyTRH2bsJXy2HQKBgQDhHgavxk/ln5mdMGGw
+rQud2vF9n7UwFiysYxocIC5/CWD0GAhnawchjPypbW/7vKM5Z9zhW3eH1U9P13sa
+2xHfrU5BZ16rxoBbKNpcr7VeEbUBAsDoGV24xjoecp7rB2hZ+mGik5/5Ig1Rk1KH
+dcvYy2KSi1h4Sm+mXwimmA4VDQKBgQDdzW+5FPbdM2sUB2gLMQtn3ICjDSu6IQ+k
+d0p3WlTIT51RUsPXXKkk96O5anUbeB3syY8tSKPGggsaXaeL3o09yIamtERgCnn3
+d9IS+4VKPWQlFUICU1KrD+TO7IYIX04iXBuVE5ihv0q3mslhDotmX4kS38NtKEFF
+jLjA2RvAdwKBgAFkIxxw+Ett+hALnX7vAtRd5wIku4TpjisejanA1Si50RyRDXQ+
+KBQf/+u4HmoK12Nibe4Cl7GCMvRGW59l3S1pr8MdtWsQVfi6Puc1usQzDdBMyQ5m
+IbsjlnZbtPm02QM9Vd8gVGvAtx5a77aglrrnPtuy+r/7jccUbURCSkv9AoGAH9m3
+WGmVRZBzqO2jWDATxjdY1ZE3nUPQHjrvG5KCKD2ehqYO72cj9uYEwcRyyp4GFhGf
+mM4cjo3wEDowrBoqSBv6kgfC5dO7TfkL1qP9sPp93gFeeD0E2wGuRrSaTqt46eA2
+KcMloNx6W0FD98cB55KCeY5eXtdwAA/EHBVRMeMCgYAd3n6PcL6rVXyE3+wRTKK4
++zvx5sjTAnljr5ttbEnpZafzrYIfDpB8NNjexy83AeC0O13LvSHIFoTwP8sywJRO
+RxbPMjhEBdVZ5NxlxYer7yKN+h5OBJfrLswPku7y4vdFYK3x/lMuNQO61hb1VFHc
+T2BDTbF0QSlPxFsv18B9zg==
+-----END PRIVATE KEY-----
+x"#;
+    Identity::from_pem(certs.as_bytes()).unwrap_err();
 }


### PR DESCRIPTION
### Motivation

This PR fixes a previously unreported bug.

If generating a CSR connection with a valid key but an invalid certificate, this previously panicked on the removed assertion.

Theoretically, something akin to this fix could be upstreamed but I am not totally confident what that fix looks like. 

@benesch if this approach is anathema to you, can I grab a bit of your time to determine how to move forward? The fix, in its most naive version if something akin to changing [this line](https://github.com/sfackler/rust-openssl/blob/master/openssl/src/x509/mod.rs#L764-L769):

```diff
diff --git a/openssl/src/x509/mod.rs b/openssl/src/x509/mod.rs
index 97242ff4..5746e88b 100644
--- a/openssl/src/x509/mod.rs
+++ b/openssl/src/x509/mod.rs
@@ -763,6 +763,7 @@ impl X509 {
                     let err = ffi::ERR_peek_last_error();
                     if ffi::ERR_GET_LIB(err) as X509LenTy == ffi::ERR_LIB_PEM
                         && ffi::ERR_GET_REASON(err) == ffi::PEM_R_NO_START_LINE
+                        && !certs.is_empty()
                     {
                         ffi::ERR_clear_error();
                         break;
```

#### Repro

```
CREATE SECRET key AS '-----BEGIN PRIVATE KEY-----
MIIEvAIBADANBgkqhkiG9w0BAQEFAASCBKYwggSiAgEAAoIBAQDDC5MP3v1BHOgI
5SsmrW8mjxzQGOz0IlC5jp1muW/kpEoE9TG317TEnO5Uye6zZudkFCP8YGEiN3Mc
FbTM7eX6PjAPdnGU7khuUt/20ZM+NX5kWZPrmPTh4WQaDCL7ah1LqzBaUAMaSXq8
iuy7LGJNF8wdx8L5BjDiGTTxZXOg0Haxknc7Mbiwc9z8eb7omvzQzsOwyqocrF2u
z86TzX1jtHP48i5CxoRHKxE94De3tNxjT/Y3OZlS4QS7iekAOQ04DVV3GIHvRUXN
2H8ayy4+yOdhHn6ER5Jn3lti1Q5XSrxkrYn7L1Vcj6IwZQhhF5vc+ovxOYb+8ert
Eo97tIkLAgMBAAECggEAQteHHRPKz9Mzs8Sxvo4GPv0hnzFDl0DhUE4PJCKdtYoV
8dADq2DJiu3LAZS4cJPt7Y63bGitMRg2oyPPM8G9pD5Goy3wq9zjRqexKDlXUCTt
/T7zofRny7c94m1RWb7ablGq/vBXt90BqnajvVtvDsN+iKAqccQM4ZdI3QdrEmt1
cHex924itzG/mqbFTAfAmVj1ZsRnJp55Txy2gqq7jX00xDM8+H49SRvUu49N64LQ
6BUWCgWCJePRtgjSHjboAzPqSkMdaTE/WDY2zgGF3Qfq4f6JCHKfm4QylCH4gYUU
1Kf7ttmhu9NoZO+hczobKkxP9RtXfyTRH2bsJXy2HQKBgQDhHgavxk/ln5mdMGGw
rQud2vF9n7UwFiysYxocIC5/CWD0GAhnawchjPypbW/7vKM5Z9zhW3eH1U9P13sa
2xHfrU5BZ16rxoBbKNpcr7VeEbUBAsDoGV24xjoecp7rB2hZ+mGik5/5Ig1Rk1KH
dcvYy2KSi1h4Sm+mXwimmA4VDQKBgQDdzW+5FPbdM2sUB2gLMQtn3ICjDSu6IQ+k
d0p3WlTIT51RUsPXXKkk96O5anUbeB3syY8tSKPGggsaXaeL3o09yIamtERgCnn3
d9IS+4VKPWQlFUICU1KrD+TO7IYIX04iXBuVE5ihv0q3mslhDotmX4kS38NtKEFF
jLjA2RvAdwKBgAFkIxxw+Ett+hALnX7vAtRd5wIku4TpjisejanA1Si50RyRDXQ+
KBQf/+u4HmoK12Nibe4Cl7GCMvRGW59l3S1pr8MdtWsQVfi6Puc1usQzDdBMyQ5m
IbsjlnZbtPm02QM9Vd8gVGvAtx5a77aglrrnPtuy+r/7jccUbURCSkv9AoGAH9m3
WGmVRZBzqO2jWDATxjdY1ZE3nUPQHjrvG5KCKD2ehqYO72cj9uYEwcRyyp4GFhGf
mM4cjo3wEDowrBoqSBv6kgfC5dO7TfkL1qP9sPp93gFeeD0E2wGuRrSaTqt46eA2
KcMloNx6W0FD98cB55KCeY5eXtdwAA/EHBVRMeMCgYAd3n6PcL6rVXyE3+wRTKK4
+zvx5sjTAnljr5ttbEnpZafzrYIfDpB8NNjexy83AeC0O13LvSHIFoTwP8sywJRO
RxbPMjhEBdVZ5NxlxYer7yKN+h5OBJfrLswPku7y4vdFYK3x/lMuNQO61hb1VFHc
T2BDTbF0QSlPxFsv18B9zg==
-----END PRIVATE KEY-----
';

CREATE CONNECTION "materialize"."public"."csr_ssl_broken" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://schema-registry:8081/', SSL KEY = SECRET "materialize"."public"."key", SSL CERTIFICATE = 'x',
SSL CERTIFICATE AUTHORITY = '-----BEGIN CERTIFICATE-----   
MIIFCzCCAvOgAwIBAgIUUj1IpxlXvWY3zaMVXNbmqjOFhJUwDQYJKoZIhvcNAQEL                       
BQAwFDESMBAGA1UEAwwJTVogUlNBIENBMCAXDTIzMDYyOTA5MzkyN1oYDzIxMjMw                       
NjA1MDkzOTI3WjAUMRIwEAYDVQQDDAlNWiBSU0EgQ0EwggIiMA0GCSqGSIb3DQEB                       
AQUAA4ICDwAwggIKAoICAQDm8MQoKzqhS/sP+UbDcxV/HdDzCJ+1om/XFyCA+LBy                       
q9R5TWg18L6LGo33+ApvTF6M9q042GeyPGgH55b83PWKy1kfhG45wKu3GvlGd26o                       
Zx/TSopnnJBANDtYqFmmurta2bDoNsYdgW7UwplKdR9FB8HE+omYs6U41W3U5IhJ                       
V8QY7lO3gJlMeIaX7wnctrCy3+DhYOZxBdSq2SV0co9CLTwtet7kaH7onFhf9Ihx                       
37o02AVbogroc5MFHXZus9UVWSPKpgW/hqUg0+DbpzUNW2aZHirOy/SSfl5zfZSY                       
BCMy6yojt5mX+0mO7nEg2zAooHeAETTu2JQEE4iFOAUNEDSbsJxse3DIQTYsCKy/                       
+5NTVoyvkYu95QQAiXrxqZi+4lxIC0dy65y165llqowkl7vt3B4TPegcB5P9+vGz                       
eM3thC2XKB5S3Hv5m6E0+8a7XLQXdGzgrAt8BKBavp/NVymfGR/0boqLZfPI+g8s                       
ZrbkRRk5aM4LQh9wGXFwXoSSEvoLGn3juW3Z20D+VHbzIlKAdP+nSWWc/CQmtVOX                       
YYQij180xepT+MW3xV8O9WclZhpiaEj7hxogYnMpMwkT5aXpA53g8/AghslD0IW9                       
QL7PYjqfWmdVKR0SIPJ3I+6TBO6Rc1DANUDpbIjTy/Wq+0ssYiI6bf6SyNIzY+Ga                       
rQIDAQABo1MwUTAdBgNVHQ4EFgQUkI1kfSi9teNgL5qMHjSYV/DobfAwHwYDVR0j                       
BBgwFoAUkI1kfSi9teNgL5qMHjSYV/DobfAwDwYDVR0TAQH/BAUwAwEB/zANBgkq                       
hkiG9w0BAQsFAAOCAgEAn3BNYywsvms5Xz/RQ9Tcbnx8BCOjxzjeKXKmKHRmKM9Z                       
Cx2GqUqEIDtfIDtTsmhcKFYC6FHthyacrZPvn09Zu0s7AkNCjL87vsO+PD8+Vll0                       
YW3t6Tcr5FrlDJI0USSyOR3oWqJECra6S/c8fVWyO45MRnG7+ZsWK+Q9YkRkAjBB                       
9nl+6SGxOdrGu/art/qbFVbeyMoWujpVs5ylr6iEChSu79NFhZxJ2S2jVFxMB6Ue                       
U2A7SkJ4baZdE+RVeq9gfYWucr1t8zSEH6eFaj6ypQC0t9IBawfHaYEUNZRmD6sf                       
aVgq/83OjxO3Wm2t9fXBYio3KWHg07RaLprdX9Lp6H9o5YtxHMxXpze9m1ZhrENS                       
GpRFj7Il8Y4yljyJlIVa2byIVOZEiSiR5o2MlHj/stwSGFaciPX+O7StJ0v2Gpsj                       
jReEo2HJFhQoeXRsGBzbOgGZiq2FPtsLOCfk7tZF1xJyP3lK6FwVa1TCRE5FULWL                       
ECt61FnNWLNylfR5LLi60hNvmuISN+Yq6eSIAJtpwl1Xbw3bpe9Bs21EKOBNtNGS                       
Er74n710GgtBRSvxhkf86KDSjh+lwGqF03bG6by+WRYp6cC0IFA9QDfQcG2wEf6p                       
r6vMvMQPrUMuKz0mreiL9J5jWt141mK01AgUcKD1tHQJ+Cyh36IohRIDeK2t2oU=                       
-----END CERTIFICATE-----');
```

This will panic.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Error instead of panic if a Confluent Schema Registry connection has a valid private key but a malformed certificate when establishing TLS credentials.
