### PR TITLE
retry http requests in the test suite

### DIFF
--- a/misc/python/materialize/cloudtest/util/web_request.py
+++ b/misc/python/materialize/cloudtest/util/web_request.py
@@ -14,6 +14,7 @@ from textwrap import dedent
 from typing import Any
 
 import requests
+from requests.adapters import HTTPAdapter, Retry
 
 from materialize.cloudtest.util.authentication import AuthConfig
 
@@ -62,7 +63,9 @@ class WebRequests:
         def try_get() -> requests.Response:
             with verbose_http_errors():
                 headers = self._create_headers(self.auth)
-                response = requests.get(
+                s = requests.Session()
+                s.mount(self.base_url, HTTPAdapter(max_retries=Retry(3)))
+                response = s.get(
                     f"{self.base_url}{path}",
                     headers=headers,
                     timeout=self._timeout_or_default(timeout_in_sec),


### PR DESCRIPTION
### Motivation

we seem to be getting a lot of timeouts in the cloud test suite, hopefully this will make things a bit better?

### Tips for reviewer

i ran the cloud test suite against this branch and it passed, so it at least shouldn't break things

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - no user facing changes