### PR TITLE
[persist/expr] Refine the output of `EXPLAIN WITH(filter_pushdown)`

### DIFF
--- a/src/expr/src/explain/mod.rs
+++ b/src/expr/src/explain/mod.rs
@@ -101,7 +101,7 @@ impl<'a> ExplainSource<'a> {
             let pushdown = op
                 .predicates
                 .iter()
-                .filter(|(_, e)| mfp_mapped.expr(e))
+                .filter(|(_, e)| mfp_mapped.expr(e).pushdownable())
                 .map(|(_, e)| e)
                 .collect();
             Some(PushdownInfo { pushdown })

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -898,33 +898,73 @@ impl<'a> Interpreter for ColumnSpecs<'a> {
 /// An interpreter that returns whether or not a particular expression is "pushdownable".
 /// Broadly speaking, an expression is pushdownable if the result of evaluating the expression
 /// depends on the range of possible column values in a way that `ColumnSpecs` is able to reason about.
-/// `Column` is trivially pushdownable; `Literal` and `CallUnmaterializable`
-/// are not, since their results don't depend on the range of possible values in any column.
 ///
-/// Functions are the most complex case. We say that a function is pushdownable for a particular
-/// argument if `ColumnSpecs` can determine the spec of the function's output given the input spec for
-/// that argument. (In practice, this is true when either the function is monotone in that argument
-/// or it's been special-cased in the interpreter.) And we say a function-call expression is
-/// pushdownable overall if at least one of its arguments is pushdownable, and the function is
-/// is pushdownable in that argument. For example, `3 + #0` is pushdownable (because the second
-/// argument to `+` is pushdownable and `+` is monotone) but `3 / #0` is not (because while the
-/// second argument is pushdownable, `/` is not monotone on the right-hand side).
+/// In practice, we internally need to distinguish between expressions that are trivially predicable
+/// (because they're constant) and expressions that depend on the column ranges themselves.
+/// See the [TraceSummary] variants for those distinctions, and [TraceSummary::pushdownable] for
+/// the overall assessment.
 #[derive(Debug)]
 pub struct Trace;
 
+/// A summary type for the [Trace] interpreter.
+///
+/// The ordering of this type is meaningful: the "smaller" the summary, the more information we have
+/// about the possible values of the expression. This means we can eg. use `max` in the
+/// interpreter below to find the summary for a function-call expression based on the summaries
+/// of its arguments.
+#[derive(Copy, Clone, Debug, PartialOrd, PartialEq, Ord, Eq)]
+pub enum TraceSummary {
+    /// The expression is constant: we can evaluate it without any runtime information.
+    /// This corresponds to a `ResultSpec` of a single value.
+    Constant,
+    /// The expression depends on runtime information, but in "predictable" way... ie. if we know
+    /// the range of possible values for all columns and unmaterializable functions, we can
+    /// predict the possible values of the output.
+    /// This corresponds to a `ResultSpec` of a perhaps range of values.
+    Dynamic,
+    /// The expression depends on runtime information in an unpredictable way.
+    /// This corresponds to a `ResultSpec::value_all()` or something similarly vague.
+    Unknown,
+}
+
+impl TraceSummary {
+    /// We say that a function is "pushdownable" for a particular
+    /// argument if `ColumnSpecs` can determine the spec of the function's output given the input spec for
+    /// that argument. (In practice, this is true when either the function is monotone in that argument
+    /// or it's been special-cased in the interpreter.)
+    fn apply_fn(self, pushdownable: bool) -> Self {
+        match self {
+            TraceSummary::Constant => TraceSummary::Constant,
+            TraceSummary::Dynamic => match pushdownable {
+                true => TraceSummary::Dynamic,
+                false => TraceSummary::Unknown,
+            },
+            TraceSummary::Unknown => TraceSummary::Unknown,
+        }
+    }
+
+    /// We say that an expression is "pushdownable" if it's either constant or dynamic.
+    pub fn pushdownable(self) -> bool {
+        match self {
+            TraceSummary::Constant | TraceSummary::Dynamic => true,
+            TraceSummary::Unknown => false,
+        }
+    }
+}
+
 impl Interpreter for Trace {
-    type Summary = bool;
+    type Summary = TraceSummary;
 
     fn column(&self, _id: usize) -> Self::Summary {
-        true
+        TraceSummary::Dynamic
     }
 
     fn literal(&self, _result: &Result<Row, EvalError>, _col_type: &ColumnType) -> Self::Summary {
-        false
+        TraceSummary::Constant
     }
 
     fn unmaterializable(&self, _func: &UnmaterializableFunc) -> Self::Summary {
-        false
+        TraceSummary::Dynamic
     }
 
     fn unary(&self, func: &UnaryFunc, expr: Self::Summary) -> Self::Summary {
@@ -932,7 +972,7 @@ impl Interpreter for Trace {
             None => func.is_monotone(),
             Some(special) => special.pushdownable,
         };
-        expr && pushdownable
+        expr.apply_fn(pushdownable)
     }
 
     fn binary(
@@ -941,30 +981,34 @@ impl Interpreter for Trace {
         left: Self::Summary,
         right: Self::Summary,
     ) -> Self::Summary {
-        // TODO: this is duplicative! If we have more than one or two special-cased functions
-        // we should find some way to share the list between `Trace` and `ColumnSpecs`.
         let (left_pushdownable, right_pushdownable) = match SpecialBinary::for_func(func) {
             None => func.is_monotone(),
             Some(special) => special.pushdownable,
         };
-        (left && left_pushdownable) || (right && right_pushdownable)
+        left.apply_fn(left_pushdownable)
+            .max(right.apply_fn(right_pushdownable))
     }
 
     fn variadic(&self, func: &VariadicFunc, exprs: Vec<Self::Summary>) -> Self::Summary {
         if !func.is_associative() && exprs.len() >= ColumnSpecs::MAX_EVAL_ARGS {
             // We can't efficiently evaluate functions with very large argument lists;
             // see the comment on ColumnSpecs::MAX_EVAL_ARGS for details.
-            return false;
+            return TraceSummary::Unknown;
         }
 
         let pushdownable_fn = func.is_monotone();
         exprs
             .into_iter()
-            .any(|pushdownable_arg| pushdownable_arg && pushdownable_fn)
+            .map(|pushdownable_arg| pushdownable_arg.apply_fn(pushdownable_fn))
+            .max()
+            .unwrap_or(TraceSummary::Constant)
     }
 
     fn cond(&self, cond: Self::Summary, then: Self::Summary, els: Self::Summary) -> Self::Summary {
-        cond || (then || els)
+        // We don't actually need to be able to predict the condition precisely to predict the output,
+        // since we can union the ranges of the two branches for a conservative estimate.
+        let cond = cond.min(TraceSummary::Dynamic);
+        cond.max(then).max(els)
     }
 }
 
@@ -1491,7 +1535,7 @@ mod tests {
                 }),
             }),
         };
-        let pushdownable = Trace.expr(&expr);
-        assert!(pushdownable);
+        let summary = Trace.expr(&expr);
+        assert!(summary.pushdownable());
     }
 }

--- a/src/expr/src/interpret.rs
+++ b/src/expr/src/interpret.rs
@@ -1530,7 +1530,7 @@ mod tests {
                 func: BinaryFunc::AddInt64,
                 expr1: Box::new(MirScalarExpr::Column(1)),
                 expr2: Box::new(MirScalarExpr::CallUnary {
-                    func: UnaryFunc::AbsInt64(AbsInt64),
+                    func: UnaryFunc::NegInt64(NegInt64),
                     expr: Box::new(MirScalarExpr::Column(3)),
                 }),
             }),

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -96,7 +96,7 @@ pub mod virtual_syntax;
 pub mod visit;
 
 pub use id::{Id, LocalId, PartitionId, ProtoId, ProtoLocalId, ProtoPartitionId, SourceInstanceId};
-pub use interpret::{ColumnSpec, ColumnSpecs, Interpreter, ResultSpec, Trace};
+pub use interpret::{ColumnSpec, ColumnSpecs, Interpreter, ResultSpec, Trace, TraceSummary};
 pub use linear::plan::{MfpPlan, SafeMfpPlan};
 pub use linear::util::{join_permutations, permutation_for_arrangement};
 pub use linear::{

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -311,3 +311,63 @@ Source materialize.public.t
   pushdown=((timestamp_to_mz_timestamp(case when (#0 = 0) then (#1 - 1 day) else (#1 - 2 days) end) < mz_now()))
 
 EOF
+
+# Regression test: should not report pushdown when one case can't be pushed down / might throw an exception.
+# (We don't infer a range for the result of EXTRACT, so the overall expression may overflow.)
+
+statement ok
+CREATE TABLE items(id int, ship_time timestamp);
+
+query T multiline
+EXPLAIN WITH(filter_pushdown)
+SELECT * from items
+WHERE mz_now() <= date_trunc(
+    'month',
+    ship_time
+    - (
+        CASE WHEN EXTRACT(MONTH FROM ship_time) < 6 THEN EXTRACT(MONTH FROM ship_time) + 6 ELSE 0 END
+        + CASE WHEN EXTRACT(MONTH FROM ship_time) >= 6 THEN EXTRACT(MONTH FROM ship_time) - 6 ELSE 0 END
+    )
+    * INTERVAL '1 months'
+)
+----
+Explained Query:
+  Project (#0, #1)
+    Filter (mz_now() <= timestamp_to_mz_timestamp(date_trunc_month_ts((#1 - (1 month * numeric_to_double((case when (#2 < 6) then (extract_month_ts(#1) + 6) else 0 end + case when (#2 >= 6) then (extract_month_ts(#1) - 6) else 0 end)))))))
+      Map (extract_month_ts(#1))
+        ReadStorage materialize.public.items
+
+Source materialize.public.items
+  filter=((mz_now() <= timestamp_to_mz_timestamp(date_trunc_month_ts((#1 - (1 month * numeric_to_double((case when (#2 < 6) then (extract_month_ts(#1) + 6) else 0 end + case when (#2 >= 6) then (extract_month_ts(#1) - 6) else 0 end))))))))
+  map=(extract_month_ts(#1))
+
+EOF
+
+query T multiline
+explain with(filter_pushdown)
+SELECT * from items
+WHERE CASE WHEN id = 10 THEN EXTRACT(MONTH FROM ship_time) ELSE 0 END < mz_now();
+----
+Explained Query:
+  Filter (numeric_to_mz_timestamp(case when (#0 = 10) then extract_month_ts(#1) else 0 end) < mz_now())
+    ReadStorage materialize.public.items
+
+Source materialize.public.items
+  filter=((numeric_to_mz_timestamp(case when (#0 = 10) then extract_month_ts(#1) else 0 end) < mz_now()))
+
+EOF
+
+query T multiline
+explain with(filter_pushdown)
+SELECT * from items
+WHERE CASE WHEN EXTRACT(MONTH FROM ship_time) >= 6 THEN 12 ELSE 0 END < mz_now();
+----
+Explained Query:
+  Filter (integer_to_mz_timestamp(case when (extract_month_ts(#1) >= 6) then 12 else 0 end) < mz_now())
+    ReadStorage materialize.public.items
+
+Source materialize.public.items
+  filter=((integer_to_mz_timestamp(case when (extract_month_ts(#1) >= 6) then 12 else 0 end) < mz_now()))
+  pushdown=((integer_to_mz_timestamp(case when (extract_month_ts(#1) >= 6) then 12 else 0 end) < mz_now()))
+
+EOF


### PR DESCRIPTION
Previously, we'd consider a function-call expression "pushdownable" if any of its arguments were, and the function itself was monotonic etc. This ends up being too generous: for example, `col + hash(col)` is not predictable even if the left-hand side is, because the right-hand side could be some arbitrary value.

Getting this right requires distinguishing between expressions that don't depend on the column ranges because they're constants, and expressions that don't depend on the column ranges because they're complicated functions... so we have to change up the summary type here as well.

### Motivation

Previously unreported bug.

In brief, we discovered a case where the EXPLAIN output was misleadingly suggesting that a particular filter would be pushed down where in practice it was never useful; see the [internal conversation](https://materializeinc.slack.com/archives/C053EPHMU05/p1698676211422729) for more details.

### Tips for reviewer

I don't feel that excited about the naming of the new types / variants; happy to take suggestions.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
