### PR TITLE
Use the new `Optimize` API for `SUBSCRIBE`

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -768,11 +768,11 @@ impl CatalogState {
         Ok(match plan {
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 if enable_unified_optimizer_api {
-                    // Collect optimizer parameters
+                    // Collect optimizer parameters.
                     let optimizer_config =
                         optimize::OptimizerConfig::from(session_catalog.system_vars());
 
-                    // Build a VIEW optimizer for this view.
+                    // Build an optimizer for this VIEW.
                     let mut optimizer = optimize::OptimizeView::new(optimizer_config);
 
                     // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
@@ -904,11 +904,11 @@ impl CatalogState {
             }),
             Plan::CreateView(CreateViewPlan { view, .. }) => {
                 if enable_unified_optimizer_api {
-                    // Collect optimizer parameters
+                    // Collect optimizer parameters.
                     let optimizer_config =
                         optimize::OptimizerConfig::from(session_catalog.system_vars());
 
-                    // Build a VIEW optimizer for this view.
+                    // Build an optimizer for this VIEW.
                     let mut optimizer = optimize::OptimizeView::new(optimizer_config);
 
                     // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -137,7 +137,7 @@ use crate::coord::timestamp_oracle::catalog_oracle::CatalogTimestampPersistence;
 use crate::coord::timestamp_selection::TimestampContext;
 use crate::error::AdapterError;
 use crate::metrics::Metrics;
-use crate::optimize::{self, Optimize, OptimizeMaterializedView, OptimizerConfig};
+use crate::optimize::{self, Optimize, OptimizerConfig};
 use crate::session::{EndTransactionAction, Session};
 use crate::statement_logging::StatementEndedExecutionReason;
 use crate::subscribe::ActiveSubscribe;
@@ -1399,14 +1399,14 @@ impl Coordinator {
                             .or_insert_with(BTreeSet::new)
                             .insert(entry.id());
                     } else if enable_unified_optimizer_api {
-                        // Collect optimizer parameters
+                        // Collect optimizer parameters.
                         let compute_instance = self
                             .instance_snapshot(idx.cluster_id)
                             .expect("compute instance does not exist");
                         let optimizer_config =
                             OptimizerConfig::from(self.catalog().system_config());
 
-                        // Build an INDEX optimizer.
+                        // Build an optimizer for this INDEX.
                         let mut optimizer = optimize::OptimizeIndex::new(
                             self.owned_catalog(),
                             compute_instance,
@@ -1515,7 +1515,7 @@ impl Coordinator {
                         .storage_ids
                         .insert(entry.id());
 
-                    // Collect optimizer parameters
+                    // Collect optimizer parameters.
                     let compute_instance = self
                         .instance_snapshot(mview.cluster_id)
                         .expect("compute instance does not exist");
@@ -1526,8 +1526,8 @@ impl Coordinator {
                         .to_string();
                     let optimizer_config = OptimizerConfig::from(self.catalog().system_config());
 
-                    // Build a MATERIALIZED VIEW optimizer for this view.
-                    let mut optimizer = OptimizeMaterializedView::new(
+                    // Build an optimizer for this MATERIALIZED VIEW.
+                    let mut optimizer = optimize::OptimizeMaterializedView::new(
                         self.owned_catalog(),
                         compute_instance,
                         entry.id(),

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -172,7 +172,7 @@ impl Coordinator {
         .await;
     }
 
-    #[deprecated = "This is being replaced by ship_dataflow1 (see #20569)."]
+    #[deprecated = "This is being replaced by ship_dataflow_new (see #20569)."]
     /// Finalizes a dataflow and then broadcasts it to all workers.
     ///
     /// Returns an error on failure. DO NOT call this for DDL. Instead, use the non-fallible version

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -298,10 +298,20 @@ impl Coordinator {
                 self.sequence_peek(ctx, plan, target_cluster).await;
             }
             Plan::Subscribe(plan) => {
-                let result = self
-                    .sequence_subscribe(&mut ctx, plan, target_cluster)
-                    .await;
-                ctx.retire(result);
+                if enable_unified_optimizer_api {
+                    let result = self
+                        .sequence_subscribe(&mut ctx, plan, target_cluster)
+                        .await;
+                    ctx.retire(result);
+                } else {
+                    // Allow while the introduction of the new optimizer API in
+                    // #20569 is in progress.
+                    #[allow(deprecated)]
+                    let result = self
+                        .sequence_subscribe_deprecated(&mut ctx, plan, target_cluster)
+                        .await;
+                    ctx.retire(result);
+                }
             }
             Plan::SideEffectingFunc(plan) => {
                 ctx.retire(self.sequence_side_effecting_func(plan));

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -893,10 +893,10 @@ impl Coordinator {
         let view_oid = self.catalog_mut().allocate_oid()?;
         let raw_expr = view.expr.clone();
         if enable_unified_optimizer_api {
-            // Collect optimizer parameters
+            // Collect optimizer parameters.
             let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
-            // Build a VIEW optimizer for this view.
+            // Build an optimizer for this VIEW.
             let mut optimizer = optimize::OptimizeView::new(optimizer_config);
 
             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
@@ -997,7 +997,7 @@ impl Coordinator {
             });
         }
 
-        // Collect optimizer parameters
+        // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(cluster_id)
             .expect("compute instance does not exist");
@@ -1006,7 +1006,7 @@ impl Coordinator {
         let debug_name = self.catalog().resolve_full_name(&name, None).to_string();
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
-        // Build a MATERIALIZED VIEW optimizer for this view.
+        // Build an optimizer for this MATERIALIZED VIEW.
         let mut optimizer = optimize::OptimizeMaterializedView::new(
             self.owned_catalog(),
             compute_instance,
@@ -1129,14 +1129,14 @@ impl Coordinator {
 
         self.ensure_cluster_can_host_compute_item(&name, cluster_id)?;
 
-        // Collect optimizer parameters
+        // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(cluster_id)
             .expect("compute instance does not exist");
         let id = self.catalog_mut().allocate_user_id().await?;
         let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
-        // Build an INDEX optimizer.
+        // Build an optimizer for this INDEX.
         let mut optimizer = optimize::OptimizeIndex::new(
             self.owned_catalog(),
             compute_instance,
@@ -3557,7 +3557,7 @@ impl Coordinator {
         // Initialize optimizer context
         // ----------------------------
 
-        // Collect optimizer parameters
+        // Collect optimizer parameters.
         let compute_instance = self
             .instance_snapshot(target_cluster_id)
             .expect("compute instance does not exist");
@@ -3567,7 +3567,7 @@ impl Coordinator {
         let system_config = self.catalog().system_config();
         let optimizer_config = optimize::OptimizerConfig::from((system_config, explain_config));
 
-        // Build a MATERIALIZED VIEW optimizer for this view.
+        // Build an optimizer for this MATERIALIZED VIEW.
         let mut optimizer = optimize::OptimizeMaterializedView::new(
             self.owned_catalog(),
             compute_instance,
@@ -3682,7 +3682,7 @@ impl Coordinator {
         let system_config = self.catalog().system_config();
         let optimizer_config = optimize::OptimizerConfig::from((system_config, explain_config));
 
-        // Build an INDEX optimizer for this index.
+        // Build an optimizer for this INDEX.
         let mut optimizer = optimize::OptimizeIndex::new(
             self.owned_catalog(),
             compute_instance,
@@ -3834,10 +3834,10 @@ impl Coordinator {
             .enable_unified_optimizer_api();
 
         let optimized_plan = if enable_unified_optimizer_api {
-            // Collect optimizer parameters
+            // Collect optimizer parameters.
             let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
-            // Build a VIEW optimizer for this view.
+            // Build an optimizer for this VIEW.
             let mut optimizer = optimize::OptimizeView::new(optimizer_config);
 
             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
@@ -3981,10 +3981,10 @@ impl Coordinator {
             let expr = return_if_err!(plan.values.lower(self.catalog().system_config()), ctx);
             OptimizedMirRelationExpr(expr)
         } else if enable_unified_optimizer_api {
-            // Collect optimizer parameters
+            // Collect optimizer parameters.
             let optimizer_config = optimize::OptimizerConfig::from(self.catalog().system_config());
 
-            // Build a VIEW optimizer for the values part.
+            // Build an optimizer for this VIEW.
             let mut optimizer = optimize::OptimizeView::new(optimizer_config);
 
             // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2759,6 +2759,8 @@ impl Coordinator {
         }
     }
 
+    /// This should mirror the operational semantics of
+    /// `Coordinator::sequence_subscribe_deprecated`.
     pub(super) async fn sequence_subscribe(
         &mut self,
         ctx: &mut ExecuteContext,
@@ -5763,7 +5765,7 @@ impl Coordinator {
 /// return a list of associated notices (today: we always emit exactly
 /// one notice if there are any per-replica log dependencies and if
 /// `emit_introspection_query_notice` is set, and none otherwise.)
-fn check_log_reads(
+pub(super) fn check_log_reads(
     catalog: &Catalog,
     cluster: &Cluster,
     source_ids: &BTreeSet<GlobalId>,

--- a/src/adapter/src/coord/sequencer/old_optimizer_api.rs
+++ b/src/adapter/src/coord/sequencer/old_optimizer_api.rs
@@ -19,26 +19,32 @@ use std::collections::BTreeMap;
 
 use differential_dataflow::lattice::Lattice;
 use mz_compute_types::dataflows::{DataflowDesc, IndexDesc};
+use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
 use mz_ore::soft_panic_or_log;
 use mz_repr::explain::{TransientItem, UsedIndexes};
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::{GlobalId, RelationDesc, Timestamp};
 use mz_sql::catalog::CatalogError;
 use mz_sql::names::{QualifiedItemName, ResolvedIds};
-use mz_sql::plan::{self, Index};
+use mz_sql::plan::{self, Index, QueryWhen, SubscribeFrom};
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::optimizer_notices::OptimizerNotice;
 use timely::progress::Antichain;
+use tokio::sync::mpsc;
 
 use crate::catalog::CatalogItem;
 use crate::coord::dataflows::{
     prep_relation_expr, prep_scalar_expr, DataflowBuilder, ExprPrepStyle,
 };
 use crate::coord::peek::FastPathPlan;
-use crate::coord::sequencer::inner::catch_unwind;
-use crate::coord::Coordinator;
+use crate::coord::sequencer::inner::{catch_unwind, check_log_reads};
+use crate::coord::{Coordinator, TargetCluster};
 use crate::optimize::OptimizerConfig;
-use crate::session::Session;
-use crate::{catalog, AdapterError, AdapterNotice, ExecuteResponse};
+use crate::session::{Session, TransactionOps};
+use crate::subscribe::ActiveSubscribe;
+use crate::util::{ComputeSinkId, ResultExt};
+use crate::{
+    catalog, AdapterError, AdapterNotice, ExecuteContext, ExecuteResponse, TimelineContext,
+};
 
 impl Coordinator {
     // Indexes
@@ -279,5 +285,215 @@ impl Coordinator {
         // Return objects that need to be passed to the `ExplainContext`
         // when rendering explanations for the various trace entries.
         Ok((used_indexes, None, df_metainfo, transient_items))
+    }
+
+    // Subscribe
+    // ---------
+
+    /// This should mirror the operational semantics of
+    /// `Coordinator::sequence_subscribe`.
+    #[deprecated = "This is being replaced by sequence_subscribe (see #20569)."]
+    pub(super) async fn sequence_subscribe_deprecated(
+        &mut self,
+        ctx: &mut ExecuteContext,
+        plan: plan::SubscribePlan,
+        target_cluster: TargetCluster,
+    ) -> Result<ExecuteResponse, AdapterError> {
+        let plan::SubscribePlan {
+            from,
+            with_snapshot,
+            when,
+            copy_to,
+            emit_progress,
+            up_to,
+            output,
+        } = plan;
+
+        let cluster = self
+            .catalog()
+            .resolve_target_cluster(target_cluster, ctx.session())?;
+        let cluster_id = cluster.id;
+
+        let target_replica_name = ctx.session().vars().cluster_replica();
+        let mut target_replica = target_replica_name
+            .map(|name| {
+                cluster
+                    .replica_id(name)
+                    .ok_or(AdapterError::UnknownClusterReplica {
+                        cluster_name: cluster.name.clone(),
+                        replica_name: name.to_string(),
+                    })
+            })
+            .transpose()?;
+
+        // SUBSCRIBE AS OF, similar to peeks, doesn't need to worry about transaction
+        // timestamp semantics.
+        if when == QueryWhen::Immediately {
+            // If this isn't a SUBSCRIBE AS OF, the SUBSCRIBE can be in a transaction if it's the
+            // only operation.
+            ctx.session_mut()
+                .add_transaction_ops(TransactionOps::Subscribe)?;
+        }
+
+        // Determine the frontier of updates to subscribe *from*.
+        // Updates greater or equal to this frontier will be produced.
+        let depends_on = from.depends_on();
+        let notices = check_log_reads(
+            self.catalog(),
+            cluster,
+            &depends_on,
+            &mut target_replica,
+            ctx.session().vars(),
+        )?;
+        ctx.session_mut().add_notices(notices);
+
+        let id_bundle = self
+            .index_oracle(cluster_id)
+            .sufficient_collections(&depends_on);
+        let mut timeline = self.validate_timeline_context(depends_on.clone())?;
+        if matches!(timeline, TimelineContext::TimestampIndependent) && from.contains_temporal() {
+            // If the from IDs are timestamp independent but the query contains temporal functions
+            // then the timeline context needs to be upgraded to timestamp dependent.
+            timeline = TimelineContext::TimestampDependent;
+        }
+        let as_of = self
+            .determine_timestamp(
+                ctx.session(),
+                &id_bundle,
+                &when,
+                cluster_id,
+                &timeline,
+                None,
+            )
+            .await?
+            .timestamp_context
+            .timestamp_or_default();
+        if let Some(id) = ctx.extra().contents() {
+            self.set_statement_execution_timestamp(id, as_of);
+        }
+
+        let up_to = up_to
+            .map(|expr| Coordinator::evaluate_when(self.catalog().state(), expr, ctx.session_mut()))
+            .transpose()?;
+        if let Some(up_to) = up_to {
+            if as_of == up_to {
+                ctx.session_mut()
+                    .add_notice(AdapterNotice::EqualSubscribeBounds { bound: up_to });
+            } else if as_of > up_to {
+                return Err(AdapterError::AbsurdSubscribeBounds { as_of, up_to });
+            }
+        }
+        let up_to = up_to.map(Antichain::from_elem).unwrap_or_default();
+
+        let (mut dataflow, dataflow_metainfo) = match from {
+            SubscribeFrom::Id(from_id) => {
+                let from = self.catalog().get_entry(&from_id);
+                let from_desc = from
+                    .desc(
+                        &self
+                            .catalog()
+                            .resolve_full_name(from.name(), Some(ctx.session().conn_id())),
+                    )
+                    .expect("subscribes can only be run on items with descs")
+                    .into_owned();
+                let sink_id = self.allocate_transient_id()?;
+                let sink_desc = ComputeSinkDesc {
+                    from: from_id,
+                    from_desc,
+                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection::default()),
+                    with_snapshot,
+                    up_to,
+                    // No `FORCE NOT NULL` for subscribes
+                    non_null_assertions: vec![],
+                };
+                let sink_name = format!("subscribe-{}", sink_id);
+                self.dataflow_builder(cluster_id)
+                    .build_sink_dataflow(sink_name, sink_id, sink_desc)?
+            }
+            SubscribeFrom::Query { expr, desc } => {
+                let id = self.allocate_transient_id()?;
+                let expr = self.view_optimizer.optimize(expr)?;
+                let desc = RelationDesc::new(expr.typ(), desc.iter_names());
+                let sink_desc = ComputeSinkDesc {
+                    from: id,
+                    from_desc: desc,
+                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection::default()),
+                    with_snapshot,
+                    up_to,
+                    // No `FORCE NOT NULL` for subscribes
+                    non_null_assertions: vec![],
+                };
+                let mut dataflow = DataflowDesc::new(format!("subscribe-{}", id));
+                let mut dataflow_builder = self.dataflow_builder(cluster_id);
+                dataflow_builder.import_view_into_dataflow(&id, &expr, &mut dataflow)?;
+                let dataflow_metainfo =
+                    dataflow_builder.build_sink_dataflow_into(&mut dataflow, id, sink_desc)?;
+                (dataflow, dataflow_metainfo)
+            }
+        };
+
+        self.emit_optimizer_notices(ctx.session(), &dataflow_metainfo.optimizer_notices);
+
+        dataflow.set_as_of(Antichain::from_elem(as_of));
+
+        let (&sink_id, sink_desc) = dataflow
+            .sink_exports
+            .iter()
+            .next()
+            .expect("subscribes have a single sink export");
+        let (tx, rx) = mpsc::unbounded_channel();
+        let active_subscribe = ActiveSubscribe {
+            user: ctx.session().user().clone(),
+            conn_id: ctx.session().conn_id().clone(),
+            channel: tx,
+            emit_progress,
+            as_of,
+            arity: sink_desc.from_desc.arity(),
+            cluster_id,
+            depends_on: depends_on.into_iter().collect(),
+            start_time: self.now(),
+            dropping: false,
+            output,
+        };
+        active_subscribe.initialize();
+        self.add_active_subscribe(sink_id, active_subscribe).await;
+
+        // Allow while the introduction of the new optimizer API in
+        // #20569 is in progress.
+        #[allow(deprecated)]
+        match self.ship_dataflow(dataflow, cluster_id).await {
+            Ok(_) => {}
+            Err(e) => {
+                self.remove_active_subscribe(sink_id).await;
+                return Err(e);
+            }
+        };
+        if let Some(target) = target_replica {
+            self.controller
+                .compute
+                .set_subscribe_target_replica(cluster_id, sink_id, target)
+                .unwrap_or_terminate("cannot fail to set subscribe target replica");
+        }
+
+        self.active_conns
+            .get_mut(ctx.session().conn_id())
+            .expect("must exist for active sessions")
+            .drop_sinks
+            .push(ComputeSinkId {
+                cluster_id,
+                global_id: sink_id,
+            });
+
+        let resp = ExecuteResponse::Subscribing {
+            rx,
+            ctx_extra: std::mem::take(ctx.extra_mut()),
+        };
+        match copy_to {
+            None => Ok(resp),
+            Some(format) => Ok(ExecuteResponse::CopyTo {
+                format,
+                resp: Box::new(resp),
+            }),
+        }
     }
 }

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -118,10 +118,10 @@ impl OptimizeIndex {
     }
 }
 
-impl<'ctx> Optimize<'ctx, Index> for OptimizeIndex {
+impl Optimize<Index> for OptimizeIndex {
     type To = GlobalMirPlan<Unresolved>;
 
-    fn optimize<'s: 'ctx>(&'s mut self, index: Index) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, index: Index) -> Result<Self::To, OptimizerError> {
         let state = self.catalog.state();
         let on_entry = state.get_entry(&index.on);
         let full_name = state.resolve_full_name(&index.name, on_entry.conn_id());
@@ -213,13 +213,10 @@ impl GlobalMirPlan<Unresolved> {
     }
 }
 
-impl<'ctx> Optimize<'ctx, GlobalMirPlan<Resolved>> for OptimizeIndex {
+impl Optimize<GlobalMirPlan<Resolved>> for OptimizeIndex {
     type To = GlobalLirPlan;
 
-    fn optimize<'s: 'ctx>(
-        &'s mut self,
-        plan: GlobalMirPlan<Resolved>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan<Resolved>) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -121,7 +121,7 @@ impl OptimizeIndex {
 impl<'ctx> Optimize<'ctx, Index> for OptimizeIndex {
     type To = GlobalMirPlan<Unresolved>;
 
-    fn optimize<'a: 'ctx>(&'a mut self, index: Index) -> Result<Self::To, OptimizerError> {
+    fn optimize<'s: 'ctx>(&'s mut self, index: Index) -> Result<Self::To, OptimizerError> {
         let state = self.catalog.state();
         let on_entry = state.get_entry(&index.on);
         let full_name = state.resolve_full_name(&index.name, on_entry.conn_id());

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -127,10 +127,10 @@ impl OptimizeMaterializedView {
     }
 }
 
-impl<'ctx> Optimize<'ctx, HirRelationExpr> for OptimizeMaterializedView {
+impl Optimize<HirRelationExpr> for OptimizeMaterializedView {
     type To = LocalMirPlan;
 
-    fn optimize<'s: 'ctx>(&'s mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
         // HIR ⇒ MIR lowering and decorrelation
         let expr = expr.lower(&self.config)?;
 
@@ -158,22 +158,19 @@ impl LocalMirPlan {
 
 /// This is needed only because the pipeline in the bootstrap code starts from an
 /// [`OptimizedMirRelationExpr`] attached to a [`crate::catalog::CatalogItem`].
-impl<'ctx> Optimize<'ctx, OptimizedMirRelationExpr> for OptimizeMaterializedView {
+impl Optimize<OptimizedMirRelationExpr> for OptimizeMaterializedView {
     type To = GlobalMirPlan<Unresolved>;
 
-    fn optimize<'s: 'ctx>(
-        &'s mut self,
-        expr: OptimizedMirRelationExpr,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, expr: OptimizedMirRelationExpr) -> Result<Self::To, OptimizerError> {
         let expr = expr.into_inner();
         self.optimize(LocalMirPlan { expr })
     }
 }
 
-impl<'ctx> Optimize<'ctx, LocalMirPlan> for OptimizeMaterializedView {
+impl Optimize<LocalMirPlan> for OptimizeMaterializedView {
     type To = GlobalMirPlan<Unresolved>;
 
-    fn optimize<'s: 'ctx>(&'s mut self, plan: LocalMirPlan) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: LocalMirPlan) -> Result<Self::To, OptimizerError> {
         let expr = OptimizedMirRelationExpr(plan.expr);
 
         let mut rel_typ = expr.typ();
@@ -276,13 +273,10 @@ impl GlobalMirPlan<Unresolved> {
     }
 }
 
-impl<'ctx> Optimize<'ctx, GlobalMirPlan<Resolved>> for OptimizeMaterializedView {
+impl Optimize<GlobalMirPlan<Resolved>> for OptimizeMaterializedView {
     type To = GlobalLirPlan;
 
-    fn optimize<'s: 'ctx>(
-        &'s mut self,
-        plan: GlobalMirPlan<Resolved>,
-    ) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan<Resolved>) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -52,11 +52,13 @@
 
 mod index;
 mod materialized_view;
+mod subscribe;
 mod view;
 
 // Re-export optimzier structs
 pub use index::{Index, OptimizeIndex};
 pub use materialized_view::OptimizeMaterializedView;
+pub use subscribe::OptimizeSubscribe;
 pub use view::OptimizeView;
 
 use mz_catalog::memory::objects::CatalogItem;

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -88,20 +88,20 @@ use crate::AdapterError;
 /// The `'s: 'ctx` bound in the `optimize` method call ensures that an optimizer
 /// instance can run an optimization stage that produces a `Self::To` with
 /// `&'ctx` references.
-pub trait Optimize<'ctx, From>: Send + Sync
+pub trait Optimize<From>: Send + Sync
 where
     From: Send + Sync,
 {
-    type To: Send + Sync + 'ctx;
+    type To: Send + Sync;
 
     /// Execute the optimization stage, transforming the input plan of type
     /// `From` to an output plan of type `To`.
-    fn optimize<'s: 'ctx>(&'s mut self, plan: From) -> Result<Self::To, OptimizerError>;
+    fn optimize(&mut self, plan: From) -> Result<Self::To, OptimizerError>;
 
     /// Execute the optimization stage and panic if an error occurs.
     ///
     /// See [`Optimize::optimize`].
-    fn must_optimize<'s: 'ctx>(&'s mut self, expr: From) -> Self::To {
+    fn must_optimize(&mut self, expr: From) -> Self::To {
         match self.optimize(expr) {
             Ok(ok) => ok,
             Err(err) => panic!("must_optimize call failed: {err}"),

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -1,0 +1,322 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Optimizer implementation for `SUBSCRIBE` statements.
+
+use std::sync::Arc;
+
+use differential_dataflow::lattice::Lattice;
+use maplit::btreemap;
+use mz_adapter_types::connection::ConnectionId;
+use mz_compute_types::plan::Plan;
+use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
+use mz_compute_types::ComputeInstanceId;
+use mz_ore::soft_assert_or_log;
+use mz_repr::explain::trace_plan;
+use mz_repr::{GlobalId, RelationDesc, Timestamp};
+use mz_sql::plan::SubscribeFrom;
+use mz_transform::dataflow::DataflowMetainfo;
+use mz_transform::normalize_lets::normalize_lets;
+use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
+use mz_transform::Optimizer as TransformOptimizer;
+use timely::progress::Antichain;
+use tracing::{span, Level};
+
+use crate::catalog::Catalog;
+use crate::coord::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
+use crate::optimize::{
+    LirDataflowDescription, MirDataflowDescription, Optimize, OptimizerConfig, OptimizerError,
+};
+use crate::CollectionIdBundle;
+
+pub struct OptimizeSubscribe {
+    /// A typechecking context to use throughout the optimizer pipeline.
+    typecheck_ctx: TypecheckContext,
+    /// A snapshot of the catalog state.
+    catalog: Arc<Catalog>,
+    /// A snapshot of the compute instance that will run the dataflows.
+    compute_instance: ComputeInstanceSnapshot,
+    /// A transient GlobalId to be used when constructing the dataflow.
+    transient_id: GlobalId,
+    /// The id of the session connection in which the optimizer will run.
+    conn_id: ConnectionId,
+    /// Should the plan produce an initial snapshot?
+    with_snapshot: bool,
+    /// Sink timestamp.
+    up_to: Option<Timestamp>,
+    // Optimizer config.
+    config: OptimizerConfig,
+}
+
+/// The (sealed intermediate) result after:
+///
+/// 1. embedding a [`SubscribeFrom`] plan into a [`MirDataflowDescription`],
+/// 2. transitively inlining referenced views, and
+/// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
+#[derive(Clone)]
+pub struct GlobalMirPlan<T: Clone> {
+    df_desc: MirDataflowDescription,
+    df_meta: DataflowMetainfo,
+    ts_info: T,
+}
+
+/// Timestamp information type for [`GlobalMirPlan`] structs representing an
+/// optimization result without a resolved timestamp.
+#[derive(Clone)]
+pub struct Unresolved {
+    compute_instance_id: ComputeInstanceId,
+}
+
+/// Timestamp information type for [`GlobalMirPlan`] structs representing an
+/// optimization result with a resolved timestamp.
+///
+/// The actual timestamp value is set in the [`MirDataflowDescription`] of the
+/// surrounding [`GlobalMirPlan`] when we call `resolve()`.
+#[derive(Clone)]
+pub struct Resolved;
+
+/// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
+/// `DataflowDescription` with `LIR` plans.
+pub struct GlobalLirPlan {
+    df_desc: LirDataflowDescription,
+    df_meta: DataflowMetainfo,
+}
+
+impl OptimizeSubscribe {
+    pub fn new(
+        catalog: Arc<Catalog>,
+        compute_instance: ComputeInstanceSnapshot,
+        transient_id: GlobalId,
+        conn_id: ConnectionId,
+        with_snapshot: bool,
+        up_to: Option<Timestamp>,
+        config: OptimizerConfig,
+    ) -> Self {
+        Self {
+            typecheck_ctx: empty_context(),
+            catalog,
+            compute_instance,
+            transient_id,
+            conn_id,
+            with_snapshot,
+            up_to,
+            config,
+        }
+    }
+}
+
+impl Optimize<SubscribeFrom> for OptimizeSubscribe {
+    type To = GlobalMirPlan<Unresolved>;
+
+    fn optimize(&mut self, plan: SubscribeFrom) -> Result<Self::To, OptimizerError> {
+        let sink_name = format!("subscribe-{}", self.transient_id);
+
+        let (df_desc, df_meta) = match plan {
+            SubscribeFrom::Id(from_id) => {
+                let from = self.catalog.get_entry(&from_id);
+                let from_desc = from
+                    .desc(
+                        &self
+                            .catalog
+                            .state()
+                            .resolve_full_name(from.name(), Some(&self.conn_id)),
+                    )
+                    .expect("subscribes can only be run on items with descs")
+                    .into_owned();
+
+                // Make SinkDesc
+                let sink_id = self.transient_id;
+                let sink_desc = ComputeSinkDesc {
+                    from: from_id,
+                    from_desc,
+                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection::default()),
+                    with_snapshot: self.with_snapshot,
+                    up_to: self.up_to.map(Antichain::from_elem).unwrap_or_default(),
+                    // No `FORCE NOT NULL` for subscribes
+                    non_null_assertions: vec![],
+                };
+
+                let mut df_builder =
+                    DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+
+                let (df_desc, df_meta) =
+                    df_builder.build_sink_dataflow(sink_name, sink_id, sink_desc)?;
+
+                (df_desc, df_meta)
+            }
+            SubscribeFrom::Query { expr, desc } => {
+                // TODO: Change the `expr` type to be `HirRelationExpr` and run
+                // HIR ⇒ MIR lowering and decorrelation here. This would allow
+                // us implement something like `EXPLAIN RAW PLAN FOR SUBSCRIBE.`
+                //
+                // let expr = expr.lower()?;
+
+                // MIR ⇒ MIR optimization (local)
+                let expr = span!(target: "optimizer", Level::TRACE, "local").in_scope(|| {
+                    let optimizer = TransformOptimizer::logical_optimizer(&self.typecheck_ctx);
+                    let expr = optimizer.optimize(expr)?;
+
+                    // Trace the result of this phase.
+                    trace_plan(&expr);
+
+                    Ok::<_, OptimizerError>(expr)
+                })?;
+
+                let from_desc = RelationDesc::new(expr.typ(), desc.iter_names());
+                let from_id = self.transient_id;
+
+                // Make SinkDesc
+                let sink_desc = ComputeSinkDesc {
+                    from: from_id,
+                    from_desc,
+                    connection: ComputeSinkConnection::Subscribe(SubscribeSinkConnection::default()),
+                    with_snapshot: self.with_snapshot,
+                    up_to: self.up_to.map(Antichain::from_elem).unwrap_or_default(),
+                    // No `FORCE NOT NULL` for subscribes
+                    non_null_assertions: vec![],
+                };
+
+                let mut df_builder =
+                    DataflowBuilder::new(self.catalog.state(), self.compute_instance.clone());
+
+                let mut df_desc = MirDataflowDescription::new(sink_name);
+
+                df_builder.import_view_into_dataflow(&from_id, &expr, &mut df_desc)?;
+                df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;
+
+                let df_meta =
+                    df_builder.build_sink_dataflow_into(&mut df_desc, from_id, sink_desc)?;
+
+                (df_desc, df_meta)
+            }
+        };
+
+        // Return the (sealed) plan at the end of this optimization step.
+        Ok(GlobalMirPlan {
+            df_desc,
+            df_meta,
+            ts_info: Unresolved {
+                compute_instance_id: self.compute_instance.instance_id(),
+            },
+        })
+    }
+}
+
+impl<T: Clone> GlobalMirPlan<T> {
+    pub fn df_desc(&self) -> &MirDataflowDescription {
+        &self.df_desc
+    }
+
+    #[allow(dead_code)] // This will be needed for EXPLAIN SUBSCRIBE
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+}
+
+impl GlobalMirPlan<Unresolved> {
+    /// Produces the [`GlobalMirPlan`] with [`Resolved`] timestamp required for
+    /// the next stage.
+    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalMirPlan<Resolved> {
+        // A datalfow description for a `SUBSCRIBE` statement should not have
+        // index exports.
+        soft_assert_or_log!(
+            self.df_desc.index_exports.is_empty(),
+            "unexpectedly setting until for a DataflowDescription with an index",
+        );
+
+        // Set the `as_of` timestamp for the dataflow.
+        self.df_desc.set_as_of(as_of);
+
+        // The only outputs of the dataflow are sinks, so we might be able to
+        // turn off the computation early, if they all have non-trivial
+        // `up_to`s.
+        self.df_desc.until = Antichain::from_elem(Timestamp::MIN);
+        for (_, sink) in &self.df_desc.sink_exports {
+            self.df_desc.until.join_assign(&sink.up_to);
+        }
+
+        GlobalMirPlan {
+            df_desc: self.df_desc,
+            df_meta: self.df_meta,
+            ts_info: Resolved,
+        }
+    }
+
+    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
+    pub fn id_bundle(&self) -> CollectionIdBundle {
+        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
+        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
+        CollectionIdBundle {
+            storage_ids,
+            compute_ids: btreemap! {self.compute_instance_id() => compute_ids},
+        }
+    }
+
+    /// Returns the [`ComputeInstanceId`] against which we should resolve the
+    /// timestamp for the next stage.
+    pub fn compute_instance_id(&self) -> ComputeInstanceId {
+        self.ts_info.compute_instance_id
+    }
+}
+
+impl Optimize<GlobalMirPlan<Resolved>> for OptimizeSubscribe {
+    type To = GlobalLirPlan;
+
+    fn optimize(&mut self, plan: GlobalMirPlan<Resolved>) -> Result<Self::To, OptimizerError> {
+        let GlobalMirPlan {
+            mut df_desc,
+            df_meta,
+            ts_info: _,
+        } = plan;
+
+        // Ensure all expressions are normalized before finalizing.
+        for build in df_desc.objects_to_build.iter_mut() {
+            normalize_lets(&mut build.plan.0)?
+        }
+
+        // Finalize the dataflow. This includes:
+        // - MIR ⇒ LIR lowering
+        // - LIR ⇒ LIR transforms
+        let df_desc = Plan::finalize_dataflow(
+            df_desc,
+            self.config.enable_consolidate_after_union_negate,
+            self.config.enable_specialized_arrangements,
+        )
+        .map_err(OptimizerError::Internal)?;
+
+        // Return the plan at the end of this `optimize` step.
+        Ok(GlobalLirPlan { df_desc, df_meta })
+    }
+}
+
+impl GlobalLirPlan {
+    pub fn unapply(self) -> (LirDataflowDescription, DataflowMetainfo) {
+        (self.df_desc, self.df_meta)
+    }
+
+    pub fn df_desc(&self) -> &LirDataflowDescription {
+        &self.df_desc
+    }
+
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+
+    pub fn sink_id(&self) -> GlobalId {
+        let sink_exports = &self.df_desc.sink_exports;
+        let sink_id = sink_exports.keys().next().expect("valid sink");
+        *sink_id
+    }
+
+    pub fn sink_desc(&self) -> &ComputeSinkDesc {
+        let sink_exports = &self.df_desc.sink_exports;
+        let sink_desc = sink_exports.values().next().expect("valid sink");
+        sink_desc
+    }
+}

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -34,10 +34,10 @@ impl OptimizeView {
     }
 }
 
-impl<'ctx> Optimize<'ctx, HirRelationExpr> for OptimizeView {
+impl Optimize<HirRelationExpr> for OptimizeView {
     type To = OptimizedMirRelationExpr;
 
-    fn optimize<'s: 'ctx>(&'s mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
         // HIR ⇒ MIR lowering and decorrelation
         let expr = expr.lower(&self.config)?;
 

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -37,7 +37,7 @@ impl OptimizeView {
 impl<'ctx> Optimize<'ctx, HirRelationExpr> for OptimizeView {
     type To = OptimizedMirRelationExpr;
 
-    fn optimize<'a: 'ctx>(&'a mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
+    fn optimize<'s: 'ctx>(&'s mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {
         // HIR ⇒ MIR lowering and decorrelation
         let expr = expr.lower(&self.config)?;
 


### PR DESCRIPTION
Add an `OptimizeSubscribe` struct using the new API and integrate it in the `SUBSCRIBE` code paths.

### Motivation

  * This PR adds a known-desirable feature.

Continues integrating the `Optimize` API proposed in #20569 according to the rollout plan from the design doc.

### Tips for reviewer

See commit messages for details.

- The first commit is just minor changes for syntactic alignment.
- The second commit simplifies the `Optimize` API a bit by removing some lifetime parameters.
- The last two commits are similar to previous PRs of that series and follow the rollout plan from #20569. 

@MaterializeInc/testing we should be worried if we see failures in [the CI](https://buildkite.com/materialize/tests/builds?branch=aalexandrov%3Aoptimize_subscribe) or [the Nightlies](https://buildkite.com/materialize/nightlies/builds?branch=aalexandrov%3Aoptimize_subscribe) runs for the PR branch that can be attributed to subscribes.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.