### PR TITLE
persist-txn: skip fetching provably irrelevant parts in TxnsCache 

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -34,6 +34,7 @@ use crate::internal::machine::retry_external;
 use crate::internal::metrics::{Metrics, ReadMetrics, ShardMetrics};
 use crate::internal::paths::PartialBatchKey;
 use crate::read::{LeasedReaderId, ReadHandle};
+use crate::stats::PartStats;
 use crate::ShardId;
 
 /// Capable of fetching [`LeasedBatchPart`] while not holding any capabilities.
@@ -437,6 +438,11 @@ where
     /// then something has gone horribly wrong.
     pub fn request_filter_pushdown_audit(&mut self) {
         self.filter_pushdown_audit = true;
+    }
+
+    /// Returns the pushdown stats for this part.
+    pub fn stats(&self) -> Option<PartStats> {
+        self.stats.as_ref().map(|x| x.decode())
     }
 }
 

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -177,6 +177,11 @@ where
         ret
     }
 
+    /// Fetches the contents of `part` and returns its lease.
+    pub async fn fetch_batch_part(&mut self, part: LeasedBatchPart<T>) -> FetchedPart<K, V, T, D> {
+        self.listen.fetch_batch_part(part).await
+    }
+
     /// Takes a [`SerdeLeasedBatchPart`] into a [`LeasedBatchPart`].
     pub fn leased_part_from_exchangeable(&self, x: SerdeLeasedBatchPart) -> LeasedBatchPart<T> {
         self.listen

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -273,6 +273,7 @@ use differential_dataflow::Hashable;
 use mz_persist_client::batch::ProtoBatch;
 use mz_persist_client::critical::SinceHandle;
 use mz_persist_client::error::UpperMismatch;
+use mz_persist_client::stats::PartStats;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{ShardId, ShardIdSchema};
 use mz_persist_types::codec_impls::VecU8Schema;
@@ -280,7 +281,7 @@ use mz_persist_types::{Codec, Codec64, Opaque, StepForward};
 use prost::Message;
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
-use tracing::{debug, instrument};
+use tracing::{debug, error, instrument};
 
 pub mod operator;
 pub mod txn_read;
@@ -294,6 +295,15 @@ pub enum TxnsEntry {
     Register(ShardId),
     /// A batch written to a data shard in a txn.
     Append(ShardId, Vec<u8>),
+}
+
+impl TxnsEntry {
+    fn data_id(&self) -> &ShardId {
+        match self {
+            TxnsEntry::Register(data_id) => data_id,
+            TxnsEntry::Append(data_id, _) => data_id,
+        }
+    }
 }
 
 /// An abstraction over the encoding format of [TxnsEntry].
@@ -314,6 +324,14 @@ pub trait TxnsCodec: Debug {
     ///
     /// Implementations should panic if the values are invalid.
     fn decode(key: Self::Key, val: Self::Val) -> TxnsEntry;
+
+    /// Returns if a part might include the given data shard based on pushdown
+    /// stats.
+    ///
+    /// False positives are okay (needless fetches) but false negatives are not
+    /// (incorrectness). Returns an Option to make `?` convenient, `None` is
+    /// treated the same as `Some(true)`.
+    fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool>;
 }
 
 /// A reasonable default implementation of [TxnsCodec].
@@ -341,6 +359,15 @@ impl TxnsCodec for TxnsCodecDefault {
         } else {
             TxnsEntry::Append(key, val)
         }
+    }
+    fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool> {
+        let stats = stats
+            .key
+            .col::<String>("")
+            .map_err(|err| error!("unexpected stats type: {}", err))
+            .ok()??;
+        let data_id_str = data_id.to_string();
+        Some(stats.lower <= data_id_str && stats.upper >= data_id_str)
     }
 }
 

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -109,7 +109,7 @@ where
     let shutdown_button = builder.build(move |capabilities| async move {
         let [mut cap]: [_; 1] = capabilities.try_into().expect("one capability per output");
         let client = client.await;
-        let mut txns_cache = TxnsCache::<T, C>::open(&client, txns_id).await;
+        let mut txns_cache = TxnsCache::<T, C>::open(&client, txns_id, Some(data_id)).await;
 
         txns_cache.update_gt(&as_of).await;
         let snap = txns_cache.data_snapshot(data_id, as_of.clone());

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -18,6 +18,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::hashable::Hashable;
 use differential_dataflow::lattice::Lattice;
 use mz_ore::collections::HashMap;
+use mz_persist_client::fetch::LeasedBatchPart;
 use mz_persist_client::read::{ListenEvent, ReadHandle, Since, Subscribe};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
@@ -91,6 +92,14 @@ pub struct TxnsCache<T: Timestamp + Lattice + Codec64, C: TxnsCodec = TxnsCodecD
     /// Invariant: Contains the minimum write time (if any) for each value in
     /// `self.datas`.
     datas_min_write_ts: BinaryHeap<Reverse<(T, ShardId)>>,
+
+    /// If Some, this cache only tracks the indicated data shard as a
+    /// performance optimization. When used, only some methods (in particular,
+    /// the ones necessary for the txns_progress operator) are supported.
+    ///
+    /// TODO: It'd be nice to make this a compile time thing. I have some ideas,
+    /// but they're decently invasive, so leave it for a followup.
+    only_data_id: Option<ShardId>,
 }
 
 impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> TxnsCache<T, C> {
@@ -100,7 +109,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
         txns_write: &mut WriteHandle<C::Key, C::Val, T, i64>,
     ) -> Self {
         let () = crate::empty_caa(|| "txns init", txns_write, init_ts.clone()).await;
-        let mut ret = Self::from_read(txns_read).await;
+        let mut ret = Self::from_read(txns_read, None).await;
         ret.update_gt(&init_ts).await;
         ret
     }
@@ -110,7 +119,11 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     /// `txns_id` identifies which shard will be used as the txns WAL. MZ will
     /// likely have one of these per env, used by all processes and the same
     /// across restarts.
-    pub async fn open(client: &PersistClient, txns_id: ShardId) -> Self {
+    pub async fn open(
+        client: &PersistClient,
+        txns_id: ShardId,
+        only_data_id: Option<ShardId>,
+    ) -> Self {
         let (txns_key_schema, txns_val_schema) = C::schemas();
         let txns_read = client
             .open_leased_reader(
@@ -124,10 +137,13 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
             )
             .await
             .expect("txns schema shouldn't change");
-        Self::from_read(txns_read).await
+        Self::from_read(txns_read, only_data_id).await
     }
 
-    pub(crate) async fn from_read(txns_read: ReadHandle<C::Key, C::Val, T, i64>) -> Self {
+    pub(crate) async fn from_read(
+        txns_read: ReadHandle<C::Key, C::Val, T, i64>,
+        only_data_id: Option<ShardId>,
+    ) -> Self {
         let txns_id = txns_read.shard_id();
         let as_of = txns_read.since().clone();
         let since_ts = as_of.as_option().expect("txns shard is not closed").clone();
@@ -145,6 +161,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
             batch_idx: HashMap::new(),
             datas: BTreeMap::new(),
             datas_min_write_ts: BinaryHeap::new(),
+            only_data_id,
         }
     }
 
@@ -159,6 +176,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     /// Specifically, a data shard is registered at a timestamp `ts` if it has a
     /// `register_ts <= ts` but no `forget_ts >= ts`.
     pub fn registered_at(&self, data_id: &ShardId, ts: &T) -> bool {
+        self.assert_only_data_id(data_id);
         let Some(data_times) = self.datas.get(data_id) else {
             return false;
         };
@@ -176,6 +194,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     ///
     /// Returns Err if that data shard has not been registered at the given ts.
     pub fn data_snapshot(&self, data_id: ShardId, as_of: T) -> DataSnapshot<T> {
+        self.assert_only_data_id(&data_id);
         assert!(self.progress_exclusive > as_of);
         let Some(all) = self.datas.get(&data_id) else {
             // Not registered at this time, so we know there are no unapplied
@@ -226,6 +245,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     ///
     /// Returns Err if that data shard has not been registered at the given ts.
     pub fn data_listen_next(&self, data_id: &ShardId, ts: T) -> DataListenNext<T> {
+        self.assert_only_data_id(data_id);
         assert!(self.progress_exclusive >= ts);
         use DataListenNext::*;
         let data_times = self.datas.get(data_id);
@@ -283,6 +303,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
 
     /// Returns the minimum timestamp not known to be applied by this cache.
     pub fn min_unapplied_ts(&self) -> &T {
+        assert_eq!(self.only_data_id, None);
         // We maintain an invariant that the values in the unapplied_batches map
         // are sorted by timestamp, thus the first one must be the minimum.
         self.unapplied_batches
@@ -296,6 +317,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
 
     /// Returns the batches needing application as of the current progress.
     pub(crate) fn unapplied_batches(&self) -> impl Iterator<Item = &(ShardId, Vec<u8>, T)> {
+        assert_eq!(self.only_data_id, None);
         self.unapplied_batches.values()
     }
 
@@ -317,6 +339,7 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
         expected_txns_upper: &T,
         retractions: impl Iterator<Item = (&'a Vec<u8>, &'a ShardId)>,
     ) -> impl Iterator<Item = (&'a Vec<u8>, &'a ShardId)> {
+        assert_eq!(self.only_data_id, None);
         assert!(&self.progress_exclusive >= expected_txns_upper);
         retractions.filter(|(batch_raw, _)| self.batch_idx.contains_key(*batch_raw))
     }
@@ -365,26 +388,51 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
 
     async fn update<F: Fn(&T) -> bool>(&mut self, done: F) {
         while !done(&self.progress_exclusive) {
-            let events = self.txns_subscribe.fetch_next().await;
+            let events = self.txns_subscribe.next().await;
             for event in events {
-                let mut updates = match event {
+                let parts = match event {
                     ListenEvent::Progress(frontier) => {
                         self.progress_exclusive = frontier
                             .into_option()
                             .expect("nothing should close the txns shard");
                         continue;
                     }
-                    ListenEvent::Updates(updates) => updates,
+                    ListenEvent::Updates(parts) => parts,
                 };
+                let mut updates = Vec::new();
+                for part in parts {
+                    let should_fetch_part = self.should_fetch_part(&part);
+                    debug!(
+                        "should_fetch_part={} for {:?} {:?}",
+                        should_fetch_part,
+                        self.only_data_id,
+                        part.stats()
+                    );
+                    if !should_fetch_part {
+                        self.txns_subscribe.return_leased_part(part);
+                        continue;
+                    }
+                    let part_updates = self.txns_subscribe.fetch_batch_part(part).await;
+                    // To keep memory usage down, filter out unrelated data
+                    // shards even before we buffer them for the timestamp sort.
+                    let part_updates = part_updates.map(|((k, v), t, d)| {
+                        let (k, v) = (k.expect("valid key"), v.expect("valid val"));
+                        (C::decode(k, v), t, d)
+                    });
+                    if let Some(only_data_id) = self.only_data_id.as_ref() {
+                        updates
+                            .extend(part_updates.filter(|(x, _, _)| x.data_id() == only_data_id));
+                    } else {
+                        updates.extend(part_updates);
+                    }
+                }
                 // Persist emits the times sorted by little endian encoding,
                 // which is not what we want. If we ever expose an interface for
                 // registering and committing to a data shard at the same
                 // timestamp, this will also have to sort registrations first.
                 updates.sort_by(|(_, at, _), (_, bt, _)| at.cmp(bt));
-                for ((k, v), t, d) in updates {
-                    let k = k.expect("valid key");
-                    let v = v.expect("valid val");
-                    match C::decode(k, v) {
+                for (e, t, d) in updates {
+                    match e {
                         TxnsEntry::Register(data_id) => self.push_register(data_id, t, d),
                         TxnsEntry::Append(data_id, batch) => self.push_append(data_id, batch, t, d),
                     }
@@ -402,7 +450,13 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     }
 
     fn push_register(&mut self, data_id: ShardId, ts: T, diff: i64) {
+        self.assert_only_data_id(&data_id);
         debug_assert!(ts >= self.progress_exclusive);
+        if let Some(only_data_id) = self.only_data_id.as_ref() {
+            if only_data_id != &data_id {
+                return;
+            }
+        }
 
         if diff == 1 {
             debug!(
@@ -438,7 +492,13 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
     }
 
     fn push_append(&mut self, data_id: ShardId, batch: Vec<u8>, ts: T, diff: i64) {
+        self.assert_only_data_id(&data_id);
         debug_assert!(ts >= self.progress_exclusive);
+        if let Some(only_data_id) = self.only_data_id.as_ref() {
+            if only_data_id != &data_id {
+                return;
+            }
+        }
 
         if diff == 1 {
             debug!(
@@ -567,6 +627,24 @@ impl<T: Timestamp + Lattice + TotalOrder + StepForward + Codec64, C: TxnsCodec> 
             self.since_ts, self.datas_min_write_ts
         );
         debug_assert_eq!(self.validate(), Ok(()));
+    }
+
+    fn should_fetch_part(&self, part: &LeasedBatchPart<T>) -> bool {
+        let Some(only_data_id) = self.only_data_id.as_ref() else {
+            return true;
+        };
+        // This `part.stats()` call involves decoding and the only_data_id=None
+        // case is common-ish, so make sure to keep it after that early return.
+        let Some(stats) = part.stats() else {
+            return true;
+        };
+        C::should_fetch_part(only_data_id, &stats).unwrap_or(true)
+    }
+
+    fn assert_only_data_id(&self, data_id: &ShardId) {
+        if let Some(only_data_id) = self.only_data_id.as_ref() {
+            assert_eq!(data_id, only_data_id);
+        }
     }
 
     pub(crate) fn validate(&self) -> Result<(), String> {
@@ -924,7 +1002,7 @@ mod tests {
             init_ts: u64,
             txns: &TxnsHandle<String, (), u64, i64>,
         ) -> Self {
-            let mut ret = TxnsCache::open(&txns.datas.client, txns.txns_id()).await;
+            let mut ret = TxnsCache::open(&txns.datas.client, txns.txns_id(), None).await;
             ret.update_gt(&init_ts).await;
             ret.compact_to(&init_ts);
             ret

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2020,7 +2020,7 @@ where
                 Arc::new(UnitSchema),
             )
             .await;
-            let txns_cache = TxnsCache::open(&client, txns_id).await;
+            let txns_cache = TxnsCache::open(&client, txns_id, None).await;
             let worker = persist_handles::PersistTableWriteWorker::new_txns(tx.clone(), txns);
             (worker, Some(txns_cache))
         } else {


### PR DESCRIPTION
The txns_progress operator only ever asks its TxnsCache questions about
a single data shard. This means it's free to skip fetching data about
other data shards, which should save a tremendous number of blob fetches
(basically all of them?).

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

Joe, happy to walk you through the pushdown related parts of this, but hopefully it should be pretty straightforward in context! Ditto Ben for the persist-txn parts.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
