### PR TITLE
storage: handle transient errors during decoding

### DIFF
--- a/src/storage/src/decode/avro.rs
+++ b/src/storage/src/decode/avro.rs
@@ -31,8 +31,11 @@ impl AvroDecoderState {
         })
     }
 
-    pub async fn decode(&mut self, bytes: &mut &[u8]) -> Result<Option<Row>, DecodeErrorKind> {
-        match self.decoder.decode(bytes).await {
+    pub async fn decode(
+        &mut self,
+        bytes: &mut &[u8],
+    ) -> Result<Result<Option<Row>, DecodeErrorKind>, anyhow::Error> {
+        let result = match self.decoder.decode(bytes).await? {
             Ok(row) => {
                 self.events_success += 1;
                 Ok(Some(row))
@@ -41,6 +44,7 @@ impl AvroDecoderState {
                 "avro deserialization error: {}",
                 err.display_with_causes()
             ))),
-        }
+        };
+        Ok(result)
     }
 }


### PR DESCRIPTION
Change the function signatures of all methods that can fail transiently to be a double `Result` where the outer `Result` represents whether a transient error happened and the inner `Result` is the definite result of decoding the bytes.

This separates things that should be permanently recorded in the shard (the inner errors) from things that should simply restart the dataflow (outer errors). At the same time it makes it easy to propagate a transient error upwards (just using the `?` operator) and hard to accidentally put a transient error in the shard (since you have to manually deconstruct the error and put it there).

This bubbling up of transient errors terminates in the future passed to `build_fallible` which was integrated in #20150 and will restart the ingestion dataflow if a transient error reaches that point.

Fixes #6185

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
