### PR TITLE
fix testdrive/mzcompose.py `default-timeout` flag

### DIFF
--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -58,8 +58,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     parser.add_argument(
         "--default-timeout",
-        type=int,
-        help="set the default timeout for Testdrive, in seconds",
+        type=str,
+        help="set the default timeout for Testdrive",
     )
 
     parser.add_argument(


### PR DESCRIPTION
This was broken as the underlying API it gets passed to expects a string like `10s`, not an integer number of seconds.