### PR TITLE
platform-checks: Set enable_specialized_arrangements to off on older …

### DIFF
--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -42,12 +42,22 @@ class StartMz(MzcomposeAction):
 
         image = f"materialize/materialized:{self.tag}" if self.tag is not None else None
         print(f"Starting Mz using image {image}")
+
+        # Before #22790, this parameter needs to be set to False to avoid a panic
+        # Importantly, the environmentd must boot with the flag set to False, so we have to set it here
+        # By the time ConfigureMz() arrives to run ALTER SYSTEM SET, it is already too late
+        # to disable it, as problematic introspection dataflows have been created already
+        additional_system_parameter_defaults = (
+            {"enable_specialized_arrangements": "false"} if self.tag else None
+        )
+
         mz = Materialized(
             image=image,
             external_cockroach=True,
             external_minio=True,
             environment_extra=self.environment_extra,
             system_parameter_defaults=self.system_parameter_defaults,
+            additional_system_parameter_defaults=additional_system_parameter_defaults,
             sanity_restart=False,
         )
 
@@ -122,6 +132,14 @@ class ConfigureMz(MzcomposeAction):
             <= MzVersion.parse("0.63.99")
         ):
             system_settings.add("ALTER SYSTEM SET enable_managed_clusters = on;")
+
+        # Before #22790, enable_specialized_arrangements=on would cause a panic on upgrade
+        # This flag must be disabled by default in StartMz() and then conditionally enabled
+        # here for the versions where it is expected to work.
+        if e.current_mz_version >= MzVersion.parse("0.75.0"):
+            system_settings.add(
+                "ALTER SYSTEM SET enable_specialized_arrangements = on;"
+            )
 
         system_settings = system_settings - e.system_settings
 


### PR DESCRIPTION
…versions

This is needed in order to avoid the following panic:

Invalid combination of type specializations: key types differ

### Motivation

Nightly CI was failing.