### PR TITLE
compute: simplify dataflow ID printing

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1738,7 +1738,7 @@ impl Coordinator {
         // Things go wrong if we try to create a dataflow with `as_of = []`, so avoid that.
         if write_frontier.is_empty() {
             tracing::info!(
-                export_ids = dataflow.format_export_ids(),
+                export_ids = %dataflow.display_export_ids(),
                 %cluster_id,
                 min_as_of = ?min_as_of.elements(),
                 write_frontier = ?write_frontier.elements(),
@@ -1773,7 +1773,7 @@ impl Coordinator {
         let as_of = min_as_of.join(&max_as_of);
 
         tracing::info!(
-            export_ids = %dataflow.format_export_ids(),
+            export_ids = %dataflow.display_export_ids(),
             %cluster_id,
             min_as_of = ?min_as_of.elements(),
             write_frontier = ?write_frontier.elements(),
@@ -1815,7 +1815,7 @@ impl Coordinator {
         };
 
         tracing::info!(
-            export_ids = %dataflow.format_export_ids(),
+            export_ids = %dataflow.display_export_ids(),
             %cluster_id,
             min_as_of = ?min_as_of.elements(),
             write_frontier = ?write_frontier.elements(),

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -840,8 +840,8 @@ where
         if augmented_dataflow.is_transient() {
             tracing::debug!(
                 name = %augmented_dataflow.debug_name,
-                import_ids = %augmented_dataflow.format_import_ids(),
-                export_ids = %augmented_dataflow.format_export_ids(),
+                import_ids = %augmented_dataflow.display_import_ids(),
+                export_ids = %augmented_dataflow.display_export_ids(),
                 as_of = ?augmented_dataflow.as_of.as_ref().unwrap().elements(),
                 until = ?augmented_dataflow.until.elements(),
                 "creating dataflow",
@@ -849,8 +849,8 @@ where
         } else {
             tracing::info!(
                 name = %augmented_dataflow.debug_name,
-                import_ids = %augmented_dataflow.format_import_ids(),
-                export_ids = %augmented_dataflow.format_export_ids(),
+                import_ids = %augmented_dataflow.display_import_ids(),
+                export_ids = %augmented_dataflow.display_export_ids(),
                 as_of = ?augmented_dataflow.as_of.as_ref().unwrap().elements(),
                 until = ?augmented_dataflow.until.elements(),
                 "creating dataflow",

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -253,8 +253,8 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         if dataflow.is_transient() {
             tracing::debug!(
                 name = %dataflow.debug_name,
-                import_ids = %dataflow.format_import_ids(),
-                export_ids = %dataflow.format_export_ids(),
+                import_ids = %dataflow.display_import_ids(),
+                export_ids = %dataflow.display_export_ids(),
                 as_of = ?as_of.elements(),
                 until = ?dataflow.until.elements(),
                 "creating dataflow",
@@ -262,8 +262,8 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
         } else {
             tracing::info!(
                 name = %dataflow.debug_name,
-                import_ids = %dataflow.format_import_ids(),
-                export_ids = %dataflow.format_export_ids(),
+                import_ids = %dataflow.display_import_ids(),
+                export_ids = %dataflow.display_export_ids(),
                 as_of = ?as_of.elements(),
                 until = ?dataflow.until.elements(),
                 "creating dataflow",


### PR DESCRIPTION
This PR simplifies the code for printing dataflow import and export IDs by making use of the formatting helper functions in `mz_ore::str`. As a side-effect of this, the formatting methods now return `Display` values rather than `String`s, making logging of dataflow IDs more efficient.

### Motivation

   * This PR refactors existing code.

Follow-up to #22818

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
