### PR TITLE
Add transient index ID to statement log

### DIFF
--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -74,7 +74,7 @@ pub enum PeekResponseUnary {
 #[derive(Debug)]
 pub struct PeekDataflowPlan<T = mz_repr::Timestamp> {
     desc: DataflowDescription<mz_compute_types::plan::Plan<T>, (), T>,
-    id: GlobalId,
+    pub(crate) id: GlobalId,
     key: Vec<MirScalarExpr>,
     permutation: BTreeMap<usize, usize>,
     thinned_arity: usize,

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -95,7 +95,7 @@ use crate::coord::dataflows::{
     ExprPrepStyle,
 };
 use crate::coord::id_bundle::CollectionIdBundle;
-use crate::coord::peek::{FastPathPlan, PlannedPeek};
+use crate::coord::peek::{FastPathPlan, PeekDataflowPlan, PlannedPeek};
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::TimelineContext;
 use crate::coord::timestamp_selection::{
@@ -2515,6 +2515,14 @@ impl Coordinator {
                 &finishing,
             )
             .await?;
+        if let Some(transient_index_id) = match &peek_plan.plan {
+            peek::PeekPlan::FastPath(_) => None,
+            peek::PeekPlan::SlowPath(PeekDataflowPlan { id, .. }) => Some(id),
+        } {
+            if let Some(statement_logging_id) = ctx.extra.contents() {
+                self.set_transient_index_id(statement_logging_id, *transient_index_id);
+            }
+        }
 
         let determination = peek_plan.determination.clone();
 

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -16,7 +16,7 @@ use mz_ore::now::to_datetime;
 use mz_ore::task::spawn;
 use mz_ore::{cast::CastFrom, now::EpochMillis};
 use mz_repr::adt::array::ArrayDimension;
-use mz_repr::{Datum, Diff, Row, RowPacker, Timestamp, GlobalId};
+use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_sql::plan::Params;
 use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;
@@ -439,11 +439,7 @@ impl Coordinator {
         });
     }
 
-    pub fn set_transient_index_id(
-        &mut self,
-        id: StatementLoggingId,
-        transient_index_id: GlobalId,
-    ) {
+    pub fn set_transient_index_id(&mut self, id: StatementLoggingId, transient_index_id: GlobalId) {
         self.mutate_record(id, |record| {
             record.transient_index_id = Some(transient_index_id)
         });

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -16,7 +16,7 @@ use mz_ore::now::to_datetime;
 use mz_ore::task::spawn;
 use mz_ore::{cast::CastFrom, now::EpochMillis};
 use mz_repr::adt::array::ArrayDimension;
-use mz_repr::{Datum, Diff, Row, RowPacker, Timestamp};
+use mz_repr::{Datum, Diff, Row, RowPacker, Timestamp, GlobalId};
 use mz_sql::plan::Params;
 use mz_storage_client::controller::IntrospectionType;
 use qcell::QCell;
@@ -250,9 +250,11 @@ impl Coordinator {
             transaction_isolation,
             execution_timestamp,
             transaction_id,
+            transient_index_id,
         } = record;
 
         let cluster = cluster_id.map(|id| id.to_string());
+        let transient_index_id = transient_index_id.map(|id| id.to_string());
         packer.extend([
             Datum::Uuid(*id),
             Datum::Uuid(*prepared_statement_id),
@@ -266,6 +268,10 @@ impl Coordinator {
             Datum::String(&*transaction_isolation),
             (*execution_timestamp).into(),
             Datum::UInt64(*transaction_id),
+            match &transient_index_id {
+                None => Datum::Null,
+                Some(transient_index_id) => Datum::String(transient_index_id),
+            },
         ]);
         packer
             .push_array(
@@ -430,7 +436,17 @@ impl Coordinator {
     ) {
         self.mutate_record(id, |record| {
             record.execution_timestamp = Some(u64::from(timestamp));
-        })
+        });
+    }
+
+    pub fn set_transient_index_id(
+        &mut self,
+        id: StatementLoggingId,
+        transient_index_id: GlobalId,
+    ) {
+        self.mutate_record(id, |record| {
+            record.transient_index_id = Some(transient_index_id)
+        });
     }
 
     /// Possibly record the beginning of statement execution, depending on a randomly-chosen value.
@@ -500,12 +516,6 @@ impl Coordinator {
             sample_rate,
             params,
             began_at: self.now(),
-            // Cluster is not known yet; we'll fill it in later
-            cluster_id: None,
-            cluster_name: None,
-            // Timetsamp is not known yet; we'll fill it in later
-            // (if any exists)
-            execution_timestamp: None,
             application_name: session.application_name().to_string(),
             transaction_isolation: session.vars().transaction_isolation().to_string(),
             transaction_id: session
@@ -513,6 +523,11 @@ impl Coordinator {
                 .inner()
                 .expect("Every statement runs in an explicit or implicit transaction")
                 .id,
+            // These are not known yet; we'll fill them in later.
+            cluster_id: None,
+            cluster_name: None,
+            execution_timestamp: None,
+            transient_index_id: None,
         };
         let mseh_update = Self::pack_statement_began_execution_update(&record);
         self.statement_logging

--- a/src/adapter/src/statement_logging.rs
+++ b/src/adapter/src/statement_logging.rs
@@ -10,6 +10,7 @@
 use mz_controller_types::ClusterId;
 use mz_ore::cast::CastFrom;
 use mz_ore::now::EpochMillis;
+use mz_repr::GlobalId;
 use uuid::Uuid;
 
 use crate::session::TransactionId;
@@ -30,6 +31,7 @@ pub struct StatementBeganExecutionRecord {
     pub transaction_isolation: String,
     pub execution_timestamp: Option<EpochMillis>,
     pub transaction_id: TransactionId,
+    pub transient_index_id: Option<GlobalId>,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2139,7 +2139,7 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY_REDACTED: BuiltinView = BuiltinView {
     sql: "CREATE VIEW mz_internal.mz_statement_execution_history_redacted AS
 SELECT id, prepared_statement_id, sample_rate, cluster_id, application_name,
 cluster_name, transaction_isolation, execution_timestamp, transaction_id,
-began_at, finished_at, finished_status,
+transient_index_id, began_at, finished_at, finished_status,
 error_message, rows_returned, execution_strategy
 FROM mz_internal.mz_statement_execution_history",
     sensitivity: DataSensitivity::SuperuserAndSupport,
@@ -2178,7 +2178,7 @@ pub static MZ_ACTIVITY_LOG: BuiltinView = BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_activity_log AS
 SELECT mseh.id AS execution_id, sample_rate, cluster_id, application_name, cluster_name,
-transaction_isolation, execution_timestamp, params, began_at, finished_at, finished_status,
+transaction_isolation, execution_timestamp, transient_index_id, params, began_at, finished_at, finished_status,
 error_message, rows_returned, execution_strategy, transaction_id,
 mpsh.id AS prepared_statement_id, sql, mpsh.name AS prepared_statement_name,
 session_id, redacted_sql, prepared_at
@@ -2192,7 +2192,7 @@ pub static MZ_ACTIVITY_LOG_REDACTED: BuiltinView = BuiltinView {
     schema: MZ_INTERNAL_SCHEMA,
     sql: "CREATE VIEW mz_internal.mz_activity_log_redacted AS
 SELECT execution_id, sample_rate, cluster_id, application_name, cluster_name,
-transaction_isolation, execution_timestamp, began_at, finished_at, finished_status,
+transaction_isolation, execution_timestamp, transient_index_id, began_at, finished_at, finished_status,
 error_message, rows_returned, execution_strategy, transaction_id, prepared_statement_id,
 prepared_statement_name, session_id, redacted_sql, prepared_at
 FROM mz_internal.mz_activity_log",

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -132,6 +132,7 @@ pub static MZ_STATEMENT_EXECUTION_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|
         // which is out of range.
         .with_column("execution_timestamp", ScalarType::UInt64.nullable(true))
         .with_column("transaction_id", ScalarType::UInt64.nullable(false))
+        .with_column("transient_index_id", ScalarType::String.nullable(true))
         .with_column(
             "params",
             ScalarType::Array(Box::new(ScalarType::String)).nullable(false),

--- a/test/testdrive/statement-logging.td
+++ b/test/testdrive/statement-logging.td
@@ -118,30 +118,30 @@ serializable
 
 > WITH all_stmts AS (SELECT * FROM mz_internal.mz_statement_execution_history mseh RIGHT JOIN mz_internal.mz_prepared_statement_history mpsh ON mseh.prepared_statement_id = mpsh.id),
        test_begin AS (SELECT began_at FROM all_stmts WHERE sql = 'SELECT ''beginning real test!''' ORDER BY began_at DESC LIMIT 1)
-  SELECT c.name, all_stmts.cluster_name, all_stmts.application_name, all_stmts.sample_rate, all_stmts.params, all_stmts.finished_status, all_stmts.error_message, all_stmts.rows_returned, all_stmts.execution_strategy, all_stmts.name LIKE 's%', all_stmts.sql, all_stmts.transaction_isolation
+  SELECT c.name, all_stmts.cluster_name, all_stmts.application_name, all_stmts.sample_rate, all_stmts.params, all_stmts.finished_status, all_stmts.error_message, all_stmts.rows_returned, all_stmts.execution_strategy, all_stmts.name LIKE 's%', all_stmts.sql, all_stmts.transaction_isolation, all_stmts.transient_index_id ~ '^t[0-9]+$'
   FROM all_stmts, test_begin LEFT JOIN mz_clusters c ON c.id = all_stmts.cluster_id WHERE all_stmts.began_at >= test_begin.began_at AND all_stmts.sql NOT LIKE '%sduiahsdfuoiahsdf%'
-<null> <null> my_app 1 {} success <null> <null> <null> true "SET transaction_isolation TO serializable" "strict serializable"
-<null> c my_app 1 {} success <null> 1 standard true "SELECT count(*) FROM t" "strict serializable"
-<null> c my_app 1 {} success <null> <null> <null> true "DROP CLUSTER c" "strict serializable"
-default default my_app 1 {} error "Evaluation error: division by zero" <null> <null> true "SELECT f/0 FROM t" "strict serializable"
-default default my_app 1 {} success <null> 1 constant true "EXECUTE p('hello world')" "strict serializable"
-default default my_app 1 {} success <null> 1 fast-path true "SELECT * FROM t" "strict serializable"
-default default my_app 1 {} success <null> 1 standard true "SELECT count(*) FROM t" "strict serializable"
-default default my_app 1 {} success <null> 2 constant true "FETCH c" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true BEGIN "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true COMMIT "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "CREATE CLUSTER c REPLICAS (r1 (size '1'))" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "CREATE DEFAULT INDEX i ON t" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "CREATE TABLE t(f int)" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "DECLARE c CURSOR FOR VALUES (1), (2)" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "FETCH c" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "FETCH c" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "INSERT INTO t VALUES (1)" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "PREPARE p AS values ($1)" "strict serializable"
-default default my_app 1 {} success <null> <null> <null> true "SET cluster TO c" "strict serializable"
-mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'beginning real test!'" "strict serializable"
-mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'serializable'" serializable
-mz_introspection mz_introspection my_app 1 {} success <null> 1 standard true "SELECT count(*) > 0 FROM mz_internal.mz_cluster_replica_metrics" "strict serializable"
+<null> <null> my_app 1 {} success <null> <null> <null> true "SET transaction_isolation TO serializable" "strict serializable" <null>
+<null> c my_app 1 {} success <null> 1 standard true "SELECT count(*) FROM t" "strict serializable" true
+<null> c my_app 1 {} success <null> <null> <null> true "DROP CLUSTER c" "strict serializable" <null>
+default default my_app 1 {} error "Evaluation error: division by zero" <null> <null> true "SELECT f/0 FROM t" "strict serializable" true
+default default my_app 1 {} success <null> 1 constant true "EXECUTE p('hello world')" "strict serializable" <null>
+default default my_app 1 {} success <null> 1 fast-path true "SELECT * FROM t" "strict serializable" <null>
+default default my_app 1 {} success <null> 1 standard true "SELECT count(*) FROM t" "strict serializable" true
+default default my_app 1 {} success <null> 2 constant true "FETCH c" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true BEGIN "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true COMMIT "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "CREATE CLUSTER c REPLICAS (r1 (size '1'))" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "CREATE DEFAULT INDEX i ON t" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "CREATE TABLE t(f int)" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "DECLARE c CURSOR FOR VALUES (1), (2)" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "FETCH c" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "FETCH c" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "INSERT INTO t VALUES (1)" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "PREPARE p AS values ($1)" "strict serializable" <null>
+default default my_app 1 {} success <null> <null> <null> true "SET cluster TO c" "strict serializable" <null>
+mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'beginning real test!'" "strict serializable" <null>
+mz_introspection mz_introspection my_app 1 {} success <null> 1 constant true "SELECT 'serializable'" serializable <null>
+mz_introspection mz_introspection my_app 1 {} success <null> 1 standard true "SELECT count(*) > 0 FROM mz_internal.mz_cluster_replica_metrics" "strict serializable" true
 
 # Test that everything in a transaction has the same transaction ID
 


### PR DESCRIPTION
### Motivation

  * This PR fixes https://github.com/MaterializeInc/materialize/issues/22471


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `transient_index_id` to the MZ activity log
