### PR TITLE
test: make tracing test more resilient to increased debug logging

### DIFF
--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -41,7 +41,7 @@ def workflow_with_otel(c: Composition) -> None:
 
     # update the stderr config
     c.sql(
-        "ALTER SYSTEM SET log_filter = 'debug'",
+        "ALTER SYSTEM SET log_filter = 'foo=debug,info'",
         user="mz_system",
         port=6877,
         print_statement=False,
@@ -51,7 +51,7 @@ def workflow_with_otel(c: Composition) -> None:
 
     # update the otel config
     c.sql(
-        "ALTER SYSTEM SET opentelemetry_filter = 'trace'",
+        "ALTER SYSTEM SET opentelemetry_filter = 'foo=trace,info'",
         user="mz_system",
         port=6877,
         print_statement=False,
@@ -91,7 +91,7 @@ def workflow_without_otel(c: Composition) -> None:
 
         # update the stderr config
         c.sql(
-            "ALTER SYSTEM SET log_filter = 'debug'",
+            "ALTER SYSTEM SET log_filter = 'foo=debug,info'",
             user="mz_system",
             port=6877,
             print_statement=False,
@@ -133,7 +133,7 @@ def workflow_clusterd(c: Composition) -> None:
     )
 
     c.sql(
-        "ALTER SYSTEM SET log_filter = 'debug'",
+        "ALTER SYSTEM SET log_filter = 'foo=debug,info'",
         user="mz_system",
         port=6877,
         print_statement=False,


### PR DESCRIPTION
This test can timeout on a PR if it adds a bunch of extra debug logging. We intend for debug logging to be something that can be turned on selectively, so this is a bug in the test, not a feature. Make the test resilient to this sort of thing by altering the less-selective filters to keep all the mz crates at the same level and change things for a fictional "foo" crate.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Any tips on how to verify that this doesn't break the test? Maybe something like comment out the fix in e9ab38bbf695522c1ae48afd6731fbb17e7dc5c0 and make sure it still fails?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
