### PR TITLE
coord: Emit OpenTelemetry trace_id for slow messages

### DIFF
--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -23,8 +23,10 @@ use mz_sql::ast::Statement;
 use mz_sql::names::ResolvedIds;
 use mz_sql::plan::{CreateSourcePlans, Plan};
 use mz_storage_types::controller::CollectionMetadata;
+use opentelemetry::trace::TraceContextExt;
 use rand::{rngs, Rng, SeedableRng};
 use tracing::{event, warn, Instrument, Level};
+use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 use crate::command::Command;
 use crate::coord::appends::Deferred;
@@ -60,6 +62,8 @@ impl Coordinator {
                 self.message_write_lock_grant(write_lock_guard).await;
             }
             Message::GroupCommitInitiate(span, permit) => {
+                // Add an OpenTelemetry link to our current span.
+                tracing::Span::current().add_link(span.context().span().span_context().clone());
                 self.try_group_commit(permit).instrument(span).await
             }
             Message::GroupCommitApply(timestamp, responses, write_lock_guard, notifies, permit) => {
@@ -241,7 +245,7 @@ impl Coordinator {
         self.handle_command(cmd).await;
     }
 
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn message_controller(&mut self, message: ControllerResponse) {
         event!(Level::TRACE, message = format!("{:?}", message));
         match message {

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -245,7 +245,7 @@ impl Coordinator {
         self.handle_command(cmd).await;
     }
 
-    #[tracing::instrument(level = "debug", skip(self))]
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn message_controller(&mut self, message: ControllerResponse) {
         event!(Level::TRACE, message = format!("{:?}", message));
         match message {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -500,7 +500,7 @@ impl Coordinator {
                                 session,
                                 tx: tx.take(),
                                 outer_ctx_extra: Some(extra),
-                                span: tracing::Span::none(),
+                                span: tracing::debug_span!("execute_plan"),
                             }))
                             .expect("sending to self.internal_cmd_tx cannot fail");
                     }

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -2114,6 +2114,7 @@ impl Coordinator {
     }
 
     /// Processes as many peek stages as possible.
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(crate) async fn sequence_peek_stage(
         &mut self,
         mut ctx: ExecuteContext,

--- a/src/adapter/src/coord/sql.rs
+++ b/src/adapter/src/coord/sql.rs
@@ -230,6 +230,7 @@ impl Coordinator {
     }
 
     /// Handle removing metadata associated with a SUBSCRIBE query.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn remove_active_subscribe(&mut self, id: GlobalId) {
         if let Some(active_subscribe) = self.active_subscribes.remove(&id) {
             let update = self

--- a/src/adapter/src/coord/statement_logging.rs
+++ b/src/adapter/src/coord/statement_logging.rs
@@ -118,6 +118,7 @@ impl Coordinator {
         });
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn drain_statement_log(&mut self) {
         let session_updates = std::mem::take(&mut self.statement_logging.pending_session_events)
             .into_iter()

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -148,6 +148,7 @@ impl Coordinator {
 
     /// Peek the current timestamp used for operations on local inputs. Used to determine how much
     /// to block group commits by.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(crate) async fn apply_local_write(&mut self, timestamp: Timestamp) {
         let now = self.now().into();
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -577,6 +577,7 @@ where
     }
 
     /// Processes the work queued by [`ComputeController::ready`].
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn process(&mut self) -> Option<ComputeControllerResponse<T>> {
         // Update controller state metrics.
         for instance in self.compute.instances.values_mut() {
@@ -620,6 +621,7 @@ where
         None
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn record_introspection_updates(&mut self) {
         for (type_, updates) in self.compute.introspection_rx.try_iter() {
             self.storage

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -302,6 +302,7 @@ where
     ///
     /// This method is **not** guaranteed to be cancellation safe. It **must**
     /// be awaited to completion.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn process(&mut self) -> Result<Option<ControllerResponse<T>>, anyhow::Error> {
         match mem::take(&mut self.readiness) {
             Readiness::NotReady => Ok(None),

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -3410,7 +3410,7 @@ impl SystemVars {
         *self.expect_value(&*WEBHOOKS_SECRETS_CACHING_TTL_SECS)
     }
 
-    pub fn coord_slow_message_reporting_threshold_ms(&self) -> Duration {
+    pub fn coord_slow_message_reporting_threshold(&self) -> Duration {
         *self.expect_value(&COORD_SLOW_MESSAGE_REPORTING_THRESHOLD)
     }
 

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -297,6 +297,7 @@ where
     }
 
     /// Returns all ((key, value), timestamp, diff) tuples in this [`TypedCollection`].
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn iter(
         &self,
         stash: &mut Stash,
@@ -313,6 +314,7 @@ where
     }
 
     /// Returns all key, value pairs in this [`TypedCollection`].
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn peek_one(&self, stash: &mut Stash) -> Result<BTreeMap<K, V>, StashError> {
         let name = self.name;
         stash
@@ -326,7 +328,7 @@ where
     }
 
     /// Returns the value of `key` in this [`TypedCollection`].
-    #[tracing::instrument(level = "trace", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn peek_key_one(&self, stash: &mut Stash, key: K) -> Result<Option<V>, StashError>
     where
         // TODO: Is it possible to remove the 'static?
@@ -347,7 +349,7 @@ where
     /// Sets the given k,v pair, if not already set.
     ///
     /// Returns the new value stored in stash after this operations.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn insert_key_without_overwrite(
         &self,
         stash: &mut Stash,
@@ -398,7 +400,7 @@ where
     /// Sets the given key value pairs, if not already set. If a new key appears
     /// multiple times in `entries`, its value will be from the first occurrence
     /// in `entries`.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn insert_without_overwrite<I>(
         &self,
         stash: &mut Stash,
@@ -451,7 +453,7 @@ where
     ///
     /// Returns the previous value if one existed and the value returned from
     /// `f`.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn upsert_key<F, R>(
         &self,
         stash: &mut Stash,
@@ -503,7 +505,7 @@ where
     }
 
     /// Sets the given key value pairs, removing existing entries match any key.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn upsert<I>(&self, stash: &mut Stash, entries: I) -> Result<(), StashError>
     where
         I: IntoIterator<Item = (K, V)>,
@@ -554,7 +556,7 @@ where
     ///   is likely not performant for more than 10-or-so keys.
     /// - This operation runs in a single transaction and cannot be combined
     ///   with other transactions.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn delete_keys(&self, stash: &mut Stash, keys: BTreeSet<K>) -> Result<(), StashError>
     where
         K: Clone + 'static,

--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -107,6 +107,7 @@ where
     ///
     /// Also waits until the `CollectionManager` has completed all outstanding work to ensure that
     /// it has stopped referencing the provided `id`.
+    #[tracing::instrument(level = "debug", skip(self))]
     pub(super) async fn unregsiter_collection(&self, id: GlobalId) -> bool {
         let prev = self
             .collections

--- a/src/storage-controller/src/command_wals.rs
+++ b/src/storage-controller/src/command_wals.rs
@@ -49,6 +49,7 @@ where
     /// finalize a shard so we can perform the finalization on reboot if we
     /// crash and do not find the shard in use in any collection.
     #[allow(dead_code)]
+    #[tracing::instrument(level = "debug", skip_all)]
     pub(super) async fn register_shards_for_finalization<I>(&mut self, entries: I)
     where
         I: IntoIterator<Item = ShardId>,

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -1447,6 +1447,7 @@ where
         self.stashed_response = Some(msg);
     }
 
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn process(&mut self) -> Result<(), anyhow::Error> {
         match self.stashed_response.take() {
             None => (),
@@ -2184,6 +2185,7 @@ where
     ///
     /// # Panics
     /// - If `id` is not registered as a managed collection.
+    #[tracing::instrument(level = "debug", skip(self, updates))]
     async fn append_to_managed_collection(&self, id: GlobalId, updates: Vec<(Row, Diff)>) {
         self.collection_manager
             .append_to_collection(id, updates)
@@ -2542,6 +2544,7 @@ where
     /// - If `IntrospectionType::ShardMapping`'s `GlobalId` is not registered as
     ///   a managed collection.
     /// - If diff is any value other than `1` or `-1`.
+    #[tracing::instrument(level = "debug", skip_all)]
     async fn append_shard_mappings<I>(&self, global_ids: I, diff: i64)
     where
         I: Iterator<Item = GlobalId>,
@@ -2705,6 +2708,7 @@ where
 
     /// Attempts to close all shards marked for finalization.
     #[allow(dead_code)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn finalize_shards(&mut self) {
         let shards = self
             .stash


### PR DESCRIPTION
This PR updates our logging around Coordinator messages such that if a message is "very" slow, e.g. >2.5 seconds, then we'll emit an OpenTelemetry `trace_id` to our logs. This way we can debug slow coordinator messages and figure out what is taking a long time.

It also adds a number of new `#[tracing::instrument(...)]` annotations to async functions.

I tested this locally on a few operations to make sure it does indeed trace slow messages.

### Motivation

Adds more visibility around slow coordinator messages

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
