### PR TITLE
sql: Remove LD RBAC flag

### DIFF
--- a/misc/dbt-materialize/mzcompose.py
+++ b/misc/dbt-materialize/mzcompose.py
@@ -60,7 +60,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
                 # TODO: Can dbt connect using mz_system user instead of materialize?
                 additional_system_parameter_defaults={
                     "enable_rbac_checks": "false",
-                    "enable_ld_rbac_checks": "false",
                 },
             )
             test_args = ["dbt-materialize/tests"]

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -193,7 +193,6 @@ class Owners(Check):
             # materialize role is not allowed to drop the objects since it is
             # not the owner, verify this:
             (
-                # Requires enable_ld_rbac_checks
                 (
                     self._drop_objects("materialize", 1, success=False, expensive=True)
                     + self._drop_objects(

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -104,7 +104,9 @@ class ConfigureMz(MzcomposeAction):
         if e.current_mz_version >= MzVersion(0, 47, 0):
             system_settings.add("ALTER SYSTEM SET enable_rbac_checks TO true;")
 
-        if e.current_mz_version >= MzVersion.parse("0.51.0-dev"):
+        if e.current_mz_version >= MzVersion.parse(
+            "0.51.0-dev"
+        ) and e.current_mz_version < MzVersion.parse("0.76.0-dev"):
             system_settings.add("ALTER SYSTEM SET enable_ld_rbac_checks TO true;")
 
         if e.current_mz_version >= MzVersion.parse("0.52.0-dev"):

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -49,7 +49,6 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "persist_pubsub_push_diff_enabled": "true",
     "persist_pubsub_client_enabled": "true",
     "persist_stats_audit_percent": "100",
-    "enable_ld_rbac_checks": "true",
     "enable_rbac_checks": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_dangerous_functions": "true",

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -688,11 +688,7 @@ impl Coordinator {
 
     fn maybe_send_rbac_notice(&self, session: &Session) {
         if !rbac::is_rbac_enabled_for_session(self.catalog.system_config(), session.vars()) {
-            if !self.catalog.system_config().enable_ld_rbac_checks() {
-                session.add_notice(AdapterNotice::RbacSystemDisabled);
-            } else {
-                session.add_notice(AdapterNotice::RbacUserDisabled);
-            }
+            session.add_notice(AdapterNotice::RbacUserDisabled);
         }
     }
 

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -88,7 +88,6 @@ pub enum AdapterNotice {
         name: String,
         reason: String,
     },
-    RbacSystemDisabled,
     RbacUserDisabled,
     RoleMembershipAlreadyExists {
         role_name: String,
@@ -164,7 +163,6 @@ impl AdapterNotice {
             AdapterNotice::UnimplementedIsolationLevel { .. } => Severity::Notice,
             AdapterNotice::DroppedSubscribe { .. } => Severity::Notice,
             AdapterNotice::BadStartupSetting { .. } => Severity::Notice,
-            AdapterNotice::RbacSystemDisabled => Severity::Notice,
             AdapterNotice::RbacUserDisabled => Severity::Notice,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => Severity::Notice,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => Severity::Warning,
@@ -208,7 +206,6 @@ impl AdapterNotice {
                     ServiceStatus::Ready => None,
                 }
             },
-            AdapterNotice::RbacSystemDisabled => Some("To enable RBAC please reach out to support with a request to turn RBAC on.".into()),
             AdapterNotice::RbacUserDisabled => Some("To enable RBAC globally run `ALTER SYSTEM SET enable_rbac_checks TO TRUE` as a superuser. TO enable RBAC for just this session run `SET enable_session_rbac_checks TO TRUE`.".into()),
             AdapterNotice::AlterIndexOwner {name: _} => Some("Change the ownership of the index's relation, instead.".into()),
             AdapterNotice::UnknownSessionDatabase(_) => Some(
@@ -247,7 +244,6 @@ impl AdapterNotice {
             AdapterNotice::UnimplementedIsolationLevel { .. } => SqlState::WARNING,
             AdapterNotice::DroppedSubscribe { .. } => SqlState::WARNING,
             AdapterNotice::BadStartupSetting { .. } => SqlState::WARNING,
-            AdapterNotice::RbacSystemDisabled => SqlState::WARNING,
             AdapterNotice::RbacUserDisabled => SqlState::WARNING,
             AdapterNotice::RoleMembershipAlreadyExists { .. } => SqlState::WARNING,
             AdapterNotice::RoleMembershipDoesNotExists { .. } => SqlState::WARNING,
@@ -351,13 +347,6 @@ impl fmt::Display for AdapterNotice {
             }
             AdapterNotice::BadStartupSetting { name, reason } => {
                 write!(f, "startup setting {name} not set: {reason}")
-            }
-            AdapterNotice::RbacSystemDisabled => {
-                write!(
-                    f,
-                    "RBAC is disabled so no role attributes or object ownership will be considered \
-                    when executing statements"
-                )
             }
             AdapterNotice::RbacUserDisabled => {
                 write!(

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3218,9 +3218,6 @@ fn test_pg_cancel_backend() {
         .connect(postgres::NoTls)
         .unwrap();
     mz_client
-        .batch_execute("ALTER SYSTEM SET enable_ld_rbac_checks TO true")
-        .unwrap();
-    mz_client
         .batch_execute("ALTER SYSTEM SET enable_rbac_checks TO true")
         .unwrap();
 

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -311,15 +311,12 @@ pub fn check_plan(
 
 /// Returns true if RBAC is turned on for a session, false otherwise.
 pub fn is_rbac_enabled_for_session(system_vars: &SystemVars, session_vars: &SessionVars) -> bool {
-    let ld_enabled = system_vars.enable_ld_rbac_checks();
     let server_enabled = system_vars.enable_rbac_checks();
     let session_enabled = session_vars.enable_session_rbac_checks();
 
-    // The LD flag acts as a global off switch in case we need to turn the feature off for
-    // everyone. Users will still need to turn one of the non-LD flags on to enable RBAC.
-    // The session flag allows users to turn RBAC on for just their session while the server flag
+    //The session flag allows users to turn RBAC on for just their session while the server flag
     // allows users to turn RBAC on for everyone.
-    ld_enabled && (server_enabled || session_enabled)
+    server_enabled || session_enabled
 }
 
 /// Generates all requirements needed to execute a given plan.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1224,14 +1224,6 @@ static UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP: ServerVar<Option<mz_repr::Timestamp>> 
     internal: true,
 };
 
-pub const ENABLE_LD_RBAC_CHECKS: ServerVar<bool> = ServerVar {
-    name: UncasedStr::new("enable_ld_rbac_checks"),
-    value: &true,
-    description:
-        "LD facing global boolean flag that allows turning RBAC off for everyone (Materialize).",
-    internal: true,
-};
-
 pub const ENABLE_RBAC_CHECKS: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_rbac_checks"),
     value: &true,
@@ -2691,7 +2683,6 @@ impl SystemVars {
             .with_var(&PERSIST_ROLLUP_THRESHOLD)
             .with_var(&METRICS_RETENTION)
             .with_var(&UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP)
-            .with_var(&ENABLE_LD_RBAC_CHECKS)
             .with_var(&ENABLE_RBAC_CHECKS)
             .with_var(&PG_SOURCE_CONNECT_TIMEOUT)
             .with_var(&PG_SOURCE_KEEPALIVES_IDLE)
@@ -3338,11 +3329,6 @@ impl SystemVars {
     /// Returns the `unsafe_mock_audit_event_timestamp` configuration parameter.
     pub fn unsafe_mock_audit_event_timestamp(&self) -> Option<mz_repr::Timestamp> {
         *self.expect_value(&UNSAFE_MOCK_AUDIT_EVENT_TIMESTAMP)
-    }
-
-    /// Returns the `enable_ld_rbac_checks` configuration parameter.
-    pub fn enable_ld_rbac_checks(&self) -> bool {
-        *self.expect_value(&ENABLE_LD_RBAC_CHECKS)
     }
 
     /// Returns the `enable_rbac_checks` configuration parameter.

--- a/test/sqllogictest/aclitem.slt
+++ b/test/sqllogictest/aclitem.slt
@@ -17,11 +17,6 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
 # Test mz_aclitem type and functions
 
 statement ok
@@ -372,10 +367,5 @@ NULL
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -18,11 +18,6 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_connection_validation_syntax TO true;
 ----
 COMPLETE 0
@@ -5167,10 +5162,5 @@ PUBLIC  NULL  NULL  type  PUBLIC  U
 # Disable rbac checks.
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -22,11 +22,6 @@ ALTER SYSTEM SET enable_rbac_checks = true
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks = true
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_index_options = true
 ----
 COMPLETE 0
@@ -3055,10 +3050,5 @@ DETAIL: The role "public" and the prefixes "mz_" and "pg_" are reserved for syst
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -19,11 +19,6 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_connection_validation_syntax TO true;
 ----
 COMPLETE 0
@@ -3263,10 +3258,5 @@ COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -18,11 +18,6 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 COMPLETE 0
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_connection_validation_syntax TO true;
 ----
 COMPLETE 0
@@ -4782,10 +4777,5 @@ COMPLETE 1
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/privileges_pg.slt
+++ b/test/sqllogictest/privileges_pg.slt
@@ -14,11 +14,6 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
 ----
 COMPLETE 0

--- a/test/sqllogictest/rbac_enabled.slt
+++ b/test/sqllogictest/rbac_enabled.slt
@@ -11,12 +11,7 @@ mode cockroach
 
 reset-server
 
-# LD - false; Server - false; Session - false
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
+# Server - false; Session - false
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
@@ -31,32 +26,7 @@ SELECT mz_internal.is_rbac_enabled();
 ----
 false
 
-# LD - true; Server - false; Session - false
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
-
-statement ok
-SET enable_session_rbac_checks TO false;
-
-query B
-SELECT mz_internal.is_rbac_enabled();
-----
-false
-
-# LD - false; Server - true; Session - false
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
+# Server - true; Session - false
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
@@ -65,58 +35,13 @@ COMPLETE 0
 
 statement ok
 SET enable_session_rbac_checks TO false;
-
-query B
-SELECT mz_internal.is_rbac_enabled();
-----
-false
-
-# LD - false; Server - false; Session - true
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-statement ok
-SET enable_session_rbac_checks TO true
-
-query B
-SELECT mz_internal.is_rbac_enabled();
-----
-false
-
-# LD - true; Server - true; Session - false
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-statement ok
-SET enable_session_rbac_checks TO false
 
 query B
 SELECT mz_internal.is_rbac_enabled();
 ----
 true
 
-# LD - true; Server - false; Session - true
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
+# Server - false; Session - true
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
@@ -131,32 +56,7 @@ SELECT mz_internal.is_rbac_enabled();
 ----
 true
 
-# LD - false; Server - true; Session - true
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_rbac_checks TO true;
-----
-COMPLETE 0
-
-statement ok
-SET enable_session_rbac_checks TO true
-
-query B
-SELECT mz_internal.is_rbac_enabled();
-----
-false
-
-# LD - true; Server - true; Session - true
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
+# Server - true; Session - true
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
@@ -172,11 +72,6 @@ SELECT mz_internal.is_rbac_enabled();
 true
 
 # Turn everything off
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;

--- a/test/sqllogictest/rbac_views.slt
+++ b/test/sqllogictest/rbac_views.slt
@@ -18,11 +18,6 @@ ALTER SYSTEM SET enable_rbac_checks TO true;
 ----
 COMPLETE 0
 
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
 # SHOW ROLE MEMBERS
 
 statement ok
@@ -535,10 +530,5 @@ PUBLIC       NULL         NULL  type        PUBLIC  USAGE
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
 ----
 COMPLETE 0

--- a/test/sqllogictest/role_create.slt
+++ b/test/sqllogictest/role_create.slt
@@ -16,11 +16,6 @@ mode cockroach
 reset-server
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
-----
-COMPLETE 0
-
-simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
 ----
 COMPLETE 0

--- a/test/sqllogictest/role_membership.slt
+++ b/test/sqllogictest/role_membership.slt
@@ -927,8 +927,3 @@ simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO false;
 ----
 COMPLETE 0
-
-simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;
-----
-COMPLETE 0

--- a/test/testdrive/privilege_checks.td
+++ b/test/testdrive/privilege_checks.td
@@ -16,7 +16,6 @@ $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdri
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_rbac_checks TO true;
-ALTER SYSTEM SET enable_ld_rbac_checks TO true;
 CREATE CONNECTION kafka_conn TO KAFKA (BROKER '${testdrive.kafka-addr}');
 CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL '${testdrive.schema-registry-url}');
 CREATE TABLE t (a INT);
@@ -304,4 +303,3 @@ $ postgres-execute connection=mz_system
 DROP CONNECTION csr_conn;
 DROP CONNECTION kafka_conn;
 ALTER SYSTEM SET enable_rbac_checks TO false;
-ALTER SYSTEM SET enable_ld_rbac_checks TO false;

--- a/test/testdrive/show_columns.td
+++ b/test/testdrive/show_columns.td
@@ -21,8 +21,6 @@ SHOW COLUMNS FROM t
 # enable RBAC
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET enable_ld_rbac_checks=true;
-$ postgres-execute connection=mz_system
 ALTER SYSTEM SET enable_rbac_checks=true;
 
 $ postgres-execute connection=mz_system


### PR DESCRIPTION
This commit removes the Launch Darkly RBAC flag because it is set to true in all environments. There is still a user facing RBAC flag that is not set to true in all environments.


### Motivation
Remove feature flag.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
