### PR TITLE
adapter: refactor in-memory dependency drops

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -1116,7 +1116,6 @@ impl Catalog {
             &mut audit_events,
             &mut tx,
             &mut state,
-            &drop_ids,
         )?;
 
         let result = f(&state)?;
@@ -1156,9 +1155,6 @@ impl Catalog {
         audit_events: &mut Vec<VersionedEvent>,
         tx: &mut Transaction<'_>,
         state: &mut CatalogState,
-        // Provide all of the IDs that are being dropped in this transaction so we can provide
-        // stronger invariants about when we change items' dependencies.
-        drop_ids: &BTreeSet<GlobalId>,
     ) -> Result<(), AdapterError> {
         // NOTE(benesch): to support altering legacy sized sources and sinks
         // (those with linked clusters), we need to generate retractions for
@@ -1228,7 +1224,6 @@ impl Catalog {
                     tx,
                     builtin_table_updates,
                     oracle_write_ts,
-                    drop_ids,
                     audit_events,
                     session,
                     id,
@@ -1323,14 +1318,7 @@ impl Catalog {
                     )?;
 
                     let to_name = entry.name().clone();
-                    Self::update_item(
-                        state,
-                        builtin_table_updates,
-                        id,
-                        to_name,
-                        sink.item,
-                        drop_ids,
-                    )?;
+                    Self::update_item(state, builtin_table_updates, id, to_name, sink.item)?;
                 }
                 Op::AlterSource { id, cluster_config } => {
                     use mz_sql::ast::Value;
@@ -1423,14 +1411,7 @@ impl Catalog {
                     )?;
 
                     let to_name = entry.name().clone();
-                    Self::update_item(
-                        state,
-                        builtin_table_updates,
-                        id,
-                        to_name,
-                        source.item,
-                        drop_ids,
-                    )?;
+                    Self::update_item(state, builtin_table_updates, id, to_name, source.item)?;
                 }
                 Op::CreateDatabase {
                     name,
@@ -2699,14 +2680,7 @@ impl Catalog {
                     builtin_table_updates.extend(state.pack_item_update(id, -1));
                     updates.push((id, to_qualified_name, new_entry.item));
                     for (id, to_name, to_item) in updates {
-                        Self::update_item(
-                            state,
-                            builtin_table_updates,
-                            id,
-                            to_name,
-                            to_item,
-                            drop_ids,
-                        )?;
+                        Self::update_item(state, builtin_table_updates, id, to_name, to_item)?;
                     }
                 }
                 Op::RenameSchema {
@@ -2861,14 +2835,7 @@ impl Catalog {
                     ));
 
                     for (id, new_name, new_item) in updates {
-                        Self::update_item(
-                            state,
-                            builtin_table_updates,
-                            id,
-                            new_name,
-                            new_item,
-                            drop_ids,
-                        )?;
+                        Self::update_item(state, builtin_table_updates, id, new_name, new_item)?;
                     }
                 }
                 Op::UpdateOwner { id, new_owner } => {
@@ -3055,7 +3022,6 @@ impl Catalog {
                         id,
                         name.clone(),
                         to_item.clone(),
-                        drop_ids,
                     )?;
                     let entry = state.get_entry(&id);
                     tx.update_item(id, entry.clone().into())?;
@@ -3154,9 +3120,6 @@ impl Catalog {
         id: GlobalId,
         to_name: QualifiedItemName,
         to_item: CatalogItem,
-        // This lets us understand which items are dropped in this transaction so we can account
-        // for changes in dependencies.
-        drop_ids: &BTreeSet<GlobalId>,
     ) -> Result<(), AdapterError> {
         let old_entry = state.entry_by_id.remove(&id).expect("catalog out of sync");
         info!(
@@ -3166,25 +3129,6 @@ impl Catalog {
             id
         );
 
-        // Ensure any removal from the uses is accompanied by a drop.
-        let to_item_uses_and_dropped_ids: BTreeSet<&GlobalId> =
-            drop_ids.iter().chain(&to_item.uses().0).collect();
-
-        assert!(
-            old_entry
-                .uses()
-                .0
-                .iter()
-                .all(|id| to_item_uses_and_dropped_ids.contains(id)),
-            "all of the old entries used items must be accompanied by a drop \
-                old_entry.uses: {:?}\
-                to_item.uses: {:?}\
-                drop_ids {:?}",
-            old_entry.uses(),
-            to_item.uses(),
-            drop_ids,
-        );
-
         let conn_id = old_entry.item().conn_id().unwrap_or(&SYSTEM_CONN_ID);
         let schema = state.get_schema_mut(
             &old_entry.name().qualifiers.database_spec,
@@ -3192,6 +3136,14 @@ impl Catalog {
             conn_id,
         );
         schema.items.remove(&old_entry.name().item);
+
+        // Dropped deps
+        let dropped_deps: Vec<_> = old_entry
+            .uses()
+            .0
+            .difference(&to_item.uses().0)
+            .cloned()
+            .collect();
 
         // We only need to install this item on items in the `used_by` of new
         // dependencies.
@@ -3207,6 +3159,14 @@ impl Catalog {
         new_entry.item = to_item;
 
         schema.items.insert(new_entry.name().item.clone(), id);
+
+        for u in dropped_deps {
+            // OK if we no longer have this entry because we are dropping our
+            // dependency on it.
+            if let Some(metadata) = state.entry_by_id.get_mut(&u) {
+                metadata.used_by.retain(|dep_id| *dep_id != id)
+            }
+        }
 
         for u in new_deps {
             match state.entry_by_id.get_mut(&u) {

--- a/src/adapter/src/catalog/inner.rs
+++ b/src/adapter/src/catalog/inner.rs
@@ -9,8 +9,6 @@
 
 //! Functionality belonging to the catalog but extracted to control file size.
 
-use std::collections::BTreeSet;
-
 use mz_audit_log::{EventDetails, EventType, VersionedEvent};
 use mz_catalog::durable::Transaction;
 use mz_controller_types::ClusterId;
@@ -35,7 +33,6 @@ impl Catalog {
         tx: &mut Transaction,
         builtin_table_updates: &mut Vec<BuiltinTableUpdate>,
         oracle_write_ts: Timestamp,
-        drop_ids: &BTreeSet<GlobalId>,
         audit_events: &mut Vec<VersionedEvent>,
         session: Option<&ConnMeta>,
         id: GlobalId,
@@ -161,6 +158,6 @@ impl Catalog {
         let to_name = entry.name().clone();
         builtin_table_updates.extend(state.pack_item_update(id, -1));
         state.move_item(id, cluster_id);
-        Self::update_item(state, builtin_table_updates, id, to_name, item, drop_ids)
+        Self::update_item(state, builtin_table_updates, id, to_name, item)
     }
 }


### PR DESCRIPTION
ALTER CONNECTION will be the first time that we can remove a dependnecy without also dropping it; to handle this, we need to update the in-memory dependency relationship.

Doing this also supersedes some of of the assert logic interior to this code, so unplumb that, as well.

Note that this feature isn't explicitly tested here but will be by the complete `ALTER CONNECTION` implementation.

### Motivation

This PR refactors existing code. Allows dependencies to be dropped when altering an item.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
