### PR TITLE
storage: allow updating multiple ingestions at once

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -18,7 +18,7 @@ use std::time::{Duration, Instant};
 use anyhow::anyhow;
 use futures::future::BoxFuture;
 use itertools::Itertools;
-use maplit::btreeset;
+use maplit::{btreemap, btreeset};
 use mz_cloud_resources::VpcEndpointConfig;
 use mz_compute_types::dataflows::{DataflowDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
@@ -4840,9 +4840,11 @@ impl Coordinator {
                     _ => unreachable!("already verified of type ingestion"),
                 };
 
+                let collection = btreemap! {id => ingestion};
+
                 self.controller
                     .storage
-                    .check_alter_collection(id, ingestion.clone())
+                    .check_alter_collection(&collection)
                     .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
 
                 // Do not drop this source, even though it's a dependency.
@@ -4886,7 +4888,7 @@ impl Coordinator {
                 // Commit the new ingestion to storage.
                 self.controller
                     .storage
-                    .alter_collection(id, ingestion)
+                    .alter_collection(collection)
                     .await
                     .expect("altering collection after txn must succeed");
             }
@@ -5051,9 +5053,11 @@ impl Coordinator {
                     _ => unreachable!("already verified of type ingestion"),
                 };
 
+                let collection = btreemap! {id => ingestion};
+
                 self.controller
                     .storage
-                    .check_alter_collection(id, ingestion.clone())
+                    .check_alter_collection(&collection)
                     .map_err(|e| AdapterError::internal(ALTER_SOURCE, e))?;
 
                 let CreateSourceInner {
@@ -5124,7 +5128,7 @@ impl Coordinator {
                 // Commit the new ingestion to storage.
                 self.controller
                     .storage
-                    .alter_collection(id, ingestion)
+                    .alter_collection(collection)
                     .await
                     .expect("altering collection after txn must succeed");
 

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -296,15 +296,13 @@ pub trait StorageController: Debug + Send {
     /// subsequent calls to `alter_collection` are guaranteed to succeed.
     fn check_alter_collection(
         &mut self,
-        id: GlobalId,
-        desc: IngestionDescription,
+        collections: &BTreeMap<GlobalId, IngestionDescription>,
     ) -> Result<(), StorageError>;
 
     /// Alter the identified collection to use the described ingestion.
     async fn alter_collection(
         &mut self,
-        id: GlobalId,
-        desc: IngestionDescription,
+        collections: BTreeMap<GlobalId, IngestionDescription>,
     ) -> Result<(), StorageError>;
 
     /// Acquire an immutable reference to the export state, should it exist.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -883,63 +883,69 @@ where
 
     fn check_alter_collection(
         &mut self,
-        id: GlobalId,
-        ingestion: IngestionDescription,
+        collections: &BTreeMap<GlobalId, IngestionDescription>,
     ) -> Result<(), StorageError> {
-        self.check_alter_collection_inner(id, ingestion)
+        for (id, ingestion) in collections {
+            self.check_alter_collection_inner(*id, ingestion.clone())?;
+        }
+        Ok(())
     }
 
     async fn alter_collection(
         &mut self,
-        id: GlobalId,
-        ingestion: IngestionDescription,
+        collections: BTreeMap<GlobalId, IngestionDescription>,
     ) -> Result<(), StorageError> {
-        self.check_alter_collection_inner(id, ingestion.clone())
+        self.check_alter_collection(&collections)
             .expect("error avoided by calling check_alter_collection first");
 
-        // Describe the ingestion in terms of collection metadata.
-        let description = self
-            .enrich_ingestion(id, ingestion.clone())
-            .expect("verified valid in check_alter_collection_inner");
+        for (id, ingestion) in collections {
+            // Describe the ingestion in terms of collection metadata.
+            let description = self
+                .enrich_ingestion(id, ingestion.clone())
+                .expect("verified valid in check_alter_collection_inner");
 
-        let collection = self.collection_mut(id).expect("validated exists");
-        let new_source_exports = match &mut collection.description.data_source {
-            DataSource::Ingestion(active_ingestion) => {
-                // Determine which IDs we're adding.
-                let new_source_exports: Vec<_> = description
-                    .source_exports
-                    .keys()
-                    .filter(|id| !active_ingestion.source_exports.contains_key(id))
-                    .cloned()
-                    .collect();
-                *active_ingestion = ingestion;
+            let collection = self.collection_mut(id).expect("validated exists");
+            let new_source_exports = match &mut collection.description.data_source {
+                DataSource::Ingestion(active_ingestion) => {
+                    // Determine which IDs we're adding.
+                    let new_source_exports: Vec<_> = description
+                        .source_exports
+                        .keys()
+                        .filter(|id| !active_ingestion.source_exports.contains_key(id))
+                        .cloned()
+                        .collect();
+                    *active_ingestion = ingestion;
 
-                new_source_exports
-            }
-            _ => unreachable!("verified collection refers to ingestion"),
-        };
+                    new_source_exports
+                }
+                _ => unreachable!("verified collection refers to ingestion"),
+            };
 
-        // Assess dependency since, which we have to fast-forward this
-        // collection's since to.
-        let storage_dependencies = collection.description.get_storage_dependencies();
+            // Assess dependency since, which we have to fast-forward this
+            // collection's since to.
+            let storage_dependencies = collection.description.get_storage_dependencies();
 
-        // Ensure this new collection's since is aligned with the dependencies.
-        // This will likely place its since beyond its upper which is OK because
-        // its snapshot will catch it up with the rest of the source, i.e. we
-        // will never see its upper at a state beyond 0 and less than its since.
-        self.install_dependency_read_holds(new_source_exports.into_iter(), &storage_dependencies)?;
+            // Ensure this new collection's since is aligned with the dependencies.
+            // This will likely place its since beyond its upper which is OK because
+            // its snapshot will catch it up with the rest of the source, i.e. we
+            // will never see its upper at a state beyond 0 and less than its since.
+            self.install_dependency_read_holds(
+                new_source_exports.into_iter(),
+                &storage_dependencies,
+            )?;
 
-        // Fetch the client for this ingestion's instance.
-        let client = self
-            .clients
-            .get_mut(&description.instance_id)
-            .expect("verified exists");
+            // Fetch the client for this ingestion's instance.
+            let client = self
+                .clients
+                .get_mut(&description.instance_id)
+                .expect("verified exists");
 
-        client.send(StorageCommand::RunIngestions(vec![RunIngestionCommand {
-            id,
-            description,
-            update: true,
-        }]));
+            client.send(StorageCommand::RunIngestions(vec![RunIngestionCommand {
+                id,
+                description,
+                update: true,
+            }]));
+        }
 
         Ok(())
     }


### PR DESCRIPTION
As part of `ALTER CONNECTION`, it's more natural to alter ingestions in batches––i.e. many sources can use the same connection and they will all need to be redefined if we alter the connection. Note that this is mostly just code movement in preparation of `ALTER CONNECTION`.

### Motivation

This PR refactors existing code.

### Tips for reviewer

This is almost entirely code movement.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
