### PR TITLE
storage: ssh followups from #22718

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -351,7 +351,7 @@ steps:
   - id: ssh-connection
     label: SSH connection tests
     depends_on: build-x86_64
-    timeout_in_minutes: 20
+    timeout_in_minutes: 30
     inputs: [test/ssh-connection]
     artifact_paths: junit_*.xml
     plugins:

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -351,7 +351,7 @@ steps:
   - id: ssh-connection
     label: SSH connection tests
     depends_on: build-x86_64
-    timeout_in_minutes: 30
+    timeout_in_minutes: 20
     inputs: [test/ssh-connection]
     artifact_paths: junit_*.xml
     plugins:

--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -119,7 +119,7 @@ pub const DEFAULT_SNAPSHOT_STATEMENT_TIMEOUT: Duration = Duration::ZERO;
 ///
 /// This wraps [`tokio_postgres::Config`] to allow the configuration of a
 /// tunnel via a [`TunnelConfig`].
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config {
     inner: tokio_postgres::Config,
     tunnel: TunnelConfig,

--- a/src/ssh-util/src/keys.rs
+++ b/src/ssh-util/src/keys.rs
@@ -11,7 +11,6 @@
 
 use std::cmp::Ordering;
 use std::fmt;
-use std::hash::{Hash, Hasher};
 
 use openssl::pkey::{PKey, Private};
 use serde::de::{self, Deserializer, MapAccess, SeqAccess, Visitor};
@@ -74,18 +73,6 @@ impl SshKeyPair {
         self.key_pair
             .to_openssh(LineEnding::LF)
             .expect("encoding as OpenSSH cannot fail")
-    }
-}
-
-impl Hash for SshKeyPair {
-    fn hash<H>(&self, state: &mut H)
-    where
-        H: Hasher,
-    {
-        self.key_pair
-            .fingerprint(HashAlg::default())
-            .as_ref()
-            .hash(state)
     }
 }
 

--- a/src/ssh-util/src/tunnel_manager.rs
+++ b/src/ssh-util/src/tunnel_manager.rs
@@ -101,15 +101,16 @@ impl SshTunnelManager {
                     if let SshTunnelStatus::Errored(e) = handle.check_status() {
                         error!(
                             "not using existing ssh tunnel \
-                            ({}:{} via {}@{}:{}) because its broken: {e}",
+                            ({}:{} via {}@{}:{}) because it's broken: {e}",
                             remote_host, remote_port, config.user, config.host, config.port,
                         );
 
-                        // This is bit unfortunate, as this method returns an `anyhow::Error`, but
-                        // the ssh status needs to share a cloneable `String`.
-                        // So we just package up the pre-`.to_string_with_causes()` error that
-                        // is at the bottom of the stack. In the future we can probably make ALL
-                        // ssh errors structured to avoid this.
+                        // This is bit unfortunate, as this method returns an
+                        // `anyhow::Error`, but the SSH status needs to share a
+                        // cloneable `String`. So we just package up the
+                        // pre-`.to_string_with_causes()` error that is at the
+                        // bottom of the stack. In the future we can probably
+                        // make ALL SSH errors structured to avoid this.
                         return Err(anyhow::anyhow!(e));
                     }
 
@@ -205,14 +206,6 @@ impl Deref for ManagedSshTunnelHandle {
 
     fn deref(&self) -> &SshTunnelHandle {
         &self.handle
-    }
-}
-
-impl ManagedSshTunnelHandle {
-    /// Return the current status of the `SshTunnelStatus`, by communicating with the
-    /// task running the ssh session.
-    pub fn check_status(&self) -> SshTunnelStatus {
-        self.handle.status.lock().expect("poisoned").clone()
     }
 }
 

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -337,7 +337,6 @@ impl SourceRender for KafkaSourceConnection {
 
                 let status_report = Arc::clone(&health_status);
 
-                let tokio_handle = tokio::runtime::Handle::current();
                 thread::Builder::new()
                     .name("kafka-metadata".to_string())
                     .spawn(move || {
@@ -381,8 +380,7 @@ impl SourceRender for KafkaSourceConnection {
                                         None,
                                     ));
 
-                                    let ssh_status = tokio_handle
-                                        .block_on(consumer.client().context().tunnel_statuses());
+                                    let ssh_status = consumer.client().context().tunnel_status();
                                     let ssh_status = match ssh_status {
                                         SshTunnelStatus::Running => {
                                             Some(HealthStatusUpdate::running())

--- a/test/ssh-connection/kafka-source.td
+++ b/test/ssh-connection/kafka-source.td
@@ -35,12 +35,6 @@ one
 > CREATE CONNECTION kafka_conn_dynamic
   TO KAFKA (BROKER '${testdrive.kafka-addr}', SSH TUNNEL thancred);
 
-# TODO(guswynn): this should be correctly namespaced as an ssh error
-! CREATE CONNECTION kafka_conn_keyless
-  TO KAFKA (BROKER '${testdrive.kafka-addr}', SSH TUNNEL keyless);
-contains:Failed to resolve hostname
-
-
 # Create source with a faster metadata refresh interval so
 # errors are detected every second instead of every minute.
 > CREATE SOURCE fixed_text IN CLUSTER sc

--- a/test/ssh-connection/mzcompose.py
+++ b/test/ssh-connection/mzcompose.py
@@ -404,9 +404,7 @@ def workflow_default(c: Composition) -> None:
     #
     # These tests core functionality related to kafka with ssh and error reporting.
     for workflow in [
-        workflow_basic_ssh_features,
         workflow_kafka,
-        workflow_kafka_restart_replica,
         workflow_hidden_hosts,
     ]:
         workflow(c, redpanda=False)
@@ -416,7 +414,9 @@ def workflow_default(c: Composition) -> None:
 
     # These tests core functionality related to pg with ssh and error reporting.
     for workflow in [
+        workflow_basic_ssh_features,
         workflow_pg,
+        workflow_kafka_restart_replica,
     ]:
         workflow(c)
         c.sanity_restart_mz()


### PR DESCRIPTION
Followups from https://github.com/MaterializeInc/materialize/pull/22718

we can go with a simpler scheme for reporting errors from kafka because we will eventually get an up-to-date view of the ssh error in the looping metadata thread!

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
