### PR TITLE
SQL: Make dangerous functions more granular

### DIFF
--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -281,11 +281,8 @@ pub fn plan(
         .iter()
         // Filter out items that may not have been created yet, such as sub-sources.
         .filter_map(|id| catalog.try_get_item(id))
-        .any(|item| {
-            item.func().is_ok()
-                && item.name().qualifiers.schema_spec
-                    == SchemaSpecifier::Id(*catalog.get_mz_internal_schema_id())
-        })
+        .filter_map(|item| item.func().ok())
+        .any(|func| func.dangerous())
     {
         scx.require_feature_flag(&vars::ENABLE_DANGEROUS_FUNCTIONS)?;
     }

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1613,7 +1613,7 @@ SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
 ----
 -1
 
-# mz_internal functions can't be executed with the enable_dangerous_functions flag turned off
+# dangerous functions can't be executed with the enable_dangerous_functions flag turned off
 
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_dangerous_functions = false
@@ -1625,6 +1625,9 @@ SELECT mz_internal.mz_sleep(10)
 
 statement error executing potentially dangerous functions is not supported
 SELECT mz_internal.mz_panic('hello')
+
+statement ok
+SELECT mz_internal.is_rbac_enabled()
 
 statement ok
 CREATE TABLE dangerous_table (a INT, b TEXT)


### PR DESCRIPTION
Previously, all functions within the `mz_internal` schema were declared dangerous, and we disallowed users from executing any of them. This was too broad and prevented users from executing useful, but not stabilized functions, such as `is_rbac_enabled`.

This commit updates functions so that each one is annotated with a dangerous flag that indicates if it's safe for a user to execute them.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Allow users to execute non-dangerous `mz_internal` functions.
