### PR TITLE
stash: Add debug events to Catalog::open for initial transaction

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -254,6 +254,7 @@ impl Catalog {
 
         let mut storage = config.storage;
         let is_read_only = storage.is_read_only();
+        tracing::debug!("Catalog::open - beginning initial transaction.");
         let mut txn = storage.transaction().await?;
         // Choose a time at which to boot. This is the time at which we will run
         // internal migrations.
@@ -844,7 +845,7 @@ impl Catalog {
         )?;
 
         txn.commit().await?;
-
+        tracing::debug!("Catalog::open - ending initial transaction.");
         let mut catalog = Catalog {
             state,
             plans: CatalogPlans {


### PR DESCRIPTION
This is in aid of debugging the transaction retry errors we see (ref: https://materializeinc.slack.com/archives/C02FWJ94HME/p1698771314593049). Of course, it's possible https://github.com/MaterializeInc/materialize/pull/22671 has rendered this moot :smile: