### PR TITLE
canary-environment: Reduce false positives when testing

### DIFF
--- a/test/canary-environment/dbt_project.yml
+++ b/test/canary-environment/dbt_project.yml
@@ -30,3 +30,6 @@ models:
       schema: tpch
     pg_cdc:
       schema: pg_cdc
+
+tests:
+    +cluster: qa_canary_environment_compute

--- a/test/canary-environment/tests/generic/makes_progress.sql
+++ b/test/canary-environment/tests/generic/makes_progress.sql
@@ -11,9 +11,11 @@
 -- {{ model }} must be mentioned somewhere in the query or dbt will croak */
 
 {% set query %}
+   SET CLUSTER = qa_canary_environment_compute;
    BEGIN;
    DECLARE c1 CURSOR FOR SUBSCRIBE ( SELECT * FROM {{ model }} )  WITH (SNAPSHOT = FALSE);
-   FETCH 1 c1 WITH (timeout='60s');
+   -- TODO: Switch timeout back to 60s after #22061 is fixed
+   FETCH 1 c1 WITH (timeout='300s');
 {% endset %}
 
 {% set result = run_query(query) %}


### PR DESCRIPTION
- Increase the time we wait for sources to make progress to 300s in order to account for #22061

- make sure all testing queries are run against the qa_canary_environment_compute cluster, as the default cluster can be arbitrarily overloaded.

### Motivation

`cd test/canary-environment; ./mzcompose run test` was acting up as I ran it as part of the release verification process.