### PR TITLE
test: close ancient TODO for args to ascii func tests

### DIFF
--- a/test/sqllogictest/string.slt
+++ b/test/sqllogictest/string.slt
@@ -31,12 +31,9 @@ column1
 statement ok
 CREATE TABLE asciitest (strcol CHAR(15), vccol VARCHAR(15))
 
-# TODO: Add two tests:
-# 1: empty string to each column
-# 2: single space in each column
 statement ok
 INSERT INTO asciitest VALUES ('hello world', 'goodbye moon'), (NULL, NULL),
-    ('你好', '再见'), ('😀', '👻')
+    ('你好', '再见'), ('😀', '👻'), ('',''), (' ', ' ');
 
 statement error
 SELECT ascii(98)
@@ -45,10 +42,12 @@ query II colnames
 SELECT ascii(strcol) AS strres, ascii(vccol) AS vcres FROM asciitest ORDER BY strres
 ----
 strres  vcres
-104     103
-20320   20877
+0  0
+0  32
+104  103
+20320  20877
 128512  128123
-NULL    NULL
+NULL  NULL
 
 query I
 SELECT ascii(NULL)


### PR DESCRIPTION
Closes out ancient TODO

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
