### PR TITLE
Reuse allocation in FromRowByTypes

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -760,6 +760,7 @@ impl PendingPeek {
         let mut datum_vec = DatumVec::new();
         let mut l_datum_vec = DatumVec::new();
         let mut r_datum_vec = DatumVec::new();
+        let mut key_buf = K::default();
 
         // We have to sort the literal constraints because cursor.seek_key can seek only forward.
         peek.literal_constraints
@@ -780,7 +781,8 @@ impl PendingPeek {
                         Some(current_literal) => {
                             // NOTE(vmarcos): We expect the extra allocations below to be manageable
                             // since we only perform as many of them as there are literals.
-                            let current_literal = K::from_row(current_literal.clone(), key_types);
+                            let current_literal =
+                                key_buf.from_row(current_literal.clone(), key_types);
                             cursor.seek_key(&storage, &current_literal);
                             if !cursor.key_valid(&storage) {
                                 return Ok(results);

--- a/src/compute/src/render/context.rs
+++ b/src/compute/src/render/context.rs
@@ -1125,21 +1125,20 @@ where
     K: Columnation + Data + FromRowByTypes,
     V: Columnation + Data + FromRowByTypes,
 {
-    let mut key_buf = Row::default();
-    let mut key_datums = DatumVec::new();
+    let mut key_buf = K::default();
+    let mut val_buf = V::default();
     let mut datums = DatumVec::new();
     move |row| {
         // TODO: Consider reusing the `row` allocation; probably in *next* invocation.
         let datums = datums.borrow_with(&row);
         let temp_storage = RowArena::new();
-        key_buf
-            .packer()
-            .try_extend(key.iter().map(|k| k.eval(&datums, &temp_storage)))?;
-        let key_datums = key_datums.borrow_with(&key_buf);
         let val_datum_iter = thinning.iter().map(|c| datums[*c]);
         Ok::<(K, V), DataflowError>((
-            K::from_datum_iter(key_datums.iter(), key_types.as_deref()),
-            V::from_datum_iter(val_datum_iter, val_types.as_deref()),
+            key_buf.try_from_datum_iter(
+                key.iter().map(|k| k.eval(&datums, &temp_storage)),
+                key_types.as_deref(),
+            )?,
+            val_buf.from_datum_iter(val_datum_iter, val_types.as_deref()),
         ))
     }
 }


### PR DESCRIPTION
Previously, the implementation for Row would allocate a new row and extend it with the provided iterator. This can be problematic because we don't size the underlying buffer correctly, causing doubling allocations each time we run out of space.

This change addresses the problem by reusing an underlying allocation as it is done elsewhere, and in the process switching the trait to operator on self instead of free-standing functions. We also add a try_from_datum_iter variant that permits passing an iterator of results, saving an intermediate packing/unpacking of rows.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
