### PR TITLE
sql: remove VALIDATE from persisted connection options

### DIFF
--- a/src/sql/src/normalize.rs
+++ b/src/sql/src/normalize.rs
@@ -425,11 +425,16 @@ pub fn create_statement(
             name,
             connection_type: _,
             values: _,
-            with_options: _,
+            with_options,
             if_not_exists,
         }) => {
             *name = allocate_name(name)?;
             *if_not_exists = false;
+
+            // Validation only occurs once during planning and should not be
+            // considered part of the statement's AST/canonical representation.
+            with_options
+                .retain(|o| o.name != mz_sql_parser::ast::CreateConnectionOptionName::Validate)
         }
 
         _ => unreachable!(),

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -1344,13 +1344,13 @@ COMPLETE 0
 simple conn=joe,user=joe
 SHOW CREATE CONNECTION csr_conn;
 ----
-materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com') WITH (VALIDATE = false)
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
 COMPLETE 1
 
 simple conn=child,user=child
 SHOW CREATE CONNECTION csr_conn;
 ----
-materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com') WITH (VALIDATE = false)
+materialize.public.csr_conn,CREATE CONNECTION "materialize"."public"."csr_conn" TO CONFLUENT SCHEMA REGISTRY (URL = 'https://google.com')
 COMPLETE 1
 
 simple conn=mz_system,user=mz_system


### PR DESCRIPTION
`WITH (VALIDATE...)` should not be part of the durably recorded AST for `CREATE CONNECTION` because it only executes a single time (during the initial sequencing) and never again.

With the upcoming changes to `ALTER CONNECTION`, removing this is more compelling, e.g. there is no way to "remove" the `VALIDATE` option using `ALTER CONNECTION`, and it would be meaningless, even if you could.

### Motivation

This PR refactors existing code.

### Tips for reviewer

I don't believe this will make this week's release, so labeled the migration for v0.77--idk how much that matters and am glad to hold off on merging this until it's true.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
