### PR TITLE
misc: add `mzexplore` command for catalog exploration

### DIFF
--- a/bin/mzexplore
+++ b/bin/mzexplore
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# dashboard-clean - Clean the dashboard model json to be fit for public consumption
+
+exec "$(dirname "$0")"/pyactivate -m materialize.cli.mzexplore "$@"

--- a/misc/python/materialize/cli/mzexplore.py
+++ b/misc/python/materialize/cli/mzexplore.py
@@ -1,0 +1,222 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from pathlib import Path
+from typing import Any
+
+import click
+
+import materialize.mzexplore as api
+
+# import logging
+# logging.basicConfig(encoding='utf-8', level=logging.DEBUG)
+
+# Click CLI Application
+# ---------------------
+
+
+@click.group()
+def app() -> None:
+    pass
+
+
+class Arg:
+    repository = dict(
+        type=click.Path(
+            exists=False,
+            file_okay=False,
+            dir_okay=True,
+            writable=True,
+            readable=True,
+            resolve_path=True,
+        ),
+        callback=lambda ctx, param, value: Path(value),
+    )
+
+
+class Opt:
+    db_port = dict(
+        default=6877,
+        help="DB connection port.",
+        envvar="PGPORT",
+    )
+
+    db_host = dict(
+        default="localhost",
+        help="DB connection host.",
+        envvar="PGHOST",
+    )
+
+    db_user = dict(
+        default="mz_support",
+        help="DB connection user.",
+        envvar="PGUSER",
+    )
+
+    db_pass = dict(
+        default=None,
+        help="DB connection password.",
+        envvar="PGPASSWORD",
+    )
+
+    db_require_ssl = dict(
+        is_flag=True,
+        help="DB connection requires SSL.",
+        envvar="PGREQUIRESSL",
+    )
+
+    mzfmt = dict(
+        default=True,
+        help="Format SQL statements with `mzfmt` if present.",
+    )
+
+    explainee_type = dict(
+        type=click.Choice([v.name.lower() for v in list(api.ExplaineeType)]),
+        default="all",  # We should have at least arity for good measure.
+        callback=lambda ctx, param, v: api.ExplaineeType[v.upper()],
+        help="EXPLAIN mode.",
+        metavar="MODE",
+    )
+
+    explain_flags = dict(
+        type=click.Choice([v.name.lower() for v in list(api.ExplainFlag)]),
+        multiple=True,
+        default=["arity"],  # We should have at least arity for good measure.
+        callback=lambda ctx, param, vals: [api.ExplainFlag[v.upper()] for v in vals],
+        help="WITH flag to pass to the EXPLAIN command.",
+        metavar="FLAG",
+    )
+
+    explain_stage = dict(
+        type=click.Choice([str(v.name.lower()) for v in list(api.ExplainStage)]),
+        multiple=True,
+        default=["optimized_plan"],  # Most often we'll only the optimized plan.
+        callback=lambda ctx, param, vals: [api.ExplainStage[v.upper()] for v in vals],
+        help="EXPLAIN stage to export.",
+        metavar="STAGE",
+    )
+
+    explain_suffix = dict(
+        type=str,
+        default="",
+        help="A suffix to append to the EXPLAIN output files.",
+        metavar="SUFFIX",
+    )
+
+
+def is_documented_by(original: Any) -> Any:
+    def wrapper(target):
+        target.__doc__ = original.__doc__
+        return target
+
+    return wrapper
+
+
+@app.group()
+@is_documented_by(api.extract)
+def extract() -> None:
+    pass
+
+
+@extract.command()
+@click.argument("target", **Arg.repository)
+@click.argument("database", type=str)
+@click.argument("schema", type=str)
+@click.argument("name", type=str)
+@click.option("--db-port", **Opt.db_port)
+@click.option("--db-host", **Opt.db_host)
+@click.option("--db-user", **Opt.db_user)
+@click.option("--db-pass", **Opt.db_pass)
+@click.option("--db-require-ssl", **Opt.db_require_ssl)
+@click.option("--mzfmt/--no-mzfmt", **Opt.mzfmt)
+@is_documented_by(api.extract.defs)
+def defs(
+    target: Path,
+    database: str,
+    schema: str,
+    name: str,
+    db_port: int,
+    db_host: str,
+    db_user: str,
+    db_pass: str | None,
+    db_require_ssl: bool,
+    mzfmt: bool,
+) -> None:
+    try:
+        api.extract.defs(
+            target,
+            database,
+            schema,
+            name,
+            db_port,
+            db_host,
+            db_user,
+            db_pass,
+            db_require_ssl,
+            mzfmt,
+        )
+    except Exception as e:
+        raise click.ClickException(f"extract defs command failed: {e=}, {type(e)=}")
+
+
+@extract.command()
+@click.argument("target", **Arg.repository)
+@click.argument("database", type=str)
+@click.argument("schema", type=str)
+@click.argument("name", type=str)
+@click.option("--db-port", **Opt.db_port)
+@click.option("--db-host", **Opt.db_host)
+@click.option("--db-user", **Opt.db_user)
+@click.option("--db-pass", **Opt.db_pass)
+@click.option("--db-require-ssl", **Opt.db_require_ssl)
+@click.option("--explainee-type", "-t", **Opt.explainee_type)
+@click.option("--with", "-w", "explain_flags", **Opt.explain_flags)
+@click.option("--stage", "-s", "explain_stages", **Opt.explain_stage)
+@click.option("--suffix", **Opt.explain_suffix)
+@is_documented_by(api.extract.defs)
+def plans(
+    target: Path,
+    database: str,
+    schema: str,
+    name: str,
+    db_port: int,
+    db_host: str,
+    db_user: str,
+    db_pass: str | None,
+    db_require_ssl: bool,
+    explainee_type: api.ExplaineeType,
+    explain_flags: list[api.ExplainFlag],
+    explain_stages: set[api.ExplainStage],
+    suffix: str | None = None,
+) -> None:
+    try:
+        api.extract.plans(
+            target,
+            database,
+            schema,
+            name,
+            db_port,
+            db_host,
+            db_user,
+            db_pass,
+            db_require_ssl,
+            explainee_type,
+            explain_flags,
+            explain_stages,
+            suffix,
+        )
+    except Exception as e:
+        raise click.ClickException(f"extract plans command failed: {e=}, {type(e)=}")
+
+
+# Entrypoint
+# ----------
+
+if __name__ == "__main__":
+    app()

--- a/misc/python/materialize/mzexplore/__init__.py
+++ b/misc/python/materialize/mzexplore/__init__.py
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# These are actually used in materialize.cli.mzexplore
+from materialize.mzexplore import extract  # noqa: F401
+from materialize.mzexplore.common import (
+    ExplaineeType,  # noqa: F401
+    ExplainFlag,  # noqa: F401
+    ExplainStage,  # noqa: F401
+)

--- a/misc/python/materialize/mzexplore/catalog/items.sql
+++ b/misc/python/materialize/mzexplore/catalog/items.sql
@@ -1,0 +1,31 @@
+-- Copyright Materialize, Inc. and contributors. All rights reserved.
+--
+-- Use of this software is governed by the Business Source License
+-- included in the LICENSE file at the root of this repository.
+--
+-- As of the Change Date specified in that file, in accordance with
+-- the Business Source License, use of this software will be governed
+-- by the Apache License, Version 2.0.
+
+-- extract objects
+SELECT
+  o.id as id,
+  o.oid as oid,
+  o.type as type,
+  o.name as name,
+  s.name as schema,
+  d.name as database
+FROM
+  mz_objects AS o JOIN
+  mz_schemas AS s ON (o.schema_id = s.id) JOIN
+  mz_databases AS d ON (s.database_id = d.id)
+WHERE
+  o.id like 'u%' AND
+  o.name like {name} AND
+  s.name like {schema} AND
+  d.name like {database}
+ORDER BY
+  o.type,
+  d.name,
+  s.name,
+  o.name;

--- a/misc/python/materialize/mzexplore/common.py
+++ b/misc/python/materialize/mzexplore/common.py
@@ -1,0 +1,106 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from enum import Enum, auto
+from importlib import resources
+from pathlib import Path
+from typing import cast
+
+import click
+
+
+class ExplaineeType(Enum):
+    CREATE_STATEMENT = 1
+    CATALOG_ITEM = 2
+    ALL = 3
+
+    def __str__(self):
+        return self.name.lower()
+
+    def contains(self, other: "ExplaineeType") -> bool:
+        return (self.value & other.value) > 0
+
+
+class ExplainStage(str, Enum):
+    RAW_PLAN = "RAW PLAN"
+    DECORRELATED_PLAN = "DECORRELATED PLAN"
+    OPTIMIZED_PLAN = "OPTIMIZED PLAN"
+    PHYSICAL_PLAN = "PHYSICAL PLAN"
+    OPTIMIZER_TRACE = "OPTIMIZER TRACE"
+
+    def __str__(self):
+        return self.value
+
+
+class ExplainFlag(Enum):
+    # Show the number of columns.
+    ARITY = auto()
+    # Render implemented MIR `Join` nodes in a way which reflects the implementation.
+    JOIN_IMPLS = auto()
+    # Show the sets of unique keys.
+    KEYS = auto()
+    # Restrict output trees to linear chains. Ignored if `raw_plans` is set.
+    LINEAR_CHAINS = auto()
+    # Show the `non_negative` in the explanation if it is supported by the backing IR.
+    NON_NEGATIVE = auto()
+    # Show the slow path plan even if a fast path plan was created. Useful for debugging.
+    # Enforced if `timing` is set.
+    NO_FAST_PATH = auto()
+    # Don't normalize plans before explaining them.
+    RAW_PLANS = auto()
+    # Disable virtual syntax in the explanation.
+    RAW_SYNTAX = auto()
+    # Show the `subtree_size` attribute in the explanation if it is supported by the backing IR.
+    SUBTREE_SIZE = auto()
+    # Print optimization timings.
+    TIMING = auto()
+    # Show the `type` attribute in the explanation.
+    TYPES = auto()
+    # Show MFP pushdown information.
+    FILTER_PUSHDOWN = auto()
+    # Show cardinality information.
+    CARDINALITY = auto()
+    # Show inferred column names.
+    COLUMN_NAMES = auto()
+    # Use inferred column names when rendering scalar and aggregate expressions.
+    HUMANIZED_EXPRS = auto()
+    # Enable outer join lowering implemented in #22343.
+    ENABLE_NEW_OUTER_JOIN_LOWERING = auto()
+
+    def __str__(self):
+        return self.name.lower()
+
+
+class ItemType(str, Enum):
+    CONNECTION = "connection"
+    INDEX = "index"
+    MATERIALIZED_VIEW = "materialized-view"
+    SECRET = "secret"
+    SINK = "sink"
+    SOURCE = "source"
+    TABLE = "table"
+    VIEW = "view"
+
+
+def resource_path(name: str) -> Path:
+    # NOTE: we have to do this cast because pyright is not comfortable with the
+    # Traversable protocol.
+    return cast(Path, resources.files(__package__)) / name
+
+
+def info(msg: str, fg: str = "green") -> None:
+    click.secho(msg, fg=fg)
+
+
+def warn(msg: str, fg: str = "yellow") -> None:
+    click.secho(msg, fg=fg, err=True)
+
+
+def err(msg: str, fg: str = "red") -> None:
+    click.secho(msg, fg=fg, err=True)

--- a/misc/python/materialize/mzexplore/extract.py
+++ b/misc/python/materialize/mzexplore/extract.py
@@ -1,0 +1,291 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""
+Utilities to extract data from a Materialize catalog for exploration purposes.
+"""
+
+import json
+import string
+import textwrap
+from contextlib import closing
+from pathlib import Path
+
+from pg8000.native import identifier
+
+from materialize.mzexplore import sql
+from materialize.mzexplore.common import (
+    ExplaineeType,
+    ExplainFlag,
+    ExplainStage,
+    ItemType,
+    info,
+    warn,
+)
+
+
+def defs(
+    target: Path,
+    database: str,
+    schema: str,
+    name: str,
+    db_port: int,
+    db_host: str,
+    db_user: str,
+    db_pass: str | None,
+    db_require_ssl: bool,
+    mzfmt: bool,
+) -> None:
+    """
+    Extract CREATE statements for selected catalog items.
+
+    Processes only items that match the ILIKE pattern defined by the parameter
+    triple (DATABASE, SCHEMA, NAME).
+    """
+
+    # Ensure that the target dir exists.
+    target.mkdir(parents=True, exist_ok=True)
+
+    with closing(
+        sql.Database(
+            port=db_port,
+            host=db_host,
+            user=db_user,
+            database=None,
+            password=db_pass,
+            require_ssl=db_require_ssl,
+        )
+    ) as db:
+        output_template = string.Template(
+            textwrap.dedent(
+                """
+                -- id: $id
+                -- oid: $oid
+                $create_sql
+                """
+            ).lstrip()
+        )
+
+        # Extract materialized view definitions
+        # -------------------------------------
+
+        for item in db.catalog_items(database, schema, name):
+            item_database = identifier(item["database"])
+            item_schema = identifier(item["schema"])
+            item_name = identifier(item["name"])
+            fqname = f"{item_database}.{item_schema}.{item_name}"
+
+            if item["type"] == "index":
+                show_create_query = f"SHOW CREATE INDEX {fqname}"
+            elif item["type"] == "materialized-view":
+                show_create_query = f"SHOW CREATE MATERIALIZED VIEW {fqname}"
+            elif item["type"] == "source" and not item["name"].endswith("_progress"):
+                show_create_query = f"SHOW CREATE SOURCE {fqname}"
+            elif item["type"] == "table":
+                show_create_query = f"SHOW CREATE TABLE {fqname}"
+            elif item["type"] == "view":
+                show_create_query = f"SHOW CREATE VIEW {fqname}"
+            else:  # "connection", "secret"
+                continue
+
+            create_sql = db.query_one(show_create_query)["create_sql"]
+            item["create_sql"] = sql.try_mzfmt(create_sql) if mzfmt else create_sql
+
+            base = Path(item["type"], item["database"], item["schema"])
+            path = base.joinpath(f"{item['name']}.sql")
+
+            (target / base).mkdir(parents=True, exist_ok=True)
+
+            # Save definitions in files.
+            info(f"Extracting {item['type']} def in `{path}`")
+            with (target / path).open("w") as file:
+                file.write(output_template.substitute(item))
+
+
+def plans(
+    target: Path,
+    database: str,
+    schema: str,
+    name: str,
+    db_port: int,
+    db_host: str,
+    db_user: str,
+    db_pass: str | None,
+    db_require_ssl: bool,
+    explainee_type: ExplaineeType,
+    explain_flags: list[ExplainFlag],
+    explain_stages: set[ExplainStage],
+    suffix: str | None = None,
+) -> None:
+    """
+    Extract EXPLAIN plans for selected catalog items.
+
+    Processes only items that match the ILIKE pattern defined by the parameter
+    triple (DATABASE, SCHEMA, NAME).
+    """
+
+    # Click doesn't deduplicate, so we need to convert explain_stages (which is
+    # actually a list) into a set explicitly.
+    explain_stages = set(explain_stages)
+
+    if not explain_flags:
+        # We should have at least arity for good measure.
+        explain_flags = [ExplainFlag.ARITY]
+
+    with closing(
+        sql.Database(
+            port=db_port,
+            host=db_host,
+            user=db_user,
+            database=None,
+            password=db_pass,
+            require_ssl=db_require_ssl,
+        )
+    ) as db:
+        for item in db.catalog_items(database, schema, name):
+            item_database = identifier(item["database"])
+            item_schema = identifier(item["schema"])
+            item_name = identifier(item["name"])
+            fqname = f"{item_database}.{item_schema}.{item_name}"
+
+            try:
+                item_type = ItemType(item["type"])
+            except ValueError:
+                warn(f"Unsupported item type {item['type']} for {fqname}")
+                continue
+
+            base = Path(item["type"], item["database"], item["schema"])
+
+            plans: dict[str, str] = {}
+
+            if ExplaineeType.CATALOG_ITEM.contains(explainee_type):
+                # If the item can be explained, explain the DDL
+                explainee = explain_item(item_type, fqname)
+                if explainee is not None:
+                    supported_stages = supported_explain_stages(item_type, create=False)
+                    for stage in explain_stages:
+                        if stage not in supported_stages:
+                            continue
+
+                        file_name = ".".join(
+                            str(part)
+                            for part in [
+                                item["name"],
+                                ExplaineeType.CATALOG_ITEM,
+                                stage.name.lower(),
+                                suffix,
+                                "txt",
+                            ]
+                            if part != None
+                        )
+                        info(f"Explaining {stage} for {explainee} in `{file_name}`")
+                        plans[file_name] = explain(
+                            db,
+                            stage,
+                            explainee,
+                            explain_flags,
+                        )
+
+            if ExplaineeType.CREATE_STATEMENT.contains(explainee_type):
+                # If the DDL for the plan exists, explain it as well
+                supported_stages = supported_explain_stages(item_type, create=True)
+
+                create_path = base.joinpath("{name}.sql".format(**item))
+                if not (target / create_path).is_file():
+                    if set.intersection(supported_stages, explain_stages):
+                        # No CREATE file, but a supported stage is requested
+                        info(
+                            f"WARNING: Skipping EXPLAIN CREATE for {fqname}: "
+                            f"CREATE statement path `{create_path}` does not exist."
+                        )
+                    continue
+
+                explainee = (target / create_path).read_text()
+
+                for stage in explain_stages:
+                    if stage not in supported_stages:
+                        continue
+
+                    file_name = ".".join(
+                        str(part)
+                        for part in [
+                            item["name"],
+                            ExplaineeType.CREATE_STATEMENT,
+                            stage.name.lower(),
+                            suffix,
+                            "txt",
+                        ]
+                        if part != None
+                    )
+                    info(f"Explaining {stage} for CREATE {fqname} in `{file_name}`")
+                    plans[file_name] = explain(
+                        db,
+                        stage,
+                        explainee,
+                        explain_flags,
+                    )
+
+            for file_name, plan in plans.items():
+                explain_path = base.joinpath(file_name)
+                with (target / explain_path).open("w") as file:
+                    file.write(plan)
+
+
+# Utility methods
+# ---------------
+
+
+def explain(
+    db: sql.Database,
+    explain_stage: ExplainStage,
+    explainee: str,
+    explain_flags: list[ExplainFlag],
+) -> str:
+    explain_query = "\n".join(
+        line
+        for line in [
+            f"EXPLAIN {explain_stage}",
+            f"WITH({', '.join(map(str, explain_flags))})" if explain_flags else "",
+            "AS TEXT FOR",
+            explainee,
+        ]
+        if line != ""
+    )
+    if explain_stage == ExplainStage.OPTIMIZER_TRACE:
+        return json.dumps(
+            {
+                "explainee": {"query": explainee},
+                "list": [
+                    {"id": id, **entry}
+                    for (id, entry) in enumerate(db.query_all(explain_query))
+                ],
+            },
+            indent=4,
+        )
+    else:
+        return next(iter(db.query_one(explain_query).values()))
+
+
+def explain_item(item_type: ItemType, fqname: str) -> str | None:
+    if item_type == ItemType.MATERIALIZED_VIEW:
+        return f"MATERIALIZED VIEW {fqname}"
+    if item_type == ItemType.INDEX:
+        return f"INDEX {fqname}"
+    else:
+        return None
+
+
+def supported_explain_stages(item_type: ItemType, create: bool) -> set[ExplainStage]:
+    if item_type in {ItemType.MATERIALIZED_VIEW, ItemType.INDEX}:
+        if create:
+            return set(ExplainStage)
+        else:
+            return set([ExplainStage.OPTIMIZED_PLAN, ExplainStage.PHYSICAL_PLAN])
+    else:
+        return set()

--- a/misc/python/materialize/mzexplore/sql.py
+++ b/misc/python/materialize/mzexplore/sql.py
@@ -1,0 +1,119 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import logging
+import ssl
+import subprocess
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any, cast
+
+import pg8000
+import sqlparse
+from pg8000.native import literal
+
+from materialize.mzexplore.common import resource_path
+
+DictGenerator = Generator[dict[Any, Any], None, None]
+
+
+class Database:
+    """An API to the database under exploration."""
+
+    def __init__(
+        self,
+        port: int,
+        host: str,
+        user: str,
+        password: str | None,
+        database: str | None,
+        require_ssl: bool,
+    ) -> None:
+        logging.debug(f"Initialize Database with host={host} port={port}, user={user}")
+
+        if require_ssl:
+            # verify_mode=ssl.CERT_REQUIRED is the default
+            ssl_context = ssl.create_default_context()
+        else:
+            ssl_context = None
+
+        self.conn = pg8000.connect(
+            host=host,
+            port=port,
+            user=user,
+            password=password,
+            database=database,
+            ssl_context=ssl_context,
+        )
+        self.conn.autocommit = True
+
+    def close(self) -> None:
+        self.conn.close()
+
+    def query_one(self, query: str) -> dict[Any, Any]:
+        with self.conn.cursor() as cursor:
+            cursor.execute(query)
+            cols = [d[0].lower() for d in cursor.description]
+            row = {key: val for key, val in zip(cols, cursor.fetchone())}
+            return cast(dict[Any, Any], row)
+
+    def query_all(self, query: str) -> DictGenerator:
+        with self.conn.cursor() as cursor:
+            cursor.execute(query)
+            cols = [d[0].lower() for d in cursor.description]
+            for row in cursor.fetchall():
+                yield {key: val for key, val in zip(cols, row)}
+
+    def catalog_items(
+        self,
+        database: str | None = None,
+        schema: str | None = None,
+        name: str | None = None,
+    ) -> DictGenerator:
+        # Warning: this is not sanitizing the input!
+        q = parse_query(resource_path("catalog/items.sql"))
+        yield from self.query_all(
+            q.format(
+                database="'%'" if database is None else literal(database),
+                schema="'%'" if schema is None else literal(schema),
+                name="'%'" if name is None else literal(name),
+            )
+        )
+
+
+# Utility functions
+# -----------------
+
+
+def parse_from_file(path: Path) -> list[str]:
+    """Parses a *.sql file to a list of queries."""
+    return sqlparse.split(path.read_text())
+
+
+def parse_query(path: Path) -> str:
+    """Parses a *.sql file to a list of queries."""
+    queries = parse_from_file(path)
+    assert len(queries) == 1, f"Exactly one query expected in {path}"
+    return queries[0]
+
+
+def try_mzfmt(sql: str) -> str:
+    sql = sql.rstrip().rstrip(";")
+
+    result = subprocess.run(
+        ["mzfmt"],
+        shell=True,
+        input=sql.encode("utf-8"),
+        capture_output=True,
+    )
+
+    if result.returncode == 0:
+        return result.stdout.decode("utf-8").rstrip()
+    else:
+        return sql.rstrip().rstrip(";")


### PR DESCRIPTION
A Skunkworks project from last month. Opening a PR to merge this in `main` because (a) several people have used from my WIP branch, and (b) we'll use the tool to inspect plans for optimizer regressions in the future.

[I've written a section in Notion](https://www.notion.so/materialize/Debugging-Materialize-Cloud-0788c1fe692b4acf9d247345e7b5346e#ab7d4ccc609248e79b0751d42d42ba5a) on how to use this command to get clone catalog definitions from cloud environment.

### Motivation

  * This PR adds a known-desirable feature.

This should be considered part of the "internal operational confidence" epic (which AFAICT is not yet created).

### Tips for reviewer

It's one big python file with two commands. see the linked Notion page above for details.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
