### PR TITLE
docs: document default ssh tunnels for kafka

### DIFF
--- a/doc/user/content/ingest-data/amazon-msk.md
+++ b/doc/user/content/ingest-data/amazon-msk.md
@@ -55,11 +55,8 @@ In Materialize, create a source connection that uses the SSH tunnel connection y
 
 ```sql
 CREATE CONNECTION kafka_connection TO KAFKA (
-BROKERS (
-    'broker1:9092' USING SSH TUNNEL ssh_connection,
-    'broker2:9092' USING SSH TUNNEL ssh_connection
-    -- Add all Kafka brokers
-    )
+  BROKER 'broker1:9092',
+  SSH TUNNEL ssh_connection
 );
 ```
 

--- a/doc/user/content/ingest-data/kafka-self-hosted.md
+++ b/doc/user/content/ingest-data/kafka-self-hosted.md
@@ -55,11 +55,8 @@ In Materialize, create a source connection that uses the SSH tunnel connection y
 
 ```sql
 CREATE CONNECTION kafka_connection TO KAFKA (
-BROKERS (
-    'broker1:9092' USING SSH TUNNEL ssh_connection,
-    'broker2:9092' USING SSH TUNNEL ssh_connection
-    -- Add all Kafka brokers
-    )
+  BROKER 'broker1:9092',
+  SSH TUNNEL ssh_connection
 );
 ```
 

--- a/doc/user/content/ingest-data/network-security/ssh-tunnel.md
+++ b/doc/user/content/ingest-data/network-security/ssh-tunnel.md
@@ -23,11 +23,8 @@ In Materialize, create a source connection that uses the SSH tunnel connection y
 {{< tab "Kafka">}}
 ```sql
 CREATE CONNECTION kafka_connection TO KAFKA (
-BROKERS (
-    'broker1:9092' USING SSH TUNNEL ssh_connection,
-    'broker2:9092' USING SSH TUNNEL ssh_connection
-    -- Add all Kafka brokers
-    )
+    BROKER 'broker1:9092',
+    SSH TUNNEL ssh_connection
 );
 ```
 

--- a/doc/user/content/sql/create-connection.md
+++ b/doc/user/content/sql/create-connection.md
@@ -195,8 +195,8 @@ check [this guide](/ops/network-security/privatelink/).
 
 {{< warning >}}
 If you do not specify a default [`SSH TUNNEL`](#kafka-options) and your Kafka
-cluster advertises brokers that are not listed in `BROKERS` clause, Materialize
-will attempt to connect to those brokers without any tunneling.
+cluster advertises brokers that are not listed in the `BROKERS` clause,
+Materialize will attempt to connect to those brokers without any tunneling.
 {{< /warning >}}
 
 {{< diagram "create-connection-kafka-brokers.svg" >}}


### PR DESCRIPTION
@morsapaes this feature will be insta-stable (see https://app.launchdarkly.com/default/production/features/enable_default_kafka_ssh_tunnel/targeting)

and will also need a release note
### Motivation

docs

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for _default_ `SSH TUNNEL`s for kafka connections
