### PR TITLE
sql: Correct timezone parsing to account for POSIX

### DIFF
--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -23,7 +23,7 @@ use mz_pgrepr::TypeFromOidError;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::InvalidArrayError;
 use mz_repr::adt::date::DateError;
-use mz_repr::adt::datetime::DateTimeUnits;
+use mz_repr::adt::datetime::{DateTimeUnits, TimezoneSpec};
 use mz_repr::adt::range::InvalidRangeError;
 use mz_repr::adt::regex::Regex;
 use mz_repr::adt::timestamp::TimestampError;
@@ -985,7 +985,7 @@ impl MirScalarExpr {
                             // time we really don't want to parse it again and again, so we parse it once and embed it into the
                             // UnaryFunc enum. The memory footprint of Timezone is small (8 bytes).
                             let tz = expr1.as_literal_str().unwrap();
-                            *e = match parse_timezone(tz) {
+                            *e = match parse_timezone(tz, TimezoneSpec::POSIX) {
                                 Ok(tz) => MirScalarExpr::CallUnary {
                                     func: UnaryFunc::TimezoneTimestamp(func::TimezoneTimestamp(tz)),
                                     expr: Box::new(expr2.take()),
@@ -997,7 +997,7 @@ impl MirScalarExpr {
                             }
                         } else if *func == BinaryFunc::TimezoneTimestampTz && expr1.is_literal() {
                             let tz = expr1.as_literal_str().unwrap();
-                            *e = match parse_timezone(tz) {
+                            *e = match parse_timezone(tz, TimezoneSpec::POSIX) {
                                 Ok(tz) => MirScalarExpr::CallUnary {
                                     func: UnaryFunc::TimezoneTimestampTz(
                                         func::TimezoneTimestampTz(tz),
@@ -1204,7 +1204,7 @@ impl MirScalarExpr {
                         } else if let VariadicFunc::TimezoneTime = func {
                             if exprs[0].is_literal() && exprs[2].is_literal_ok() {
                                 let tz = exprs[0].as_literal_str().unwrap();
-                                *e = match parse_timezone(tz) {
+                                *e = match parse_timezone(tz, TimezoneSpec::POSIX) {
                                     Ok(tz) => MirScalarExpr::CallUnary {
                                         func: UnaryFunc::TimezoneTime(func::TimezoneTime {
                                             tz,

--- a/src/repr/src/strconv.rs
+++ b/src/repr/src/strconv.rs
@@ -50,7 +50,7 @@ use uuid::Uuid;
 
 use crate::adt::array::ArrayDimension;
 use crate::adt::date::Date;
-use crate::adt::datetime::{self, DateTimeField, ParsedDateTime};
+use crate::adt::datetime::{self, DateTimeField, ParsedDateTime, Timezone, TimezoneSpec};
 use crate::adt::interval::Interval;
 use crate::adt::jsonb::{Jsonb, JsonbRef};
 use crate::adt::mz_acl_item::{AclItem, MzAclItem};
@@ -393,7 +393,7 @@ fn parse_timestamp_string(s: &str) -> Result<(NaiveDate, NaiveTime, datetime::Ti
     let offset = if tz_string.is_empty() {
         Default::default()
     } else {
-        tz_string.parse()?
+        Timezone::parse(tz_string, TimezoneSpec::ISO)?
     };
 
     Ok((d, t, offset))

--- a/test/sqllogictest/timezone.slt
+++ b/test/sqllogictest/timezone.slt
@@ -128,3 +128,25 @@ SELECT pg_catalog.timezone(-INTERVAL '1' MINUTE, TIMESTAMP '95143-12-31 23:59:59
 # Regression for #20514
 query error timestamp out of range
 SELECT pg_catalog.timezone('JAPAN', TIMESTAMPTZ '95143-12-31 23:59:59+06' + INTERVAL '167 MILLENNIUM')
+
+# Test that POSIX is used for timezone() and AT TIME ZONE.
+
+query T
+SELECT timezone('+5', '0001-01-01 12:00:00 +6'::TIMESTAMPTZ);
+----
+0001-01-01 01:00:00
+
+query T
+SELECT '0001-01-01 12:00:00 +6'::TIMESTAMPTZ AT TIME ZONE '+5';
+----
+0001-01-01 01:00:00
+
+query T
+SELECT timezone('-5', '0001-01-01 12:00:00 -6'::TIMESTAMPTZ);
+----
+0001-01-01 23:00:00
+
+query T
+SELECT '0001-01-01 12:00:00 -6'::TIMESTAMPTZ AT TIME ZONE '-5';
+----
+0001-01-01 23:00:00


### PR DESCRIPTION
PostgreSQL uses different timezone specification for parsing timezone offsets depending on the context or the parsing. When parsing a type, such as `TIMESTAMPTZ`, PostgreSQL uses ISO 8601 to parse the timezone. However, for all other timezone parsing, such as the `timezone` function or `SET TIMEZONE`, PostgreSQL uses the POSIX standard to parse the timezone.

The PostgreSQL docs are fairly confusing on this matter, so there isn't a single doc to link. As of version 16, the relevant information is spread out across the following docs:

  - https://www.postgresql.org/docs/16/functions-datetime.html#FUNCTIONS-DATETIME-ZONECONVERT
  - https://www.postgresql.org/docs/16/datatype-datetime.html#DATATYPE-DATETIME-INPUT-TIMES
  - https://www.postgresql.org/docs/16/datatype-datetime.html#DATATYPE-TIMEZONES
  - https://www.postgresql.org/docs/16/datetime-posix-timezone-specs.html
  - https://www.postgresql.org/docs/16/sql-set.html

Previously, Materialize always used ISO 8601 to parse timezone offsets. This commit updates the timezone parsing logic to use the correct timezone in the correct context.

Fixes #21999

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix timezone offset parsing for `timezone` function and `AT TIME ZONE` operator. This is a **Backwards-incompatible change.**
