### PR TITLE
persist-txn: always CaDS in txns shard

### DIFF
--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -51,8 +51,8 @@ where
     ///
     /// The timestamp will be assigned at commit time.
     ///
-    /// TODO(txn): Allow this to spill to s3 (for bounded memory) once persist
-    /// can make the ts rewrite op efficient.
+    /// TODO: Allow this to spill to s3 (for bounded memory) once persist can
+    /// make the ts rewrite op efficient.
     #[allow(clippy::unused_async)]
     pub async fn write(&mut self, data_id: &ShardId, key: K, val: V, diff: D) {
         self.writes

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -180,8 +180,8 @@ where
     /// Returns a new, empty transaction that can involve the data shards
     /// registered with this handle.
     pub fn begin(&self) -> Txn<K, V, D> {
-        // TODO(txn): This is a method on the handle because we'll need
-        // WriteHandles once we start spilling to s3.
+        // TODO: This is a method on the handle because we'll need WriteHandles
+        // once we start spilling to s3.
         Txn::new()
     }
 

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -491,7 +491,7 @@ where
         if min_unapplied_ts < &since_ts {
             since_ts.clone_from(min_unapplied_ts);
         }
-        crate::maybe_cads::<T, O, C>(&mut self.txns_since, since_ts).await;
+        crate::cads::<T, O, C>(&mut self.txns_since, since_ts).await;
     }
 
     /// Returns the [ShardId] of the txns shard.


### PR DESCRIPTION
In practice, it's quite clear from graphs of my staging env that the
perf impact of a bunch of places reading uncompacted data from the txns
shard (which consolidates really well) definitely outweighs the cost of
running CaDS every time (instead of rate-limiting as the `maybe_`
variant does).

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

I snuck a TODO cleanup commit in here too.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
