### PR TITLE
scalability framework: Support remote url ending on .git

### DIFF
--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -183,6 +183,8 @@ def try_get_remote_name_by_url(url: str) -> str | None:
         remote, desc = line.split("\t")
         if desc.lower() == f"{url} (fetch)".lower():
             return remote
+        if f"{desc.lower()}.git" == f"{url} (fetch)".lower():
+            return remote
     return None
 
 


### PR DESCRIPTION
Reported in https://materializeinc.slack.com/archives/C01LKF361MZ/p1698955685048729

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
