### PR TITLE
stash-debug: Add more debug logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5443,6 +5443,8 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-postgres",
+ "tracing",
+ "tracing-subscriber",
  "workspace-hack",
 ]
 

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -254,7 +254,7 @@ impl Catalog {
 
         let mut storage = config.storage;
         let is_read_only = storage.is_read_only();
-        tracing::debug!("Catalog::open - beginning initial transaction.");
+        tracing::info!("Catalog::open - beginning initial transaction.");
         let mut txn = storage.transaction().await?;
         // Choose a time at which to boot. This is the time at which we will run
         // internal migrations.
@@ -845,7 +845,7 @@ impl Catalog {
         )?;
 
         txn.commit().await?;
-        tracing::debug!("Catalog::open - ending initial transaction.");
+        tracing::info!("Catalog::open - ending initial transaction.");
         let mut catalog = Catalog {
             state,
             plans: CatalogPlans {

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -23,6 +23,8 @@ prost = { version = "0.11.3", features = ["no-recursion-limit"] }
 serde_json = "1.0.89"
 tokio = "1.32.0"
 tokio-postgres = { version = "0.7.8", features = [ "with-serde_json-1" ] }
+tracing = "0.1.37"
+tracing-subscriber = { version = "0.3.16", default-features = false, features = ["env-filter", "fmt"] }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [package.metadata.cargo-udeps.ignore]


### PR DESCRIPTION
1. Turns out the `stash-debug` CLI was not actually outputting debug logs, as there was no `tracing_subscriber` listening for them. Remedy this.
2. Output logs for the stash-opening transaction at `warn` level, so that they're easier to filter out

### Motivation

  * This PR adds a known-desirable feature.

  Further progress towards debugging https://github.com/MaterializeInc/cloud/issues/5057

### Tips for reviewer

Should be straightforward