### PR TITLE
storage: connection improvements

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -14,6 +14,7 @@ from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodS
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_pod import K8sPod
+from materialize.mzcompose import DEFAULT_MZ_ENVIRONMENT_ID
 
 
 class TestdriveBase:
@@ -56,6 +57,7 @@ class TestdriveBase:
             f"--schema-registry-url={self.schema_registry_url}",
             f"--default-timeout={default_timeout}",
             f"--log-filter={log_filter}",
+            f"--environment-id={DEFAULT_MZ_ENVIRONMENT_ID}",
             "--var=replicas=1",
             "--var=default-storage-size=1",
             "--var=default-replica-size=1",

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -11,6 +11,7 @@ import os
 import random
 
 from materialize.mzcompose import (
+    DEFAULT_MZ_ENVIRONMENT_ID,
     DEFAULT_MZ_VOLUMES,
 )
 from materialize.mzcompose.service import (
@@ -39,6 +40,7 @@ class Testdrive(Service):
         entrypoint: list[str] | None = None,
         entrypoint_extra: list[str] = [],
         environment: list[str] | None = None,
+        environment_id: str | None = None,
         volumes_extra: list[str] = [],
         volume_workdir: str = ".:/workdir",
         propagate_uid_gid: bool = True,
@@ -142,6 +144,10 @@ class Testdrive(Service):
             entrypoint.append(
                 "--persist-consensus-url=postgres://root@materialized:26257?options=--search_path=consensus"
             )
+
+        if not environment_id:
+            environment_id = DEFAULT_MZ_ENVIRONMENT_ID
+        entrypoint.append(f"--environment-id={environment_id}")
 
         entrypoint.extend(entrypoint_extra)
 

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -112,9 +112,14 @@ fn bench_transact(c: &mut Criterion) {
                 .await
                 .unwrap();
 
-            Catalog::open_debug_stash_catalog_url(postgres_url, schema.into(), SYSTEM_TIME.clone())
-                .await
-                .unwrap()
+            Catalog::open_debug_stash_catalog_url(
+                postgres_url,
+                schema.into(),
+                SYSTEM_TIME.clone(),
+                None,
+            )
+            .await
+            .unwrap()
         });
         let mut id = 0;
         b.iter(|| {

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -92,7 +92,7 @@ pub use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, Cluster, ClusterConfig, ClusterReplica, ClusterReplicaProcessStatus,
     ClusterVariant, ClusterVariantManaged, CommentsMap, Connection, DataSourceDesc, Database,
     DefaultPrivileges, Func, Index, Log, MaterializedView, Role, Schema, Secret, Sink, Source,
-    StorageSinkConnectionState, Table, Type, View,
+    Table, Type, View,
 };
 
 mod builtin_table_updates;

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -631,9 +631,6 @@ pub struct Log {
 pub struct Sink {
     pub create_sql: String,
     pub from: GlobalId,
-    // TODO(benesch): this field duplicates information that could be derived
-    // from the connection ID. Too hard to fix at the moment.
-    #[serde(skip)]
     pub connection: StorageSinkConnection<ReferencedConnection>,
     pub envelope: SinkEnvelope,
     pub with_snapshot: bool,
@@ -657,12 +654,6 @@ impl Sink {
     pub fn connection_id(&self) -> Option<GlobalId> {
         self.connection.connection_id()
     }
-}
-
-#[derive(Debug, Clone, Serialize)]
-pub enum StorageSinkConnectionState {
-    Pending(StorageSinkConnection<ReferencedConnection>),
-    Ready(StorageSinkConnection<ReferencedConnection>),
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/sql/src/kafka_util.rs
+++ b/src/sql/src/kafka_util.rs
@@ -97,7 +97,11 @@ generate_extracted_config!(
     (RetentionMs, i64)
 );
 
-/// The config options we expect to pass along when connecting to librdkafka
+/// The config options we expect to pass along when connecting to librdkafka.
+///
+/// Note that these are meant to be disjoint from the options we permit being
+/// set on Kafka connections (CREATE CONNECTION), i.e. these are meant to be
+/// per-client options (CREATE SOURCE, CREATE SINK).
 #[derive(Debug)]
 pub struct LibRdKafkaConfig(pub BTreeMap<String, StringOrSecret>);
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -723,7 +723,7 @@ pub fn plan_create_source(
                 group_id_prefix,
                 environment_id: scx.catalog.config().environment_id.to_string(),
                 metadata_columns,
-                connection_options,
+                connection_options: Some(connection_options),
             };
 
             let connection = GenericSourceConnection::Kafka(connection);
@@ -2497,7 +2497,7 @@ fn kafka_sink_builder(
 
     let extracted_options: KafkaConfigOptionExtracted = options.try_into()?;
 
-    let connection_options = kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?;
+    let connection_options = kafka_util::LibRdKafkaConfig::try_from(&extracted_options)?.0;
 
     let connection_id = item.id();
     let KafkaConfigOptionExtracted {
@@ -2646,7 +2646,7 @@ fn kafka_sink_builder(
         key_desc_and_indices,
         value_desc,
         retention,
-        connection_options: connection_options.0,
+        connection_options: Some(connection_options),
     }))
 }
 

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -243,6 +243,13 @@ impl Connection<InlinedConnection> {
             o => unreachable!("{o:?} is not an SSH connection"),
         }
     }
+
+    pub fn unwrap_csr(self) -> <InlinedConnection as ConnectionAccess>::Csr {
+        match self {
+            Self::Csr(conn) => conn,
+            o => unreachable!("{o:?} is not a Kafka connection"),
+        }
+    }
 }
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]

--- a/src/storage-types/src/connections/inline.rs
+++ b/src/storage-types/src/connections/inline.rs
@@ -72,6 +72,14 @@ pub trait ConnectionAccess:
         + Hash
         + Serialize
         + for<'a> Deserialize<'a>;
+    type Csr: Arbitrary
+        + Clone
+        + Debug
+        + Eq
+        + PartialEq
+        + Hash
+        + Serialize
+        + for<'a> Deserialize<'a>;
 }
 
 /// Expresses that the struct contains references to connections. Use a
@@ -84,6 +92,7 @@ impl ConnectionAccess for ReferencedConnection {
     type Kafka = GlobalId;
     type Pg = GlobalId;
     type Ssh = GlobalId;
+    type Csr = GlobalId;
 }
 
 /// Expresses that the struct contains an inlined definition of a connection.
@@ -94,4 +103,5 @@ impl ConnectionAccess for InlinedConnection {
     type Kafka = super::KafkaConnection;
     type Pg = super::PostgresConnection;
     type Ssh = super::SshConnection;
+    type Csr = super::CsrConnection;
 }

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -112,6 +112,7 @@ message ProtoKafkaSinkConnectionV2 {
     ProtoKafkaConsistencyConfig consistency_config = 10;
     ProtoKafkaSinkFormat format = 11;
     int32 partition_count = 12;
+    map<string, mz_storage_types.connections.ProtoStringOrSecret> connection_options = 13;
 }
 
 message ProtoPersistSinkConnection {

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -23,7 +23,7 @@ use serde::{Deserialize, Serialize};
 use timely::progress::frontier::Antichain;
 use timely::PartialOrder;
 
-use crate::connections::{CsrConnection, StringOrSecret};
+use crate::connections::StringOrSecret;
 use crate::controller::{CollectionMetadata, StorageError};
 
 use crate::connections::inline::{
@@ -569,7 +569,7 @@ pub enum KafkaSinkAvroFormatState<C: ConnectionAccess = InlinedConnection> {
     UnpublishedMaybe {
         key_schema: Option<String>,
         value_schema: String,
-        csr_connection: CsrConnection<C>,
+        csr_connection: C::Csr,
     },
     /// After communicating with the CSR, the IDs we've been given for the
     /// schemas.
@@ -591,7 +591,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkAvroFormatState, R>
             } => KafkaSinkAvroFormatState::UnpublishedMaybe {
                 key_schema,
                 value_schema,
-                csr_connection: csr_connection.into_inline_connection(r),
+                csr_connection: r.resolve_connection(csr_connection).unwrap_csr(),
             },
             Self::Published {
                 key_schema_id,

--- a/src/storage-types/src/sources.proto
+++ b/src/storage-types/src/sources.proto
@@ -153,6 +153,7 @@ message ProtoKafkaSourceConnection {
     optional mz_proto.ProtoU128 environment_id = 5;
     optional string environment_name = 12;
     repeated ProtoKafkaMetadataColumn metadata_columns = 11;
+    map<string, mz_storage_types.connections.ProtoStringOrSecret> connection_options = 14;
 }
 
 message ProtoSourceDesc {

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -1407,7 +1407,7 @@ pub struct KafkaSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub metadata_columns: Vec<(String, KafkaMetadataKind)>,
     /// Additional options that need to be set on the connection whenever it's
     /// inlined.
-    pub connection_options: BTreeMap<String, StringOrSecret>,
+    pub connection_options: Option<BTreeMap<String, StringOrSecret>>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
@@ -1426,7 +1426,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
         } = self;
 
         let mut connection = r.resolve_connection(connection).unwrap_kafka();
-        connection.options.extend(connection_options);
+        connection_options.map(|options| connection.options.extend(options));
 
         KafkaSourceConnection {
             connection,
@@ -1436,7 +1436,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
             group_id_prefix,
             environment_id,
             metadata_columns,
-            connection_options: BTreeMap::default(),
+            connection_options: None,
         }
     }
 }
@@ -1559,7 +1559,11 @@ where
                     group_id_prefix,
                     environment_id,
                     metadata_columns,
-                    connection_options,
+                    connection_options: if connection_options.is_empty() {
+                        None
+                    } else {
+                        Some(connection_options)
+                    },
                 },
             )
             .boxed()
@@ -1584,11 +1588,10 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection<InlinedConne
                     kind: Some(kind.into_proto()),
                 })
                 .collect(),
-            connection_options: self
-                .connection_options
-                .iter()
-                .map(|(k, v)| (k.clone(), v.into_proto()))
-                .collect(),
+            connection_options: match &self.connection_options {
+                None => BTreeMap::default(),
+                Some(o) => o.iter().map(|(k, v)| (k.clone(), v.into_proto())).collect(),
+            },
         }
     }
 
@@ -1618,11 +1621,19 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection<InlinedConne
                 }
             },
             metadata_columns,
-            connection_options: proto
-                .connection_options
-                .into_iter()
-                .map(|(k, v)| StringOrSecret::from_proto(v).map(|v| (k, v)))
-                .collect::<Result<_, _>>()?,
+            connection_options: {
+                if proto.connection_options.is_empty() {
+                    None
+                } else {
+                    Some(
+                        proto
+                            .connection_options
+                            .into_iter()
+                            .map(|(k, v)| StringOrSecret::from_proto(v).map(|v| (k, v)))
+                            .collect::<Result<_, _>>()?,
+                    )
+                }
+            },
         })
     }
 }

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -51,6 +51,7 @@ use crate::connections::inline::{
     ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
     ReferencedConnection,
 };
+use crate::connections::StringOrSecret;
 use crate::controller::{CollectionMetadata, StorageError};
 use crate::errors::{DataflowError, ProtoDataflowError};
 use crate::instances::StorageInstanceId;
@@ -1404,6 +1405,9 @@ pub struct KafkaSourceConnection<C: ConnectionAccess = InlinedConnection> {
     pub group_id_prefix: Option<String>,
     pub environment_id: String,
     pub metadata_columns: Vec<(String, KafkaMetadataKind)>,
+    /// Additional options that need to be set on the connection whenever it's
+    /// inlined.
+    pub connection_options: BTreeMap<String, StringOrSecret>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
@@ -1418,16 +1422,21 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSourceConnection, R>
             group_id_prefix,
             environment_id,
             metadata_columns,
+            connection_options,
         } = self;
 
+        let mut connection = r.resolve_connection(connection).unwrap_kafka();
+        connection.options.extend(connection_options);
+
         KafkaSourceConnection {
-            connection: r.resolve_connection(connection).unwrap_kafka(),
+            connection,
             connection_id,
             topic,
             start_offsets,
             group_id_prefix,
             environment_id,
             metadata_columns,
+            connection_options: BTreeMap::default(),
         }
     }
 }
@@ -1530,6 +1539,7 @@ where
             any::<Option<String>>(),
             any::<String>(),
             proptest::collection::vec(any::<(String, KafkaMetadataKind)>(), 0..4),
+            proptest::collection::btree_map(any::<String>(), any::<StringOrSecret>(), 0..4),
         )
             .prop_map(
                 |(
@@ -1540,6 +1550,7 @@ where
                     group_id_prefix,
                     environment_id,
                     metadata_columns,
+                    connection_options,
                 )| KafkaSourceConnection {
                     connection,
                     connection_id,
@@ -1548,6 +1559,7 @@ where
                     group_id_prefix,
                     environment_id,
                     metadata_columns,
+                    connection_options,
                 },
             )
             .boxed()
@@ -1571,6 +1583,11 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection<InlinedConne
                     name: name.into_proto(),
                     kind: Some(kind.into_proto()),
                 })
+                .collect(),
+            connection_options: self
+                .connection_options
+                .iter()
+                .map(|(k, v)| (k.clone(), v.into_proto()))
                 .collect(),
         }
     }
@@ -1601,6 +1618,11 @@ impl RustType<ProtoKafkaSourceConnection> for KafkaSourceConnection<InlinedConne
                 }
             },
             metadata_columns,
+            connection_options: proto
+                .connection_options
+                .into_iter()
+                .map(|(k, v)| StringOrSecret::from_proto(v).map(|v| (k, v)))
+                .collect::<Result<_, _>>()?,
         })
     }
 }

--- a/src/storage-types/src/sources/encoding.rs
+++ b/src/storage-types/src/sources/encoding.rs
@@ -18,8 +18,6 @@ use proptest::prelude::{Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use crate::connections::CsrConnection;
-
 use crate::connections::inline::{
     ConnectionAccess, ConnectionResolver, InlinedConnection, IntoInlineConnection,
     ReferencedConnection,
@@ -369,7 +367,7 @@ impl<C: ConnectionAccess> DataEncoding<C> {
 #[derive(Arbitrary, Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 pub struct AvroEncoding<C: ConnectionAccess = InlinedConnection> {
     pub schema: String,
-    pub csr_connection: Option<CsrConnection<C>>,
+    pub csr_connection: Option<C::Csr>,
     pub confluent_wire_format: bool,
 }
 
@@ -384,7 +382,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<AvroEncoding, R>
         } = self;
         AvroEncoding {
             schema,
-            csr_connection: csr_connection.map(|csr| csr.into_inline_connection(r)),
+            csr_connection: csr_connection.map(|csr| r.resolve_connection(csr).unwrap_csr()),
             confluent_wire_format,
         }
     }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -30,6 +30,7 @@ use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_ore::retry::Retry;
 use mz_ore::task;
+use mz_sql::catalog::EnvironmentId;
 use mz_stash::StashFactory;
 use mz_tls_util::make_tls;
 use once_cell::sync::Lazy;
@@ -120,6 +121,8 @@ pub struct Config {
     pub materialize_catalog_postgres_stash: Option<String>,
     /// Build information
     pub build_info: &'static BuildInfo,
+    /// The environment ID to use for this run
+    pub environment_id: EnvironmentId,
 
     // === Persist options. ===
     /// Handle to the persist consensus system.
@@ -183,6 +186,7 @@ pub struct State {
     materialize_internal_http_addr: String,
     materialize_user: String,
     pgclient: tokio_postgres::Client,
+    environment_id: EnvironmentId,
 
     // === Persist state. ===
     persist_consensus_url: Option<String>,
@@ -872,6 +876,7 @@ pub async fn create_state(
         materialize_internal_http_addr,
         materialize_user,
         pgclient,
+        environment_id: config.environment_id.clone(),
 
         // === Persist state. ===
         persist_consensus_url: config.persist_consensus_url.clone(),

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -309,6 +309,7 @@ impl State {
                     tls,
                 },
                 SYSTEM_TIME.clone(),
+                Some(self.environment_id.clone()),
             )
             .await?;
             let res = f(catalog.for_session(&Session::dummy()));

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -90,6 +90,7 @@ use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
+use mz_sql::catalog::EnvironmentId;
 use mz_testdrive::Config;
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -302,6 +303,9 @@ struct Args {
     // is started with, or the tests of catalog serialization will get confused.
     #[clap(long)]
     variable_length_row_encoding: bool,
+
+    #[clap(long)]
+    environment_id: String,
 }
 
 #[tokio::main]
@@ -413,6 +417,8 @@ async fn main() {
         materialize_params: args.materialize_param,
         materialize_catalog_postgres_stash: args.validate_postgres_stash,
         build_info: &BUILD_INFO,
+        environment_id: <EnvironmentId as std::str::FromStr>::from_str(&args.environment_id)
+            .unwrap(),
 
         // === Persist options. ===
         persist_consensus_url: args.persist_consensus_url,

--- a/test/testdrive/connection-create-drop.td
+++ b/test/testdrive/connection-create-drop.td
@@ -155,6 +155,13 @@ contains:CONFLUENT SCHEMA REGISTRY connections do not support TOKEN values
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
+! CREATE SOURCE csr_source
+  FROM KAFKA CONNECTION csr_conn (TOPIC 'testdrive-csr_test-${testdrive.seed}')
+    FORMAT AVRO
+    USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+    ENVELOPE DEBEZIUM
+contains:is not a KAFKA CONNECTION
+
 > CREATE SOURCE csr_source
     FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-csr_test-${testdrive.seed}')
     FORMAT AVRO


### PR DESCRIPTION
When introducing `into_inline_connection`, the PR did not include either connections on sinks or CSR connections. This PR fixes this, in addition to propagating connection options specified on the source to the connection.

### Motivation

- This PR refactors existing code.
- This PR fixes a previously unreported bug. We did not propagate Kafka source connection options onto the source connection (though we did use it in purification).

### Tips for reviewer

Likely commit by commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug where options specified on Kafka sources were not propagated to the Kafka client that ingested data from the source's broker.
