### PR TITLE
dbt-materialize: release v1.6.1

### DIFF
--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -1,6 +1,6 @@
 # dbt-materialize Changelog
 
-## Unreleased
+## 1.6.1 - 2023-11-03
 
 * Support the [`ASSERT NOT NULL` option](https://materialize.com/docs/sql/create-materialized-view/#non-null-assertions)
   for `materialized_view` materializations via the `not_null` column-level

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -2,12 +2,13 @@
 
 [dbt] adapter for [Materialize].
 
-For a complete step-by-step guide on how to use dbt and Materialize, check the [documentation](https://materialize.com/docs/guides/dbt/).
+For a complete step-by-step guide on how to use dbt and Materialize, check the
+[documentation](https://materialize.com/docs/guides/dbt/).
 
 ## Installation
 
-`dbt-materialize` is available on [PyPI]. To install the latest version via `pip` (optionally using a virtual environment),
-run:
+`dbt-materialize` is available on [PyPI]. To install the latest version via
+`pip` (optionally using a virtual environment), run:
 
 ```nofmt
 python3 -m venv dbt-venv         # create the virtual environment
@@ -18,12 +19,12 @@ pip install dbt-materialize      # install the adapter
 ## Requirements
 
 <!-- If you update this, bump the constraint in connections.py too. -->
-`dbt-materialize` requires Materialize v0.49.0+.
+`dbt-materialize` requires Materialize v0.68.0+.
 
 ## Configuring your profile
 
-To connect to a Materialize instance, use the reference [profile configuration](https://docs.getdbt.com/reference/warehouse-profiles/materialize-profile#connecting-to-materialize-with-dbt-materialize) in your
-connection profile:
+To connect to a Materialize instance, use the reference [profile configuration](https://docs.getdbt.com/reference/warehouse-profiles/materialize-profile#connecting-to-materialize-with-dbt-materialize)
+in your connection profile:
 
 ```yml
 dbt-materialize:
@@ -65,7 +66,9 @@ Type                | Supported? | Details
 
 ### Indexes
 
-Use the indexes option to define a list of [indexes](/sql/create-index/) on `source`, `view`, `table` or `materialized view` materializations. Each Materialize index can have the following components:
+Use the indexes option to define a list of [indexes](/sql/create-index/) on
+`source`, `view`, `table` or `materialized view` materializations. Each
+Materialize index can have the following components:
 
 Component                            | Value     | Description
 -------------------------------------|-----------|--------------------------------------------------
@@ -76,30 +79,41 @@ Component                            | Value     | Description
 
 ### Additional macros
 
-We provide a `materialize-dbt-utils` package with Materialize-specific implementations of dispatched macros from `dbt-utils`. To use this package in your dbt project, check the latest installation instructions in [dbt Hub](https://hub.getdbt.com/materializeinc/materialize_dbt_utils/latest/).
+We provide a `materialize-dbt-utils` package with Materialize-specific
+implementations of dispatched macros from `dbt-utils`. To use this package in
+your dbt project, check the latest installation instructions in [dbt Hub](https://hub.getdbt.com/materializeinc/materialize_dbt_utils/latest/).
 
 ### Hooks
 
-Not tested.
+Supported.
 
 ### Custom Schemas
 
-Not tested.
+Supported. Custom schemas in dbt might behave differently than you'd expect, so
+make sure to read the [documentation](https://docs.getdbt.com/docs/build/custom-schemas)!
 
 ### Sources
 
-You can instruct dbt to create a [`dbt source`](https://docs.getdbt.com/docs/build/sources) in Materialize using the custom [source] materialization, which allows for injecting the complete source statement into your .sql file.
+You can instruct dbt to create a [`dbt source`](https://docs.getdbt.com/docs/build/sources)
+in Materialize using the custom[source] materialization, which allows for
+injecting the complete source statement into your .sql file.
 
-`source freshness` is not supported because using Materialize, your sources will always be fresh.
+`source freshness` is not supported because using Materialize, your sources will
+always be fresh.
 
 ### Documentation
-[`dbt docs`](https://docs.getdbt.com/reference/commands/cmd-docs) is supported.
+
+[`dbt docs`](https://docs.getdbt.com/reference/commands/cmd-docs) is supported,
+as well as [`--persist-docs`](https://docs.getdbt.com/reference/resource-configs/persist_docs).
 
 ### Testing
+
 [`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported.
 
-If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures), dbt will save the results of a test query to a `materialized_view`.
-These will be created in a schema suffixed or named `dbt_test__audit` by default. Change this value by setting a `schema` config.
+If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures),
+dbt will save the results of a test query to a `materialized_view`. These will
+be created in a schema suffixed or named `dbt_test__audit` by default. Change
+this value by setting a `schema` config.
 
 ### Snapshots
 
@@ -108,7 +122,7 @@ Not supported. Support is not planned for the near term.
 ## Contributors
 
 A huge thank you to [Josh Wills](https://github.com/jwills), who created the
-original version of this adapter.
+original version of this adapter. 🤠
 
 [#5266]: https://github.com/MaterializeInc/materialize/issues/5266
 [dbt]: https://www.getdbt.com/

--- a/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/__version__.py
@@ -15,4 +15,4 @@
 # limitations under the License.
 
 # If you bump this version, bump it in setup.py too.
-version = "1.6.0"
+version = "1.6.1"

--- a/misc/dbt-materialize/dbt/adapters/materialize/connections.py
+++ b/misc/dbt-materialize/dbt/adapters/materialize/connections.py
@@ -25,7 +25,7 @@ from dbt.events import AdapterLogger
 from dbt.semver import versions_compatible
 
 # If you bump this version, bump it in README.md too.
-SUPPORTED_MATERIALIZE_VERSIONS = ">=0.49.0"
+SUPPORTED_MATERIALIZE_VERSIONS = ">=0.68.0"
 
 logger = AdapterLogger("Materialize")
 

--- a/misc/dbt-materialize/setup.py
+++ b/misc/dbt-materialize/setup.py
@@ -26,12 +26,12 @@ setup(
     # This adapter's minor version should match the required dbt-postgres version,
     # but patch versions may differ.
     # If you bump this version, bump it in __version__.py too.
-    version="1.6.0",
+    version="1.6.1",
     description="The Materialize adapter plugin for dbt.",
     long_description=(Path(__file__).parent / "README.md").open().read(),
     long_description_content_type="text/markdown",
     author="Materialize, Inc.",
-    author_email="support@materialize.com",
+    author_email="devex@materialize.com",
     url="https://github.com/MaterializeInc/materialize/blob/main/misc/dbt-materialize",
     packages=find_packages(),
     package_data={


### PR DESCRIPTION
Release `dbt-materialize` v1.6.1. 

See `CHANGELOG.md` for an overview of the release.