### PR TITLE
scalability framework: include zero in y-axis

### DIFF
--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -20,7 +20,9 @@ from materialize.scalability.endpoints import endpoint_name_to_description
 
 
 def scatterplot_tps_per_connections(
-    figure: SubFigure, df_totals_by_endpoint_name: dict[str, pd.DataFrame]
+    figure: SubFigure,
+    df_totals_by_endpoint_name: dict[str, pd.DataFrame],
+    include_zero_in_y_axis: bool,
 ) -> None:
     legend = []
     plot: Axes = figure.subplots(1, 1)
@@ -41,11 +43,17 @@ def scatterplot_tps_per_connections(
 
     plot.set_ylabel("Transactions Per Second (tps)")
     plot.set_xlabel("Concurrent SQL Connections")
+
+    if include_zero_in_y_axis:
+        plot.set_ylim(ymin=0)
+
     plot.legend(legend)
 
 
 def scatterplot_latency_per_connections(
-    figure: SubFigure, df_details_by_endpoint_name: dict[str, pd.DataFrame]
+    figure: SubFigure,
+    df_details_by_endpoint_name: dict[str, pd.DataFrame],
+    include_zero_in_y_axis: bool,
 ) -> None:
     legend = []
     plot: Axes = figure.subplots(1, 1)
@@ -65,11 +73,17 @@ def scatterplot_latency_per_connections(
 
     plot.set_ylabel("Latency in Seconds")
     plot.set_xlabel("Concurrent SQL Connections")
+
+    if include_zero_in_y_axis:
+        plot.set_ylim(ymin=0)
+
     plot.legend(legend)
 
 
 def boxplot_latency_per_connections(
-    figure: SubFigure, df_details_by_endpoint_name: dict[str, pd.DataFrame]
+    figure: SubFigure,
+    df_details_by_endpoint_name: dict[str, pd.DataFrame],
+    include_zero_in_y_axis: bool,
 ) -> None:
     if len(df_details_by_endpoint_name) == 0:
         return
@@ -126,6 +140,9 @@ def boxplot_latency_per_connections(
 
         if is_in_first_column:
             plot.set_ylabel("Latency in Seconds")
+
+        if include_zero_in_y_axis:
+            plot.set_ylim(ymin=0)
 
         plot.set_title(f"# connections: {concurrency}")
 

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -22,7 +22,7 @@ from materialize.scalability.plot.plot import (
 USE_BOXPLOT = True
 
 
-def plotit(workload_name: str) -> None:
+def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
     fig = plt.figure(layout="constrained", figsize=(16, 14))
     (tps_figure, latency_figure) = fig.subfigures(2, 1)
 
@@ -30,12 +30,24 @@ def plotit(workload_name: str) -> None:
         workload_name
     )
 
-    scatterplot_tps_per_connections(tps_figure, df_totals_by_endpoint_name)
+    scatterplot_tps_per_connections(
+        tps_figure,
+        df_totals_by_endpoint_name,
+        include_zero_in_y_axis=include_zero_in_y_axis,
+    )
 
     if USE_BOXPLOT:
-        boxplot_latency_per_connections(latency_figure, df_details_by_endpoint_name)
+        boxplot_latency_per_connections(
+            latency_figure,
+            df_details_by_endpoint_name,
+            include_zero_in_y_axis=include_zero_in_y_axis,
+        )
     else:
-        scatterplot_latency_per_connections(latency_figure, df_details_by_endpoint_name)
+        scatterplot_latency_per_connections(
+            latency_figure,
+            df_details_by_endpoint_name,
+            include_zero_in_y_axis=include_zero_in_y_axis,
+        )
 
 
 def load_data_from_filesystem(

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -51,6 +51,8 @@ SERVICES = [
 
 REGRESSION_THRESHOLD_AS_PERCENT_DECIMAL = 0.2
 
+INCLUDE_ZERO_IN_Y_AXIS = True
+
 
 def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
@@ -297,7 +299,11 @@ def create_plots(result: BenchmarkResult) -> None:
     ) in result.get_df_total_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 6))
         (subfigure) = fig.subfigures(1, 1)
-        scatterplot_tps_per_connections(subfigure, results_by_endpoint)
+        scatterplot_tps_per_connections(
+            subfigure,
+            results_by_endpoint,
+            include_zero_in_y_axis=INCLUDE_ZERO_IN_Y_AXIS,
+        )
         plt.savefig(paths.plot_png("tps", workload_name), bbox_inches="tight", dpi=300)
 
     for (
@@ -306,7 +312,11 @@ def create_plots(result: BenchmarkResult) -> None:
     ) in result.get_df_details_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
-        boxplot_latency_per_connections(subfigure, results_by_endpoint)
+        boxplot_latency_per_connections(
+            subfigure,
+            results_by_endpoint,
+            include_zero_in_y_axis=INCLUDE_ZERO_IN_Y_AXIS,
+        )
         plt.savefig(
             paths.plot_png("latency", workload_name), bbox_inches="tight", dpi=300
         )

--- a/test/scalability/scalability.ipynb
+++ b/test/scalability/scalability.ipynb
@@ -26,7 +26,13 @@
     "    options=list(workloads[\"workload\"]),\n",
     "    description=\"Workload:\",\n",
     ")\n",
-    "interactive(plotit, workload_name=workload_name)"
+    "include_zero_in_y_axis = widgets.Checkbox(\n",
+    "    value=True,\n",
+    "    description=\"Include zero in y-axis\",\n",
+    ")\n",
+    "interactive(\n",
+    "    plotit, workload_name=workload_name, include_zero_in_y_axis=include_zero_in_y_axis\n",
+    ")"
    ]
   }
  ],


### PR DESCRIPTION
* `include_zero_in_y_axis=True` is the default for CI. I will need to double-check if this produces satisfying plots.
* The setting is configurable in the Jupyter notebook.

<img width="504" alt="Bildschirmfoto 2023-11-03 um 11 55 27" src="https://github.com/MaterializeInc/materialize/assets/129728240/2abbbb42-87c0-487a-bef0-87609179394a">
