### PR TITLE
bounded-memory: Reproduce index hydration spike

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -25,15 +25,13 @@ PAD_LEN = 1024
 STRING_PAD = "x" * PAD_LEN
 REPEAT = 16 * 1024
 ITERATIONS = 128
-MATERIALIZED_MEMORY = "5Gb"
-CLUSTERD_MEMORY = "3.5Gb"
 
 SERVICES = [
-    Materialized(memory=MATERIALIZED_MEMORY),
+    Materialized(),
     Testdrive(no_reset=True, seed=1, default_timeout="3600s"),
     Redpanda(),
     Postgres(),
-    Clusterd(memory=CLUSTERD_MEMORY),
+    Clusterd(),
 ]
 
 
@@ -43,6 +41,8 @@ class Scenario:
     pre_restart: str
     post_restart: str
     disabled: bool = False
+    materialized_memory: str = "5Gb"
+    clusterd_memory: str = "3.5Gb"
 
 
 class PgCdcScenario(Scenario):
@@ -238,7 +238,7 @@ SCENARIOS = [
         ),
         post_restart=KafkaScenario.SCHEMAS + KafkaScenario.POST_RESTART,
     ),
-    # Peform updates while the source is ingesting
+    # Perform updates while the source is ingesting
     KafkaScenario(
         name="upsert-update",
         pre_restart=KafkaScenario.SCHEMAS
@@ -265,7 +265,7 @@ SCENARIOS = [
         ),
         post_restart=KafkaScenario.SCHEMAS + KafkaScenario.POST_RESTART,
     ),
-    # Peform inserts+deletes while the source is ingesting
+    # Perform inserts+deletes while the source is ingesting
     KafkaScenario(
         name="upsert-insert-delete",
         pre_restart=KafkaScenario.SCHEMAS
@@ -333,6 +333,94 @@ SCENARIOS = [
            """
         ),
     ),
+    Scenario(
+        name="table-index-hydration",
+        pre_restart=dedent(
+            """
+            > DROP CLUSTER REPLICA clusterd.r1;
+
+            > CREATE TABLE t (a bigint, b bigint);
+
+            > CREATE INDEX idx IN CLUSTER clusterd ON t (a);
+
+            > INSERT INTO t SELECT a, a FROM generate_series(1, 2000000) AS a;
+            > UPDATE t SET b = b + 100000;
+            > UPDATE t SET b = b + 1000000;
+            > UPDATE t SET b = b + 10000000;
+            > UPDATE t SET b = b + 100000000;
+            > UPDATE t SET b = b + 1000000000;
+            > UPDATE t SET a = a + 100000;
+            > UPDATE t SET a = a + 1000000;
+            > UPDATE t SET a = a + 10000000;
+            > UPDATE t SET a = a + 100000000;
+            > UPDATE t SET a = a + 1000000000;
+
+            > CREATE CLUSTER REPLICA clusterd.r1
+              STORAGECTL ADDRESSES ['clusterd:2100'],
+              STORAGE ADDRESSES ['clusterd:2103'],
+              COMPUTECTL ADDRESSES ['clusterd:2101'],
+              COMPUTE ADDRESSES ['clusterd:2102'];
+
+            > SET CLUSTER = clusterd
+
+            > SELECT count(*) FROM t;
+            2000000
+            """
+        ),
+        post_restart=dedent(
+            """
+            > SET CLUSTER = clusterd
+
+            > SELECT count(*) FROM t;
+            2000000
+            """
+        ),
+        materialized_memory="10Gb",
+        clusterd_memory="3.2Gb",
+    ),
+    KafkaScenario(
+        name="upsert-index-hydration",
+        pre_restart=KafkaScenario.SCHEMAS
+        + KafkaScenario.CONNECTIONS
+        + dedent(
+            f"""
+            $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}} repeat={90 * REPEAT}
+            "${{kafka-ingest.iteration}}" {{"f1": "{STRING_PAD}"}}
+            """
+        )
+        + KafkaScenario.END_MARKER
+        + dedent(
+            """
+            > CREATE SOURCE s1
+              FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
+              FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+              ENVELOPE UPSERT;
+
+            > DROP CLUSTER REPLICA clusterd.r1;
+
+            > CREATE INDEX i1 IN CLUSTER clusterd ON s1 (f1);
+            """
+        ),
+        post_restart=KafkaScenario.SCHEMAS
+        + dedent(
+            f"""
+            > CREATE CLUSTER REPLICA clusterd.r1
+              STORAGECTL ADDRESSES ['clusterd:2100'],
+              STORAGE ADDRESSES ['clusterd:2103'],
+              COMPUTECTL ADDRESSES ['clusterd:2101'],
+              COMPUTE ADDRESSES ['clusterd:2102'];
+
+            > SET CLUSTER = clusterd;
+
+            > SELECT count(*) FROM s1;
+            {90 * REPEAT + 2}
+            # Delete all rows except markers
+            $ kafka-ingest format=avro key-format=avro topic=topic1 schema=${{value-schema}} key-schema=${{key-schema}} repeat={REPEAT}
+            "${{kafka-ingest.iteration}}"
+            """
+        ),
+        materialized_memory="10Gb",
+    ),
 ]
 
 
@@ -361,30 +449,34 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
         c.down(destroy_volumes=True)
 
-        c.up("redpanda", "materialized", "postgres", "clusterd")
+        with c.override(
+            Materialized(memory=scenario.materialized_memory),
+            Clusterd(memory=scenario.clusterd_memory),
+        ):
+            c.up("redpanda", "materialized", "postgres", "clusterd")
 
-        c.sql(
-            "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
-            port=6877,
-            user="mz_system",
-        )
+            c.sql(
+                "ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;",
+                port=6877,
+                user="mz_system",
+            )
 
-        c.sql(
+            c.sql(
+                """
+                CREATE CLUSTER clusterd REPLICAS (r1 (
+                    STORAGECTL ADDRESSES ['clusterd:2100'],
+                    STORAGE ADDRESSES ['clusterd:2103'],
+                    COMPUTECTL ADDRESSES ['clusterd:2101'],
+                    COMPUTE ADDRESSES ['clusterd:2102']
+                ))
             """
-            CREATE CLUSTER clusterd REPLICAS (r1 (
-                STORAGECTL ADDRESSES ['clusterd:2100'],
-                STORAGE ADDRESSES ['clusterd:2103'],
-                COMPUTECTL ADDRESSES ['clusterd:2101'],
-                COMPUTE ADDRESSES ['clusterd:2102']
-            ))
-        """
-        )
+            )
 
-        c.up("testdrive", persistent=True)
-        c.testdrive(scenario.pre_restart)
+            c.up("testdrive", persistent=True)
+            c.testdrive(scenario.pre_restart)
 
-        # Restart Mz to confirm that re-hydration is also bounded memory
-        c.kill("materialized", "clusterd")
-        c.up("materialized", "clusterd")
+            # Restart Mz to confirm that re-hydration is also bounded memory
+            c.kill("materialized", "clusterd")
+            c.up("materialized", "clusterd")
 
-        c.testdrive(scenario.post_restart)
+            c.testdrive(scenario.post_restart)


### PR DESCRIPTION
Since the real sources/views are huge and not well suited for cutting down into smaller, more debuggable pieces. Hydration of index on a source with many distinct values already seems to do the trick. We had no indexes in our bounded-memory testing, which was a definite miss.

Reproduces https://github.com/MaterializeInc/materialize/issues/22885 reliably. On code state 247dae52868cd572c646740efe48c92105227630 the separate clusterd peaks at 18 GB of memory during rehydration. On the code state just before https://github.com/MaterializeInc/materialize/pull/21968 (448c1d7833920bf0e2c42ac3788a38cef072715c) memory peaks at 11 GB.

I will now clean this up and make it smaller so we can run it in CI. Will also check if the supposed fix (https://github.com/MaterializeInc/materialize/pull/22887) actually fixes this increased memory usage.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
