### PR TITLE
compute: initialize write frontiers without replicas

### DIFF
--- a/test/testdrive/controller-frontiers.td
+++ b/test/testdrive/controller-frontiers.td
@@ -329,5 +329,20 @@ r3 <null>
   FROM mz_internal.mz_frontiers frontiers
   WHERE object_id LIKE 'u%'
 
+# Test that frontiers are correctly initialized on for collections on clusters
+# with zero replicas.
+
+> CREATE CLUSTER empty SIZE '1', REPLICATION FACTOR 0
+> CREATE TABLE t2 (a int)
+> CREATE INDEX idx2 IN CLUSTER empty ON t2 (a)
+
+> SELECT read_frontier > 0, read_frontier = write_frontier
+  FROM mz_internal.mz_frontiers
+  JOIN mz_indexes ON (id = object_id)
+  WHERE name = 'idx2'
+true true
+
+# Cleanup
+
 > DROP CLUSTER test CASCADE
 > DROP CLUSTER test_source CASCADE


### PR DESCRIPTION
This PR makes the compute controller properly initialize the write frontiers of collections that are installed on clusters with zero replicas to the respective dataflow `as_of`s. Previously, they would be initialized to `0`, which is not incorrect but potentially confusing.

### Motivation

  * This PR fixes a previously unreported bug.

When a compute collection is installed on a cluster that has no replicas, its write frontier is initialized to `0`, as can be observed in `mz_frontiers`.

### Tips for reviewer

I stumbled over this when debugging https://github.com/MaterializeInc/cloud/issues/7998. This does nothing to fix that bug, but I thought it would be useful to have anyway.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
