### PR TITLE
output-consistency: add ignores

### DIFF
--- a/misc/python/materialize/output_consistency/generators/query_generator.py
+++ b/misc/python/materialize/output_consistency/generators/query_generator.py
@@ -207,7 +207,7 @@ class QueryGenerator:
                     [expression],
                     None,
                     storage_layout,
-                    False,
+                    expression.is_aggregate,
                     row_selection,
                 )
             )

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -250,12 +250,7 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             # mz handles this better
             return YesIgnore("accepted")
 
-        if (
-            "value out of range: overflow" in pg_error_msg
-            or "value out of range: underflow" in pg_error_msg
-            or "timestamp out of range" in pg_error_msg
-            or "integer out of range" in pg_error_msg
-        ):
+        if " out of range" in pg_error_msg:
             return YesIgnore("#22265")
 
         if _error_message_is_about_zero_or_value_ranges(pg_error_msg):

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -75,11 +75,11 @@ class PostgresResultComparator(ResultComparator):
 
     def is_timestamp_equal(self, value1: str, value2: str) -> bool:
         # a timezone might be at the end, do not discard that
-        milliseconds_pattern = re.compile(r"\.\d+")
+        milliseconds_pattern = re.compile(r"\d\.\d+")
 
         if milliseconds_pattern.search(value1) and milliseconds_pattern.search(value2):
-            # drop milliseconds
-            value1 = milliseconds_pattern.sub(value1, "")
-            value2 = milliseconds_pattern.sub(value2, "")
+            # drop milliseconds and trunc last digit of second
+            value1 = milliseconds_pattern.sub(value1, "0")
+            value2 = milliseconds_pattern.sub(value2, "0")
 
         return value1 == value2


### PR DESCRIPTION
06227aab61 postgres consistency: generalize "out of range" ignore
addresses https://buildkite.com/materialize/nightlies/builds/4986#018b94f3-a99a-4e35-8bf9-5a6584fd7bbf

977f7d36f9 postgres consistency: decrease precision of timestamp comparison
addresses https://buildkite.com/materialize/nightlies/builds/4961#018b8d39-c51f-4afe-80cd-e49b12e436d62ef9066b8a 

bb00a48388 output consistency: fix query characteristics so that _uses_shortcut_optimization can match in ignore filter
addresses https://buildkite.com/materialize/nightlies/builds/4958#018b8cbb-26cc-4637-8658-f3e40642a42c