### PR TITLE
*: feature plumbing for pretty, parser, and lexer

### DIFF
--- a/src/sql-lexer/Cargo.toml
+++ b/src/sql-lexer/Cargo.toml
@@ -24,7 +24,7 @@ phf_codegen = "0.11.1"
 uncased = "0.9.7"
 
 [features]
-default = ["workspace-hack"]
+default = ["workspace-hack", "mz-ore/workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]

--- a/src/sql-parser/Cargo.toml
+++ b/src/sql-parser/Cargo.toml
@@ -12,8 +12,8 @@ bytesize = "1.1.0"
 datadriven = { version = "0.6.0", optional = true }
 enum-kinds = "0.5.1"
 itertools = "0.10.5"
-mz-ore = { path = "../ore", default-features = false, features = ["stack"] }
-mz-sql-lexer = { path = "../sql-lexer" }
+mz-ore = { path = "../ore", default-features = false, features = ["stack", "test"] }
+mz-sql-lexer = { path = "../sql-lexer", default-features = false }
 phf = { version = "0.11.1", features = ["uncased"] }
 serde = { version = "1.0.152", features = ["derive"] }
 tracing = "0.1.37"
@@ -31,7 +31,7 @@ mz-ore = { path = "../ore", default-features = false }
 mz-walkabout = { path = "../walkabout", default-features = false }
 
 [features]
-default = ["workspace-hack"]
+default = ["workspace-hack", "mz-sql-lexer/workspace-hack"]
 test = ["datadriven", "unicode-width"]
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/sql-pretty/Cargo.toml
+++ b/src/sql-pretty/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 publish = false
 
 [dependencies]
-mz-sql-parser = { path = "../sql-parser" }
+mz-sql-parser = { path = "../sql-parser", default-features = false }
 pretty = "0.12.3"
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
@@ -17,7 +17,7 @@ mz-ore = { path = "../ore", default-features = false, features = ["test"] }
 mz-sql-parser = { path = "../sql-parser", features = ["test"] }
 
 [features]
-default = ["workspace-hack"]
+default = ["workspace-hack", "mz-sql-parser/workspace-hack"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]


### PR DESCRIPTION
This makes these crates able to plumb through their non-dependency of workspace-hack. Required for wasm building.

Rejigger assert.rs to also allow for wasm builds that don't have env.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a