### PR TITLE
stash-debug: Correctly retry opening the catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5429,6 +5429,7 @@ version = "0.77.0-dev"
 dependencies = [
  "anyhow",
  "clap",
+ "futures",
  "mz-adapter",
  "mz-build-info",
  "mz-catalog",

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -254,7 +254,6 @@ impl Catalog {
 
         let mut storage = config.storage;
         let is_read_only = storage.is_read_only();
-        tracing::info!("Catalog::open - beginning initial transaction.");
         let mut txn = storage.transaction().await?;
         // Choose a time at which to boot. This is the time at which we will run
         // internal migrations.
@@ -845,7 +844,6 @@ impl Catalog {
         )?;
 
         txn.commit().await?;
-        tracing::info!("Catalog::open - ending initial transaction.");
         let mut catalog = Catalog {
             state,
             plans: CatalogPlans {

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "3.2.24", features = ["derive", "env"] }
+futures = "0.3.25"
 mz-adapter = { path = "../adapter" }
 mz-catalog = { path = "../catalog" }
 mz-build-info = { path = "../build-info" }


### PR DESCRIPTION
Add up to 30 seconds' worth of retries for the upgrade-check tool to open the catalog, enabling us to check in spite of transaction errors that might occur when running against a live environment.

The existing code would retry when opening the connection, but once the connection was open would assume everything succeeded; this retries the whole process.

Sample logs from running this, with the retries in place (note the `TransactionRetryError`s that were previously blocking us):

```
2023-11-03T20:19:31.158857Z  WARN catalog::open:load_system_configuration: mz_adapter::catalog::open: cannot load unknown system parameter from stash name=dataflow_max_inflight_bytes
....<snip dozens of lines>...
2023-11-03T20:19:35.323486Z  INFO catalog::open:load_catalog_items: mz_adapter::catalog::state: create index materialize.public.v_id_idx (u984)
2023-11-03T20:19:35.408680Z  INFO catalog::open: mz_stash::postgres: tokio-postgres stash error, retry attempt 1: stash error: postgres: db error: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: ReadWithinUncertaintyIntervalError: read at time 1699042770.654905677,0 encountered previous write with future timestamp 1699042770.885155761,0 within uncertainty interval `t <= (local=0,0, global=1699042770.904905677,0)`; observed timestamps: [{1 1699042770.806887749,0} {2 1699042770.806249212,0} {4 1699042770.654905677,0} {5 1699042770.686485360,0} {6 1699042770.676252900,0}]: "sql txn" meta={id=9eda5d4b key=/Min pri=0.00000000 epo=0 ts=1699042770.654905677,0 min=1699042770.654905677,0 seq=0} lock=false stat=PENDING rts=1699042770.654905677,0 wto=false gul=1699042770.904905677,0
HINT: See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#readwithinuncertaintyinterval, code: Some(SqlState(E40001))
2023-11-03T20:19:35.413240Z  WARN mz_stash_debug: Could not open catalog. Retrying... e=Catalog(Error { kind: Durable(MiscStash(StashError { inner: Postgres(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E40001), message: "restart transaction: TransactionRetryWithProtoRefreshError: ReadWithinUncertaintyIntervalError: read at time 1699042770.654905677,0 encountered previous write with future timestamp 1699042770.885155761,0 within uncertainty interval `t <= (local=0,0, global=1699042770.904905677,0)`; observed timestamps: [{1 1699042770.806887749,0} {2 1699042770.806249212,0} {4 1699042770.654905677,0} {5 1699042770.686485360,0} {6 1699042770.676252900,0}]: \"sql txn\" meta={id=9eda5d4b key=/Min pri=0.00000000 epo=0 ts=1699042770.654905677,0 min=1699042770.654905677,0 seq=0} lock=false stat=PENDING rts=1699042770.654905677,0 wto=false gul=1699042770.904905677,0", detail: None, hint: Some("See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#readwithinuncertaintyinterval"), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: None, line: None, routine: None }) }) })) })
2023-11-03T20:19:37.099150Z  WARN catalog::open:load_system_configuration: mz_adapter::catalog::open: cannot load unknown system parameter from stash name=dataflow_max_inflight_bytes
....<snip dozens of lines>...
2023-11-03T20:19:41.265314Z  INFO catalog::open:load_catalog_items: mz_adapter::catalog::state: create index materialize.public.v_id_idx (u984)
2023-11-03T20:19:41.348961Z  INFO catalog::open: mz_stash::postgres: tokio-postgres stash error, retry attempt 1: stash error: postgres: db error: ERROR: restart transaction: TransactionRetryWithProtoRefreshError: ReadWithinUncertaintyIntervalError: read at time 1699042776.314425754,0 encountered previous write with future timestamp 1699042776.489784422,0 within uncertainty interval `t <= (local=0,0, global=1699042776.564425754,0)`; observed timestamps: [{3 1699042776.314425754,0} {4 1699042776.414522806,0} {5 1699042776.357601446,0} {6 1699042776.341235406,0}]: "sql txn" meta={id=a51fa235 key=/Min pri=0.00000000 epo=0 ts=1699042776.314425754,0 min=1699042776.314425754,0 seq=0} lock=false stat=PENDING rts=1699042776.314425754,0 wto=false gul=1699042776.564425754,0
HINT: See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#readwithinuncertaintyinterval, code: Some(SqlState(E40001))
2023-11-03T20:19:41.353539Z  WARN mz_stash_debug: Could not open catalog. Retrying... e=Catalog(Error { kind: Durable(MiscStash(StashError { inner: Postgres(Error { kind: Db, cause: Some(DbError { severity: "ERROR", parsed_severity: Some(Error), code: SqlState(E40001), message: "restart transaction: TransactionRetryWithProtoRefreshError: ReadWithinUncertaintyIntervalError: read at time 1699042776.314425754,0 encountered previous write with future timestamp 1699042776.489784422,0 within uncertainty interval `t <= (local=0,0, global=1699042776.564425754,0)`; observed timestamps: [{3 1699042776.314425754,0} {4 1699042776.414522806,0} {5 1699042776.357601446,0} {6 1699042776.341235406,0}]: \"sql txn\" meta={id=a51fa235 key=/Min pri=0.00000000 epo=0 ts=1699042776.314425754,0 min=1699042776.314425754,0 seq=0} lock=false stat=PENDING rts=1699042776.314425754,0 wto=false gul=1699042776.564425754,0", detail: None, hint: Some("See: https://www.cockroachlabs.com/docs/v23.1/transaction-retry-error-reference.html#readwithinuncertaintyinterval"), position: None, where_: None, schema: None, table: None, column: None, datatype: None, constraint: None, file: None, line: None, routine: None }) }) })) })
2023-11-03T20:19:42.892015Z  WARN catalog::open:load_system_configuration: mz_adapter::catalog::open: cannot load unknown system parameter from stash name=dataflow_max_inflight_bytes
....<snip dozens of lines>...
2023-11-03T20:19:47.369925Z ERROR catalog::open: mz_adapter::catalog::builtin_table_updates: Missing AWS principal context, cannot write to mz_aws_privatelink_connections table
catalog upgrade from 0.76.0 to v0.28.0-dev (60f76a424) would succeed
```