### PR TITLE
ore: Add retry_async_state method

### DIFF
--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -284,7 +284,7 @@ impl Retry {
     }
 
     /// Like [`Retry::retry_async`] but can pass around user specified state.
-    pub async fn retry_async_state<F, S, U, R, T, E>(
+    pub async fn retry_async_with_state<F, S, U, R, T, E>(
         self,
         mut user_state: S,
         mut f: F,
@@ -974,7 +974,7 @@ mod tests {
         let (_new_s, res) = Retry::default()
             .max_tries(10)
             .clamp_backoff(Duration::from_nanos(0))
-            .retry_async_state(s, |_, mut s| async {
+            .retry_async_with_state(s, |_, mut s| async {
                 let res = s.try_inc().await;
                 (s, res)
             })
@@ -985,7 +985,7 @@ mod tests {
         let (_new_s, res) = Retry::default()
             .max_tries(11)
             .clamp_backoff(Duration::from_nanos(0))
-            .retry_async_state(s, |_, mut s| async {
+            .retry_async_with_state(s, |_, mut s| async {
                 let res = s.try_inc().await;
                 (s, res)
             })

--- a/src/ore/src/retry.rs
+++ b/src/ore/src/retry.rs
@@ -283,6 +283,37 @@ impl Retry {
         Err(err.expect("retry produces at least one element"))
     }
 
+    /// Like [`Retry::retry_async`] but can pass around user specified state.
+    pub async fn retry_async_state<F, S, U, R, T, E>(
+        self,
+        mut user_state: S,
+        mut f: F,
+    ) -> (S, Result<T, E>)
+    where
+        F: FnMut(RetryState, S) -> U,
+        U: Future<Output = (S, R)>,
+        R: Into<RetryResult<T, E>>,
+    {
+        let stream = self.into_retry_stream();
+        tokio::pin!(stream);
+        let mut err = None;
+        while let Some(retry_state) = stream.next().await {
+            let (s, r) = f(retry_state, user_state).await;
+            match r.into() {
+                RetryResult::Ok(v) => return (s, Ok(v)),
+                RetryResult::FatalErr(e) => return (s, Err(e)),
+                RetryResult::RetryableErr(e) => {
+                    err = Some(e);
+                    user_state = s;
+                }
+            }
+        }
+        (
+            user_state,
+            Err(err.expect("retry produces at least one element")),
+        )
+    }
+
     /// Convert into [`RetryStream`]
     pub fn into_retry_stream(self) -> RetryStream {
         RetryStream {
@@ -919,5 +950,46 @@ mod tests {
         let mut data = Vec::new();
         reader.read_to_end(&mut data).await.unwrap();
         assert_eq!(data, vec![b'A'; 256]);
+    }
+
+    #[mz_test_macro::test(tokio::test)]
+    #[cfg_attr(miri, ignore)] // unsupported operation: cannot write to event
+    async fn test_retry_async_state() {
+        struct S {
+            i: i64,
+        }
+        impl S {
+            #[allow(clippy::unused_async)]
+            async fn try_inc(&mut self) -> Result<i64, ()> {
+                self.i += 1;
+                if self.i > 10 {
+                    Ok(self.i)
+                } else {
+                    Err(())
+                }
+            }
+        }
+
+        let s = S { i: 0 };
+        let (_new_s, res) = Retry::default()
+            .max_tries(10)
+            .clamp_backoff(Duration::from_nanos(0))
+            .retry_async_state(s, |_, mut s| async {
+                let res = s.try_inc().await;
+                (s, res)
+            })
+            .await;
+        assert_eq!(res, Err(()));
+
+        let s = S { i: 0 };
+        let (_new_s, res) = Retry::default()
+            .max_tries(11)
+            .clamp_backoff(Duration::from_nanos(0))
+            .retry_async_state(s, |_, mut s| async {
+                let res = s.try_inc().await;
+                (s, res)
+            })
+            .await;
+        assert_eq!(res, Ok(11));
     }
 }


### PR DESCRIPTION
This commit adds the retry_async_state method to `Retry`. It is like `Retry::retry_async`, but it allows the caller to include some user specified state in the closure. This is very useful for retrying some async method that needs a mutable borrow.

Co-authored-by: Petros Angelatos <petrosagg@gmail.com>

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
