### PR TITLE
scalability framework: rename latency to duration

### DIFF
--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -61,7 +61,7 @@ def scatterplot_tps_per_connections(
     plot.legend(legend)
 
 
-def scatterplot_latency_per_connections(
+def scatterplot_duration_per_connections(
     workload_name: str,
     figure: SubFigure,
     df_details_by_endpoint_name: dict[str, pd.DataFrame],
@@ -86,7 +86,7 @@ def scatterplot_latency_per_connections(
 
         i = i + 1
 
-    plot.set_ylabel("Latency in Seconds")
+    plot.set_ylabel("Duration in Seconds")
     plot.set_xlabel("Concurrent SQL Connections")
 
     if include_zero_in_y_axis:
@@ -98,7 +98,7 @@ def scatterplot_latency_per_connections(
     plot.legend(legend)
 
 
-def boxplot_latency_per_connections(
+def boxplot_duration_per_connections(
     workload_name: str,
     figure: SubFigure,
     df_details_by_endpoint_name: dict[str, pd.DataFrame],
@@ -159,7 +159,7 @@ def boxplot_latency_per_connections(
         plot.boxplot(wallclocks_of_endpoints, labels=legend)
 
         if is_in_first_column:
-            plot.set_ylabel("Latency in Seconds")
+            plot.set_ylabel("Duration in Seconds")
 
         if include_zero_in_y_axis:
             plot.set_ylim(ymin=0)

--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -108,7 +108,7 @@ operations was used when benchmarking concurrency 256, the test would complete i
 
 This diagram show the transactions per second per concurrency. Higher values are better.
 
-## Latency
+## Duration per transaction
 
 These boxplots show the duration of the individual statements per concurrency. They provide information about the mean
 duration of an operation and their timing reliability. Lower values are better.

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -14,8 +14,8 @@ from matplotlib import pyplot as plt
 
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_latency_per_connections,
-    scatterplot_latency_per_connections,
+    boxplot_duration_per_connections,
+    scatterplot_duration_per_connections,
     scatterplot_tps_per_connections,
 )
 
@@ -24,7 +24,7 @@ USE_BOXPLOT = True
 
 def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
     fig = plt.figure(layout="constrained", figsize=(16, 14))
-    (tps_figure, latency_figure) = fig.subfigures(2, 1)
+    (tps_figure, duration_figure) = fig.subfigures(2, 1)
 
     df_totals_by_endpoint_name, df_details_by_endpoint_name = load_data_from_filesystem(
         workload_name
@@ -39,16 +39,16 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
     )
 
     if USE_BOXPLOT:
-        boxplot_latency_per_connections(
+        boxplot_duration_per_connections(
             workload_name,
-            latency_figure,
+            duration_figure,
             df_details_by_endpoint_name,
             include_zero_in_y_axis=include_zero_in_y_axis,
         )
     else:
-        scatterplot_latency_per_connections(
+        scatterplot_duration_per_connections(
             workload_name,
-            latency_figure,
+            duration_figure,
             df_details_by_endpoint_name,
             baseline_version_name=None,
             include_zero_in_y_axis=include_zero_in_y_axis,

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -32,7 +32,7 @@ from materialize.scalability.endpoints import (
 )
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_latency_per_connections,
+    boxplot_duration_per_connections,
     scatterplot_tps_per_connections,
 )
 from materialize.scalability.regression import RegressionOutcome
@@ -324,7 +324,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
     ) in result.get_df_details_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
-        boxplot_latency_per_connections(
+        boxplot_duration_per_connections(
             workload_name,
             subfigure,
             results_by_endpoint,
@@ -332,7 +332,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
             include_workload_in_title=True,
         )
         plt.savefig(
-            paths.plot_png("latency", workload_name), bbox_inches="tight", dpi=300
+            paths.plot_png("duration", workload_name), bbox_inches="tight", dpi=300
         )
 
 


### PR DESCRIPTION
I believe that the term `latency` is not appropriate here and propose to rename it to `duration`.