### PR TITLE
scalability framework: introduce duration boxplot allowing comparison by concurrent connections

### DIFF
--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -98,7 +98,7 @@ def scatterplot_duration_per_connections(
     plot.legend(legend)
 
 
-def boxplot_duration_per_connections(
+def boxplot_duration_by_connections_for_workload(
     workload_name: str,
     figure: SubFigure,
     df_details_by_endpoint_name: dict[str, pd.DataFrame],

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -112,8 +112,8 @@ def boxplot_duration_by_connections_for_workload(
         df_details_cols.CONCURRENCY
     ].unique()
 
-    endpoint_names = df_details_by_endpoint_name.keys()
-    use_short_names = len(endpoint_names) > 2
+    endpoint_version_names = df_details_by_endpoint_name.keys()
+    use_short_names = len(endpoint_version_names) > 2
 
     num_rows, num_cols = _compute_plot_grid(len(concurrencies), 3)
 
@@ -127,26 +127,26 @@ def boxplot_duration_by_connections_for_workload(
         legend = []
         durations: list[list[float]] = []
 
-        for endpoint_name, df_details in df_details_by_endpoint_name.items():
+        for endpoint_version_name, df_details in df_details_by_endpoint_name.items():
             formatted_endpoint_name = (
-                endpoint_name
+                endpoint_version_name
                 if not use_short_names
-                else _shorten_endpoint_name(endpoint_name)
+                else _shorten_endpoint_version_name(endpoint_version_name)
             )
             legend.append(formatted_endpoint_name)
 
             df_details_of_concurrency = df_details.loc[
                 df_details[df_details_cols.CONCURRENCY] == concurrency
             ]
-            wallclocks_of_concurrency = df_details_of_concurrency[
+            durations_of_concurrency = df_details_of_concurrency[
                 df_details_cols.WALLCLOCK
             ]
-            durations.append(wallclocks_of_concurrency)
+            durations.append(durations_of_concurrency)
 
         plot.boxplot(durations, labels=legend)
 
         if is_in_first_column:
-            plot.set_ylabel("Duration in Seconds")
+            plot.set_ylabel("Duration (seconds)")
 
         if include_zero_in_y_axis:
             plot.set_ylim(ymin=0)
@@ -157,11 +157,11 @@ def boxplot_duration_by_connections_for_workload(
         plot.set_title(title)
 
 
-def _shorten_endpoint_name(endpoint_name: str) -> str:
-    if " " not in endpoint_name:
-        return endpoint_name
+def _shorten_endpoint_version_name(endpoint_version_name: str) -> str:
+    if " " not in endpoint_version_name:
+        return endpoint_version_name
 
-    return endpoint_name.split(" ")[0]
+    return endpoint_version_name.split(" ")[0]
 
 
 def _get_plot_marker(

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -189,14 +189,16 @@ def _get_subplot_in_grid(
     num_cols: int,
 ) -> tuple[Axes, bool]:
     use_no_grid = num_rows == 1 and num_cols == 1
-    use_single_row = num_rows == 1 and num_cols > 1
+    use_single_dimension = (num_rows == 1 and num_cols > 1) or (
+        num_cols == 1 and num_rows > 1
+    )
 
     if use_no_grid:
         plot: Axes = subplots
         is_in_first_column = True
-    elif use_single_row:
+    elif use_single_dimension:
         plot: Axes = subplots[index]
-        is_in_first_column = index == 0
+        is_in_first_column = index == 0 or num_cols == 1
     else:
         row = math.floor(index / num_cols)
         column = index % num_cols

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -15,6 +15,7 @@ from matplotlib import pyplot as plt
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
     boxplot_duration_by_connections_for_workload,
+    boxplot_duration_by_endpoints_for_workload,
     scatterplot_duration_per_connections,
     scatterplot_tps_per_connections,
 )
@@ -23,8 +24,12 @@ USE_BOXPLOT = True
 
 
 def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
-    fig = plt.figure(layout="constrained", figsize=(16, 14))
-    (tps_figure, duration_figure) = fig.subfigures(2, 1)
+    fig = plt.figure(layout="constrained", figsize=(16, 22))
+    (
+        tps_figure,
+        duration_per_connections_figure,
+        duration_per_endpoints_figure,
+    ) = fig.subfigures(3, 1)
 
     df_totals_by_endpoint_name, df_details_by_endpoint_name = load_data_from_filesystem(
         workload_name
@@ -41,14 +46,20 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
     if USE_BOXPLOT:
         boxplot_duration_by_connections_for_workload(
             workload_name,
-            duration_figure,
+            duration_per_connections_figure,
+            df_details_by_endpoint_name,
+            include_zero_in_y_axis=include_zero_in_y_axis,
+        )
+        boxplot_duration_by_endpoints_for_workload(
+            workload_name,
+            duration_per_endpoints_figure,
             df_details_by_endpoint_name,
             include_zero_in_y_axis=include_zero_in_y_axis,
         )
     else:
         scatterplot_duration_per_connections(
             workload_name,
-            duration_figure,
+            duration_per_connections_figure,
             df_details_by_endpoint_name,
             baseline_version_name=None,
             include_zero_in_y_axis=include_zero_in_y_axis,

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -14,7 +14,7 @@ from matplotlib import pyplot as plt
 
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_duration_per_connections,
+    boxplot_duration_by_connections_for_workload,
     scatterplot_duration_per_connections,
     scatterplot_tps_per_connections,
 )
@@ -39,7 +39,7 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
     )
 
     if USE_BOXPLOT:
-        boxplot_duration_per_connections(
+        boxplot_duration_by_connections_for_workload(
             workload_name,
             duration_figure,
             df_details_by_endpoint_name,

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -32,7 +32,7 @@ from materialize.scalability.endpoints import (
 )
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_duration_per_connections,
+    boxplot_duration_by_connections_for_workload,
     scatterplot_tps_per_connections,
 )
 from materialize.scalability.regression import RegressionOutcome
@@ -324,7 +324,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
     ) in result.get_df_details_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
-        boxplot_duration_per_connections(
+        boxplot_duration_by_connections_for_workload(
             workload_name,
             subfigure,
             results_by_endpoint,
@@ -332,7 +332,9 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
             include_workload_in_title=True,
         )
         plt.savefig(
-            paths.plot_png("duration", workload_name), bbox_inches="tight", dpi=300
+            paths.plot_png("duration_by_connections", workload_name),
+            bbox_inches="tight",
+            dpi=300,
         )
 
 

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -33,6 +33,7 @@ from materialize.scalability.endpoints import (
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
     boxplot_duration_by_connections_for_workload,
+    boxplot_duration_by_endpoints_for_workload,
     scatterplot_tps_per_connections,
 )
 from materialize.scalability.regression import RegressionOutcome
@@ -333,6 +334,21 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
         )
         plt.savefig(
             paths.plot_png("duration_by_connections", workload_name),
+            bbox_inches="tight",
+            dpi=300,
+        )
+
+        fig = plt.figure(layout="constrained", figsize=(16, 10))
+        (subfigure) = fig.subfigures(1, 1)
+        boxplot_duration_by_endpoints_for_workload(
+            workload_name,
+            subfigure,
+            results_by_endpoint,
+            include_zero_in_y_axis=INCLUDE_ZERO_IN_Y_AXIS,
+            include_workload_in_title=True,
+        )
+        plt.savefig(
+            paths.plot_png("duration_by_endpoints", workload_name),
             bbox_inches="tight",
             dpi=300,
         )


### PR DESCRIPTION
Nightly: https://buildkite.com/materialize/nightlies/builds/4988

This adds plots that allow comparisons by connection concurrencies (as requested in https://github.com/MaterializeInc/materialize/pull/22913#issuecomment-1792305087).

![duration_by_endpoints_InsertAndSelectCountWorkload](https://github.com/MaterializeInc/materialize/assets/129728240/305e0d89-d2a7-4550-8824-65a3b555d58b)
