### PR TITLE
webhooks: Support now() in `CHECK` statements

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5392,6 +5392,7 @@ mod tests {
         let prep_style = ExprPrepStyle::OneShot {
             logical_time: EvalTime::Time(Timestamp::MIN),
             session: &session,
+            catalog_state: &catalog.state,
         };
 
         // Execute the function as much as possible, ensuring no panics occur, but
@@ -5401,8 +5402,7 @@ mod tests {
         if let Ok(hir) = res {
             if let Ok(mut mir) = hir.lower_uncorrelated() {
                 // Populate unmaterialized functions.
-                prep_scalar_expr(&catalog.state, &mut mir, prep_style.clone())
-                    .expect("must succeed");
+                prep_scalar_expr(&mut mir, prep_style.clone()).expect("must succeed");
 
                 if let Ok(eval_result_datum) = mir.eval(&[], &arena) {
                     if let Some(return_styp) = return_styp {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5141,11 +5141,11 @@ impl Coordinator {
     ) -> Result<Vec<u8>, AdapterError> {
         let temp_storage = RowArena::new();
         prep_scalar_expr(
-            self.catalog().state(),
             secret_as,
             ExprPrepStyle::OneShot {
                 logical_time: EvalTime::NotAvailable,
                 session,
+                catalog_state: self.catalog().state(),
             },
         )?;
         let evaled = secret_as.eval(&[], &temp_storage)?;

--- a/src/adapter/src/coord/timestamp_selection.rs
+++ b/src/adapter/src/coord/timestamp_selection.rs
@@ -516,7 +516,7 @@ impl Coordinator {
         session: &Session,
     ) -> Result<mz_repr::Timestamp, AdapterError> {
         let temp_storage = RowArena::new();
-        prep_scalar_expr(catalog, &mut timestamp, ExprPrepStyle::AsOfUpTo)?;
+        prep_scalar_expr(&mut timestamp, ExprPrepStyle::AsOfUpTo)?;
         let evaled = timestamp.eval(&[], &temp_storage)?;
         if evaled.is_null() {
             coord_bail!("can't use {} as a mz_timestamp for AS OF or UP TO", evaled);

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -136,7 +136,7 @@ impl Optimize<Index> for OptimizeIndex {
         df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;
 
         for desc in df_desc.objects_to_build.iter_mut() {
-            prep_relation_expr(state, &mut desc.plan, ExprPrepStyle::Index)?;
+            prep_relation_expr(&mut desc.plan, ExprPrepStyle::Index)?;
         }
 
         let mut index_desc = IndexDesc {
@@ -145,7 +145,7 @@ impl Optimize<Index> for OptimizeIndex {
         };
 
         for key in index_desc.key.iter_mut() {
-            prep_scalar_expr(state, key, ExprPrepStyle::Index)?;
+            prep_scalar_expr(key, ExprPrepStyle::Index)?;
         }
 
         df_desc.export_index(self.exported_index_id, index_desc, on_desc.typ().clone());

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -187,7 +187,7 @@ impl Optimize<LocalMirPlan> for OptimizeMaterializedView {
         df_builder.reoptimize_imported_views(&mut df_desc, &self.config)?;
 
         for BuildDesc { plan, .. } in &mut df_desc.objects_to_build {
-            prep_relation_expr(self.catalog.state(), plan, ExprPrepStyle::Index)?;
+            prep_relation_expr(plan, ExprPrepStyle::Index)?;
         }
 
         let sink_description = ComputeSinkDesc {

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -283,10 +283,11 @@ impl<'s> Optimize<LocalMirPlan<ResolvedLocal<'s>>> for OptimizePeek {
         let style = ExprPrepStyle::OneShot {
             logical_time: EvalTime::Deferred,
             session,
+            catalog_state: self.catalog.state(),
         };
         df_desc.visit_children(
-            |r| prep_relation_expr(self.catalog.state(), r, style),
-            |s| prep_scalar_expr(self.catalog.state(), s, style),
+            |r| prep_relation_expr(r, style),
+            |s| prep_scalar_expr(s, style),
         )?;
 
         // TODO(aalexandrov): Instead of conditioning here we should really
@@ -373,10 +374,11 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for OptimizePeek {
         let style = ExprPrepStyle::OneShot {
             logical_time: EvalTime::Time(as_of),
             session,
+            catalog_state: self.catalog.state(),
         };
         df_desc.visit_children(
-            |r| prep_relation_expr(self.catalog.state(), r, style),
-            |s| prep_scalar_expr(self.catalog.state(), s, style),
+            |r| prep_relation_expr(r, style),
+            |s| prep_scalar_expr(s, style),
         )?;
 
         // TODO: grab this bit from the index exports once it's always

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -12,7 +12,7 @@ use std::fmt;
 use std::sync::Arc;
 
 use anyhow::Context;
-use mz_ore::now::NowFn;
+use mz_ore::now::{to_datetime, NowFn};
 use mz_repr::{ColumnType, Datum, Row, RowArena};
 use mz_secrets::cache::CachingSecretsReader;
 use mz_secrets::SecretsReader;
@@ -103,7 +103,9 @@ impl AppendWebhookValidator {
         // boundary errors, and this shouldn't be too computationally expensive.
         prep_scalar_expr(
             &mut expression,
-            ExprPrepStyle::WebhookValidation { now: now_fn() },
+            ExprPrepStyle::WebhookValidation {
+                now: to_datetime(now_fn()),
+            },
         )
         .map_err(|err| {
             tracing::error!(?err, "failed to evaluate current time");

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -1867,6 +1867,18 @@ impl MirScalarExpr {
         contains
     }
 
+    /// True iff the expression contains an `UnmaterializableFunc` that is not in the `exceptions`
+    /// list.
+    pub fn contains_unmaterializable_except(&self, exceptions: &[UnmaterializableFunc]) -> bool {
+        let mut contains = false;
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| match e {
+            MirScalarExpr::CallUnmaterializable(f) if !exceptions.contains(f) => contains = true,
+            _ => (),
+        });
+        contains
+    }
+
     /// True iff the expression contains a `Column`.
     pub fn contains_column(&self) -> bool {
         let mut contains = false;

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -18,7 +18,7 @@ use std::iter;
 
 use itertools::Itertools;
 use mz_controller_types::{ClusterId, ReplicaId, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS};
-use mz_expr::CollectionPlan;
+use mz_expr::{CollectionPlan, UnmaterializableFunc};
 use mz_interchange::avro::{AvroSchemaGenerator, AvroSchemaOptions, DocTarget};
 use mz_ore::cast::{self, CastFrom, TryCastFrom};
 use mz_ore::collections::HashSet;
@@ -415,8 +415,10 @@ pub fn plan_create_webhook_source(
         if !expression.contains_column() {
             return Err(PlanError::WebhookValidationDoesNotUseColumns);
         }
-        // Validation expressions cannot contain unmaterializable functions, e.g. now().
-        if expression.contains_unmaterializable() {
+        // Validation expressions cannot contain unmaterializable functions, except `now()`. We
+        // allow calls to `now()` because some webhook providers recommend rejecting requests that
+        // are older than a certain threshold.
+        if expression.contains_unmaterializable_except(&[UnmaterializableFunc::CurrentTimestamp]) {
             return Err(PlanError::WebhookValidationNonDeterministic);
         }
     }

--- a/test/sqllogictest/webhook.slt
+++ b/test/sqllogictest/webhook.slt
@@ -183,28 +183,39 @@ CREATE SOURCE webhook_validation_with_subquery IN CLUSTER webhook_cluster FROM W
     headers->'signature' IN (select * from mz_tables)
   )
 
-statement error expression provided in CHECK is not deterministic
+# Some webhook providers (e.g. Stripe) suggest you should reject any request whose provided
+# timestamp is older than a certain threshold.
+
+statement ok
 CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
     WITH (HEADERS)
-    headers->'signature' = to_char(now(), 'YYYY/MM/DD HH12:MM:SS')
+    (headers->'event_ts'::text)::timestamp + INTERVAL '30s' >= now()
+  )
+
+statement ok
+CREATE SOURCE webhook_validation_with_current_timestamp IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT BYTES
+  CHECK (
+    WITH (HEADERS)
+    headers->'event_ts' = current_timestamp()::text
   )
 
 statement error expression provided in CHECK is not deterministic
-CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
+CREATE SOURCE webhook_validation_with_mz_now IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
     WITH (HEADERS)
-    headers->'signature' = mz_now()::text
+    headers->'event_ts' = mz_now()::text
   )
 
 statement error expression provided in CHECK is not deterministic
-CREATE SOURCE webhook_validation_with_now IN CLUSTER webhook_cluster FROM WEBHOOK
+CREATE SOURCE webhook_validation_with_current_db IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT BYTES
   CHECK (
     WITH (HEADERS)
-    headers->'signature' = current_timestamp()::text
+    headers->'database' = current_database()
   )
 
 statement error unknown cluster 'i_do_not_exist'

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -299,6 +299,25 @@ request_missing_some_mapped_headers
 request_1 "{content-type=>text/example,x-id=>a,x-timestamp=>100}" 100 a
 request_missing_some_mapped_headers "{x-random=>foo}" <null> <null>
 
+> CREATE SOURCE webhook_with_time_based_rejection IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT TEXT
+  CHECK (
+    WITH (HEADERS)
+    (headers->'timestamp'::text)::timestamp + INTERVAL '30s' >= now()
+  )
+
+$ webhook-append name=webhook_with_time_based_rejection timestamp=2020-01-01 status=400
+this_will_get_rejected
+
+$ set-from-sql var=current_ts
+SELECT now()::text
+
+$ webhook-append name=webhook_with_time_based_rejection timestamp=${current_ts}
+this_will_work
+
+> SELECT body FROM webhook_with_time_based_rejection
+this_will_work
+
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id


### PR DESCRIPTION
This PR adds support for calling `now()` in the `CHECK` statement of a webhook source.

### Motivation

This PR adds a feature that has not yet been specified.

There are some webhook providers that recommend rejecting requests when a timestamp provided in the headers is too far behind Materialize's clock, this help prevents replay attacks. 

Stripe is one example where they suggest rejecting requests that are more than 30 seconds old, [Slack](https://materializeinc.slack.com/archives/CU7ELJ6E9/p1698977065629039).

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for the `now()` function in the `CHECK` statement of a webhook source.
