### PR TITLE
adapter: bootstrap: create all storage collections upfront

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1223,9 +1223,6 @@ impl Coordinator {
             .map(|log| self.catalog().resolve_builtin_log(log))
             .collect();
 
-        // This is disabled for the moment because it has unusual upper
-        // advancement behavior.
-        // See: https://materializeinc.slack.com/archives/C01CFKM1QRF/p1660726837927649
         let source_status_collection_id = Some(
             self.catalog()
                 .resolve_builtin_storage_collection(&mz_catalog::builtin::MZ_SOURCE_STATUS_HISTORY),

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1110,6 +1110,9 @@ impl Coordinator {
             .storage
             .drop_sinks_unvalidated(builtin_migration_metadata.previous_sink_ids);
 
+        debug!("coordinator init: initializing storage collections");
+        self.bootstrap_storage_collections().await;
+
         // Load catalog entries based on topological dependency sorting. We do
         // this to reinforce that `GlobalId`'s `Ord` implementation does not
         // express the entries' dependency graph.
@@ -1222,115 +1225,6 @@ impl Coordinator {
         let logs: BTreeSet<_> = BUILTINS::logs()
             .map(|log| self.catalog().resolve_builtin_log(log))
             .collect();
-
-        let source_status_collection_id = Some(
-            self.catalog()
-                .resolve_builtin_storage_collection(&mz_catalog::builtin::MZ_SOURCE_STATUS_HISTORY),
-        );
-
-        let mut collections_to_create = Vec::new();
-
-        fn source_desc<T>(
-            catalog: &Catalog,
-            source_status_collection_id: Option<GlobalId>,
-            source: &Source,
-        ) -> CollectionDescription<T> {
-            let (data_source, status_collection_id) = match &source.data_source {
-                // Re-announce the source description.
-                DataSourceDesc::Ingestion(ingestion) => {
-                    let ingestion = ingestion.clone().into_inline_connection(catalog.state());
-
-                    (
-                        DataSource::Ingestion(ingestion.clone()),
-                        source_status_collection_id,
-                    )
-                }
-                // Subsources use source statuses.
-                DataSourceDesc::Source => (
-                    DataSource::Other(DataSourceOther::Source),
-                    source_status_collection_id,
-                ),
-                DataSourceDesc::Webhook { .. } => {
-                    (DataSource::Webhook, source_status_collection_id)
-                }
-                DataSourceDesc::Progress => (DataSource::Progress, None),
-                DataSourceDesc::Introspection(introspection) => {
-                    (DataSource::Introspection(*introspection), None)
-                }
-            };
-            CollectionDescription {
-                desc: source.desc.clone(),
-                data_source,
-                since: None,
-                status_collection_id,
-            }
-        }
-
-        let migratable_collections = entries
-            .iter()
-            .filter_map(|entry| match entry.item() {
-                CatalogItem::Source(source) => Some((
-                    entry.id(),
-                    source_desc(self.catalog(), source_status_collection_id, source),
-                )),
-                CatalogItem::Table(table) => {
-                    let collection_desc = CollectionDescription::from_desc(
-                        table.desc.clone(),
-                        DataSourceOther::TableWrites,
-                    );
-                    Some((entry.id(), collection_desc))
-                }
-                CatalogItem::MaterializedView(mview) => {
-                    let collection_desc = CollectionDescription::from_desc(
-                        mview.desc.clone(),
-                        DataSourceOther::Compute,
-                    );
-                    Some((entry.id(), collection_desc))
-                }
-                _ => None,
-            })
-            .collect();
-
-        self.controller
-            .storage
-            .migrate_collections(migratable_collections)
-            .await?;
-
-        // Do a first pass looking for collections to create so we can call
-        // create_collections only once with a large batch.
-        for entry in &entries {
-            match entry.item() {
-                CatalogItem::Table(table) => {
-                    let collection_desc = CollectionDescription::from_desc(
-                        table.desc.clone(),
-                        DataSourceOther::TableWrites,
-                    );
-                    collections_to_create.push((entry.id(), collection_desc));
-                }
-                CatalogItem::Source(source) => {
-                    collections_to_create.push((
-                        entry.id(),
-                        source_desc(self.catalog(), source_status_collection_id, source),
-                    ));
-                }
-                CatalogItem::MaterializedView(mv) => {
-                    let collection_desc =
-                        CollectionDescription::from_desc(mv.desc.clone(), DataSourceOther::Compute);
-                    collections_to_create.push((entry.id(), collection_desc));
-                }
-                _ => {
-                    // No collections to create.
-                }
-            }
-        }
-
-        let register_ts = self.get_local_write_ts().await.timestamp;
-        self.controller
-            .storage
-            .create_collections(Some(register_ts), collections_to_create)
-            .await
-            .unwrap_or_terminate("cannot fail to create collections");
-        self.apply_local_write(register_ts).await;
 
         debug!("coordinator init: installing existing objects in catalog");
         let mut privatelink_connections = BTreeMap::new();
@@ -1691,6 +1585,94 @@ impl Coordinator {
 
         info!("coordinator init: bootstrap complete");
         Ok(())
+    }
+
+    /// Initializes all storage collections required by catalog objects in the storage controller.
+    ///
+    /// This method takes care of collection creation, as well as migration of existing
+    /// collections.
+    ///
+    /// Creating all storage collections in a single `create_collections` call, rather than on
+    /// demand, is more efficient as it reduces the number of writes to durable storage. It also
+    /// allows subsequent bootstrap logic to fetch metadata (such as frontiers) of arbitrary
+    /// storage collections, without needing to worry about dependency order.
+    async fn bootstrap_storage_collections(&mut self) {
+        let catalog = self.catalog();
+        let source_status_collection_id = catalog
+            .resolve_builtin_storage_collection(&mz_catalog::builtin::MZ_SOURCE_STATUS_HISTORY);
+
+        let source_desc = |source: &Source| {
+            let (data_source, status_collection_id) = match &source.data_source {
+                // Re-announce the source description.
+                DataSourceDesc::Ingestion(ingestion) => {
+                    let ingestion = ingestion.clone().into_inline_connection(catalog.state());
+
+                    (
+                        DataSource::Ingestion(ingestion.clone()),
+                        Some(source_status_collection_id),
+                    )
+                }
+                // Subsources use source statuses.
+                DataSourceDesc::Source => (
+                    DataSource::Other(DataSourceOther::Source),
+                    Some(source_status_collection_id),
+                ),
+                DataSourceDesc::Webhook { .. } => {
+                    (DataSource::Webhook, Some(source_status_collection_id))
+                }
+                DataSourceDesc::Progress => (DataSource::Progress, None),
+                DataSourceDesc::Introspection(introspection) => {
+                    (DataSource::Introspection(*introspection), None)
+                }
+            };
+            CollectionDescription {
+                desc: source.desc.clone(),
+                data_source,
+                since: None,
+                status_collection_id,
+            }
+        };
+
+        let collections: Vec<_> = catalog
+            .entries()
+            .filter_map(|entry| {
+                let id = entry.id();
+                match entry.item() {
+                    CatalogItem::Source(source) => Some((id, source_desc(source))),
+                    CatalogItem::Table(table) => {
+                        let collection_desc = CollectionDescription::from_desc(
+                            table.desc.clone(),
+                            DataSourceOther::TableWrites,
+                        );
+                        Some((id, collection_desc))
+                    }
+                    CatalogItem::MaterializedView(mv) => {
+                        let collection_desc = CollectionDescription::from_desc(
+                            mv.desc.clone(),
+                            DataSourceOther::Compute,
+                        );
+                        Some((id, collection_desc))
+                    }
+                    _ => None,
+                }
+            })
+            .collect();
+
+        self.controller
+            .storage
+            .migrate_collections(collections.clone())
+            .await
+            .unwrap_or_terminate("cannot fail to migrate collections");
+
+        let register_ts = self.get_local_write_ts().await.timestamp;
+
+        self.controller
+            .storage
+            .create_collections(Some(register_ts), collections)
+            .await
+            .unwrap_or_terminate("cannot fail to create collections");
+
+        self.apply_local_write(register_ts).await;
     }
 
     /// Returns an `as_of` suitable for bootstrapping the given index dataflow.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -531,21 +531,20 @@ where
             )
             .await?;
 
-        let mut durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> =
-            METADATA_COLLECTION
-                .peek_one(&mut self.stash)
-                .await?
-                .into_iter()
-                .map(RustType::from_proto)
-                .collect::<Result<_, _>>()
-                .map_err(|e| StorageError::IOError(e.into()))?;
+        let durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> = METADATA_COLLECTION
+            .peek_one(&mut self.stash)
+            .await?
+            .into_iter()
+            .map(RustType::from_proto)
+            .collect::<Result<_, _>>()
+            .map_err(|e| StorageError::IOError(e.into()))?;
 
         // We first enrich each collection description with some additional metadata...
         use futures::stream::{StreamExt, TryStreamExt};
         let enriched_with_metadata = collections
             .into_iter()
             .map(|(id, description)| {
-                let collection_shards = durable_metadata.remove(&id).expect("inserted above");
+                let collection_shards = durable_metadata.get(&id).expect("inserted above");
 
                 let status_shard =
                     if let Some(status_collection_id) = description.status_collection_id {


### PR DESCRIPTION
This PR changes the bootstrap logic to create all collections, not just tables and system sources, upfront. This has the benefit of being more efficient.

This change is also a precondition for fixing a current bug with selecting index as-of frontiers in https://github.com/MaterializeInc/materialize/pull/22938, as it allows the as-of selection logic to query the storage controller about the frontiers of dependent collections, which would not have been registered with the storage controller otherwise.

The change in the storage controller is required to ensure that the `create_collections` call doesn't fail because the IDs of status and progress collections are missing from `durable_metadata` during enrichment.

### Motivation

  * This PR fixes a recognized bug.

Part of https://github.com/MaterializeInc/cloud/issues/7998

### Tips for reviewer

The commits can be reviewed separately:

* The actual functional change is in the first commit.
* The second commit removes an outdated comment. 
* The third commit moves the storage collection bootstrapping code into its own method and simplifies it a bit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A