### PR TITLE
storage: dont render permanently stalled sources

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -782,6 +782,11 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
 
+                // If all subsources of the source are finished, we can skip rendering.
+                if resume_uppers.values().all(|frontier| frontier.is_empty()) {
+                    return;
+                }
+
                 crate::render::build_ingestion_dataflow(
                     self.timely_worker,
                     &mut self.storage_state,

--- a/test/testdrive/kafka-recreate-topic.td
+++ b/test/testdrive/kafka-recreate-topic.td
@@ -7,13 +7,10 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-
-$ set schema={"type" : "record", "name" : "test", "fields": [ { "name": "f2", "type": "long" } ] }
-
 $ kafka-create-topic topic=topic0 partitions=4
 
-$ kafka-ingest format=avro topic=topic0 schema=${schema} repeat=1
-{"f2": 1}
+$ kafka-ingest key-format=bytes format=bytes key-terminator=: topic=topic0 repeat=1
+1:1
 
 > CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (
     URL '${testdrive.schema-registry-url}'
@@ -22,15 +19,20 @@ $ kafka-ingest format=avro topic=topic0 schema=${schema} repeat=1
 > CREATE CONNECTION kafka_conn
   TO KAFKA (BROKER '${testdrive.kafka-addr}');
 
+> DROP CLUSTER IF EXISTS to_recreate CASCADE;
+> CREATE CLUSTER to_recreate SIZE '1', REPLICATION FACTOR 1;
+
 > CREATE SOURCE source0
+  IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic0-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
-  ENVELOPE NONE
+  KEY FORMAT TEXT
+  VALUE FORMAT TEXT
+  ENVELOPE UPSERT
 
 > SELECT * FROM source0
-f2
----
-1
+key   text
+----------
+1     1
 
 # Now recreate the topic with fewer partitions and observe the error
 
@@ -54,17 +56,18 @@ contains:topic was recreated: partition count regressed from 4 to 2
 
 $ kafka-create-topic topic=topic1 partitions=1
 
-$ kafka-ingest format=avro topic=topic1 schema=${schema} repeat=1
-{"f2": 1}
+$ kafka-ingest format=bytes topic=topic1 repeat=1
+1
 
 > CREATE SOURCE source1
+  IN CLUSTER to_recreate
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-topic1-${testdrive.seed}')
-  FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
+  FORMAT TEXT
   ENVELOPE NONE
 
 > SELECT * FROM source1
-f2
----
+text
+----
 1
 
 # Now recreate the topic with the same number of partitions and observe the error
@@ -84,3 +87,32 @@ $ kafka-create-topic topic=topic1 partitions=1
 
 ! SELECT * FROM source1
 contains:topic was recreated: high watermark of partition 0 regressed from 1 to 0
+
+# Ensure we don't panic after we restart due to the above finished ingestions.
+$ kafka-create-topic topic=good-topic
+
+> CREATE SOURCE good_source
+  IN CLUSTER to_recreate
+  FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-good-topic-${testdrive.seed}')
+  FORMAT TEXT
+  ENVELOPE NONE
+
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 0)
+> ALTER CLUSTER to_recreate SET (REPLICATION FACTOR 1)
+
+$ kafka-ingest format=bytes topic=good-topic repeat=1
+1
+
+> SELECT * FROM good_source
+text
+----
+1
+
+> SELECT name, status, error FROM mz_internal.mz_source_statuses WHERE type != 'progress'
+name            status    error
+-------------------------------
+good_source     running   <null>
+source0         stalled  "kafka: topic was recreated: partition count regressed from 4 to 2"
+source1         stalled  "kafka: topic was recreated: high watermark of partition 0 regressed from 1 to 0"
+
+> DROP CLUSTER IF EXISTS to_recreate CASCADE;


### PR DESCRIPTION
Closes https://github.com/MaterializeInc/materialize/issues/22681

This pr fixes the above issue by giving up on rendering source streams for sources with empty uppers. This is a very targeted change, and avoids messing with `storage_state`, the controller, or side operators (like the health operator and remap operator)

### Motivation
  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
