### PR TITLE
webhooks: Attempt to reduce `CHECK` expression

### DIFF
--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -35,6 +35,7 @@ pub struct Metrics {
     pub slow_message_handling: HistogramVec,
     pub optimization_notices: IntCounterVec,
     pub append_table_duration_seconds: HistogramVec,
+    pub webhook_validation_reduce_failures: IntCounterVec,
 }
 
 impl Metrics {
@@ -133,6 +134,11 @@ impl Metrics {
                 var_labels: ["is_blocking"],
                 buckets: histogram_seconds_buckets(0.128, 32.0),
             )),
+            webhook_validation_reduce_failures: registry.register(metric!(
+                name: "mz_webhook_validation_reduce_failures",
+                help: "Count of how many times we've failed to reduce a webhook source's CHECK statement.",
+                var_labels: ["reason"],
+            ))
         }
     }
 }

--- a/src/adapter/src/webhook.rs
+++ b/src/adapter/src/webhook.rs
@@ -66,6 +66,7 @@ impl AppendWebhookValidator {
 
         let WebhookValidation {
             expression,
+            relation_desc: _,
             secrets,
             bodies: body_columns,
             headers: header_columns,

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -243,6 +243,11 @@ impl RelationType {
         }
         true
     }
+
+    /// Returns all the [`ColumnType`]s, in order, for this relation.
+    pub fn columns(&self) -> &[ColumnType] {
+        &self.column_types
+    }
 }
 
 impl RustType<ProtoRelationType> for RelationType {

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1314,7 +1314,7 @@ impl WebhookValidation {
     /// Attempt to reduce the internal [`MirScalarExpr`] into a simpler expression.
     ///
     /// The reduction happens on a separate thread, we also only wait for
-    /// [`WebhookValidation::MAX_REDUCE_TIME`] before timing out and returning an error.
+    /// `WebhookValidation::MAX_REDUCE_TIME` before timing out and returning an error.
     pub async fn reduce_expression(&mut self) -> Result<(), &'static str> {
         let WebhookValidation {
             expression,

--- a/src/sql/src/plan/query.rs
+++ b/src/sql/src/plan/query.rs
@@ -1069,6 +1069,7 @@ pub fn plan_webhook_validate_using(
         .lower_uncorrelated()?;
     let validation = WebhookValidation {
         expression: expr,
+        relation_desc: desc,
         bodies: body_tuples,
         headers: header_tuples,
         secrets: validation_secrets,

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -222,24 +222,6 @@ $ webhook-append name=webhook_hex status=400
 # 'z' is an invalid character in hex which causes an evaluation failure.
 z
 
-# Enable unstable dependencies so we can use mz_panic.
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unstable_dependencies = true;
-
-# Create a source that will panic when we run validation. Validation panicking should not take down
-# all of environmentd, we should catch the panic.
-#
-# Note: if you change the message in the panic, then you need to update ci_logged_errors_detect.py.
-> CREATE SOURCE webhook_validation_panic IN CLUSTER webhook_cluster FROM WEBHOOK
-  BODY FORMAT TEXT
-  CHECK (
-    WITH (HEADERS)
-    mz_internal.mz_panic('forced panic') = headers::text
-  );
-
-$ webhook-append name=webhook_validation_panic status=500
-abc
-
 # Can use SECRETs as both Bytes and Strings.
 
 > CREATE SECRET webhook_secret_bytes AS 'this_key_is_bytes';
@@ -332,6 +314,3 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 
 # Cleanup.
 > DROP CLUSTER webhook_cluster CASCADE;
-
-$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
-ALTER SYSTEM SET enable_unstable_dependencies = false;


### PR DESCRIPTION
This PR introduces a change to sequencing when creating a webhook source. We now best-effort attempt to reduce the `MirScalarExpr` used for validation, in a bounded amount of time.

### Motivation

I noticed this when working on https://github.com/MaterializeInc/materialize/pull/22931. Some webhook providers suggest a check statement which can get pretty complex. I figured it was a good idea to try reducing these statements since they have to run on every webhook event.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal performance improvement
