### PR TITLE
infra: Include stash-debug tool in version bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5425,7 +5425,7 @@ dependencies = [
 
 [[package]]
 name = "mz-stash-debug"
-version = "0.28.0-dev"
+version = "0.77.0-dev"
 dependencies = [
  "anyhow",
  "clap",

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -29,7 +29,7 @@ version=${1#v}
 
 sed -i.bak \
     "s/^version = .*/version = \"$version\"/" \
-    src/{clusterd,environmentd,persist-client,testdrive}/Cargo.toml
+    src/{clusterd,environmentd,persist-client,testdrive,stash-debug}/Cargo.toml
 
 if ! [[ "$version" = *dev ]]; then
     sed -i.bak \
@@ -49,7 +49,7 @@ else
     done
 fi
 
-rm -f src/{clusterd,environmentd,persist-client}/Cargo.toml.bak LICENSE.bak
+rm -f src/{clusterd,environmentd,persist-client,stash-debug}/Cargo.toml.bak LICENSE.bak
 
 cargo check
 

--- a/src/stash-debug/Cargo.toml
+++ b/src/stash-debug/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-stash-debug"
 description = "Durable metadata storage."
-version = "0.28.0-dev"
+version = "0.77.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION


### Motivation

This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
