### PR TITLE
storage: Add some testing for SSH tunnels

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -501,7 +501,7 @@ steps:
         plugins:
           - ./ci/plugins/mzcompose:
               composition: platform-checks
-              args: [--scenario=RestartSourcePostgres, --check=PgCdc]
+              args: [--scenario=RestartSourcePostgres, --check=PgCdc, --check=PgCdcNoWait, --check=PgCdcMzNow, --check=SshPg, --check=DebeziumPostgres]
 
   - id: cloudtest
     label: Cloudtest %n

--- a/misc/python/materialize/checks/all_checks/ssh.py
+++ b/misc/python/materialize/checks/all_checks/ssh.py
@@ -1,0 +1,209 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+from textwrap import dedent
+
+from materialize.checks.actions import Testdrive
+from materialize.checks.checks import Check
+from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
+
+
+def schemas() -> str:
+    return dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
+
+
+class SshPg(Check):
+    """
+    Testing Postgres CDC source with SSH tunnel
+    """
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            schemas()
+            + dedent(
+                """
+                > CREATE SECRET pgpass AS 'postgres'
+
+                > CREATE CONNECTION pg_ssh1 TO POSTGRES (
+                  HOST postgres,
+                  DATABASE postgres,
+                  USER postgres,
+                  PASSWORD SECRET pgpass,
+                  SSL MODE require,
+                  SSH TUNNEL thancred);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                ALTER USER postgres WITH replication;
+                CREATE TABLE t_ssh1 (f1 INTEGER);
+                ALTER TABLE t_ssh1 REPLICA IDENTITY FULL;
+                CREATE TABLE t_ssh2 (f1 INTEGER);
+                ALTER TABLE t_ssh2 REPLICA IDENTITY FULL;
+                CREATE TABLE t_ssh3 (f1 INTEGER);
+                ALTER TABLE t_ssh3 REPLICA IDENTITY FULL;
+                CREATE PUBLICATION mz_source_ssh FOR ALL TABLES;
+                INSERT INTO t_ssh1 VALUES (1), (2), (3), (4), (5);
+
+                > CREATE SOURCE mz_source_ssh1
+                  FROM POSTGRES CONNECTION pg_ssh1
+                  (PUBLICATION 'mz_source_ssh')
+                  FOR TABLES (t_ssh1);
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(schemas() + dedent(s))
+            for s in [
+                """
+                > CREATE CONNECTION pg_ssh2 TO POSTGRES (
+                  HOST postgres,
+                  DATABASE postgres,
+                  USER postgres,
+                  PASSWORD SECRET pgpass,
+                  SSL MODE require,
+                  SSH TUNNEL thancred);
+
+                > CREATE SOURCE mz_source_ssh2
+                  FROM POSTGRES CONNECTION pg_ssh2
+                  (PUBLICATION 'mz_source_ssh')
+                  FOR TABLES (t_ssh2);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO t_ssh1 VALUES (6), (7), (8), (9), (10);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO t_ssh2 VALUES (6), (7), (8), (9), (10);
+                """,
+                """
+                > CREATE CONNECTION pg_ssh3 TO POSTGRES (
+                  HOST postgres,
+                  DATABASE postgres,
+                  USER postgres,
+                  PASSWORD SECRET pgpass,
+                  SSL MODE require,
+                  SSH TUNNEL thancred);
+
+                > CREATE SOURCE mz_source_ssh3
+                  FROM POSTGRES CONNECTION pg_ssh3
+                  (PUBLICATION 'mz_source_ssh')
+                  FOR TABLES (t_ssh3);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO t_ssh1 VALUES (11), (12), (13), (14), (15);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO t_ssh2 VALUES (11), (12), (13), (14), (15);
+
+                $ postgres-execute connection=postgres://postgres:postgres@postgres
+                INSERT INTO t_ssh3 VALUES (11), (12), (13), (14), (15);
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT COUNT(*) FROM t_ssh1;
+                15
+
+                > SELECT COUNT(*) FROM t_ssh2;
+                10
+
+                > SELECT COUNT(*) FROM t_ssh3;
+                5
+           """
+            )
+        )
+
+
+class SshKafka(Check):
+    """
+    Testing Kafka source with SSH tunnel
+    """
+
+    def initialize(self) -> Testdrive:
+        return Testdrive(
+            schemas()
+            + dedent(
+                """
+                $ kafka-create-topic topic=ssh1
+
+                $ kafka-ingest topic=ssh1 format=bytes
+                one
+
+                > CREATE CONNECTION kafka_conn_ssh1
+                  TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
+
+                > CREATE SOURCE ssh1
+                  FROM KAFKA CONNECTION kafka_conn_ssh1 (TOPIC 'testdrive-ssh1-${testdrive.seed}')
+                  FORMAT TEXT
+                  ENVELOPE NONE;
+                """
+            )
+        )
+
+    def manipulate(self) -> list[Testdrive]:
+        return [
+            Testdrive(schemas() + dedent(s))
+            for s in [
+                """
+                > CREATE CONNECTION kafka_conn_ssh2
+                  TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
+
+                > CREATE SOURCE ssh2
+                  FROM KAFKA CONNECTION kafka_conn_ssh2 (TOPIC 'testdrive-ssh2-${testdrive.seed}')
+                  FORMAT TEXT
+                  ENVELOPE NONE;
+
+                $ kafka-ingest topic=ssh1 format=bytes
+                two
+
+                $ kafka-ingest topic=ssh2 format=bytes
+                two
+                """,
+                """
+                > CREATE CONNECTION kafka_conn_ssh3
+                  TO KAFKA (BROKER '${testdrive.kafka-addr}' USING SSH TUNNEL thancred);
+
+                > CREATE SOURCE ssh3
+                  FROM KAFKA CONNECTION kafka_conn_ssh3 (TOPIC 'testdrive-ssh3-${testdrive.seed}')
+                  FORMAT TEXT
+                  ENVELOPE NONE;
+
+                $ kafka-ingest topic=ssh1 format=bytes
+                three
+
+                $ kafka-ingest topic=ssh2 format=bytes
+                three
+
+                $ kafka-ingest topic=ssh3 format=bytes
+                three
+                """,
+            ]
+        ]
+
+    def validate(self) -> Testdrive:
+        return Testdrive(
+            dedent(
+                """
+                > SELECT * FROM ssh1;
+                one
+                two
+                three
+
+                > SELECT * FROM ssh2;
+                two
+                three
+
+                > SELECT * FROM ssh3;
+                three
+           """
+            )
+        )

--- a/src/sql-parser/tests/testdata/ddl
+++ b/src/sql-parser/tests/testdata/ddl
@@ -431,11 +431,11 @@ CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1
 CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }], with_options: [] })
 
 parse-statement
-CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo)
+CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK db.schema.item, PORT 1234, HOST foo, SSL CERTIFICATE 'cert', SSL CERTIFICATE AUTHORITY 'auth', SSL KEY 'key')
 ----
-CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo)
+CREATE CONNECTION pgconn TO POSTGRES (AWS PRIVATELINK = db.schema.item, PORT = 1234, HOST = foo, SSL CERTIFICATE = 'cert', SSL CERTIFICATE AUTHORITY = 'auth', SSL KEY = 'key')
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("pgconn")]), connection_type: Postgres, if_not_exists: false, values: [ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("db"), Ident("schema"), Ident("item")])))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: Host, value: Some(Ident(Ident("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("cert"))) }, ConnectionOption { name: SslCertificateAuthority, value: Some(Value(String("auth"))) }, ConnectionOption { name: SslKey, value: Some(Value(String("key"))) }], with_options: [] })
 
 
 parse-statement
@@ -1846,11 +1846,11 @@ ALTER SECRET secret AS decode('new c2VjcmV0Cg==', 'base64')
 AlterSecret(AlterSecretStatement { name: UnresolvedItemName([Ident("secret")]), if_exists: false, value: Function(Function { name: Name(UnresolvedItemName([Ident("decode")])), args: Args { args: [Value(String("new c2VjcmV0Cg==")), Value(String("base64"))], order_by: [] }, filter: None, over: None, distinct: false }) })
 
 parse-statement
-CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux';
+CREATE CONNECTION conn1 FOR KAFKA BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux', SSH TUNNEL = tunnel;
 ----
-CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux')
+CREATE CONNECTION conn1 TO KAFKA (BROKER = 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux', SSH TUNNEL = tunnel)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Kafka, if_not_exists: false, values: [ConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, ConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Kafka, if_not_exists: false, values: [ConnectionOption { name: Broker, value: Some(ConnectionKafkaBroker(KafkaBroker { address: "kafka:1234", tunnel: Direct })) }, ConnectionOption { name: SslKey, value: Some(Value(String("foo"))) }, ConnectionOption { name: SslCertificate, value: Some(Value(String("qux"))) }, ConnectionOption { name: SshTunnel, value: Some(Item(Name(UnresolvedItemName([Ident("tunnel")])))) }], with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO KAFKA (BROKER 'kafka:1234', SSL KEY = 'foo', SSL CERTIFICATE = 'qux');
@@ -1963,11 +1963,11 @@ CREATE SOURCE src1 (PRIMARY KEY (key1, key2) NOT ENFORCED) FROM KAFKA CONNECTION
 CreateSource(CreateSourceStatement { name: UnresolvedItemName([Ident("src1")]), in_cluster: None, col_names: [], connection: Kafka(KafkaSourceConnection { connection: KafkaConnection { connection: Name(UnresolvedItemName([Ident("conn1")])), options: [KafkaConfigOption { name: Topic, value: Some(Value(String("baz"))) }] }, key: None }), include_metadata: [], format: Bare(Bytes), envelope: None, if_not_exists: false, key_constraint: Some(PrimaryKeyNotEnforced { columns: [Ident("key1"), Ident("key2")] }), with_options: [], referenced_subsources: None, progress_subsource: None })
 
 parse-statement
-CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word'
+CREATE CONNECTION conn1 FOR CONFLUENT SCHEMA REGISTRY URL 'http://localhost:8081', USERNAME 'user', PASSWORD 'word', PORT 1234, AWS PRIVATELINK apl
 ----
-CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USER = 'user', PASSWORD = 'word')
+CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USER = 'user', PASSWORD = 'word', PORT = 1234, AWS PRIVATELINK = apl)
 =>
-CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, ConnectionOption { name: User, value: Some(Value(String("user"))) }, ConnectionOption { name: Password, value: Some(Value(String("word"))) }], with_options: [] })
+CreateConnection(CreateConnectionStatement { name: UnresolvedItemName([Ident("conn1")]), connection_type: Csr, if_not_exists: false, values: [ConnectionOption { name: Url, value: Some(Value(String("http://localhost:8081"))) }, ConnectionOption { name: User, value: Some(Value(String("user"))) }, ConnectionOption { name: Password, value: Some(Value(String("word"))) }, ConnectionOption { name: Port, value: Some(Value(Number("1234"))) }, ConnectionOption { name: AwsPrivatelink, value: Some(Item(Name(UnresolvedItemName([Ident("apl")])))) }], with_options: [] })
 
 parse-statement roundtrip
 CREATE CONNECTION conn1 TO CONFLUENT SCHEMA REGISTRY (URL = 'http://localhost:8081', USERNAME = 'user', PASSWORD = 'word')

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -14,6 +14,7 @@ import pytest
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.all_checks import *  # noqa: F401 F403
+from materialize.checks.all_checks.ssh import SshKafka, SshPg
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
 from materialize.checks.executors import CloudtestExecutor
@@ -64,5 +65,7 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
     )
 
     executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
-    scenario = CloudtestUpgrade(checks=list(all_subclasses(Check)), executor=executor)
+    # No SSH bastion host in cloudtest (yet)
+    checks = list(all_subclasses(Check) - {SshPg, SshKafka})
+    scenario = CloudtestUpgrade(checks=checks, executor=executor)
     scenario.run()

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -25,6 +25,7 @@ from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
+from materialize.mzcompose.services.ssh_bastion_host import SshBastionHost
 from materialize.mzcompose.services.testdrive import Testdrive as TestdriveService
 from materialize.util import all_subclasses
 
@@ -57,6 +58,7 @@ SERVICES = [
         name="persistcli",
         config={"mzbuild": "jobs"},
     ),
+    SshBastionHost(),
 ]
 
 
@@ -73,7 +75,7 @@ def setup(c: Composition) -> None:
     c.up("testdrive", persistent=True)
     c.up("cockroach")
 
-    c.up("redpanda", "postgres", "debezium", "minio")
+    c.up("redpanda", "postgres", "debezium", "minio", "ssh-bastion-host")
     c.up("mc", persistent=True)
     c.exec(
         "mc",

--- a/test/ssh-connection/pg-source.td
+++ b/test/ssh-connection/pg-source.td
@@ -10,6 +10,17 @@
 # Test creating a Postgres source using SSH
 
 > CREATE SECRET pgpass AS 'postgres'
+
+! CREATE CONNECTION pg TO POSTGRES (
+    HOST postgres,
+    HOST postgres2,
+    DATABASE postgres,
+    USER postgres,
+    PASSWORD SECRET pgpass,
+    SSH TUNNEL thancred
+  );
+contains: HOST specified more than once
+
 > CREATE CONNECTION pg TO POSTGRES (
     HOST postgres,
     DATABASE postgres,


### PR DESCRIPTION
- new platform-checks
- extended ssh-connection
- extended sql-parser datadriven

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
