### PR TITLE
adapter: fix index as-of bootstrapping

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1839,13 +1839,13 @@ impl Coordinator {
         tracing::info!(
             export_ids = %dataflow.display_export_ids(),
             %cluster_id,
+            as_of = ?as_of.elements(),
             min_as_of = ?min_as_of.elements(),
             max_as_of = ?max_as_of.elements(),
             write_frontier = ?write_frontier.elements(),
             %lag,
             max_compaction_frontier = ?max_compaction_frontier.elements(),
-            "selecting index `as_of` as {:?}",
-            as_of.elements(),
+            "bootstrapping index `as_of`",
         );
 
         as_of
@@ -1883,10 +1883,10 @@ impl Coordinator {
         tracing::info!(
             export_ids = %dataflow.display_export_ids(),
             %cluster_id,
+            as_of = ?as_of.elements(),
             min_as_of = ?min_as_of.elements(),
             write_frontier = ?write_frontier.elements(),
-            "selecting materialized view `as_of` as {:?}",
-            as_of.elements(),
+            "bootstrapping materialized view `as_of`",
         );
 
         as_of

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1630,8 +1630,8 @@ impl Coordinator {
 
                     // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
                     let global_lir_plan = optimizer.optimize(global_mir_plan)?;
-                    let physical_plan = global_lir_plan.df_desc().clone();
-                    let metainfo = global_lir_plan.df_meta().clone();
+
+                    let (physical_plan, metainfo) = global_lir_plan.unapply();
 
                     let catalog = self.catalog_mut();
                     catalog.set_optimized_plan(id, optimized_plan);
@@ -1671,8 +1671,8 @@ impl Coordinator {
 
                     // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
                     let global_lir_plan = optimizer.optimize(global_mir_plan)?;
-                    let physical_plan = global_lir_plan.df_desc().clone();
-                    let metainfo = global_lir_plan.df_meta().clone();
+
+                    let (physical_plan, metainfo) = global_lir_plan.unapply();
 
                     let catalog = self.catalog_mut();
                     catalog.set_optimized_plan(id, optimized_plan);

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -79,6 +79,11 @@ impl ComputeInstanceSnapshot {
     pub fn contains_collection(&self, id: &GlobalId) -> bool {
         self.collections.contains(id)
     }
+
+    /// Inserts the given collection into the snapshot.
+    pub fn insert_collection(&mut self, id: GlobalId) {
+        self.collections.insert(id);
+    }
 }
 
 /// Borrows of catalog and indexes sufficient to build dataflow descriptions.
@@ -257,8 +262,8 @@ impl Coordinator {
 }
 
 /// Returns an ID bundle with the given dataflows imports.
-pub fn dataflow_import_id_bundle(
-    dataflow: &DataflowDesc,
+pub fn dataflow_import_id_bundle<P>(
+    dataflow: &DataflowDescription<P>,
     compute_instance: ComputeInstanceId,
 ) -> CollectionIdBundle {
     let storage_ids = dataflow.source_imports.keys().copied().collect();

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -8,21 +8,33 @@
 // by the Apache License, Version 2.0.
 
 //! Optimizer implementation for `CREATE INDEX` statements.
+//!
+//! Note that, in contrast to other optimization pipelines, timestamp selection is not part of
+//! index optimization. Instead users are expected to separately set the as-of on the optimized
+//! `DataflowDescription` received from `GlobalLirPlan::unapply`. Reasons for choosing to exclude
+//! timestamp selection from the index optimization pipeline are:
+//!
+//!  (a) Indexes don't support non-empty `until` frontiers, so they don't provide opportunity for
+//!      optimizations based on the selected timestamp.
+//!  (b) We want to generate dataflow plans early during environment bootstrapping, before we have
+//!      access to all information required for timestamp selection.
+//!
+//! None of this is set in stone though. If we find an opportunity for optimizing indexes based on
+//! their timestamps, we'll want to make timestamp selection part of the index optimization again
+//! and find a different approach to bootstrapping.
+//!
+//! See also MaterializeInc/materialize#22940.
 
-use std::marker::PhantomData;
 use std::sync::Arc;
 
-use maplit::btreemap;
 use mz_compute_types::dataflows::IndexDesc;
 use mz_compute_types::plan::Plan;
-use mz_compute_types::ComputeInstanceId;
-use mz_repr::{GlobalId, Timestamp};
+use mz_repr::GlobalId;
 use mz_sql::names::QualifiedItemName;
 use mz_transform::dataflow::DataflowMetainfo;
 use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::optimizer_notices::OptimizerNotice;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
-use timely::progress::Antichain;
 
 use crate::catalog::Catalog;
 use crate::coord::dataflows::{
@@ -31,7 +43,6 @@ use crate::coord::dataflows::{
 use crate::optimize::{
     LirDataflowDescription, MirDataflowDescription, Optimize, OptimizerConfig, OptimizerError,
 };
-use crate::CollectionIdBundle;
 
 pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.
@@ -60,10 +71,6 @@ impl Optimizer {
             exported_index_id,
             config,
         }
-    }
-
-    pub fn cluster_id(&self) -> ComputeInstanceId {
-        self.compute_instance.instance_id()
     }
 }
 
@@ -112,13 +119,12 @@ impl GlobalMirPlan {
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
 #[derive(Clone)]
-pub struct GlobalLirPlan<T: Clone> {
+pub struct GlobalLirPlan {
     df_desc: LirDataflowDescription,
     df_meta: DataflowMetainfo,
-    phantom: PhantomData<T>,
 }
 
-impl<T: Clone> GlobalLirPlan<T> {
+impl GlobalLirPlan {
     pub fn df_desc(&self) -> &LirDataflowDescription {
         &self.df_desc
     }
@@ -126,30 +132,7 @@ impl<T: Clone> GlobalLirPlan<T> {
     pub fn df_meta(&self) -> &DataflowMetainfo {
         &self.df_meta
     }
-
-    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
-    pub fn id_bundle(&self, compute_instance_id: ComputeInstanceId) -> CollectionIdBundle {
-        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
-        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
-        CollectionIdBundle {
-            storage_ids,
-            compute_ids: btreemap! {compute_instance_id => compute_ids},
-        }
-    }
 }
-
-/// Marker type for [`GlobalLirPlan`] structs representing an optimization
-/// result without a resolved timestamp.
-#[derive(Clone)]
-pub struct Unresolved;
-
-/// Marker type for [`GlobalLirPlan`] structs representing an optimization
-/// result with a resolved timestamp.
-///
-/// The actual timestamp value is set in the [`LirDataflowDescription`] of the
-/// surrounding [`GlobalLirPlan`] when we call `resolve()`.
-#[derive(Clone)]
-pub struct Resolved;
 
 impl Optimize<Index> for Optimizer {
     type To = GlobalMirPlan;
@@ -200,7 +183,7 @@ impl Optimize<Index> for Optimizer {
 }
 
 impl Optimize<GlobalMirPlan> for Optimizer {
-    type To = GlobalLirPlan<Unresolved>;
+    type To = GlobalLirPlan;
 
     fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
@@ -224,35 +207,11 @@ impl Optimize<GlobalMirPlan> for Optimizer {
         .map_err(OptimizerError::Internal)?;
 
         // Return the plan at the end of this `optimize` step.
-        Ok(GlobalLirPlan {
-            df_desc,
-            df_meta,
-            phantom: PhantomData::<Unresolved>,
-        })
+        Ok(GlobalLirPlan { df_desc, df_meta })
     }
 }
 
-impl GlobalLirPlan<Unresolved> {
-    /// Produces the [`GlobalLirPlan`] with [`Resolved`] timestamp.
-    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalLirPlan<Resolved> {
-        // Set the `as_of` timestamp for the dataflow.
-        self.df_desc.set_as_of(as_of);
-
-        // The only dataflow exports are indexes, so the `df_desc.until` should
-        // be the empty frontier.
-        assert!(self.df_desc.sink_exports.is_empty());
-        // The `until` is set to the empty frontier in the `df_desc` constructor.
-        assert!(self.df_desc.until.is_empty());
-
-        GlobalLirPlan {
-            df_desc: self.df_desc,
-            df_meta: self.df_meta,
-            phantom: PhantomData::<Resolved>,
-        }
-    }
-}
-
-impl GlobalLirPlan<Resolved> {
+impl GlobalLirPlan {
     /// Unwraps the parts of the final result of the optimization pipeline.
     pub fn unapply(self) -> (LirDataflowDescription, DataflowMetainfo) {
         (self.df_desc, self.df_meta)

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -13,7 +13,6 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
-use maplit::btreemap;
 use mz_adapter_types::connection::ConnectionId;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, SubscribeSinkConnection};
@@ -30,7 +29,9 @@ use timely::progress::Antichain;
 use tracing::{span, Level};
 
 use crate::catalog::Catalog;
-use crate::coord::dataflows::{ComputeInstanceSnapshot, DataflowBuilder};
+use crate::coord::dataflows::{
+    dataflow_import_id_bundle, ComputeInstanceSnapshot, DataflowBuilder,
+};
 use crate::optimize::{
     LirDataflowDescription, MirDataflowDescription, Optimize, OptimizerConfig, OptimizerError,
 };
@@ -106,12 +107,7 @@ impl<T: Clone> GlobalMirPlan<T> {
 
     /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
     pub fn id_bundle(&self, compute_instance_id: ComputeInstanceId) -> CollectionIdBundle {
-        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
-        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
-        CollectionIdBundle {
-            storage_ids,
-            compute_ids: btreemap! {compute_instance_id => compute_ids},
-        }
+        dataflow_import_id_bundle(&self.df_desc, compute_instance_id)
     }
 }
 

--- a/test/cluster/github-cloud-7998/check.td
+++ b/test/cluster/github-cloud-7998/check.td
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Verify that the serving cluster index is still queryable under serializable
+# isolation.
+
+> SET cluster = serving
+> SET transaction_isolation = serializable
+
+> SELECT * FROM mv1
+1
+
+> SELECT * FROM mv2
+4
+
+> SELECT * FROM mv3
+4

--- a/test/cluster/github-cloud-7998/setup.td
+++ b/test/cluster/github-cloud-7998/setup.td
@@ -1,0 +1,69 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_unmanaged_cluster_replicas = true;
+
+# Create a cluster that we can make unavailable.
+> CREATE CLUSTER compute REPLICAS (
+    r1 (
+      STORAGECTL ADDRESSES ['clusterd1:2100'],
+      COMPUTECTL ADDRESSES ['clusterd1:2101'],
+      STORAGE ADDRESSES ['clusterd1:2102'],
+      COMPUTE ADDRESSES ['clusterd1:2103'],
+      WORKERS 1
+    )
+  )
+
+# Create a serving cluster that should still respond to queries.
+> CREATE CLUSTER serving SIZE '1'
+
+# Create an MV maintained on the compute cluster and indexed on the serving
+# cluster. It's important that the MV reads from an index too, to reproduce
+# the bug.
+
+> CREATE TABLE source (a int)
+> CREATE INDEX source_idx IN CLUSTER compute ON source (a)
+> CREATE MATERIALIZED VIEW mv1 IN CLUSTER compute AS SELECT * FROM source
+> CREATE INDEX mv1_idx IN CLUSTER serving ON mv1 (a)
+
+# Create a second MV that transitively depends on several indexes, to also test
+# this case.
+
+> CREATE VIEW v1 AS SELECT a + 1 AS b FROM source;
+> CREATE INDEX v1_idx IN CLUSTER compute ON v1 (b);
+> CREATE VIEW v2 AS SELECT b + 1 AS c FROM v1;
+> CREATE INDEX v2_idx IN CLUSTER compute ON v2 (c);
+> CREATE VIEW v3 AS SELECT c + 1 AS d FROM v2;
+> CREATE INDEX v3_idx IN CLUSTER compute ON v3 (d);
+> CREATE MATERIALIZED VIEW mv2 IN CLUSTER compute AS SELECT * FROM v3
+> CREATE INDEX mv2_idx IN CLUSTER serving ON mv2 (d)
+
+# ... and an MV that depends on multiple indexes directly.
+
+> CREATE VIEW v4 AS SELECT a + 1 AS e FROM source;
+> CREATE INDEX v4_idx IN CLUSTER compute ON v4 (e);
+> CREATE VIEW v5 AS SELECT a + 1 AS f FROM source;
+> CREATE INDEX v5_idx IN CLUSTER compute ON v5 (f);
+> CREATE MATERIALIZED VIEW mv3 IN CLUSTER compute AS SELECT e + f AS g FROM v4, v5
+> CREATE INDEX mv3_idx IN CLUSTER serving ON mv3 (g)
+
+# Let things hydrate.
+
+> INSERT INTO source VALUES (1)
+> SET cluster = serving
+
+> SELECT * FROM mv1
+1
+
+> SELECT * FROM mv2
+4
+
+> SELECT * FROM mv3
+4

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2811,3 +2811,35 @@ def workflow_test_index_source_stuck(
         c.up("clusterd1")
         c.up("clusterd2")
         c.run("testdrive", "index-source-stuck/run.td")
+
+
+def workflow_test_github_cloud_7998(
+    c: Composition, parser: WorkflowArgumentParser
+) -> None:
+    """Regression test for MaterializeInc/cloud#7998."""
+
+    c.down(destroy_volumes=True)
+
+    with c.override(
+        Testdrive(no_reset=True),
+        Clusterd(name="clusterd1"),
+        Materialized(),
+    ):
+        c.up("materialized")
+        c.up("clusterd1")
+
+        c.run("testdrive", "github-cloud-7998/setup.td")
+
+        # Make the compute cluster unavailable.
+        c.kill("clusterd1")
+        c.run("testdrive", "github-cloud-7998/check.td")
+
+        # Trigger an environment bootstrap.
+        c.kill("materialized")
+        c.up("materialized")
+        c.run("testdrive", "github-cloud-7998/check.td")
+
+        # Run a second bootstrap check, just to be sure.
+        c.kill("materialized")
+        c.up("materialized")
+        c.run("testdrive", "github-cloud-7998/check.td")


### PR DESCRIPTION
This PR fixes a bug in index as-of bootstrapping that occurs when the selected as-of is advanced past the write frontiers of dependent materialized views. The fix consists of ensuring that the selected as-of is at most the meet (i.e. minimum) of the write frontiers of dependent materialized views.

A number of preconditions were requires to facilitate this check:

* All storage collections must be registered upfront, so we hav access to frontiers of dependent MVs stored in persist. Implemented by https://github.com/MaterializeInc/materialize/pull/22932.
* Optimization has to be run upfront, so we know what indexes MVs depend on. Implemented in this PR.
  * This in turn is made possible by moving the timestamp selection after optimization of indexes and MVs, rather than having it be an intermediate step of the optimization. Implemented by https://github.com/MaterializeInc/materialize/pull/22971.

### Motivation

  * This PR fixes a recognized bug.

Fixes https://github.com/MaterializeInc/cloud/issues/7998

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
