### PR TITLE
output consistency: remove ignore on timezone function after issue has been resolved

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -117,9 +117,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("inconsistent ordering, not an error")
 
-        if db_function.function_name_in_lower_case == "timezone":
-            return YesIgnore("#21999: timezone")
-
         if db_function.function_name_in_lower_case == "date_trunc":
             precision = expression.args[0]
             if isinstance(precision, EnumConstant) and precision.value == "second":


### PR DESCRIPTION
Reenabling `timezone` function because https://github.com/MaterializeInc/materialize/issues/21999 was closed.

Nightly: https://buildkite.com/materialize/nightlies/builds/5005