### PR TITLE
ci: closed issue detector: extend pattern

### DIFF
--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -43,6 +43,8 @@ REFERENCE_RE = re.compile(
     | @disabled
     # Used in pytest
     | @pytest.mark.skip
+    # Used in output-consistency framework
+    | YesIgnore
     )
     """,
     re.VERBOSE | re.IGNORECASE,


### PR DESCRIPTION
To match stuff like

```
            return YesIgnore("#21999: timezone")
```

in output-consistencies' ignore definitions.