### PR TITLE
bounded-memory: Bump clusterd memory for index hydration

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -170,6 +170,7 @@ SCENARIOS = [
             {ITERATIONS * REPEAT}
             """
         ),
+        clusterd_memory="3.6Gb",
     ),
     PgCdcScenario(
         name="pg-cdc-update",
@@ -376,7 +377,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="3.2Gb",
+        clusterd_memory="3.5Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",


### PR DESCRIPTION
Started failing often in CI, seems to have been chosen too close

See for example https://buildkite.com/materialize/nightlies/builds/4994#018b9a19-9312-4e25-92e2-90d4674cfa5d

Similar problem for pg-cdc-snapshot: https://buildkite.com/materialize/nightlies/builds/5006#018ba3e1-9b52-4183-a48c-7362cd49d03c

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
