### PR TITLE
ci: Bump cloudtest upgrade, random upgrades  test timeout

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -549,7 +549,7 @@ steps:
 
       - id: checks-upgrade-matrix
         label: "Random upgrades over the entire matrix"
-        timeout_in_minutes: 300
+        timeout_in_minutes: 360
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -560,7 +560,7 @@ steps:
 
       - id: cloudtest-upgrade
         label: "Platform checks upgrade in Cloudtest/K8s"
-        timeout_in_minutes: 30
+        timeout_in_minutes: 60
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml


### PR DESCRIPTION
cloudtest upgrade timed out in https://buildkite.com/materialize/nightlies/builds/4994#018b9a19-92fc-4527-bd5b-60017bd6d0c2

Before that it was at 30:00 minutes, so super close to timing out too, seems to slowly have crept up: https://buildkite.com/materialize/nightlies/builds/4983#018b9260-1dbc-4f78-b6e8-cee184cc7894

Random upgrades timed out in https://buildkite.com/materialize/nightlies/builds/5003#018b9f76-93c2-4153-865c-392624f2e902


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
