### PR TITLE
explain: change `humanized_exprs` output format

### DIFF
--- a/src/repr/src/explain/mod.rs
+++ b/src/repr/src/explain/mod.rs
@@ -33,6 +33,7 @@
 use itertools::Itertools;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::fmt::{Display, Formatter};
@@ -680,6 +681,13 @@ impl<'a> fmt::Display for HumanizedAttributes<'a> {
 
         if self.config.column_names {
             let column_names = self.attrs.column_names.as_ref().expect("column_names");
+            let column_names = column_names.into_iter().enumerate().map(|(i, c)| {
+                if c.is_empty() {
+                    Cow::Owned(format!("#{i}"))
+                } else {
+                    Cow::Borrowed(c)
+                }
+            });
             let column_names = bracketed("(", ")", separated(", ", column_names)).to_string();
             builder.field("column_names", &column_names);
         }

--- a/src/transform/src/attribute/mod.rs
+++ b/src/transform/src/attribute/mod.rs
@@ -586,11 +586,6 @@ pub fn annotate_plan<'a>(
                 subtree_refs.iter(),
                 attributes.remove_results::<ColumnNames>().into_iter(),
             ) {
-                let column_names = column_names
-                    .into_iter()
-                    .enumerate()
-                    .map(|(i, c)| if c.is_empty() { format!("#{i}") } else { c })
-                    .collect();
                 let attrs = annotations.entry(expr).or_default();
                 attrs.column_names = Some(column_names);
             }

--- a/src/transform/tests/test_transforms/humanized_exprs.spec
+++ b/src/transform/tests/test_transforms/humanized_exprs.spec
@@ -75,7 +75,7 @@ explain with=humanized_exprs
 Map (#1, #0 + #1, #0)
   Get t0
 ----
-Map (c1, (c0 + c1), c0)
+Map (#1{c1}, (#0{c0} + #1{c1}), #0{c0})
   Get t0
 
 # FlatMap
@@ -83,7 +83,7 @@ explain with=humanized_exprs
 FlatMap generate_series(#0, #1, 1)
   Get t0
 ----
-FlatMap generate_series(c0, c1, 1)
+FlatMap generate_series(#0{c0}, #1{c1}, 1)
   Get t0
 
 # Filter
@@ -91,7 +91,7 @@ explain with=humanized_exprs
 Filter (#0 > #1 + 42)
   Get t0
 ----
-Filter (c0 > (c1 + 42))
+Filter (#0{c0} > (#1{c1} + 42))
   Get t0
 
 # Reduce
@@ -99,7 +99,7 @@ explain with=humanized_exprs
 Reduce group_by=[#0, 42] aggregates=[min(#1), max(#1)]
   Get t0
 ----
-Reduce group_by=[c0, 42] aggregates=[min(c1), max(c1)]
+Reduce group_by=[#0{c0}, 42] aggregates=[min(#1{c1}), max(#1{c1})]
   Get t0
 
 # TopK
@@ -107,7 +107,7 @@ explain with=humanized_exprs
 TopK group_by=[#1] order_by=[#0 desc nulls_first] limit=3
   Get t0
 ----
-TopK group_by=[c1] order_by=[c0 desc nulls_first] limit=3
+TopK group_by=[#1{c1}] order_by=[#0{c0} desc nulls_first] limit=3
   Get t0
 
 # Negate
@@ -131,7 +131,7 @@ explain with=humanized_exprs
 ArrangeBy keys=[[#1], [#1, #0]]
   Get t0
 ----
-ArrangeBy keys=[[c1], [c1, c0]]
+ArrangeBy keys=[[#1{c1}], [#1{c1}, #0{c0}]]
   Get t0
 
 # Union (anonymous last)
@@ -160,6 +160,6 @@ Join on=(#1 = #2)
   Get t0
   Get t0
 ----
-Join on=(c1 = c0)
+Join on=(#1{c1} = #2{c0})
   Get t0
   Get t0

--- a/test/sqllogictest/attributes/mir_unique_keys.slt
+++ b/test/sqllogictest/attributes/mir_unique_keys.slt
@@ -135,8 +135,8 @@ Used Indexes:
   - materialize.public.v_primary_idx (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.v_primary_idx on v(c, d) is too wide to use for literal equalities `c = 1`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (c).
+  - Notice: Index materialize.public.v_primary_idx on v(#0{c}, #1{d}) is too wide to use for literal equalities `#0{c} = 1`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{c}).
 
 EOF
 

--- a/test/sqllogictest/chbench.slt
+++ b/test/sqllogictest/chbench.slt
@@ -1320,8 +1320,8 @@ Used Indexes:
   - materialize.public.fk_orderline_item (differential join)
 
 Notices:
-  - Notice: Index materialize.public.fk_orderline_order on orderline(ol_w_id, ol_d_id, ol_o_id) is too wide to use for literal equalities `ol_w_id IN (1, 2, 3, 4, 5)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (ol_w_id).
+  - Notice: Index materialize.public.fk_orderline_order on orderline(#2{ol_w_id}, #1{ol_d_id}, #0{ol_o_id}) is too wide to use for literal equalities `#2{ol_w_id} IN (1, 2, 3, 4, 5)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{ol_w_id}).
 
 EOF
 

--- a/test/sqllogictest/filter-pushdown.slt
+++ b/test/sqllogictest/filter-pushdown.slt
@@ -52,12 +52,12 @@ Explained Query:
     cte l0 =
       Reduce aggregates=[count(*)]
         Project ()
-          Filter (mz_now() < numeric_to_mz_timestamp(delete_ms)) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms))
+          Filter (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})) AND (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms}))
             ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp(delete_ms)))
-  pushdown=((mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp(delete_ms)))
+  filter=((mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})))
+  pushdown=((mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp(#2{delete_ms})))
 
 EOF
 
@@ -74,12 +74,12 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
 Explained Query:
   Project (#0, #1)
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3))))
-      Map ((insert_ms / 10000))
+      Map ((#1{insert_ms} / 10000))
         ReadStorage materialize.public.events
 
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
-  map=((insert_ms / 10000))
+  map=((#1{insert_ms} / 10000))
   pushdown=((mz_now() < numeric_to_mz_timestamp((10000 * (1 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
@@ -97,12 +97,12 @@ WHERE mz_now() >= 10000 * (insert_ms / 10000)
 Explained Query:
   Project (#0, #1)
     Filter (mz_now() >= numeric_to_mz_timestamp((10000 * #3))) AND (mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3))))
-      Map ((insert_ms / 10000))
+      Map ((#1{insert_ms} / 10000))
         ReadStorage materialize.public.events
 
 Source materialize.public.events
   filter=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
-  map=((insert_ms / 10000))
+  map=((#1{insert_ms} / 10000))
   pushdown=((mz_now() < numeric_to_mz_timestamp((6 * (10000 + #3)))) AND (mz_now() >= numeric_to_mz_timestamp((10000 * #3))))
 
 EOF
@@ -120,12 +120,12 @@ WHERE mz_now() >= insert_ms
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (mz_now() >= numeric_to_mz_timestamp(insert_ms)) AND (mz_now() < numeric_to_mz_timestamp((insert_ms + 30000)))
+    Filter (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})) AND (mz_now() < numeric_to_mz_timestamp((#1{insert_ms} + 30000)))
       ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() < numeric_to_mz_timestamp((insert_ms + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms)))
-  pushdown=((mz_now() < numeric_to_mz_timestamp((insert_ms + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(insert_ms)))
+  filter=((mz_now() < numeric_to_mz_timestamp((#1{insert_ms} + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})))
+  pushdown=((mz_now() < numeric_to_mz_timestamp((#1{insert_ms} + 30000))) AND (mz_now() >= numeric_to_mz_timestamp(#1{insert_ms})))
 
 EOF
 
@@ -137,12 +137,12 @@ WHERE mz_now() >= insert_ms + 60000
   AND mz_now() < delete_ms + 60000;
 ----
 Explained Query:
-  Filter (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000)))
+  Filter (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() >= numeric_to_mz_timestamp((#1{insert_ms} + 60000)))
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))))
-  pushdown=((mz_now() >= numeric_to_mz_timestamp((insert_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))))
+  filter=((mz_now() >= numeric_to_mz_timestamp((#1{insert_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))))
+  pushdown=((mz_now() >= numeric_to_mz_timestamp((#1{insert_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))))
 
 EOF
 
@@ -158,12 +158,12 @@ FROM events
 WHERE COALESCE(delete_ms, insert_ms) < mz_now();
 ----
 Explained Query:
-  Filter (numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now())
+  Filter (numeric_to_mz_timestamp(coalesce(#2{delete_ms}, #1{insert_ms})) < mz_now())
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now()))
-  pushdown=((numeric_to_mz_timestamp(coalesce(delete_ms, insert_ms)) < mz_now()))
+  filter=((numeric_to_mz_timestamp(coalesce(#2{delete_ms}, #1{insert_ms})) < mz_now()))
+  pushdown=((numeric_to_mz_timestamp(coalesce(#2{delete_ms}, #1{insert_ms})) < mz_now()))
 
 EOF
 
@@ -182,12 +182,12 @@ WHERE mz_now() < delete_ms + 10000
   AND mz_now() < delete_ms + 90000;
 ----
 Explained Query:
-  Filter (mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000)))
+  Filter (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 90000)))
     ReadStorage materialize.public.events
 
 Source materialize.public.events
-  filter=((mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000))))
-  pushdown=((mz_now() < numeric_to_mz_timestamp((delete_ms + 10000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 20000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 30000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 40000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 50000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 60000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 70000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 80000))) AND (mz_now() < numeric_to_mz_timestamp((delete_ms + 90000))))
+  filter=((mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 90000))))
+  pushdown=((mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 10000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 20000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 30000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 40000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 50000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 60000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 70000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 80000))) AND (mz_now() < numeric_to_mz_timestamp((#2{delete_ms} + 90000))))
 
 EOF
 
@@ -206,12 +206,12 @@ WHERE EXTRACT(YEAR FROM inserted_at) = 2021;
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (2021 = extract_year_ts(inserted_at))
+    Filter (2021 = extract_year_ts(#1{inserted_at}))
       ReadStorage materialize.public.events_timestamped
 
 Source materialize.public.events_timestamped
-  filter=((2021 = extract_year_ts(inserted_at)))
-  pushdown=((2021 = extract_year_ts(inserted_at)))
+  filter=((2021 = extract_year_ts(#1{inserted_at})))
+  pushdown=((2021 = extract_year_ts(#1{inserted_at})))
 
 EOF
 
@@ -231,12 +231,12 @@ WHERE mz_now() < try_parse_monotonic_iso8601_timestamp(content);
 ----
 Explained Query:
   Project (#0, #1)
-    Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content)))
+    Filter (mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0{content})))
       ReadStorage materialize.public.events_timestamped
 
 Source materialize.public.events_timestamped
-  filter=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content))))
-  pushdown=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(content))))
+  filter=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0{content}))))
+  pushdown=((mz_now() < timestamp_to_mz_timestamp(try_parse_monotonic_iso8601_timestamp(#0{content}))))
 
 EOF
 

--- a/test/sqllogictest/ldbc_bi.slt
+++ b/test/sqllogictest/ldbc_bi.slt
@@ -435,14 +435,14 @@ Explained Query:
     Return // { arity: 7 }
       Project (#0..=#2, #4, #7, #5, #8) // { arity: 7 }
         Map ((#5 / bigint_to_numeric(case when (#6 = 0) then null else #6 end)), (bigint_to_numeric(#4) / #3)) // { arity: 9 }
-          Reduce group_by=[#1, #2, #3, #4] aggregates=[count(*), sum(integer_to_bigint(length)), count(integer_to_bigint(length))] // { arity: 7 }
+          Reduce group_by=[#1, #2, #3, #4] aggregates=[count(*), sum(integer_to_bigint(#0{length})), count(integer_to_bigint(#0{length}))] // { arity: 7 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]U » %0:message[×]if
               ArrangeBy keys=[[]] // { arity: 4 }
                 Project (#8, #13..=#15) // { arity: 4 }
-                  Filter (creationdate < 2010-06-11 09:21:46 UTC) AND (content) IS NOT NULL // { arity: 16 }
-                    Map (extract_year_tstz(creationdate), (parentmessageid) IS NOT NULL, case when (length < 40) then 0 else case when (length < 80) then 1 else case when (length < 160) then 2 else 3 end end end) // { arity: 16 }
+                  Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) AND (#4{content}) IS NOT NULL // { arity: 16 }
+                    Map (extract_year_tstz(#0{creationdate}), (#12{parentmessageid}) IS NOT NULL, case when (#8{length} < 40) then 0 else case when (#8{length} < 80) then 1 else case when (#8{length} < 160) then 2 else 3 end end end) // { arity: 16 }
                       ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
               ArrangeBy keys=[[]] // { arity: 1 }
                 Project (#1) // { arity: 1 }
@@ -460,7 +460,7 @@ Explained Query:
       cte l0 =
         Reduce aggregates=[count(*)] // { arity: 1 }
           Project () // { arity: 0 }
-            Filter (creationdate < 2010-06-11 09:21:46 UTC) // { arity: 13 }
+            Filter (#0{creationdate} < 2010-06-11 09:21:46 UTC) // { arity: 13 }
               ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -506,7 +506,7 @@ SELECT t.name AS "tag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, name asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
         Map (coalesce(#1, 0), coalesce(#2, 0), abs((#3 - #4))) // { arity: 6 }
@@ -522,39 +522,39 @@ Explained Query:
     With
       cte l2 =
         Project (#1, #3, #4) // { arity: 3 }
-          Join on=(id = id) type=differential // { arity: 5 }
+          Join on=(#0{id} = #2{id}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l1[#0]K
-            ArrangeBy keys=[[id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[id]] // { arity: 3 }
-              Reduce group_by=[id] aggregates=[count(case when (creationdate < 2010-09-16 00:00:00 UTC) then messageid else null end), count(case when (creationdate >= 2010-09-16 00:00:00 UTC) then messageid else null end)] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 3 }
+              Reduce group_by=[#0{id}] aggregates=[count(case when (#2{creationdate} < 2010-09-16 00:00:00 UTC) then #1{messageid} else null end), count(case when (#2{creationdate} >= 2010-09-16 00:00:00 UTC) then #1{messageid} else null end)] // { arity: 3 }
                 Project (#0, #2, #4) // { arity: 3 }
-                  Filter (creationdate < 2010-12-25 00:00:00 UTC) AND (creationdate >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
-                    Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 17 }
+                  Filter (#4{creationdate} < 2010-12-25 00:00:00 UTC) AND (#4{creationdate} >= 2010-06-08 00:00:00 UTC) // { arity: 17 }
+                    Join on=(#0{id} = #3{tagid} AND #2{messageid} = #5{messageid}) type=delta // { arity: 17 }
                       implementation
                         %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif
                         %1:message_hastag_tag » %2:message[#1]KAiif » %0:l1[#0]KA
                         %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KA
-                      ArrangeBy keys=[[id]] // { arity: 1 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+                      ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                      ArrangeBy keys=[[messageid]] // { arity: 13 }
+                      ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                         ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
       cte l1 =
-        Filter (id) IS NOT NULL // { arity: 2 }
+        Filter (#0{id}) IS NOT NULL // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#5, #6) // { arity: 2 }
-          Filter (id) IS NOT NULL // { arity: 9 }
-            Join on=(id = typetagclassid) type=differential // { arity: 9 }
+          Filter (#0{id}) IS NOT NULL // { arity: 9 }
+            Join on=(#0{id} = #8{typetagclassid}) type=differential // { arity: 9 }
               implementation
                 %0:tagclass[#0]KAe » %1:tag[#3]KAe
-              ArrangeBy keys=[[id]] // { arity: 5 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("ChristianBishop")] // { arity: 5 }
-              ArrangeBy keys=[[typetagclassid]] // { arity: 4 }
+              ArrangeBy keys=[[#3{typetagclassid}]] // { arity: 4 }
                 ReadIndex on=tag tag_typetagclassid=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -602,37 +602,37 @@ ORDER BY messageCount DESC, Forum.id
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, containerforumid asc nulls_last] limit=20 output=[#0..=#4]
-    Reduce group_by=[containerforumid, title, creationdate, moderatorpersonid] aggregates=[count(*)] // { arity: 5 }
+  Finish order_by=[#4 desc nulls_first, #0{containerforumid} asc nulls_last] limit=20 output=[#0..=#4]
+    Reduce group_by=[#0{containerforumid}, #2{title}, #1{creationdate}, #3{moderatorpersonid}] aggregates=[count(*)] // { arity: 5 }
       Project (#10, #13, #15, #16) // { arity: 4 }
-        Filter (name = "China") AND (containerforumid) IS NOT NULL AND (moderatorpersonid) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 37 }
-          Join on=(messageid = messageid AND containerforumid = id AND moderatorpersonid = id AND locationcityid = id AND partofcountryid = id) type=differential // { arity: 37 }
+        Filter (#33{name} = "China") AND (#10{containerforumid}) IS NOT NULL AND (#16{moderatorpersonid}) IS NOT NULL AND (#25{locationcityid}) IS NOT NULL AND (#31{partofcountryid}) IS NOT NULL // { arity: 37 }
+          Join on=(#1{messageid} = #36{messageid} AND #10{containerforumid} = #14{id} AND #16{moderatorpersonid} = #18{id} AND #25{locationcityid} = #28{id} AND #31{partofcountryid} = #32{id}) type=differential // { arity: 37 }
             implementation
               %5[#0]UKA » %0:message[#1]KA » %1:forum[#1]KA » %2:person[#1]KA » %3:city[#0]KA » %4:country[#0]KAef
-            ArrangeBy keys=[[messageid]] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[id]] // { arity: 4 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 4 }
               ReadIndex on=forum forum_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[id]] // { arity: 11 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 11 }
               ReadIndex on=person person_id=[differential join] // { arity: 11 }
-            ArrangeBy keys=[[id]] // { arity: 4 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
               ReadIndex on=city city_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[id]] // { arity: 4 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
               ReadIndex on=country country_id=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct project=[messageid] // { arity: 1 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (id) IS NOT NULL AND (id) IS NOT NULL // { arity: 12 }
-                    Join on=(id = typetagclassid AND id = tagid) type=delta // { arity: 12 }
+                  Filter (#0{id}) IS NOT NULL AND (#5{id}) IS NOT NULL // { arity: 12 }
+                    Join on=(#0{id} = #8{typetagclassid} AND #5{id} = #11{tagid}) type=delta // { arity: 12 }
                       implementation
                         %0:tagclass » %1:tag[#3]KA » %2:message_hastag_tag[#2]KA
                         %1:tag » %0:tagclass[#0]KAe » %2:message_hastag_tag[#2]KA
                         %2:message_hastag_tag » %1:tag[#0]KA » %0:tagclass[#0]KAe
-                      ArrangeBy keys=[[id]] // { arity: 5 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                         ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Philosopher")] // { arity: 5 }
-                      ArrangeBy keys=[[id], [typetagclassid]] // { arity: 4 }
+                      ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
                         ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                      ArrangeBy keys=[[tagid]] // { arity: 3 }
+                      ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                         ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -718,20 +718,20 @@ ORDER BY messageCount DESC, au.id
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
-      Reduce group_by=[id, firstname, lastname, creationdate] aggregates=[count(messageid)] // { arity: 5 }
+      Reduce group_by=[#1{id}, #2{firstname}, #3{lastname}, #0{creationdate}] aggregates=[count(#4{messageid})] // { arity: 5 }
         Union // { arity: 5 }
           Map (null) // { arity: 5 }
             Union // { arity: 4 }
               Negate // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
-                  Join on=(id = id) type=differential // { arity: 5 }
+                  Join on=(#1{id} = #4{id}) type=differential // { arity: 5 }
                     implementation
                       %1[#0]UKA » %0:l2[#1]K
                     Get l2 // { arity: 4 }
-                    ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct project=[id] // { arity: 1 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
                         Project (#1) // { arity: 1 }
                           Get l3 // { arity: 5 }
               Get l1 // { arity: 4 }
@@ -739,52 +739,52 @@ Explained Query:
     With
       cte l3 =
         Project (#0..=#3, #5) // { arity: 5 }
-          Join on=(id = creatorpersonid AND eq(containerforumid, containerforumid, id)) type=differential // { arity: 19 }
+          Join on=(#1{id} = #13{creatorpersonid} AND eq(#14{containerforumid}, #17{containerforumid}, #18{id})) type=differential // { arity: 19 }
             implementation
               %0:l2[#1]K » %1:message[#9]KA » %2[#0]UKA » %3[#0]UKA
             Get l2 // { arity: 4 }
-            ArrangeBy keys=[[creatorpersonid]] // { arity: 13 }
+            ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
               ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-              Distinct project=[containerforumid] // { arity: 1 }
+            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+              Distinct project=[#0{containerforumid}] // { arity: 1 }
                 Project (#10) // { arity: 1 }
-                  Filter (containerforumid) IS NOT NULL // { arity: 13 }
+                  Filter (#10{containerforumid}) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_creatorpersonid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Get l0 // { arity: 1 }
       cte l2 =
-        ArrangeBy keys=[[id]] // { arity: 4 }
+        ArrangeBy keys=[[#1{id}]] // { arity: 4 }
           Get l1 // { arity: 4 }
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(eq(id, id, personid)) type=delta // { arity: 13 }
+          Join on=(eq(#1{id}, #11{id}, #12{personid})) type=delta // { arity: 13 }
             implementation
               %0:person » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:person[#1]KA
               %2 » %1[#0]UKA » %0:person[#1]KA
-            ArrangeBy keys=[[id]] // { arity: 11 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (id) IS NOT NULL // { arity: 11 }
+                  Filter (#1{id}) IS NOT NULL // { arity: 11 }
                     ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-            ArrangeBy keys=[[personid]] // { arity: 1 }
-              Distinct project=[personid] // { arity: 1 }
+            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+              Distinct project=[#0{personid}] // { arity: 1 }
                 Project (#3) // { arity: 1 }
-                  Join on=(id = forumid) type=differential // { arity: 4 }
+                  Join on=(#0{id} = #2{forumid}) type=differential // { arity: 4 }
                     implementation
                       %1:forum_hasmember_person[#1]KA » %0:l0[#0]K
-                    ArrangeBy keys=[[id]] // { arity: 1 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
                       Get l0 // { arity: 1 }
-                    ArrangeBy keys=[[forumid]] // { arity: 3 }
+                    ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
                       ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0) // { arity: 1 }
-          TopK order_by=[maxnumberofmembers desc nulls_first, id asc nulls_last] limit=100 // { arity: 2 }
+          TopK order_by=[#1{maxnumberofmembers} desc nulls_first, #0{id} asc nulls_last] limit=100 // { arity: 2 }
             Project (#0, #2) // { arity: 2 }
-              Filter (creationdate > 2010-02-12 00:00:00 UTC) // { arity: 3 }
+              Filter (#1{creationdate} > 2010-02-12 00:00:00 UTC) // { arity: 3 }
                 ReadIndex on=top100popularforumsq04 top100popularforumsq04_id=[*** full scan ***] // { arity: 3 }
 
 Used Indexes:
@@ -828,10 +828,10 @@ SELECT CreatorPersonId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0..=#4]
+  Finish order_by=[#4 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0..=#4]
     Return // { arity: 5 }
       Map (((bigint_to_numeric((1 * #3)) + (2 * #1)) + (10 * #2))) // { arity: 5 }
-        Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1, 0)), sum(coalesce(#2, 0)), count(*)] // { arity: 4 }
           Union // { arity: 3 }
             Map (null) // { arity: 3 }
               Union // { arity: 2 }
@@ -844,13 +844,13 @@ Explained Query:
     With
       cte l3 =
         Project (#1, #2, #4) // { arity: 3 }
-          Join on=(messageid = messageid) type=differential // { arity: 5 }
+          Join on=(#0{messageid} = #3{messageid}) type=differential // { arity: 5 }
             implementation
               %1[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[messageid]] // { arity: 3 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[messageid]] // { arity: 2 }
-              Reduce group_by=[messageid] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
+              Reduce group_by=[#0{messageid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
                   ReadIndex on=person_likes_message person_likes_message_personid=[*** full scan ***] // { arity: 3 }
       cte l2 =
@@ -864,29 +864,29 @@ Explained Query:
           Get l1 // { arity: 3 }
       cte l1 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(messageid = parentmessageid) type=differential // { arity: 4 }
+          Join on=(#0{messageid} = #2{parentmessageid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l0[#0]K
-            ArrangeBy keys=[[messageid]] // { arity: 2 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
               Get l0 // { arity: 2 }
-            ArrangeBy keys=[[parentmessageid]] // { arity: 2 }
-              Reduce group_by=[parentmessageid] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[#0{parentmessageid}]] // { arity: 2 }
+              Reduce group_by=[#0{parentmessageid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#12) // { arity: 1 }
-                  Filter (parentmessageid) IS NOT NULL // { arity: 13 }
+                  Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (id) IS NOT NULL // { arity: 21 }
-            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
+          Filter (#0{id}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[id]] // { arity: 5 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Sikh_Empire")] // { arity: 5 }
-              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[messageid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -950,9 +950,9 @@ LIMIT 100
 ;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -965,27 +965,27 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(personid = person2id) type=differential // { arity: 4 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[personid]] // { arity: 2 }
-              Filter (personid) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(messageid = messageid) type=differential // { arity: 3 }
+                    Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct project=[messageid] // { arity: 1 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                        Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -994,28 +994,28 @@ Explained Query:
               Get l2 // { arity: 3 }
       cte l2 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(messageid = messageid) type=differential // { arity: 5 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
             Get l1 // { arity: 2 }
-            ArrangeBy keys=[[messageid]] // { arity: 3 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[messageid]] // { arity: 2 }
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (id) IS NOT NULL // { arity: 21 }
-            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
+          Filter (#0{id}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[id]] // { arity: 5 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[messageid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1055,9 +1055,9 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -1070,27 +1070,27 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(personid = person2id) type=differential // { arity: 4 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[personid]] // { arity: 2 }
-              Filter (personid) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(messageid = messageid) type=differential // { arity: 3 }
+                    Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l1[#0]K
                       Get l1 // { arity: 2 }
-                      ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct project=[messageid] // { arity: 1 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                        Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l2 // { arity: 3 }
                 Project (#1) // { arity: 1 }
@@ -1099,28 +1099,28 @@ Explained Query:
               Get l2 // { arity: 3 }
       cte l2 =
         Project (#0, #1, #3) // { arity: 3 }
-          Join on=(messageid = messageid) type=differential // { arity: 5 }
+          Join on=(#0{messageid} = #4{messageid}) type=differential // { arity: 5 }
             implementation
               %1:person_likes_message[#2]KA » %0:l1[#0]K
             Get l1 // { arity: 2 }
-            ArrangeBy keys=[[messageid]] // { arity: 3 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[messageid]] // { arity: 2 }
+        ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
           Get l0 // { arity: 2 }
       cte l0 =
         Project (#6, #17) // { arity: 2 }
-          Filter (id) IS NOT NULL // { arity: 21 }
-            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 21 }
+          Filter (#0{id}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid}) type=delta // { arity: 21 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KAe » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KAe
-              ArrangeBy keys=[[id]] // { arity: 5 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Bob_Geldof")] // { arity: 5 }
-              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[messageid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1161,9 +1161,9 @@ ORDER BY authorityScore DESC, pl.person1id ASC
 LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[creatorpersonid] aggregates=[sum(coalesce(popularityscore, 0))] // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[sum(coalesce(#1{popularityscore}, 0))] // { arity: 2 }
         Union // { arity: 2 }
           Map (null) // { arity: 2 }
             Union // { arity: 1 }
@@ -1176,61 +1176,61 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #3) // { arity: 2 }
-          Join on=(personid = person2id) type=differential // { arity: 4 }
+          Join on=(#1{personid} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %1:popularityscoreq06[#0]UKA » %0:l3[#1]K
-            ArrangeBy keys=[[personid]] // { arity: 2 }
-              Filter (personid) IS NOT NULL // { arity: 2 }
+            ArrangeBy keys=[[#1{personid}]] // { arity: 2 }
+              Filter (#1{personid}) IS NOT NULL // { arity: 2 }
                 Get l3 // { arity: 2 }
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               ReadIndex on=popularityscoreq06 popularityscoreq06_person2id=[differential join] // { arity: 2 }
       cte l3 =
-        Distinct project=[creatorpersonid, personid] // { arity: 2 }
+        Distinct project=[#0{creatorpersonid}, #1{personid}] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Join on=(messageid = messageid) type=differential // { arity: 3 }
+                    Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
                       implementation
                         %1[#0]UKA » %0:l2[#0]Kef
-                      ArrangeBy keys=[[messageid]] // { arity: 2 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
                         Project (#1, #2) // { arity: 2 }
                           Get l2 // { arity: 3 }
-                      ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct project=[messageid] // { arity: 1 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                        Distinct project=[#0{messageid}] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             Get l1 // { arity: 4 }
                 Project (#2) // { arity: 1 }
                   Get l2 // { arity: 3 }
             Project (#2, #3) // { arity: 2 }
-              Filter (name = "Bob_Geldof") // { arity: 4 }
+              Filter (#0{name} = "Bob_Geldof") // { arity: 4 }
                 Get l1 // { arity: 4 }
       cte l2 =
-        Filter (name = "Bob_Geldof") // { arity: 3 }
+        Filter (#0{name} = "Bob_Geldof") // { arity: 3 }
           Get l0 // { arity: 3 }
       cte l1 =
         Project (#0..=#2, #4) // { arity: 4 }
-          Join on=(messageid = messageid) type=differential // { arity: 6 }
+          Join on=(#1{messageid} = #5{messageid}) type=differential // { arity: 6 }
             implementation
               %1:person_likes_message[#2]KA » %0:l0[#1]K
-            ArrangeBy keys=[[messageid]] // { arity: 3 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[messageid]] // { arity: 3 }
+            ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
               ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#1, #5, #16) // { arity: 3 }
-          Filter (id) IS NOT NULL // { arity: 20 }
-            Join on=(id = tagid AND messageid = messageid) type=delta // { arity: 20 }
+          Filter (#0{id}) IS NOT NULL // { arity: 20 }
+            Join on=(#0{id} = #6{tagid} AND #5{messageid} = #8{messageid}) type=delta // { arity: 20 }
               implementation
                 %0:tag » %1:message_hastag_tag[#2]KA » %2:message[#1]KA
                 %1:message_hastag_tag » %0:tag[#0]KA » %2:message[#1]KA
                 %2:message » %1:message_hastag_tag[#1]KA » %0:tag[#0]KA
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[messageid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] // { arity: 13 }
 
 Used Indexes:
@@ -1277,59 +1277,59 @@ SELECT RelatedTag.name AS "relatedTag.name"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, name asc nulls_last] limit=100 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{name} asc nulls_last] limit=100 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[name] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Join on=(messageid = messageid) type=differential // { arity: 3 }
+          Join on=(#0{messageid} = #2{messageid}) type=differential // { arity: 3 }
             implementation
               %0:l1[#0]K » %1[#0]K
-            ArrangeBy keys=[[messageid]] // { arity: 2 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[messageid]] // { arity: 1 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Join on=(messageid = messageid) type=differential // { arity: 2 }
+                    Join on=(#0{messageid} = #1{messageid}) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[messageid]] // { arity: 1 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[messageid]] // { arity: 1 }
-                        Distinct project=[messageid] // { arity: 1 }
+                      ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                        Distinct project=[#0{messageid}] // { arity: 1 }
                           Get l0 // { arity: 1 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct project=[messageid] // { arity: 1 }
+        Distinct project=[#0{messageid}] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 2 }
       cte l1 =
         Project (#2, #18) // { arity: 2 }
-          Filter (messageid) IS NOT NULL AND (tagid) IS NOT NULL // { arity: 21 }
-            Join on=(messageid = parentmessageid AND messageid = messageid AND tagid = id) type=delta // { arity: 21 }
+          Filter (#0{messageid}) IS NOT NULL AND (#16{tagid}) IS NOT NULL // { arity: 21 }
+            Join on=(#0{messageid} = #13{parentmessageid} AND #2{messageid} = #15{messageid} AND #16{tagid} = #17{id}) type=delta // { arity: 21 }
               implementation
                 %0:l0 » %1:message[#12]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
                 %1:message » %0:l0[#0]KA » %2:message_hastag_tag[#1]KA » %3:tag[#0]KA
                 %2:message_hastag_tag » %1:message[#1]KA » %0:l0[#0]KA » %3:tag[#0]KA
                 %3:tag » %2:message_hastag_tag[#2]KA » %1:message[#1]KA » %0:l0[#0]KA
-              ArrangeBy keys=[[messageid]] // { arity: 1 }
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
                 Get l0 // { arity: 1 }
-              ArrangeBy keys=[[messageid], [parentmessageid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}], [#12{parentmessageid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] message_parentmessageid=[delta join lookup] // { arity: 13 }
-              ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[delta join lookup] // { arity: 4 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (tagid) IS NOT NULL // { arity: 8 }
-            Join on=(tagid = id) type=differential // { arity: 8 }
+          Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
+            Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
               implementation
                 %1:tag[#0]KAe » %0:message_hastag_tag[#2]KAe
-              ArrangeBy keys=[[tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[id]] // { arity: 5 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                 ReadIndex on=materialize.public.tag tag_name=[lookup value=("Slovenia")] // { arity: 5 }
 
 Used Indexes:
@@ -1405,13 +1405,13 @@ Explained Query:
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(person2id = person2id) type=differential // { arity: 4 }
+                    Join on=(#2{person2id} = #3{person2id}) type=differential // { arity: 4 }
                       implementation
                         %1[#0]UKA » %0:l10[#2]K
-                      ArrangeBy keys=[[person2id]] // { arity: 3 }
+                      ArrangeBy keys=[[#2{person2id}]] // { arity: 3 }
                         Get l10 // { arity: 3 }
-                      ArrangeBy keys=[[person2id]] // { arity: 1 }
-                        Distinct project=[person2id] // { arity: 1 }
+                      ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                        Distinct project=[#0{person2id}] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l11 // { arity: 4 }
                 Project (#0, #1) // { arity: 2 }
@@ -1421,11 +1421,11 @@ Explained Query:
     With
       cte l11 =
         Project (#0..=#2, #4) // { arity: 4 }
-          Join on=(person2id = #3) type=differential // { arity: 5 }
+          Join on=(#2{person2id} = #3) type=differential // { arity: 5 }
             implementation
               %0:l10[#2]K » %1:l8[#0]K
-            ArrangeBy keys=[[person2id]] // { arity: 3 }
-              Filter (person2id) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[#2{person2id}]] // { arity: 3 }
+              Filter (#2{person2id}) IS NOT NULL // { arity: 3 }
                 Get l10 // { arity: 3 }
             Get l8 // { arity: 2 }
       cte l10 =
@@ -1447,11 +1447,11 @@ Explained Query:
           Get l9 // { arity: 3 }
       cte l9 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(#0 = person1id) type=differential // { arity: 5 }
+          Join on=(#0 = #3{person1id}) type=differential // { arity: 5 }
             implementation
               %1:person_knows_person[#1]KA » %0:l8[#0]K
             Get l8 // { arity: 2 }
-            ArrangeBy keys=[[person1id]] // { arity: 3 }
+            ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
       cte l8 =
         ArrangeBy keys=[[#0]] // { arity: 2 }
@@ -1459,19 +1459,19 @@ Explained Query:
             Get l7 // { arity: 2 }
       cte l7 =
         Project (#3, #4) // { arity: 2 }
-          Map (coalesce(id, creatorpersonid), (integer_to_bigint(case when (id) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
+          Map (coalesce(#0{id}, #1{creatorpersonid}), (integer_to_bigint(case when (#0{id}) IS NULL then 0 else 100 end) + coalesce(#2, 0))) // { arity: 5 }
             Union // { arity: 3 }
               Project (#2, #0, #1) // { arity: 3 }
                 Map (null) // { arity: 3 }
                   Union // { arity: 2 }
                     Negate // { arity: 2 }
                       Project (#0, #1) // { arity: 2 }
-                        Join on=(creatorpersonid = id) type=differential // { arity: 3 }
+                        Join on=(#0{creatorpersonid} = #2{id}) type=differential // { arity: 3 }
                           implementation
                             %0:l4[#0]UKA » %1[#0]UKA
                           Get l4 // { arity: 2 }
-                          ArrangeBy keys=[[id]] // { arity: 1 }
-                            Distinct project=[id] // { arity: 1 }
+                          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                            Distinct project=[#0{id}] // { arity: 1 }
                               Get l6 // { arity: 1 }
                     Get l3 // { arity: 2 }
               Map (null, null) // { arity: 3 }
@@ -1486,46 +1486,46 @@ Explained Query:
           Get l5 // { arity: 2 }
       cte l5 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(id = creatorpersonid) type=differential // { arity: 3 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 3 }
             implementation
               %1:l4[#0]UKA » %0:l2[#0]K
-            ArrangeBy keys=[[id]] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Get l2 // { arity: 1 }
             Get l4 // { arity: 2 }
       cte l4 =
-        ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
+        ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
           Get l3 // { arity: 2 }
       cte l3 =
-        Reduce group_by=[creatorpersonid] aggregates=[count(*)] // { arity: 2 }
+        Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*)] // { arity: 2 }
           Project (#17) // { arity: 1 }
-            Filter (creationdate < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < creationdate) AND (id) IS NOT NULL AND (creatorpersonid) IS NOT NULL // { arity: 32 }
-              Join on=(id = tagid AND messageid = messageid AND creatorpersonid = id) type=delta // { arity: 32 }
+            Filter (#8{creationdate} < 2010-06-28 00:00:00 UTC) AND (2010-06-14 00:00:00 UTC < #8{creationdate}) AND (#0{id}) IS NOT NULL AND (#17{creatorpersonid}) IS NOT NULL // { arity: 32 }
+              Join on=(#0{id} = #7{tagid} AND #6{messageid} = #9{messageid} AND #17{creatorpersonid} = #22{id}) type=delta // { arity: 32 }
                 implementation
                   %0:l1 » %1:message_hastag_tag[#2]KA » %2:message[#1]KAiif » %3:l0[#1]KA
                   %1:message_hastag_tag » %0:l1[#0]KAe » %2:message[#1]KAiif » %3:l0[#1]KA
                   %2:message » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe » %3:l0[#1]KA
                   %3:l0 » %2:message[#9]KAiif » %1:message_hastag_tag[#1]KA » %0:l1[#0]KAe
                 Get l1 // { arity: 5 }
-                ArrangeBy keys=[[messageid], [tagid]] // { arity: 3 }
+                ArrangeBy keys=[[#1{messageid}], [#2{tagid}]] // { arity: 3 }
                   ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[delta join lookup] message_hastag_tag_tagid=[delta join lookup] // { arity: 3 }
-                ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
+                ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
                   ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
                 Get l0 // { arity: 11 }
       cte l2 =
         Project (#1) // { arity: 1 }
-          Filter (id) IS NOT NULL AND (tagid) IS NOT NULL // { arity: 19 }
-            Join on=(id = personid AND tagid = id) type=differential // { arity: 19 }
+          Filter (#1{id}) IS NOT NULL AND (#13{tagid}) IS NOT NULL // { arity: 19 }
+            Join on=(#1{id} = #12{personid} AND #13{tagid} = #14{id}) type=differential // { arity: 19 }
               implementation
                 %2:l1[#0]KAe » %1:person_hasinterest_tag[#2]KAe » %0:l0[#1]KAe
               Get l0 // { arity: 11 }
-              ArrangeBy keys=[[tagid]] // { arity: 3 }
+              ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                 ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[differential join] // { arity: 3 }
               Get l1 // { arity: 5 }
       cte l1 =
-        ArrangeBy keys=[[id]] // { arity: 5 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
           ReadIndex on=materialize.public.tag tag_name=[lookup value=("Abbas_I_of_Persia")] // { arity: 5 }
       cte l0 =
-        ArrangeBy keys=[[id]] // { arity: 11 }
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join, delta join lookup] // { arity: 11 }
 
 Used Indexes:
@@ -1566,23 +1566,23 @@ SELECT Person.id AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#4 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#4]
-    Reduce group_by=[id, firstname, lastname] aggregates=[count(*), sum(#3)] // { arity: 5 }
+  Finish order_by=[#4 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#4]
+    Reduce group_by=[#0{id}, #1{firstname}, #2{lastname}] aggregates=[count(*), sum(#3)] // { arity: 5 }
       Project (#1..=#3, #25) // { arity: 4 }
-        Filter (parentmessageid) IS NULL AND (creationdate <= 2012-11-24 00:00:00 UTC) AND (creationdate >= 2012-08-29 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 26 }
-          Join on=(id = creatorpersonid AND messageid = rootpostid) type=delta // { arity: 26 }
+        Filter (#23{parentmessageid}) IS NULL AND (#11{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#11{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 26 }
+          Join on=(#1{id} = #20{creatorpersonid} AND #12{messageid} = #24{rootpostid}) type=delta // { arity: 26 }
             implementation
               %0:person » %1:message[#9]KAniif » %2[#0]UKA
               %1:message » %2[#0]UKA » %0:person[#1]KA
               %2 » %1:message[#1]KAniif » %0:person[#1]KA
-            ArrangeBy keys=[[id]] // { arity: 11 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[rootpostid]] // { arity: 2 }
-              Reduce group_by=[rootpostid] aggregates=[count(*)] // { arity: 2 }
+            ArrangeBy keys=[[#0{rootpostid}]] // { arity: 2 }
+              Reduce group_by=[#0{rootpostid}] aggregates=[count(*)] // { arity: 2 }
                 Project (#2) // { arity: 1 }
-                  Filter (creationdate <= 2012-11-24 00:00:00 UTC) AND (creationdate >= 2012-08-29 00:00:00 UTC) AND (rootpostid) IS NOT NULL // { arity: 13 }
+                  Filter (#0{creationdate} <= 2012-11-24 00:00:00 UTC) AND (#0{creationdate} >= 2012-08-29 00:00:00 UTC) AND (#2{rootpostid}) IS NOT NULL // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -1674,84 +1674,84 @@ SELECT m.friendId AS "person.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, name asc nulls_last, person2id asc nulls_last] limit=100 output=[#0..=#2]
+  Finish order_by=[#2 desc nulls_first, #1{name} asc nulls_last, #0{person2id} asc nulls_last] limit=100 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[person2id, name] aggregates=[count(*)] // { arity: 3 }
+      Reduce group_by=[#0{person2id}, #1{name}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #9) // { arity: 2 }
-          Filter (tagid) IS NOT NULL // { arity: 12 }
-            Join on=(eq(person2id, id, creatorpersonid) AND eq(messageid, messageid, messageid) AND tagid = id) type=differential // { arity: 12 }
+          Filter (#7{tagid}) IS NOT NULL // { arity: 12 }
+            Join on=(eq(#0{person2id}, #1{id}, #2{creatorpersonid}) AND eq(#3{messageid}, #4{messageid}, #6{messageid}) AND #7{tagid} = #8{id}) type=differential // { arity: 12 }
               implementation
                 %0[#0]UKA » %1[#0]UKA » %2[#0]K » %3[#0]UKA » %4:message_hastag_tag[#1]KA » %5:tag[#0]KA
-              ArrangeBy keys=[[person2id]] // { arity: 1 }
-                Distinct project=[person2id] // { arity: 1 }
+              ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
+                Distinct project=[#0{person2id}] // { arity: 1 }
                   Threshold // { arity: 1 }
                     Union // { arity: 1 }
-                      Distinct project=[person2id] // { arity: 1 }
+                      Distinct project=[#0{person2id}] // { arity: 1 }
                         Project (#6) // { arity: 1 }
-                          Join on=(person2id = person1id AND person2id = person1id) type=differential // { arity: 7 }
+                          Join on=(#0{person2id} = #2{person1id} AND #3{person2id} = #5{person1id}) type=differential // { arity: 7 }
                             implementation
                               %0:l2[#0]UKA » %1:l0[#1]KA » %2:l0[#1]KA
-                            ArrangeBy keys=[[person2id]] // { arity: 1 }
+                            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
                               Get l2 // { arity: 1 }
                             Get l0 // { arity: 3 }
                             Get l0 // { arity: 3 }
                       Negate // { arity: 1 }
                         Get l2 // { arity: 1 }
-              ArrangeBy keys=[[id]] // { arity: 1 }
-                Distinct project=[id] // { arity: 1 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                Distinct project=[#0{id}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (name = "Italy") AND (id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 19 }
-                      Join on=(locationcityid = id AND partofcountryid = id) type=delta // { arity: 19 }
+                    Filter (#16{name} = "Italy") AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 19 }
+                      Join on=(#8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 19 }
                         implementation
                           %0:person » %1:city[#0]KA » %2:country[#0]KAef
                           %1:city » %2:country[#0]KAef » %0:person[#8]KA
                           %2:country » %1:city[#3]KA » %0:person[#8]KA
-                        ArrangeBy keys=[[locationcityid]] // { arity: 11 }
+                        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
                           ReadIndex on=person person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-                        ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
                           ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[id]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-                Distinct project=[creatorpersonid, messageid] // { arity: 2 }
+              ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
+                Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                   Project (#1, #9) // { arity: 2 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-              ArrangeBy keys=[[messageid]] // { arity: 1 }
-                Distinct project=[messageid] // { arity: 1 }
+              ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+                Distinct project=[#0{messageid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (tagid) IS NOT NULL AND (typetagclassid) IS NOT NULL // { arity: 12 }
-                      Join on=(tagid = id AND typetagclassid = id) type=delta // { arity: 12 }
+                    Filter (#2{tagid}) IS NOT NULL AND (#6{typetagclassid}) IS NOT NULL // { arity: 12 }
+                      Join on=(#2{tagid} = #3{id} AND #6{typetagclassid} = #7{id}) type=delta // { arity: 12 }
                         implementation
                           %0:message_hastag_tag » %1:tag[#0]KA » %2:tagclass[#0]KAe
                           %1:tag » %2:tagclass[#0]KAe » %0:message_hastag_tag[#2]KA
                           %2:tagclass » %1:tag[#3]KA » %0:message_hastag_tag[#2]KA
-                        ArrangeBy keys=[[tagid]] // { arity: 3 }
+                        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                           ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[delta join 1st input (full scan)] // { arity: 3 }
-                        ArrangeBy keys=[[id], [typetagclassid]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}], [#3{typetagclassid}]] // { arity: 4 }
                           ReadIndex on=tag tag_id=[delta join lookup] tag_typetagclassid=[delta join lookup] // { arity: 4 }
-                        ArrangeBy keys=[[id]] // { arity: 5 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                           ReadIndex on=materialize.public.tagclass tagclass_name=[lookup value=("Thing")] // { arity: 5 }
-              ArrangeBy keys=[[messageid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{messageid}]] // { arity: 3 }
                 ReadIndex on=message_hastag_tag message_hastag_tag_messageid=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=tag tag_id=[differential join] // { arity: 4 }
     With
       cte l2 =
-        Distinct project=[person2id] // { arity: 1 }
+        Distinct project=[#0{person2id}] // { arity: 1 }
           Union // { arity: 1 }
             Get l1 // { arity: 1 }
             Project (#3) // { arity: 1 }
-              Join on=(person2id = person1id) type=differential // { arity: 4 }
+              Join on=(#0{person2id} = #2{person1id}) type=differential // { arity: 4 }
                 implementation
                   %1:l0[#1]KA » %0:l1[#0]Ke
-                ArrangeBy keys=[[person2id]] // { arity: 1 }
+                ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
                   Get l1 // { arity: 1 }
                 Get l0 // { arity: 3 }
       cte l1 =
         Project (#2) // { arity: 1 }
           ReadIndex on=materialize.public.person_knows_person person_knows_person_person1id=[lookup value=(6597069770479)] // { arity: 4 }
       cte l0 =
-        ArrangeBy keys=[[person1id]] // { arity: 3 }
+        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[differential join, lookup] // { arity: 3 }
 
 Used Indexes:
@@ -1822,34 +1822,34 @@ Explained Query:
     cte l2 =
       Reduce aggregates=[count(*)] // { arity: 1 }
         Project () // { arity: 0 }
-          Join on=(id = person2id AND person2id = id AND person2id = id) type=differential // { arity: 6 }
+          Join on=(#0{id} = #5{person2id} AND #1{person2id} = #2{id} AND #3{person2id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l1[#1]Kf » %1:l1[#0]Kf » %2:l0[#0, #1]KKf
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
               Get l0 // { arity: 2 }
     cte l1 =
-      Filter (id < person2id) // { arity: 2 }
+      Filter (#0{id} < #1{person2id}) // { arity: 2 }
         Get l0 // { arity: 2 }
     cte l0 =
       Project (#1, #21) // { arity: 2 }
-        Filter (name = "India") AND (creationdate <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= creationdate) AND (id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 22 }
-          Join on=(id = person1id AND locationcityid = id AND partofcountryid = id) type=delta // { arity: 22 }
+        Filter (#16{name} = "India") AND (#19{creationdate} <= 2013-01-10 00:00:00 UTC) AND (2012-09-28 00:00:00 UTC <= #19{creationdate}) AND (#1{id}) IS NOT NULL AND (#8{locationcityid}) IS NOT NULL AND (#14{partofcountryid}) IS NOT NULL // { arity: 22 }
+          Join on=(#1{id} = #20{person1id} AND #8{locationcityid} = #11{id} AND #14{partofcountryid} = #15{id}) type=delta // { arity: 22 }
             implementation
               %0:person » %3:person_knows_person[#1]KAiif » %1:city[#0]KA » %2:country[#0]KAef
               %1:city » %2:country[#0]KAef » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %2:country » %1:city[#3]KA » %0:person[#8]KA » %3:person_knows_person[#1]KAiif
               %3:person_knows_person » %0:person[#1]KA » %1:city[#0]KA » %2:country[#0]KAef
-            ArrangeBy keys=[[id], [locationcityid]] // { arity: 11 }
+            ArrangeBy keys=[[#1{id}], [#8{locationcityid}]] // { arity: 11 }
               ReadIndex on=person person_id=[delta join 1st input (full scan)] person_locationcityid=[delta join 1st input (full scan)] // { arity: 11 }
-            ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
+            ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
               ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[id]] // { arity: 4 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 4 }
               ReadIndex on=country country_id=[delta join lookup] // { arity: 4 }
-            ArrangeBy keys=[[person1id]] // { arity: 3 }
+            ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -1903,18 +1903,18 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[id] aggregates=[count(messageid)] // { arity: 2 }
+          Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#1) // { arity: 1 }
-                      Join on=(id = id) type=differential // { arity: 12 }
+                      Join on=(#1{id} = #11{id}) type=differential // { arity: 12 }
                         implementation
                           %1[#0]UKA » %0:l0[#1]KA
                         Get l0 // { arity: 11 }
-                        ArrangeBy keys=[[id]] // { arity: 1 }
-                          Distinct project=[id] // { arity: 1 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                          Distinct project=[#0{id}] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#1) // { arity: 1 }
@@ -1923,15 +1923,15 @@ Explained Query:
     With
       cte l1 =
         Project (#1, #12) // { arity: 2 }
-          Filter (length < 120) AND (creationdate > 2012-06-03 00:00:00 UTC) AND (id) IS NOT NULL AND (content) IS NOT NULL // { arity: 25 }
-            Join on=(id = creatorpersonid) type=differential // { arity: 25 }
+          Filter (#19{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#1{id}) IS NOT NULL AND (#15{content}) IS NOT NULL // { arity: 25 }
+            Join on=(#1{id} = #20{creatorpersonid}) type=differential // { arity: 25 }
               implementation
                 %1:message[#9]KAeiif » %0:l0[#1]KAeiif
               Get l0 // { arity: 11 }
-              ArrangeBy keys=[[creatorpersonid]] // { arity: 14 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 14 }
                 ReadIndex on=materialize.public.message message_rootpostlanguage=[lookup values=[("es"); ("pt"); ("ta")]] // { arity: 14 }
       cte l0 =
-        ArrangeBy keys=[[id]] // { arity: 11 }
+        ArrangeBy keys=[[#1{id}]] // { arity: 11 }
           ReadIndex on=person person_id=[differential join] // { arity: 11 }
 
 Used Indexes:
@@ -1969,41 +1969,41 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[id] aggregates=[count(messageid)] // { arity: 2 }
+          Reduce group_by=[#0{id}] aggregates=[count(#1{messageid})] // { arity: 2 }
             Union // { arity: 2 }
               Project (#1, #11) // { arity: 2 }
                 Get l1 // { arity: 12 }
               Project (#1, #22) // { arity: 2 }
                 Map (null) // { arity: 23 }
-                  Join on=(creationdate = creationdate AND id = id AND firstname = firstname AND lastname = lastname AND gender = gender AND birthday = birthday AND locationip = locationip AND browserused = browserused AND locationcityid = locationcityid AND speaks = speaks AND email = email) type=differential // { arity: 22 }
+                  Join on=(#0{creationdate} = #11{creationdate} AND #1{id} = #12{id} AND #2{firstname} = #13{firstname} AND #3{lastname} = #14{lastname} AND #4{gender} = #15{gender} AND #5{birthday} = #16{birthday} AND #6{locationip} = #17{locationip} AND #7{browserused} = #18{browserused} AND #8{locationcityid} = #19{locationcityid} AND #9{speaks} = #20{speaks} AND #10{email} = #21{email}) type=differential // { arity: 22 }
                     implementation
                       %0[#0..=#10]KKKKKKKKKKK » %1:person[#0..=#10]KKKKKKKKKKK
-                    ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
+                    ArrangeBy keys=[[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}]] // { arity: 11 }
                       Union // { arity: 11 }
                         Negate // { arity: 11 }
-                          Distinct project=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
+                          Distinct project=[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}] // { arity: 11 }
                             Project (#0..=#10) // { arity: 11 }
                               Get l1 // { arity: 12 }
-                        Distinct project=[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email] // { arity: 11 }
+                        Distinct project=[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}] // { arity: 11 }
                           ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
-                    ArrangeBy keys=[[creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, locationcityid, speaks, email]] // { arity: 11 }
+                    ArrangeBy keys=[[#0{creationdate}, #1{id}, #2{firstname}, #3{lastname}, #4{gender}, #5{birthday}, #6{locationip}, #7{browserused}, #8{locationcityid}, #9{speaks}, #10{email}]] // { arity: 11 }
                       ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
     With
       cte l1 =
         Project (#0..=#11) // { arity: 12 }
-          Join on=(rootpostlanguage = rootpostlanguage) type=differential // { arity: 14 }
+          Join on=(#12{rootpostlanguage} = #13{rootpostlanguage}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:l0[#12]Kiif
-            ArrangeBy keys=[[rootpostlanguage]] // { arity: 13 }
+            ArrangeBy keys=[[#12{rootpostlanguage}]] // { arity: 13 }
               Project (#0..=#10, #12, #13) // { arity: 13 }
-                Filter (length < 120) AND (creationdate > 2012-06-03 00:00:00 UTC) AND (content) IS NOT NULL AND (id = creatorpersonid) // { arity: 17 }
+                Filter (#15{length} < 120) AND (#11{creationdate} > 2012-06-03 00:00:00 UTC) AND (#14{content}) IS NOT NULL AND (#1{id} = #16{creatorpersonid}) // { arity: 17 }
                   Get l0 // { arity: 17 }
-            ArrangeBy keys=[[rootpostlanguage]] // { arity: 1 }
-              Distinct project=[rootpostlanguage] // { arity: 1 }
+            ArrangeBy keys=[[#0{rootpostlanguage}]] // { arity: 1 }
+              Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (rootpostlanguage = varchar_to_text(#1)) // { arity: 2 }
+                  Filter (#0{rootpostlanguage} = varchar_to_text(#1)) // { arity: 2 }
                     FlatMap unnest_array({"es", "ta", "pt"}) // { arity: 2 }
-                      Distinct project=[rootpostlanguage] // { arity: 1 }
+                      Distinct project=[#0{rootpostlanguage}] // { arity: 1 }
                         Project (#13) // { arity: 1 }
                           Get l0 // { arity: 17 }
       cte l0 =
@@ -2063,7 +2063,7 @@ SELECT Z.zombieid AS "zombie.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, id asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #3..=#5) // { arity: 4 }
         Map (coalesce(#2, 0), coalesce(#1, 0), case when (#1 > 0) then (bigint_to_double(#2) / bigint_to_double(#1)) else 0 end) // { arity: 6 }
@@ -2078,19 +2078,19 @@ Explained Query:
     With
       cte l8 =
         Project (#0, #2, #3) // { arity: 3 }
-          Join on=(id = creatorpersonid) type=differential // { arity: 4 }
+          Join on=(#0{id} = #1{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %1[#0]UKA » %0:l4[#0]K
             Get l4 // { arity: 1 }
-            ArrangeBy keys=[[creatorpersonid]] // { arity: 3 }
-              Reduce group_by=[creatorpersonid] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
+            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 3 }
+              Reduce group_by=[#0{creatorpersonid}] aggregates=[count(*), sum(case when #1 then 1 else 0 end)] // { arity: 3 }
                 Project (#1, #3) // { arity: 2 }
-                  Join on=(id = id) type=differential // { arity: 4 }
+                  Join on=(#0{id} = #2{id}) type=differential // { arity: 4 }
                     implementation
                       %0:l5[#0]K » %1[#0]K
-                    ArrangeBy keys=[[id]] // { arity: 2 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
                       Get l5 // { arity: 2 }
-                    ArrangeBy keys=[[id]] // { arity: 2 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 2 }
                       Union // { arity: 2 }
                         Map (true) // { arity: 2 }
                           Get l7 // { arity: 1 }
@@ -2101,88 +2101,88 @@ Explained Query:
                             Get l6 // { arity: 1 }
       cte l7 =
         Project (#0) // { arity: 1 }
-          Join on=(id = id) type=differential // { arity: 2 }
+          Join on=(#0{id} = #1{id}) type=differential // { arity: 2 }
             implementation
               %0:l6[#0]UKA » %1[#0]UKA
-            ArrangeBy keys=[[id]] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
               Get l6 // { arity: 1 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Get l3 // { arity: 1 }
       cte l6 =
-        Distinct project=[id] // { arity: 1 }
+        Distinct project=[#0{id}] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l5 // { arity: 2 }
       cte l5 =
         Project (#1, #23) // { arity: 2 }
-          Filter (creationdate < 2012-11-09 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 28 }
-            Join on=(id = personid AND messageid = messageid AND creatorpersonid = id) type=delta // { arity: 28 }
+          Filter (#0{creationdate} < 2012-11-09 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 28 }
+            Join on=(#1{id} = #12{personid} AND #13{messageid} = #15{messageid} AND #23{creatorpersonid} = #27{id}) type=delta // { arity: 28 }
               implementation
                 %0:person » %1:person_likes_message[#1]KA » %2:message[#1]KA » %3:l4[#0]KA
                 %1:person_likes_message » %0:person[#1]KAif » %2:message[#1]KA » %3:l4[#0]KA
                 %2:message » %1:person_likes_message[#2]KA » %0:person[#1]KAif » %3:l4[#0]KA
                 %3:l4 » %2:message[#9]KA » %1:person_likes_message[#2]KA » %0:person[#1]KAif
-              ArrangeBy keys=[[id]] // { arity: 11 }
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
                 ReadIndex on=person person_id=[delta join 1st input (full scan)] // { arity: 11 }
-              ArrangeBy keys=[[personid], [messageid]] // { arity: 3 }
+              ArrangeBy keys=[[#1{personid}], [#2{messageid}]] // { arity: 3 }
                 ReadIndex on=person_likes_message person_likes_message_personid=[delta join lookup] person_likes_message_messageid=[delta join lookup] // { arity: 3 }
-              ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
+              ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
                 ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
               Get l4 // { arity: 1 }
       cte l4 =
-        ArrangeBy keys=[[id]] // { arity: 1 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
           Get l3 // { arity: 1 }
       cte l3 =
-        Filter (id) IS NOT NULL // { arity: 1 }
+        Filter (#0{id}) IS NOT NULL // { arity: 1 }
           Get l2 // { arity: 1 }
       cte l2 =
         Project (#0) // { arity: 1 }
-          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(creationdate)) + extract_month_tstz(creationdate))) + 1)) // { arity: 3 }
-            Reduce group_by=[id, creationdate] aggregates=[count(messageid)] // { arity: 3 }
+          Filter (bigint_to_numeric(#2) < ((24155 - ((12 * extract_year_tstz(#1{creationdate})) + extract_month_tstz(#1{creationdate}))) + 1)) // { arity: 3 }
+            Reduce group_by=[#1{id}, #0{creationdate}] aggregates=[count(#2{messageid})] // { arity: 3 }
               Union // { arity: 3 }
                 Project (#6, #7, #16) // { arity: 3 }
                   Get l1 // { arity: 17 }
                 Project (#6, #7, #32) // { arity: 3 }
                   Map (null) // { arity: 33 }
-                    Join on=(id = id AND url = url AND partofcontinentid = partofcontinentid AND id = id AND name = name AND url = url AND creationdate = creationdate AND id = id AND firstname = firstname AND lastname = lastname AND gender = gender AND birthday = birthday AND locationip = locationip AND browserused = browserused AND speaks = speaks AND email = email) type=differential // { arity: 32 }
+                    Join on=(#0{id} = #16{id} AND #1{url} = #17{url} AND #2{partofcontinentid} = #18{partofcontinentid} AND #3{id} = #19{id} AND #4{name} = #20{name} AND #5{url} = #21{url} AND #6{creationdate} = #22{creationdate} AND #7{id} = #23{id} AND #8{firstname} = #24{firstname} AND #9{lastname} = #25{lastname} AND #10{gender} = #26{gender} AND #11{birthday} = #27{birthday} AND #12{locationip} = #28{locationip} AND #13{browserused} = #29{browserused} AND #14{speaks} = #30{speaks} AND #15{email} = #31{email}) type=differential // { arity: 32 }
                       implementation
                         %0[#0..=#15]KKKKKKKKKKKKKKKK » %1:l0[#0..=#15]KKKKKKKKKKKKKKKK
-                      ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
+                      ArrangeBy keys=[[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}]] // { arity: 16 }
                         Union // { arity: 16 }
                           Negate // { arity: 16 }
-                            Distinct project=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
+                            Distinct project=[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}] // { arity: 16 }
                               Project (#0..=#15) // { arity: 16 }
-                                Filter (id = id) AND (id = id) // { arity: 17 }
+                                Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 17 }
                                   Get l1 // { arity: 17 }
-                          Distinct project=[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email] // { arity: 16 }
-                            Filter (id = id) AND (id = id) // { arity: 16 }
+                          Distinct project=[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}] // { arity: 16 }
+                            Filter (#0{id} = #0{id}) AND (#3{id} = #3{id}) // { arity: 16 }
                               Get l0 // { arity: 16 }
-                      ArrangeBy keys=[[id, url, partofcontinentid, id, name, url, creationdate, id, firstname, lastname, gender, birthday, locationip, browserused, speaks, email]] // { arity: 16 }
+                      ArrangeBy keys=[[#0{id}, #1{url}, #2{partofcontinentid}, #3{id}, #4{name}, #5{url}, #6{creationdate}, #7{id}, #8{firstname}, #9{lastname}, #10{gender}, #11{birthday}, #12{locationip}, #13{browserused}, #14{speaks}, #15{email}]] // { arity: 16 }
                         Get l0 // { arity: 16 }
       cte l1 =
         Project (#0..=#15, #17) // { arity: 17 }
-          Filter (creationdate <= 2012-11-09 00:00:00 UTC) AND (creationdate >= creationdate) // { arity: 29 }
-            Join on=(id = creatorpersonid) type=differential // { arity: 29 }
+          Filter (#16{creationdate} <= 2012-11-09 00:00:00 UTC) AND (#16{creationdate} >= #6{creationdate}) // { arity: 29 }
+            Join on=(#7{id} = #25{creatorpersonid}) type=differential // { arity: 29 }
               implementation
                 %1:message[#9]KAif » %0:l0[#7]Kif
-              ArrangeBy keys=[[id]] // { arity: 16 }
-                Filter (id) IS NOT NULL // { arity: 16 }
+              ArrangeBy keys=[[#7{id}]] // { arity: 16 }
+                Filter (#7{id}) IS NOT NULL // { arity: 16 }
                   Get l0 // { arity: 16 }
-              ArrangeBy keys=[[creatorpersonid]] // { arity: 13 }
+              ArrangeBy keys=[[#9{creatorpersonid}]] // { arity: 13 }
                 ReadIndex on=message message_creatorpersonid=[differential join] // { arity: 13 }
       cte l0 =
         Project (#0, #2..=#6, #8..=#15, #17, #18) // { arity: 16 }
-          Filter (name = "India") AND (creationdate < 2012-11-09 00:00:00 UTC) AND (id) IS NOT NULL AND (id) IS NOT NULL // { arity: 19 }
-            Join on=(id = partofcountryid AND id = locationcityid) type=delta // { arity: 19 }
+          Filter (#1{name} = "India") AND (#8{creationdate} < 2012-11-09 00:00:00 UTC) AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL // { arity: 19 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid}) type=delta // { arity: 19 }
               implementation
                 %0:country » %1:city[#3]KA » %2:person[#8]KAif
                 %1:city » %0:country[#0]KAef » %2:person[#8]KAif
                 %2:person » %1:city[#0]KA » %0:country[#0]KAef
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=country country_id=[delta join 1st input (full scan)] // { arity: 4 }
-              ArrangeBy keys=[[id], [partofcountryid]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}], [#3{partofcountryid}]] // { arity: 4 }
                 ReadIndex on=city city_id=[delta join lookup] city_partofcountryid=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[locationcityid]] // { arity: 11 }
+              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[delta join lookup] // { arity: 11 }
 
 Used Indexes:
@@ -2265,10 +2265,10 @@ SELECT score_ranks.Person1Id AS "person1.id"
  LIMIT 100
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, id asc nulls_last, person2id asc nulls_last] limit=100 output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=100 output=[#0..=#3]
     Return // { arity: 4 }
       Project (#0, #1, #3, #4) // { arity: 4 }
-        TopK group_by=[id] order_by=[#4 desc nulls_first, id asc nulls_last, person2id asc nulls_last] limit=1 // { arity: 5 }
+        TopK group_by=[#2{id}] order_by=[#4 desc nulls_first, #0{id} asc nulls_last, #1{person2id} asc nulls_last] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Map (null) // { arity: 5 }
               Union // { arity: 4 }
@@ -2282,20 +2282,20 @@ Explained Query:
     With
       cte l9 =
         Project (#0..=#3, #6) // { arity: 5 }
-          Join on=(id = #4 AND person2id = #5) type=differential // { arity: 7 }
+          Join on=(#2{id} = #4 AND #3{person2id} = #5) type=differential // { arity: 7 }
             implementation
               %1[#0, #1]UKKA » %0:l1[#2, #3]KK
-            ArrangeBy keys=[[id, person2id]] // { arity: 4 }
+            ArrangeBy keys=[[#2{id}, #3{person2id}]] // { arity: 4 }
               Get l1 // { arity: 4 }
             ArrangeBy keys=[[#0, #1]] // { arity: 3 }
               Reduce group_by=[#1, #2] aggregates=[sum((case when #3 then case when #0 then 1 else 4 end else 0 end + case when #4 then case when #0 then 1 else 10 end else 0 end))] // { arity: 3 }
                 Project (#2..=#5, #8) // { arity: 5 }
-                  Join on=(id = id AND person2id = person2id) type=differential // { arity: 9 }
+                  Join on=(#0{id} = #6{id} AND #1{person2id} = #7{person2id}) type=differential // { arity: 9 }
                     implementation
                       %0:l6[#0, #1]KK » %1[#0, #1]KK
-                    ArrangeBy keys=[[id, person2id]] // { arity: 6 }
+                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 6 }
                       Get l6 // { arity: 6 }
-                    ArrangeBy keys=[[id, person2id]] // { arity: 3 }
+                    ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
                       Union // { arity: 3 }
                         Map (true) // { arity: 3 }
                           Get l8 // { arity: 2 }
@@ -2306,32 +2306,32 @@ Explained Query:
                             Get l7 // { arity: 2 }
       cte l8 =
         Project (#0, #1) // { arity: 2 }
-          Join on=(id = personid AND person2id = creatorpersonid) type=differential // { arity: 4 }
+          Join on=(#0{id} = #2{personid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l7[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
               Get l7 // { arity: 2 }
-            ArrangeBy keys=[[personid, creatorpersonid]] // { arity: 2 }
-              Distinct project=[personid, creatorpersonid] // { arity: 2 }
+            ArrangeBy keys=[[#0{personid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{personid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9, #14) // { arity: 2 }
-                  Join on=(messageid = messageid) type=differential // { arity: 16 }
+                  Join on=(#1{messageid} = #15{messageid}) type=differential // { arity: 16 }
                     implementation
                       %0:l4[#1]KA » %1:person_likes_message[#2]KA
                     Get l4 // { arity: 13 }
-                    ArrangeBy keys=[[messageid]] // { arity: 3 }
+                    ArrangeBy keys=[[#2{messageid}]] // { arity: 3 }
                       ReadIndex on=person_likes_message person_likes_message_messageid=[differential join] // { arity: 3 }
       cte l7 =
-        Distinct project=[id, person2id] // { arity: 2 }
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l6 // { arity: 6 }
       cte l6 =
         Project (#0..=#4, #7) // { arity: 6 }
-          Join on=(id = id AND person2id = person2id) type=differential // { arity: 8 }
+          Join on=(#0{id} = #5{id} AND #1{person2id} = #6{person2id}) type=differential // { arity: 8 }
             implementation
               %0:l2[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[id, person2id]] // { arity: 5 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 5 }
               Get l2 // { arity: 5 }
-            ArrangeBy keys=[[id, person2id]] // { arity: 3 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 3 }
               Union // { arity: 3 }
                 Map (true) // { arity: 3 }
                   Get l5 // { arity: 2 }
@@ -2342,30 +2342,30 @@ Explained Query:
                     Get l3 // { arity: 2 }
       cte l5 =
         Project (#0, #1) // { arity: 2 }
-          Join on=(id = creatorpersonid AND person2id = creatorpersonid) type=differential // { arity: 4 }
+          Join on=(#0{id} = #2{creatorpersonid} AND #1{person2id} = #3{creatorpersonid}) type=differential // { arity: 4 }
             implementation
               %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-            ArrangeBy keys=[[id, person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}, #1{person2id}]] // { arity: 2 }
               Get l3 // { arity: 2 }
-            ArrangeBy keys=[[creatorpersonid, creatorpersonid]] // { arity: 2 }
-              Distinct project=[creatorpersonid, creatorpersonid] // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{creatorpersonid}] // { arity: 2 }
                 Project (#9, #22) // { arity: 2 }
-                  Filter (messageid) IS NOT NULL // { arity: 26 }
-                    Join on=(messageid = parentmessageid) type=differential // { arity: 26 }
+                  Filter (#1{messageid}) IS NOT NULL // { arity: 26 }
+                    Join on=(#1{messageid} = #25{parentmessageid}) type=differential // { arity: 26 }
                       implementation
                         %0:l4[#1]KA » %1:message[#12]KA
                       Get l4 // { arity: 13 }
-                      ArrangeBy keys=[[parentmessageid]] // { arity: 13 }
+                      ArrangeBy keys=[[#12{parentmessageid}]] // { arity: 13 }
                         ReadIndex on=message message_parentmessageid=[differential join] // { arity: 13 }
       cte l4 =
-        ArrangeBy keys=[[messageid]] // { arity: 13 }
+        ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
           ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
       cte l3 =
-        Distinct project=[id, person2id] // { arity: 2 }
+        Distinct project=[#0{id}, #1{person2id}] // { arity: 2 }
           Project (#0, #1) // { arity: 2 }
             Get l2 // { arity: 5 }
       cte l2 =
-        Map (case when #2 then person2id else id end, case when #2 then id else person2id end) // { arity: 5 }
+        Map (case when #2 then #1{person2id} else #0{id} end, case when #2 then #0{id} else #1{person2id} end) // { arity: 5 }
           Union // { arity: 3 }
             Project (#2..=#4) // { arity: 3 }
               Map (false) // { arity: 5 }
@@ -2375,24 +2375,24 @@ Explained Query:
                 Get l1 // { arity: 4 }
       cte l1 =
         Project (#4, #5, #9, #21) // { arity: 4 }
-          Filter (name = "Philippines") AND (name = "Taiwan") AND (id) IS NOT NULL AND (id) IS NOT NULL AND (id) IS NOT NULL AND (person2id) IS NOT NULL AND (locationcityid) IS NOT NULL AND (partofcountryid) IS NOT NULL // { arity: 41 }
-            Join on=(id = partofcountryid AND id = locationcityid AND id = person1id AND person2id = id AND locationcityid = id AND partofcountryid = id) type=differential // { arity: 41 }
+          Filter (#1{name} = "Philippines") AND (#38{name} = "Taiwan") AND (#0{id}) IS NOT NULL AND (#4{id}) IS NOT NULL AND (#9{id}) IS NOT NULL AND (#21{person2id}) IS NOT NULL AND (#30{locationcityid}) IS NOT NULL AND (#36{partofcountryid}) IS NOT NULL // { arity: 41 }
+            Join on=(#0{id} = #7{partofcountryid} AND #4{id} = #16{locationcityid} AND #9{id} = #20{person1id} AND #21{person2id} = #23{id} AND #30{locationcityid} = #33{id} AND #36{partofcountryid} = #37{id}) type=differential // { arity: 41 }
               implementation
                 %0:l0[#0]KAef » %1:city[#3]KAef » %2:person[#8]KAef » %3:person_knows_person[#1]KAef » %4:person[#1]KAef » %5:city[#0]KAef » %6:l0[#0]KAef
               Get l0 // { arity: 4 }
-              ArrangeBy keys=[[partofcountryid]] // { arity: 4 }
+              ArrangeBy keys=[[#3{partofcountryid}]] // { arity: 4 }
                 ReadIndex on=city city_partofcountryid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[locationcityid]] // { arity: 11 }
+              ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
                 ReadIndex on=person person_locationcityid=[differential join] // { arity: 11 }
-              ArrangeBy keys=[[person1id]] // { arity: 3 }
+              ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
-              ArrangeBy keys=[[id]] // { arity: 11 }
+              ArrangeBy keys=[[#1{id}]] // { arity: 11 }
                 ReadIndex on=person person_id=[differential join] // { arity: 11 }
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=city city_id=[differential join] // { arity: 4 }
               Get l0 // { arity: 4 }
       cte l0 =
-        ArrangeBy keys=[[id]] // { arity: 4 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
           ReadIndex on=country country_id=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -2476,24 +2476,24 @@ Explained Query:
   Finish order_by=[#1 asc nulls_last] limit=20 output=[#2]
     Return // { arity: 3 }
       Project (#1, #2, #2) // { arity: 3 }
-        Filter (person2id = 15393162796819) AND (#2 = #2) // { arity: 3 }
+        Filter (#1{person2id} = 15393162796819) AND (#2 = #2) // { arity: 3 }
           Get l4 // { arity: 3 }
     With Mutually Recursive
       cte l4 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (1450) // { arity: 3 }
-            Reduce group_by=[person2id] aggregates=[min(#1)] // { arity: 2 }
-              Distinct project=[person2id, #1] // { arity: 2 }
+            Reduce group_by=[#0{person2id}] aggregates=[min(#1)] // { arity: 2 }
+              Distinct project=[#0{person2id}, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
                     Map ((#1 + #4)) // { arity: 6 }
-                      Join on=(#0 = person1id) type=differential // { arity: 5 }
+                      Join on=(#0 = #2{person1id}) type=differential // { arity: 5 }
                         implementation
                           %0:l4[#0]K » %1[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             Get l4 // { arity: 3 }
-                        ArrangeBy keys=[[person1id]] // { arity: 3 }
+                        ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                           Project (#0, #1, #3) // { arity: 3 }
                             Map ((10 / bigint_to_double((coalesce(#2, 0) + 10)))) // { arity: 4 }
                               Union // { arity: 3 }
@@ -2501,13 +2501,13 @@ Explained Query:
                                   Union // { arity: 2 }
                                     Negate // { arity: 2 }
                                       Project (#0, #1) // { arity: 2 }
-                                        Join on=(#2 = least(person1id, person2id) AND #3 = greatest(person1id, person2id)) type=differential // { arity: 4 }
+                                        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                                           implementation
                                             %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
-                                          ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 2 }
+                                          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                                             Get l3 // { arity: 2 }
                                           ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                                            Distinct project=[least(person1id, person2id), greatest(person1id, person2id)] // { arity: 2 }
+                                            Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                                               Project (#0, #1) // { arity: 2 }
                                                 Get l2 // { arity: 3 }
                                     Get l3 // { arity: 2 }
@@ -2519,65 +2519,65 @@ Explained Query:
           ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
       cte l2 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(#2 = least(person1id, person2id) AND #3 = greatest(person1id, person2id)) type=differential // { arity: 5 }
+          Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-            ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 2 }
+            ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
               Project (#1, #2) // { arity: 2 }
                 ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
             ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-              Reduce group_by=[least(person1id, person2id), greatest(person1id, person2id)] aggregates=[sum(case when (parentmessageid) IS NULL then 10 else 5 end)] // { arity: 3 }
+              Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
                 Project (#0..=#2) // { arity: 3 }
-                  Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 6 }
+                  Join on=(eq(#3{containerforumid}, #4{containerforumid}, #5{id})) type=delta // { arity: 6 }
                     implementation
                       %0:l1 » %1[#0]UKA » %2[#0]UKA
                       %1 » %2[#0]UKA » %0:l1[#3]KA
                       %2 » %1[#0]UKA » %0:l1[#3]KA
-                    ArrangeBy keys=[[containerforumid]] // { arity: 4 }
+                    ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
                       Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-                      Distinct project=[containerforumid] // { arity: 1 }
+                    ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+                      Distinct project=[#0{containerforumid}] // { arity: 1 }
                         Project (#3) // { arity: 1 }
-                          Filter (containerforumid) IS NOT NULL // { arity: 4 }
+                          Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
                             Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct project=[id] // { arity: 1 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
                         Project (#1) // { arity: 1 }
-                          Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
+                          Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                             ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l1 =
         Project (#0, #1, #3, #4) // { arity: 4 }
-          Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 7 }
+          Join on=(eq(#2{containerforumid}, #5{containerforumid}, #6{id})) type=delta // { arity: 7 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:l0[#2]KA
               %2 » %1[#0]UKA » %0:l0[#2]KA
-            ArrangeBy keys=[[containerforumid]] // { arity: 5 }
+            ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
               Get l0 // { arity: 5 }
-            ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-              Distinct project=[containerforumid] // { arity: 1 }
+            ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+              Distinct project=[#0{containerforumid}] // { arity: 1 }
                 Project (#2) // { arity: 1 }
-                  Filter (containerforumid) IS NOT NULL // { arity: 5 }
+                  Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
+                  Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                     ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
       cte l0 =
         Project (#1, #2, #13, #15, #17) // { arity: 5 }
-          Join on=(person1id = creatorpersonid AND person2id = creatorpersonid AND messageid = parentmessageid) type=delta // { arity: 19 }
+          Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #16{creatorpersonid} AND #4{messageid} = #18{parentmessageid}) type=delta // { arity: 19 }
             implementation
               %0:person_knows_person » %1:message[#9]KA » %2:message[#0, #2]KKA
               %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KKA
               %2:message » %1:message[#1]KA » %0:person_knows_person[#1, #2]KKA
-            ArrangeBy keys=[[person1id], [person1id, person2id]] // { arity: 3 }
+            ArrangeBy keys=[[#1{person1id}], [#1{person1id}, #2{person2id}]] // { arity: 3 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person1id_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-            ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-            ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 3 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
               Project (#9, #10, #12) // { arity: 3 }
-                Filter (parentmessageid) IS NOT NULL // { arity: 13 }
+                Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                   ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -2715,14 +2715,14 @@ Explained Query:
           Project (#2) // { arity: 1 }
             Reduce group_by=[#0, #2] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(person2id = person2id) type=differential // { arity: 6 }
+                Join on=(#1{person2id} = #4{person2id}) type=differential // { arity: 6 }
                   implementation
                     %0:l18[#1]Kef » %1:l18[#1]Kef
-                  ArrangeBy keys=[[person2id]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l18 // { arity: 4 }
-                  ArrangeBy keys=[[person2id]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{person2id}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l18 // { arity: 4 }
@@ -2742,7 +2742,7 @@ Explained Query:
                     Get l17 // { arity: 6 }
   With Mutually Recursive
     cte l17 =
-      Distinct project=[#0, #1, person2id, #3, #4, #5] // { arity: 6 }
+      Distinct project=[#0, #1, #2{person2id}, #3, #4, #5] // { arity: 6 }
         Union // { arity: 6 }
           Map (0) // { arity: 6 }
             Union // { arity: 5 }
@@ -2778,7 +2778,7 @@ Explained Query:
     cte l16 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Filter #1 AND (person2id = -1) // { arity: 2 }
+          Filter #1 AND (#0{person2id} = -1) // { arity: 2 }
             Get l8 // { arity: 2 }
     cte l15 =
       Project (#1) // { arity: 1 }
@@ -2795,26 +2795,26 @@ Explained Query:
     cte l14 =
       Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
         Project (#1, #3) // { arity: 2 }
-          Join on=(person2id = person2id) type=differential // { arity: 4 }
+          Join on=(#0{person2id} = #2{person2id}) type=differential // { arity: 4 }
             implementation
               %0:l13[#0]Kef » %1:l13[#0]Kef
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = false) // { arity: 5 }
                   Get l13 // { arity: 5 }
-            ArrangeBy keys=[[person2id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 2 }
               Project (#2, #3) // { arity: 2 }
                 Filter (#0 = true) // { arity: 5 }
                   Get l13 // { arity: 5 }
     cte l13 =
-      TopK group_by=[#0, #1, person2id] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+      TopK group_by=[#0, #1, #2{person2id}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
         Union // { arity: 5 }
           Project (#3, #4, #1, #7, #8) // { arity: 5 }
             Map ((#6 + #2), false) // { arity: 9 }
-              Join on=(person1id = #5) type=differential // { arity: 7 }
+              Join on=(#0{person1id} = #5) type=differential // { arity: 7 }
                 implementation
                   %0:l4[#0]K » %1:l9[#2]K
-                ArrangeBy keys=[[person1id]] // { arity: 3 }
+                ArrangeBy keys=[[#0{person1id}]] // { arity: 3 }
                   Get l4 // { arity: 3 }
                 ArrangeBy keys=[[#2]] // { arity: 4 }
                   Project (#0..=#3) // { arity: 4 }
@@ -2868,9 +2868,9 @@ Explained Query:
           Filter (#4 = false) // { arity: 6 }
             Get l17 // { arity: 6 }
     cte l8 =
-      Distinct project=[person2id, #1] // { arity: 2 }
+      Distinct project=[#0{person2id}, #1] // { arity: 2 }
         Union // { arity: 2 }
-          Distinct project=[person2id, #1] // { arity: 2 }
+          Distinct project=[#0{person2id}, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#1, #0) // { arity: 2 }
                 CrossJoin type=differential // { arity: 2 }
@@ -2893,14 +2893,14 @@ Explained Query:
     cte l7 =
       Distinct project=[] // { arity: 0 }
         Project () // { arity: 0 }
-          Join on=(person2id = person2id) type=differential // { arity: 2 }
+          Join on=(#0{person2id} = #1{person2id}) type=differential // { arity: 2 }
             implementation
               %0:l6[#0]Kf » %1:l6[#0]Kf
-            ArrangeBy keys=[[person2id]] // { arity: 1 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter #1 // { arity: 2 }
                   Get l6 // { arity: 2 }
-            ArrangeBy keys=[[person2id]] // { arity: 1 }
+            ArrangeBy keys=[[#0{person2id}]] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Filter NOT(#1) // { arity: 2 }
                   Get l6 // { arity: 2 }
@@ -2911,12 +2911,12 @@ Explained Query:
         Get l8 // { arity: 2 }
     cte l5 =
       Project (#1, #3) // { arity: 2 }
-        Join on=(#0 = person1id) type=differential // { arity: 4 }
+        Join on=(#0 = #2{person1id}) type=differential // { arity: 4 }
           implementation
             %0:l8[#0]K » %1:l4[#0]K
           ArrangeBy keys=[[#0]] // { arity: 2 }
             Get l8 // { arity: 2 }
-          ArrangeBy keys=[[person1id]] // { arity: 2 }
+          ArrangeBy keys=[[#0{person1id}]] // { arity: 2 }
             Project (#0, #1) // { arity: 2 }
               Get l4 // { arity: 3 }
     cte l4 =
@@ -2927,13 +2927,13 @@ Explained Query:
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(#2 = least(person1id, person2id) AND #3 = greatest(person1id, person2id)) type=differential // { arity: 4 }
+                    Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 4 }
                       implementation
                         %1[#1, #0]UKK » %0:l3[greatest(#0, #1), least(#0, #1)]KK
-                      ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 2 }
+                      ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
                         Get l3 // { arity: 2 }
                       ArrangeBy keys=[[#1, #0]] // { arity: 2 }
-                        Distinct project=[least(person1id, person2id), greatest(person1id, person2id)] // { arity: 2 }
+                        Distinct project=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] // { arity: 2 }
                           Project (#0, #1) // { arity: 2 }
                             Get l2 // { arity: 3 }
                 Get l3 // { arity: 2 }
@@ -2943,65 +2943,65 @@ Explained Query:
         ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
     cte l2 =
       Project (#0, #1, #4) // { arity: 3 }
-        Join on=(#2 = least(person1id, person2id) AND #3 = greatest(person1id, person2id)) type=differential // { arity: 5 }
+        Join on=(#2 = least(#0{person1id}, #1{person2id}) AND #3 = greatest(#0{person1id}, #1{person2id})) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:person_knows_person[greatest(#0, #1), least(#0, #1)]KK
-          ArrangeBy keys=[[greatest(person1id, person2id), least(person1id, person2id)]] // { arity: 2 }
+          ArrangeBy keys=[[greatest(#0{person1id}, #1{person2id}), least(#0{person1id}, #1{person2id})]] // { arity: 2 }
             Project (#1, #2) // { arity: 2 }
               ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
           ArrangeBy keys=[[#1, #0]] // { arity: 3 }
-            Reduce group_by=[least(person1id, person2id), greatest(person1id, person2id)] aggregates=[sum(case when (parentmessageid) IS NULL then 10 else 5 end)] // { arity: 3 }
+            Reduce group_by=[least(#0{person1id}, #1{person2id}), greatest(#0{person1id}, #1{person2id})] aggregates=[sum(case when (#2{parentmessageid}) IS NULL then 10 else 5 end)] // { arity: 3 }
               Project (#0..=#2) // { arity: 3 }
-                Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 6 }
+                Join on=(eq(#3{containerforumid}, #4{containerforumid}, #5{id})) type=delta // { arity: 6 }
                   implementation
                     %0:l1 » %1[#0]UKA » %2[#0]UKA
                     %1 » %2[#0]UKA » %0:l1[#3]KA
                     %2 » %1[#0]UKA » %0:l1[#3]KA
-                  ArrangeBy keys=[[containerforumid]] // { arity: 4 }
+                  ArrangeBy keys=[[#3{containerforumid}]] // { arity: 4 }
                     Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-                    Distinct project=[containerforumid] // { arity: 1 }
+                  ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+                    Distinct project=[#0{containerforumid}] // { arity: 1 }
                       Project (#3) // { arity: 1 }
-                        Filter (containerforumid) IS NOT NULL // { arity: 4 }
+                        Filter (#3{containerforumid}) IS NOT NULL // { arity: 4 }
                           Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[id]] // { arity: 1 }
-                    Distinct project=[id] // { arity: 1 }
+                  ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                    Distinct project=[#0{id}] // { arity: 1 }
                       Project (#1) // { arity: 1 }
-                        Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
+                        Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                           ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l1 =
       Project (#0, #1, #3, #4) // { arity: 4 }
-        Join on=(eq(containerforumid, containerforumid, id)) type=delta // { arity: 7 }
+        Join on=(eq(#2{containerforumid}, #5{containerforumid}, #6{id})) type=delta // { arity: 7 }
           implementation
             %0:l0 » %1[#0]UKA » %2[#0]UKA
             %1 » %2[#0]UKA » %0:l0[#2]KA
             %2 » %1[#0]UKA » %0:l0[#2]KA
-          ArrangeBy keys=[[containerforumid]] // { arity: 5 }
+          ArrangeBy keys=[[#2{containerforumid}]] // { arity: 5 }
             Get l0 // { arity: 5 }
-          ArrangeBy keys=[[containerforumid]] // { arity: 1 }
-            Distinct project=[containerforumid] // { arity: 1 }
+          ArrangeBy keys=[[#0{containerforumid}]] // { arity: 1 }
+            Distinct project=[#0{containerforumid}] // { arity: 1 }
               Project (#2) // { arity: 1 }
-                Filter (containerforumid) IS NOT NULL // { arity: 5 }
+                Filter (#2{containerforumid}) IS NOT NULL // { arity: 5 }
                   Get l0 // { arity: 5 }
-          ArrangeBy keys=[[id]] // { arity: 1 }
-            Distinct project=[id] // { arity: 1 }
+          ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+            Distinct project=[#0{id}] // { arity: 1 }
               Project (#1) // { arity: 1 }
-                Filter (creationdate <= 2012-11-10 00:00:00 UTC) AND (creationdate >= 2012-11-06 00:00:00 UTC) AND (id) IS NOT NULL // { arity: 4 }
+                Filter (#0{creationdate} <= 2012-11-10 00:00:00 UTC) AND (#0{creationdate} >= 2012-11-06 00:00:00 UTC) AND (#1{id}) IS NOT NULL // { arity: 4 }
                   ReadIndex on=forum forum_id=[*** full scan ***] // { arity: 4 }
     cte l0 =
       Project (#1, #2, #13, #15, #17) // { arity: 5 }
-        Join on=(person1id = creatorpersonid AND person2id = creatorpersonid AND messageid = parentmessageid) type=delta // { arity: 19 }
+        Join on=(#1{person1id} = #12{creatorpersonid} AND #2{person2id} = #16{creatorpersonid} AND #4{messageid} = #18{parentmessageid}) type=delta // { arity: 19 }
           implementation
             %0:person_knows_person » %1:message[#9]KA » %2:message[#0, #2]KKA
             %1:message » %0:person_knows_person[#1]KA » %2:message[#0, #2]KKA
             %2:message » %1:message[#1]KA » %0:person_knows_person[#1, #2]KKA
-          ArrangeBy keys=[[person1id], [person1id, person2id]] // { arity: 3 }
+          ArrangeBy keys=[[#1{person1id}], [#1{person1id}, #2{person2id}]] // { arity: 3 }
             ReadIndex on=person_knows_person person_knows_person_person1id=[delta join 1st input (full scan)] person_knows_person_person1id_person2id=[delta join 1st input (full scan)] // { arity: 3 }
-          ArrangeBy keys=[[messageid], [creatorpersonid]] // { arity: 13 }
+          ArrangeBy keys=[[#1{messageid}], [#9{creatorpersonid}]] // { arity: 13 }
             ReadIndex on=message message_messageid=[delta join lookup] message_creatorpersonid=[delta join lookup] // { arity: 13 }
-          ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 3 }
+          ArrangeBy keys=[[#0{creatorpersonid}, #2{parentmessageid}]] // { arity: 3 }
             Project (#9, #10, #12) // { arity: 3 }
-              Filter (parentmessageid) IS NOT NULL // { arity: 13 }
+              Filter (#12{parentmessageid}) IS NOT NULL // { arity: 13 }
                 ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
 
 Used Indexes:
@@ -3088,117 +3088,117 @@ ORDER BY personA.cm + personB.cm DESC, PersonId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#6 desc nulls_first, id asc nulls_last] limit=20 output=[#0, #1, #4]
+  Finish order_by=[#6 desc nulls_first, #0{id} asc nulls_last] limit=20 output=[#0, #1, #4]
     Return // { arity: 7 }
       Project (#0..=#2, #0, #4..=#6) // { arity: 7 }
         Filter (#2 <= 5) AND (#5 <= 5) // { arity: 7 }
           Map ((#1 + #4)) // { arity: 7 }
-            Join on=(id = id) type=differential // { arity: 6 }
+            Join on=(#0{id} = #3{id}) type=differential // { arity: 6 }
               implementation
                 %0[#0]UKAif » %1[#0]UKAiif
-              ArrangeBy keys=[[id]] // { arity: 3 }
-                Reduce group_by=[id] aggregates=[count(distinct messageid), count(distinct person2id)] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 3 }
+                Reduce group_by=[#0{id}] aggregates=[count(distinct #1{messageid}), count(distinct #2{person2id})] // { arity: 3 }
                   Union // { arity: 3 }
                     Get l5 // { arity: 3 }
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct project=[id, messageid] // { arity: 2 }
+                          Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l5 // { arity: 3 }
                         Get l3 // { arity: 2 }
-              ArrangeBy keys=[[id]] // { arity: 3 }
-                Reduce group_by=[id] aggregates=[count(distinct messageid), count(distinct person2id)] // { arity: 3 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 3 }
+                Reduce group_by=[#0{id}] aggregates=[count(distinct #1{messageid}), count(distinct #2{person2id})] // { arity: 3 }
                   Union // { arity: 3 }
                     Get l7 // { arity: 3 }
                     Map (null) // { arity: 3 }
                       Union // { arity: 2 }
                         Negate // { arity: 2 }
-                          Distinct project=[id, messageid] // { arity: 2 }
+                          Distinct project=[#0{id}, #1{messageid}] // { arity: 2 }
                             Project (#0, #1) // { arity: 2 }
                               Get l7 // { arity: 3 }
                         Get l6 // { arity: 2 }
     With
       cte l7 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(id = person1id AND person2id = id) type=differential // { arity: 6 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=differential // { arity: 6 }
             implementation
               %0:l6[#0]K » %1:l4[#1]KA » %2[#0]UKA
-            ArrangeBy keys=[[id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
               Get l6 // { arity: 2 }
             Get l4 // { arity: 3 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l6 // { arity: 2 }
       cte l6 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(id = creatorpersonid AND messageid = messageid) type=differential // { arity: 4 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=differential // { arity: 4 }
             implementation
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
-            ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-              Distinct project=[creatorpersonid, messageid] // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
-                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
+                  Filter (2012-12-14 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct project=[messageid] // { arity: 1 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (tagid) IS NOT NULL // { arity: 8 }
-                    Join on=(tagid = id) type=differential // { arity: 8 }
+                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                       implementation
                         %1:tag[#0]KAe » %0:l1[#2]KAe
                       Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[id]] // { arity: 5 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Thailand_Noriega")] // { arity: 5 }
       cte l5 =
         Project (#0, #1, #4) // { arity: 3 }
-          Join on=(id = person1id AND person2id = id) type=differential // { arity: 6 }
+          Join on=(#0{id} = #3{person1id} AND #4{person2id} = #5{id}) type=differential // { arity: 6 }
             implementation
               %0:l3[#0]K » %1:l4[#1]KA » %2[#0]UKA
-            ArrangeBy keys=[[id]] // { arity: 2 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 2 }
               Get l3 // { arity: 2 }
             Get l4 // { arity: 3 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l3 // { arity: 2 }
       cte l4 =
-        ArrangeBy keys=[[person1id]] // { arity: 3 }
+        ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
           ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
       cte l3 =
         Project (#0, #2) // { arity: 2 }
-          Join on=(id = creatorpersonid AND messageid = messageid) type=differential // { arity: 4 }
+          Join on=(#0{id} = #1{creatorpersonid} AND #2{messageid} = #3{messageid}) type=differential // { arity: 4 }
             implementation
               %0:l0[#0]UKA » %1[#0]K » %2[#0]UKA
             Get l0 // { arity: 1 }
-            ArrangeBy keys=[[creatorpersonid]] // { arity: 2 }
-              Distinct project=[creatorpersonid, messageid] // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}]] // { arity: 2 }
+              Distinct project=[#1{creatorpersonid}, #0{messageid}] // { arity: 2 }
                 Project (#1, #9) // { arity: 2 }
-                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(creationdate))) // { arity: 13 }
+                  Filter (2012-10-07 00:00:00 = date_to_timestamp(timestamp_with_time_zone_to_date(#0{creationdate}))) // { arity: 13 }
                     ReadIndex on=message message_messageid=[*** full scan ***] // { arity: 13 }
-            ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct project=[messageid] // { arity: 1 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (tagid) IS NOT NULL // { arity: 8 }
-                    Join on=(tagid = id) type=differential // { arity: 8 }
+                  Filter (#2{tagid}) IS NOT NULL // { arity: 8 }
+                    Join on=(#2{tagid} = #3{id}) type=differential // { arity: 8 }
                       implementation
                         %1:tag[#0]KAe » %0:l1[#2]KAe
                       Get l1 // { arity: 3 }
-                      ArrangeBy keys=[[id]] // { arity: 5 }
+                      ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                         ReadIndex on=materialize.public.tag tag_name=[lookup value=("Diosdado_Macapagal")] // { arity: 5 }
       cte l2 =
-        ArrangeBy keys=[[name]] // { arity: 4 }
+        ArrangeBy keys=[[#1{name}]] // { arity: 4 }
           ReadIndex on=tag tag_name=[lookup] // { arity: 4 }
       cte l1 =
-        ArrangeBy keys=[[tagid]] // { arity: 3 }
+        ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
           ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
       cte l0 =
-        ArrangeBy keys=[[id]] // { arity: 1 }
-          Distinct project=[id] // { arity: 1 }
+        ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+          Distinct project=[#0{id}] // { arity: 1 }
             Project (#1) // { arity: 1 }
-              Filter (id) IS NOT NULL // { arity: 11 }
+              Filter (#1{id}) IS NOT NULL // { arity: 11 }
                 ReadIndex on=person person_id=[*** full scan ***] // { arity: 11 }
 
 Used Indexes:
@@ -3254,75 +3254,75 @@ ORDER BY messageCount DESC, Message1.CreatorPersonId ASC
 LIMIT 10
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, creatorpersonid asc nulls_last] limit=10 output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{creatorpersonid} asc nulls_last] limit=10 output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[creatorpersonid] aggregates=[count(distinct messageid)] // { arity: 2 }
+      Reduce group_by=[#0{creatorpersonid}] aggregates=[count(distinct #1{messageid})] // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(creatorpersonid = creatorpersonid AND containerforumid = containerforumid) type=differential // { arity: 5 }
+          Join on=(#0{creatorpersonid} = #3{creatorpersonid} AND #2{containerforumid} = #4{containerforumid}) type=differential // { arity: 5 }
             implementation
               %0:l2[#0, #2]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 3 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #2{containerforumid}]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 2 }
+            ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(creatorpersonid = personid AND containerforumid = forumid) type=differential // { arity: 4 }
+                    Join on=(#0{creatorpersonid} = #2{personid} AND #1{containerforumid} = #3{forumid}) type=differential // { arity: 4 }
                       implementation
                         %0:l3[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[creatorpersonid, containerforumid]] // { arity: 2 }
+                      ArrangeBy keys=[[#0{creatorpersonid}, #1{containerforumid}]] // { arity: 2 }
                         Get l3 // { arity: 2 }
-                      ArrangeBy keys=[[personid, forumid]] // { arity: 2 }
-                        Distinct project=[personid, forumid] // { arity: 2 }
+                      ArrangeBy keys=[[#0{personid}, #1{forumid}]] // { arity: 2 }
+                        Distinct project=[#1{personid}, #0{forumid}] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[*** full scan ***] // { arity: 3 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct project=[creatorpersonid, containerforumid] // { arity: 2 }
+        Distinct project=[#0{creatorpersonid}, #1{containerforumid}] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
         Project (#1, #4, #6) // { arity: 3 }
-          Filter (containerforumid != containerforumid) AND (creatorpersonid != creatorpersonid) AND ((creationdate + 12:00:00) < creationdate) // { arity: 15 }
-            Join on=(eq(containerforumid, forumid, forumid) AND messageid = parentmessageid AND creatorpersonid = personid AND creatorpersonid = personid) type=differential // { arity: 15 }
+          Filter (#2{containerforumid} != #6{containerforumid}) AND (#5{creatorpersonid} != #7{creatorpersonid}) AND ((#0{creationdate} + 12:00:00) < #3{creationdate}) // { arity: 15 }
+            Join on=(eq(#2{containerforumid}, #10{forumid}, #13{forumid}) AND #4{messageid} = #8{parentmessageid} AND #5{creatorpersonid} = #14{personid} AND #7{creatorpersonid} = #11{personid}) type=differential // { arity: 15 }
               implementation
                 %3:l1[#1]KA » %4:l1[#1]KA » %0:l0[#2]K » %1:l0[#2]K » %2:l0[#0, #1]KK
-              ArrangeBy keys=[[containerforumid]] // { arity: 3 }
+              ArrangeBy keys=[[#2{containerforumid}]] // { arity: 3 }
                 Project (#0, #2, #3) // { arity: 3 }
-                  Filter (containerforumid) IS NOT NULL // { arity: 5 }
+                  Filter (#3{containerforumid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
-              ArrangeBy keys=[[creatorpersonid]] // { arity: 4 }
+              ArrangeBy keys=[[#2{creatorpersonid}]] // { arity: 4 }
                 Project (#0..=#3) // { arity: 4 }
                   Get l0 // { arity: 5 }
-              ArrangeBy keys=[[creatorpersonid, parentmessageid]] // { arity: 2 }
+              ArrangeBy keys=[[#0{creatorpersonid}, #1{parentmessageid}]] // { arity: 2 }
                 Project (#2, #4) // { arity: 2 }
-                  Filter (parentmessageid) IS NOT NULL // { arity: 5 }
+                  Filter (#4{parentmessageid}) IS NOT NULL // { arity: 5 }
                     Get l0 // { arity: 5 }
               Get l1 // { arity: 3 }
               Get l1 // { arity: 3 }
       cte l1 =
-        ArrangeBy keys=[[forumid]] // { arity: 3 }
+        ArrangeBy keys=[[#1{forumid}]] // { arity: 3 }
           ReadIndex on=forum_hasmember_person forum_hasmember_person_forumid=[differential join] // { arity: 3 }
       cte l0 =
         Project (#0, #1, #9, #10, #12) // { arity: 5 }
-          Join on=(messageid = messageid) type=differential // { arity: 14 }
+          Join on=(#1{messageid} = #13{messageid}) type=differential // { arity: 14 }
             implementation
               %1[#0]UKA » %0:message[#1]KA
-            ArrangeBy keys=[[messageid]] // { arity: 13 }
+            ArrangeBy keys=[[#1{messageid}]] // { arity: 13 }
               ReadIndex on=message message_messageid=[differential join] // { arity: 13 }
-            ArrangeBy keys=[[messageid]] // { arity: 1 }
-              Distinct project=[messageid] // { arity: 1 }
+            ArrangeBy keys=[[#0{messageid}]] // { arity: 1 }
+              Distinct project=[#0{messageid}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Join on=(tagid = id) type=differential // { arity: 4 }
+                  Join on=(#2{tagid} = #3{id}) type=differential // { arity: 4 }
                     implementation
                       %1[#0]UKA » %0:message_hastag_tag[#2]KA
-                    ArrangeBy keys=[[tagid]] // { arity: 3 }
+                    ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                       ReadIndex on=message_hastag_tag message_hastag_tag_tagid=[differential join] // { arity: 3 }
-                    ArrangeBy keys=[[id]] // { arity: 1 }
-                      Distinct project=[id] // { arity: 1 }
+                    ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+                      Distinct project=[#0{id}] // { arity: 1 }
                         Project (#0) // { arity: 1 }
-                          Filter (id) IS NOT NULL // { arity: 5 }
+                          Filter (#0{id}) IS NOT NULL // { arity: 5 }
                             ReadIndex on=materialize.public.tag tag_name=[lookup value=("Cosmic_Egg")] // { arity: 5 }
 
 Used Indexes:
@@ -3367,53 +3367,53 @@ ORDER BY mutualFriendCount DESC, k1.InterestedId ASC, k2.InterestedId ASC
 LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[#2 desc nulls_first, personid asc nulls_last, personid asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[#2 desc nulls_first, #0{personid} asc nulls_last, #1{personid} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[personid, personid] aggregates=[count(*)] // { arity: 3 }
+      Reduce group_by=[#0{personid}, #1{personid}] aggregates=[count(*)] // { arity: 3 }
         Project (#0, #1) // { arity: 2 }
-          Join on=(personid = personid AND personid = personid) type=differential // { arity: 4 }
+          Join on=(#0{personid} = #2{personid} AND #1{personid} = #3{personid}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0, #1]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[personid, personid]] // { arity: 2 }
+            ArrangeBy keys=[[#0{personid}, #1{personid}]] // { arity: 2 }
               Get l1 // { arity: 2 }
-            ArrangeBy keys=[[personid, personid]] // { arity: 2 }
+            ArrangeBy keys=[[#0{personid}, #1{personid}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Join on=(personid = person2id AND personid = person1id) type=differential // { arity: 4 }
+                    Join on=(#0{personid} = #2{person2id} AND #1{personid} = #3{person1id}) type=differential // { arity: 4 }
                       implementation
                         %0:l2[#0, #1]UKKA » %1[#0, #1]UKKA
-                      ArrangeBy keys=[[personid, personid]] // { arity: 2 }
+                      ArrangeBy keys=[[#0{personid}, #1{personid}]] // { arity: 2 }
                         Get l2 // { arity: 2 }
-                      ArrangeBy keys=[[person2id, person1id]] // { arity: 2 }
-                        Distinct project=[person2id, person1id] // { arity: 2 }
+                      ArrangeBy keys=[[#0{person2id}, #1{person1id}]] // { arity: 2 }
+                        Distinct project=[#1{person2id}, #0{person1id}] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             ReadIndex on=person_knows_person person_knows_person_person1id=[*** full scan ***] // { arity: 3 }
                 Get l2 // { arity: 2 }
     With
       cte l2 =
-        Distinct project=[personid, personid] // { arity: 2 }
+        Distinct project=[#0{personid}, #1{personid}] // { arity: 2 }
           Get l1 // { arity: 2 }
       cte l1 =
         Project (#0, #2) // { arity: 2 }
-          Filter (personid != personid) // { arity: 4 }
-            Join on=(person2id = person2id) type=differential // { arity: 4 }
+          Filter (#0{personid} != #2{personid}) // { arity: 4 }
+            Join on=(#1{person2id} = #3{person2id}) type=differential // { arity: 4 }
               implementation
                 %0:l0[#1]K » %1:l0[#1]K
               Get l0 // { arity: 2 }
               Get l0 // { arity: 2 }
       cte l0 =
-        ArrangeBy keys=[[person2id]] // { arity: 2 }
+        ArrangeBy keys=[[#1{person2id}]] // { arity: 2 }
           Project (#1, #10) // { arity: 2 }
-            Filter (tagid) IS NOT NULL // { arity: 11 }
-              Join on=(personid = person1id AND tagid = id) type=differential // { arity: 11 }
+            Filter (#2{tagid}) IS NOT NULL // { arity: 11 }
+              Join on=(#1{personid} = #9{person1id} AND #2{tagid} = #3{id}) type=differential // { arity: 11 }
                 implementation
                   %1:tag[#0]KAe » %0:person_hasinterest_tag[#2]KAe » %2:person_knows_person[#1]KAe
-                ArrangeBy keys=[[tagid]] // { arity: 3 }
+                ArrangeBy keys=[[#2{tagid}]] // { arity: 3 }
                   ReadIndex on=person_hasinterest_tag person_hasinterest_tag_tagid=[differential join] // { arity: 3 }
-                ArrangeBy keys=[[id]] // { arity: 5 }
+                ArrangeBy keys=[[#0{id}]] // { arity: 5 }
                   ReadIndex on=materialize.public.tag tag_name=[lookup value=("Fyodor_Dostoyevsky")] // { arity: 5 }
-                ArrangeBy keys=[[person1id]] // { arity: 3 }
+                ArrangeBy keys=[[#1{person1id}]] // { arity: 3 }
                   ReadIndex on=person_knows_person person_knows_person_person1id=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -3512,40 +3512,40 @@ Explained Query:
     With
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(eq(id, id, id)) type=delta // { arity: 5 }
+          Join on=(eq(#1{id}, #3{id}, #4{id})) type=delta // { arity: 5 }
             implementation
               %0:l0 » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:l0[#1]KA
               %2 » %1[#0]UKA » %0:l0[#1]KA
-            ArrangeBy keys=[[id]] // { arity: 3 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (id) IS NOT NULL // { arity: 3 }
+                  Filter (#1{id}) IS NOT NULL // { arity: 3 }
                     Get l0 // { arity: 3 }
-            ArrangeBy keys=[[id]] // { arity: 1 }
-              Distinct project=[id] // { arity: 1 }
+            ArrangeBy keys=[[#0{id}]] // { arity: 1 }
+              Distinct project=[#0{id}] // { arity: 1 }
                 Project (#1) // { arity: 1 }
-                  Filter (id) IS NOT NULL // { arity: 12 }
+                  Filter (#1{id}) IS NOT NULL // { arity: 12 }
                     ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
   With Mutually Recursive
     cte l0 =
-      Reduce group_by=[id, id] aggregates=[min(#2)] // { arity: 3 }
-        Distinct project=[id, id, #2] // { arity: 3 }
+      Reduce group_by=[#0{id}, #1{id}] aggregates=[min(#2)] // { arity: 3 }
+        Distinct project=[#0{id}, #1{id}, #2] // { arity: 3 }
           Union // { arity: 3 }
             Project (#1, #1, #12) // { arity: 3 }
               Map (0) // { arity: 13 }
                 ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
             Project (#0, #4, #6) // { arity: 3 }
-              Map ((#2 + bigint_to_double(w))) // { arity: 7 }
-                Join on=(#1 = src) type=differential // { arity: 6 }
+              Map ((#2 + bigint_to_double(#5{w}))) // { arity: 7 }
+                Join on=(#1 = #3{src}) type=differential // { arity: 6 }
                   implementation
                     %1:pathq19[#0]KA » %0:l0[#1]K
                   ArrangeBy keys=[[#1]] // { arity: 3 }
                     Filter (#1) IS NOT NULL // { arity: 3 }
                       Get l0 // { arity: 3 }
-                  ArrangeBy keys=[[src]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -3639,27 +3639,27 @@ Explained Query:
         Project (#2) // { arity: 1 }
           Get l4 // { arity: 3 }
     cte l4 =
-      Reduce group_by=[id, id] aggregates=[min((#1 + #3))] // { arity: 3 }
+      Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
         Project (#0, #2, #3, #5) // { arity: 4 }
-          Join on=(id = id) type=differential // { arity: 6 }
+          Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
             implementation
               %0:l1[#1]K » %1:l3[#1]K
-            ArrangeBy keys=[[id]] // { arity: 3 }
-              Filter (id) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
                 Get l1 // { arity: 3 }
-            ArrangeBy keys=[[id]] // { arity: 3 }
-              Filter (id) IS NOT NULL // { arity: 3 }
+            ArrangeBy keys=[[#1{id}]] // { arity: 3 }
+              Filter (#1{id}) IS NOT NULL // { arity: 3 }
                 Get l3 // { arity: 3 }
     cte l3 =
-      TopK group_by=[id, id] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1, #1, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(1138)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(w))) // { arity: 8 }
-                Join on=(#1 = src) type=differential // { arity: 7 }
+              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                Join on=(#1 = #4{src}) type=differential // { arity: 7 }
                   implementation
                     %2:pathq19[#0]KA » %0:l3[#1]K » %1[×]
                   ArrangeBy keys=[[#1]] // { arity: 3 }
@@ -3676,7 +3676,7 @@ Explained Query:
                                 Get l2 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-                  ArrangeBy keys=[[src]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
     cte l2 =
       Union // { arity: 1 }
@@ -3690,15 +3690,15 @@ Explained Query:
                 Project () // { arity: 0 }
                   Get l6 // { arity: 1 }
     cte l1 =
-      TopK group_by=[id, id] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
+      TopK group_by=[#0{id}, #1{id}] order_by=[#2 asc nulls_last] limit=1 // { arity: 3 }
         Union // { arity: 3 }
           Project (#1, #1, #12) // { arity: 3 }
             Map (0) // { arity: 13 }
               ReadIndex on=materialize.public.person person_locationcityid=[lookup value=(655)] // { arity: 12 }
           Project (#0, #5, #7) // { arity: 3 }
             Filter coalesce((#2 < #3), true) // { arity: 8 }
-              Map ((#2 + bigint_to_double(w))) // { arity: 8 }
-                Join on=(#1 = src) type=differential // { arity: 7 }
+              Map ((#2 + bigint_to_double(#6{w}))) // { arity: 8 }
+                Join on=(#1 = #4{src}) type=differential // { arity: 7 }
                   implementation
                     %2:pathq19[#0]KA » %0:l1[#1]K » %1[×]
                   ArrangeBy keys=[[#1]] // { arity: 3 }
@@ -3715,7 +3715,7 @@ Explained Query:
                                 Get l0 // { arity: 1 }
                           Constant // { arity: 0 }
                             - ()
-                  ArrangeBy keys=[[src]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
     cte l0 =
       Union // { arity: 1 }
@@ -3789,7 +3789,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
 SELECT * FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY f, t
 ----
 Explained Query:
-  Finish order_by=[id asc nulls_last, id asc nulls_last] output=[#0..=#2]
+  Finish order_by=[#0{id} asc nulls_last, #1{id} asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
@@ -3806,16 +3806,16 @@ Explained Query:
                     Get l10 // { arity: 3 }
       With
         cte l10 =
-          Reduce group_by=[id, id] aggregates=[min((#1 + #3))] // { arity: 3 }
+          Reduce group_by=[#0{id}, #2{id}] aggregates=[min((#1 + #3))] // { arity: 3 }
             Project (#0, #2, #3, #5) // { arity: 4 }
-              Join on=(id = id) type=differential // { arity: 6 }
+              Join on=(#1{id} = #4{id}) type=differential // { arity: 6 }
                 implementation
                   %0:l9[#1]Kef » %1:l9[#1]Kef
-                ArrangeBy keys=[[id]] // { arity: 3 }
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
                   Project (#1..=#3) // { arity: 3 }
                     Filter (#0 = false) // { arity: 4 }
                       Get l9 // { arity: 4 }
-                ArrangeBy keys=[[id]] // { arity: 3 }
+                ArrangeBy keys=[[#1{id}]] // { arity: 3 }
                   Project (#1..=#3) // { arity: 3 }
                     Filter (#0 = true) // { arity: 4 }
                       Get l9 // { arity: 4 }
@@ -3826,7 +3826,7 @@ Explained Query:
                 %1[#0]UK » %0:l8[#4]K
               ArrangeBy keys=[[#4]] // { arity: 5 }
                 Project (#0..=#3, #5) // { arity: 5 }
-                  Filter (id) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
+                  Filter (#2{id}) IS NOT NULL AND (#5) IS NOT NULL // { arity: 6 }
                     Get l8 // { arity: 6 }
               ArrangeBy keys=[[#0]] // { arity: 1 }
                 Filter (#0) IS NOT NULL // { arity: 1 }
@@ -3835,7 +3835,7 @@ Explained Query:
                       Get l8 // { arity: 6 }
     With Mutually Recursive
       cte l8 =
-        Distinct project=[#0, id, id, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, #1{id}, #2{id}, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Map (0) // { arity: 6 }
               Union // { arity: 5 }
@@ -3869,7 +3869,7 @@ Explained Query:
                           Constant // { arity: 0 }
                             - ()
       cte l7 =
-        ArrangeBy keys=[[locationcityid]] // { arity: 11 }
+        ArrangeBy keys=[[#8{locationcityid}]] // { arity: 11 }
           ReadIndex on=person person_locationcityid=[lookup] // { arity: 11 }
       cte l6 =
         Project (#1) // { arity: 1 }
@@ -3886,27 +3886,27 @@ Explained Query:
       cte l5 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
-            Join on=(dst = dst) type=differential // { arity: 4 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
                 %0:l4[#0]Kef » %1:l4[#0]Kef
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = false) AND (dst) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = false) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l4 // { arity: 5 }
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
-                  Filter (#0 = true) AND (dst) IS NOT NULL // { arity: 5 }
+                  Filter (#0 = true) AND (#2{dst}) IS NOT NULL // { arity: 5 }
                     Get l4 // { arity: 5 }
       cte l4 =
-        TopK group_by=[#0, #1, dst] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
-          Distinct project=[#0, #1, dst, #3, #4] // { arity: 5 }
+        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+          Distinct project=[#0, #1, #2{dst}, #3, #4] // { arity: 5 }
             Union // { arity: 5 }
               Project (#3, #4, #1, #7, #8) // { arity: 5 }
-                Map ((#6 + bigint_to_double(w)), false) // { arity: 9 }
-                  Join on=(src = #5) type=differential // { arity: 7 }
+                Map ((#6 + bigint_to_double(#2{w})), false) // { arity: 9 }
+                  Join on=(#0{src} = #5) type=differential // { arity: 7 }
                     implementation
                       %0:pathq19[#0]KA » %1:l0[#2]K
-                    ArrangeBy keys=[[src]] // { arity: 3 }
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                       ReadIndex on=pathq19 pathq19_src=[differential join] // { arity: 3 }
                     ArrangeBy keys=[[#2]] // { arity: 4 }
                       Project (#0..=#3) // { arity: 4 }
@@ -4023,7 +4023,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[dst asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4049,39 +4049,39 @@ Explained Query:
             Get l1 // { arity: 2 }
         cte l1 =
           Project (#0, #1) // { arity: 2 }
-            Join on=(dst = personid) type=differential // { arity: 3 }
+            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#1, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
-              ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct project=[personid] // { arity: 1 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
-                      Join on=(companyid = id) type=differential // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[companyid]] // { arity: 4 }
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[id]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#2, #0, #1) // { arity: 3 }
           Map (10995116285979) // { arity: 3 }
-            Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
-              Distinct project=[dst, #1] // { arity: 2 }
+            Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
+              Distinct project=[#0{dst}, #1] // { arity: 2 }
                 Union // { arity: 2 }
                   Project (#3, #5) // { arity: 2 }
-                    Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
-                      Join on=(#0 = src) type=differential // { arity: 5 }
+                    Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
+                      Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                         implementation
                           %1:pathq20[#0]KA » %0:l0[#0]K
                         ArrangeBy keys=[[#0]] // { arity: 2 }
                           Project (#1, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
-                        ArrangeBy keys=[[src]] // { arity: 3 }
+                        ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                           ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   Constant // { arity: 2 }
                     - (10995116285979, 0)
@@ -4129,7 +4129,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[dst asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4155,35 +4155,35 @@ Explained Query:
             Get l1 // { arity: 2 }
         cte l1 =
           Project (#0, #1) // { arity: 2 }
-            Join on=(dst = personid) type=differential // { arity: 3 }
+            Join on=(#0{dst} = #2{personid}) type=differential // { arity: 3 }
               implementation
                 %1[#0]UKA » %0:l0[#0]UK
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Get l0 // { arity: 2 }
-              ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct project=[personid] // { arity: 1 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
-                      Join on=(companyid = id) type=differential // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[companyid]] // { arity: 4 }
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[id]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
-        Reduce group_by=[dst] aggregates=[min(#1)] // { arity: 2 }
-          Distinct project=[dst, #1] // { arity: 2 }
+        Reduce group_by=[#0{dst}] aggregates=[min(#1)] // { arity: 2 }
+          Distinct project=[#0{dst}, #1] // { arity: 2 }
             Union // { arity: 2 }
               Project (#3, #5) // { arity: 2 }
-                Map ((#1 + integer_to_bigint(w))) // { arity: 6 }
-                  Join on=(#0 = src) type=differential // { arity: 5 }
+                Map ((#1 + integer_to_bigint(#4{w}))) // { arity: 6 }
+                  Join on=(#0 = #2{src}) type=differential // { arity: 5 }
                     implementation
                       %1:pathq20[#0]KA » %0:l0[#0]K
                     ArrangeBy keys=[[#0]] // { arity: 2 }
                       Get l0 // { arity: 2 }
-                    ArrangeBy keys=[[src]] // { arity: 3 }
+                    ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                       ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
               Constant // { arity: 2 }
                 - (10995116285979, 0)
@@ -4236,7 +4236,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH minimal_paths AS (
 SELECT dst, w, hops FROM results ORDER BY dst LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[dst asc nulls_last] limit=20 output=[#0..=#2]
+  Finish order_by=[#0{dst} asc nulls_last] limit=20 output=[#0..=#2]
     Return // { arity: 3 }
       Return // { arity: 3 }
         Project (#0..=#2) // { arity: 3 }
@@ -4262,40 +4262,40 @@ Explained Query:
             Get l1 // { arity: 3 }
         cte l1 =
           Project (#0..=#2) // { arity: 3 }
-            Join on=(dst = personid) type=differential // { arity: 4 }
+            Join on=(#0{dst} = #3{personid}) type=differential // { arity: 4 }
               implementation
                 %1[#0]UKA » %0:l0[#0]K
-              ArrangeBy keys=[[dst]] // { arity: 3 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 3 }
                 Project (#1..=#3) // { arity: 3 }
                   Get l0 // { arity: 4 }
-              ArrangeBy keys=[[personid]] // { arity: 1 }
-                Distinct project=[personid] // { arity: 1 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
+                Distinct project=[#0{personid}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
-                    Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
-                      Join on=(companyid = id) type=differential // { arity: 8 }
+                    Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+                      Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
                         implementation
                           %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-                        ArrangeBy keys=[[companyid]] // { arity: 4 }
+                        ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
                           ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-                        ArrangeBy keys=[[id]] // { arity: 4 }
+                        ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                           ReadIndex on=company company_id=[differential join] // { arity: 4 }
     With Mutually Recursive
       cte l0 =
         Project (#3, #0..=#2) // { arity: 4 }
           Map (10995116285979) // { arity: 4 }
-            Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
-              Reduce group_by=[dst, #2] aggregates=[min(#1)] // { arity: 3 }
-                Distinct project=[dst, #1, #2] // { arity: 3 }
+            Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
+              Reduce group_by=[#0{dst}, #2] aggregates=[min(#1)] // { arity: 3 }
+                Distinct project=[#0{dst}, #1, #2] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#4, #6, #7) // { arity: 3 }
-                      Map ((#1 + integer_to_bigint(w)), (#2 + 1)) // { arity: 8 }
-                        Join on=(#0 = src) type=differential // { arity: 6 }
+                      Map ((#1 + integer_to_bigint(#5{w})), (#2 + 1)) // { arity: 8 }
+                        Join on=(#0 = #3{src}) type=differential // { arity: 6 }
                           implementation
                             %1:pathq20[#0]KA » %0:l0[#0]K
                           ArrangeBy keys=[[#0]] // { arity: 3 }
                             Project (#1..=#3) // { arity: 3 }
                               Get l0 // { arity: 4 }
-                          ArrangeBy keys=[[src]] // { arity: 3 }
+                          ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                             ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                     Constant // { arity: 3 }
                       - (10995116285979, 0, 0)
@@ -4385,7 +4385,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls) WITH MUTUALLY RECURSIVE
 SELECT t, w FROM results WHERE w = (SELECT min(w) FROM results) ORDER BY t LIMIT 20
 ----
 Explained Query:
-  Finish order_by=[personid asc nulls_last] limit=20 output=[#0, #1]
+  Finish order_by=[#0{personid} asc nulls_last] limit=20 output=[#0, #1]
     Return // { arity: 2 }
       Return // { arity: 2 }
         Project (#0, #1) // { arity: 2 }
@@ -4403,16 +4403,16 @@ Explained Query:
       With
         cte l13 =
           Project (#1, #2) // { arity: 2 }
-            Reduce group_by=[personid, personid] aggregates=[min((#1 + #3))] // { arity: 3 }
+            Reduce group_by=[#0{personid}, #2{personid}] aggregates=[min((#1 + #3))] // { arity: 3 }
               Project (#0, #2, #3, #5) // { arity: 4 }
-                Join on=(personid = personid) type=differential // { arity: 6 }
+                Join on=(#1{personid} = #4{personid}) type=differential // { arity: 6 }
                   implementation
                     %0:l12[#1]Kef » %1:l12[#1]Kef
-                  ArrangeBy keys=[[personid]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = false) // { arity: 4 }
                         Get l12 // { arity: 4 }
-                  ArrangeBy keys=[[personid]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{personid}]] // { arity: 3 }
                     Project (#1..=#3) // { arity: 3 }
                       Filter (#0 = true) // { arity: 4 }
                         Get l12 // { arity: 4 }
@@ -4432,11 +4432,11 @@ Explained Query:
                       Get l11 // { arity: 6 }
     With Mutually Recursive
       cte l11 =
-        Distinct project=[#0, personid, personid, #3, #4, #5] // { arity: 6 }
+        Distinct project=[#0, #1{personid}, #2{personid}, #3, #4, #5] // { arity: 6 }
           Union // { arity: 6 }
             Project (#0..=#2, #4, #3, #5) // { arity: 6 }
               Map (false, 0, 0) // { arity: 6 }
-                Distinct project=[#0, personid, personid] // { arity: 3 }
+                Distinct project=[#0, #1{personid}, #2{personid}] // { arity: 3 }
                   Union // { arity: 3 }
                     Project (#1, #0, #0) // { arity: 3 }
                       Map (10995116285979, false) // { arity: 2 }
@@ -4476,12 +4476,12 @@ Explained Query:
       cte l10 =
         Distinct project=[] // { arity: 0 }
           Project () // { arity: 0 }
-            Join on=(dst = personid) type=differential // { arity: 2 }
+            Join on=(#0{dst} = #1{personid}) type=differential // { arity: 2 }
               implementation
                 %0:l2[#0]UK » %1:l0[#0]K
-              ArrangeBy keys=[[dst]] // { arity: 1 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 1 }
                 Get l2 // { arity: 1 }
-              ArrangeBy keys=[[personid]] // { arity: 1 }
+              ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                 Get l0 // { arity: 1 }
       cte l9 =
         Project (#1) // { arity: 1 }
@@ -4498,26 +4498,26 @@ Explained Query:
       cte l8 =
         Reduce aggregates=[min((#0 + #1))] // { arity: 1 }
           Project (#1, #3) // { arity: 2 }
-            Join on=(dst = dst) type=differential // { arity: 4 }
+            Join on=(#0{dst} = #2{dst}) type=differential // { arity: 4 }
               implementation
                 %0:l7[#0]Kef » %1:l7[#0]Kef
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = false) // { arity: 5 }
                     Get l7 // { arity: 5 }
-              ArrangeBy keys=[[dst]] // { arity: 2 }
+              ArrangeBy keys=[[#0{dst}]] // { arity: 2 }
                 Project (#2, #3) // { arity: 2 }
                   Filter (#0 = true) // { arity: 5 }
                     Get l7 // { arity: 5 }
       cte l7 =
-        TopK group_by=[#0, #1, dst] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
+        TopK group_by=[#0, #1, #2{dst}] order_by=[#3 asc nulls_last, #4 desc nulls_first] limit=1 // { arity: 5 }
           Union // { arity: 5 }
             Project (#3, #4, #1, #7, #8) // { arity: 5 }
-              Map ((#6 + integer_to_bigint(w)), false) // { arity: 9 }
-                Join on=(src = #5) type=differential // { arity: 7 }
+              Map ((#6 + integer_to_bigint(#2{w})), false) // { arity: 9 }
+                Join on=(#0{src} = #5) type=differential // { arity: 7 }
                   implementation
                     %0:pathq20[#0]KA » %1:l3[#2]K
-                  ArrangeBy keys=[[src]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                     ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                   ArrangeBy keys=[[#2]] // { arity: 4 }
                     Project (#0..=#3) // { arity: 4 }
@@ -4571,25 +4571,25 @@ Explained Query:
             Filter (#4 = false) // { arity: 6 }
               Get l11 // { arity: 6 }
       cte l2 =
-        Distinct project=[dst] // { arity: 1 }
+        Distinct project=[#0{dst}] // { arity: 1 }
           Union // { arity: 1 }
             Project (#2) // { arity: 1 }
-              Join on=(#0 = src) type=differential // { arity: 4 }
+              Join on=(#0 = #1{src}) type=differential // { arity: 4 }
                 implementation
                   %1:pathq20[#0]KA » %0:l1[#0]K » %2[×]
                 Get l1 // { arity: 1 }
-                ArrangeBy keys=[[src]] // { arity: 3 }
+                ArrangeBy keys=[[#0{src}]] // { arity: 3 }
                   ReadIndex on=pathq20 pathq20_src=[differential join] // { arity: 3 }
                 ArrangeBy keys=[[]] // { arity: 0 }
                   Union // { arity: 0 }
                     Negate // { arity: 0 }
                       Distinct project=[] // { arity: 0 }
                         Project () // { arity: 0 }
-                          Join on=(#0 = personid) type=differential // { arity: 2 }
+                          Join on=(#0 = #1{personid}) type=differential // { arity: 2 }
                             implementation
                               %0:l1[#0]K » %1:l0[#0]K
                             Get l1 // { arity: 1 }
-                            ArrangeBy keys=[[personid]] // { arity: 1 }
+                            ArrangeBy keys=[[#0{personid}]] // { arity: 1 }
                               Get l0 // { arity: 1 }
                     Constant // { arity: 0 }
                       - ()
@@ -4600,13 +4600,13 @@ Explained Query:
           Get l2 // { arity: 1 }
       cte l0 =
         Project (#1) // { arity: 1 }
-          Filter (name = "Balkh_Airlines") AND (companyid) IS NOT NULL // { arity: 8 }
-            Join on=(companyid = id) type=differential // { arity: 8 }
+          Filter (#5{name} = "Balkh_Airlines") AND (#2{companyid}) IS NOT NULL // { arity: 8 }
+            Join on=(#2{companyid} = #4{id}) type=differential // { arity: 8 }
               implementation
                 %1:company[#0]KAef » %0:person_workat_company[#2]KAef
-              ArrangeBy keys=[[companyid]] // { arity: 4 }
+              ArrangeBy keys=[[#2{companyid}]] // { arity: 4 }
                 ReadIndex on=person_workat_company person_workat_company_companyid=[differential join] // { arity: 4 }
-              ArrangeBy keys=[[id]] // { arity: 4 }
+              ArrangeBy keys=[[#0{id}]] // { arity: 4 }
                 ReadIndex on=company company_id=[differential join] // { arity: 4 }
 
 Used Indexes:

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -111,19 +111,19 @@ Return // { arity: 4 }
       Get l1 // { arity: 15 }
       CrossJoin // { arity: 15 }
         Project (#0..=#8) // { arity: 9 }
-          Join on=(facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) // { arity: 18 }
+          Join on=(#0{facts_k01} = #9{facts_k01} AND #1{dim01_k01} = #10{dim01_k01} AND #2{dim02_k01} = #11{dim02_k01} AND #3{dim03_k01} = #12{dim03_k01} AND #4{facts_d01} = #13{facts_d01} AND #5{facts_d02} = #14{facts_d02} AND #6{facts_d03} = #15{facts_d03} AND #7{facts_d04} = #16{facts_d04} AND #8{facts_d05} = #17{facts_d05}) // { arity: 18 }
             Union // { arity: 9 }
               Negate // { arity: 9 }
-                Distinct project=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+                Distinct project=[#0{facts_k01}, #1{dim01_k01}, #2{dim02_k01}, #3{dim03_k01}, #4{facts_d01}, #5{facts_d02}, #6{facts_d03}, #7{facts_d04}, #8{facts_d05}] // { arity: 9 }
                   Get l1 // { arity: 15 }
-              Distinct project=[facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 9 }
+              Distinct project=[#0{facts_k01}, #1{dim01_k01}, #2{dim02_k01}, #3{dim03_k01}, #4{facts_d01}, #5{facts_d02}, #6{facts_d03}, #7{facts_d04}, #8{facts_d05}] // { arity: 9 }
                 Get l0 // { arity: 9 }
             Get l0 // { arity: 9 }
         Constant // { arity: 6 }
           - (null, null, null, null, null, null)
 With
   cte l1 =
-    Filter (dim01_k01 > dim01_k01) // { arity: 15 }
+    Filter (#1{dim01_k01} > #9{dim01_k01}) // { arity: 15 }
       Project (#0..=#14) // { arity: 15 }
         CrossJoin // { arity: 15 }
           Get l0 // { arity: 9 }
@@ -169,16 +169,16 @@ Return // { arity: 4 }
         Union // { arity: 9 }
           Negate // { arity: 9 }
             Project (#0..=#8) // { arity: 9 }
-              Join on=(dim01_k01 = dim01_k01) // { arity: 10 }
+              Join on=(#1{dim01_k01} = #9{dim01_k01}) // { arity: 10 }
                 Get l0 // { arity: 9 }
-                Distinct project=[dim01_k01] // { arity: 1 }
+                Distinct project=[#0{dim01_k01}] // { arity: 1 }
                   Project (#1) // { arity: 1 }
                     Get l1 // { arity: 15 }
           Get l0 // { arity: 9 }
       Get l1 // { arity: 15 }
 With
   cte l1 =
-    Filter (dim01_k01 = dim01_k01) // { arity: 15 }
+    Filter (#1{dim01_k01} = #9{dim01_k01}) // { arity: 15 }
       Project (#0..=#14) // { arity: 15 }
         CrossJoin // { arity: 15 }
           Get l0 // { arity: 9 }
@@ -212,7 +212,7 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0..=#2, #6, #3, #12) // { arity: 6 }
           Union // { arity: 17 }
@@ -220,19 +220,19 @@ Return // { arity: 6 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
                   Project (#0..=#10) // { arity: 11 }
-                    Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
+                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                       Get l2 // { arity: 11 }
-                      Distinct project=[x, y, #2] // { arity: 3 }
+                      Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
-                          Map (x, y, (dim01_k01 + x)) // { arity: 20 }
+                          Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
             Get l3 // { arity: 17 }
 With
   cte l3 =
-    Filter ((dim01_k01 + x) = (dim01_k01 + y)) // { arity: 17 }
+    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
       Project (#0..=#10, #13..=#18) // { arity: 17 }
-        Join on=(x = x AND y = y) // { arity: 19 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
@@ -242,7 +242,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -270,7 +270,7 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0, #1, #8, #12, #9, #3) // { arity: 6 }
           Union // { arity: 17 }
@@ -279,19 +279,19 @@ Return // { arity: 6 }
                 Union // { arity: 11 }
                   Negate // { arity: 11 }
                     Project (#0..=#10) // { arity: 11 }
-                      Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
+                      Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
                         Get l2 // { arity: 11 }
-                        Distinct project=[x, y, #2] // { arity: 3 }
+                        Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
-                            Map (x, y, (dim01_k01 + y)) // { arity: 20 }
+                            Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                               Get l3 // { arity: 17 }
                   Get l2 // { arity: 11 }
             Get l3 // { arity: 17 }
 With
   cte l3 =
-    Filter ((dim01_k01 + y) = (dim01_k01 + x)) // { arity: 17 }
+    Filter ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
       Project (#0..=#7, #10..=#18) // { arity: 17 }
-        Join on=(x = x AND y = y) // { arity: 19 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
@@ -301,7 +301,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -333,7 +333,7 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0..=#2, #6, #3, #12) // { arity: 6 }
           Union // { arity: 17 }
@@ -341,20 +341,20 @@ Return // { arity: 6 }
               Union // { arity: 11 }
                 Negate // { arity: 11 }
                   Project (#0..=#10) // { arity: 11 }
-                    Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
-                      Filter (facts_d02 = 42) // { arity: 11 }
+                    Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                      Filter (#7{facts_d02} = 42) // { arity: 11 }
                         Get l2 // { arity: 11 }
-                      Distinct project=[x, y, #2] // { arity: 3 }
+                      Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
                         Project (#17..=#19) // { arity: 3 }
-                          Map (x, y, (dim01_k01 + x)) // { arity: 20 }
+                          Map (#0{x}, #1{y}, (#3{dim01_k01} + #0{x})) // { arity: 20 }
                             Get l3 // { arity: 17 }
                 Get l2 // { arity: 11 }
             Get l3 // { arity: 17 }
 With
   cte l3 =
-    Filter (facts_d02 = 42) AND (dim01_d02 = 24) AND ((dim01_k01 + x) = (dim01_k01 + y)) // { arity: 17 }
+    Filter (#7{facts_d02} = 42) AND (#13{dim01_d02} = 24) AND ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
       Project (#0..=#10, #13..=#18) // { arity: 17 }
-        Join on=(x = x AND y = y) // { arity: 19 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
           Get l2 // { arity: 11 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
@@ -364,7 +364,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -396,7 +396,7 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0, #1, #8, #12, #9, #3) // { arity: 6 }
           Union // { arity: 17 }
@@ -405,20 +405,20 @@ Return // { arity: 6 }
                 Union // { arity: 11 }
                   Negate // { arity: 11 }
                     Project (#0..=#10) // { arity: 11 }
-                      Join on=(x = x AND y = y AND (dim01_k01 + x) = #13) // { arity: 14 }
-                        Filter (facts_d02 = 42) // { arity: 11 }
+                      Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND (#3{dim01_k01} + #0{x}) = #13) // { arity: 14 }
+                        Filter (#7{facts_d02} = 42) // { arity: 11 }
                           Get l2 // { arity: 11 }
-                        Distinct project=[x, y, #2] // { arity: 3 }
+                        Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
                           Project (#17..=#19) // { arity: 3 }
-                            Map (x, y, (dim01_k01 + y)) // { arity: 20 }
+                            Map (#0{x}, #1{y}, (#2{dim01_k01} + #1{y})) // { arity: 20 }
                               Get l3 // { arity: 17 }
                   Get l2 // { arity: 11 }
             Get l3 // { arity: 17 }
 With
   cte l3 =
-    Filter (dim01_d02 = 24) AND (facts_d02 = 42) AND ((dim01_k01 + y) = (dim01_k01 + x)) // { arity: 17 }
+    Filter (#4{dim01_d02} = 24) AND (#13{facts_d02} = 42) AND ((#2{dim01_k01} + #1{y}) = (#9{dim01_k01} + #0{x})) // { arity: 17 }
       Project (#0..=#7, #10..=#18) // { arity: 17 }
-        Join on=(x = x AND y = y) // { arity: 19 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 19 }
           CrossJoin // { arity: 8 }
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
@@ -428,7 +428,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -459,7 +459,7 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0..=#2, #2, #10, #10) // { arity: 6 }
           Union // { arity: 14 }
@@ -468,8 +468,8 @@ Return // { arity: 6 }
                 Union // { arity: 8 }
                   Negate // { arity: 8 }
                     Project (#0..=#7) // { arity: 8 }
-                      Join on=(x = x AND y = y AND coalesce(dim02_k01, y) = #10) // { arity: 11 }
-                        Filter (dim02_d03 < 24) // { arity: 8 }
+                      Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim02_k01}, #1{y}) = #10) // { arity: 11 }
+                        Filter (#5{dim02_d03} < 24) // { arity: 8 }
                           Get l3 // { arity: 8 }
                         Get l5 // { arity: 3 }
                   Get l3 // { arity: 8 }
@@ -477,22 +477,22 @@ Return // { arity: 6 }
               Union // { arity: 8 }
                 Negate // { arity: 8 }
                   Project (#0..=#7) // { arity: 8 }
-                    Join on=(x = x AND y = y AND coalesce(dim01_k01, x) = #10) // { arity: 11 }
-                      Filter (dim01_d03 > 42) // { arity: 8 }
+                    Join on=(#0{x} = #8{x} AND #1{y} = #9{y} AND coalesce(#2{dim01_k01}, #0{x}) = #10) // { arity: 11 }
+                      Filter (#5{dim01_d03} > 42) // { arity: 8 }
                         Get l2 // { arity: 8 }
                       Get l5 // { arity: 3 }
                 Get l2 // { arity: 8 }
             Get l4 // { arity: 14 }
 With
   cte l5 =
-    Distinct project=[x, y, #2] // { arity: 3 }
+    Distinct project=[#0{x}, #1{y}, #2] // { arity: 3 }
       Project (#14..=#16) // { arity: 3 }
-        Map (x, y, coalesce(dim01_k01, x)) // { arity: 17 }
+        Map (#0{x}, #1{y}, coalesce(#2{dim01_k01}, #0{x})) // { arity: 17 }
           Get l4 // { arity: 14 }
   cte l4 =
-    Filter (coalesce(dim01_k01, x) = coalesce(dim02_k01, y)) AND (dim02_d03 < 24) AND (dim01_d03 > 42) // { arity: 14 }
+    Filter (coalesce(#2{dim01_k01}, #0{x}) = coalesce(#8{dim02_k01}, #1{y})) AND (#11{dim02_d03} < 24) AND (#5{dim01_d03} > 42) // { arity: 14 }
       Project (#0..=#7, #10..=#15) // { arity: 14 }
-        Join on=(x = x AND y = y) // { arity: 16 }
+        Join on=(#0{x} = #8{x} AND #1{y} = #9{y}) // { arity: 16 }
           Get l2 // { arity: 8 }
           Get l3 // { arity: 8 }
   cte l3 =
@@ -504,7 +504,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.dim01 // { arity: 6 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -536,19 +536,19 @@ SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
 Return // { arity: 6 }
   Filter true // { arity: 6 }
     Project (#0, #1, #4..=#7) // { arity: 6 }
-      Join on=(x = x AND y = y) // { arity: 8 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
         Get l0 // { arity: 2 }
         Project (#0..=#2, #6, #3, #12) // { arity: 6 }
           Union // { arity: 17 }
             Get l8 // { arity: 17 }
             CrossJoin // { arity: 17 }
               Project (#0..=#10) // { arity: 11 }
-                Join on=(x = x AND y = y AND facts_k01 = facts_k01 AND dim01_k01 = dim01_k01 AND dim02_k01 = dim02_k01 AND dim03_k01 = dim03_k01 AND facts_d01 = facts_d01 AND facts_d02 = facts_d02 AND facts_d03 = facts_d03 AND facts_d04 = facts_d04 AND facts_d05 = facts_d05) // { arity: 22 }
+                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
                   Union // { arity: 11 }
                     Negate // { arity: 11 }
-                      Distinct project=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
+                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
                         Get l8 // { arity: 17 }
-                    Distinct project=[x, y, facts_k01, dim01_k01, dim02_k01, dim03_k01, facts_d01, facts_d02, facts_d03, facts_d04, facts_d05] // { arity: 11 }
+                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
                       Get l2 // { arity: 11 }
                   Get l2 // { arity: 11 }
               Constant // { arity: 6 }
@@ -556,20 +556,20 @@ Return // { arity: 6 }
 With
   cte l8 =
     Project (#0..=#16) // { arity: 17 }
-      Filter ((((dim01_k01 + x) = (dim01_k01 + y)) AND (facts_d02 = 42)) AND #17) // { arity: 18 }
+      Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND #17) // { arity: 18 }
         Project (#0..=#16, #18) // { arity: 18 }
-          Join on=(dim01_d01 = dim01_d01) // { arity: 19 }
+          Join on=(#12{dim01_d01} = #17{dim01_d01}) // { arity: 19 }
             Get l3 // { arity: 17 }
             Union // { arity: 2 }
               Get l7 // { arity: 2 }
               CrossJoin // { arity: 2 }
                 Project (#0) // { arity: 1 }
-                  Join on=(dim01_d01 = dim01_d01) // { arity: 2 }
+                  Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
                     Union // { arity: 1 }
                       Negate // { arity: 1 }
-                        Distinct project=[dim01_d01] // { arity: 1 }
+                        Distinct project=[#0{dim01_d01}] // { arity: 1 }
                           Get l7 // { arity: 2 }
-                      Distinct project=[dim01_d01] // { arity: 1 }
+                      Distinct project=[#0{dim01_d01}] // { arity: 1 }
                         Get l4 // { arity: 1 }
                     Get l4 // { arity: 1 }
                 Constant // { arity: 1 }
@@ -580,33 +580,33 @@ With
       Map (error("more than one record produced in subquery")) // { arity: 2 }
         Project (#0) // { arity: 1 }
           Filter (#1 > 1) // { arity: 2 }
-            Reduce group_by=[dim01_d01] aggregates=[count(*)] // { arity: 2 }
+            Reduce group_by=[#0{dim01_d01}] aggregates=[count(*)] // { arity: 2 }
               Get l6 // { arity: 2 }
   cte l6 =
     Union // { arity: 2 }
       Get l5 // { arity: 2 }
       CrossJoin // { arity: 2 }
         Project (#0) // { arity: 1 }
-          Join on=(dim01_d01 = dim01_d01) // { arity: 2 }
+          Join on=(#0{dim01_d01} = #1{dim01_d01}) // { arity: 2 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct project=[dim01_d01] // { arity: 1 }
+                Distinct project=[#0{dim01_d01}] // { arity: 1 }
                   Get l5 // { arity: 2 }
-              Distinct project=[dim01_d01] // { arity: 1 }
+              Distinct project=[#0{dim01_d01}] // { arity: 1 }
                 Get l4 // { arity: 1 }
             Get l4 // { arity: 1 }
         Constant // { arity: 1 }
           - (false)
   cte l5 =
-    Reduce group_by=[dim01_d01] aggregates=[any((dim01_d01 = #1))] // { arity: 2 }
+    Reduce group_by=[#0{dim01_d01}] aggregates=[any((#0{dim01_d01} = #1))] // { arity: 2 }
       FlatMap unnest_array(strtoarray("{24, 42}")) // { arity: 2 }
         Get l4 // { arity: 1 }
   cte l4 =
-    Distinct project=[dim01_d01] // { arity: 1 }
+    Distinct project=[#12{dim01_d01}] // { arity: 1 }
       Get l3 // { arity: 17 }
   cte l3 =
     Project (#0..=#10, #13..=#18) // { arity: 17 }
-      Join on=(x = x AND y = y) // { arity: 19 }
+      Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
         Get l2 // { arity: 11 }
         CrossJoin // { arity: 8 }
           Get l1 // { arity: 2 }
@@ -616,7 +616,7 @@ With
       Get l1 // { arity: 2 }
       Get materialize.left_joins_raw.facts // { arity: 9 }
   cte l1 =
-    Distinct project=[x, y] // { arity: 2 }
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
       Get l0 // { arity: 2 }
   cte l0 =
     CrossJoin // { arity: 2 }
@@ -657,10 +657,10 @@ Explained Query:
         Union // { arity: 3 }
           Negate // { arity: 3 }
             Project (#0, #2, #3) // { arity: 3 }
-              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+              Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -669,20 +669,20 @@ Explained Query:
         Get l1 // { arity: 7 }
   With
     cte l1 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Filter (dim01_d02 < 24) // { arity: 6 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
-      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
         Project (#0, #1, #4, #5) // { arity: 4 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
-  filter=((dim01_d02 < 24))
+  filter=((#2{dim01_d02} < 24))
 
 EOF
 
@@ -715,10 +715,10 @@ Explained Query:
         Union // { arity: 3 }
           Negate // { arity: 3 }
             Project (#0, #2, #3) // { arity: 3 }
-              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+              Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -727,20 +727,20 @@ Explained Query:
         Get l1 // { arity: 7 }
   With
     cte l1 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Filter (dim01_d02 < 24) // { arity: 6 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
-      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
         Project (#0, #1, #4, #5) // { arity: 4 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
-  filter=((dim01_d02 < 24))
+  filter=((#2{dim01_d02} < 24))
 
 EOF
 
@@ -750,7 +750,7 @@ EXPLAIN OPTIMIZED PLAN WITH(enable_new_outer_join_lowering, humanized_exprs, ari
 CREATE INDEX ON v(facts_k01);
 ----
 materialize.public.v_facts_k01_idx:
-  ArrangeBy keys=[[facts_k01]] // { arity: 6 }
+  ArrangeBy keys=[[#0{facts_k01}]] // { arity: 6 }
     ReadGlobalFromSameDataflow materialize.public.v // { arity: 6 }
 
 materialize.public.v:
@@ -760,10 +760,10 @@ materialize.public.v:
         Union // { arity: 3 }
           Negate // { arity: 3 }
             Project (#0, #2, #3) // { arity: 3 }
-              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+              Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -772,20 +772,20 @@ materialize.public.v:
         Get l1 // { arity: 7 }
   With
     cte l1 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Filter (dim01_d02 < 24) // { arity: 6 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
-      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
         Project (#0, #1, #4, #5) // { arity: 4 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
-  filter=((dim01_d02 < 24))
+  filter=((#2{dim01_d02} < 24))
 
 EOF
 
@@ -814,10 +814,10 @@ materialize.public.mv:
         Union // { arity: 3 }
           Negate // { arity: 3 }
             Project (#0, #2, #3) // { arity: 3 }
-              Join on=(#4 = coalesce(dim01_k01, 5)) type=differential // { arity: 5 }
+              Join on=(#4 = coalesce(#1{dim01_k01}, 5)) type=differential // { arity: 5 }
                 Get l0 // { arity: 4 }
                 ArrangeBy keys=[[#0]] // { arity: 1 }
-                  Distinct project=[coalesce(dim01_k01, 5)] // { arity: 1 }
+                  Distinct project=[coalesce(#0{dim01_k01}, 5)] // { arity: 1 }
                     Project (#1) // { arity: 1 }
                       Get l1 // { arity: 7 }
           Project (#0, #4, #5) // { arity: 3 }
@@ -826,19 +826,19 @@ materialize.public.mv:
         Get l1 // { arity: 7 }
   With
     cte l1 =
-      Join on=(coalesce(dim01_k01, 5) = coalesce(dim01_k01, 5)) type=differential // { arity: 7 }
+      Join on=(coalesce(#1{dim01_k01}, 5) = coalesce(#4{dim01_k01}, 5)) type=differential // { arity: 7 }
         Get l0 // { arity: 4 }
-        ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 3 }
+        ArrangeBy keys=[[coalesce(#0{dim01_k01}, 5)]] // { arity: 3 }
           Project (#0..=#2) // { arity: 3 }
-            Filter (dim01_d02 < 24) // { arity: 6 }
+            Filter (#2{dim01_d02} < 24) // { arity: 6 }
               ReadStorage materialize.left_joins_raw.dim01 // { arity: 6 }
     cte l0 =
-      ArrangeBy keys=[[coalesce(dim01_k01, 5)]] // { arity: 4 }
+      ArrangeBy keys=[[coalesce(#1{dim01_k01}, 5)]] // { arity: 4 }
         Project (#0, #1, #4, #5) // { arity: 4 }
-          Filter (facts_d01 > 42) // { arity: 9 }
+          Filter (#4{facts_d01} > 42) // { arity: 9 }
             ReadStorage materialize.left_joins_raw.facts // { arity: 9 }
 
 Source materialize.left_joins_raw.dim01
-  filter=((dim01_d02 < 24))
+  filter=((#2{dim01_d02} < 24))
 
 EOF

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -194,15 +194,15 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q01;
 ----
 materialize.public.q01_primary_idx:
-  ArrangeBy keys=[[l_returnflag, l_linestatus]] // { arity: 10 }
+  ArrangeBy keys=[[#0{l_returnflag}, #1{l_linestatus}]] // { arity: 10 }
     ReadGlobalFromSameDataflow materialize.public.q01 // { arity: 10 }
 
 materialize.public.q01:
   Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
-      Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)] // { arity: 8 }
+      Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
         Project (#4..=#9) // { arity: 6 }
-          Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00) // { arity: 16 }
+          Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -256,30 +256,30 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q02;
 ----
 materialize.public.q02_primary_idx:
-  ArrangeBy keys=[[s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment]] // { arity: 8 }
+  ArrangeBy keys=[[#0{s_acctbal}, #1{s_name}, #2{n_name}, #3{p_partkey}, #4{p_mfgr}, #5{s_address}, #6{s_phone}, #7{s_comment}]] // { arity: 8 }
     ReadGlobalFromSameDataflow materialize.public.q02 // { arity: 8 }
 
 materialize.public.q02:
   Return // { arity: 8 }
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-      Join on=(p_partkey = p_partkey AND ps_supplycost = #10) type=differential // { arity: 11 }
+      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
-        ArrangeBy keys=[[p_partkey, ps_supplycost]] // { arity: 9 }
+        ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
           Get l4 // { arity: 9 }
-        ArrangeBy keys=[[p_partkey, #1]] // { arity: 2 }
-          Reduce group_by=[p_partkey] aggregates=[min(ps_supplycost)] // { arity: 2 }
+        ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+          Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
-              Filter (r_name = "EUROPE") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 20 }
-                Join on=(p_partkey = ps_partkey AND ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 20 }
+              Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+                Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
                     %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                  ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                    Distinct project=[p_partkey] // { arity: 1 }
+                  ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                    Distinct project=[#0{p_partkey}] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
@@ -289,31 +289,31 @@ materialize.public.q02:
   With
     cte l4 =
       Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (p_size = 15) AND (r_name = "EUROPE") AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND like["%BRASS"](varchar_to_text(p_type)) // { arity: 28 }
-          Join on=(p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 28 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
               %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
               %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
               %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
               %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
               %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
             Get l0 // { arity: 7 }
             Get l1 // { arity: 5 }
             Get l2 // { arity: 4 }
             Get l3 // { arity: 3 }
     cte l3 =
-      ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
         ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
     cte l2 =
-      ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
     cte l1 =
-      ArrangeBy keys=[[ps_partkey], [ps_suppkey]] // { arity: 5 }
+      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
         ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
     cte l0 =
-      ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
         ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
@@ -362,24 +362,24 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q03;
 ----
 materialize.public.q03_primary_idx:
-  ArrangeBy keys=[[l_orderkey, o_orderdate, o_shippriority]] // { arity: 4 }
+  ArrangeBy keys=[[#0{l_orderkey}, #2{o_orderdate}, #3{o_shippriority}]] // { arity: 4 }
     ReadGlobalFromSameDataflow materialize.public.q03 // { arity: 4 }
 
 materialize.public.q03:
   Project (#0, #3, #1, #2) // { arity: 4 }
-    Reduce group_by=[o_orderkey, o_orderdate, o_shippriority] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+    Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
-        Filter (c_mktsegment = "BUILDING") AND (o_orderdate < 1995-03-15) AND (l_shipdate > 1995-03-15) AND (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
               %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
               %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
-            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -423,29 +423,29 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q04;
 ----
 materialize.public.q04_primary_idx:
-  ArrangeBy keys=[[o_orderpriority]] // { arity: 2 }
+  ArrangeBy keys=[[#0{o_orderpriority}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q04 // { arity: 2 }
 
 materialize.public.q04:
-  Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
+  Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (o_orderdate >= 1993-07-01) AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(eq(o_orderkey, o_orderkey, l_orderkey)) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
+        Join on=(eq(#0{o_orderkey}, #9{o_orderkey}, #10{l_orderkey})) type=delta // { arity: 11 }
           implementation
             %0:orders » %1[#0]UKA » %2[#0]UKA
             %1 » %2[#0]UKA » %0:orders[#0]KAiif
             %2 » %1[#0]UKA » %0:orders[#0]KAiif
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-            Distinct project=[o_orderkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+            Distinct project=[#0{o_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
+                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-            Distinct project=[l_orderkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
+            Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (l_commitdate < l_receiptdate) // { arity: 16 }
+                Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -490,29 +490,29 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q05;
 ----
 materialize.public.q05_primary_idx:
-  ArrangeBy keys=[[n_name]] // { arity: 2 }
+  ArrangeBy keys=[[#0{n_name}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q05 // { arity: 2 }
 
 materialize.public.q05:
-  Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+  Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
     Project (#22, #23, #36) // { arity: 3 }
-      Filter (r_name = "ASIA") AND (o_orderdate < 1995-01-01) AND (o_orderdate >= 1994-01-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 42 }
-        Join on=(c_custkey = o_custkey AND eq(c_nationkey, s_nationkey, n_nationkey) AND o_orderkey = l_orderkey AND l_suppkey = s_suppkey AND n_regionkey = r_regionkey) type=differential // { arity: 42 }
+      Filter (#40{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#37{n_regionkey}) IS NOT NULL // { arity: 42 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND eq(#3{c_nationkey}, #34{s_nationkey}, #35{n_nationkey}) AND #8{o_orderkey} = #17{l_orderkey} AND #19{l_suppkey} = #33{s_suppkey} AND #37{n_regionkey} = #39{r_regionkey}) type=differential // { arity: 42 }
           implementation
             %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKeiif
-          ArrangeBy keys=[[c_nationkey]] // { arity: 8 }
+          ArrangeBy keys=[[#3{c_nationkey}]] // { arity: 8 }
             ReadIndex on=customer fk_customer_nationkey=[differential join] // { arity: 8 }
-          ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+          ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-          ArrangeBy keys=[[s_suppkey, s_nationkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
             Project (#0, #3) // { arity: 2 }
-              Filter (s_suppkey) IS NOT NULL // { arity: 7 }
+              Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
-          ArrangeBy keys=[[n_regionkey]] // { arity: 4 }
+          ArrangeBy keys=[[#2{n_regionkey}]] // { arity: 4 }
             ReadIndex on=nation fk_nation_regionkey=[differential join] // { arity: 4 }
-          ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
             ReadIndex on=region pk_region_regionkey=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -546,7 +546,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q06;
 ----
 materialize.public.q06_primary_idx:
-  ArrangeBy keys=[[revenue]] // { arity: 1 }
+  ArrangeBy keys=[[#0{revenue}]] // { arity: 1 }
     ReadGlobalFromSameDataflow materialize.public.q06 // { arity: 1 }
 
 materialize.public.q06:
@@ -562,9 +562,9 @@ materialize.public.q06:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * l_discount))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_quantity < 24) AND (l_discount <= 0.07) AND (l_discount >= 0.05) AND (l_shipdate >= 1994-01-01) AND (date_to_timestamp(l_shipdate) < 1995-01-01 00:00:00) // { arity: 16 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -623,16 +623,16 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q07;
 ----
 materialize.public.q07_primary_idx:
-  ArrangeBy keys=[[supp_nation, cust_nation, l_year]] // { arity: 4 }
+  ArrangeBy keys=[[#0{supp_nation}, #1{cust_nation}, #2{l_year}]] // { arity: 4 }
     ReadGlobalFromSameDataflow materialize.public.q07 // { arity: 4 }
 
 materialize.public.q07:
   Return // { arity: 4 }
-    Reduce group_by=[n_name, n_name, extract_year_d(l_shipdate)] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+    Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
-        Filter (l_shipdate <= 1996-12-31) AND (l_shipdate >= 1995-01-01) AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
-          Map ((n_name = "FRANCE"), (n_name = "GERMANY"), (n_name = "FRANCE"), (n_name = "GERMANY")) // { arity: 52 }
-            Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey) type=delta // { arity: 48 }
+        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+          Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
+            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
               implementation
                 %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
@@ -640,19 +640,19 @@ materialize.public.q07:
                 %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                 %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-              ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
               Get l0 // { arity: 4 }
               Get l0 // { arity: 4 }
   With
     cte l0 =
-      ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -717,16 +717,16 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q08;
 ----
 materialize.public.q08_primary_idx:
-  ArrangeBy keys=[[o_year]] // { arity: 2 }
+  ArrangeBy keys=[[#0{o_year}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q08 // { arity: 2 }
 
 materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
     Map ((#1 / #2)) // { arity: 4 }
-      Reduce group_by=[extract_year_d(o_orderdate)] aggregates=[sum(case when (n_name = "BRAZIL") then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 3 }
+      Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
-          Filter (r_name = "AMERICA") AND (o_orderdate <= 1996-12-31) AND (o_orderdate >= 1995-01-01) AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(p_type)) // { arity: 60 }
-            Join on=(p_partkey = l_partkey AND s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 60 }
+          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+            Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
                 %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
                 %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -736,21 +736,21 @@ materialize.public.q08:
                 %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
                 %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
                 %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-              ArrangeBy keys=[[l_orderkey], [l_partkey], [l_suppkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
-              ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+              ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
                 ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -814,14 +814,14 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q09;
 ----
 materialize.public.q09_primary_idx:
-  ArrangeBy keys=[[nation, o_year]] // { arity: 3 }
+  ArrangeBy keys=[[#0{nation}, #1{o_year}]] // { arity: 3 }
     ReadGlobalFromSameDataflow materialize.public.q09 // { arity: 3 }
 
 materialize.public.q09:
-  Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
+  Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
     Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-      Filter (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND like["%green%"](varchar_to_text(p_name)) // { arity: 50 }
-        Join on=(eq(p_partkey, l_partkey, ps_partkey) AND eq(s_suppkey, l_suppkey, ps_suppkey) AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 50 }
+      Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+        Join on=(eq(#0{p_partkey}, #17{l_partkey}, #32{ps_partkey}) AND eq(#9{s_suppkey}, #18{l_suppkey}, #33{ps_suppkey}) AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
             %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
             %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
@@ -829,17 +829,17 @@ materialize.public.q09:
             %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
             %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
             %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
-          ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
             ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+          ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-          ArrangeBy keys=[[l_orderkey], [l_partkey], [l_partkey, l_suppkey], [l_suppkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#1{l_partkey}, #2{l_suppkey}], [#2{l_suppkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] fk_lineitem_partsuppkey=[delta join lookup] // { arity: 16 }
-          ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 5 }
+          ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 5 }
             ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[delta join lookup] // { arity: 5 }
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-          ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+          ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
             ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -900,27 +900,27 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q10;
 ----
 materialize.public.q10_primary_idx:
-  ArrangeBy keys=[[c_custkey, c_name, c_acctbal, n_name, c_address, c_phone, c_comment]] // { arity: 8 }
+  ArrangeBy keys=[[#0{c_custkey}, #1{c_name}, #3{c_acctbal}, #4{n_name}, #5{c_address}, #6{c_phone}, #7{c_comment}]] // { arity: 8 }
     ReadGlobalFromSameDataflow materialize.public.q10 // { arity: 8 }
 
 materialize.public.q10:
   Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
-    Reduce group_by=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 8 }
+    Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
       Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
-        Filter (l_returnflag = "R") AND (o_orderdate < 1994-01-01) AND (o_orderdate >= 1993-10-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1994-01-01 00:00:00) // { arity: 37 }
-          Join on=(c_custkey = o_custkey AND c_nationkey = n_nationkey AND o_orderkey = l_orderkey) type=delta // { arity: 37 }
+        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
               %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
               %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
               %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
               %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
-            ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -972,7 +972,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q11;
 ----
 materialize.public.q11_primary_idx:
-  ArrangeBy keys=[[ps_partkey]] // { arity: 2 }
+  ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q11 // { arity: 2 }
 
 materialize.public.q11:
@@ -983,26 +983,26 @@ materialize.public.q11:
           implementation
             %1[×]UA » %0[×]
           ArrangeBy keys=[[]] // { arity: 2 }
-            Reduce group_by=[ps_partkey] aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 2 }
+            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
-            Reduce aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 1 }
+            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
               Project (#1, #2) // { arity: 2 }
                 Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #2, #3) // { arity: 3 }
-        Filter (n_name = "GERMANY") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL // { arity: 16 }
-          Join on=(ps_suppkey = s_suppkey AND s_nationkey = n_nationkey) type=delta // { arity: 16 }
+        Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+          Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
               %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
               %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
               %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
-            ArrangeBy keys=[[ps_suppkey]] // { arity: 5 }
+            ArrangeBy keys=[[#1{ps_suppkey}]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_suppkey=[delta join 1st input (full scan)] // { arity: 5 }
-            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -1053,19 +1053,19 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q12;
 ----
 materialize.public.q12_primary_idx:
-  ArrangeBy keys=[[l_shipmode]] // { arity: 3 }
+  ArrangeBy keys=[[#0{l_shipmode}]] // { arity: 3 }
     ReadGlobalFromSameDataflow materialize.public.q12 // { arity: 3 }
 
 materialize.public.q12:
-  Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
+  Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
     Project (#5, #23) // { arity: 2 }
-      Filter (l_receiptdate >= 1994-01-01) AND (o_orderkey) IS NOT NULL AND (l_shipdate < l_commitdate) AND (l_commitdate < l_receiptdate) AND (date_to_timestamp(l_receiptdate) < 1995-01-01 00:00:00) AND ((l_shipmode = "MAIL") OR (l_shipmode = "SHIP")) // { arity: 25 }
-        Join on=(o_orderkey = l_orderkey) type=differential // { arity: 25 }
+      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
             %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -1106,25 +1106,25 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q13;
 ----
 materialize.public.q13_primary_idx:
-  ArrangeBy keys=[[c_count]] // { arity: 2 }
+  ArrangeBy keys=[[#0{c_count}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q13 // { arity: 2 }
 
 materialize.public.q13:
   Return // { arity: 2 }
     Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Reduce group_by=[c_custkey] aggregates=[count(o_orderkey)] // { arity: 2 }
+        Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Join on=(c_custkey = c_custkey) type=differential // { arity: 9 }
+                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                       implementation
                         %1[#0]UKA » %0:l0[#0]KA
                       Get l0 // { arity: 8 }
-                      ArrangeBy keys=[[c_custkey]] // { arity: 1 }
-                        Distinct project=[c_custkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{c_custkey}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 2 }
                 Project (#0) // { arity: 1 }
@@ -1133,15 +1133,15 @@ materialize.public.q13:
   With
     cte l1 =
       Project (#0, #8) // { arity: 2 }
-        Filter (c_custkey) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(o_comment))) // { arity: 17 }
-          Join on=(c_custkey = o_custkey) type=differential // { arity: 17 }
+        Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
               %1:orders[#1]KAf » %0:l0[#0]KAf
             Get l0 // { arity: 8 }
-            ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
         ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
@@ -1175,7 +1175,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q14;
 ----
 materialize.public.q14_primary_idx:
-  ArrangeBy keys=[[promo_revenue]] // { arity: 1 }
+  ArrangeBy keys=[[#0{promo_revenue}]] // { arity: 1 }
     ReadGlobalFromSameDataflow materialize.public.q14 // { arity: 1 }
 
 materialize.public.q14:
@@ -1193,15 +1193,15 @@ materialize.public.q14:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(p_type)) then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (l_shipdate >= 1995-09-01) AND (l_partkey) IS NOT NULL AND (date_to_timestamp(l_shipdate) < 1995-10-01 00:00:00) // { arity: 25 }
-            Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+            Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
-              ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+              ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1254,19 +1254,19 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q15;
 ----
 materialize.public.q15_primary_idx:
-  ArrangeBy keys=[[s_suppkey, s_name, s_address, s_phone, total_revenue]] // { arity: 5 }
+  ArrangeBy keys=[[#0{s_suppkey}, #1{s_name}, #2{s_address}, #3{s_phone}, #4{total_revenue}]] // { arity: 5 }
     ReadGlobalFromSameDataflow materialize.public.q15 // { arity: 5 }
 
 materialize.public.q15:
   Return // { arity: 5 }
     Project (#0..=#2, #4, #8) // { arity: 5 }
-      Filter (s_suppkey) IS NOT NULL // { arity: 10 }
-        Join on=(s_suppkey = l_suppkey AND #8 = #9) type=differential // { arity: 10 }
+      Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
+        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=differential // { arity: 10 }
           implementation
             %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UK
-          ArrangeBy keys=[[s_suppkey]] // { arity: 7 }
+          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[differential join] // { arity: 7 }
-          ArrangeBy keys=[[l_suppkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_suppkey}]] // { arity: 2 }
             Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Reduce aggregates=[max(#0)] // { arity: 1 }
@@ -1274,9 +1274,9 @@ materialize.public.q15:
                 Get l0 // { arity: 2 }
   With
     cte l0 =
-      Reduce group_by=[l_suppkey] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
         Project (#2, #5, #6) // { arity: 3 }
-          Filter (l_shipdate >= 1996-01-01) AND (date_to_timestamp(l_shipdate) < 1996-04-01 00:00:00) // { arity: 16 }
+          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -1327,24 +1327,24 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q16;
 ----
 materialize.public.q16_primary_idx:
-  ArrangeBy keys=[[p_brand, p_type, p_size]] // { arity: 4 }
+  ArrangeBy keys=[[#0{p_brand}, #1{p_type}, #2{p_size}]] // { arity: 4 }
     ReadGlobalFromSameDataflow materialize.public.q16 // { arity: 4 }
 
 materialize.public.q16:
   Return // { arity: 4 }
-    Reduce group_by=[p_brand, p_type, p_size] aggregates=[count(distinct ps_suppkey)] // { arity: 4 }
+    Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0..=#3) // { arity: 4 }
-        Join on=(ps_suppkey = ps_suppkey) type=differential // { arity: 5 }
+        Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
             %0:l0[#0]K » %1[#0]K
-          ArrangeBy keys=[[ps_suppkey]] // { arity: 4 }
+          ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
             Get l0 // { arity: 4 }
-          ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
+          ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct project=[ps_suppkey] // { arity: 1 }
+                Distinct project=[#0{ps_suppkey}] // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
+                    Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
                         implementation
                           %1:supplier[×]lf » %0:l1[×]lf
@@ -1352,23 +1352,23 @@ materialize.public.q16:
                           Get l1 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Project (#0) // { arity: 1 }
-                            Filter like["%Customer%Complaints%"](varchar_to_text(s_comment)) // { arity: 7 }
+                            Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
   With
     cte l1 =
-      Distinct project=[ps_suppkey] // { arity: 1 }
+      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
       Project (#1, #8..=#10) // { arity: 4 }
-        Filter (p_brand != "Brand#45") AND (ps_partkey) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(p_type))) AND ((p_size = 3) OR (p_size = 9) OR (p_size = 14) OR (p_size = 19) OR (p_size = 23) OR (p_size = 36) OR (p_size = 45) OR (p_size = 49)) // { arity: 14 }
-          Join on=(ps_partkey = p_partkey) type=differential // { arity: 14 }
+        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
               %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1407,7 +1407,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q17;
 ----
 materialize.public.q17_primary_idx:
-  ArrangeBy keys=[[avg_yearly]] // { arity: 1 }
+  ArrangeBy keys=[[#0{avg_yearly}]] // { arity: 1 }
     ReadGlobalFromSameDataflow materialize.public.q17 // { arity: 1 }
 
 materialize.public.q17:
@@ -1425,36 +1425,36 @@ materialize.public.q17:
                 - ()
   With
     cte l2 =
-      Reduce aggregates=[sum(l_extendedprice)] // { arity: 1 }
+      Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (l_quantity < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(l_partkey = l_partkey) type=differential // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
-                Reduce group_by=[l_partkey] aggregates=[sum(l_quantity), count(*)] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(l_partkey = l_partkey) type=differential // { arity: 17 }
+                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct project=[l_partkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{l_partkey}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1, #4, #5) // { arity: 3 }
-        Filter (p_brand = "Brand#23") AND (p_container = "MED BOX") AND (l_partkey) IS NOT NULL // { arity: 25 }
-          Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -1507,46 +1507,46 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q18;
 ----
 materialize.public.q18_primary_idx:
-  ArrangeBy keys=[[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice]] // { arity: 6 }
+  ArrangeBy keys=[[#0{c_name}, #1{c_custkey}, #2{o_orderkey}, #3{o_orderdate}, #4{o_totalprice}]] // { arity: 6 }
     ReadGlobalFromSameDataflow materialize.public.q18 // { arity: 6 }
 
 materialize.public.q18:
   Return // { arity: 6 }
-    Reduce group_by=[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] aggregates=[sum(l_quantity)] // { arity: 6 }
+    Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0..=#5) // { arity: 6 }
         Filter (#7 > 300) // { arity: 8 }
-          Join on=(o_orderkey = o_orderkey) type=differential // { arity: 8 }
+          Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
               %1[#0]UKAif » %0:l1[#2]Kif
-            ArrangeBy keys=[[o_orderkey]] // { arity: 6 }
+            ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
               Get l1 // { arity: 6 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 2 }
-              Reduce group_by=[o_orderkey] aggregates=[sum(l_quantity)] // { arity: 2 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
+              Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                 Project (#0, #5) // { arity: 2 }
-                  Join on=(o_orderkey = l_orderkey) type=differential // { arity: 17 }
+                  Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
-                    ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                      Distinct project=[o_orderkey] // { arity: 1 }
+                    ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+                      Distinct project=[#0{o_orderkey}] // { arity: 1 }
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
   With
     cte l1 =
       Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-        Filter (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
               %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
               %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             Get l0 // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -1604,7 +1604,7 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q19;
 ----
 materialize.public.q19_primary_idx:
-  ArrangeBy keys=[[revenue]] // { arity: 1 }
+  ArrangeBy keys=[[#0{revenue}]] // { arity: 1 }
     ReadGlobalFromSameDataflow materialize.public.q19 // { arity: 1 }
 
 materialize.public.q19:
@@ -1620,16 +1620,16 @@ materialize.public.q19:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_shipinstruct = "DELIVER IN PERSON") AND (p_size >= 1) AND (l_partkey) IS NOT NULL AND ((l_shipmode = "AIR") OR (l_shipmode = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
-            Map ((l_quantity <= 20), (l_quantity >= 10), (l_quantity <= 30), (l_quantity >= 20), (l_quantity <= 11), (l_quantity >= 1), (p_brand = "Brand#12"), (p_size <= 5), ((p_container = "SM BOX") OR (p_container = "SM PKG") OR (p_container = "SM CASE") OR (p_container = "SM PACK")), (p_brand = "Brand#23"), (p_size <= 10), ((p_container = "MED BAG") OR (p_container = "MED BOX") OR (p_container = "MED PKG") OR (p_container = "MED PACK")), (p_brand = "Brand#34"), (p_size <= 15), ((p_container = "LG BOX") OR (p_container = "LG PKG") OR (p_container = "LG CASE") OR (p_container = "LG PACK"))) // { arity: 40 }
-              Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+            Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
+              Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
                   %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
-                ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+                ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1687,69 +1687,69 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q20;
 ----
 materialize.public.q20_primary_idx:
-  ArrangeBy keys=[[s_name, s_address]] // { arity: 2 }
+  ArrangeBy keys=[[#0{s_name}, #1{s_address}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q20 // { arity: 2 }
 
 materialize.public.q20:
   Return // { arity: 2 }
     Project (#1, #2) // { arity: 2 }
-      Join on=(s_suppkey = s_suppkey) type=differential // { arity: 4 }
+      Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
-        ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
           Get l0 // { arity: 3 }
-        ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-          Distinct project=[s_suppkey] // { arity: 1 }
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
+          Distinct project=[#0{s_suppkey}] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
-                Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
+              Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
+                Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                  ArrangeBy keys=[[s_suppkey, ps_partkey]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
-                      Filter (s_suppkey = ps_suppkey) // { arity: 4 }
+                      Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[ps_suppkey, ps_partkey]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
                       Map ((0.5 * #2)) // { arity: 4 }
-                        Reduce group_by=[ps_partkey, ps_suppkey] aggregates=[sum(l_quantity)] // { arity: 3 }
+                        Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                           Project (#0, #1, #6) // { arity: 3 }
-                            Filter (l_shipdate >= 1995-01-01) AND (date_to_timestamp(l_shipdate) < 1996-01-01 00:00:00) // { arity: 18 }
-                              Join on=(ps_partkey = l_partkey AND ps_suppkey = l_suppkey) type=differential // { arity: 18 }
+                            Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                              Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                  Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                                  Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
                                     Project (#1, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
-                                ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
+                                ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
       Project (#0..=#3) // { arity: 4 }
-        Join on=(ps_partkey = p_partkey) type=differential // { arity: 7 }
+        Join on=(#1{ps_partkey} = #6{p_partkey}) type=differential // { arity: 7 }
           implementation
             %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[s_suppkey] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get l0 // { arity: 3 }
-          ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+          ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
             ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-          ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-            Distinct project=[p_partkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+            Distinct project=[#0{p_partkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
+                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (n_name = "CANADA") AND (s_nationkey) IS NOT NULL // { arity: 11 }
-          Join on=(s_nationkey = n_nationkey) type=differential // { arity: 11 }
+        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
               %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -1812,74 +1812,74 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q21;
 ----
 materialize.public.q21_primary_idx:
-  ArrangeBy keys=[[s_name]] // { arity: 2 }
+  ArrangeBy keys=[[#0{s_name}]] // { arity: 2 }
     ReadGlobalFromSameDataflow materialize.public.q21 // { arity: 2 }
 
 materialize.public.q21:
   Return // { arity: 2 }
-    Reduce group_by=[s_name] aggregates=[count(*)] // { arity: 2 }
+    Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %0:l2[#2, #0]KK » %1[#0, #1]KK
-          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 3 }
+          ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
             Get l2 // { arity: 3 }
-          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
             Union // { arity: 2 }
               Negate // { arity: 2 }
-                Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
-                      Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                    Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                         implementation
                           %1:l1[#0]KAf » %0:l3[#0]Kf
-                        ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                           Get l3 // { arity: 2 }
                         Get l1 // { arity: 16 }
               Get l3 // { arity: 2 }
   With
     cte l3 =
-      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
         Project (#0, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
       Project (#0..=#2) // { arity: 3 }
-        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:l0[#0, #2]KK
-          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
             Get l0 // { arity: 3 }
-          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-            Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
-                Filter (s_suppkey != l_suppkey) // { arity: 18 }
-                  Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
                         Project (#0, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l1 =
-      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
       Project (#0, #1, #7) // { arity: 3 }
-        Filter (o_orderstatus = "F") AND (n_name = "SAUDI ARABIA") AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (l_receiptdate > l_commitdate) // { arity: 36 }
-          Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 36 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
               %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
               %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
               %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
               %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -1951,41 +1951,41 @@ EXPLAIN WITH(humanized_exprs, arity, join_impls)
 CREATE DEFAULT INDEX ON Q22;
 ----
 materialize.public.q22_primary_idx:
-  ArrangeBy keys=[[cntrycode]] // { arity: 3 }
+  ArrangeBy keys=[[#0{cntrycode}]] // { arity: 3 }
     ReadGlobalFromSameDataflow materialize.public.q22 // { arity: 3 }
 
 materialize.public.q22:
   Return // { arity: 3 }
-    Reduce group_by=[substr(char_to_text(c_phone), 1, 2)] aggregates=[count(*), sum(c_acctbal)] // { arity: 3 }
+    Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(c_custkey = c_custkey) type=differential // { arity: 4 }
+        Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
-          ArrangeBy keys=[[c_custkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
             Get l1 // { arity: 3 }
-          ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (c_custkey) IS NOT NULL // { arity: 2 }
-                    Join on=(c_custkey = o_custkey) type=differential // { arity: 2 }
+                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                        Distinct project=[o_custkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{o_custkey}] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =
-      Distinct project=[c_custkey] // { arity: 1 }
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (c_acctbal > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef
@@ -1994,12 +1994,12 @@ materialize.public.q22:
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce aggregates=[sum(c_acctbal), count(*)] // { arity: 2 }
+              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                 Project (#5) // { arity: 1 }
-                  Filter (c_acctbal > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
     cte l0 =
-      Map (substr(char_to_text(c_phone), 1, 2)) // { arity: 9 }
+      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:

--- a/test/sqllogictest/tpch_create_materialized_view.slt
+++ b/test/sqllogictest/tpch_create_materialized_view.slt
@@ -193,9 +193,9 @@ ORDER BY
 materialize.public.q01:
   Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
     Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
-      Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)] // { arity: 8 }
+      Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
         Project (#4..=#9) // { arity: 6 }
-          Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00) // { arity: 16 }
+          Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -246,24 +246,24 @@ ORDER BY
 materialize.public.q02:
   Return // { arity: 8 }
     Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-      Join on=(p_partkey = p_partkey AND ps_supplycost = #10) type=differential // { arity: 11 }
+      Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
         implementation
           %1[#0, #1]UKK » %0:l4[#0, #7]KK
-        ArrangeBy keys=[[p_partkey, ps_supplycost]] // { arity: 9 }
+        ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
           Get l4 // { arity: 9 }
-        ArrangeBy keys=[[p_partkey, #1]] // { arity: 2 }
-          Reduce group_by=[p_partkey] aggregates=[min(ps_supplycost)] // { arity: 2 }
+        ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+          Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
             Project (#0, #4) // { arity: 2 }
-              Filter (r_name = "EUROPE") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 20 }
-                Join on=(p_partkey = ps_partkey AND ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 20 }
+              Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+                Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                   implementation
                     %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
                     %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                     %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                  ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                    Distinct project=[p_partkey] // { arity: 1 }
+                  ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                    Distinct project=[#0{p_partkey}] // { arity: 1 }
                       Project (#0) // { arity: 1 }
                         Get l4 // { arity: 9 }
                   Get l1 // { arity: 5 }
@@ -273,31 +273,31 @@ materialize.public.q02:
   With
     cte l4 =
       Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-        Filter (p_size = 15) AND (r_name = "EUROPE") AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND like["%BRASS"](varchar_to_text(p_type)) // { arity: 28 }
-          Join on=(p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 28 }
+        Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+          Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
             implementation
               %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
               %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
               %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
               %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
               %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
             Get l0 // { arity: 7 }
             Get l1 // { arity: 5 }
             Get l2 // { arity: 4 }
             Get l3 // { arity: 3 }
     cte l3 =
-      ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+      ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
         ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
     cte l2 =
-      ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+      ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
     cte l1 =
-      ArrangeBy keys=[[ps_partkey], [ps_suppkey]] // { arity: 5 }
+      ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
         ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
     cte l0 =
-      ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+      ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
         ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
@@ -342,19 +342,19 @@ ORDER BY
 ----
 materialize.public.q03:
   Project (#0, #3, #1, #2) // { arity: 4 }
-    Reduce group_by=[o_orderkey, o_orderdate, o_shippriority] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+    Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
       Project (#8, #12, #15, #22, #23) // { arity: 5 }
-        Filter (c_mktsegment = "BUILDING") AND (o_orderdate < 1995-03-15) AND (l_shipdate > 1995-03-15) AND (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+        Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
               %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
               %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
-            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -393,25 +393,25 @@ ORDER BY
     o_orderpriority;
 ----
 materialize.public.q04:
-  Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
+  Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
     Project (#5) // { arity: 1 }
-      Filter (o_orderdate >= 1993-07-01) AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 11 }
-        Join on=(eq(o_orderkey, o_orderkey, l_orderkey)) type=delta // { arity: 11 }
+      Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
+        Join on=(eq(#0{o_orderkey}, #9{o_orderkey}, #10{l_orderkey})) type=delta // { arity: 11 }
           implementation
             %0:orders » %1[#0]UKA » %2[#0]UKA
             %1 » %2[#0]UKA » %0:orders[#0]KAiif
             %2 » %1[#0]UKA » %0:orders[#0]KAiif
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-            Distinct project=[o_orderkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+            Distinct project=[#0{o_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
+                Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-            Distinct project=[l_orderkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
+            Distinct project=[#0{l_orderkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (l_commitdate < l_receiptdate) // { arity: 16 }
+                Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                   ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -451,25 +451,25 @@ ORDER BY
     revenue DESC;
 ----
 materialize.public.q05:
-  Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+  Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
     Project (#22, #23, #36) // { arity: 3 }
-      Filter (r_name = "ASIA") AND (o_orderdate < 1995-01-01) AND (o_orderdate >= 1994-01-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 42 }
-        Join on=(c_custkey = o_custkey AND eq(c_nationkey, s_nationkey, n_nationkey) AND o_orderkey = l_orderkey AND l_suppkey = s_suppkey AND n_regionkey = r_regionkey) type=differential // { arity: 42 }
+      Filter (#40{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#37{n_regionkey}) IS NOT NULL // { arity: 42 }
+        Join on=(#0{c_custkey} = #9{o_custkey} AND eq(#3{c_nationkey}, #34{s_nationkey}, #35{n_nationkey}) AND #8{o_orderkey} = #17{l_orderkey} AND #19{l_suppkey} = #33{s_suppkey} AND #37{n_regionkey} = #39{r_regionkey}) type=differential // { arity: 42 }
           implementation
             %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKeiif
-          ArrangeBy keys=[[c_nationkey]] // { arity: 8 }
+          ArrangeBy keys=[[#3{c_nationkey}]] // { arity: 8 }
             ReadIndex on=customer fk_customer_nationkey=[differential join] // { arity: 8 }
-          ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+          ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
             ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-          ArrangeBy keys=[[s_suppkey, s_nationkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
             Project (#0, #3) // { arity: 2 }
-              Filter (s_suppkey) IS NOT NULL // { arity: 7 }
+              Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
-          ArrangeBy keys=[[n_regionkey]] // { arity: 4 }
+          ArrangeBy keys=[[#2{n_regionkey}]] // { arity: 4 }
             ReadIndex on=nation fk_nation_regionkey=[differential join] // { arity: 4 }
-          ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
             ReadIndex on=region pk_region_regionkey=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -510,9 +510,9 @@ materialize.public.q06:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * l_discount))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_quantity < 24) AND (l_discount <= 0.07) AND (l_discount >= 0.05) AND (l_shipdate >= 1994-01-01) AND (date_to_timestamp(l_shipdate) < 1995-01-01 00:00:00) // { arity: 16 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -567,11 +567,11 @@ ORDER BY
 ----
 materialize.public.q07:
   Return // { arity: 4 }
-    Reduce group_by=[n_name, n_name, extract_year_d(l_shipdate)] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+    Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
       Project (#12, #13, #17, #41, #45) // { arity: 5 }
-        Filter (l_shipdate <= 1996-12-31) AND (l_shipdate >= 1995-01-01) AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
-          Map ((n_name = "FRANCE"), (n_name = "GERMANY"), (n_name = "FRANCE"), (n_name = "GERMANY")) // { arity: 52 }
-            Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey) type=delta // { arity: 48 }
+        Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+          Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
+            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
               implementation
                 %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
@@ -579,19 +579,19 @@ materialize.public.q07:
                 %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                 %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                 %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-              ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
               Get l0 // { arity: 4 }
               Get l0 // { arity: 4 }
   With
     cte l0 =
-      ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+      ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
         ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -653,10 +653,10 @@ ORDER BY
 materialize.public.q08:
   Project (#0, #3) // { arity: 2 }
     Map ((#1 / #2)) // { arity: 4 }
-      Reduce group_by=[extract_year_d(o_orderdate)] aggregates=[sum(case when (n_name = "BRAZIL") then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 3 }
+      Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
         Project (#21, #22, #36, #54) // { arity: 4 }
-          Filter (r_name = "AMERICA") AND (o_orderdate <= 1996-12-31) AND (o_orderdate >= 1995-01-01) AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(p_type)) // { arity: 60 }
-            Join on=(p_partkey = l_partkey AND s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 60 }
+          Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+            Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
               implementation
                 %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
                 %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -666,21 +666,21 @@ materialize.public.q08:
                 %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
                 %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
                 %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-              ArrangeBy keys=[[l_orderkey], [l_partkey], [l_suppkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
-              ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
-              ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+              ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
                 ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -739,10 +739,10 @@ ORDER BY
     o_year DESC;
 ----
 materialize.public.q09:
-  Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
+  Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
     Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-      Filter (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND like["%green%"](varchar_to_text(p_name)) // { arity: 50 }
-        Join on=(eq(p_partkey, l_partkey, ps_partkey) AND eq(s_suppkey, l_suppkey, ps_suppkey) AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 50 }
+      Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+        Join on=(eq(#0{p_partkey}, #17{l_partkey}, #32{ps_partkey}) AND eq(#9{s_suppkey}, #18{l_suppkey}, #33{ps_suppkey}) AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
           implementation
             %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
             %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
@@ -750,17 +750,17 @@ materialize.public.q09:
             %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
             %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
             %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
-          ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
             ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-          ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+          ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-          ArrangeBy keys=[[l_orderkey], [l_partkey], [l_partkey, l_suppkey], [l_suppkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#1{l_partkey}, #2{l_suppkey}], [#2{l_suppkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] fk_lineitem_partsuppkey=[delta join lookup] // { arity: 16 }
-          ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 5 }
+          ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 5 }
             ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[delta join lookup] // { arity: 5 }
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-          ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+          ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
             ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -817,22 +817,22 @@ ORDER BY
 ----
 materialize.public.q10:
   Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
-    Reduce group_by=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 8 }
+    Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
       Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
-        Filter (l_returnflag = "R") AND (o_orderdate < 1994-01-01) AND (o_orderdate >= 1993-10-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1994-01-01 00:00:00) // { arity: 37 }
-          Join on=(c_custkey = o_custkey AND c_nationkey = n_nationkey AND o_orderkey = l_orderkey) type=delta // { arity: 37 }
+        Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
             implementation
               %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
               %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
               %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
               %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
-            ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -886,26 +886,26 @@ materialize.public.q11:
           implementation
             %1[×]UA » %0[×]
           ArrangeBy keys=[[]] // { arity: 2 }
-            Reduce group_by=[ps_partkey] aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 2 }
+            Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
               Get l0 // { arity: 3 }
           ArrangeBy keys=[[]] // { arity: 1 }
-            Reduce aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 1 }
+            Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
               Project (#1, #2) // { arity: 2 }
                 Get l0 // { arity: 3 }
   With
     cte l0 =
       Project (#0, #2, #3) // { arity: 3 }
-        Filter (n_name = "GERMANY") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL // { arity: 16 }
-          Join on=(ps_suppkey = s_suppkey AND s_nationkey = n_nationkey) type=delta // { arity: 16 }
+        Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+          Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
             implementation
               %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
               %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
               %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
-            ArrangeBy keys=[[ps_suppkey]] // { arity: 5 }
+            ArrangeBy keys=[[#1{ps_suppkey}]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_suppkey=[delta join 1st input (full scan)] // { arity: 5 }
-            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -951,15 +951,15 @@ ORDER BY
     l_shipmode;
 ----
 materialize.public.q12:
-  Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
+  Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
     Project (#5, #23) // { arity: 2 }
-      Filter (l_receiptdate >= 1994-01-01) AND (o_orderkey) IS NOT NULL AND (l_shipdate < l_commitdate) AND (l_commitdate < l_receiptdate) AND (date_to_timestamp(l_receiptdate) < 1995-01-01 00:00:00) AND ((l_shipmode = "MAIL") OR (l_shipmode = "SHIP")) // { arity: 25 }
-        Join on=(o_orderkey = l_orderkey) type=differential // { arity: 25 }
+      Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+        Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
           implementation
             %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
-          ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+          ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
             ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
-          ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
             ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -998,18 +998,18 @@ materialize.public.q13:
   Return // { arity: 2 }
     Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Reduce group_by=[c_custkey] aggregates=[count(o_orderkey)] // { arity: 2 }
+        Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
           Union // { arity: 2 }
             Map (null) // { arity: 2 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Join on=(c_custkey = c_custkey) type=differential // { arity: 9 }
+                    Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                       implementation
                         %1[#0]UKA » %0:l0[#0]KA
                       Get l0 // { arity: 8 }
-                      ArrangeBy keys=[[c_custkey]] // { arity: 1 }
-                        Distinct project=[c_custkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{c_custkey}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 2 }
                 Project (#0) // { arity: 1 }
@@ -1018,15 +1018,15 @@ materialize.public.q13:
   With
     cte l1 =
       Project (#0, #8) // { arity: 2 }
-        Filter (c_custkey) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(o_comment))) // { arity: 17 }
-          Join on=(c_custkey = o_custkey) type=differential // { arity: 17 }
+        Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+          Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
             implementation
               %1:orders[#1]KAf » %0:l0[#0]KAf
             Get l0 // { arity: 8 }
-            ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
         ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
@@ -1069,15 +1069,15 @@ materialize.public.q14:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(p_type)) then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (l_shipdate >= 1995-09-01) AND (l_partkey) IS NOT NULL AND (date_to_timestamp(l_shipdate) < 1995-10-01 00:00:00) // { arity: 25 }
-            Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+            Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
-              ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+              ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1127,13 +1127,13 @@ ORDER BY
 materialize.public.q15:
   Return // { arity: 5 }
     Project (#0..=#2, #4, #8) // { arity: 5 }
-      Filter (s_suppkey) IS NOT NULL // { arity: 10 }
-        Join on=(s_suppkey = l_suppkey AND #8 = #9) type=differential // { arity: 10 }
+      Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
+        Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=differential // { arity: 10 }
           implementation
             %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UK
-          ArrangeBy keys=[[s_suppkey]] // { arity: 7 }
+          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
             ReadIndex on=supplier pk_supplier_suppkey=[differential join] // { arity: 7 }
-          ArrangeBy keys=[[l_suppkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_suppkey}]] // { arity: 2 }
             Get l0 // { arity: 2 }
           ArrangeBy keys=[[#0]] // { arity: 1 }
             Reduce aggregates=[max(#0)] // { arity: 1 }
@@ -1141,9 +1141,9 @@ materialize.public.q15:
                 Get l0 // { arity: 2 }
   With
     cte l0 =
-      Reduce group_by=[l_suppkey] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+      Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
         Project (#2, #5, #6) // { arity: 3 }
-          Filter (l_shipdate >= 1996-01-01) AND (date_to_timestamp(l_shipdate) < 1996-04-01 00:00:00) // { arity: 16 }
+          Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -1193,19 +1193,19 @@ ORDER BY
 ----
 materialize.public.q16:
   Return // { arity: 4 }
-    Reduce group_by=[p_brand, p_type, p_size] aggregates=[count(distinct ps_suppkey)] // { arity: 4 }
+    Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
       Project (#0..=#3) // { arity: 4 }
-        Join on=(ps_suppkey = ps_suppkey) type=differential // { arity: 5 }
+        Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
           implementation
             %0:l0[#0]K » %1[#0]K
-          ArrangeBy keys=[[ps_suppkey]] // { arity: 4 }
+          ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
             Get l0 // { arity: 4 }
-          ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
+          ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
-                Distinct project=[ps_suppkey] // { arity: 1 }
+                Distinct project=[#0{ps_suppkey}] // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
+                    Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                       CrossJoin type=differential // { arity: 2 }
                         implementation
                           %1:supplier[×]lf » %0:l1[×]lf
@@ -1213,23 +1213,23 @@ materialize.public.q16:
                           Get l1 // { arity: 1 }
                         ArrangeBy keys=[[]] // { arity: 1 }
                           Project (#0) // { arity: 1 }
-                            Filter like["%Customer%Complaints%"](varchar_to_text(s_comment)) // { arity: 7 }
+                            Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                               ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
               Get l1 // { arity: 1 }
   With
     cte l1 =
-      Distinct project=[ps_suppkey] // { arity: 1 }
+      Distinct project=[#0{ps_suppkey}] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l0 // { arity: 4 }
     cte l0 =
       Project (#1, #8..=#10) // { arity: 4 }
-        Filter (p_brand != "Brand#45") AND (ps_partkey) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(p_type))) AND ((p_size = 3) OR (p_size = 9) OR (p_size = 14) OR (p_size = 19) OR (p_size = 23) OR (p_size = 36) OR (p_size = 45) OR (p_size = 49)) // { arity: 14 }
-          Join on=(ps_partkey = p_partkey) type=differential // { arity: 14 }
+        Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+          Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
             implementation
               %1:part[#0]KAef » %0:partsupp[#0]KAef
-            ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1277,36 +1277,36 @@ materialize.public.q17:
                 - ()
   With
     cte l2 =
-      Reduce aggregates=[sum(l_extendedprice)] // { arity: 1 }
+      Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (l_quantity < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(l_partkey = l_partkey) type=differential // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
-                Reduce group_by=[l_partkey] aggregates=[sum(l_quantity), count(*)] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(l_partkey = l_partkey) type=differential // { arity: 17 }
+                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct project=[l_partkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{l_partkey}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1, #4, #5) // { arity: 3 }
-        Filter (p_brand = "Brand#23") AND (p_container = "MED BOX") AND (l_partkey) IS NOT NULL // { arity: 25 }
-          Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -1355,41 +1355,41 @@ ORDER BY
 ----
 materialize.public.q18:
   Return // { arity: 6 }
-    Reduce group_by=[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] aggregates=[sum(l_quantity)] // { arity: 6 }
+    Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
       Project (#0..=#5) // { arity: 6 }
         Filter (#7 > 300) // { arity: 8 }
-          Join on=(o_orderkey = o_orderkey) type=differential // { arity: 8 }
+          Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
             implementation
               %1[#0]UKAif » %0:l1[#2]Kif
-            ArrangeBy keys=[[o_orderkey]] // { arity: 6 }
+            ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
               Get l1 // { arity: 6 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 2 }
-              Reduce group_by=[o_orderkey] aggregates=[sum(l_quantity)] // { arity: 2 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
+              Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                 Project (#0, #5) // { arity: 2 }
-                  Join on=(o_orderkey = l_orderkey) type=differential // { arity: 17 }
+                  Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                     implementation
                       %0[#0]UKA » %1:l0[#0]KA
-                    ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                      Distinct project=[o_orderkey] // { arity: 1 }
+                    ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+                      Distinct project=[#0{o_orderkey}] // { arity: 1 }
                         Project (#2) // { arity: 1 }
                           Get l1 // { arity: 6 }
                     Get l0 // { arity: 16 }
   With
     cte l1 =
       Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-        Filter (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-          Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+        Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
             implementation
               %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
               %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
               %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-            ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
               ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-            ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
             Get l0 // { arity: 16 }
     cte l0 =
-      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -1454,16 +1454,16 @@ materialize.public.q19:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_shipinstruct = "DELIVER IN PERSON") AND (p_size >= 1) AND (l_partkey) IS NOT NULL AND ((l_shipmode = "AIR") OR (l_shipmode = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
-            Map ((l_quantity <= 20), (l_quantity >= 10), (l_quantity <= 30), (l_quantity >= 20), (l_quantity <= 11), (l_quantity >= 1), (p_brand = "Brand#12"), (p_size <= 5), ((p_container = "SM BOX") OR (p_container = "SM PKG") OR (p_container = "SM CASE") OR (p_container = "SM PACK")), (p_brand = "Brand#23"), (p_size <= 10), ((p_container = "MED BAG") OR (p_container = "MED BOX") OR (p_container = "MED PKG") OR (p_container = "MED PACK")), (p_brand = "Brand#34"), (p_size <= 15), ((p_container = "LG BOX") OR (p_container = "LG PKG") OR (p_container = "LG CASE") OR (p_container = "LG PACK"))) // { arity: 40 }
-              Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+            Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
+              Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
                   %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
-                ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+                ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1518,63 +1518,63 @@ ORDER BY
 materialize.public.q20:
   Return // { arity: 2 }
     Project (#1, #2) // { arity: 2 }
-      Join on=(s_suppkey = s_suppkey) type=differential // { arity: 4 }
+      Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
         implementation
           %1[#0]UKA » %0:l0[#0]K
-        ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
           Get l0 // { arity: 3 }
-        ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-          Distinct project=[s_suppkey] // { arity: 1 }
+        ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
+          Distinct project=[#0{s_suppkey}] // { arity: 1 }
             Project (#0) // { arity: 1 }
-              Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
-                Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
+              Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
+                Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                   implementation
                     %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                  ArrangeBy keys=[[s_suppkey, ps_partkey]] // { arity: 3 }
+                  ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
-                      Filter (s_suppkey = ps_suppkey) // { arity: 4 }
+                      Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                         Get l1 // { arity: 4 }
-                  ArrangeBy keys=[[ps_suppkey, ps_partkey]] // { arity: 3 }
+                  ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                     Project (#0, #1, #3) // { arity: 3 }
                       Map ((0.5 * #2)) // { arity: 4 }
-                        Reduce group_by=[ps_partkey, ps_suppkey] aggregates=[sum(l_quantity)] // { arity: 3 }
+                        Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                           Project (#0, #1, #6) // { arity: 3 }
-                            Filter (l_shipdate >= 1995-01-01) AND (date_to_timestamp(l_shipdate) < 1996-01-01 00:00:00) // { arity: 18 }
-                              Join on=(ps_partkey = l_partkey AND ps_suppkey = l_suppkey) type=differential // { arity: 18 }
+                            Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                              Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                 implementation
                                   %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                  Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                                  Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
                                     Project (#1, #2) // { arity: 2 }
                                       Get l1 // { arity: 4 }
-                                ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
+                                ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                   ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
   With
     cte l1 =
       Project (#0..=#3) // { arity: 4 }
-        Join on=(ps_partkey = p_partkey) type=differential // { arity: 7 }
+        Join on=(#1{ps_partkey} = #6{p_partkey}) type=differential // { arity: 7 }
           implementation
             %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
           ArrangeBy keys=[[]] // { arity: 1 }
-            Distinct project=[s_suppkey] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
                 Get l0 // { arity: 3 }
-          ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+          ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
             ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-          ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-            Distinct project=[p_partkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+            Distinct project=[#0{p_partkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
+                Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
     cte l0 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (n_name = "CANADA") AND (s_nationkey) IS NOT NULL // { arity: 11 }
-          Join on=(s_nationkey = n_nationkey) type=differential // { arity: 11 }
+        Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+          Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
             implementation
               %1:nation[#0]KAef » %0:supplier[#3]KAef
-            ArrangeBy keys=[[s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -1633,69 +1633,69 @@ ORDER BY
 ----
 materialize.public.q21:
   Return // { arity: 2 }
-    Reduce group_by=[s_name] aggregates=[count(*)] // { arity: 2 }
+    Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
       Project (#1) // { arity: 1 }
-        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %0:l2[#2, #0]KK » %1[#0, #1]KK
-          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 3 }
+          ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
             Get l2 // { arity: 3 }
-          ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
+          ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
             Union // { arity: 2 }
               Negate // { arity: 2 }
-                Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
                   Project (#0, #1) // { arity: 2 }
-                    Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
-                      Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                    Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                      Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                         implementation
                           %1:l1[#0]KAf » %0:l3[#0]Kf
-                        ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                           Get l3 // { arity: 2 }
                         Get l1 // { arity: 16 }
               Get l3 // { arity: 2 }
   With
     cte l3 =
-      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
         Project (#0, #2) // { arity: 2 }
           Get l2 // { arity: 3 }
     cte l2 =
       Project (#0..=#2) // { arity: 3 }
-        Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+        Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
           implementation
             %1[#1, #0]UKK » %0:l0[#0, #2]KK
-          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
             Get l0 // { arity: 3 }
-          ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-            Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+          ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+            Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
               Project (#0, #1) // { arity: 2 }
-                Filter (s_suppkey != l_suppkey) // { arity: 18 }
-                  Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                  Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                     implementation
                       %1:l1[#0]KA » %0[#0]K
-                    ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                      Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                    ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                      Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
                         Project (#0, #2) // { arity: 2 }
                           Get l0 // { arity: 3 }
                     Get l1 // { arity: 16 }
     cte l1 =
-      ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
     cte l0 =
       Project (#0, #1, #7) // { arity: 3 }
-        Filter (o_orderstatus = "F") AND (n_name = "SAUDI ARABIA") AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (l_receiptdate > l_commitdate) // { arity: 36 }
-          Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 36 }
+        Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+          Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
             implementation
               %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
               %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
               %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
               %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-            ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -1763,36 +1763,36 @@ ORDER BY
 ----
 materialize.public.q22:
   Return // { arity: 3 }
-    Reduce group_by=[substr(char_to_text(c_phone), 1, 2)] aggregates=[count(*), sum(c_acctbal)] // { arity: 3 }
+    Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(c_custkey = c_custkey) type=differential // { arity: 4 }
+        Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
           implementation
             %0:l1[#0]K » %1[#0]K
-          ArrangeBy keys=[[c_custkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
             Get l1 // { arity: 3 }
-          ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+          ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
             Union // { arity: 1 }
               Negate // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (c_custkey) IS NOT NULL // { arity: 2 }
-                    Join on=(c_custkey = o_custkey) type=differential // { arity: 2 }
+                  Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                    Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                       implementation
                         %0:l2[#0]UKA » %1[#0]UKA
-                      ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+                      ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                         Get l2 // { arity: 1 }
-                      ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                        Distinct project=[o_custkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                        Distinct project=[#0{o_custkey}] // { arity: 1 }
                           Project (#1) // { arity: 1 }
                             ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
               Get l2 // { arity: 1 }
   With
     cte l2 =
-      Distinct project=[c_custkey] // { arity: 1 }
+      Distinct project=[#0{c_custkey}] // { arity: 1 }
         Project (#0) // { arity: 1 }
           Get l1 // { arity: 3 }
     cte l1 =
       Project (#0..=#2) // { arity: 3 }
-        Filter (c_acctbal > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+        Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
           CrossJoin type=differential // { arity: 5 }
             implementation
               %1[×]UA » %0:l0[×]ef
@@ -1801,12 +1801,12 @@ materialize.public.q22:
                 Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                   Get l0 // { arity: 9 }
             ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce aggregates=[sum(c_acctbal), count(*)] // { arity: 2 }
+              Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                 Project (#5) // { arity: 1 }
-                  Filter (c_acctbal > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                  Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
     cte l0 =
-      Map (substr(char_to_text(c_phone), 1, 2)) // { arity: 9 }
+      Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
         ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:

--- a/test/sqllogictest/tpch_select.slt
+++ b/test/sqllogictest/tpch_select.slt
@@ -189,12 +189,12 @@ ORDER BY
 	l_linestatus;
 ----
 Explained Query:
-  Finish order_by=[l_returnflag asc nulls_last, l_linestatus asc nulls_last] output=[#0..=#9]
+  Finish order_by=[#0{l_returnflag} asc nulls_last, #1{l_linestatus} asc nulls_last] output=[#0..=#9]
     Project (#0..=#5, #9..=#11, #6) // { arity: 10 }
       Map (bigint_to_numeric(case when (#6 = 0) then null else #6 end), (#2 / #8), (#3 / #8), (#7 / #8)) // { arity: 12 }
-        Reduce group_by=[l_returnflag, l_linestatus] aggregates=[sum(l_quantity), sum(l_extendedprice), sum((l_extendedprice * (1 - l_discount))), sum(((l_extendedprice * (1 - l_discount)) * (1 + l_tax))), count(*), sum(l_discount)] // { arity: 8 }
+        Reduce group_by=[#4{l_returnflag}, #5{l_linestatus}] aggregates=[sum(#0{l_quantity}), sum(#1{l_extendedprice}), sum((#1{l_extendedprice} * (1 - #2{l_discount}))), sum(((#1{l_extendedprice} * (1 - #2{l_discount})) * (1 + #3{l_tax}))), count(*), sum(#2{l_discount})] // { arity: 8 }
           Project (#4..=#9) // { arity: 6 }
-            Filter (date_to_timestamp(l_shipdate) <= 1998-10-02 00:00:00) // { arity: 16 }
+            Filter (date_to_timestamp(#10{l_shipdate}) <= 1998-10-02 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -242,27 +242,27 @@ ORDER BY
     s_acctbal DESC, n_name, s_name, p_partkey;
 ----
 Explained Query:
-  Finish order_by=[s_acctbal desc nulls_first, n_name asc nulls_last, s_name asc nulls_last, p_partkey asc nulls_last] output=[#0..=#7]
+  Finish order_by=[#0{s_acctbal} desc nulls_first, #2{n_name} asc nulls_last, #1{s_name} asc nulls_last, #3{p_partkey} asc nulls_last] output=[#0..=#7]
     Return // { arity: 8 }
       Project (#5, #2, #8, #0, #1, #3, #4, #6) // { arity: 8 }
-        Join on=(p_partkey = p_partkey AND ps_supplycost = #10) type=differential // { arity: 11 }
+        Join on=(#0{p_partkey} = #9{p_partkey} AND #7{ps_supplycost} = #10) type=differential // { arity: 11 }
           implementation
             %1[#0, #1]UKK » %0:l4[#0, #7]KK
-          ArrangeBy keys=[[p_partkey, ps_supplycost]] // { arity: 9 }
+          ArrangeBy keys=[[#0{p_partkey}, #7{ps_supplycost}]] // { arity: 9 }
             Get l4 // { arity: 9 }
-          ArrangeBy keys=[[p_partkey, #1]] // { arity: 2 }
-            Reduce group_by=[p_partkey] aggregates=[min(ps_supplycost)] // { arity: 2 }
+          ArrangeBy keys=[[#0{p_partkey}, #1]] // { arity: 2 }
+            Reduce group_by=[#0{p_partkey}] aggregates=[min(#1{ps_supplycost})] // { arity: 2 }
               Project (#0, #4) // { arity: 2 }
-                Filter (r_name = "EUROPE") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 20 }
-                  Join on=(p_partkey = ps_partkey AND ps_suppkey = s_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 20 }
+                Filter (#18{r_name} = "EUROPE") AND (#2{ps_suppkey}) IS NOT NULL AND (#9{s_nationkey}) IS NOT NULL AND (#15{n_regionkey}) IS NOT NULL // { arity: 20 }
+                  Join on=(#0{p_partkey} = #1{ps_partkey} AND #2{ps_suppkey} = #6{s_suppkey} AND #9{s_nationkey} = #13{n_nationkey} AND #15{n_regionkey} = #17{r_regionkey}) type=delta // { arity: 20 }
                     implementation
                       %0 » %1:l1[#0]KA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %1:l1 » %0[#0]UKA » %2:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %2:l0 » %1:l1[#1]KA » %0[#0]UKA » %3:l2[#0]KA » %4:l3[#0]KAef
                       %3:l2 » %4:l3[#0]KAef » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
                       %4:l3 » %3:l2[#2]KA » %2:l0[#3]KA » %1:l1[#1]KA » %0[#0]UKA
-                    ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-                      Distinct project=[p_partkey] // { arity: 1 }
+                    ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+                      Distinct project=[#0{p_partkey}] // { arity: 1 }
                         Project (#0) // { arity: 1 }
                           Get l4 // { arity: 9 }
                     Get l1 // { arity: 5 }
@@ -272,31 +272,31 @@ Explained Query:
     With
       cte l4 =
         Project (#0, #2, #10, #11, #13..=#15, #19, #22) // { arity: 9 }
-          Filter (p_size = 15) AND (r_name = "EUROPE") AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND like["%BRASS"](varchar_to_text(p_type)) // { arity: 28 }
-            Join on=(p_partkey = ps_partkey AND s_suppkey = ps_suppkey AND s_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 28 }
+          Filter (#5{p_size} = 15) AND (#26{r_name} = "EUROPE") AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#23{n_regionkey}) IS NOT NULL AND like["%BRASS"](varchar_to_text(#4{p_type})) // { arity: 28 }
+            Join on=(#0{p_partkey} = #16{ps_partkey} AND #9{s_suppkey} = #17{ps_suppkey} AND #12{s_nationkey} = #21{n_nationkey} AND #23{n_regionkey} = #25{r_regionkey}) type=delta // { arity: 28 }
               implementation
                 %0:part » %2:l1[#0]KA » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                 %1:l0 » %2:l1[#1]KA » %0:part[#0]KAelf » %3:l2[#0]KA » %4:l3[#0]KAef
                 %2:l1 » %0:part[#0]KAelf » %1:l0[#0]KA » %3:l2[#0]KA » %4:l3[#0]KAef
                 %3:l2 » %4:l3[#0]KAef » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
                 %4:l3 » %3:l2[#2]KA » %1:l0[#3]KA » %2:l1[#1]KA » %0:part[#0]KAelf
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
               Get l0 // { arity: 7 }
               Get l1 // { arity: 5 }
               Get l2 // { arity: 4 }
               Get l3 // { arity: 3 }
       cte l3 =
-        ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+        ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
           ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
       cte l2 =
-        ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+        ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
           ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
       cte l1 =
-        ArrangeBy keys=[[ps_partkey], [ps_suppkey]] // { arity: 5 }
+        ArrangeBy keys=[[#0{ps_partkey}], [#1{ps_suppkey}]] // { arity: 5 }
           ReadIndex on=partsupp fk_partsupp_partkey=[delta join lookup] fk_partsupp_suppkey=[delta join lookup] // { arity: 5 }
       cte l0 =
-        ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+        ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
           ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
 
 Used Indexes:
@@ -339,21 +339,21 @@ ORDER BY
     o_orderdate;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, o_orderdate asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#1 desc nulls_first, #2{o_orderdate} asc nulls_last] output=[#0..=#3]
     Project (#0, #3, #1, #2) // { arity: 4 }
-      Reduce group_by=[o_orderkey, o_orderdate, o_shippriority] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+      Reduce group_by=[#0{o_orderkey}, #1{o_orderdate}, #2{o_shippriority}] aggregates=[sum((#3{l_extendedprice} * (1 - #4{l_discount})))] // { arity: 4 }
         Project (#8, #12, #15, #22, #23) // { arity: 5 }
-          Filter (c_mktsegment = "BUILDING") AND (o_orderdate < 1995-03-15) AND (l_shipdate > 1995-03-15) AND (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-            Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+          Filter (#6{c_mktsegment} = "BUILDING") AND (#12{o_orderdate} < 1995-03-15) AND (#27{l_shipdate} > 1995-03-15) AND (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+            Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
               implementation
                 %0:customer » %1:orders[#1]KAif » %2:lineitem[#0]KAif
                 %1:orders » %0:customer[#0]KAef » %2:lineitem[#0]KAif
                 %2:lineitem » %1:orders[#0]KAif » %0:customer[#0]KAef
-              ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -391,26 +391,26 @@ ORDER BY
     o_orderpriority;
 ----
 Explained Query:
-  Finish order_by=[o_orderpriority asc nulls_last] output=[#0, #1]
-    Reduce group_by=[o_orderpriority] aggregates=[count(*)] // { arity: 2 }
+  Finish order_by=[#0{o_orderpriority} asc nulls_last] output=[#0, #1]
+    Reduce group_by=[#0{o_orderpriority}] aggregates=[count(*)] // { arity: 2 }
       Project (#5) // { arity: 1 }
-        Filter (o_orderdate >= 1993-07-01) AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 11 }
-          Join on=(eq(o_orderkey, o_orderkey, l_orderkey)) type=delta // { arity: 11 }
+        Filter (#4{o_orderdate} >= 1993-07-01) AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 11 }
+          Join on=(eq(#0{o_orderkey}, #9{o_orderkey}, #10{l_orderkey})) type=delta // { arity: 11 }
             implementation
               %0:orders » %1[#0]UKA » %2[#0]UKA
               %1 » %2[#0]UKA » %0:orders[#0]KAiif
               %2 » %1[#0]UKA » %0:orders[#0]KAiif
-            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-              Distinct project=[o_orderkey] // { arity: 1 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+              Distinct project=[#0{o_orderkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (o_orderdate >= 1993-07-01) AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1993-10-01 00:00:00) // { arity: 9 }
+                  Filter (#4{o_orderdate} >= 1993-07-01) AND (#0{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#4{o_orderdate}) < 1993-10-01 00:00:00) // { arity: 9 }
                     ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 1 }
-              Distinct project=[l_orderkey] // { arity: 1 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 1 }
+              Distinct project=[#0{l_orderkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (l_commitdate < l_receiptdate) // { arity: 16 }
+                  Filter (#11{l_commitdate} < #12{l_receiptdate}) // { arity: 16 }
                     ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -450,25 +450,25 @@ ORDER BY
 ----
 Explained Query:
   Finish order_by=[#1 desc nulls_first] output=[#0, #1]
-    Reduce group_by=[n_name] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+    Reduce group_by=[#2{n_name}] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
       Project (#22, #23, #36) // { arity: 3 }
-        Filter (r_name = "ASIA") AND (o_orderdate < 1995-01-01) AND (o_orderdate >= 1994-01-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (n_regionkey) IS NOT NULL // { arity: 42 }
-          Join on=(c_custkey = o_custkey AND eq(c_nationkey, s_nationkey, n_nationkey) AND o_orderkey = l_orderkey AND l_suppkey = s_suppkey AND n_regionkey = r_regionkey) type=differential // { arity: 42 }
+        Filter (#40{r_name} = "ASIA") AND (#12{o_orderdate} < 1995-01-01) AND (#12{o_orderdate} >= 1994-01-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (#37{n_regionkey}) IS NOT NULL // { arity: 42 }
+          Join on=(#0{c_custkey} = #9{o_custkey} AND eq(#3{c_nationkey}, #34{s_nationkey}, #35{n_nationkey}) AND #8{o_orderkey} = #17{l_orderkey} AND #19{l_suppkey} = #33{s_suppkey} AND #37{n_regionkey} = #39{r_regionkey}) type=differential // { arity: 42 }
             implementation
               %5:region[#0]KAef » %4:nation[#2]KAef » %0:customer[#3]KAef » %1:orders[#1]KAeiif » %2:lineitem[#0]KAeiif » %3:supplier[#0, #1]KKeiif
-            ArrangeBy keys=[[c_nationkey]] // { arity: 8 }
+            ArrangeBy keys=[[#3{c_nationkey}]] // { arity: 8 }
               ReadIndex on=customer fk_customer_nationkey=[differential join] // { arity: 8 }
-            ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+            ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
               ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
-            ArrangeBy keys=[[s_suppkey, s_nationkey]] // { arity: 2 }
+            ArrangeBy keys=[[#0{s_suppkey}, #1{s_nationkey}]] // { arity: 2 }
               Project (#0, #3) // { arity: 2 }
-                Filter (s_suppkey) IS NOT NULL // { arity: 7 }
+                Filter (#0{s_suppkey}) IS NOT NULL // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
-            ArrangeBy keys=[[n_regionkey]] // { arity: 4 }
+            ArrangeBy keys=[[#2{n_regionkey}]] // { arity: 4 }
               ReadIndex on=nation fk_nation_regionkey=[differential join] // { arity: 4 }
-            ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+            ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
               ReadIndex on=region pk_region_regionkey=[differential join] // { arity: 3 }
 
 Used Indexes:
@@ -508,9 +508,9 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * l_discount))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * #1{l_discount}))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_quantity < 24) AND (l_discount <= 0.07) AND (l_discount >= 0.05) AND (l_shipdate >= 1994-01-01) AND (date_to_timestamp(l_shipdate) < 1995-01-01 00:00:00) // { arity: 16 }
+          Filter (#4{l_quantity} < 24) AND (#6{l_discount} <= 0.07) AND (#6{l_discount} >= 0.05) AND (#10{l_shipdate} >= 1994-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1995-01-01 00:00:00) // { arity: 16 }
             ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -563,13 +563,13 @@ ORDER BY
     l_year;
 ----
 Explained Query:
-  Finish order_by=[n_name asc nulls_last, n_name asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#0{n_name} asc nulls_last, #1{n_name} asc nulls_last, #2 asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[n_name, n_name, extract_year_d(l_shipdate)] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 4 }
+      Reduce group_by=[#3{n_name}, #4{n_name}, extract_year_d(#2{l_shipdate})] aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 4 }
         Project (#12, #13, #17, #41, #45) // { arity: 5 }
-          Filter (l_shipdate <= 1996-12-31) AND (l_shipdate >= 1995-01-01) AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
-            Map ((n_name = "FRANCE"), (n_name = "GERMANY"), (n_name = "FRANCE"), (n_name = "GERMANY")) // { arity: 52 }
-              Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey) type=delta // { arity: 48 }
+          Filter (#17{l_shipdate} <= 1996-12-31) AND (#17{l_shipdate} >= 1995-01-01) AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#24{o_custkey}) IS NOT NULL AND (#35{c_nationkey}) IS NOT NULL AND (#48 OR #49) AND (#50 OR #51) AND ((#48 AND #51) OR (#49 AND #50)) // { arity: 52 }
+            Map ((#41{n_name} = "FRANCE"), (#41{n_name} = "GERMANY"), (#45{n_name} = "FRANCE"), (#45{n_name} = "GERMANY")) // { arity: 52 }
+              Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #40{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey} AND #24{o_custkey} = #32{c_custkey} AND #35{c_nationkey} = #44{n_nationkey}) type=delta // { arity: 48 }
                 implementation
                   %0:supplier » %4:l0[#0]KAef » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                   %1:lineitem » %0:supplier[#0]KA » %4:l0[#0]KAef » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
@@ -577,19 +577,19 @@ Explained Query:
                   %3:customer » %5:l0[#0]KAef » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
                   %4:l0 » %0:supplier[#3]KA » %1:lineitem[#2]KAiif » %2:orders[#0]KA » %3:customer[#0]KA » %5:l0[#0]KAef
                   %5:l0 » %3:customer[#3]KA » %2:orders[#1]KA » %1:lineitem[#0]KAiif » %0:supplier[#0]KA » %4:l0[#0]KAef
-                ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+                ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-                ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+                ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-                ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-                ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+                ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                   ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
                 Get l0 // { arity: 4 }
                 Get l0 // { arity: 4 }
     With
       cte l0 =
-        ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+        ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
           ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -651,10 +651,10 @@ Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0, #1]
     Project (#0, #3) // { arity: 2 }
       Map ((#1 / #2)) // { arity: 4 }
-        Reduce group_by=[extract_year_d(o_orderdate)] aggregates=[sum(case when (n_name = "BRAZIL") then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 3 }
+        Reduce group_by=[extract_year_d(#2{o_orderdate})] aggregates=[sum(case when (#3{n_name} = "BRAZIL") then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 3 }
           Project (#21, #22, #36, #54) // { arity: 4 }
-            Filter (r_name = "AMERICA") AND (o_orderdate <= 1996-12-31) AND (o_orderdate >= 1995-01-01) AND (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (o_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (n_regionkey) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(p_type)) // { arity: 60 }
-              Join on=(p_partkey = l_partkey AND s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey AND o_custkey = c_custkey AND c_nationkey = n_nationkey AND n_regionkey = r_regionkey) type=delta // { arity: 60 }
+            Filter (#58{r_name} = "AMERICA") AND (#36{o_orderdate} <= 1996-12-31) AND (#36{o_orderdate} >= 1995-01-01) AND (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND (#33{o_custkey}) IS NOT NULL AND (#44{c_nationkey}) IS NOT NULL AND (#51{n_regionkey}) IS NOT NULL AND ("ECONOMY ANODIZED STEEL" = varchar_to_text(#4{p_type})) // { arity: 60 }
+              Join on=(#0{p_partkey} = #17{l_partkey} AND #9{s_suppkey} = #18{l_suppkey} AND #12{s_nationkey} = #53{n_nationkey} AND #16{l_orderkey} = #32{o_orderkey} AND #33{o_custkey} = #41{c_custkey} AND #44{c_nationkey} = #49{n_nationkey} AND #51{n_regionkey} = #57{r_regionkey}) type=delta // { arity: 60 }
                 implementation
                   %0:part » %2:lineitem[#1]KA » %3:orders[#0]KAiif » %1:supplier[#0]KA » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
                   %1:supplier » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef » %6:nation[#0]KA
@@ -664,21 +664,21 @@ Explained Query:
                   %5:nation » %7:region[#0]KAef » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
                   %6:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %0:part[#0]KAef » %3:orders[#0]KAiif » %4:customer[#0]KA » %5:nation[#0]KA » %7:region[#0]KAef
                   %7:region » %5:nation[#2]KA » %4:customer[#3]KA » %3:orders[#1]KAiif » %2:lineitem[#0]KA » %0:part[#0]KAef » %1:supplier[#0]KA » %6:nation[#0]KA
-                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-                ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+                ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                   ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-                ArrangeBy keys=[[l_orderkey], [l_partkey], [l_suppkey]] // { arity: 16 }
+                ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#2{l_suppkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-                ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                   ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-                ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+                ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                   ReadIndex on=customer pk_customer_custkey=[delta join lookup] fk_customer_nationkey=[delta join lookup] // { arity: 8 }
-                ArrangeBy keys=[[n_nationkey], [n_regionkey]] // { arity: 4 }
+                ArrangeBy keys=[[#0{n_nationkey}], [#2{n_regionkey}]] // { arity: 4 }
                   ReadIndex on=nation pk_nation_nationkey=[delta join lookup] fk_nation_regionkey=[delta join lookup] // { arity: 4 }
-                ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+                ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                   ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
-                ArrangeBy keys=[[r_regionkey]] // { arity: 3 }
+                ArrangeBy keys=[[#0{r_regionkey}]] // { arity: 3 }
                   ReadIndex on=region pk_region_regionkey=[delta join lookup] // { arity: 3 }
 
 Used Indexes:
@@ -736,11 +736,11 @@ ORDER BY
     o_year DESC;
 ----
 Explained Query:
-  Finish order_by=[n_name asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
-    Reduce group_by=[n_name, extract_year_d(o_orderdate)] aggregates=[sum(((l_extendedprice * (1 - l_discount)) - (ps_supplycost * l_quantity)))] // { arity: 3 }
+  Finish order_by=[#0{n_name} asc nulls_last, #1 desc nulls_first] output=[#0..=#2]
+    Reduce group_by=[#5{n_name}, extract_year_d(#4{o_orderdate})] aggregates=[sum(((#1{l_extendedprice} * (1 - #2{l_discount})) - (#3{ps_supplycost} * #0{l_quantity})))] // { arity: 3 }
       Project (#20..=#22, #35, #41, #47) // { arity: 6 }
-        Filter (p_partkey) IS NOT NULL AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND like["%green%"](varchar_to_text(p_name)) // { arity: 50 }
-          Join on=(eq(p_partkey, l_partkey, ps_partkey) AND eq(s_suppkey, l_suppkey, ps_suppkey) AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 50 }
+        Filter (#0{p_partkey}) IS NOT NULL AND (#9{s_suppkey}) IS NOT NULL AND (#12{s_nationkey}) IS NOT NULL AND (#16{l_orderkey}) IS NOT NULL AND like["%green%"](varchar_to_text(#1{p_name})) // { arity: 50 }
+          Join on=(eq(#0{p_partkey}, #17{l_partkey}, #32{ps_partkey}) AND eq(#9{s_suppkey}, #18{l_suppkey}, #33{ps_suppkey}) AND #12{s_nationkey} = #46{n_nationkey} AND #16{l_orderkey} = #37{o_orderkey}) type=delta // { arity: 50 }
             implementation
               %0:part » %2:lineitem[#1]KA » %3:partsupp[#0, #1]KKA » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
               %1:supplier » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA » %5:nation[#0]KA
@@ -748,17 +748,17 @@ Explained Query:
               %3:partsupp » %2:lineitem[#1, #2]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %4:orders[#0]KA » %5:nation[#0]KA
               %4:orders » %2:lineitem[#0]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %1:supplier[#0]KA » %5:nation[#0]KA
               %5:nation » %1:supplier[#3]KA » %2:lineitem[#2]KA » %3:partsupp[#0, #1]KKA » %0:part[#0]KAlf » %4:orders[#0]KA
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[delta join 1st input (full scan)] // { arity: 9 }
-            ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-            ArrangeBy keys=[[l_orderkey], [l_partkey], [l_partkey, l_suppkey], [l_suppkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}], [#1{l_partkey}], [#1{l_partkey}, #2{l_suppkey}], [#2{l_suppkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_partkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] fk_lineitem_partsuppkey=[delta join lookup] // { arity: 16 }
-            ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 5 }
+            ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 5 }
               ReadIndex on=partsupp pk_partsupp_partkey_suppkey=[delta join lookup] // { arity: 5 }
-            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-            ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
               ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -815,22 +815,22 @@ ORDER BY
 Explained Query:
   Finish order_by=[#2 desc nulls_first] output=[#0..=#7]
     Project (#0, #1, #7, #2, #4, #5, #3, #6) // { arity: 8 }
-      Reduce group_by=[c_custkey, c_name, c_acctbal, c_phone, n_name, c_address, c_comment] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 8 }
+      Reduce group_by=[#0{c_custkey}, #1{c_name}, #4{c_acctbal}, #3{c_phone}, #8{n_name}, #2{c_address}, #5{c_comment}] aggregates=[sum((#6{l_extendedprice} * (1 - #7{l_discount})))] // { arity: 8 }
         Project (#0..=#2, #4, #5, #7, #22, #23, #34) // { arity: 9 }
-          Filter (l_returnflag = "R") AND (o_orderdate < 1994-01-01) AND (o_orderdate >= 1993-10-01) AND (c_custkey) IS NOT NULL AND (c_nationkey) IS NOT NULL AND (o_orderkey) IS NOT NULL AND (date_to_timestamp(o_orderdate) < 1994-01-01 00:00:00) // { arity: 37 }
-            Join on=(c_custkey = o_custkey AND c_nationkey = n_nationkey AND o_orderkey = l_orderkey) type=delta // { arity: 37 }
+          Filter (#25{l_returnflag} = "R") AND (#12{o_orderdate} < 1994-01-01) AND (#12{o_orderdate} >= 1993-10-01) AND (#0{c_custkey}) IS NOT NULL AND (#3{c_nationkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL AND (date_to_timestamp(#12{o_orderdate}) < 1994-01-01 00:00:00) // { arity: 37 }
+            Join on=(#0{c_custkey} = #9{o_custkey} AND #3{c_nationkey} = #33{n_nationkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 37 }
               implementation
                 %0:customer » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef » %3:nation[#0]KA
                 %1:orders » %2:lineitem[#0]KAef » %0:customer[#0]KA » %3:nation[#0]KA
                 %2:lineitem » %1:orders[#0]KAiiif » %0:customer[#0]KA » %3:nation[#0]KA
                 %3:nation » %0:customer[#3]KA » %1:orders[#1]KAiiif » %2:lineitem[#0]KAef
-              ArrangeBy keys=[[c_custkey], [c_nationkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}], [#3{c_nationkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] fk_customer_nationkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -884,26 +884,26 @@ Explained Query:
             implementation
               %1[×]UA » %0[×]
             ArrangeBy keys=[[]] // { arity: 2 }
-              Reduce group_by=[ps_partkey] aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 2 }
+              Reduce group_by=[#0{ps_partkey}] aggregates=[sum((#2{ps_supplycost} * integer_to_numeric(#1{ps_availqty})))] // { arity: 2 }
                 Get l0 // { arity: 3 }
             ArrangeBy keys=[[]] // { arity: 1 }
-              Reduce aggregates=[sum((ps_supplycost * integer_to_numeric(ps_availqty)))] // { arity: 1 }
+              Reduce aggregates=[sum((#1{ps_supplycost} * integer_to_numeric(#0{ps_availqty})))] // { arity: 1 }
                 Project (#1, #2) // { arity: 2 }
                   Get l0 // { arity: 3 }
     With
       cte l0 =
         Project (#0, #2, #3) // { arity: 3 }
-          Filter (n_name = "GERMANY") AND (ps_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL // { arity: 16 }
-            Join on=(ps_suppkey = s_suppkey AND s_nationkey = n_nationkey) type=delta // { arity: 16 }
+          Filter (#13{n_name} = "GERMANY") AND (#1{ps_suppkey}) IS NOT NULL AND (#8{s_nationkey}) IS NOT NULL // { arity: 16 }
+            Join on=(#1{ps_suppkey} = #5{s_suppkey} AND #8{s_nationkey} = #12{n_nationkey}) type=delta // { arity: 16 }
               implementation
                 %0:partsupp » %1:supplier[#0]KA » %2:nation[#0]KAef
                 %1:supplier » %2:nation[#0]KAef » %0:partsupp[#1]KA
                 %2:nation » %1:supplier[#3]KA » %0:partsupp[#1]KA
-              ArrangeBy keys=[[ps_suppkey]] // { arity: 5 }
+              ArrangeBy keys=[[#1{ps_suppkey}]] // { arity: 5 }
                 ReadIndex on=partsupp fk_partsupp_suppkey=[delta join 1st input (full scan)] // { arity: 5 }
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join lookup] fk_supplier_nationkey=[delta join lookup] // { arity: 7 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -948,16 +948,16 @@ ORDER BY
     l_shipmode;
 ----
 Explained Query:
-  Finish order_by=[l_shipmode asc nulls_last] output=[#0..=#2]
-    Reduce group_by=[l_shipmode] aggregates=[sum(case when ((o_orderpriority = "2-HIGH") OR (o_orderpriority = "1-URGENT")) then 1 else 0 end), sum(case when ((o_orderpriority != "2-HIGH") AND (o_orderpriority != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
+  Finish order_by=[#0{l_shipmode} asc nulls_last] output=[#0..=#2]
+    Reduce group_by=[#1{l_shipmode}] aggregates=[sum(case when ((#0{o_orderpriority} = "2-HIGH") OR (#0{o_orderpriority} = "1-URGENT")) then 1 else 0 end), sum(case when ((#0{o_orderpriority} != "2-HIGH") AND (#0{o_orderpriority} != "1-URGENT")) then 1 else 0 end)] // { arity: 3 }
       Project (#5, #23) // { arity: 2 }
-        Filter (l_receiptdate >= 1994-01-01) AND (o_orderkey) IS NOT NULL AND (l_shipdate < l_commitdate) AND (l_commitdate < l_receiptdate) AND (date_to_timestamp(l_receiptdate) < 1995-01-01 00:00:00) AND ((l_shipmode = "MAIL") OR (l_shipmode = "SHIP")) // { arity: 25 }
-          Join on=(o_orderkey = l_orderkey) type=differential // { arity: 25 }
+        Filter (#21{l_receiptdate} >= 1994-01-01) AND (#0{o_orderkey}) IS NOT NULL AND (#19{l_shipdate} < #20{l_commitdate}) AND (#20{l_commitdate} < #21{l_receiptdate}) AND (date_to_timestamp(#21{l_receiptdate}) < 1995-01-01 00:00:00) AND ((#23{l_shipmode} = "MAIL") OR (#23{l_shipmode} = "SHIP")) // { arity: 25 }
+          Join on=(#0{o_orderkey} = #9{l_orderkey}) type=differential // { arity: 25 }
             implementation
               %1:lineitem[#0]KAeiif » %0:orders[#0]KAeiif
-            ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
               ReadIndex on=orders pk_orders_orderkey=[differential join] // { arity: 9 }
-            ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+            ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
               ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -996,18 +996,18 @@ Explained Query:
     Return // { arity: 2 }
       Reduce group_by=[#0] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Reduce group_by=[c_custkey] aggregates=[count(o_orderkey)] // { arity: 2 }
+          Reduce group_by=[#0{c_custkey}] aggregates=[count(#1{o_orderkey})] // { arity: 2 }
             Union // { arity: 2 }
               Map (null) // { arity: 2 }
                 Union // { arity: 1 }
                   Negate // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Join on=(c_custkey = c_custkey) type=differential // { arity: 9 }
+                      Join on=(#0{c_custkey} = #8{c_custkey}) type=differential // { arity: 9 }
                         implementation
                           %1[#0]UKA » %0:l0[#0]KA
                         Get l0 // { arity: 8 }
-                        ArrangeBy keys=[[c_custkey]] // { arity: 1 }
-                          Distinct project=[c_custkey] // { arity: 1 }
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{c_custkey}] // { arity: 1 }
                             Project (#0) // { arity: 1 }
                               Get l1 // { arity: 2 }
                   Project (#0) // { arity: 1 }
@@ -1016,15 +1016,15 @@ Explained Query:
     With
       cte l1 =
         Project (#0, #8) // { arity: 2 }
-          Filter (c_custkey) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(o_comment))) // { arity: 17 }
-            Join on=(c_custkey = o_custkey) type=differential // { arity: 17 }
+          Filter (#0{c_custkey}) IS NOT NULL AND NOT(like["%special%requests%"](varchar_to_text(#16{o_comment}))) // { arity: 17 }
+            Join on=(#0{c_custkey} = #9{o_custkey}) type=differential // { arity: 17 }
               implementation
                 %1:orders[#1]KAf » %0:l0[#0]KAf
               Get l0 // { arity: 8 }
-              ArrangeBy keys=[[o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders fk_orders_custkey=[differential join] // { arity: 9 }
       cte l0 =
-        ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
           ReadIndex on=customer pk_customer_custkey=[differential join] // { arity: 8 }
 
 Used Indexes:
@@ -1066,15 +1066,15 @@ Explained Query:
                 - ()
   With
     cte l0 =
-      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(p_type)) then (l_extendedprice * (1 - l_discount)) else 0 end), sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+      Reduce aggregates=[sum(case when like["PROMO%"](varchar_to_text(#2{p_type})) then (#0{l_extendedprice} * (1 - #1{l_discount})) else 0 end), sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 2 }
         Project (#5, #6, #20) // { arity: 3 }
-          Filter (l_shipdate >= 1995-09-01) AND (l_partkey) IS NOT NULL AND (date_to_timestamp(l_shipdate) < 1995-10-01 00:00:00) // { arity: 25 }
-            Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#10{l_shipdate} >= 1995-09-01) AND (#1{l_partkey}) IS NOT NULL AND (date_to_timestamp(#10{l_shipdate}) < 1995-10-01 00:00:00) // { arity: 25 }
+            Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
               implementation
                 %0:lineitem[#1]KAiif » %1:part[#0]KAiif
-              ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+              ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1121,16 +1121,16 @@ ORDER BY
     s_suppkey;
 ----
 Explained Query:
-  Finish order_by=[s_suppkey asc nulls_last] output=[#0..=#4]
+  Finish order_by=[#0{s_suppkey} asc nulls_last] output=[#0..=#4]
     Return // { arity: 5 }
       Project (#0..=#2, #4, #8) // { arity: 5 }
-        Filter (s_suppkey) IS NOT NULL // { arity: 10 }
-          Join on=(s_suppkey = l_suppkey AND #8 = #9) type=differential // { arity: 10 }
+        Filter (#0{s_suppkey}) IS NOT NULL // { arity: 10 }
+          Join on=(#0{s_suppkey} = #7{l_suppkey} AND #8 = #9) type=differential // { arity: 10 }
             implementation
               %0:supplier[#0]KA » %1:l0[#0]UKA » %2[#0]UK
-            ArrangeBy keys=[[s_suppkey]] // { arity: 7 }
+            ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 7 }
               ReadIndex on=supplier pk_supplier_suppkey=[differential join] // { arity: 7 }
-            ArrangeBy keys=[[l_suppkey]] // { arity: 2 }
+            ArrangeBy keys=[[#0{l_suppkey}]] // { arity: 2 }
               Get l0 // { arity: 2 }
             ArrangeBy keys=[[#0]] // { arity: 1 }
               Reduce aggregates=[max(#0)] // { arity: 1 }
@@ -1138,9 +1138,9 @@ Explained Query:
                   Get l0 // { arity: 2 }
     With
       cte l0 =
-        Reduce group_by=[l_suppkey] aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 2 }
+        Reduce group_by=[#0{l_suppkey}] aggregates=[sum((#1{l_extendedprice} * (1 - #2{l_discount})))] // { arity: 2 }
           Project (#2, #5, #6) // { arity: 3 }
-            Filter (l_shipdate >= 1996-01-01) AND (date_to_timestamp(l_shipdate) < 1996-04-01 00:00:00) // { arity: 16 }
+            Filter (#10{l_shipdate} >= 1996-01-01) AND (date_to_timestamp(#10{l_shipdate}) < 1996-04-01 00:00:00) // { arity: 16 }
               ReadIndex on=lineitem pk_lineitem_orderkey_linenumber=[*** full scan ***] // { arity: 16 }
 
 Used Indexes:
@@ -1188,21 +1188,21 @@ ORDER BY
     p_size;
 ----
 Explained Query:
-  Finish order_by=[#3 desc nulls_first, p_brand asc nulls_last, p_type asc nulls_last, p_size asc nulls_last] output=[#0..=#3]
+  Finish order_by=[#3 desc nulls_first, #0{p_brand} asc nulls_last, #1{p_type} asc nulls_last, #2{p_size} asc nulls_last] output=[#0..=#3]
     Return // { arity: 4 }
-      Reduce group_by=[p_brand, p_type, p_size] aggregates=[count(distinct ps_suppkey)] // { arity: 4 }
+      Reduce group_by=[#1{p_brand}, #2{p_type}, #3{p_size}] aggregates=[count(distinct #0{ps_suppkey})] // { arity: 4 }
         Project (#0..=#3) // { arity: 4 }
-          Join on=(ps_suppkey = ps_suppkey) type=differential // { arity: 5 }
+          Join on=(#0{ps_suppkey} = #4{ps_suppkey}) type=differential // { arity: 5 }
             implementation
               %0:l0[#0]K » %1[#0]K
-            ArrangeBy keys=[[ps_suppkey]] // { arity: 4 }
+            ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 4 }
               Get l0 // { arity: 4 }
-            ArrangeBy keys=[[ps_suppkey]] // { arity: 1 }
+            ArrangeBy keys=[[#0{ps_suppkey}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
-                  Distinct project=[ps_suppkey] // { arity: 1 }
+                  Distinct project=[#0{ps_suppkey}] // { arity: 1 }
                     Project (#0) // { arity: 1 }
-                      Filter ((s_suppkey) IS NULL OR (ps_suppkey = s_suppkey)) // { arity: 2 }
+                      Filter ((#1{s_suppkey}) IS NULL OR (#0{ps_suppkey} = #1{s_suppkey})) // { arity: 2 }
                         CrossJoin type=differential // { arity: 2 }
                           implementation
                             %1:supplier[×]lf » %0:l1[×]lf
@@ -1210,23 +1210,23 @@ Explained Query:
                             Get l1 // { arity: 1 }
                           ArrangeBy keys=[[]] // { arity: 1 }
                             Project (#0) // { arity: 1 }
-                              Filter like["%Customer%Complaints%"](varchar_to_text(s_comment)) // { arity: 7 }
+                              Filter like["%Customer%Complaints%"](varchar_to_text(#6{s_comment})) // { arity: 7 }
                                 ReadIndex on=supplier pk_supplier_suppkey=[*** full scan ***] // { arity: 7 }
                 Get l1 // { arity: 1 }
     With
       cte l1 =
-        Distinct project=[ps_suppkey] // { arity: 1 }
+        Distinct project=[#0{ps_suppkey}] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l0 // { arity: 4 }
       cte l0 =
         Project (#1, #8..=#10) // { arity: 4 }
-          Filter (p_brand != "Brand#45") AND (ps_partkey) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(p_type))) AND ((p_size = 3) OR (p_size = 9) OR (p_size = 14) OR (p_size = 19) OR (p_size = 23) OR (p_size = 36) OR (p_size = 45) OR (p_size = 49)) // { arity: 14 }
-            Join on=(ps_partkey = p_partkey) type=differential // { arity: 14 }
+          Filter (#8{p_brand} != "Brand#45") AND (#0{ps_partkey}) IS NOT NULL AND NOT(like["MEDIUM POLISHED%"](varchar_to_text(#9{p_type}))) AND ((#10{p_size} = 3) OR (#10{p_size} = 9) OR (#10{p_size} = 14) OR (#10{p_size} = 19) OR (#10{p_size} = 23) OR (#10{p_size} = 36) OR (#10{p_size} = 45) OR (#10{p_size} = 49)) // { arity: 14 }
+            Join on=(#0{ps_partkey} = #5{p_partkey}) type=differential // { arity: 14 }
               implementation
                 %1:part[#0]KAef » %0:partsupp[#0]KAef
-              ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+              ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
                 ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-              ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                 ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1273,36 +1273,36 @@ Explained Query:
                 - ()
   With
     cte l2 =
-      Reduce aggregates=[sum(l_extendedprice)] // { arity: 1 }
+      Reduce aggregates=[sum(#0{l_extendedprice})] // { arity: 1 }
         Project (#2) // { arity: 1 }
-          Filter (l_quantity < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
-            Join on=(l_partkey = l_partkey) type=differential // { arity: 6 }
+          Filter (#1{l_quantity} < (0.2 * (#4 / bigint_to_numeric(case when (#5 = 0) then null else #5 end)))) // { arity: 6 }
+            Join on=(#0{l_partkey} = #3{l_partkey}) type=differential // { arity: 6 }
               implementation
                 %1[#0]UKA » %0:l1[#0]K
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
                 Get l1 // { arity: 3 }
-              ArrangeBy keys=[[l_partkey]] // { arity: 3 }
-                Reduce group_by=[l_partkey] aggregates=[sum(l_quantity), count(*)] // { arity: 3 }
+              ArrangeBy keys=[[#0{l_partkey}]] // { arity: 3 }
+                Reduce group_by=[#0{l_partkey}] aggregates=[sum(#1{l_quantity}), count(*)] // { arity: 3 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(l_partkey = l_partkey) type=differential // { arity: 17 }
+                    Join on=(#0{l_partkey} = #2{l_partkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#1]KA
-                      ArrangeBy keys=[[l_partkey]] // { arity: 1 }
-                        Distinct project=[l_partkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{l_partkey}]] // { arity: 1 }
+                        Distinct project=[#0{l_partkey}] // { arity: 1 }
                           Project (#0) // { arity: 1 }
                             Get l1 // { arity: 3 }
                       Get l0 // { arity: 16 }
     cte l1 =
       Project (#1, #4, #5) // { arity: 3 }
-        Filter (p_brand = "Brand#23") AND (p_container = "MED BOX") AND (l_partkey) IS NOT NULL // { arity: 25 }
-          Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+        Filter (#19{p_brand} = "Brand#23") AND (#22{p_container} = "MED BOX") AND (#1{l_partkey}) IS NOT NULL // { arity: 25 }
+          Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
             implementation
               %1:part[#0]KAef » %0:l0[#1]KAef
             Get l0 // { arity: 16 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
               ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
     cte l0 =
-      ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+      ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
         ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
 
 Used Indexes:
@@ -1349,43 +1349,43 @@ ORDER BY
     o_orderdate;
 ----
 Explained Query:
-  Finish order_by=[o_totalprice desc nulls_first, o_orderdate asc nulls_last] output=[#0..=#5]
+  Finish order_by=[#4{o_totalprice} desc nulls_first, #3{o_orderdate} asc nulls_last] output=[#0..=#5]
     Return // { arity: 6 }
-      Reduce group_by=[c_name, c_custkey, o_orderkey, o_orderdate, o_totalprice] aggregates=[sum(l_quantity)] // { arity: 6 }
+      Reduce group_by=[#1{c_name}, #0{c_custkey}, #2{o_orderkey}, #4{o_orderdate}, #3{o_totalprice}] aggregates=[sum(#5{l_quantity})] // { arity: 6 }
         Project (#0..=#5) // { arity: 6 }
           Filter (#7 > 300) // { arity: 8 }
-            Join on=(o_orderkey = o_orderkey) type=differential // { arity: 8 }
+            Join on=(#2{o_orderkey} = #6{o_orderkey}) type=differential // { arity: 8 }
               implementation
                 %1[#0]UKAif » %0:l1[#2]Kif
-              ArrangeBy keys=[[o_orderkey]] // { arity: 6 }
+              ArrangeBy keys=[[#2{o_orderkey}]] // { arity: 6 }
                 Get l1 // { arity: 6 }
-              ArrangeBy keys=[[o_orderkey]] // { arity: 2 }
-                Reduce group_by=[o_orderkey] aggregates=[sum(l_quantity)] // { arity: 2 }
+              ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 2 }
+                Reduce group_by=[#0{o_orderkey}] aggregates=[sum(#1{l_quantity})] // { arity: 2 }
                   Project (#0, #5) // { arity: 2 }
-                    Join on=(o_orderkey = l_orderkey) type=differential // { arity: 17 }
+                    Join on=(#0{o_orderkey} = #1{l_orderkey}) type=differential // { arity: 17 }
                       implementation
                         %0[#0]UKA » %1:l0[#0]KA
-                      ArrangeBy keys=[[o_orderkey]] // { arity: 1 }
-                        Distinct project=[o_orderkey] // { arity: 1 }
+                      ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 1 }
+                        Distinct project=[#0{o_orderkey}] // { arity: 1 }
                           Project (#2) // { arity: 1 }
                             Get l1 // { arity: 6 }
                       Get l0 // { arity: 16 }
     With
       cte l1 =
         Project (#0, #1, #8, #11, #12, #21) // { arity: 6 }
-          Filter (c_custkey) IS NOT NULL AND (o_orderkey) IS NOT NULL // { arity: 33 }
-            Join on=(c_custkey = o_custkey AND o_orderkey = l_orderkey) type=delta // { arity: 33 }
+          Filter (#0{c_custkey}) IS NOT NULL AND (#8{o_orderkey}) IS NOT NULL // { arity: 33 }
+            Join on=(#0{c_custkey} = #9{o_custkey} AND #8{o_orderkey} = #17{l_orderkey}) type=delta // { arity: 33 }
               implementation
                 %0:customer » %1:orders[#1]KA » %2:l0[#0]KA
                 %1:orders » %0:customer[#0]KA » %2:l0[#0]KA
                 %2:l0 » %1:orders[#0]KA » %0:customer[#0]KA
-              ArrangeBy keys=[[c_custkey]] // { arity: 8 }
+              ArrangeBy keys=[[#0{c_custkey}]] // { arity: 8 }
                 ReadIndex on=customer pk_customer_custkey=[delta join 1st input (full scan)] // { arity: 8 }
-              ArrangeBy keys=[[o_orderkey], [o_custkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}], [#1{o_custkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] fk_orders_custkey=[delta join lookup] // { arity: 9 }
               Get l0 // { arity: 16 }
       cte l0 =
-        ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join, delta join lookup] // { arity: 16 }
 
 Used Indexes:
@@ -1449,16 +1449,16 @@ Explained Query:
             - ()
   With
     cte l0 =
-      Reduce aggregates=[sum((l_extendedprice * (1 - l_discount)))] // { arity: 1 }
+      Reduce aggregates=[sum((#0{l_extendedprice} * (1 - #1{l_discount})))] // { arity: 1 }
         Project (#5, #6) // { arity: 2 }
-          Filter (l_shipinstruct = "DELIVER IN PERSON") AND (p_size >= 1) AND (l_partkey) IS NOT NULL AND ((l_shipmode = "AIR") OR (l_shipmode = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
-            Map ((l_quantity <= 20), (l_quantity >= 10), (l_quantity <= 30), (l_quantity >= 20), (l_quantity <= 11), (l_quantity >= 1), (p_brand = "Brand#12"), (p_size <= 5), ((p_container = "SM BOX") OR (p_container = "SM PKG") OR (p_container = "SM CASE") OR (p_container = "SM PACK")), (p_brand = "Brand#23"), (p_size <= 10), ((p_container = "MED BAG") OR (p_container = "MED BOX") OR (p_container = "MED PKG") OR (p_container = "MED PACK")), (p_brand = "Brand#34"), (p_size <= 15), ((p_container = "LG BOX") OR (p_container = "LG PKG") OR (p_container = "LG CASE") OR (p_container = "LG PACK"))) // { arity: 40 }
-              Join on=(l_partkey = p_partkey) type=differential // { arity: 25 }
+          Filter (#13{l_shipinstruct} = "DELIVER IN PERSON") AND (#21{p_size} >= 1) AND (#1{l_partkey}) IS NOT NULL AND ((#14{l_shipmode} = "AIR") OR (#14{l_shipmode} = "AIR REG")) AND ((#25 AND #26) OR (#27 AND #28) OR (#29 AND #30)) AND ((#31 AND #32 AND #33) OR (#34 AND #35 AND #36) OR (#37 AND #38 AND #39)) AND ((#25 AND #26 AND #34 AND #35 AND #36) OR (#27 AND #28 AND #37 AND #38 AND #39) OR (#29 AND #30 AND #31 AND #32 AND #33)) // { arity: 40 }
+            Map ((#4{l_quantity} <= 20), (#4{l_quantity} >= 10), (#4{l_quantity} <= 30), (#4{l_quantity} >= 20), (#4{l_quantity} <= 11), (#4{l_quantity} >= 1), (#19{p_brand} = "Brand#12"), (#21{p_size} <= 5), ((#22{p_container} = "SM BOX") OR (#22{p_container} = "SM PKG") OR (#22{p_container} = "SM CASE") OR (#22{p_container} = "SM PACK")), (#19{p_brand} = "Brand#23"), (#21{p_size} <= 10), ((#22{p_container} = "MED BAG") OR (#22{p_container} = "MED BOX") OR (#22{p_container} = "MED PKG") OR (#22{p_container} = "MED PACK")), (#19{p_brand} = "Brand#34"), (#21{p_size} <= 15), ((#22{p_container} = "LG BOX") OR (#22{p_container} = "LG PKG") OR (#22{p_container} = "LG CASE") OR (#22{p_container} = "LG PACK"))) // { arity: 40 }
+              Join on=(#1{l_partkey} = #16{p_partkey}) type=differential // { arity: 25 }
                 implementation
                   %1:part[#0]KAeiiif » %0:lineitem[#1]KAeiiiiif
-                ArrangeBy keys=[[l_partkey]] // { arity: 16 }
+                ArrangeBy keys=[[#1{l_partkey}]] // { arity: 16 }
                   ReadIndex on=lineitem fk_lineitem_partkey=[differential join] // { arity: 16 }
-                ArrangeBy keys=[[p_partkey]] // { arity: 9 }
+                ArrangeBy keys=[[#0{p_partkey}]] // { arity: 9 }
                   ReadIndex on=part pk_part_partkey=[differential join] // { arity: 9 }
 
 Used Indexes:
@@ -1510,66 +1510,66 @@ ORDER BY
     s_name;
 ----
 Explained Query:
-  Finish order_by=[s_name asc nulls_last] output=[#0, #1]
+  Finish order_by=[#0{s_name} asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
       Project (#1, #2) // { arity: 2 }
-        Join on=(s_suppkey = s_suppkey) type=differential // { arity: 4 }
+        Join on=(#0{s_suppkey} = #3{s_suppkey}) type=differential // { arity: 4 }
           implementation
             %1[#0]UKA » %0:l0[#0]K
-          ArrangeBy keys=[[s_suppkey]] // { arity: 3 }
+          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 3 }
             Get l0 // { arity: 3 }
-          ArrangeBy keys=[[s_suppkey]] // { arity: 1 }
-            Distinct project=[s_suppkey] // { arity: 1 }
+          ArrangeBy keys=[[#0{s_suppkey}]] // { arity: 1 }
+            Distinct project=[#0{s_suppkey}] // { arity: 1 }
               Project (#0) // { arity: 1 }
-                Filter (integer_to_numeric(ps_availqty) > #5) // { arity: 6 }
-                  Join on=(s_suppkey = ps_suppkey AND ps_partkey = ps_partkey) type=differential // { arity: 6 }
+                Filter (integer_to_numeric(#2{ps_availqty}) > #5) // { arity: 6 }
+                  Join on=(#0{s_suppkey} = #4{ps_suppkey} AND #1{ps_partkey} = #3{ps_partkey}) type=differential // { arity: 6 }
                     implementation
                       %1[#1, #0]UKK » %0:l1[#0, #1]KKf
-                    ArrangeBy keys=[[s_suppkey, ps_partkey]] // { arity: 3 }
+                    ArrangeBy keys=[[#0{s_suppkey}, #1{ps_partkey}]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
-                        Filter (s_suppkey = ps_suppkey) // { arity: 4 }
+                        Filter (#0{s_suppkey} = #2{ps_suppkey}) // { arity: 4 }
                           Get l1 // { arity: 4 }
-                    ArrangeBy keys=[[ps_suppkey, ps_partkey]] // { arity: 3 }
+                    ArrangeBy keys=[[#1{ps_suppkey}, #0{ps_partkey}]] // { arity: 3 }
                       Project (#0, #1, #3) // { arity: 3 }
                         Map ((0.5 * #2)) // { arity: 4 }
-                          Reduce group_by=[ps_partkey, ps_suppkey] aggregates=[sum(l_quantity)] // { arity: 3 }
+                          Reduce group_by=[#0{ps_partkey}, #1{ps_suppkey}] aggregates=[sum(#2{l_quantity})] // { arity: 3 }
                             Project (#0, #1, #6) // { arity: 3 }
-                              Filter (l_shipdate >= 1995-01-01) AND (date_to_timestamp(l_shipdate) < 1996-01-01 00:00:00) // { arity: 18 }
-                                Join on=(ps_partkey = l_partkey AND ps_suppkey = l_suppkey) type=differential // { arity: 18 }
+                              Filter (#12{l_shipdate} >= 1995-01-01) AND (date_to_timestamp(#12{l_shipdate}) < 1996-01-01 00:00:00) // { arity: 18 }
+                                Join on=(#0{ps_partkey} = #3{l_partkey} AND #1{ps_suppkey} = #4{l_suppkey}) type=differential // { arity: 18 }
                                   implementation
                                     %0[#0, #1]UKKA » %1:lineitem[#1, #2]KKAiif
-                                  ArrangeBy keys=[[ps_partkey, ps_suppkey]] // { arity: 2 }
-                                    Distinct project=[ps_partkey, ps_suppkey] // { arity: 2 }
+                                  ArrangeBy keys=[[#0{ps_partkey}, #1{ps_suppkey}]] // { arity: 2 }
+                                    Distinct project=[#0{ps_partkey}, #1{ps_suppkey}] // { arity: 2 }
                                       Project (#1, #2) // { arity: 2 }
                                         Get l1 // { arity: 4 }
-                                  ArrangeBy keys=[[l_partkey, l_suppkey]] // { arity: 16 }
+                                  ArrangeBy keys=[[#1{l_partkey}, #2{l_suppkey}]] // { arity: 16 }
                                     ReadIndex on=lineitem fk_lineitem_partsuppkey=[differential join] // { arity: 16 }
     With
       cte l1 =
         Project (#0..=#3) // { arity: 4 }
-          Join on=(ps_partkey = p_partkey) type=differential // { arity: 7 }
+          Join on=(#1{ps_partkey} = #6{p_partkey}) type=differential // { arity: 7 }
             implementation
               %2[#0]UKA » %1:partsupp[#0]KA » %0[×]
             ArrangeBy keys=[[]] // { arity: 1 }
-              Distinct project=[s_suppkey] // { arity: 1 }
+              Distinct project=[#0{s_suppkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
                   Get l0 // { arity: 3 }
-            ArrangeBy keys=[[ps_partkey]] // { arity: 5 }
+            ArrangeBy keys=[[#0{ps_partkey}]] // { arity: 5 }
               ReadIndex on=partsupp fk_partsupp_partkey=[differential join] // { arity: 5 }
-            ArrangeBy keys=[[p_partkey]] // { arity: 1 }
-              Distinct project=[p_partkey] // { arity: 1 }
+            ArrangeBy keys=[[#0{p_partkey}]] // { arity: 1 }
+              Distinct project=[#0{p_partkey}] // { arity: 1 }
                 Project (#0) // { arity: 1 }
-                  Filter (p_partkey) IS NOT NULL AND like["forest%"](varchar_to_text(p_name)) // { arity: 9 }
+                  Filter (#0{p_partkey}) IS NOT NULL AND like["forest%"](varchar_to_text(#1{p_name})) // { arity: 9 }
                     ReadIndex on=part pk_part_partkey=[*** full scan ***] // { arity: 9 }
       cte l0 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (n_name = "CANADA") AND (s_nationkey) IS NOT NULL // { arity: 11 }
-            Join on=(s_nationkey = n_nationkey) type=differential // { arity: 11 }
+          Filter (#8{n_name} = "CANADA") AND (#3{s_nationkey}) IS NOT NULL // { arity: 11 }
+            Join on=(#3{s_nationkey} = #7{n_nationkey}) type=differential // { arity: 11 }
               implementation
                 %1:nation[#0]KAef » %0:supplier[#3]KAef
-              ArrangeBy keys=[[s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier fk_supplier_nationkey=[differential join] // { arity: 7 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[differential join] // { arity: 4 }
 
 Used Indexes:
@@ -1626,71 +1626,71 @@ ORDER BY
     s_name;
 ----
 Explained Query:
-  Finish order_by=[#1 desc nulls_first, s_name asc nulls_last] output=[#0, #1]
+  Finish order_by=[#1 desc nulls_first, #0{s_name} asc nulls_last] output=[#0, #1]
     Return // { arity: 2 }
-      Reduce group_by=[s_name] aggregates=[count(*)] // { arity: 2 }
+      Reduce group_by=[#0{s_name}] aggregates=[count(*)] // { arity: 2 }
         Project (#1) // { arity: 1 }
-          Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
             implementation
               %0:l2[#2, #0]KK » %1[#0, #1]KK
-            ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 3 }
+            ArrangeBy keys=[[#2{l_orderkey}, #0{s_suppkey}]] // { arity: 3 }
               Get l2 // { arity: 3 }
-            ArrangeBy keys=[[l_orderkey, s_suppkey]] // { arity: 2 }
+            ArrangeBy keys=[[#0{l_orderkey}, #1{s_suppkey}]] // { arity: 2 }
               Union // { arity: 2 }
                 Negate // { arity: 2 }
-                  Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                  Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
                     Project (#0, #1) // { arity: 2 }
-                      Filter (s_suppkey != l_suppkey) AND (l_receiptdate > l_commitdate) // { arity: 18 }
-                        Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                      Filter (#1{s_suppkey} != #4{l_suppkey}) AND (#14{l_receiptdate} > #13{l_commitdate}) // { arity: 18 }
+                        Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                           implementation
                             %1:l1[#0]KAf » %0:l3[#0]Kf
-                          ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
+                          ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
                             Get l3 // { arity: 2 }
                           Get l1 // { arity: 16 }
                 Get l3 // { arity: 2 }
     With
       cte l3 =
-        Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
           Project (#0, #2) // { arity: 2 }
             Get l2 // { arity: 3 }
       cte l2 =
         Project (#0..=#2) // { arity: 3 }
-          Join on=(s_suppkey = s_suppkey AND l_orderkey = l_orderkey) type=differential // { arity: 5 }
+          Join on=(#0{s_suppkey} = #4{s_suppkey} AND #2{l_orderkey} = #3{l_orderkey}) type=differential // { arity: 5 }
             implementation
               %1[#1, #0]UKK » %0:l0[#0, #2]KK
-            ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 3 }
+            ArrangeBy keys=[[#0{s_suppkey}, #2{l_orderkey}]] // { arity: 3 }
               Get l0 // { arity: 3 }
-            ArrangeBy keys=[[s_suppkey, l_orderkey]] // { arity: 2 }
-              Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+            ArrangeBy keys=[[#1{s_suppkey}, #0{l_orderkey}]] // { arity: 2 }
+              Distinct project=[#0{l_orderkey}, #1{s_suppkey}] // { arity: 2 }
                 Project (#0, #1) // { arity: 2 }
-                  Filter (s_suppkey != l_suppkey) // { arity: 18 }
-                    Join on=(l_orderkey = l_orderkey) type=differential // { arity: 18 }
+                  Filter (#1{s_suppkey} != #4{l_suppkey}) // { arity: 18 }
+                    Join on=(#0{l_orderkey} = #2{l_orderkey}) type=differential // { arity: 18 }
                       implementation
                         %1:l1[#0]KA » %0[#0]K
-                      ArrangeBy keys=[[l_orderkey]] // { arity: 2 }
-                        Distinct project=[l_orderkey, s_suppkey] // { arity: 2 }
+                      ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 2 }
+                        Distinct project=[#1{l_orderkey}, #0{s_suppkey}] // { arity: 2 }
                           Project (#0, #2) // { arity: 2 }
                             Get l0 // { arity: 3 }
                       Get l1 // { arity: 16 }
       cte l1 =
-        ArrangeBy keys=[[l_orderkey]] // { arity: 16 }
+        ArrangeBy keys=[[#0{l_orderkey}]] // { arity: 16 }
           ReadIndex on=lineitem fk_lineitem_orderkey=[differential join] // { arity: 16 }
       cte l0 =
         Project (#0, #1, #7) // { arity: 3 }
-          Filter (o_orderstatus = "F") AND (n_name = "SAUDI ARABIA") AND (s_suppkey) IS NOT NULL AND (s_nationkey) IS NOT NULL AND (l_orderkey) IS NOT NULL AND (l_receiptdate > l_commitdate) // { arity: 36 }
-            Join on=(s_suppkey = l_suppkey AND s_nationkey = n_nationkey AND l_orderkey = o_orderkey) type=delta // { arity: 36 }
+          Filter (#25{o_orderstatus} = "F") AND (#33{n_name} = "SAUDI ARABIA") AND (#0{s_suppkey}) IS NOT NULL AND (#3{s_nationkey}) IS NOT NULL AND (#7{l_orderkey}) IS NOT NULL AND (#19{l_receiptdate} > #18{l_commitdate}) // { arity: 36 }
+            Join on=(#0{s_suppkey} = #9{l_suppkey} AND #3{s_nationkey} = #32{n_nationkey} AND #7{l_orderkey} = #23{o_orderkey}) type=delta // { arity: 36 }
               implementation
                 %0:supplier » %3:nation[#0]KAef » %1:lineitem[#2]KAf » %2:orders[#0]KAef
                 %1:lineitem » %2:orders[#0]KAef » %0:supplier[#0]KA » %3:nation[#0]KAef
                 %2:orders » %1:lineitem[#0]KAf » %0:supplier[#0]KA » %3:nation[#0]KAef
                 %3:nation » %0:supplier[#3]KA » %1:lineitem[#2]KAf » %2:orders[#0]KAef
-              ArrangeBy keys=[[s_suppkey], [s_nationkey]] // { arity: 7 }
+              ArrangeBy keys=[[#0{s_suppkey}], [#3{s_nationkey}]] // { arity: 7 }
                 ReadIndex on=supplier pk_supplier_suppkey=[delta join 1st input (full scan)] fk_supplier_nationkey=[delta join 1st input (full scan)] // { arity: 7 }
-              ArrangeBy keys=[[l_orderkey], [l_suppkey]] // { arity: 16 }
+              ArrangeBy keys=[[#0{l_orderkey}], [#2{l_suppkey}]] // { arity: 16 }
                 ReadIndex on=lineitem fk_lineitem_orderkey=[delta join lookup] fk_lineitem_suppkey=[delta join lookup] // { arity: 16 }
-              ArrangeBy keys=[[o_orderkey]] // { arity: 9 }
+              ArrangeBy keys=[[#0{o_orderkey}]] // { arity: 9 }
                 ReadIndex on=orders pk_orders_orderkey=[delta join lookup] // { arity: 9 }
-              ArrangeBy keys=[[n_nationkey]] // { arity: 4 }
+              ArrangeBy keys=[[#0{n_nationkey}]] // { arity: 4 }
                 ReadIndex on=nation pk_nation_nationkey=[delta join lookup] // { arity: 4 }
 
 Used Indexes:
@@ -1758,36 +1758,36 @@ ORDER BY
 Explained Query:
   Finish order_by=[#0 asc nulls_last] output=[#0..=#2]
     Return // { arity: 3 }
-      Reduce group_by=[substr(char_to_text(c_phone), 1, 2)] aggregates=[count(*), sum(c_acctbal)] // { arity: 3 }
+      Reduce group_by=[substr(char_to_text(#0{c_phone}), 1, 2)] aggregates=[count(*), sum(#1{c_acctbal})] // { arity: 3 }
         Project (#1, #2) // { arity: 2 }
-          Join on=(c_custkey = c_custkey) type=differential // { arity: 4 }
+          Join on=(#0{c_custkey} = #3{c_custkey}) type=differential // { arity: 4 }
             implementation
               %0:l1[#0]K » %1[#0]K
-            ArrangeBy keys=[[c_custkey]] // { arity: 3 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 3 }
               Get l1 // { arity: 3 }
-            ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+            ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
               Union // { arity: 1 }
                 Negate // { arity: 1 }
                   Project (#0) // { arity: 1 }
-                    Filter (c_custkey) IS NOT NULL // { arity: 2 }
-                      Join on=(c_custkey = o_custkey) type=differential // { arity: 2 }
+                    Filter (#0{c_custkey}) IS NOT NULL // { arity: 2 }
+                      Join on=(#0{c_custkey} = #1{o_custkey}) type=differential // { arity: 2 }
                         implementation
                           %0:l2[#0]UKA » %1[#0]UKA
-                        ArrangeBy keys=[[c_custkey]] // { arity: 1 }
+                        ArrangeBy keys=[[#0{c_custkey}]] // { arity: 1 }
                           Get l2 // { arity: 1 }
-                        ArrangeBy keys=[[o_custkey]] // { arity: 1 }
-                          Distinct project=[o_custkey] // { arity: 1 }
+                        ArrangeBy keys=[[#0{o_custkey}]] // { arity: 1 }
+                          Distinct project=[#0{o_custkey}] // { arity: 1 }
                             Project (#1) // { arity: 1 }
                               ReadIndex on=orders pk_orders_orderkey=[*** full scan ***] // { arity: 9 }
                 Get l2 // { arity: 1 }
     With
       cte l2 =
-        Distinct project=[c_custkey] // { arity: 1 }
+        Distinct project=[#0{c_custkey}] // { arity: 1 }
           Project (#0) // { arity: 1 }
             Get l1 // { arity: 3 }
       cte l1 =
         Project (#0..=#2) // { arity: 3 }
-          Filter (c_acctbal > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
+          Filter (#2{c_acctbal} > (#3 / bigint_to_numeric(case when (#4 = 0) then null else #4 end))) // { arity: 5 }
             CrossJoin type=differential // { arity: 5 }
               implementation
                 %1[×]UA » %0:l0[×]ef
@@ -1796,12 +1796,12 @@ Explained Query:
                   Filter ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                     Get l0 // { arity: 9 }
               ArrangeBy keys=[[]] // { arity: 2 }
-                Reduce aggregates=[sum(c_acctbal), count(*)] // { arity: 2 }
+                Reduce aggregates=[sum(#0{c_acctbal}), count(*)] // { arity: 2 }
                   Project (#5) // { arity: 1 }
-                    Filter (c_acctbal > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
+                    Filter (#5{c_acctbal} > 0) AND ((#8 = "13") OR (#8 = "17") OR (#8 = "18") OR (#8 = "23") OR (#8 = "29") OR (#8 = "30") OR (#8 = "31")) // { arity: 9 }
                       Get l0 // { arity: 9 }
       cte l0 =
-        Map (substr(char_to_text(c_phone), 1, 2)) // { arity: 9 }
+        Map (substr(char_to_text(#4{c_phone}), 1, 2)) // { arity: 9 }
           ReadIndex on=customer pk_customer_custkey=[*** full scan ***] // { arity: 8 }
 
 Used Indexes:

--- a/test/sqllogictest/transform/literal_constraints.slt
+++ b/test/sqllogictest/transform/literal_constraints.slt
@@ -48,8 +48,8 @@ Used Indexes:
   - materialize.public.idx_t1_a_b (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.idx_t1_a_b on t1(a, b) is too wide to use for literal equalities `a IN (1, 2)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (a).
+  - Notice: Index materialize.public.idx_t1_a_b on t1(#0{a}, #1{b}) is too wide to use for literal equalities `#0{a} IN (1, 2)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{a}).
 
 EOF
 
@@ -1359,8 +1359,8 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#0{x} = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
 
 EOF
 
@@ -1382,10 +1382,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `x = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `x = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (x).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#0{x} = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#0{x} = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{x}).
 
 EOF
 
@@ -1455,10 +1455,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 6`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 6`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} = 6`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} = 6`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
 
 EOF
 
@@ -1494,8 +1494,8 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 7`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#2{z} = 7`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{z}).
 
 EOF
 
@@ -1517,10 +1517,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y = 5`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} = 5`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
 
 EOF
 
@@ -1539,10 +1539,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (4, 8)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `y IN (4, 8)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} IN (4, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#1{y} IN (4, 8)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}).
 
 EOF
 
@@ -1561,10 +1561,10 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y on t6(x, y) is too wide to use for literal equalities `y IN (2, 5)`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `(y, z) IN ((2, 3), (5, 7))`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (y, z).
+  - Notice: Index materialize.public.t6_idx_x_y on t6(#0{x}, #1{y}) is too wide to use for literal equalities `#1{y} IN (2, 5)`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}, #2{z}).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `(#1{y}, #2{z}) IN ((2, 3), (5, 7))`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{y}, #2{z}).
 
 EOF
 
@@ -1583,7 +1583,7 @@ Used Indexes:
   - materialize.public.t6_idx_x_y (*** full scan ***)
 
 Notices:
-  - Notice: Index materialize.public.t6_idx_x_y_z on t6(x, y, z) is too wide to use for literal equalities `z = 9`.
-    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (z, w).
+  - Notice: Index materialize.public.t6_idx_x_y_z on t6(#0{x}, #1{y}, #2{z}) is too wide to use for literal equalities `#2{z} = 9`.
+    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#2{z}, #3{w}).
 
 EOF

--- a/test/testdrive/primary-key-optimizations.td
+++ b/test/testdrive/primary-key-optimizations.td
@@ -79,7 +79,7 @@ $ kafka-ingest format=avro topic=t1 key-format=avro key-schema=${keyschema-2keys
 "Explained Query (fast path):  ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key1, key2 FROM t1 GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(key1, key2) is too wide to use for literal equalities `key1 = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (key1)."
+"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{key1}, #1{key2}) is too wide to use for literal equalities `#0{key1} = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{key1})."
 
 # Optimization not possible - explicit distinct is present in planFor certain types of tests the 
 
@@ -190,7 +190,7 @@ $ kafka-ingest format=avro topic=t1-pkne schema=${schema}
 "Explained Query (fast path):  ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)"
 
 > EXPLAIN SELECT key1, key2 FROM t1_pkne GROUP BY key1, key2 HAVING key1 = 'a';
-"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_pkne_primary_idx on t1_pkne(key1, key2) is too wide to use for literal equalities `key1 = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (key1)."
+"Explained Query (fast path):  Project (#3, #1)    Filter (#0 = \"a\")      Map (\"a\")        ReadIndex on=t1_pkne t1_pkne_primary_idx=[*** full scan ***]Used Indexes:  - t1_pkne_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_pkne_primary_idx on t1_pkne(#0{key1}, #1{key2}) is too wide to use for literal equalities `#0{key1} = \"a\"`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{key1})."
 
 # Optimization not possible - explicit distinct is present in plan
 

--- a/test/testdrive/subexpression-replacement.td
+++ b/test/testdrive/subexpression-replacement.td
@@ -25,7 +25,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # The simplest expression there could be
 
 > EXPLAIN SELECT * FROM t1 WHERE col_null IS NULL AND (col_null IS NULL AND col_not_null = 5);
-"Explained Query (fast path):  Filter (#0) IS NULL AND (#1 = 5)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(col_null, col_not_null) is too wide to use for literal equalities `col_not_null = 5`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (col_not_null)."
+"Explained Query (fast path):  Filter (#0) IS NULL AND (#1 = 5)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 5`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND (col_not_null = 1 AND col_null = 5);
 "Explained Query (fast path):  Project (#0, #1)    ReadIndex on=t1 t1_primary_idx=[lookup value=(5, 1)]Used Indexes:  - t1_primary_idx (lookup)"
@@ -59,7 +59,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # A more complex expression
 
 > EXPLAIN SELECT * FROM t1 WHERE (col_not_null + 1 / col_not_null) = 5 AND ((col_not_null + 1 / col_not_null) = 5 AND col_null = 6);
-"Explained Query (fast path):  Filter (#0 = 6) AND (5 = (#1 + (1 / #1)))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(col_null, col_not_null) is too wide to use for literal equalities `col_null = 6`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (col_null, (col_not_null + (1 / col_not_null)))."
+"Explained Query (fast path):  Filter (#0 = 6) AND (5 = (#1 + (1 / #1)))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#0{col_null} = 6`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#0{col_null}, (#1{col_not_null} + (1 / #1{col_not_null})))."
 
 # More nesting
 
@@ -99,12 +99,12 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # IN list inside the expression
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (2, 3);
-"Explained Query (fast path):  Filter ((#1 = 2) OR (#1 = 3))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(col_null, col_not_null) is too wide to use for literal equalities `col_not_null IN (2, 3)`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (col_not_null)."
+"Explained Query (fast path):  Filter ((#1 = 2) OR (#1 = 3))    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} IN (2, 3)`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
 
 # Partial matches
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (3, 4);
-"Explained Query (fast path):  Filter (#1 = 3)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(col_null, col_not_null) is too wide to use for literal equalities `col_not_null = 3`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (col_not_null)."
+"Explained Query (fast path):  Filter (#1 = 3)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 3`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null IN (2, 3) AND col_not_null IN (4, 5);
 "Explained Query (fast path):  Constant <empty>"
@@ -114,7 +114,7 @@ $ set-regex match=(\s\(u\d+\)|\n|materialize\.public\.) replacement=
 # Optimized in AND/conjunctions
 
 > EXPLAIN SELECT * FROM t1 WHERE col_not_null = 1 AND TRUE IN (col_not_null = 1, col_not_null = 2);
-"Explained Query (fast path):  Filter (#1 = 1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(col_null, col_not_null) is too wide to use for literal equalities `col_not_null = 1`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (col_not_null)."
+"Explained Query (fast path):  Filter (#1 = 1)    ReadIndex on=t1 t1_primary_idx=[*** full scan ***]Used Indexes:  - t1_primary_idx (*** full scan ***)Notices:  - Notice: Index t1_primary_idx on t1(#0{col_null}, #1{col_not_null}) is too wide to use for literal equalities `#1{col_not_null} = 1`.    Hint: If your literal equalities filter out many rows, create an index whose key exactly matches your literal equalities: (#1{col_not_null})."
 
 # Not optimized in OR/disjunctions
 


### PR DESCRIPTION
Change the output format when the `humanized_exprs` flag is `on`. We now write `#$i{$column_name}` instead of just `$column_name` in order to avoid ambiguities when multiple columns have the same name.

### Motivation

   * This PR refactors existing code.

Addressing some [internal feedback](https://materializeinc.slack.com/archives/C02PPB50ZHS/p1698433510758219).

### Tips for reviewer

N/A

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Change the `EXPLAIN AS TEXT` output format when the `humanized_exprs` flag is `on`. We now write `#$i{$column_name}` instead of just `$column_name`.
