### PR TITLE
infra: Remove testdrive bak files in version bump

### DIFF
--- a/bin/bump-version
+++ b/bin/bump-version
@@ -49,7 +49,7 @@ else
     done
 fi
 
-rm -f src/{clusterd,environmentd,persist-client,stash-debug}/Cargo.toml.bak LICENSE.bak
+rm -f src/{clusterd,environmentd,persist-client,testdrive,stash-debug}/Cargo.toml.bak LICENSE.bak
 
 cargo check
 


### PR DESCRIPTION
The bin/bump-version removes some temporary .bak from all the binaries that had their version bumped. Testdrive was mistakenly omitted from the list of binaries to clean up. This commit adds testdrive to that list.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
