### PR TITLE
[persist] Advance the frontier to the end of time when past until

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -374,6 +374,8 @@ where
                 }
             }
 
+            yield ListenEvent::Progress(Antichain::new());
+
             // intentionally keep this stream from dropping until the operator
             // is dropped. this ensures our Subscribe handle stays alive for as
             // long as is needed to finish fetching all of its parts.


### PR DESCRIPTION
### Motivation

Previously-unreported bug.

The equivalent behaviour for referencing an arrangement [is documented upstream](https://github.com/MaterializeInc/differential-dataflow/blob/2ebd82d88393b521bd2dcaeb082f4f1d51734ef6/src/operators/arrange/agent.rs#L447-L449). I'm unsure if shard_source ever worked this way or whether this was a regression, but anyways let's match behaviour.

### Tips for reviewer

**I think this is probably not the right way to do it.** In particular, IIRC timely may drop our operator if we've promised to never emit output, which would also drop the subscription. In that case we'll need to wait to advance the frontier to `{}` until all the leased parts have had their leases returned, which requires something fancier.

This change is not observable in practice currently: the existing users of `until` do not require in practice that the frontier advances promptly to `{}`, only past `until`. So I don't think we can write end-to-end tests for this until other features are added. However, we should add a unit test.

I did run nightlies: https://buildkite.com/materialize/nightlies/builds/4990. A couple failures, though at least one seems to be a known issue, and neither includes the panic you'd expect if a reader lease was dropped too early.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
