### PR TITLE
adapter: move timestamp resolution after optimization

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -773,7 +773,7 @@ impl CatalogState {
                         optimize::OptimizerConfig::from(session_catalog.system_vars());
 
                     // Build an optimizer for this VIEW.
-                    let mut optimizer = optimize::OptimizeView::new(optimizer_config);
+                    let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
                     // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
                     let raw_expr = view.expr;
@@ -909,7 +909,7 @@ impl CatalogState {
                         optimize::OptimizerConfig::from(session_catalog.system_vars());
 
                     // Build an optimizer for this VIEW.
-                    let mut optimizer = optimize::OptimizeView::new(optimizer_config);
+                    let mut optimizer = optimize::view::Optimizer::new(optimizer_config);
 
                     // HIR ⇒ MIR lowering and MIR ⇒ MIR optimization (local)
                     let raw_expr = view.expr;

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1299,15 +1299,15 @@ impl Coordinator {
                         let index_plan =
                             optimize::index::Index::new(entry.name(), &idx.on, &idx.keys);
                         let global_mir_plan = optimizer.optimize(index_plan)?;
+                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
                         // Timestamp selection
                         let as_of = self.bootstrap_index_as_of(
                             global_mir_plan.df_desc(),
-                            global_mir_plan.compute_instance_id(),
+                            optimizer.cluster_id(),
                             idx.is_retained_metrics_object,
                         );
-                        let global_mir_plan = global_mir_plan.resolve(as_of);
-                        // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                        let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
+                        let global_lir_plan = global_lir_plan.resolve(as_of);
 
                         // Note: ideally, the optimized_plan should be computed
                         // and set when the CatalogItem is re-constructed (in
@@ -1372,14 +1372,14 @@ impl Coordinator {
 
                     // MIR ⇒ MIR optimization (global)
                     let global_mir_plan = optimizer.optimize(mview.optimized_expr.clone())?;
+                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
+                    let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
                     // Timestamp selection
                     let as_of = self.bootstrap_materialized_view_as_of(
                         global_mir_plan.df_desc(),
-                        global_mir_plan.compute_instance_id(),
+                        optimizer.cluster_id(),
                     );
-                    let global_mir_plan = global_mir_plan.resolve(as_of);
-                    // MIR ⇒ LIR lowering and LIR ⇒ LIR optimization (global)
-                    let global_lir_plan = optimizer.optimize(global_mir_plan.clone())?;
+                    let global_lir_plan = global_lir_plan.resolve(as_of);
 
                     // Note: ideally, the optimized_plan should be computed
                     // and set when the CatalogItem is re-constructed (in

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -320,7 +320,7 @@ pub enum RealTimeRecencyContext {
         timeline_context: TimelineContext,
         source_ids: BTreeSet<GlobalId>,
         in_immediate_multi_stmt_txn: bool,
-        optimizer: optimize::OptimizePeek,
+        optimizer: optimize::peek::Optimizer,
         global_mir_plan: optimize::peek::GlobalMirPlan,
     },
     PeekDeprecated {
@@ -387,7 +387,7 @@ pub struct PeekStageOptimize {
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
-    optimizer: optimize::OptimizePeek,
+    optimizer: optimize::peek::Optimizer,
 }
 
 #[derive(Debug)]
@@ -400,7 +400,7 @@ pub struct PeekStageTimestamp {
     target_replica: Option<ReplicaId>,
     timeline_context: TimelineContext,
     in_immediate_multi_stmt_txn: bool,
-    optimizer: optimize::OptimizePeek,
+    optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
 }
 
@@ -414,7 +414,7 @@ pub struct PeekStageFinish {
     timeline_context: TimelineContext,
     source_ids: BTreeSet<GlobalId>,
     real_time_recency_ts: Option<mz_repr::Timestamp>,
-    optimizer: optimize::OptimizePeek,
+    optimizer: optimize::peek::Optimizer,
     global_mir_plan: optimize::peek::GlobalMirPlan,
 }
 
@@ -1288,7 +1288,7 @@ impl Coordinator {
                             OptimizerConfig::from(self.catalog().system_config());
 
                         // Build an optimizer for this INDEX.
-                        let mut optimizer = optimize::OptimizeIndex::new(
+                        let mut optimizer = optimize::index::Optimizer::new(
                             self.owned_catalog(),
                             compute_instance,
                             entry.id(),
@@ -1359,7 +1359,7 @@ impl Coordinator {
                     let optimizer_config = OptimizerConfig::from(self.catalog().system_config());
 
                     // Build an optimizer for this MATERIALIZED VIEW.
-                    let mut optimizer = optimize::OptimizeMaterializedView::new(
+                    let mut optimizer = optimize::materialized_view::Optimizer::new(
                         self.owned_catalog(),
                         compute_instance,
                         entry.id(),

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -9,6 +9,7 @@
 
 //! Optimizer implementation for `CREATE INDEX` statements.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
 use maplit::btreemap;
@@ -45,6 +46,12 @@ pub struct OptimizeIndex {
     config: OptimizerConfig,
 }
 
+impl OptimizeIndex {
+    pub fn cluster_id(&self) -> ComputeInstanceId {
+        self.compute_instance.instance_id()
+    }
+}
+
 /// A wrapper of index parts needed to start the optimization process.
 pub struct Index {
     name: QualifiedItemName,
@@ -72,34 +79,62 @@ impl Index {
 /// 2. transitively inlining referenced views, and
 /// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
 #[derive(Clone)]
-pub struct GlobalMirPlan<T: Clone> {
+pub struct GlobalMirPlan {
     df_desc: MirDataflowDescription,
     df_meta: DataflowMetainfo,
-    ts_info: T,
 }
 
-/// Timestamp information type for [`GlobalMirPlan`] structs representing an
-/// optimization result without a resolved timestamp.
-#[derive(Clone)]
-pub struct Unresolved {
-    compute_instance_id: ComputeInstanceId,
-}
+impl GlobalMirPlan {
+    pub fn df_desc(&self) -> &MirDataflowDescription {
+        &self.df_desc
+    }
 
-/// Timestamp information type for [`GlobalMirPlan`] structs representing an
-/// optimization result with a resolved timestamp.
-///
-/// The actual timestamp value is set in the [`MirDataflowDescription`] of the
-/// surrounding [`GlobalMirPlan`] when we call `resolve()`.
-#[derive(Clone)]
-pub struct Resolved;
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+}
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
 #[derive(Clone)]
-pub struct GlobalLirPlan {
+pub struct GlobalLirPlan<T: Clone> {
     df_desc: LirDataflowDescription,
     df_meta: DataflowMetainfo,
+    phantom: PhantomData<T>,
 }
+
+impl<T: Clone> GlobalLirPlan<T> {
+    pub fn df_desc(&self) -> &LirDataflowDescription {
+        &self.df_desc
+    }
+
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+
+    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
+    pub fn id_bundle(&self, compute_instance_id: ComputeInstanceId) -> CollectionIdBundle {
+        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
+        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
+        CollectionIdBundle {
+            storage_ids,
+            compute_ids: btreemap! {compute_instance_id => compute_ids},
+        }
+    }
+}
+
+/// Marker type for [`GlobalLirPlan`] structs representing an optimization
+/// result without a resolved timestamp.
+#[derive(Clone)]
+pub struct Unresolved;
+
+/// Marker type for [`GlobalLirPlan`] structs representing an optimization
+/// result with a resolved timestamp.
+///
+/// The actual timestamp value is set in the [`LirDataflowDescription`] of the
+/// surrounding [`GlobalLirPlan`] when we call `resolve()`.
+#[derive(Clone)]
+pub struct Resolved;
 
 impl OptimizeIndex {
     pub fn new(
@@ -119,7 +154,7 @@ impl OptimizeIndex {
 }
 
 impl Optimize<Index> for OptimizeIndex {
-    type To = GlobalMirPlan<Unresolved>;
+    type To = GlobalMirPlan;
 
     fn optimize(&mut self, index: Index) -> Result<Self::To, OptimizerError> {
         let state = self.catalog.state();
@@ -161,66 +196,18 @@ impl Optimize<Index> for OptimizeIndex {
             df_meta.push_optimizer_notice_dedup(OptimizerNotice::IndexKeyEmpty);
         }
 
-        // Return.
-        Ok(GlobalMirPlan {
-            df_desc,
-            df_meta,
-            ts_info: Unresolved {
-                compute_instance_id: self.compute_instance.instance_id(),
-            },
-        })
+        // Return the (sealed) plan at the end of this optimization step.
+        Ok(GlobalMirPlan { df_desc, df_meta })
     }
 }
 
-impl<T: Clone> GlobalMirPlan<T> {
-    pub fn df_desc(&self) -> &MirDataflowDescription {
-        &self.df_desc
-    }
+impl Optimize<GlobalMirPlan> for OptimizeIndex {
+    type To = GlobalLirPlan<Unresolved>;
 
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
-    }
-}
-
-impl GlobalMirPlan<Unresolved> {
-    /// Produces the [`GlobalMirPlan`] with [`Resolved`] timestamp required for
-    /// the next stage.
-    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalMirPlan<Resolved> {
-        // Set the `as_of` timestamp for the dataflow.
-        self.df_desc.set_as_of(as_of);
-
-        GlobalMirPlan {
-            df_desc: self.df_desc,
-            df_meta: self.df_meta,
-            ts_info: Resolved,
-        }
-    }
-
-    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
-    pub fn id_bundle(&self) -> CollectionIdBundle {
-        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
-        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
-        CollectionIdBundle {
-            storage_ids,
-            compute_ids: btreemap! {self.compute_instance_id() => compute_ids},
-        }
-    }
-
-    /// Returns the [`ComputeInstanceId`] against which we should resolve the
-    /// timestamp for the next stage.
-    pub fn compute_instance_id(&self) -> ComputeInstanceId {
-        self.ts_info.compute_instance_id
-    }
-}
-
-impl Optimize<GlobalMirPlan<Resolved>> for OptimizeIndex {
-    type To = GlobalLirPlan;
-
-    fn optimize(&mut self, plan: GlobalMirPlan<Resolved>) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,
-            ts_info: _,
         } = plan;
 
         // Ensure all expressions are normalized before finalizing.
@@ -239,20 +226,37 @@ impl Optimize<GlobalMirPlan<Resolved>> for OptimizeIndex {
         .map_err(OptimizerError::Internal)?;
 
         // Return the plan at the end of this `optimize` step.
-        Ok(GlobalLirPlan { df_desc, df_meta })
+        Ok(GlobalLirPlan {
+            df_desc,
+            df_meta,
+            phantom: PhantomData::<Unresolved>,
+        })
     }
 }
 
-impl GlobalLirPlan {
+impl GlobalLirPlan<Unresolved> {
+    /// Produces the [`GlobalLirPlan`] with [`Resolved`] timestamp.
+    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalLirPlan<Resolved> {
+        // Set the `as_of` timestamp for the dataflow.
+        self.df_desc.set_as_of(as_of);
+
+        // The only dataflow exports are indexes, so the `df_desc.until` should
+        // be the empty frontier.
+        assert!(self.df_desc.sink_exports.is_empty());
+        // The `until` is set to the empty frontier in the `df_desc` constructor.
+        assert!(self.df_desc.until.is_empty());
+
+        GlobalLirPlan {
+            df_desc: self.df_desc,
+            df_meta: self.df_meta,
+            phantom: PhantomData::<Resolved>,
+        }
+    }
+}
+
+impl GlobalLirPlan<Resolved> {
+    /// Unwraps the parts of the final result of the optimization pipeline.
     pub fn unapply(self) -> (LirDataflowDescription, DataflowMetainfo) {
         (self.df_desc, self.df_meta)
-    }
-
-    pub fn df_desc(&self) -> &LirDataflowDescription {
-        &self.df_desc
-    }
-
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
     }
 }

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -9,16 +9,15 @@
 
 //! Optimizer implementation for `CREATE MATERIALIZED VIEW` statements.
 
+use std::marker::PhantomData;
 use std::sync::Arc;
 
-use differential_dataflow::lattice::Lattice;
 use maplit::btreemap;
 use mz_compute_types::dataflows::BuildDesc;
 use mz_compute_types::plan::Plan;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc, PersistSinkConnection};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
-use mz_ore::soft_assert_or_log;
 use mz_repr::explain::trace_plan;
 use mz_repr::{ColumnName, GlobalId, RelationDesc, Timestamp};
 use mz_sql::plan::HirRelationExpr;
@@ -60,6 +59,12 @@ pub struct OptimizeMaterializedView {
     config: OptimizerConfig,
 }
 
+impl OptimizeMaterializedView {
+    pub fn cluster_id(&self) -> ComputeInstanceId {
+        self.compute_instance.instance_id()
+    }
+}
+
 /// The (sealed intermediate) result after HIR ⇒ MIR lowering and decorrelation
 /// and MIR optimization.
 #[derive(Clone)]
@@ -73,34 +78,68 @@ pub struct LocalMirPlan {
 /// 2. transitively inlining referenced views, and
 /// 3. jointly optimizing the `MIR` plans in the [`MirDataflowDescription`].
 #[derive(Clone)]
-pub struct GlobalMirPlan<T: Clone> {
+pub struct GlobalMirPlan {
     df_desc: MirDataflowDescription,
     df_meta: DataflowMetainfo,
-    ts_info: T,
 }
 
-/// Timestamp information type for [`GlobalMirPlan`] structs representing an
-/// optimization result without a resolved timestamp.
-#[derive(Clone)]
-pub struct Unresolved {
-    compute_instance_id: ComputeInstanceId,
-}
+impl GlobalMirPlan {
+    pub fn df_desc(&self) -> &MirDataflowDescription {
+        &self.df_desc
+    }
 
-/// Timestamp information type for [`GlobalMirPlan`] structs representing an
-/// optimization result with a resolved timestamp.
-///
-/// The actual timestamp value is set in the [`MirDataflowDescription`] of the
-/// surrounding [`GlobalMirPlan`] when we call `resolve()`.
-#[derive(Clone)]
-pub struct Resolved;
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+}
 
 /// The (final) result after MIR ⇒ LIR lowering and optimizing the resulting
 /// `DataflowDescription` with `LIR` plans.
 #[derive(Clone)]
-pub struct GlobalLirPlan {
+pub struct GlobalLirPlan<T: Clone> {
     df_desc: LirDataflowDescription,
     df_meta: DataflowMetainfo,
+    phantom: PhantomData<T>,
 }
+
+impl<T: Clone> GlobalLirPlan<T> {
+    pub fn df_desc(&self) -> &LirDataflowDescription {
+        &self.df_desc
+    }
+
+    pub fn df_meta(&self) -> &DataflowMetainfo {
+        &self.df_meta
+    }
+
+    pub fn desc(&self) -> &RelationDesc {
+        let sink_exports = &self.df_desc.sink_exports;
+        let sink = sink_exports.values().next().expect("valid sink");
+        &sink.from_desc
+    }
+
+    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
+    pub fn id_bundle(&self, compute_instance_id: ComputeInstanceId) -> CollectionIdBundle {
+        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
+        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
+        CollectionIdBundle {
+            storage_ids,
+            compute_ids: btreemap! {compute_instance_id => compute_ids},
+        }
+    }
+}
+
+/// Marker type for [`GlobalLirPlan`] structs representing an optimization
+/// result without a resolved timestamp.
+#[derive(Clone)]
+pub struct Unresolved;
+
+/// Marker type for [`GlobalLirPlan`] structs representing an optimization
+/// result with a resolved timestamp.
+///
+/// The actual timestamp value is set in the [`LirDataflowDescription`] of the
+/// surrounding [`GlobalLirPlan`] when we call `resolve()`.
+#[derive(Clone)]
+pub struct Resolved;
 
 impl OptimizeMaterializedView {
     pub fn new(
@@ -159,7 +198,7 @@ impl LocalMirPlan {
 /// This is needed only because the pipeline in the bootstrap code starts from an
 /// [`OptimizedMirRelationExpr`] attached to a [`crate::catalog::CatalogItem`].
 impl Optimize<OptimizedMirRelationExpr> for OptimizeMaterializedView {
-    type To = GlobalMirPlan<Unresolved>;
+    type To = GlobalMirPlan;
 
     fn optimize(&mut self, expr: OptimizedMirRelationExpr) -> Result<Self::To, OptimizerError> {
         let expr = expr.into_inner();
@@ -168,7 +207,7 @@ impl Optimize<OptimizedMirRelationExpr> for OptimizeMaterializedView {
 }
 
 impl Optimize<LocalMirPlan> for OptimizeMaterializedView {
-    type To = GlobalMirPlan<Unresolved>;
+    type To = GlobalMirPlan;
 
     fn optimize(&mut self, plan: LocalMirPlan) -> Result<Self::To, OptimizerError> {
         let expr = OptimizedMirRelationExpr(plan.expr);
@@ -209,78 +248,17 @@ impl Optimize<LocalMirPlan> for OptimizeMaterializedView {
         )?;
 
         // Return the (sealed) plan at the end of this optimization step.
-        Ok(GlobalMirPlan {
-            df_desc,
-            df_meta,
-            ts_info: Unresolved {
-                compute_instance_id: self.compute_instance.instance_id(),
-            },
-        })
+        Ok(GlobalMirPlan { df_desc, df_meta })
     }
 }
 
-impl<T: Clone> GlobalMirPlan<T> {
-    pub fn df_desc(&self) -> &MirDataflowDescription {
-        &self.df_desc
-    }
+impl Optimize<GlobalMirPlan> for OptimizeMaterializedView {
+    type To = GlobalLirPlan<Unresolved>;
 
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
-    }
-}
-
-impl GlobalMirPlan<Unresolved> {
-    /// Produces the [`GlobalMirPlan`] with [`Resolved`] timestamp required for
-    /// the next stage.
-    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalMirPlan<Resolved> {
-        // Set the `as_of` timestamp for the dataflow.
-        self.df_desc.set_as_of(as_of);
-
-        soft_assert_or_log!(
-            self.df_desc.index_exports.is_empty(),
-            "unexpectedly setting until for a DataflowDescription with an index",
-        );
-
-        // The only outputs of the dataflow are sinks, so we might be able to
-        // turn off the computation early, if they all have non-trivial
-        // `up_to`s.
-        self.df_desc.until = Antichain::from_elem(Timestamp::MIN);
-        for (_, sink) in &self.df_desc.sink_exports {
-            self.df_desc.until.join_assign(&sink.up_to);
-        }
-
-        GlobalMirPlan {
-            df_desc: self.df_desc,
-            df_meta: self.df_meta,
-            ts_info: Resolved,
-        }
-    }
-
-    /// Computes the [`CollectionIdBundle`] of the wrapped dataflow.
-    pub fn id_bundle(&self) -> CollectionIdBundle {
-        let storage_ids = self.df_desc.source_imports.keys().copied().collect();
-        let compute_ids = self.df_desc.index_imports.keys().copied().collect();
-        CollectionIdBundle {
-            storage_ids,
-            compute_ids: btreemap! {self.compute_instance_id() => compute_ids},
-        }
-    }
-
-    /// Returns the [`ComputeInstanceId`] against which we should resolve the
-    /// timestamp for the next stage.
-    pub fn compute_instance_id(&self) -> ComputeInstanceId {
-        self.ts_info.compute_instance_id
-    }
-}
-
-impl Optimize<GlobalMirPlan<Resolved>> for OptimizeMaterializedView {
-    type To = GlobalLirPlan;
-
-    fn optimize(&mut self, plan: GlobalMirPlan<Resolved>) -> Result<Self::To, OptimizerError> {
+    fn optimize(&mut self, plan: GlobalMirPlan) -> Result<Self::To, OptimizerError> {
         let GlobalMirPlan {
             mut df_desc,
             df_meta,
-            ts_info: _,
         } = plan;
 
         // Ensure all expressions are normalized before finalizing.
@@ -299,26 +277,40 @@ impl Optimize<GlobalMirPlan<Resolved>> for OptimizeMaterializedView {
         .map_err(OptimizerError::Internal)?;
 
         // Return the plan at the end of this `optimize` step.
-        Ok(GlobalLirPlan { df_desc, df_meta })
+        Ok(GlobalLirPlan {
+            df_desc,
+            df_meta,
+            phantom: PhantomData::<Unresolved>,
+        })
     }
 }
 
-impl GlobalLirPlan {
+impl GlobalLirPlan<Unresolved> {
+    /// Produces the [`GlobalLirPlan`] with [`Resolved`] timestamp.
+    pub fn resolve(mut self, as_of: Antichain<Timestamp>) -> GlobalLirPlan<Resolved> {
+        // Set the `as_of` timestamp for the dataflow.
+        self.df_desc.set_as_of(as_of);
+
+        // The only dataflow exports are sinks with an empty `up_to` frontier,
+        // so the `df_desc.until` should also be the empty frontier.
+        assert!(self.df_desc.index_exports.is_empty());
+        for (_, sink) in &self.df_desc.sink_exports {
+            assert!(sink.up_to.is_empty());
+        }
+        // The `until` is set to the empty frontier in the `df_desc` constructor.
+        assert!(self.df_desc.until.is_empty());
+
+        GlobalLirPlan {
+            df_desc: self.df_desc,
+            df_meta: self.df_meta,
+            phantom: PhantomData::<Resolved>,
+        }
+    }
+}
+
+impl GlobalLirPlan<Resolved> {
+    /// Unwraps the parts of the final result of the optimization pipeline.
     pub fn unapply(self) -> (LirDataflowDescription, DataflowMetainfo) {
         (self.df_desc, self.df_meta)
-    }
-
-    pub fn df_desc(&self) -> &LirDataflowDescription {
-        &self.df_desc
-    }
-
-    pub fn df_meta(&self) -> &DataflowMetainfo {
-        &self.df_meta
-    }
-
-    pub fn desc(&self) -> RelationDesc {
-        let sink_exports = &self.df_desc.sink_exports;
-        let sink = sink_exports.values().next().expect("valid sink");
-        sink.from_desc.clone()
     }
 }

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -23,7 +23,7 @@
 //!
 //! - Implementors of this trait are structs that encapsulate all context
 //!   required to optimize a statement of type `T` end-to-end (for example
-//!   [`OptimizeMaterializedView`] for `T` = `MaterializedView`).
+//!   [`materialized_view::Optimizer`] for `T` = `MaterializedView`).
 //! - Each struct implements [`Optimize`] once for each optimization stage. The
 //!   `From` type represents the input of the stage and `Self::To` the
 //!   associated stage output. This allows to have more than one entrypoints to
@@ -57,13 +57,6 @@ pub mod materialized_view;
 pub mod peek;
 pub mod subscribe;
 pub mod view;
-
-// Re-export optimzier structs
-pub use index::OptimizeIndex;
-pub use materialized_view::OptimizeMaterializedView;
-pub use peek::OptimizePeek;
-pub use subscribe::OptimizeSubscribe;
-pub use view::OptimizeView;
 
 use mz_catalog::memory::objects::CatalogItem;
 use mz_compute_types::dataflows::DataflowDescription;
@@ -131,7 +124,7 @@ pub struct OptimizerConfig {
     pub enable_specialized_arrangements: bool,
     /// An exclusive upper bound on the number of results we may return from a
     /// Persist fast-path peek. Required by the `create_fast_path_plan` call in
-    /// [`OptimizePeek`].
+    /// [`peek::Optimizer`].
     pub persist_fast_path_limit: usize,
     /// Enable outer join lowering implemented in #22343.
     pub enable_new_outer_join_lowering: bool,
@@ -231,7 +224,7 @@ impl<'a> DataflowBuilder<'a> {
                         path.segment = desc.id.to_string()
                     );
                     desc.plan = span.in_scope(|| {
-                        let mut view_optimizer = OptimizeView::new(config.clone());
+                        let mut view_optimizer = view::Optimizer::new(config.clone());
                         view_optimizer.optimize(view.raw_expr.clone())
                     })?;
                 }

--- a/src/adapter/src/optimize/view.rs
+++ b/src/adapter/src/optimize/view.rs
@@ -18,14 +18,14 @@ use tracing::{span, Level};
 
 use crate::optimize::{Optimize, OptimizerConfig, OptimizerError};
 
-pub struct OptimizeView {
+pub struct Optimizer {
     /// A typechecking context to use throughout the optimizer pipeline.
     typecheck_ctx: TypecheckContext,
     // Optimizer config.
     config: OptimizerConfig,
 }
 
-impl OptimizeView {
+impl Optimizer {
     pub fn new(config: OptimizerConfig) -> Self {
         Self {
             typecheck_ctx: empty_context(),
@@ -34,7 +34,7 @@ impl OptimizeView {
     }
 }
 
-impl Optimize<HirRelationExpr> for OptimizeView {
+impl Optimize<HirRelationExpr> for Optimizer {
     type To = OptimizedMirRelationExpr;
 
     fn optimize(&mut self, expr: HirRelationExpr) -> Result<Self::To, OptimizerError> {

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -173,33 +173,6 @@ impl<T> DataflowDescription<OptimizedMirRelationExpr, (), T> {
             || self.source_imports.keys().any(|i| i == id)
     }
 
-    /// Assigns the `as_of` frontier to the supplied argument.
-    ///
-    /// This method allows the dataflow to indicate a frontier up through
-    /// which all times should be advanced. This can be done for at least
-    /// two reasons: 1. correctness and 2. performance.
-    ///
-    /// Correctness may require an `as_of` to ensure that historical detail
-    /// is consolidated at representative times that do not present specific
-    /// detail that is not specifically correct. For example, updates may be
-    /// compacted to times that are no longer the source times, but instead
-    /// some byproduct of when compaction was executed; we should not present
-    /// those specific times as meaningfully different from other equivalent
-    /// times.
-    ///
-    /// Performance may benefit from an aggressive `as_of` as it reduces the
-    /// number of distinct moments at which collections vary. Differential
-    /// dataflow will refresh its outputs at each time its inputs change and
-    /// to moderate that we can minimize the volume of distinct input times
-    /// as much as possible.
-    ///
-    /// Generally, one should consider setting `as_of` at least to the `since`
-    /// frontiers of contributing data sources and as aggressively as the
-    /// computation permits.
-    pub fn set_as_of(&mut self, as_of: Antichain<T>) {
-        self.as_of = Some(as_of);
-    }
-
     /// The number of columns associated with an identifier in the dataflow.
     pub fn arity_of(&self, id: &GlobalId) -> usize {
         for (source_id, (source, _monotonic)) in self.source_imports.iter() {
@@ -248,6 +221,33 @@ impl<P, S, T> DataflowDescription<P, S, T>
 where
     P: CollectionPlan,
 {
+    /// Assigns the `as_of` frontier to the supplied argument.
+    ///
+    /// This method allows the dataflow to indicate a frontier up through
+    /// which all times should be advanced. This can be done for at least
+    /// two reasons: 1. correctness and 2. performance.
+    ///
+    /// Correctness may require an `as_of` to ensure that historical detail
+    /// is consolidated at representative times that do not present specific
+    /// detail that is not specifically correct. For example, updates may be
+    /// compacted to times that are no longer the source times, but instead
+    /// some byproduct of when compaction was executed; we should not present
+    /// those specific times as meaningfully different from other equivalent
+    /// times.
+    ///
+    /// Performance may benefit from an aggressive `as_of` as it reduces the
+    /// number of distinct moments at which collections vary. Differential
+    /// dataflow will refresh its outputs at each time its inputs change and
+    /// to moderate that we can minimize the volume of distinct input times
+    /// as much as possible.
+    ///
+    /// Generally, one should consider setting `as_of` at least to the `since`
+    /// frontiers of contributing data sources and as aggressively as the
+    /// computation permits.
+    pub fn set_as_of(&mut self, as_of: Antichain<T>) {
+        self.as_of = Some(as_of);
+    }
+
     /// Identifiers of imported objects (indexes and sources).
     pub fn import_ids(&self) -> impl Iterator<Item = GlobalId> + Clone + '_ {
         self.index_imports


### PR DESCRIPTION
This commit moves timestamp resolution for dataflows implementing indexes, materialized views, and subscribes after the full optimization.

The rationale for why this is sound is that the plans of standing dataflows should never be affected by the selected as-of, so as-of
selection can happen whenever.

The advantage of moving as-of selection to the end is that this allows us to pull optimization before as-of selection during bootstrap, so as-of selection can make use of index dependency information discovered during optimization.


### Motivation

   * This PR refactors existing code.

This is a change requested by @teskje in order to simplify the diff in #22940.

### Tips for reviewer

I actually did this for `Subscribe` as well.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
