### PR TITLE
webhooks: Forward fix reduce timeout

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -206,6 +206,9 @@ impl Coordinator {
                         .webhook_validation_reduce_failures
                         .with_label_values(&[reason])
                         .inc();
+                    return Err(AdapterError::Internal(format!(
+                        "failed to reduce check expression, {reason}"
+                    )));
                 }
             }
 

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1309,7 +1309,7 @@ pub struct WebhookValidation {
 }
 
 impl WebhookValidation {
-    const MAX_REDUCE_TIME: Duration = Duration::from_secs(2);
+    const MAX_REDUCE_TIME: Duration = Duration::from_secs(60);
 
     /// Attempt to reduce the internal [`MirScalarExpr`] into a simpler expression.
     ///


### PR DESCRIPTION
This PR increases the timeout for reducing a webhook `CHECK` expression from 2 to 60 seconds, and in the event that we fail to reduce it, we error the creation of a webhook source.

### Motivation

This PR addresses some comments that I didn't notice before merging https://github.com/MaterializeInc/materialize/pull/22934.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
