### PR TITLE
persist: replace should_fetch_part semantics with should_filter_part

### DIFF
--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -310,7 +310,7 @@ impl DataSubscribe {
                     false.then_some(|_, _: &_, _| unreachable!()),
                     Arc::new(StringSchema),
                     Arc::new(UnitSchema),
-                    |_, _| true,
+                    |_, _| false,
                 );
                 (data_stream.leave(), token)
             });

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -271,9 +271,9 @@ where
                     desc: &desc,
                     stats,
                 };
-                filter_may_match(desc.typ(), time_range, stats, plan)
+                !filter_may_match(desc.typ(), time_range, stats, plan)
             } else {
-                true
+                false
             }
         },
     );

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -337,7 +337,7 @@ impl TxnsCodec for TxnsCodecRow {
         }
     }
 
-    fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool> {
+    fn should_filter_part(data_id: &ShardId, stats: &PartStats) -> Option<bool> {
         fn col<'a, T: Data>(stats: &'a StructStats, col: &str) -> Option<&'a T::Stats> {
             stats
                 .col::<T>(col)
@@ -347,6 +347,6 @@ impl TxnsCodec for TxnsCodecRow {
         let stats = col::<Option<DynStruct>>(&stats.key, "ok")?;
         let stats = col::<String>(&stats.some, "shard_id")?;
         let data_id_str = data_id.to_string();
-        Some(stats.lower <= data_id_str && stats.upper >= data_id_str)
+        Some(stats.lower > data_id_str || stats.upper < data_id_str)
     }
 }


### PR DESCRIPTION
The semantics of should_fetch_part require it to turn "I don't know" into "true", which in practice has seemed to be a touch confusing. This was confirmed in the code review for #22838 where Joe encountered pushdown for the first time. Instead, flip the semantics to should_filter_part, where "I don't know" (e.g. a `None`) gets mapped to "false, which we hope will be easier to reason about when reading code.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
