### PR TITLE
data-ingest: Fix waiting for key schema

### DIFF
--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -85,7 +85,7 @@ class Executor:
         self,
         cur: pg8000.Cursor,
         query: str,
-        required_error_message_substr: str | None,
+        required_error_message_substrs: list[str],
         max_tries: int = 5,
         wait_time_in_sec: int = 1,
     ) -> None:
@@ -94,10 +94,7 @@ class Executor:
                 self.execute(cur, query)
                 return
             except Exception as e:
-                if (
-                    required_error_message_substr is not None
-                    and required_error_message_substr not in e.__str__()
-                ):
+                if not any([s in e.__str__() for s in required_error_message_substrs]):
                     raise
                 elif try_count == max_tries:
                     raise
@@ -448,7 +445,10 @@ class KafkaRoundtripExecutor(Executor):
                     ENVELOPE DEBEZIUM""",
                 wait_time_in_sec=1,
                 max_tries=15,
-                required_error_message_substr="No value schema found",
+                required_error_message_substrs=[
+                    "No value schema found",
+                    "Key schema is required for ENVELOPE DEBEZIUM",
+                ],
             )
         self.mz_conn.autocommit = False
 


### PR DESCRIPTION
Follow-up to https://github.com/MaterializeInc/materialize/pull/22663

Seen in https://buildkite.com/materialize/nightlies/builds/5015#018ba49d-0c09-41e0-be59-d2e7b775ff62

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
