### PR TITLE
catalog: Update persist impl to use proto

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3740,6 +3740,7 @@ dependencies = [
  "postgres-openssl",
  "proptest",
  "proptest-derive",
+ "prost",
  "rand",
  "serde",
  "serde_json",

--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -38,6 +38,8 @@ breaking:
     # reason: does currently not require backward-compatibility
     - stash-types/protos/objects_v41.proto
     # reason: does currently not require backward-compatibility
+    - stash-types/protos/objects_v42.proto
+    # reason: does currently not require backward-compatibility
     - storage-client/src/client.proto
     # reason: Ignored until #21887 is reverted
     - storage-types/src/errors.proto

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -38,6 +38,7 @@ mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
+prost = { version = "0.11.9" }
 postgres-openssl = { version = "0.5.0" }
 serde = "1.0.152"
 serde_json = "1.0.89"

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -27,7 +27,6 @@ use mz_ore::{soft_assert, soft_assert_eq};
 use mz_persist_client::read::ReadHandle;
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
-use mz_persist_types::codec_impls::VecU8Schema;
 use mz_proto::RustType;
 use mz_repr::Diff;
 use mz_stash::USER_VERSION_KEY;
@@ -40,8 +39,10 @@ use tracing::debug;
 use uuid::Uuid;
 
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
-use crate::durable::impls::persist::state_update::StateUpdateKindTag;
 pub use crate::durable::impls::persist::state_update::{StateUpdate, StateUpdateKind};
+use crate::durable::impls::persist::state_update::{
+    StateUpdateKindSchema, StateUpdateKindTag, StateUpdateKindTagSchema,
+};
 use crate::durable::initialize::DEPLOY_GENERATION;
 use crate::durable::objects::{AuditLogKey, DurableType, Snapshot, StorageUsageKey};
 use crate::durable::transaction::TransactionBatch;
@@ -94,8 +95,8 @@ impl PersistHandle {
         let (write_handle, read_handle) = persist_client
             .open(
                 shard_id,
-                Arc::new(VecU8Schema::default()),
-                Arc::new(VecU8Schema::default()),
+                Arc::new(StateUpdateKindTagSchema::default()),
+                Arc::new(StateUpdateKindSchema::default()),
                 Diagnostics {
                     shard_name: "catalog".to_string(),
                     handle_purpose: "durable catalog state".to_string(),

--- a/src/catalog/src/durable/impls/persist/state_update.rs
+++ b/src/catalog/src/durable/impls/persist/state_update.rs
@@ -1,0 +1,620 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use prost::Message;
+use std::fmt::Debug;
+
+use mz_persist_types::codec_impls::{SimpleDecoder, SimpleEncoder, SimpleSchema, VecU8Schema};
+use mz_persist_types::dyn_struct::{ColumnsMut, ColumnsRef, DynStructCfg};
+use mz_persist_types::Codec;
+use mz_proto::{ProtoType, RustType, TryFromProtoError};
+use mz_repr::Diff;
+use mz_stash_types::objects::proto;
+
+use crate::durable::impls::persist::Timestamp;
+use crate::durable::transaction::TransactionBatch;
+use crate::durable::Epoch;
+
+/// A single update to the catalog state.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StateUpdate {
+    /// They kind and contents of the state update.
+    pub(super) kind: StateUpdateKind,
+    /// The timestamp at which the update occurred.
+    pub(super) ts: Timestamp,
+    /// Record count difference for the update.
+    pub(super) diff: Diff,
+}
+
+impl StateUpdate {
+    /// Convert a [`TransactionBatch`] to a list of [`StateUpdate`]s at timestamp `ts`.
+    pub(super) fn from_txn_batch(txn_batch: TransactionBatch, ts: Timestamp) -> Vec<StateUpdate> {
+        fn from_batch<K, V>(
+            batch: Vec<(K, V, Diff)>,
+            ts: Timestamp,
+            kind: fn(K, V) -> StateUpdateKind,
+        ) -> impl Iterator<Item = StateUpdate> {
+            batch.into_iter().map(move |(k, v, diff)| StateUpdate {
+                kind: kind(k, v),
+                ts,
+                diff,
+            })
+        }
+        let TransactionBatch {
+            databases,
+            schemas,
+            items,
+            comments,
+            roles,
+            clusters,
+            cluster_replicas,
+            introspection_sources,
+            id_allocator,
+            configs,
+            settings,
+            timestamps,
+            system_gid_mapping,
+            system_configurations,
+            default_privileges,
+            system_privileges,
+            audit_log_updates,
+            storage_usage_updates,
+            // Persist implementation does not use the connection timeout.
+            connection_timeout: _,
+        } = txn_batch;
+        let databases = from_batch(databases, ts, StateUpdateKind::Database);
+        let schemas = from_batch(schemas, ts, StateUpdateKind::Schema);
+        let items = from_batch(items, ts, StateUpdateKind::Item);
+        let comments = from_batch(comments, ts, StateUpdateKind::Comment);
+        let roles = from_batch(roles, ts, StateUpdateKind::Role);
+        let clusters = from_batch(clusters, ts, StateUpdateKind::Cluster);
+        let cluster_replicas = from_batch(cluster_replicas, ts, StateUpdateKind::ClusterReplica);
+        let introspection_sources = from_batch(
+            introspection_sources,
+            ts,
+            StateUpdateKind::IntrospectionSourceIndex,
+        );
+        let id_allocators = from_batch(id_allocator, ts, StateUpdateKind::IdAllocator);
+        let configs = from_batch(configs, ts, StateUpdateKind::Config);
+        let settings = from_batch(settings, ts, StateUpdateKind::Setting);
+        let timestamps = from_batch(timestamps, ts, StateUpdateKind::Timestamp);
+        let system_object_mappings =
+            from_batch(system_gid_mapping, ts, StateUpdateKind::SystemObjectMapping);
+        let system_configurations = from_batch(
+            system_configurations,
+            ts,
+            StateUpdateKind::SystemConfiguration,
+        );
+        let default_privileges =
+            from_batch(default_privileges, ts, StateUpdateKind::DefaultPrivilege);
+        let system_privileges = from_batch(system_privileges, ts, StateUpdateKind::SystemPrivilege);
+        let audit_logs = from_batch(audit_log_updates, ts, StateUpdateKind::AuditLog);
+        let storage_usage_updates =
+            from_batch(storage_usage_updates, ts, StateUpdateKind::StorageUsage);
+
+        databases
+            .chain(schemas)
+            .chain(items)
+            .chain(comments)
+            .chain(roles)
+            .chain(clusters)
+            .chain(cluster_replicas)
+            .chain(introspection_sources)
+            .chain(id_allocators)
+            .chain(configs)
+            .chain(settings)
+            .chain(timestamps)
+            .chain(system_object_mappings)
+            .chain(system_configurations)
+            .chain(default_privileges)
+            .chain(system_privileges)
+            .chain(audit_logs)
+            .chain(storage_usage_updates)
+            .collect()
+    }
+}
+
+/// The contents of a single state update.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum StateUpdateKind {
+    AuditLog(proto::AuditLogKey, ()),
+    Cluster(proto::ClusterKey, proto::ClusterValue),
+    ClusterReplica(proto::ClusterReplicaKey, proto::ClusterReplicaValue),
+    Comment(proto::CommentKey, proto::CommentValue),
+    Config(proto::ConfigKey, proto::ConfigValue),
+    Database(proto::DatabaseKey, proto::DatabaseValue),
+    DefaultPrivilege(proto::DefaultPrivilegesKey, proto::DefaultPrivilegesValue),
+    Epoch(Epoch),
+    IdAllocator(proto::IdAllocKey, proto::IdAllocValue),
+    IntrospectionSourceIndex(
+        proto::ClusterIntrospectionSourceIndexKey,
+        proto::ClusterIntrospectionSourceIndexValue,
+    ),
+    Item(proto::ItemKey, proto::ItemValue),
+    Role(proto::RoleKey, proto::RoleValue),
+    Schema(proto::SchemaKey, proto::SchemaValue),
+    Setting(proto::SettingKey, proto::SettingValue),
+    StorageUsage(proto::StorageUsageKey, ()),
+    SystemConfiguration(
+        proto::ServerConfigurationKey,
+        proto::ServerConfigurationValue,
+    ),
+    SystemObjectMapping(proto::GidMappingKey, proto::GidMappingValue),
+    SystemPrivilege(proto::SystemPrivilegesKey, proto::SystemPrivilegesValue),
+    Timestamp(proto::TimestampKey, proto::TimestampValue),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(super) struct StateUpdateKindTag(u64);
+
+impl StateUpdateKind {
+    /// Returns a tag to differentiate between different variants.
+    pub(super) fn tag(&self) -> StateUpdateKindTag {
+        StateUpdateKindTag(match self {
+            StateUpdateKind::AuditLog(_, _) => 1,
+            StateUpdateKind::Cluster(_, _) => 2,
+            StateUpdateKind::ClusterReplica(_, _) => 3,
+            StateUpdateKind::Comment(_, _) => 4,
+            StateUpdateKind::Config(_, _) => 5,
+            StateUpdateKind::Database(_, _) => 6,
+            StateUpdateKind::DefaultPrivilege(_, _) => 7,
+            StateUpdateKind::Epoch(_) => 8,
+            StateUpdateKind::IdAllocator(_, _) => 9,
+            StateUpdateKind::IntrospectionSourceIndex(_, _) => 10,
+            StateUpdateKind::Item(_, _) => 11,
+            StateUpdateKind::Role(_, _) => 12,
+            StateUpdateKind::Schema(_, _) => 13,
+            StateUpdateKind::Setting(_, _) => 14,
+            StateUpdateKind::StorageUsage(_, _) => 15,
+            StateUpdateKind::SystemConfiguration(_, _) => 16,
+            StateUpdateKind::SystemObjectMapping(_, _) => 17,
+            StateUpdateKind::SystemPrivilege(_, _) => 18,
+            StateUpdateKind::Timestamp(_, _) => 19,
+        })
+    }
+}
+
+impl RustType<proto::StateUpdateKind> for StateUpdateKind {
+    fn into_proto(&self) -> proto::StateUpdateKind {
+        proto::StateUpdateKind {
+            kind: Some(match self {
+                StateUpdateKind::AuditLog(key, _value) => {
+                    proto::state_update_kind::Kind::AuditLog(proto::state_update_kind::AuditLog {
+                        key: Some(key.clone()),
+                    })
+                }
+                StateUpdateKind::Cluster(key, value) => {
+                    proto::state_update_kind::Kind::Cluster(proto::state_update_kind::Cluster {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::ClusterReplica(key, value) => {
+                    proto::state_update_kind::Kind::ClusterReplica(
+                        proto::state_update_kind::ClusterReplica {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::Comment(key, value) => {
+                    proto::state_update_kind::Kind::Comment(proto::state_update_kind::Comment {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::Config(key, value) => {
+                    proto::state_update_kind::Kind::Config(proto::state_update_kind::Config {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::Database(key, value) => {
+                    proto::state_update_kind::Kind::Database(proto::state_update_kind::Database {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::DefaultPrivilege(key, value) => {
+                    proto::state_update_kind::Kind::DefaultPrivileges(
+                        proto::state_update_kind::DefaultPrivileges {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::Epoch(epoch) => {
+                    proto::state_update_kind::Kind::Epoch(proto::state_update_kind::Epoch {
+                        epoch: epoch.get(),
+                    })
+                }
+                StateUpdateKind::IdAllocator(key, value) => {
+                    proto::state_update_kind::Kind::IdAlloc(proto::state_update_kind::IdAlloc {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::IntrospectionSourceIndex(key, value) => {
+                    proto::state_update_kind::Kind::ClusterIntrospectionSourceIndex(
+                        proto::state_update_kind::ClusterIntrospectionSourceIndex {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::Item(key, value) => {
+                    proto::state_update_kind::Kind::Item(proto::state_update_kind::Item {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::Role(key, value) => {
+                    proto::state_update_kind::Kind::Role(proto::state_update_kind::Role {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::Schema(key, value) => {
+                    proto::state_update_kind::Kind::Schema(proto::state_update_kind::Schema {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::Setting(key, value) => {
+                    proto::state_update_kind::Kind::Setting(proto::state_update_kind::Setting {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+                StateUpdateKind::StorageUsage(key, _value) => {
+                    proto::state_update_kind::Kind::StorageUsage(
+                        proto::state_update_kind::StorageUsage {
+                            key: Some(key.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::SystemConfiguration(key, value) => {
+                    proto::state_update_kind::Kind::ServerConfiguration(
+                        proto::state_update_kind::ServerConfiguration {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::SystemObjectMapping(key, value) => {
+                    proto::state_update_kind::Kind::GidMapping(
+                        proto::state_update_kind::GidMapping {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::SystemPrivilege(key, value) => {
+                    proto::state_update_kind::Kind::SystemPrivileges(
+                        proto::state_update_kind::SystemPrivileges {
+                            key: Some(key.clone()),
+                            value: Some(value.clone()),
+                        },
+                    )
+                }
+                StateUpdateKind::Timestamp(key, value) => {
+                    proto::state_update_kind::Kind::Timestamp(proto::state_update_kind::Timestamp {
+                        key: Some(key.clone()),
+                        value: Some(value.clone()),
+                    })
+                }
+            }),
+        }
+    }
+
+    fn from_proto(proto: proto::StateUpdateKind) -> Result<StateUpdateKind, TryFromProtoError> {
+        Ok(
+            match proto
+                .kind
+                .ok_or_else(|| TryFromProtoError::missing_field("StateUpdateKind::kind"))?
+            {
+                proto::state_update_kind::Kind::AuditLog(proto::state_update_kind::AuditLog {
+                    key,
+                }) => StateUpdateKind::AuditLog(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::AuditLog::key")
+                    })?,
+                    (),
+                ),
+                proto::state_update_kind::Kind::Cluster(proto::state_update_kind::Cluster {
+                    key,
+                    value,
+                }) => StateUpdateKind::Cluster(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Cluster::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Cluster::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::ClusterReplica(
+                    proto::state_update_kind::ClusterReplica { key, value },
+                ) => StateUpdateKind::ClusterReplica(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::ClusterReplica::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::ClusterReplica::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Comment(proto::state_update_kind::Comment {
+                    key,
+                    value,
+                }) => StateUpdateKind::Comment(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Comment::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Comment::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Config(proto::state_update_kind::Config {
+                    key,
+                    value,
+                }) => StateUpdateKind::Config(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Config::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Config::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Database(proto::state_update_kind::Database {
+                    key,
+                    value,
+                }) => StateUpdateKind::Database(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Database::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Database::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::DefaultPrivileges(
+                    proto::state_update_kind::DefaultPrivileges { key, value },
+                ) => StateUpdateKind::DefaultPrivilege(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::DefaultPrivileges::key",
+                        )
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::DefaultPrivileges::value",
+                        )
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Epoch(proto::state_update_kind::Epoch {
+                    epoch,
+                }) => StateUpdateKind::Epoch(Epoch::new(epoch).ok_or_else(|| {
+                    TryFromProtoError::missing_field("state_update_kind::Epoch::epoch")
+                })?),
+                proto::state_update_kind::Kind::IdAlloc(proto::state_update_kind::IdAlloc {
+                    key,
+                    value,
+                }) => StateUpdateKind::IdAllocator(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::IdAlloc::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::IdAlloc::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::ClusterIntrospectionSourceIndex(
+                    proto::state_update_kind::ClusterIntrospectionSourceIndex { key, value },
+                ) => StateUpdateKind::IntrospectionSourceIndex(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::ClusterIntrospectionSourceIndex::key",
+                        )
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::ClusterIntrospectionSourceIndex::value",
+                        )
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Item(proto::state_update_kind::Item {
+                    key,
+                    value,
+                }) => StateUpdateKind::Item(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Item::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Item::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Role(proto::state_update_kind::Role {
+                    key,
+                    value,
+                }) => StateUpdateKind::Role(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Role::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Role::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Schema(proto::state_update_kind::Schema {
+                    key,
+                    value,
+                }) => StateUpdateKind::Schema(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Schema::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Schema::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Setting(proto::state_update_kind::Setting {
+                    key,
+                    value,
+                }) => StateUpdateKind::Setting(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Setting::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Setting::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::StorageUsage(
+                    proto::state_update_kind::StorageUsage { key },
+                ) => StateUpdateKind::StorageUsage(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::StorageUsage::key")
+                    })?,
+                    (),
+                ),
+                proto::state_update_kind::Kind::ServerConfiguration(
+                    proto::state_update_kind::ServerConfiguration { key, value },
+                ) => StateUpdateKind::SystemConfiguration(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::ServerConfiguration::key",
+                        )
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::ServerConfiguration::value",
+                        )
+                    })?,
+                ),
+                proto::state_update_kind::Kind::GidMapping(
+                    proto::state_update_kind::GidMapping { key, value },
+                ) => StateUpdateKind::SystemObjectMapping(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::GidMapping::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::GidMapping::value")
+                    })?,
+                ),
+                proto::state_update_kind::Kind::SystemPrivileges(
+                    proto::state_update_kind::SystemPrivileges { key, value },
+                ) => StateUpdateKind::SystemPrivilege(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::SystemPrivileges::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field(
+                            "state_update_kind::SystemPrivileges::value",
+                        )
+                    })?,
+                ),
+                proto::state_update_kind::Kind::Timestamp(
+                    proto::state_update_kind::Timestamp { key, value },
+                ) => StateUpdateKind::Timestamp(
+                    key.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Timestamp::key")
+                    })?,
+                    value.ok_or_else(|| {
+                        TryFromProtoError::missing_field("state_update_kind::Timestamp::value")
+                    })?,
+                ),
+            },
+        )
+    }
+}
+
+impl Codec for StateUpdateKindTag {
+    type Schema = VecU8Schema;
+
+    fn codec_name() -> String {
+        "StateUpdateTag".to_string()
+    }
+
+    fn encode<B>(&self, buf: &mut B)
+    where
+        B: bytes::BufMut,
+    {
+        let bytes = self.0.to_le_bytes();
+        buf.put(bytes.as_slice());
+    }
+
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+        assert_eq!(buf.len(), 8, "u64 is 8 bytes");
+        let tag = u64::from_le_bytes(buf[0..8].try_into().expect("asserted above"));
+        Ok(Self(tag))
+    }
+}
+
+impl mz_persist_types::columnar::Schema<StateUpdateKindTag> for VecU8Schema {
+    type Encoder<'a> = SimpleEncoder<'a, StateUpdateKindTag, Vec<u8>>;
+
+    type Decoder<'a> = SimpleDecoder<'a, StateUpdateKindTag, Vec<u8>>;
+
+    fn columns(&self) -> DynStructCfg {
+        SimpleSchema::<StateUpdateKindTag, Vec<u8>>::columns(&())
+    }
+
+    fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        SimpleSchema::<StateUpdateKindTag, Vec<u8>>::decoder(cols, |val, ret| {
+            *ret = StateUpdateKindTag::decode(val).expect("should be valid StateUpdateKindTag")
+        })
+    }
+
+    fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        SimpleSchema::<StateUpdateKindTag, Vec<u8>>::push_encoder(cols, |col, val| {
+            let mut buf = Vec::new();
+            StateUpdateKindTag::encode(val, &mut buf);
+            mz_persist_types::columnar::ColumnPush::<Vec<u8>>::push(col, &buf)
+        })
+    }
+}
+
+impl Codec for StateUpdateKind {
+    type Schema = VecU8Schema;
+
+    fn codec_name() -> String {
+        "StateUpdateProto".to_string()
+    }
+
+    fn encode<B>(&self, buf: &mut B)
+    where
+        B: bytes::BufMut,
+    {
+        let bytes = self.into_proto().encode_to_vec();
+        buf.put(bytes.as_slice());
+    }
+
+    fn decode<'a>(buf: &'a [u8]) -> Result<Self, String> {
+        let kind = proto::StateUpdateKind::decode(buf).map_err(|err| err.to_string())?;
+        kind.into_rust().map_err(|err| err.to_string())
+    }
+}
+
+impl mz_persist_types::columnar::Schema<StateUpdateKind> for VecU8Schema {
+    type Encoder<'a> = SimpleEncoder<'a, StateUpdateKind, Vec<u8>>;
+
+    type Decoder<'a> = SimpleDecoder<'a, StateUpdateKind, Vec<u8>>;
+
+    fn columns(&self) -> DynStructCfg {
+        SimpleSchema::<StateUpdateKind, Vec<u8>>::columns(&())
+    }
+
+    fn decoder<'a>(&self, cols: ColumnsRef<'a>) -> Result<Self::Decoder<'a>, String> {
+        SimpleSchema::<StateUpdateKind, Vec<u8>>::decoder(cols, |val, ret| {
+            *ret = StateUpdateKind::decode(val).expect("should be valid StateUpdateKind")
+        })
+    }
+
+    fn encoder<'a>(&self, cols: ColumnsMut<'a>) -> Result<Self::Encoder<'a>, String> {
+        SimpleSchema::<StateUpdateKind, Vec<u8>>::push_encoder(cols, |col, val| {
+            let mut buf = Vec::new();
+            StateUpdateKind::encode(val, &mut buf);
+            mz_persist_types::columnar::ColumnPush::<Vec<u8>>::push(col, &buf)
+        })
+    }
+}

--- a/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
@@ -624,7 +624,7 @@ Trace {
                         key: "user_version",
                     },
                     ConfigValue {
-                        value: 41,
+                        value: 42,
                     },
                 ),
                 "0",

--- a/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
@@ -612,7 +612,7 @@ Trace {
                         key: "user_version",
                     },
                     ConfigValue {
-                        value: 41,
+                        value: 42,
                     },
                 ),
                 "-9223372036854775808",

--- a/src/catalog/tests/snapshots/open__initial_snapshot.snap
+++ b/src/catalog/tests/snapshots/open__initial_snapshot.snap
@@ -957,7 +957,7 @@ Snapshot {
         ConfigKey {
             key: "user_version",
         }: ConfigValue {
-            value: 41,
+            value: 42,
         },
     },
     settings: {},

--- a/src/stash-types/build.rs
+++ b/src/stash-types/build.rs
@@ -220,6 +220,7 @@ fn main() -> anyhow::Result<()> {
         .enum_attribute("ResolvedDatabaseSpecifier.spec", ATTR)
         .enum_attribute("SchemaSpecifier.spec", ATTR)
         .enum_attribute("RoleVars.Entry.val", ATTR)
+        .enum_attribute("StateUpdateKind.kind", ATTR)
         // We derive Arbitrary for all protobuf types for wire compatibility testing.
         .message_attribute(".", ARBITRARY_ATTR)
         .enum_attribute(".", ARBITRARY_ATTR)

--- a/src/stash-types/protos/hashes.json
+++ b/src/stash-types/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "37364f92957ab02b17a939f3fbc95f87"
+    "md5": "ce61d36b3a277dd3647425ef27c6392d"
   },
   {
     "name": "objects_v35.proto",
@@ -30,5 +30,9 @@
   {
     "name": "objects_v41.proto",
     "md5": "bb5920a095e501a1efd2d43a057d0b84"
+  },
+  {
+    "name": "objects_v42.proto",
+    "md5": "78ab44ed4cf6d27f9e4cd6b2a904dfd5"
   }
 ]

--- a/src/stash-types/protos/objects_v42.proto
+++ b/src/stash-types/protos/objects_v42.proto
@@ -19,7 +19,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v42;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash-types/src/lib.rs
+++ b/src/stash-types/src/lib.rs
@@ -101,7 +101,7 @@ pub mod upgrade {
         }
     }
 
-    objects!(v35, v36, v37, v38, v39, v40);
+    objects!(v35, v36, v37, v38, v39, v40, v41, v42);
 }
 
 /// The current version of the `Stash`.
@@ -109,7 +109,7 @@ pub mod upgrade {
 /// We will initialize new `Stash`es with this version, and migrate existing `Stash`es to this
 /// version. Whenever the `Stash` changes, e.g. the protobufs we serialize in the `Stash`
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 41;
+pub const STASH_VERSION: u64 = 42;
 
 /// The minimum `Stash` version number that we support migrating from.
 ///

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -940,6 +940,7 @@ impl Stash {
                             38 => upgrade::v38_to_v39::upgrade(&tx).await?,
                             39 => upgrade::v39_to_v40::upgrade(&tx).await?,
                             40 => upgrade::v40_to_v41::upgrade(),
+                            41 => upgrade::v41_to_v42::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -51,6 +51,7 @@ pub(crate) mod v37_to_v38;
 pub(crate) mod v38_to_v39;
 pub(crate) mod v39_to_v40;
 pub(crate) mod v40_to_v41;
+pub(crate) mod v41_to_v42;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v41_to_v42.rs
+++ b/src/stash/src/upgrade/v41_to_v42.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for adding a new type for persist catalog implementation.
+pub fn upgrade() {}


### PR DESCRIPTION
This commit updates the persist implementation of the durable catalog to use protobuf for serialization/deserialization instead of JSON.

Works towards resolving #22977

### Motivation
This PR adds a known-desirable feature.


### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
