### PR TITLE
persist-txn: hook enable_persist_txn_tables up to Launch Darkly

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -125,6 +125,13 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 
+    /// Get the `enabled_persist_txn_tables` config value of this instance.
+    ///
+    /// This mirrors the `enabled_persist_txn_tables` "system var" so that we
+    /// can toggle the flag with Launch Darkly, but use it in boot before Launch
+    /// Darkly is available.
+    async fn get_enable_persist_txn_tables(&mut self) -> Result<Option<bool>, CatalogError>;
+
     /// Generate an unconsolidated [`Trace`] of catalog contents.
     async fn trace(&mut self) -> Result<Trace, CatalogError>;
 

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 use crate::durable::debug::{Collection, DebugCatalogState, Trace};
 use crate::durable::impls::persist::state_update::StateUpdateKindSchema;
 pub use crate::durable::impls::persist::state_update::{StateUpdate, StateUpdateKind};
-use crate::durable::initialize::DEPLOY_GENERATION;
+use crate::durable::initialize::{DEPLOY_GENERATION, ENABLE_PERSIST_TXN_TABLES};
 use crate::durable::objects::{AuditLogKey, DurableType, Snapshot, StorageUsageKey};
 use crate::durable::transaction::TransactionBatch;
 use crate::durable::{
@@ -431,6 +431,13 @@ impl OpenableDurableCatalogState for PersistHandle {
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         let upper = self.current_upper().await;
         Ok(self.get_config(DEPLOY_GENERATION, upper).await)
+    }
+
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn get_enable_persist_txn_tables(&mut self) -> Result<Option<bool>, CatalogError> {
+        let upper = self.current_upper().await;
+        let value = self.get_config(ENABLE_PERSIST_TXN_TABLES, upper).await;
+        Ok(value.map(|value| value > 0))
     }
 
     #[tracing::instrument(level = "info", skip_all)]

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -144,6 +144,10 @@ where
         compare_and_return_async!(self, get_deployment_generation)
     }
 
+    async fn get_enable_persist_txn_tables(&mut self) -> Result<Option<bool>, CatalogError> {
+        compare_and_return_async!(self, get_enable_persist_txn_tables)
+    }
+
     async fn trace(&mut self) -> Result<Trace, CatalogError> {
         panic!("ShadowCatalog is not used for catalog-debug tool");
     }

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -32,7 +32,7 @@ use mz_stash_types::StashError;
 use mz_storage_types::sources::Timeline;
 
 use crate::durable::debug::{Collection, CollectionTrace, Trace};
-use crate::durable::initialize::DEPLOY_GENERATION;
+use crate::durable::initialize::{DEPLOY_GENERATION, ENABLE_PERSIST_TXN_TABLES};
 use crate::durable::objects::{
     AuditLogKey, DurableType, IdAllocKey, IdAllocValue, Snapshot, StorageUsageKey,
     TimelineTimestamp, TimestampValue,
@@ -250,6 +250,29 @@ impl OpenableDurableCatalogState for OpenableConnection {
             .map(|v| v.value);
 
         Ok(deployment_generation)
+    }
+
+    async fn get_enable_persist_txn_tables(&mut self) -> Result<Option<bool>, CatalogError> {
+        let stash = match &mut self.stash {
+            None => match self.open_stash_read_only().await {
+                Ok(stash) => stash,
+                Err(e) if e.can_recover_with_write_mode() => return Ok(None),
+                Err(e) => return Err(e.into()),
+            },
+            Some(stash) => stash,
+        };
+
+        let value = CONFIG_COLLECTION
+            .peek_key_one(
+                stash,
+                proto::ConfigKey {
+                    key: ENABLE_PERSIST_TXN_TABLES.into(),
+                },
+            )
+            .await?
+            .map(|v| v.value);
+
+        Ok(value.map(|value| value > 0))
     }
 
     #[tracing::instrument(level = "info", skip_all)]
@@ -1093,6 +1116,12 @@ impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
 
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError> {
         self.openable_connection.get_deployment_generation().await
+    }
+
+    async fn get_enable_persist_txn_tables(&mut self) -> Result<Option<bool>, CatalogError> {
+        self.openable_connection
+            .get_enable_persist_txn_tables()
+            .await
     }
 
     async fn trace(&mut self) -> Result<Trace, CatalogError> {

--- a/src/catalog/src/durable/initialize.rs
+++ b/src/catalog/src/durable/initialize.rs
@@ -41,6 +41,12 @@ use crate::durable::{
 /// The key used within the "config" collection where we store the deploy generation.
 pub(crate) const DEPLOY_GENERATION: &str = "deploy_generation";
 
+/// The key used within the "config" collection where we store a mirror of the
+/// `enable_persist_txn_tables` "system var" value. This is mirrored so that we
+/// can toggle the flag with Launch Darkly, but use it in boot before Launch
+/// Darkly is available.
+pub(crate) const ENABLE_PERSIST_TXN_TABLES: &str = "enable_persist_txn_tables";
+
 const USER_ID_ALLOC_KEY: &str = "user";
 const SYSTEM_ID_ALLOC_KEY: &str = "system";
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -29,6 +29,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 
 use crate::builtin::BuiltinLog;
+use crate::durable::initialize::ENABLE_PERSIST_TXN_TABLES;
 use crate::durable::objects::ClusterConfig;
 use crate::durable::objects::{
     AuditLogKey, Cluster, ClusterIntrospectionSourceIndexKey, ClusterIntrospectionSourceIndexValue,
@@ -1028,6 +1029,17 @@ impl<'a> Transaction<'a> {
         let config = Config { key, value };
         let (key, value) = config.into_key_value();
         self.configs.set(key, Some(value))?;
+        Ok(())
+    }
+
+    /// Updates the catalog stash `enable_persist_txn_tables` "config" value to
+    /// match the `enable_persist_txn_tables` "system var" value.
+    ///
+    /// These are mirrored so that we can toggle the flag with Launch Darkly,
+    /// but use it in boot before Launch Darkly is available.
+    pub fn set_enable_persist_txn_tables(&mut self, value: bool) -> Result<(), CatalogError> {
+        let value = if value { 1 } else { 0 };
+        self.set_config(ENABLE_PERSIST_TXN_TABLES.into(), value)?;
         Ok(())
     }
 

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -159,9 +159,6 @@ pub struct ControllerConfig {
     pub persist_pubsub_url: String,
     /// Arguments for secrets readers.
     pub secrets_args: SecretsReaderCliArgs,
-    /// Whether to use the new persist-txn tables implementation or the legacy
-    /// one.
-    pub enable_persist_txn_tables: bool,
 }
 
 /// Responses that [`Controller`] can produce.
@@ -373,7 +370,13 @@ where
     mz_storage_controller::Controller<T>: StorageController<Timestamp = T>,
 {
     /// Creates a new controller.
-    pub async fn new(config: ControllerConfig, envd_epoch: NonZeroI64) -> Self {
+    pub async fn new(
+        config: ControllerConfig,
+        envd_epoch: NonZeroI64,
+        // Whether to use the new persist-txn tables implementation or the
+        // legacy one.
+        enable_persist_txn_tables: bool,
+    ) -> Self {
         let storage_controller = mz_storage_controller::Controller::new(
             config.build_info,
             config.storage_stash_url,
@@ -383,7 +386,7 @@ where
             config.stash_metrics,
             envd_epoch,
             config.metrics_registry.clone(),
-            config.enable_persist_txn_tables,
+            enable_persist_txn_tables,
         )
         .await;
 
@@ -409,7 +412,7 @@ where
             metrics_rx: UnboundedReceiverStream::new(metrics_rx).peekable(),
             frontiers_ticker,
             persist_pubsub_url: config.persist_pubsub_url,
-            enable_persist_txn_tables: config.enable_persist_txn_tables,
+            enable_persist_txn_tables,
             secrets_args: config.secrets_args,
         }
     }

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -486,8 +486,6 @@ impl Listeners {
                             secrets_reader_aws_region: None,
                             secrets_reader_aws_prefix: None,
                         },
-                        // TODO(txn): Get this flipped to true before turning anything on in prod.
-                        enable_persist_txn_tables: false,
                     },
                     secrets_controller,
                     cloud_resource_controller: None,
@@ -520,6 +518,8 @@ impl Listeners {
                     deploy_generation: config.deploy_generation,
                     http_host_name: Some(host_name),
                     internal_console_redirect_url: config.internal_console_redirect_url,
+                    // TODO(txn): Get this flipped to true before turning anything on in prod.
+                    enable_persist_txn_tables_cli: None,
                 })
                 .await
         })?;

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2040,6 +2040,22 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_persist_txn_tables,
+        desc: "\
+            Whether to use the new persist-txn tables implementation or the legacy \
+            one.
+
+            Only takes effect on restart. Any changes will also cause clusterd \
+            processes to restart.
+
+            This value is also configurable via a Launch Darkly parameter of the \
+            same name, but we keep the flag to make testing easier. If specified, \
+            the flag takes precedence over the Launch Darkly param.",
+        default: &false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 /// Represents the input to a variable.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1001,8 +1001,6 @@ impl<'a> RunnerInner<'a> {
                     secrets_reader_aws_region: None,
                     secrets_reader_aws_prefix: None,
                 },
-                // TODO(txn): Get this flipped to true before turning anything on in prod.
-                enable_persist_txn_tables: false,
             },
             secrets_controller,
             cloud_resource_controller: None,
@@ -1043,6 +1041,8 @@ impl<'a> RunnerInner<'a> {
             deploy_generation: None,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
+            // TODO(txn): Get this flipped to true before turning anything on in prod.
+            enable_persist_txn_tables_cli: None,
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned


### PR DESCRIPTION
Only takes effect on restart. Any changes will also cause clusterd processes to restart.

The usual Launch Darkly system vars hookup is not available early enough in the boot process to use directly, so we mirror it to an entry in the catalog stash "config" collection and read that. Leave the environmentd cli flag around as an override to make testing easier.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
