### PR TITLE
doc/user: upsize TPC-H load generator

### DIFF
--- a/doc/user/content/sql/create-source/load-generator.md
+++ b/doc/user/content/sql/create-source/load-generator.md
@@ -352,7 +352,7 @@ To create the load generator source and its associated subsources:
 CREATE SOURCE tpch
   FROM LOAD GENERATOR TPCH (SCALE FACTOR 1)
   FOR ALL TABLES
-  WITH (SIZE = '3xsmall');
+  WITH (SIZE = '2xsmall');
 ```
 
 To display the created subsources:
@@ -363,7 +363,7 @@ SHOW SOURCES;
 ```nofmt
       name     |      type      |  size
 ---------------+----------------+---------
- tpch          | load-generator | 3xsmall
+ tpch          | load-generator | 2xsmall
  tpch_progress | progress       |
  supplier      | subsource      |
  region        | subsource      |


### PR DESCRIPTION
The TPC-H load generator, even at scale factor 1, requires more resources to initialize than are available on a 3xsmall cluster.

Fix #22980.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
