### PR TITLE
ci: closed issues detector: remove unnecessary code

### DIFF
--- a/misc/python/materialize/cli/ci_closed_issues_detect.py
+++ b/misc/python/materialize/cli/ci_closed_issues_detect.py
@@ -96,11 +96,6 @@ def detect_closed_issues(filename: str) -> list[IssueRef]:
                     ]
                     assert len(groups) == 1, f"Expected only 1 element in {groups}"
                     group, issue_id = groups[0]
-                    (
-                        "TimelyDataflow/timely-dataflow"
-                        if issue_match.group("timelydataflow")
-                        else "MaterializeInc/materialize"
-                    )
                     issue_refs.append(
                         IssueRef(
                             GROUP_REPO[group],


### PR DESCRIPTION
This code has no effect and I believe it is not necessary because the mapping is done through the dict `GROUP_REPO`.