### PR TITLE
output consistency: add ignores

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -218,7 +218,7 @@ class PostExecutionInconsistencyIgnoreFilter(
             return False
 
         def is_function_taking_shortcut(expression: Expression) -> bool:
-            functions_taking_shortcuts = {"count", "string_agg"}
+            functions_taking_shortcuts = {"count", "string_agg", "coalesce"}
 
             if isinstance(expression, ExpressionWithArgs):
                 operation = expression.operation

--- a/misc/python/materialize/output_consistency/input_data/operations/date_time_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/date_time_operations_provider.py
@@ -141,7 +141,7 @@ DATE_TIME_OPERATION_TYPES.append(
 DATE_TIME_OPERATION_TYPES.append(
     DbFunction(
         "timezone",
-        [TIME_ZONE_PARAM, DateTimeOperationParam()],
+        [TIME_ZONE_PARAM, DateTimeOperationParam(support_time=False)],
         DateTimeReturnTypeSpec(TIMESTAMPTZ_TYPE_IDENTIFIER),
     )
 )

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -250,6 +250,9 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         if " out of range" in pg_error_msg:
             return YesIgnore("#22265")
 
+        if "value overflows numeric format" in pg_error_msg:
+            return YesIgnore("#21994")
+
         if _error_message_is_about_zero_or_value_ranges(pg_error_msg):
             return YesIgnore("Caused by a different precision")
 
@@ -301,13 +304,13 @@ class PgPostExecutionInconsistencyIgnoreFilter(
             or 'inf" real out of range' in mz_error_msg
             or 'inf" double precision out of range' in mz_error_msg
         ):
-            return YesIgnore("#21994: overflow in mz")
+            return YesIgnore("#21994: overflow")
 
         if (
             "value out of range: underflow" in mz_error_msg
             or '"-inf" real out of range' in mz_error_msg
         ):
-            return YesIgnore("#21995: underflow in mz")
+            return YesIgnore("#21995: underflow")
 
         if (
             "precision for type timestamp or timestamptz must be between 0 and 6"

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -333,6 +333,9 @@ class PgPostExecutionInconsistencyIgnoreFilter(
         if "unit 'invalid_value_123' not recognized" in mz_error_msg:
             return YesIgnore("#22957")
 
+        if "invalid time zone" in mz_error_msg:
+            return YesIgnore("#22984")
+
         if _error_message_is_about_zero_or_value_ranges(mz_error_msg):
             return YesIgnore("Caused by a different precision")
 

--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -117,6 +117,9 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("inconsistent ordering, not an error")
 
+        if db_function.function_name_in_lower_case == "timezone":
+            return YesIgnore("#21999: timezone")
+
         if db_function.function_name_in_lower_case == "date_trunc":
             precision = expression.args[0]
             if isinstance(precision, EnumConstant) and precision.value == "second":


### PR DESCRIPTION
**Commits:**
7de7748d42 postgres consistency: add ignore for different error handling with invalid time zone
7ed71c4d82 postgres consistency: add ignore for pg overflow error where mz produces Infinity
24f015d9f6 output consistency: add ignore for 'coalesce' evaluation order
8fb518f770 Revert "output consistency: remove ignore on timezone function after issue has been resolved (#22946)"
a93e879c4f output consistency: disable timezone function with time type
