### PR TITLE
mzcompose: Make output buildkite-compatible

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -261,7 +261,7 @@ class Composition:
         """
 
         if not self.silent:
-            print(f"$ docker compose {' '.join(args)}", file=sys.stderr)
+            print(f"--- docker compose {' '.join(args)}", file=sys.stderr)
 
         self.file.seek(0)
 

--- a/misc/python/materialize/ui.py
+++ b/misc/python/materialize/ui.py
@@ -58,7 +58,7 @@ def speaker(prefix: str) -> Callable[..., None]:
     return say
 
 
-header = speaker("==> ")
+header = speaker("--- ")
 say = speaker("")
 
 


### PR DESCRIPTION
Use '---' as section header so that the sections are properly collapsed in the Buildkite UI.

### Motivation

The Buildkite logs as presented in the UI were dominated by docker pulls and other cruft.

They now look more compact

https://buildkite.com/materialize/tests/builds/68025#018ba963-02a3-48fd-9f00-ecf8379cd897