### PR TITLE
balancerd: Add the mz-balancerd binary to .gitignore

### DIFF
--- a/misc/images/balancerd/.gitignore
+++ b/misc/images/balancerd/.gitignore
@@ -1,0 +1,1 @@
+/mz-balancerd


### PR DESCRIPTION
### Motivation

This needs the same treatment as the binaries in misc/images/materialize/*