### PR TITLE
coverage: Enable coverage for balancerd

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -44,7 +44,7 @@ if [ -n "${CI_COVERAGE_ENABLED:-}" ] && [ -z "${BUILDKITE_MZCOMPOSE_PLUGIN_SKIP_
         find . -name '*.profraw' -delete
 
         ARGS=()
-        for program in clusterd environmentd sqllogictest testdrive; do
+        for program in clusterd environmentd balancerd sqllogictest testdrive; do
             if [ -f coverage/"$program" ]; then
                 export_cov coverage/"$program"
                 ARGS+=("-a" coverage/"$BUILDKITE_JOB_ID"-"$program".lcov)
@@ -77,11 +77,13 @@ if find cores -name 'core.*' | grep -q .; then
     # Best effort attempt to fetch interesting executables to get backtrace of core files
     bin/ci-builder run stable cp /mnt/build/debug/clusterd cores/ || true
     bin/ci-builder run stable cp /mnt/build/debug/environmentd cores/ || true
+    bin/ci-builder run stable cp /mnt/build/debug/mz-balancerd cores/balancerd || true
     bin/ci-builder run stable cp /mnt/build/debug/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/sqllogictest cores/ || true
     run cp sqllogictest:/usr/local/bin/clusterd cores/ || true
     run cp materialized:/usr/local/bin/environmentd cores/ || true
     run cp materialized:/usr/local/bin/clusterd cores/ || true
+    run cp balancerd:/usr/local/bin/balancerd cores/ || true
     run cp testdrive:/usr/local/bin/testdrive cores/ || true
 fi
 


### PR DESCRIPTION
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
