### PR TITLE
storage: allow extra allocation when inlining Kafka connections

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -723,7 +723,7 @@ pub fn plan_create_source(
                 group_id_prefix,
                 environment_id: scx.catalog.config().environment_id.to_string(),
                 metadata_columns,
-                connection_options: Some(connection_options),
+                connection_options,
             };
 
             let connection = GenericSourceConnection::Kafka(connection);
@@ -2646,7 +2646,7 @@ fn kafka_sink_builder(
         key_desc_and_indices,
         value_desc,
         retention,
-        connection_options: Some(connection_options),
+        connection_options,
     }))
 }
 

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -437,7 +437,7 @@ pub struct KafkaSinkConnection<C: ConnectionAccess = InlinedConnection> {
     pub retention: KafkaSinkConnectionRetention,
     /// Additional options that need to be set on the connection whenever it's
     /// inlined.
-    pub connection_options: Option<BTreeMap<String, StringOrSecret>>,
+    pub connection_options: BTreeMap<String, StringOrSecret>,
 }
 
 impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnection, R>
@@ -461,7 +461,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnection, R>
         } = self;
 
         let mut connection = r.resolve_connection(connection).unwrap_kafka();
-        connection_options.map(|options| connection.options.extend(options));
+        connection.options.extend(connection_options);
 
         KafkaSinkConnection {
             connection_id,
@@ -476,7 +476,7 @@ impl<R: ConnectionResolver> IntoInlineConnection<KafkaSinkConnection, R>
             replication_factor,
             fuel,
             retention,
-            connection_options: None,
+            connection_options: BTreeMap::default(),
         }
     }
 }
@@ -496,10 +496,11 @@ impl RustType<ProtoKafkaSinkConnectionV2> for KafkaSinkConnection {
             replication_factor: self.replication_factor,
             fuel: u64::cast_from(self.fuel),
             retention: Some(self.retention.into_proto()),
-            connection_options: match &self.connection_options {
-                None => BTreeMap::default(),
-                Some(o) => o.iter().map(|(k, v)| (k.clone(), v.into_proto())).collect(),
-            },
+            connection_options: self
+                .connection_options
+                .iter()
+                .map(|(k, v)| (k.clone(), v.into_proto()))
+                .collect(),
         }
     }
 
@@ -529,19 +530,11 @@ impl RustType<ProtoKafkaSinkConnectionV2> for KafkaSinkConnection {
             retention: proto
                 .retention
                 .into_rust_if_some("ProtoKafkaSinkConnectionV2::retention")?,
-            connection_options: {
-                if proto.connection_options.is_empty() {
-                    None
-                } else {
-                    Some(
-                        proto
-                            .connection_options
-                            .into_iter()
-                            .map(|(k, v)| StringOrSecret::from_proto(v).map(|v| (k, v)))
-                            .collect::<Result<_, _>>()?,
-                    )
-                }
-            },
+            connection_options: proto
+                .connection_options
+                .into_iter()
+                .map(|(k, v)| StringOrSecret::from_proto(v).map(|v| (k, v)))
+                .collect::<Result<_, _>>()?,
         })
     }
 }


### PR DESCRIPTION
Tried to remove a useless allocation when inlining Kafka connections, but this introduces an ambiguity between Some w/ an empty set of values and None, which breaks our protobuf roundtrip unit tests.

The extra allocation is not so dire, so just re-adding it.

Fixes #22987

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
