### PR TITLE
feature-benchmark: Add HydrateIndex scenario

### DIFF
--- a/misc/python/materialize/feature_benchmark/scenario.py
+++ b/misc/python/materialize/feature_benchmark/scenario.py
@@ -17,7 +17,7 @@ BenchmarkingSequence = MeasurementSource | list[Action | MeasurementSource]
 
 class RootScenario:
     SCALE: float = 6
-    FIXED_SCALE: bool = False  # Will --scale=N have effect on the scenarioo
+    FIXED_SCALE: bool = False  # Will --scale=N have effect on the scenario
 
     def __init__(self, scale: float) -> None:
         self._name = self.__class__.__name__


### PR DESCRIPTION
The memory measurements in feature-benchmark seem to jump around a lot, @philip-stoev Do you have any idea if I'm doing something wrong here or is this how Mz is?
```
0    2181.053(memory)
1       4.104(wallclock)
1    3556.252(memory)
2       5.049(wallclock)
2    3514.290(memory)
3       4.481(wallclock)
3    3383.636(memory)
4       5.771(wallclock)
4    3098.488(memory)
5       4.525(wallclock)
5    3749.847(memory)
6       4.124(wallclock)
6    3508.568(memory)
7       4.549(wallclock)
7    3839.493(memory)
8       6.769(wallclock)
8    3153.801(memory)
9       5.234(wallclock)
9    3169.060(memory)
10       5.080(wallclock)
10    3453.255(memory)
11       5.609(wallclock)
11    3723.145(memory)
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
