### PR TITLE
[persist] Use key lower to block on fewer parts in consolidation

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -375,6 +375,9 @@ pub struct LeasedBatchPart<T> {
     pub(crate) leased_seqno: Option<SeqNo>,
     pub(crate) stats: Option<LazyPartStats>,
     pub(crate) filter_pushdown_audit: bool,
+    /// A lower bound on the key. If a tight lower bound is not available, the
+    /// empty vec (as the minimum vec) is a conservative choice.
+    pub(crate) key_lower: Vec<u8>,
 }
 
 impl<T> LeasedBatchPart<T>
@@ -403,6 +406,7 @@ where
             reader_id: self.reader_id.clone(),
             stats: self.stats.clone(),
             filter_pushdown_audit: self.filter_pushdown_audit,
+            key_lower: std::mem::take(&mut self.key_lower),
         };
         // If `x` has a lease, we've effectively transferred it to `r`.
         let _ = self.leased_seqno.take();
@@ -716,6 +720,7 @@ pub struct SerdeLeasedBatchPart {
     reader_id: LeasedReaderId,
     stats: Option<LazyPartStats>,
     filter_pushdown_audit: bool,
+    key_lower: Vec<u8>,
 }
 
 impl SerdeLeasedBatchPart {
@@ -751,6 +756,7 @@ impl<T: Timestamp + Codec64> LeasedBatchPart<T> {
             reader_id: x.reader_id,
             stats: x.stats,
             filter_pushdown_audit: x.filter_pushdown_audit,
+            key_lower: x.key_lower,
         }
     }
 }

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -23,7 +23,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::trace::Description;
 use futures_util::stream::FuturesUnordered;
-use futures_util::TryStreamExt;
+use futures_util::StreamExt;
 use mz_persist::location::Blob;
 use mz_persist_types::Codec64;
 use semver::Version;
@@ -67,6 +67,7 @@ pub(crate) enum FetchData<T> {
         shard_metrics: Arc<ShardMetrics>,
         part_key: PartialBatchKey,
         part_desc: Description<T>,
+        key_lower: Vec<u8>,
     },
     Leased {
         blob: Arc<dyn Blob + Send + Sync>,
@@ -92,6 +93,14 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
         mem::replace(self, FetchData::AlreadyFetched)
     }
 
+    fn key_lower(&self) -> &[u8] {
+        match self {
+            FetchData::Unleased { key_lower, .. } => key_lower.as_slice(),
+            FetchData::Leased { part, .. } => part.key_lower.as_slice(),
+            FetchData::AlreadyFetched => &[],
+        }
+    }
+
     async fn fetch(self) -> anyhow::Result<EncodedPart<T>> {
         match self {
             FetchData::Unleased {
@@ -102,6 +111,7 @@ impl<T: Codec64 + Timestamp + Lattice> FetchData<T> {
                 shard_metrics,
                 part_key,
                 part_desc,
+                ..
             } => {
                 fetch_batch_part(
                     &shard_id,
@@ -151,6 +161,7 @@ pub(crate) enum ConsolidationPart<T, D> {
     Prefetched {
         handle: JoinHandle<anyhow::Result<EncodedPart<T>>>,
         maybe_unconsolidated: bool,
+        key_lower: Vec<u8>,
     },
     Encoded {
         part: EncodedPart<T>,
@@ -183,6 +194,23 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidation
         let mut data: Vec<_> = data.into_iter().map(clone_tuple).collect();
         consolidate_updates(&mut data);
         Self::Sorted { data, index: 0 }
+    }
+
+    fn kvt_lower(&mut self) -> Option<(&[u8], &[u8], T)> {
+        match self {
+            ConsolidationPart::Queued { data } => Some((data.key_lower(), &[], T::minimum())),
+            ConsolidationPart::Prefetched { key_lower, .. } => {
+                Some((key_lower.as_slice(), &[], T::minimum()))
+            }
+            ConsolidationPart::Encoded { part, cursor } => {
+                let (k, v, t, _) = cursor.peek(part)?;
+                Some((k, v, t))
+            }
+            ConsolidationPart::Sorted { data, index } => {
+                let ((k, v), t, _) = data.get(*index)?;
+                Some((k.as_slice(), v.as_slice(), t.clone()))
+            }
+        }
     }
 
     /// This requires a mutable pointer because the cursor may need to scan ahead to find the next
@@ -276,6 +304,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         shard_metrics: Arc::clone(shard_metrics),
                         part_key: part.key.clone(),
                         part_desc: desc.clone(),
+                        key_lower: part.key_lower.clone(),
                     },
                 };
                 (c_part, part.encoded_size_bytes)
@@ -345,38 +374,58 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
         for run in &mut self.runs {
             let last_in_run = run.len() < 2;
             if let Some((part, _)) = run.front_mut() {
-                let part_iter = match part {
+                match part {
                     ConsolidationPart::Encoded { part, cursor } => {
-                        ConsolidationPartIter::encoded(part, cursor, &self.filter)
+                        iter.push(
+                            ConsolidationPartIter::encoded(part, cursor, &self.filter),
+                            last_in_run,
+                        );
                     }
                     ConsolidationPart::Sorted { data, index } => {
-                        ConsolidationPartIter::Sorted { data, index }
+                        iter.push(ConsolidationPartIter::Sorted { data, index }, last_in_run);
                     }
-                    ConsolidationPart::Queued { .. } | ConsolidationPart::Prefetched { .. } => {
-                        // Unreachable from the public API: we always join on the first part of every
-                        // run in `next`, so we should never encounter an unfetched part here.
-                        // TODO: when we have lower bounds on keys in the stats, we could insert a
-                        // placeholder here instead.
-                        panic!("trying to create an interator from an unfetched part!")
+                    other @ ConsolidationPart::Queued { .. }
+                    | other @ ConsolidationPart::Prefetched { .. } => {
+                        // We don't want the iterator to return anything at or above this bound,
+                        // since it might require data that we haven't fetched yet.
+                        if let Some(bound) = other.kvt_lower() {
+                            iter.push_upper(bound);
+                        }
                     }
                 };
-                iter.push(part_iter, last_in_run);
             }
         }
 
         Some(iter)
     }
 
-    /// Wait until the next part in every run is available, then return an iterator over the next
-    /// consolidated chunk of output. If this method returns `None`, that all the data has been
-    /// exhausted and the full consolidated dataset has been returned.
-    pub(crate) async fn next(&mut self) -> anyhow::Result<Option<ConsolidatingIter<T, D>>> {
-        self.trim();
-        let futures: FuturesUnordered<_> = self
+    /// We don't need to have fetched every part to make progress, but we do at least need
+    /// to have fetched _some_ parts: in particular, parts at the beginning of their runs
+    /// which may include the smallest remaining KVT.
+    ///
+    /// Returns success when we've successfully fetched enough parts to be able to make progress.
+    async fn unblock_progress(&mut self) -> anyhow::Result<()> {
+        let global_lower = self
+            .runs
+            .iter_mut()
+            .filter_map(|run| run.front_mut().and_then(|(part, _)| part.kvt_lower()))
+            .min();
+
+        let Some((k, v, t)) = global_lower else {
+            return Ok(());
+        };
+        let (k, v) = (k.to_vec(), v.to_vec());
+        let global_lower = (k.as_slice(), v.as_slice(), t);
+
+        let mut ready_futures: FuturesUnordered<_> = self
             .runs
             .iter_mut()
             .map(|run| async {
                 let part = &mut run.front_mut().expect("trimmed run should be nonempty").0;
+                match part.kvt_lower() {
+                    Some(lower) if lower > global_lower => return Ok(false),
+                    _ => {}
+                }
                 match part {
                     ConsolidationPart::Queued { data } => {
                         self.metrics.compaction.parts_waited.inc();
@@ -391,6 +440,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                     ConsolidationPart::Prefetched {
                         handle,
                         maybe_unconsolidated,
+                        ..
                     } => {
                         if handle.is_finished() {
                             self.metrics.compaction.parts_prefetched.inc();
@@ -406,10 +456,31 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                     }
                     ConsolidationPart::Encoded { .. } | ConsolidationPart::Sorted { .. } => {}
                 }
-                Ok::<(), anyhow::Error>(())
+                Ok::<_, anyhow::Error>(true)
             })
             .collect();
-        let () = futures.try_collect().await?;
+
+        // Wait for all the needed parts to be fetched, and assert that there's at least one.
+        let mut total_ready = 0;
+        while let Some(awaited) = ready_futures.next().await {
+            if awaited? {
+                total_ready += 1;
+            }
+        }
+        assert!(
+            total_ready > 0,
+            "at least one part should be fetched and ready to go"
+        );
+
+        Ok(())
+    }
+
+    /// Wait until data is available, then return an iterator over the next
+    /// consolidated chunk of output. If this method returns `None`, that all the data has been
+    /// exhausted and the full consolidated dataset has been returned.
+    pub(crate) async fn next(&mut self) -> anyhow::Result<Option<ConsolidatingIter<T, D>>> {
+        self.trim();
+        self.unblock_progress().await?;
         Ok(self.iter())
     }
 
@@ -466,7 +537,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         }
                         _ => continue,
                     };
-
+                    let key_lower = data.key_lower().to_vec();
                     let maybe_unconsolidated = data.maybe_unconsolidated();
                     let span = debug_span!("compaction::prefetch");
                     let handle = mz_ore::task::spawn(
@@ -476,6 +547,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                     *c_part = ConsolidationPart::Prefetched {
                         handle,
                         maybe_unconsolidated,
+                        key_lower,
                     };
                 }
             }
@@ -642,6 +714,7 @@ impl<'a, T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> PartRef<'a, T
 pub(crate) struct ConsolidatingIter<'a, T: Timestamp, D> {
     parts: Vec<ConsolidationPartIter<'a, T, D>>,
     heap: BinaryHeap<PartRef<'a, T, D>>,
+    upper_bound: Option<(&'a [u8], &'a [u8], T)>,
     state: Option<TupleRef<'a, T, D>>,
     drop_stash: &'a mut Option<Tuple<T, D>>,
 }
@@ -658,6 +731,7 @@ where
         Self {
             parts: vec![],
             heap: BinaryHeap::new(),
+            upper_bound: None,
             state: init_state,
             drop_stash,
         }
@@ -673,6 +747,18 @@ where
         part_ref.update_peek(&iter);
         self.parts.push(iter);
         self.heap.push(part_ref);
+    }
+
+    /// Set an upper bound based on the stats from an unfetched part. If there's already
+    /// an upper bound set, keep the most conservative / smallest one.
+    fn push_upper(&mut self, upper: (&'a [u8], &'a [u8], T)) {
+        let update_bound = self
+            .upper_bound
+            .as_ref()
+            .map_or(true, |existing| *existing > upper);
+        if update_bound {
+            self.upper_bound = Some(upper);
+        }
     }
 
     /// Attempt to consolidate as much into the current state as possible.
@@ -704,18 +790,27 @@ where
                         break;
                     }
                 } else {
+                    // Don't start consolidating a new KVT that's past our provided upper bound,
+                    // since that data may also live in some unfetched part.
+                    if let Some((k0, v0, t0)) = &self.upper_bound {
+                        if (k0, v0, t0) <= (k1, v1, t1) {
+                            return None;
+                        }
+                    }
+
                     self.state = part.pop(&mut self.parts);
                 }
             } else {
                 if part.last_in_run {
                     PeekMut::pop(part);
                 } else {
-                    // NB: this is the only case this method exits without returning the current state:
-                    // there may be more instances of the KVT in a later part of the same run.
+                    // There may be more instances of the KVT in a later part of the same run;
+                    // exit without returning the current state.
                     return None;
                 }
             }
         }
+
         self.state.take()
     }
 }

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -768,6 +768,7 @@ where
             encoded_size_bytes: part.encoded_size_bytes,
             leased_seqno: Some(self.lease_seqno()),
             filter_pushdown_audit: false,
+            key_lower: part.key_lower,
         }
     }
 

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -271,6 +271,7 @@ parts=1 len=4
 fetch-batch input=b0 stats=lower
 ----
 <part 0>
+<key lower=a>
 d 0 1
 a 0 1
 b 0 1
@@ -294,15 +295,19 @@ parts=4 len=8
 fetch-batch input=b0 stats=lower
 ----
 <part 0>
+<key lower=y>
 y 0 1
 z 0 1
 <part 1>
+<key lower=m>
 n 0 1
 m 0 1
 <part 2>
+<key lower=a>
 a 0 1
 a 0 1
 <part 3>
+<key lower=a>
 a 0 1
 a 0 1
 <run 0>


### PR DESCRIPTION
This:
- collects lower-bound stats on keys for even non-consolidated shards;
- uses the lower-bound stats to make consolidation block less: we now block on just the minimum number of parts we need to make progress.

### Motivation

Epic: #21265.

### Tips for reviewer

I've kicked off a nightly run, mostly to check for any performance regressions.

Otherwise: the consolidating iter is well-covered by existing tests and this should only affect performance, so I feel good about the overall test converage.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
