### PR TITLE
dbt-materialize: Migrate `date_spine` Tests

### DIFF
--- a/misc/dbt-materialize/tests/adapter/test_utils.py
+++ b/misc/dbt-materialize/tests/adapter/test_utils.py
@@ -17,8 +17,18 @@ import pytest
 from dbt.tests.adapter.utils.fixture_cast_bool_to_text import (
     models__test_cast_bool_to_text_yml,
 )
+from dbt.tests.adapter.utils.fixture_date_spine import (
+    models__test_date_spine_yml,
+)
+from dbt.tests.adapter.utils.fixture_get_intervals_between import (
+    models__test_get_intervals_between_yml,
+)
 from dbt.tests.adapter.utils.test_cast_bool_to_text import BaseCastBoolToText
 from dbt.tests.adapter.utils.test_current_timestamp import BaseCurrentTimestampAware
+from dbt.tests.adapter.utils.test_date_spine import BaseDateSpine
+from dbt.tests.adapter.utils.test_generate_series import BaseGenerateSeries
+from dbt.tests.adapter.utils.test_get_intervals_between import BaseGetIntervalsBetween
+from dbt.tests.adapter.utils.test_get_powers_of_two import BaseGetPowersOfTwo
 from dbt.tests.adapter.utils.test_listagg import BaseListagg
 from dbt.tests.adapter.utils.test_timestamps import BaseCurrentTimestamps
 
@@ -42,6 +52,49 @@ select
 from data_null
 """
 
+# The upstream test_date_spine has PostgreSQL-specific logic that doesn't
+# get picked up because it conditions on `target == "postgres"`. So we just
+# hardcode that PostgreSQL-specific logic here.
+models__test_date_spine_sql = """
+with generated_dates as (
+    {{ date_spine("day", "'2023-09-01'::date", "'2023-09-10'::date") }}
+), expected_dates as (
+    select '2023-09-01'::date as expected
+    union all
+    select '2023-09-02'::date as expected
+    union all
+    select '2023-09-03'::date as expected
+    union all
+    select '2023-09-04'::date as expected
+    union all
+    select '2023-09-05'::date as expected
+    union all
+    select '2023-09-06'::date as expected
+    union all
+    select '2023-09-07'::date as expected
+    union all
+    select '2023-09-08'::date as expected
+    union all
+    select '2023-09-09'::date as expected
+), joined as (
+    select
+        generated_dates.date_day,
+        expected_dates.expected
+    from generated_dates
+    left join expected_dates on generated_dates.date_day = expected_dates.expected
+)
+
+SELECT * from joined
+"""
+
+# The upstream get_intervals_between has PostgreSQL-specific logic that doesn't
+# get picked up because it conditions on `target == "postgres"`. So we just
+# hardcode that PostgreSQL-specific logic here.
+models__test_get_intervals_between_sql = """
+SELECT
+    {{ get_intervals_between("'2023-09-01'::date", "'2023-09-12'::date", "day") }} as intervals,
+  11 as expected
+"""
 
 # The `cast_bool_to_text` macro works as expected, but we must alter the test case
 # because set operation type conversions do not work properly.
@@ -80,4 +133,34 @@ class TestCurrentTimestamps(BaseCurrentTimestamps):
 
 
 class TestCurrentTimestamp(BaseCurrentTimestampAware):
+    pass
+
+
+class TestDateSpine(BaseDateSpine):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_date_spine.yml": models__test_date_spine_yml,
+            "test_date_spine.sql": self.interpolate_macro_namespace(
+                models__test_date_spine_sql, "date_spine"
+            ),
+        }
+
+
+class TestGenerateSeries(BaseGenerateSeries):
+    pass
+
+
+class TestGetIntervalsBeteween(BaseGetIntervalsBetween):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "test_get_intervals_between.yml": models__test_get_intervals_between_yml,
+            "test_get_intervals_between.sql": self.interpolate_macro_namespace(
+                models__test_get_intervals_between_sql, "get_intervals_between"
+            ),
+        }
+
+
+class TestGetPowersOfTwo(BaseGetPowersOfTwo):
     pass


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As part of the dbt v1.7.0 upgrade. Moving the tests for `date_spine` (and related functions) into the adapter.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
