### PR TITLE
[persist] Consolidate everything except compaction output

### DIFF
--- a/src/persist-client/src/internal/machine.rs
+++ b/src/persist-client/src/internal/machine.rs
@@ -1474,7 +1474,7 @@ pub mod datadriven {
             .unwrap_or_else(|| Antichain::from_elem(0));
         let target_size = args.optional("target_size");
         let parts_size_override = args.optional("parts_size_override");
-        let consolidate = args.optional("consolidate").unwrap_or(true);
+        let preconsolidated = args.optional("preconsolidated").unwrap_or(false);
         let updates = args.input.split('\n').flat_map(DirectiveArgs::parse_update);
 
         let mut cfg = BatchBuilderConfig::new(&datadriven.client.cfg, &WriterId::new());
@@ -1498,7 +1498,7 @@ pub mod datadriven {
             datadriven.client.cfg.build_version.clone(),
             since,
             Some(upper.clone()),
-            consolidate,
+            preconsolidated,
         );
         let mut builder = BatchBuilder {
             builder,

--- a/src/persist-client/tests/machine/batch
+++ b/src/persist-client/tests/machine/batch
@@ -260,7 +260,7 @@ a 10 1
 parts=1 len=1
 
 # batches can be written unsorted
-write-batch output=b0 lower=0 upper=2 consolidate=false
+write-batch output=b0 lower=0 upper=2
 d 0 1
 a 0 1
 b 0 1
@@ -268,18 +268,20 @@ c 0 1
 ----
 parts=1 len=4
 
+# all parts will be consolidated before being persisted
 fetch-batch input=b0 stats=lower
 ----
 <part 0>
-d 0 1
+<key lower=a>
 a 0 1
 b 0 1
 c 0 1
+d 0 1
 <run 0>
 part 0
 
-# unsorted batches record each part in their own run
-write-batch output=b0 lower=0 upper=2 consolidate=false target_size=50
+# if input arrives in unsorted order we may generate multiple runs
+write-batch output=b0 lower=0 upper=2 target_size=50
 y 0 1
 z 0 1
 n 0 1
@@ -289,29 +291,30 @@ a 0 1
 a 0 1
 a 0 1
 ----
-parts=4 len=8
+parts=4 len=6
 
 fetch-batch input=b0 stats=lower
 ----
 <part 0>
+<key lower=y>
 y 0 1
 z 0 1
 <part 1>
-n 0 1
+<key lower=m>
 m 0 1
+n 0 1
 <part 2>
-a 0 1
-a 0 1
+<key lower=a>
+a 0 2
 <part 3>
-a 0 1
-a 0 1
+<key lower=a>
+a 0 2
 <run 0>
 part 0
 <run 1>
 part 1
 <run 2>
 part 2
-<run 3>
 part 3
 
 # raw key stats are bounded size
@@ -335,7 +338,7 @@ b 0 1
 ----
 parts=2 len=2
 
-write-batch output=b1 lower=0 upper=2 target_size=10 consolidate=false
+write-batch output=b1 lower=0 upper=2 target_size=10 preconsolidated=true
 c 0 1
 d 0 1
 ----
@@ -361,9 +364,8 @@ b 1 1
 <run 1>
 <part 0>
 c 1 1
-<run 2>
-<part 0>
+<part 1>
 d 1 1
-<run 3>
+<run 2>
 <part 0>
 e 1 1


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
