### PR TITLE
stash: Remove storage proto objects from stash

### DIFF
--- a/src/buf.yaml
+++ b/src/buf.yaml
@@ -40,6 +40,8 @@ breaking:
     # reason: does currently not require backward-compatibility
     - stash-types/protos/objects_v42.proto
     # reason: does currently not require backward-compatibility
+    - stash-types/protos/objects_v43.proto
+    # reason: does currently not require backward-compatibility
     - storage-client/src/client.proto
     # reason: Ignored until #21887 is reverted
     - storage-types/src/errors.proto

--- a/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__persist_opened_trace.snap
@@ -624,7 +624,7 @@ Trace {
                         key: "user_version",
                     },
                     ConfigValue {
-                        value: 42,
+                        value: 43,
                     },
                 ),
                 "0",

--- a/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
+++ b/src/catalog/tests/snapshots/debug__stash_opened_trace.snap
@@ -612,7 +612,7 @@ Trace {
                         key: "user_version",
                     },
                     ConfigValue {
-                        value: 42,
+                        value: 43,
                     },
                 ),
                 "-9223372036854775808",

--- a/src/catalog/tests/snapshots/open__initial_snapshot.snap
+++ b/src/catalog/tests/snapshots/open__initial_snapshot.snap
@@ -957,7 +957,7 @@ Snapshot {
         ConfigKey {
             key: "user_version",
         }: ConfigValue {
-            value: 42,
+            value: 43,
         },
     },
     settings: {},

--- a/src/stash-types/protos/hashes.json
+++ b/src/stash-types/protos/hashes.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "objects.proto",
-    "md5": "ce61d36b3a277dd3647425ef27c6392d"
+    "md5": "d063e7ce50fca717c26b78b636c26b23"
   },
   {
     "name": "objects_v35.proto",
@@ -34,5 +34,9 @@
   {
     "name": "objects_v42.proto",
     "md5": "78ab44ed4cf6d27f9e4cd6b2a904dfd5"
+  },
+  {
+    "name": "objects_v43.proto",
+    "md5": "ce66c8524532beec9b4212a30dbc4c8f"
   }
 ]

--- a/src/stash-types/protos/objects_v43.proto
+++ b/src/stash-types/protos/objects_v43.proto
@@ -19,7 +19,7 @@
 
 syntax = "proto3";
 
-package objects;
+package objects_v43;
 
 message ConfigKey {
     string key = 1;

--- a/src/stash-types/src/lib.rs
+++ b/src/stash-types/src/lib.rs
@@ -101,7 +101,7 @@ pub mod upgrade {
         }
     }
 
-    objects!(v35, v36, v37, v38, v39, v40, v41, v42);
+    objects!(v35, v36, v37, v38, v39, v40, v41, v42, v43);
 }
 
 /// The current version of the `Stash`.
@@ -109,7 +109,7 @@ pub mod upgrade {
 /// We will initialize new `Stash`es with this version, and migrate existing `Stash`es to this
 /// version. Whenever the `Stash` changes, e.g. the protobufs we serialize in the `Stash`
 /// change, we need to bump this version.
-pub const STASH_VERSION: u64 = 42;
+pub const STASH_VERSION: u64 = 43;
 
 /// The minimum `Stash` version number that we support migrating from.
 ///

--- a/src/stash-types/src/objects.rs
+++ b/src/stash-types/src/objects.rs
@@ -12,7 +12,6 @@
 use std::time::Duration;
 
 use mz_proto::IntoRustIfSome;
-use timely::progress::Antichain;
 
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
@@ -77,32 +76,6 @@ impl RustType<proto::MzAclItem> for MzAclItem {
             grantor: proto.grantor.into_rust_if_some("MzAclItem::grantor")?,
             acl_mode: proto.acl_mode.into_rust_if_some("MzAclItem::acl_mode")?,
         })
-    }
-}
-
-impl<T> RustType<proto::TimestampAntichain> for Antichain<T>
-where
-    T: RustType<proto::Timestamp> + Clone + timely::PartialOrder,
-{
-    fn into_proto(&self) -> proto::TimestampAntichain {
-        proto::TimestampAntichain {
-            elements: self
-                .elements()
-                .into_iter()
-                .cloned()
-                .map(|e| e.into_proto())
-                .collect(),
-        }
-    }
-
-    fn from_proto(proto: proto::TimestampAntichain) -> Result<Self, TryFromProtoError> {
-        let elements: Vec<_> = proto
-            .elements
-            .into_iter()
-            .map(|e| T::from_proto(e))
-            .collect::<Result<_, _>>()?;
-
-        Ok(Antichain::from_iter(elements))
     }
 }
 

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -941,6 +941,7 @@ impl Stash {
                             39 => upgrade::v39_to_v40::upgrade(&tx).await?,
                             40 => upgrade::v40_to_v41::upgrade(),
                             41 => upgrade::v41_to_v42::upgrade(),
+                            42 => upgrade::v42_to_v43::upgrade(),
 
                             // Up-to-date, no migration needed!
                             STASH_VERSION => return Ok(STASH_VERSION),

--- a/src/stash/src/upgrade.rs
+++ b/src/stash/src/upgrade.rs
@@ -52,6 +52,7 @@ pub(crate) mod v38_to_v39;
 pub(crate) mod v39_to_v40;
 pub(crate) mod v40_to_v41;
 pub(crate) mod v41_to_v42;
+pub(crate) mod v42_to_v43;
 
 pub(crate) enum MigrationAction<K1, K2, V2> {
     /// Deletes the provided key.

--- a/src/stash/src/upgrade/v42_to_v43.rs
+++ b/src/stash/src/upgrade/v42_to_v43.rs
@@ -1,0 +1,11 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// No-op migration for removing storage objects.
+pub fn upgrade() {}

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -112,7 +112,6 @@ use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{ColumnName, Datum, Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
 use mz_stash::{self, AppendBatch, StashFactory, TypedCollection};
 use mz_stash_types::metrics::Metrics as StashMetrics;
-use mz_stash_types::objects::proto;
 use mz_storage_client::client::{
     CreateSinkCommand, ProtoStorageCommand, ProtoStorageResponse, RunIngestionCommand,
     SinkStatisticsUpdate, SourceStatisticsUpdate, StorageCommand, StorageResponse,
@@ -128,6 +127,7 @@ use mz_storage_client::healthcheck::{
     MZ_STATEMENT_EXECUTION_HISTORY_DESC,
 };
 use mz_storage_client::metrics::StorageControllerMetrics;
+use mz_storage_types::collections as proto;
 use mz_storage_types::controller::{
     CollectionMetadata, DurableCollectionMetadata, StorageError, TxnsCodecRow,
 };
@@ -223,17 +223,17 @@ impl RustType<ProtoDurableExportMetadata> for DurableExportMetadata<mz_repr::Tim
     }
 }
 
-impl RustType<mz_stash_types::objects::proto::DurableExportMetadata>
+impl RustType<mz_storage_types::collections::DurableExportMetadata>
     for DurableExportMetadata<mz_repr::Timestamp>
 {
-    fn into_proto(&self) -> mz_stash_types::objects::proto::DurableExportMetadata {
-        mz_stash_types::objects::proto::DurableExportMetadata {
+    fn into_proto(&self) -> mz_storage_types::collections::DurableExportMetadata {
+        mz_storage_types::collections::DurableExportMetadata {
             initial_as_of: Some(self.initial_as_of.into_proto()),
         }
     }
 
     fn from_proto(
-        proto: mz_stash_types::objects::proto::DurableExportMetadata,
+        proto: mz_storage_types::collections::DurableExportMetadata,
     ) -> Result<Self, TryFromProtoError> {
         Ok(DurableExportMetadata {
             initial_as_of: proto

--- a/src/storage-types/build.rs
+++ b/src/storage-types/build.rs
@@ -80,6 +80,8 @@ use std::env;
 fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
+    const ATTR: &str = "#[derive(Eq, PartialOrd, Ord, ::serde::Serialize, ::serde::Deserialize)]";
+
     let mut config = prost_build::Config::new();
     config.btree_map(["."]);
 
@@ -90,6 +92,8 @@ fn main() {
         // is to re-run if any file in the crate changes; that's still a bit too
         // broad, but it's better.
         .emit_rerun_if_changed(false)
+        .message_attribute(".mz_storage_types.collections", ATTR)
+        .enum_attribute("GlobalId.value", ATTR)
         .extern_path(".mz_ccsr.config", "::mz_ccsr")
         .extern_path(".mz_expr.id", "::mz_expr")
         .extern_path(".mz_expr.linear", "::mz_expr")
@@ -115,6 +119,7 @@ fn main() {
             config,
             &[
                 "storage-types/src/controller.proto",
+                "storage-types/src/collections.proto",
                 "storage-types/src/shim.proto",
                 "storage-types/src/errors.proto",
                 "storage-types/src/connections/aws.proto",

--- a/src/storage-types/build.rs
+++ b/src/storage-types/build.rs
@@ -80,7 +80,7 @@ use std::env;
 fn main() {
     env::set_var("PROTOC", protobuf_src::protoc());
 
-    const ATTR: &str = "#[derive(Eq, PartialOrd, Ord, ::serde::Serialize, ::serde::Deserialize)]";
+    const ATTR: &str = "#[derive(Eq, PartialOrd, Ord, ::serde::Serialize, ::serde::Deserialize, ::proptest_derive::Arbitrary)]";
 
     let mut config = prost_build::Config::new();
     config.btree_map(["."]);

--- a/src/storage-types/src/collections.proto
+++ b/src/storage-types/src/collections.proto
@@ -1,0 +1,49 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+syntax = "proto3";
+
+import "google/protobuf/empty.proto";
+
+package mz_storage_types.collections;
+
+message GlobalId {
+    oneof value {
+        uint64 system = 1;
+        uint64 user = 2;
+        uint64 transient = 3;
+        google.protobuf.Empty explain = 4;
+    }
+}
+
+// Opaque timestamp type that is specific to Materialize.
+message Timestamp {
+    uint64 internal = 1;
+}
+
+message TimestampAntichain {
+    repeated Timestamp elements = 1;
+}
+
+message SinkAsOf {
+    TimestampAntichain frontier = 1;
+    bool strict = 2;
+}
+
+message DurableExportMetadata {
+    SinkAsOf initial_as_of = 1;
+}
+
+message DurableCollectionMetadata {
+    reserved 1;
+    reserved "remap_shard";
+
+    // StringWrapper remap_shard = 1;
+    string data_shard = 2;
+}

--- a/src/storage-types/src/collections.rs
+++ b/src/storage-types/src/collections.rs
@@ -1,0 +1,111 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Types stored in the storage stash collections.
+
+include!(concat!(env!("OUT_DIR"), "/mz_storage_types.collections.rs"));
+
+use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_repr::{GlobalId as RustGlobalId, Timestamp as RustTimestamp};
+use timely::progress::Antichain;
+
+use crate::controller::DurableCollectionMetadata as RustDurableCollectionMetadata;
+use crate::sinks::SinkAsOf as RustSinkAsOf;
+
+impl RustType<GlobalId> for RustGlobalId {
+    fn into_proto(&self) -> GlobalId {
+        GlobalId {
+            value: Some(match self {
+                RustGlobalId::System(x) => global_id::Value::System(*x),
+                RustGlobalId::User(x) => global_id::Value::User(*x),
+                RustGlobalId::Transient(x) => global_id::Value::Transient(*x),
+                RustGlobalId::Explain => global_id::Value::Explain(Default::default()),
+            }),
+        }
+    }
+
+    fn from_proto(proto: GlobalId) -> Result<Self, TryFromProtoError> {
+        match proto.value {
+            Some(global_id::Value::System(x)) => Ok(RustGlobalId::System(x)),
+            Some(global_id::Value::User(x)) => Ok(RustGlobalId::User(x)),
+            Some(global_id::Value::Transient(x)) => Ok(RustGlobalId::Transient(x)),
+            Some(global_id::Value::Explain(_)) => Ok(RustGlobalId::Explain),
+            None => Err(TryFromProtoError::missing_field("GlobalId::kind")),
+        }
+    }
+}
+
+impl RustType<Timestamp> for RustTimestamp {
+    fn into_proto(&self) -> Timestamp {
+        Timestamp {
+            internal: self.into(),
+        }
+    }
+
+    fn from_proto(proto: Timestamp) -> Result<Self, TryFromProtoError> {
+        Ok(RustTimestamp::new(proto.internal))
+    }
+}
+
+impl<T> RustType<TimestampAntichain> for Antichain<T>
+where
+    T: RustType<Timestamp> + Clone + timely::PartialOrder,
+{
+    fn into_proto(&self) -> TimestampAntichain {
+        TimestampAntichain {
+            elements: self
+                .elements()
+                .into_iter()
+                .cloned()
+                .map(|e| e.into_proto())
+                .collect(),
+        }
+    }
+
+    fn from_proto(proto: TimestampAntichain) -> Result<Self, TryFromProtoError> {
+        let elements: Vec<_> = proto
+            .elements
+            .into_iter()
+            .map(|e| T::from_proto(e))
+            .collect::<Result<_, _>>()?;
+
+        Ok(Antichain::from_iter(elements))
+    }
+}
+
+impl RustType<SinkAsOf> for RustSinkAsOf<mz_repr::Timestamp> {
+    fn into_proto(&self) -> SinkAsOf {
+        SinkAsOf {
+            frontier: Some(self.frontier.into_proto()),
+            strict: self.strict,
+        }
+    }
+
+    fn from_proto(proto: SinkAsOf) -> Result<Self, TryFromProtoError> {
+        let frontier = proto.frontier.into_rust_if_some("SinkAsOf::frontier")?;
+        Ok(RustSinkAsOf {
+            frontier,
+            strict: proto.strict,
+        })
+    }
+}
+
+impl RustType<DurableCollectionMetadata> for RustDurableCollectionMetadata {
+    fn into_proto(&self) -> DurableCollectionMetadata {
+        DurableCollectionMetadata {
+            data_shard: self.data_shard.into_proto(),
+        }
+    }
+
+    fn from_proto(proto: DurableCollectionMetadata) -> Result<Self, TryFromProtoError> {
+        Ok(RustDurableCollectionMetadata {
+            data_shard: proto.data_shard.into_rust()?,
+        })
+    }
+}

--- a/src/storage-types/src/controller.rs
+++ b/src/storage-types/src/controller.rs
@@ -18,7 +18,7 @@ use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::columnar::Data;
 use mz_persist_types::dyn_struct::DynStruct;
 use mz_persist_types::stats::StructStats;
-use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
+use mz_proto::{IntoRustIfSome, RustType, TryFromProtoError};
 use mz_repr::{Datum, GlobalId, RelationDesc, Row, ScalarType};
 use mz_stash_types::StashError;
 use proptest_derive::Arbitrary;
@@ -110,24 +110,6 @@ impl RustType<ProtoDurableCollectionMetadata> for DurableCollectionMetadata {
                 .data_shard
                 .parse()
                 .map_err(TryFromProtoError::InvalidShardId)?,
-        })
-    }
-}
-
-impl RustType<mz_stash_types::objects::proto::DurableCollectionMetadata>
-    for DurableCollectionMetadata
-{
-    fn into_proto(&self) -> mz_stash_types::objects::proto::DurableCollectionMetadata {
-        mz_stash_types::objects::proto::DurableCollectionMetadata {
-            data_shard: self.data_shard.into_proto(),
-        }
-    }
-
-    fn from_proto(
-        proto: mz_stash_types::objects::proto::DurableCollectionMetadata,
-    ) -> Result<Self, TryFromProtoError> {
-        Ok(DurableCollectionMetadata {
-            data_shard: proto.data_shard.into_rust()?,
         })
     }
 }

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -77,6 +77,7 @@
 
 //! Shared types for the `mz-storage*` crates
 
+pub mod collections;
 pub mod connections;
 pub mod controller;
 pub mod errors;

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -16,7 +16,6 @@ use mz_ore::cast::CastFrom;
 use mz_persist_client::ShardId;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationDesc};
-use mz_stash_types::objects::proto;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -274,23 +273,6 @@ impl RustType<ProtoSinkAsOf> for SinkAsOf<mz_repr::Timestamp> {
             frontier: proto
                 .frontier
                 .into_rust_if_some("ProtoSinkAsOf::frontier")?,
-            strict: proto.strict,
-        })
-    }
-}
-
-impl RustType<proto::SinkAsOf> for SinkAsOf<mz_repr::Timestamp> {
-    fn into_proto(&self) -> proto::SinkAsOf {
-        proto::SinkAsOf {
-            frontier: Some(self.frontier.into_proto()),
-            strict: self.strict,
-        }
-    }
-
-    fn from_proto(proto: proto::SinkAsOf) -> Result<Self, TryFromProtoError> {
-        let frontier = proto.frontier.into_rust_if_some("SinkAsOf::frontier")?;
-        Ok(SinkAsOf {
-            frontier,
             strict: proto.strict,
         })
     }


### PR DESCRIPTION
The current users of the stash are the adapter for the catalog and the
storage-controller for metadata. All objects that users of the stash
store in the stash, are defined within the mz-stash-types crate. All
objects across both uses are stored in a file called objects.proto, and
a hash of objects.proto is compiled into the binary. If anyone changes
anything in objects.proto then Materialize fails to compile unless an
explicit migration is written for that object using the stash migration
framework.

However, if any object is an object that was used by the storage
controller is changed, then the data within the stash is never actually
migrated. Even if a migration is written, the storage data will not be
migrated. The reason is that the stash user needs to create a
collection named "config" and store a value with the key
"user_version", and then manually call the upgrade function in the
Stash.

This commit moves all the storage protobuf objects out of the
mz-stash-types crate and into the mz-storage-types crates. In addition
to avoiding issues around migrating storage objects, this is a step in
the direction of moving the migration responsibility from the stash to
the catalog.

Works towards resolving #22977

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
