### PR TITLE
expr: optimize `sum_numeric`

### DIFF
--- a/test/sqllogictest/aggregates.slt
+++ b/test/sqllogictest/aggregates.slt
@@ -129,6 +129,28 @@ SELECT 2 * a, sum(b) FROM t GROUP BY 1
 4  3
 6  1
 
+# Ensure that the sum of NULLs is NULL.
+
+query T
+SELECT sum(column1) FROM (VALUES (NULL::int2), (NULL))
+----
+NULL
+
+query T
+SELECT sum(column1) FROM (VALUES (NULL::int4), (NULL))
+----
+NULL
+
+query T
+SELECT sum(column1) FROM (VALUES (NULL::int8), (NULL))
+----
+NULL
+
+query T
+SELECT sum(column1) FROM (VALUES (NULL::numeric), (NULL))
+----
+NULL
+
 query TTT colnames
 SHOW COLUMNS FROM t
 ----


### PR DESCRIPTION
The `cx.sum` method's signature prevents it from being called with an iterator over owned `Decimal`s. That means that `sum_numeric` needs to first collect its iterator into a `Vec`, which uses memory proportional to the number of elements in the iterator.

Instead of using `cx.sum`, open code the sum, which has no such borrowing issues.

Fix #23006.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
