### PR TITLE
sql: Support `ALTER [ SWAP | RENAME ]` in Transactions

### DIFF
--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -184,8 +184,12 @@ impl CatalogState {
             .database_by_name
             .get(session.vars().database())
             .map(|id| id.clone());
+        let state = match session.transaction().catalog_state() {
+            Some(txn_catalog_state) => Cow::Borrowed(txn_catalog_state),
+            None => Cow::Borrowed(self),
+        };
         ConnCatalog {
-            state: Cow::Borrowed(self),
+            state,
             unresolvable_ids: BTreeSet::new(),
             conn_id: session.conn_id().clone(),
             cluster: session.vars().cluster().into(),

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -1005,7 +1005,7 @@ impl Coordinator {
 
     pub(super) async fn sequence_alter_cluster_rename(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         AlterClusterRenamePlan { id, name, to_name }: AlterClusterRenamePlan,
     ) -> Result<ExecuteResponse, AdapterError> {
         let op = Op::RenameCluster {
@@ -1014,7 +1014,10 @@ impl Coordinator {
             to_name,
             check_reserved_names: true,
         };
-        match self.catalog_transact(Some(session), vec![op]).await {
+        match self
+            .catalog_transact_with_ddl_transaction(session, vec![op])
+            .await
+        {
             Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::Cluster)),
             Err(err) => Err(err),
         }
@@ -1022,7 +1025,7 @@ impl Coordinator {
 
     pub(super) async fn sequence_alter_cluster_swap(
         &mut self,
-        session: &Session,
+        session: &mut Session,
         AlterClusterSwapPlan {
             id_a,
             id_b,
@@ -1051,7 +1054,7 @@ impl Coordinator {
         };
 
         match self
-            .catalog_transact(Some(session), vec![op_a, op_b, op_temp])
+            .catalog_transact_with_ddl_transaction(session, vec![op_a, op_b, op_temp])
             .await
         {
             Ok(()) => Ok(ExecuteResponse::AlteredObject(ObjectType::Cluster)),

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -1107,17 +1107,20 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
                     TransactionOps::DDL {
                         ops: og_ops,
                         revision: og_revision,
-                        state: _,
+                        state: og_state,
                     } => match add_ops {
                         TransactionOps::DDL {
                             ops: new_ops,
                             revision: new_revision,
-                            state: _,
+                            state: new_state,
                         } => {
                             if *og_revision != new_revision {
                                 return Err(AdapterError::DDLTransactionRace);
                             }
-                            og_ops.extend(new_ops);
+                            if !new_ops.is_empty() {
+                                *og_ops = new_ops;
+                                *og_state = new_state;
+                            }
                         }
                         _ => return Err(AdapterError::DDLOnlyTransaction),
                     },

--- a/src/adapter/src/session.rs
+++ b/src/adapter/src/session.rs
@@ -46,6 +46,7 @@ use tokio::sync::watch;
 use tokio::sync::OwnedMutexGuard;
 use uuid::Uuid;
 
+use crate::catalog::CatalogState;
 use crate::client::RecordFirstRowStream;
 use crate::coord::peek::PeekResponseUnary;
 use crate::coord::statement_logging::PreparedStatementLoggingInfo;
@@ -236,7 +237,8 @@ impl<T: TimestampManipulation> Session<T> {
                 }
                 TransactionOps::None
                 | TransactionOps::Writes(_)
-                | TransactionOps::SingleStatement { .. } => false,
+                | TransactionOps::SingleStatement { .. }
+                | TransactionOps::DDL { .. } => false,
             };
 
             if read_write_prohibited && access == Some(TransactionAccessMode::ReadWrite) {
@@ -993,6 +995,17 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
         }
     }
 
+    /// Snapshot of the catalog that reflects DDL operations run in this transaction.
+    pub fn catalog_state(&self) -> Option<&CatalogState> {
+        match self.inner() {
+            Some(Transaction {
+                ops: TransactionOps::DDL { state, .. },
+                ..
+            }) => Some(state),
+            _ => None,
+        }
+    }
+
     /// Reports whether any operations have been executed as part of this transaction
     pub fn contains_ops(&self) -> bool {
         match self.inner() {
@@ -1091,6 +1104,23 @@ impl<T: TimestampManipulation> TransactionStatus<T> {
                     TransactionOps::SingleStatement { .. } => {
                         return Err(AdapterError::SingleStatementTransaction)
                     }
+                    TransactionOps::DDL {
+                        ops: og_ops,
+                        revision: og_revision,
+                        state: _,
+                    } => match add_ops {
+                        TransactionOps::DDL {
+                            ops: new_ops,
+                            revision: new_revision,
+                            state: _,
+                        } => {
+                            if *og_revision != new_revision {
+                                return Err(AdapterError::DDLTransactionRace);
+                            }
+                            og_ops.extend(new_ops);
+                        }
+                        _ => return Err(AdapterError::DDLOnlyTransaction),
+                    },
                 }
             }
             TransactionStatus::Default | TransactionStatus::Failed(_) => {
@@ -1149,7 +1179,8 @@ impl<T> Transaction<T> {
             | TransactionOps::None
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_)
-            | TransactionOps::SingleStatement { .. } => None,
+            | TransactionOps::SingleStatement { .. }
+            | TransactionOps::DDL { .. } => None,
         }
     }
 
@@ -1160,7 +1191,8 @@ impl<T> Transaction<T> {
             TransactionOps::None
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_)
-            | TransactionOps::SingleStatement { .. } => None,
+            | TransactionOps::SingleStatement { .. }
+            | TransactionOps::DDL { .. } => None,
         }
     }
 
@@ -1242,6 +1274,15 @@ pub enum TransactionOps<T> {
         /// The statement params.
         params: mz_sql::plan::Params,
     },
+    /// This transaction has run some _simple_ DDL and must do nothing else.
+    DDL {
+        /// Catalog operations that have already run, and must run before each subsequent op.
+        ops: Vec<crate::catalog::Op>,
+        /// In-memory state that reflects the previously applied ops.
+        state: CatalogState,
+        /// Transient revision of the `Catalog` when this transaction started.
+        revision: u64,
+    },
 }
 
 impl<T> TransactionOps<T> {
@@ -1251,7 +1292,8 @@ impl<T> TransactionOps<T> {
             TransactionOps::None
             | TransactionOps::Subscribe
             | TransactionOps::Writes(_)
-            | TransactionOps::SingleStatement { .. } => None,
+            | TransactionOps::SingleStatement { .. }
+            | TransactionOps::DDL { .. } => None,
         }
     }
 }

--- a/test/sqllogictest/transactions.slt
+++ b/test/sqllogictest/transactions.slt
@@ -976,20 +976,254 @@ EOF
 statement ok
 COMMIT
 
-statement ok
-BEGIN
-
-statement error db error: ERROR: ALTER SCHEMA s SWAP WITH t cannot be run inside a transaction block
-ALTER SCHEMA s SWAP WITH t
-
-statement ok
-ROLLBACK
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_alter_swap = true;
+----
+COMPLETE 0
 
 statement ok
-BEGIN
-
-statement error db error: ERROR: ALTER CLUSTER s SWAP WITH t cannot be run inside a transaction block
-ALTER CLUSTER s SWAP WITH t
+CREATE SCHEMA blue;
 
 statement ok
-ROLLBACK
+CREATE SCHEMA green;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+blue  u6
+green  u7
+public  u3
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER SCHEMA blue SWAP WITH green;
+
+statement ok
+COMMIT;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+blue  u7
+green  u6
+public  u3
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER SCHEMA blue SWAP WITH green;
+
+statement ok
+ALTER SCHEMA green RENAME TO purple;
+
+statement ok
+ROLLBACK;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+blue  u7
+green  u6
+public  u3
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER SCHEMA green RENAME TO purple;
+
+# Modify the Catalog from a different session while a transaction is open.
+
+simple conn=mz_system,user=mz_system
+CREATE TABLE yellow_t1 (x int);
+----
+COMPLETE 0
+
+statement error db error: ERROR: object state changed while transaction was in progress
+ALTER SCHEMA blue RENAME to pink;
+
+statement ok
+ROLLBACK;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+blue  u7
+green  u6
+public  u3
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER SCHEMA blue RENAME TO pink;
+
+statement ok
+ALTER SCHEMA pink RENAME TO purple;
+
+statement ok
+ALTER SCHEMA purple RENAME TO orange;
+
+statement ok
+ALTER SCHEMA orange RENAME TO red;
+
+statement ok
+ALTER SCHEMA red RENAME TO orange;
+
+statement ok
+COMMIT;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+green  u6
+orange  u7
+public  u3
+
+statement ok
+BEGIN;
+
+statement error db error: ERROR: schema 'green' already exists
+ALTER SCHEMA orange RENAME TO green;
+
+statement ok
+COMMIT;
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+green  u6
+orange  u7
+public  u3
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER SCHEMA green RENAME TO red;
+
+statement error db error: ERROR: schema 'red' already exists
+ALTER SCHEMA orange RENAME TO red;
+
+statement ok
+COMMIT;
+
+# Transaction should be rolled back and nothing should change.
+
+query TT
+SELECT name, id FROM mz_schemas WHERE id LIKE 'u%';
+----
+green  u6
+orange  u7
+public  u3
+
+statement ok
+CREATE TABLE green_t1 (x int);
+
+statement ok
+CREATE VIEW green_v1 AS ( SELECT SUM(x) FROM green_t1 );
+
+statement ok
+CREATE CLUSTER green_compute SIZE '1';
+
+statement ok
+CREATE MATERIALIZED VIEW green_mv1 IN CLUSTER green_compute AS ( SELECT AVG(x) FROM green_t1 );
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE green_t1 RENAME TO blue_t1;
+
+statement ok
+ALTER VIEW green_v1 RENAME TO blue_v1;
+
+statement ok
+ALTER MATERIALIZED VIEW green_mv1 RENAME TO blue_mv1;
+
+statement ok
+ALTER CLUSTER green_compute RENAME TO blue_compute;
+
+statement ok
+COMMIT;
+
+statement ok
+INSERT INTO blue_t1 VALUES (10), (20), (30);
+
+query I
+SELECT * FROM blue_v1;
+----
+60
+
+query I
+SELECT * FROM blue_mv1;
+----
+20
+
+query TT
+SELECT name, id FROM mz_clusters WHERE id LIKE 'u%';
+----
+c u3
+default u1
+blue_compute u4
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO blue_t1 VALUES (40), (50), (60);
+
+statement error db error: ERROR: transaction in write-only mode
+ALTER TABLE blue_t1 RENAME TO red_t1;
+
+statement ok
+COMMIT;
+
+query I
+SELECT * FROM blue_t1 LIMIT 1;
+----
+10
+
+statement ok
+BEGIN;
+
+query I
+SELECT * FROM blue_v1;
+----
+60
+
+statement error db error: ERROR: transaction in read-only mode
+ALTER TABLE blue_t1 RENAME TO red_t1;
+
+statement ok
+COMMIT;
+
+query I
+SELECT * FROM blue_t1 LIMIT 1;
+----
+10
+
+statement ok
+BEGIN;
+
+statement ok
+ALTER TABLE blue_t1 RENAME TO purple_t1;
+
+statement error db error: ERROR: transactions which modify objects are restricted to just modifying objects
+SELECT * FROM blue_mv1;
+
+statement ok
+COMMIT;
+
+query I
+SELECT * FROM blue_t1 LIMIT 1;
+----
+10
+
+# Cleanup.
+
+statement ok
+DROP CLUSTER blue_compute CASCADE;

--- a/test/testdrive/blue-green.td
+++ b/test/testdrive/blue-green.td
@@ -1,0 +1,163 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_alter_swap = true;
+
+> CREATE SCHEMA blue;
+
+> CREATE SCHEMA green;
+
+$ set-from-sql var=og-blue-schema-id
+SELECT id FROM mz_schemas WHERE name = 'blue';
+
+$ set-from-sql var=og-green-schema-id
+SELECT id FROM mz_schemas WHERE name = 'green';
+
+> BEGIN;
+
+> ALTER SCHEMA blue SWAP WITH green;
+
+> COMMIT;
+
+> SELECT name FROM mz_schemas WHERE id = '${og-blue-schema-id}'
+"green"
+
+> BEGIN
+
+> ALTER SCHEMA green RENAME TO purple;
+
+> ALTER SCHEMA purple RENAME TO orange;
+
+> ALTER SCHEMA orange RENAME TO green;
+
+> ALTER SCHEMA green SWAP WITH blue;
+
+> COMMIT
+
+> SELECT name FROM mz_schemas WHERE ID = '${og-blue-schema-id}'
+"blue"
+
+> BEGIN
+
+> ALTER SCHEMA blue RENAME TO purple
+
+> ROLLBACK
+
+# Should stay blue since we rolled back the transaction.
+
+> SELECT name FROM mz_schemas WHERE ID = '${og-blue-schema-id}'
+"blue"
+
+# Cleanup.
+
+> DROP SCHEMA blue
+> DROP SCHEMA green
+
+# Mock out a real-ish Blue/Green scenario.
+
+> CREATE TABLE source_data (x int)
+
+> INSERT INTO source_data VALUES (10), (20), (30)
+
+> CREATE CLUSTER blue_compute SIZE '1'
+> CREATE CLUSTER blue_serving SIZE '1'
+
+> CREATE SCHEMA blue
+
+> CREATE MATERIALIZED VIEW blue.mv1 IN CLUSTER blue_compute AS ( SELECT SUM(x) FROM source_data );
+> CREATE DEFAULT INDEX IN CLUSTER blue_serving ON blue.mv1;
+
+> SET cluster TO blue_serving;
+
+> SELECT * FROM blue.mv1;
+60
+
+> EXPLAIN SELECT * FROM blue.mv1;
+"Explained Query (fast path):\n  ReadIndex on=materialize.blue.mv1 mv1_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.blue.mv1_primary_idx (*** full scan ***)\n"
+
+> SET cluster TO default;
+
+# Spin up a new stack.
+
+> CREATE CLUSTER green_compute SIZE '1'
+> CREATE CLUSTER green_serving SIZE '1'
+
+> CREATE SCHEMA green
+
+> CREATE MATERIALIZED VIEW green.mv1 IN CLUSTER green_compute AS ( SELECT AVG(x) FROM source_data );
+> CREATE DEFAULT INDEX IN CLUSTER green_serving ON green.mv1;
+
+> SET cluster to green_serving;
+
+> SELECT * FROM green.mv1;
+20
+
+> EXPLAIN SELECT * FROM green.mv1;
+"Explained Query (fast path):\n  ReadIndex on=materialize.green.mv1 mv1_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.green.mv1_primary_idx (*** full scan ***)\n"
+
+> SET cluster to defaut;
+
+# Do the swap!
+
+$ set-from-sql var=og-green-schema-id
+SELECT id FROM mz_schemas WHERE name = 'green';
+
+$ set-from-sql var=og-green-compute-id
+SELECT id FROM mz_clusters WHERE name = 'green_compute';
+
+$ set-from-sql var=og-green-serving-id
+SELECT id FROM mz_clusters WHERE name = 'green_serving';
+
+> BEGIN;
+
+> ALTER SCHEMA blue SWAP WITH green;
+> ALTER CLUSTER blue_serving SWAP WITH green_serving;
+> ALTER CLUSTER blue_compute SWAP WITH green_compute;
+
+> COMMIT;
+
+# Validate the swap.
+
+> SET CLUSTER to blue_serving;
+
+> SELECT * FROM blue.mv1;
+20
+
+> EXPLAIN SELECT * FROM blue.mv1;
+"Explained Query (fast path):\n  ReadIndex on=materialize.blue.mv1 mv1_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.blue.mv1_primary_idx (*** full scan ***)\n"
+
+> SELECT name FROM mz_schemas WHERE id = '${og-green-schema-id}';
+"blue"
+
+> SELECT name FROM mz_clusters WHERE id = '${og-green-compute-id}';
+"blue_compute"
+
+> SELECT name FROM mz_clusters WHERE id = '${og-green-serving-id}';
+"blue_serving"
+
+# Drop unused resources.
+
+> DROP CLUSTER green_compute CASCADE;
+> DROP CLUSTER green_serving CASCADE;
+
+# Make sure everything still works.
+
+> SELECT * FROM blue.mv1;
+20
+
+> EXPLAIN SELECT * FROM blue.mv1;
+"Explained Query (fast path):\n  ReadIndex on=materialize.blue.mv1 mv1_primary_idx=[*** full scan ***]\n\nUsed Indexes:\n  - materialize.blue.mv1_primary_idx (*** full scan ***)\n"
+
+# Cleanup.
+
+> SET CLUSTER TO default;
+
+> DROP CLUSTER blue_compute CASCADE;
+> DROP CLUSTER blue_serving CASCADE;


### PR DESCRIPTION
This PR implements limited support for DDL in SQL transactions, specifically you can do something like:

```
BEGIN;

ALTER SCHEMA blue SWAP WITH green;
ALTER CLUSTER blue_serving SWAP WITH green_serving;
ALTER CLUSTER blue_compute SWAP WITH green_compute;

COMMIT;
```

The approach we take is to add a new `TransactionOps` variant called `DDL`. This variant buffers all of the `catalog::Ops` we've run thus far, a version of `CatalogState` with the ops applied, and the `transient_revision` of the `Catalog` for when the transaction was started. 

We update the `Catalog::for_session(...)` method to now also check if we have a DDL transaction in-progress, and use the stashed `CatalogState` if so. This allows us to accurately run steps like planing and name resolution. Then for sequencing, we "replay" all of the buffered ops before running the current operation, and utilize an existing method on Catalog transactions to bail right before comitting the Catalog Transaction to durable storage. When committing the transaction we re-run all of the buffered `Ops` and commit them durably. To guard against races we check to make sure our stored `transient_revision` matches the current revision, bailing if it does not.

### Motivation

Closes #22854 

### Tips for reviewer

This PR is split into two commits, which could be reviewed independently if you want:

1. The implementation of DDL in transactions
2. sqllogictest and testdrive tests

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds support for limited DDL in SQL transactions.
