### PR TITLE
sqlsmith: Another versioning fix

### DIFF
--- a/test/sqlsmith/Dockerfile
+++ b/test/sqlsmith/Dockerfile
@@ -26,7 +26,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ADD https://api.github.com/repos/MaterializeInc/sqlsmith/git/refs/heads/master version.json
 
 # Build SQLsmith
-RUN git clone --depth=1 --single-branch --branch=master https://github.com/MaterializeInc/sqlsmith \
+RUN git clone --single-branch --branch=master https://github.com/MaterializeInc/sqlsmith \
     && cd sqlsmith \
     && git checkout 981f55a5573a338068d53385e5155bbb7af2905f \
     && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ . \


### PR DESCRIPTION
Otherwise old versions can't be found: fatal: reference is not a tree: efba94d292c7f32c46e2637a3e05d6f95acf944b

Seen in https://buildkite.com/materialize/coverage/builds/303#018bae39-331b-438f-93a5-7be322bfa428

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
