### PR TITLE
adapter: never remove timeline state

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2235,9 +2235,6 @@ impl Catalog {
                         }
                     }
                 }
-                Op::DropTimeline(timeline) => {
-                    tx.remove_timestamp(timeline);
-                }
                 Op::GrantRole {
                     role_id,
                     member_id,
@@ -3673,7 +3670,6 @@ pub enum Op {
         comment: Option<String>,
     },
     DropObject(ObjectId),
-    DropTimeline(Timeline),
     GrantRole {
         role_id: RoleId,
         member_id: RoleId,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -100,7 +100,7 @@ impl Coordinator {
     pub(crate) async fn catalog_transact_with<'a, F, R>(
         &mut self,
         conn_id: Option<&ConnectionId>,
-        mut ops: Vec<catalog::Op>,
+        ops: Vec<catalog::Op>,
         f: F,
     ) -> Result<R, AdapterError>
     where
@@ -116,7 +116,6 @@ impl Coordinator {
         let mut views_to_drop = vec![];
         let mut replication_slots_to_drop: Vec<(mz_postgres_util::Config, String)> = vec![];
         let mut secrets_to_drop = vec![];
-        let mut timelines_to_drop = vec![];
         let mut vpc_endpoints_to_drop = vec![];
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
@@ -341,18 +340,6 @@ impl Coordinator {
                 Some((timeline, (empty, bundle)))
             })
             .collect();
-        timelines_to_drop.extend(
-            timeline_associations
-                .iter()
-                .filter_map(|(timeline, (is_empty, _))| is_empty.then_some(timeline))
-                .cloned(),
-        );
-        ops.extend(
-            timelines_to_drop
-                .iter()
-                .cloned()
-                .map(catalog::Op::DropTimeline),
-        );
 
         self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID))?;
 
@@ -1055,7 +1042,6 @@ impl Coordinator {
                 | Op::AlterSink { .. }
                 | Op::AlterSource { .. }
                 | Op::AlterSetCluster { .. }
-                | Op::DropTimeline(_)
                 | Op::UpdatePrivilege { .. }
                 | Op::UpdateDefaultPrivilege { .. }
                 | Op::GrantRole { .. }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -281,11 +281,6 @@ impl Coordinator {
         }
         let became_empty = read_holds.is_empty();
 
-        // Finally, remove the Timeline if it's empty.
-        if became_empty {
-            self.global_timelines.remove(&timeline);
-        }
-
         became_empty
     }
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1084,15 +1084,6 @@ impl<'a> Transaction<'a> {
         self.system_configurations.delete(|_k, _v| true);
     }
 
-    pub fn remove_timestamp(&mut self, timeline: Timeline) {
-        let timeline_str = timeline.to_string();
-        let prev = self
-            .timestamps
-            .set(TimestampKey { id: timeline_str }, None)
-            .expect("cannot have uniqueness violation");
-        assert!(prev.is_some());
-    }
-
     pub(crate) fn insert_config(&mut self, key: String, value: u64) -> Result<(), CatalogError> {
         match self
             .configs


### PR DESCRIPTION
This is motivated by the addition of an external, distributed timestamp oracle which makes it harder to remove timeline state atomically with the DDL/catalog/stash changes that cause said removal.

Additionally, it seems incorrect that a timelines' timestamp state can vanish and then be re-created in the future, potentially at a lower timestamp, which would violate linearizability.

### Tips for reviewer

For now, I opened this to see what, if any, breaks. So hold off on reviewing, please!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
