### PR TITLE
[WIP] dbt-materialize: 1.7.0 Additional Tests

### DIFF
--- a/misc/dbt-materialize/tests/adapter/test_dbt_clone.py
+++ b/misc/dbt-materialize/tests/adapter/test_dbt_clone.py
@@ -1,0 +1,106 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.tests.adapter.dbt_clone.fixtures import (
+    custom_can_clone_tables_false_macros_sql,
+    get_schema_name_sql,
+    infinite_macros_sql,
+    macros_sql,
+)
+from dbt.tests.adapter.dbt_clone.test_dbt_clone import BaseClone
+from dbt.tests.util import run_dbt
+
+
+class BaseCloneOverride(BaseClone):
+    @pytest.fixture(scope="class")
+    def snapshots(self):
+        pass
+
+    def run_and_save_state(self, project_root, with_snapshot=False):
+        results = run_dbt(["seed"])
+        assert len(results) == 1
+        assert not any(r.node.deferred for r in results)
+        results = run_dbt(["run"])
+        assert len(results) == 2
+        assert not any(r.node.deferred for r in results)
+        results = run_dbt(["test"])
+        assert len(results) == 2
+
+        # copy files
+        self.copy_state(project_root)
+
+
+class BaseCloneNotPossible(BaseCloneOverride):
+    @pytest.fixture(scope="class")
+    def macros(self):
+        return {
+            "macros.sql": macros_sql,
+            "my_can_clone_tables.sql": custom_can_clone_tables_false_macros_sql,
+            "infinite_macros.sql": infinite_macros_sql,
+            "get_schema_name.sql": get_schema_name_sql,
+        }
+
+    def test_can_clone_false(self, project, unique_schema, other_schema):
+        project.create_test_schema(other_schema)
+        self.run_and_save_state(project.project_root, with_snapshot=True)
+
+        clone_args = [
+            "clone",
+            "--state",
+            "state",
+            "--target",
+            "otherschema",
+        ]
+
+        results = run_dbt(clone_args)
+        assert len(results) == 3
+
+        schema_relations = project.adapter.list_relations(
+            database=project.database, schema=other_schema
+        )
+        assert all(r.type == "view" for r in schema_relations)
+
+        # objects already exist, so this is a no-op
+        results = run_dbt(clone_args)
+        assert len(results) == 3
+        assert all("no-op" in r.message.lower() for r in results)
+
+        # recreate all objects
+        results = run_dbt([*clone_args, "--full-refresh"])
+        assert len(results) == 3
+
+        # select only models this time
+        results = run_dbt([*clone_args, "--resource-type", "model"])
+        assert len(results) == 2
+        assert all("no-op" in r.message.lower() for r in results)
+
+
+class TestMaterializeCloneNotPossible(BaseCloneNotPossible):
+    @pytest.fixture(autouse=True)
+    def clean_up(self, project):
+        yield
+        with project.adapter.connection_named("__test"):
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=f"{project.test_schema}_seeds"
+            )
+            project.adapter.drop_schema(relation)
+
+            relation = project.adapter.Relation.create(
+                database=project.database, schema=project.test_schema
+            )
+            project.adapter.drop_schema(relation)
+
+    pass

--- a/misc/dbt-materialize/tests/adapter/test_seed.py
+++ b/misc/dbt-materialize/tests/adapter/test_seed.py
@@ -14,7 +14,9 @@
 # limitations under the License.
 
 import pytest
-from dbt.tests.adapter.simple_seed.test_seed import SeedConfigBase
+from dbt.tests.adapter.simple_seed.test_seed import (
+    SeedConfigBase,
+)
 from dbt.tests.adapter.simple_seed.test_seed_type_override import (
     BaseSimpleSeedColumnOverride,
 )


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Additional tests added as part of v1.7.0.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
