### PR TITLE
dbt-materialize: Store Failures As

### DIFF
--- a/doc/user/content/manage/dbt.md
+++ b/doc/user/content/manage/dbt.md
@@ -414,8 +414,8 @@ That's it! From here on, Materialize makes sure that your models are **increment
 
 ## Test and document a dbt project
 
-[//]: # "TODO(morsapaes) Call out the cluster configuration for tests once this
-page is rehashed."
+[//]: # "TODO(morsapaes) Call out the cluster configuration for tests and
+store_failures_as once this page is rehashed."
 
 ### Configure continuous testing
 

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -7,6 +7,29 @@
   checks, but the value of this feature in a real-time data warehouse is
   limited.
 
+* Support for `store_failures_as` which can be `table`, `view`,`ephemeral` or `materialized_view` (like models, a `table` will be a `materialized_view`).
+
+  * Project level
+  ```yaml
+  tests:
+    my_project:
+      +store_failures_as: table
+  ```
+  * Model level
+  ```yaml
+  models:
+    - name: my_model
+      columns:
+        - name: id
+          tests:
+            - not_null:
+                config:
+                  store_failures_as: view
+            - unique:
+                config:
+                  store_failures_as: materialized_view
+  ```
+
 ## 1.6.1 - 2023-11-03
 
 * Support the [`ASSERT NOT NULL` option](https://materialize.com/docs/sql/create-materialized-view/#non-null-assertions)

--- a/misc/dbt-materialize/CHANGELOG.md
+++ b/misc/dbt-materialize/CHANGELOG.md
@@ -2,20 +2,18 @@
 
 ## Unreleased
 
-* Mark `dbt source freshness` as not supported. Materialize supports the
-  functionality required to enable column- and metadata-based source freshness
-  checks, but the value of this feature in a real-time data warehouse is
-  limited.
+* Support specifying the materialization type used to store test failures via
+  the new [`store_failures_as` configuration](https://docs.getdbt.com/reference/resource-configs/store_failures_as).
+  Accepted values: `materialized_view` (default), `view`, `ephemeral`.
 
-* Support for `store_failures_as` which can be `table`, `view`,`ephemeral` or `materialized_view` (like models, a `table` will be a `materialized_view`).
-
-  * Project level
+  * **Project level**
   ```yaml
   tests:
     my_project:
-      +store_failures_as: table
+      +store_failures_as: view
   ```
-  * Model level
+
+  * **Model level**
   ```yaml
   models:
     - name: my_model
@@ -27,8 +25,16 @@
                   store_failures_as: view
             - unique:
                 config:
-                  store_failures_as: materialized_view
+                  store_failures_as: ephemeral
   ```
+
+  If both [`store_failures`](https://docs.getdbt.com/reference/resource-configs/store_failures)
+  and `store_failures_as` are specified, `store_failures_as` takes precedence.
+
+* Mark `dbt source freshness` as not supported. Materialize supports the
+  functionality required to enable column- and metadata-based source freshness
+  checks, but the value of this feature in a real-time data warehouse is
+  limited.
 
 ## 1.6.1 - 2023-11-03
 

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -110,10 +110,14 @@ as well as [`--persist-docs`](https://docs.getdbt.com/reference/resource-configs
 
 [`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported.
 
-If you set the optional flags `--store-failures` or `--store-failures-as` (or config [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures) or [`store_failures_as` config](https://docs.getdbt.com/reference/resource-configs/store_failures_as)),
-By default dbt will save the results of a test query to a `materialized_view`. These will
-be created in a schema suffixed or named `dbt_test__audit` by default. Change
-this value by setting a `schema` config.
+If you set the optional [`--store-failures` flag or `store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures),
+dbt will save the results of a test query to a `materialized_view`. To use a
+`view` instead, use the [`store_failures_as` config](https://docs.getdbt.com/reference/resource-configs/store_failures_as).
+
+These objects will be created in a schema suffixed or named `dbt_test__audit` by
+default. Change this value by setting a `schema` config. If both
+[`store_failures`](https://docs.getdbt.com/reference/resource-configs/store_failures) and
+`store_failures_as` are specified, `store_failures_as` takes precedence.
 
 ### Snapshots
 

--- a/misc/dbt-materialize/README.md
+++ b/misc/dbt-materialize/README.md
@@ -110,8 +110,8 @@ as well as [`--persist-docs`](https://docs.getdbt.com/reference/resource-configs
 
 [`dbt test`](https://docs.getdbt.com/reference/commands/test) is supported.
 
-If you set the optional `--store-failures` flag or [`store-failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures),
-dbt will save the results of a test query to a `materialized_view`. These will
+If you set the optional flags `--store-failures` or `--store-failures-as` (or config [`store_failures` config](https://docs.getdbt.com/reference/resource-configs/store_failures) or [`store_failures_as` config](https://docs.getdbt.com/reference/resource-configs/store_failures_as)),
+By default dbt will save the results of a test query to a `materialized_view`. These will
 be created in a schema suffixed or named `dbt_test__audit` by default. Change
 this value by setting a `schema` config.
 

--- a/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
+++ b/misc/dbt-materialize/dbt/include/materialize/macros/materializations/test.sql
@@ -25,7 +25,7 @@
     {% set old_relation = adapter.get_relation(database=database, schema=schema, identifier=identifier) %}
 
     {% set store_failures_as = config.get('store_failures_as') %}
-    {% if store_failures_as == none %}{% set store_failures_as = 'materialized_view' %}{% endif %}
+    {% if store_failures_as == none %}{% set store_failures_as = 'table' %}{% endif %}
     {% if store_failures_as not in ['table', 'view', 'materialized_view'] %}
         {{ exceptions.raise_compiler_error(
             "'" ~ store_failures_as ~ "' is not a valid value for `store_failures_as`. "

--- a/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
+++ b/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
@@ -94,7 +94,7 @@ class TestStoreTestFailuresAsExceptions(basic.StoreTestFailuresAsExceptions):
         assert "Compilation Error" in result.message
         assert "'error' is not a valid value" in result.message
         assert (
-            "Accepted values are: ['ephemeral', 'table', 'view', 'materialized_view']"
+            "Accepted values are: ['table', 'view', 'materialized_view']"
             in result.message
         )
 

--- a/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
+++ b/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
@@ -15,7 +15,16 @@
 
 import pytest
 from dbt.contracts.results import TestStatus
-from dbt.tests.adapter.store_test_failures_tests import basic
+from dbt.tests.adapter.store_test_failures_tests.basic import (
+    StoreTestFailuresAsBase,
+    StoreTestFailuresAsExceptions,
+    StoreTestFailuresAsGeneric,
+    StoreTestFailuresAsInteractions,
+    StoreTestFailuresAsProjectLevelEphemeral,
+    StoreTestFailuresAsProjectLevelOff,
+    StoreTestFailuresAsProjectLevelView,
+    TestResult,
+)
 from dbt.tests.adapter.store_test_failures_tests.fixtures import (
     models__file_model_but_with_a_no_good_very_long_name,
     models__fine_model,
@@ -62,31 +71,29 @@ class TestMaterializeStoreTestFailures(TestStoreTestFailures):
     pass
 
 
-class TestStoreTestFailuresAsInteractions(basic.StoreTestFailuresAsInteractions):
+class TestStoreTestFailuresAsInteractions(StoreTestFailuresAsInteractions):
     pass
 
 
-class TestStoreTestFailuresAsProjectLevelOff(basic.StoreTestFailuresAsProjectLevelOff):
+class TestStoreTestFailuresAsProjectLevelOff(StoreTestFailuresAsProjectLevelOff):
     pass
 
 
-class TestStoreTestFailuresAsProjectLevelView(
-    basic.StoreTestFailuresAsProjectLevelView
-):
+class TestStoreTestFailuresAsProjectLevelView(StoreTestFailuresAsProjectLevelView):
     pass
 
 
-class TestStoreTestFailuresAsGeneric(basic.StoreTestFailuresAsGeneric):
+class TestStoreTestFailuresAsGeneric(StoreTestFailuresAsGeneric):
     pass
 
 
 class TestStoreTestFailuresAsProjectLevelEphemeral(
-    basic.StoreTestFailuresAsProjectLevelEphemeral
+    StoreTestFailuresAsProjectLevelEphemeral
 ):
     pass
 
 
-class TestStoreTestFailuresAsExceptions(basic.StoreTestFailuresAsExceptions):
+class TestStoreTestFailuresAsExceptions(StoreTestFailuresAsExceptions):
     def test_tests_run_unsuccessfully_and_raise_appropriate_exception(self, project):
         results = run_dbt(["test"], expect_pass=False)
         assert len(results) == 1
@@ -94,12 +101,12 @@ class TestStoreTestFailuresAsExceptions(basic.StoreTestFailuresAsExceptions):
         assert "Compilation Error" in result.message
         assert "'error' is not a valid value" in result.message
         assert (
-            "Accepted values are: ['table', 'view', 'materialized_view']"
+            "Accepted values are: ['ephemeral', 'table', 'view', 'materialized_view']"
             in result.message
         )
 
 
-class TestStoreTestFailuresAsProjectLevelMaterializeView(basic.StoreTestFailuresAsBase):
+class TestStoreTestFailuresAsProjectLevelMaterializeView(StoreTestFailuresAsBase):
     """
     These scenarios test that `store_failures_as` at the project level takes precedence over `store_failures`
     at the model level.
@@ -128,8 +135,8 @@ class TestStoreTestFailuresAsProjectLevelMaterializeView(basic.StoreTestFailures
 
     def test_tests_run_successfully_and_are_stored_as_expected(self, project):
         expected_results = {
-            basic.TestResult("results_true", TestStatus.Fail, "materialized_view"),
-            basic.TestResult("results_false", TestStatus.Fail, "materialized_view"),
-            basic.TestResult("results_unset", TestStatus.Fail, "materialized_view"),
+            TestResult("results_true", TestStatus.Fail, "materialized_view"),
+            TestResult("results_false", TestStatus.Fail, "materialized_view"),
+            TestResult("results_unset", TestStatus.Fail, "materialized_view"),
         }
         self.run_and_assert(project, expected_results)

--- a/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
+++ b/misc/dbt-materialize/tests/adapter/test_store_test_failures.py
@@ -1,0 +1,135 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License in the LICENSE file at the
+# root of this repository, or online at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from dbt.contracts.results import TestStatus
+from dbt.tests.adapter.store_test_failures_tests import basic
+from dbt.tests.adapter.store_test_failures_tests.fixtures import (
+    models__file_model_but_with_a_no_good_very_long_name,
+    models__fine_model,
+)
+from dbt.tests.adapter.store_test_failures_tests.test_store_test_failures import (
+    StoreTestFailuresBase,
+)
+from dbt.tests.util import run_dbt
+
+TEST__MATERIALIZED_VIEW_TRUE = """
+{{ config(store_failures_as="materialized_view", store_failures=True) }}
+select *
+from {{ ref('chipmunks') }}
+where shirt = 'green'
+"""
+
+
+TEST__MATERIALIZED_VIEW_FALSE = """
+{{ config(store_failures_as="materialized_view", store_failures=False) }}
+select *
+from {{ ref('chipmunks') }}
+where shirt = 'green'
+"""
+
+
+TEST__MATERIALIZED_VIEW_UNSET = """
+{{ config(store_failures_as="materialized_view") }}
+select *
+from {{ ref('chipmunks') }}
+where shirt = 'green'
+"""
+
+
+class TestStoreTestFailures(StoreTestFailuresBase):
+    @pytest.fixture(scope="class")
+    def models(self):
+        return {
+            "fine_model.sql": models__fine_model,
+            "fine_model_but_with_a_no_good_very_long_name.sql": models__file_model_but_with_a_no_good_very_long_name,
+        }
+
+
+class TestMaterializeStoreTestFailures(TestStoreTestFailures):
+    pass
+
+
+class TestStoreTestFailuresAsInteractions(basic.StoreTestFailuresAsInteractions):
+    pass
+
+
+class TestStoreTestFailuresAsProjectLevelOff(basic.StoreTestFailuresAsProjectLevelOff):
+    pass
+
+
+class TestStoreTestFailuresAsProjectLevelView(
+    basic.StoreTestFailuresAsProjectLevelView
+):
+    pass
+
+
+class TestStoreTestFailuresAsGeneric(basic.StoreTestFailuresAsGeneric):
+    pass
+
+
+class TestStoreTestFailuresAsProjectLevelEphemeral(
+    basic.StoreTestFailuresAsProjectLevelEphemeral
+):
+    pass
+
+
+class TestStoreTestFailuresAsExceptions(basic.StoreTestFailuresAsExceptions):
+    def test_tests_run_unsuccessfully_and_raise_appropriate_exception(self, project):
+        results = run_dbt(["test"], expect_pass=False)
+        assert len(results) == 1
+        result = results[0]
+        assert "Compilation Error" in result.message
+        assert "'error' is not a valid value" in result.message
+        assert (
+            "Accepted values are: ['ephemeral', 'table', 'view', 'materialized_view']"
+            in result.message
+        )
+
+
+class TestStoreTestFailuresAsProjectLevelMaterializeView(basic.StoreTestFailuresAsBase):
+    """
+    These scenarios test that `store_failures_as` at the project level takes precedence over `store_failures`
+    at the model level.
+
+    Test Scenarios:
+
+    - If `store_failures_as = "materialized_view"` in the project and `store_failures = False` in the model,
+    then store the failures in a materialized view.
+    - If `store_failures_as = "materialized_view"` in the project and `store_failures = True` in the model,
+    then store the failures in a materialized view.
+    - If `store_failures_as = "materialized_view"` in the project and `store_failures` is not set,
+    then store the failures in a materialized view.
+    """
+
+    @pytest.fixture(scope="class")
+    def tests(self):
+        return {
+            "results_true.sql": TEST__MATERIALIZED_VIEW_TRUE,
+            "results_false.sql": TEST__MATERIALIZED_VIEW_FALSE,
+            "results_unset.sql": TEST__MATERIALIZED_VIEW_UNSET,
+        }
+
+    @pytest.fixture(scope="class")
+    def project_config_update(self):
+        return {"tests": {"store_failures_as": "materialized_view"}}
+
+    def test_tests_run_successfully_and_are_stored_as_expected(self, project):
+        expected_results = {
+            basic.TestResult("results_true", TestStatus.Fail, "materialized_view"),
+            basic.TestResult("results_false", TestStatus.Fail, "materialized_view"),
+            basic.TestResult("results_unset", TestStatus.Fail, "materialized_view"),
+        }
+        self.run_and_assert(project, expected_results)


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

As part of the dbt v1.7.0 upgrade. Modify the ability to store tests as additional materializations with `store_failures_as`. Tests can be materialized as `table`, `view` or `materialized view` (like models, selecting `table` will materialize as a materialized view).

  * Project level
  ```yaml
  tests:
    my_project:
      +store_failures_as: table
  ```
  * Model level
  ```yaml
  models:
    - name: my_model
      columns:
        - name: id
          tests:
            - not_null:
                config:
                  store_failures_as: view
            - unique:
                config:
                  store_failures_as: materialized_view
  ```

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
