### PR TITLE
Control arrangement merging with `default_exert_logic`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#2ebd82d88393b521bd2dcaeb082f4f1d51734ef6"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#40fbd33810198116f7a3562e86495233184acbd4"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1786,7 +1786,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#2ebd82d88393b521bd2dcaeb082f4f1d51734ef6"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#40fbd33810198116f7a3562e86495233184acbd4"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1060,12 +1060,15 @@ impl Coordinator {
         let storage_config = flags::storage_config(system_config);
         let scheduling_config = flags::orchestrator_scheduling_config(system_config);
         let merge_effort = system_config.default_idle_arrangement_merge_effort();
+        let exert_prop = system_config.default_arrangement_exert_proportionality();
         self.controller.compute.update_configuration(compute_config);
         self.controller.storage.update_configuration(storage_config);
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller
             .set_default_idle_arrangement_merge_effort(merge_effort);
+        self.controller
+            .set_default_arrangement_exert_proportionality(exert_prop);
 
         // Capture identifiers that need to have their read holds relaxed once the bootstrap completes.
         //

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -127,7 +127,7 @@ impl Coordinator {
         let mut update_secrets_caching_config = false;
         let mut update_cluster_scheduling_config = false;
         let mut update_jemalloc_profiling_config = false;
-        let mut update_default_arrangement_idle_merge_effort = false;
+        let mut update_default_arrangement_merge_options = false;
         let mut update_http_config = false;
         let mut log_indexes_to_drop = Vec::new();
 
@@ -224,8 +224,10 @@ impl Coordinator {
                     update_cluster_scheduling_config |= vars::is_cluster_scheduling_var(name);
                     update_jemalloc_profiling_config |=
                         name == vars::ENABLE_JEMALLOC_PROFILING.name();
-                    update_default_arrangement_idle_merge_effort |=
+                    update_default_arrangement_merge_options |=
                         name == vars::DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT.name();
+                    update_default_arrangement_merge_options |=
+                        name == vars::DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY.name();
                     update_http_config |= vars::is_http_config_var(name);
                 }
                 catalog::Op::ResetAllSystemConfiguration => {
@@ -239,7 +241,7 @@ impl Coordinator {
                     update_secrets_caching_config = true;
                     update_cluster_scheduling_config = true;
                     update_jemalloc_profiling_config = true;
-                    update_default_arrangement_idle_merge_effort = true;
+                    update_default_arrangement_merge_options = true;
                     update_http_config = true;
                 }
                 _ => (),
@@ -506,8 +508,8 @@ impl Coordinator {
             if update_jemalloc_profiling_config {
                 self.update_jemalloc_profiling_config().await;
             }
-            if update_default_arrangement_idle_merge_effort {
-                self.update_default_idle_arrangement_merge_effort();
+            if update_default_arrangement_merge_options {
+                self.update_default_arrangement_merge_options();
             }
             if update_http_config {
                 self.update_http_config();
@@ -787,7 +789,7 @@ impl Coordinator {
         }
     }
 
-    fn update_default_idle_arrangement_merge_effort(&mut self) {
+    fn update_default_arrangement_merge_options(&mut self) {
         let effort = self
             .catalog()
             .system_config()
@@ -795,6 +797,14 @@ impl Coordinator {
         self.controller
             .compute
             .set_default_idle_arrangement_merge_effort(effort);
+
+        let prop = self
+            .catalog()
+            .system_config()
+            .default_arrangement_exert_proportionality();
+        self.controller
+            .compute
+            .set_default_arrangement_exert_proportionality(prop);
     }
 
     fn update_http_config(&mut self) {

--- a/src/cluster-client/src/client.proto
+++ b/src/cluster-client/src/client.proto
@@ -24,4 +24,5 @@ message ProtoTimelyConfig {
     repeated string addresses = 3;
     uint32 idle_arrangement_merge_effort = 4;
     bool variable_length_row_encoding = 5;
+    uint32 arrangement_exert_proportionality = 6;
 }

--- a/src/cluster-client/src/client.rs
+++ b/src/cluster-client/src/client.rs
@@ -139,6 +139,15 @@ pub struct TimelyConfig {
     ///
     /// See `differential_dataflow::Config::idle_merge_effort`.
     pub idle_arrangement_merge_effort: u32,
+    /// Proportionality value that decides whether to exert additional arrangement merge effort.
+    ///
+    /// Specifically, additional merge effort is exerted when the size of the second-largest batch
+    /// in an arrangement is within a factor of `arrangement_exert_proportionality` of the size of
+    /// the largest batch, or when a merge is already in progress.
+    ///
+    /// The higher the proportionality value, the more eagerly arrangement batches are merged. A
+    /// value of `0` (or `1`) disables eager merging.
+    pub arrangement_exert_proportionality: u32,
     /// Whether to enable variable-length row encoding.
     pub variable_length_row_encoding: bool,
 }
@@ -150,6 +159,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             addresses: self.addresses.into_proto(),
             process: self.process.into_proto(),
             idle_arrangement_merge_effort: self.idle_arrangement_merge_effort,
+            arrangement_exert_proportionality: self.arrangement_exert_proportionality,
             variable_length_row_encoding: self.variable_length_row_encoding,
         }
     }
@@ -160,6 +170,7 @@ impl RustType<ProtoTimelyConfig> for TimelyConfig {
             workers: proto.workers.into_rust()?,
             addresses: proto.addresses.into_rust()?,
             idle_arrangement_merge_effort: proto.idle_arrangement_merge_effort,
+            arrangement_exert_proportionality: proto.arrangement_exert_proportionality,
             variable_length_row_encoding: proto.variable_length_row_encoding,
         })
     }

--- a/src/cluster/src/server.rs
+++ b/src/cluster/src/server.rs
@@ -176,7 +176,7 @@ where
         // configure the effort to `None`, not when we set it to `Some(0)`.
         let idle_merge_effort = (idle_merge_effort > 0).then_some(idle_merge_effort);
 
-        // By default, se only set the idle_merge_effort
+        // By default, only set the idle_merge_effort
         differential_dataflow::configure(
             &mut worker_config,
             &differential_dataflow::Config {
@@ -188,6 +188,12 @@ where
         // This avoids turning on proportionality for replicas with default idle merge effort.
         if idle_merge_effort.is_none() && config.arrangement_exert_proportionality > 0 {
             let idle_merge_effort = Some(1000);
+
+            // ExertionLogic defines a function to determine if a spine is sufficiently tidied.
+            // Its arguments are an iterator over the index of a layer, the count of batches in the
+            // layer and the length of batches at the layer. The iterator enumerates layers from the
+            // largest to the smallest layer.
+
             let arc: ExertionLogic = Arc::new(move |layers| {
                 let mut prop = config.arrangement_exert_proportionality;
 

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -136,6 +136,8 @@ pub struct ComputeController<T> {
     config: ComputeParameters,
     /// Default value for `idle_arrangement_merge_effort`.
     default_idle_arrangement_merge_effort: u32,
+    /// Default value for `arrangement_exert_proportionality`.
+    default_arrangement_exert_proportionality: u32,
     /// A replica response to be handled by the corresponding `Instance` on a subsequent call to
     /// `ActiveComputeController::process`.
     stashed_replica_response: Option<(ComputeInstanceId, ReplicaId, ComputeResponse<T>)>,
@@ -172,6 +174,7 @@ impl<T> ComputeController<T> {
             initialized: false,
             config: Default::default(),
             default_idle_arrangement_merge_effort: 1000,
+            default_arrangement_exert_proportionality: 16,
             stashed_replica_response: None,
             envd_epoch,
             metrics: ComputeControllerMetrics::new(metrics_registry),
@@ -241,6 +244,10 @@ impl<T> ComputeController<T> {
 
     pub fn set_default_idle_arrangement_merge_effort(&mut self, value: u32) {
         self.default_idle_arrangement_merge_effort = value;
+    }
+
+    pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
+        self.default_arrangement_exert_proportionality = value;
     }
 }
 
@@ -462,6 +469,10 @@ where
             .idle_arrangement_merge_effort
             .unwrap_or(self.compute.default_idle_arrangement_merge_effort);
 
+        // TODO(teskje): make configurable via replica option
+        let arrangement_exert_proportionality =
+            self.compute.default_arrangement_exert_proportionality;
+
         let replica_config = ReplicaConfig {
             location,
             logging: LoggingConfig {
@@ -471,6 +482,7 @@ where
                 index_logs: Default::default(),
             },
             idle_arrangement_merge_effort,
+            arrangement_exert_proportionality,
             grpc_client: self.compute.config.grpc_client.clone(),
         };
 

--- a/src/compute-client/src/controller/replica.rs
+++ b/src/compute-client/src/controller/replica.rs
@@ -44,6 +44,7 @@ pub(super) struct ReplicaConfig {
     pub location: ClusterReplicaLocation,
     pub logging: LoggingConfig,
     pub idle_arrangement_merge_effort: u32,
+    pub arrangement_exert_proportionality: u32,
     pub grpc_client: GrpcClientParameters,
 }
 
@@ -274,6 +275,7 @@ where
                 process: 0,
                 addresses: self.config.location.dataflow_addrs.clone(),
                 idle_arrangement_merge_effort: self.config.idle_arrangement_merge_effort,
+                arrangement_exert_proportionality: self.config.arrangement_exert_proportionality,
                 variable_length_row_encoding: config.variable_length_row_encoding,
             };
             *epoch = self.epoch;

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -246,6 +246,11 @@ impl<T> Controller<T> {
         self.compute
             .set_default_idle_arrangement_merge_effort(value);
     }
+
+    pub fn set_default_arrangement_exert_proportionality(&mut self, value: u32) {
+        self.compute
+            .set_default_arrangement_exert_proportionality(value);
+    }
 }
 
 impl<T> Controller<T>

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1359,6 +1359,14 @@ pub const DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT: ServerVar<u32> = ServerVar {
     internal: true,
 };
 
+pub const DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("default_arrangement_exert_proportionality"),
+    value: &16,
+    description:
+        "The default value to use for the `ARRANGEMENT EXERT PROPORTIONALITY` cluster/replica option.",
+    internal: true,
+};
+
 pub const ENABLE_DEFAULT_CONNECTION_VALIDATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_default_connection_validation"),
     value: &true,
@@ -2771,6 +2779,7 @@ impl SystemVars {
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&LINEAR_JOIN_YIELDING)
             .with_var(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
+            .with_var(&DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY)
             .with_var(&ENABLE_STORAGE_SHARD_FINALIZATION)
             .with_var(&ENABLE_CONSOLIDATE_AFTER_UNION_NEGATE)
             .with_var(&ENABLE_SPECIALIZED_ARRANGEMENTS)
@@ -3451,6 +3460,11 @@ impl SystemVars {
     /// Returns the `default_idle_arrangement_merge_effort` configuration parameter.
     pub fn default_idle_arrangement_merge_effort(&self) -> u32 {
         *self.expect_value(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
+    }
+
+    /// Returns the `default_arrangement_exert_proportionality` configuration parameter.
+    pub fn default_arrangement_exert_proportionality(&self) -> u32 {
+        *self.expect_value(&DEFAULT_ARRANGEMENT_EXERT_PROPORTIONALITY)
     }
 
     /// Returns the `enable_storage_shard_finalization` configuration parameter.

--- a/src/storage-controller/src/rehydration.rs
+++ b/src/storage-controller/src/rehydration.rs
@@ -259,12 +259,13 @@ where
                 // Overridden by the storage `PartitionedState` implementation.
                 process: 0,
                 addresses: location.dataflow_addrs.clone(),
-                // This value is not currently used by storage, so we just choose
+                // These values are not currently used by storage, so we just choose
                 // some identifiable value.
                 //
                 // TODO(guswynn): cluster-unification: ensure this is cleaned up when
                 // the compute and storage command streams are merged.
                 idle_arrangement_merge_effort: 1337,
+                arrangement_exert_proportionality: 1337,
                 variable_length_row_encoding: self.variable_length_row_encoding,
             };
             let dests = location


### PR DESCRIPTION
Add an alternative merging strategy for arrangements.

Up to this point, we could either not merge arrangements outside of ingesting updates, or always keep them in the most compacted form by specifying `idle_merge_effort`. Since https://github.com/TimelyDataflow/differential-dataflow/pull/411 landed, Differential offers to replace the whole exertion logic, which we conditionally do with this PR. When the idle merge effort is 0, we honor an alternative setting of default_arrangement_exert_proprotionality that specifies which batches in an arrangement should be merged. Specifically, the proportionality determines when to merge the largest with the next largest batch.

### Motivation

  * This PR adds a known-desirable feature: #22469

We don't disable idle merging, but provide a different policy that might eventually replace the current idle merging behavior.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
