### PR TITLE
docs: Add docs about catalog in timedomain

### DIFF
--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -48,7 +48,7 @@ A **read-only** transaction can produce an error with the text:
 
 > Transactions can only reference objects in the same timedomain.
 
-The first `SELECT` in a transaction assumes that any object in that `SELECT`, any other object in the same schemas, and all pg_catalog objects are assumed to be possible query targets.
+The first `SELECT` in a transaction assumes that any object in that `SELECT`, any other object in the same schemas, and all `pg_catalog` objects are assumed to be possible query targets.
 If an object in the timedomain is a view, it will be replaced with the objects in the view definition.
 If a later `SELECT` references another object, the transaction will fail.
 This can happen if the object is in a schema not referenced by the first `SELECT`.

--- a/doc/user/content/sql/begin.md
+++ b/doc/user/content/sql/begin.md
@@ -48,7 +48,8 @@ A **read-only** transaction can produce an error with the text:
 
 > Transactions can only reference objects in the same timedomain.
 
-The first `SELECT` in a transaction assumes that any object in that `SELECT` and any other object in the same schemas are assumed to be possible query targets.
+The first `SELECT` in a transaction assumes that any object in that `SELECT`, any other object in the same schemas, and all pg_catalog objects are assumed to be possible query targets.
+If an object in the timedomain is a view, it will be replaced with the objects in the view definition.
 If a later `SELECT` references another object, the transaction will fail.
 This can happen if the object is in a schema not referenced by the first `SELECT`.
 It can also happen if a new object (table, view, source, or index) was created after the transaction started, even if the new object is in the same schemas as the first `SELECT`.


### PR DESCRIPTION
This commit expands on the timedomain docs to indicate that pg_catalog objects are included in all timedomains. Additionally, it explains how views are treated in timedomains.

### Motivation
Docs

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
