### PR TITLE
output consistency: add further ignores (2)

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -176,6 +176,9 @@ class PostExecutionInconsistencyIgnoreFilter(
             # errors (while the other uses another order).
             return YesIgnore("#17189")
 
+        if self._uses_eager_evaluation(query_template):
+            return YesIgnore("#17189")
+
         return NoIgnore()
 
     def _shall_ignore_error_mismatch(

--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -46,6 +46,7 @@ from materialize.output_consistency.operation.operation import (
     DbOperationOrFunction,
     OperationRelevance,
 )
+from materialize.util import MzVersion
 
 TEXT_OPERATION_TYPES: list[DbOperationOrFunction] = []
 
@@ -382,5 +383,6 @@ TEXT_OPERATION_TYPES.append(
         [TextOperationParam(), TextOperationParam()],
         BooleanReturnTypeSpec(),
         is_pg_compatible=False,
+        since_mz_version=MzVersion.parse_mz("v0.77.0"),
     )
 )

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -19,6 +19,7 @@ from materialize.output_consistency.operation.operation_args_validator import (
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
 from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
+from materialize.util import MzVersion
 
 EXPRESSION_PLACEHOLDER = "$"
 
@@ -43,6 +44,7 @@ class DbOperationOrFunction:
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         is_enabled: bool = True,
         is_pg_compatible: bool = True,
+        since_mz_version: MzVersion | None = None,
     ):
         """
         :param is_enabled: an operation should only be disabled if its execution causes problems;
@@ -60,6 +62,7 @@ class DbOperationOrFunction:
         self.relevance = relevance
         self.is_enabled = is_enabled
         self.is_pg_compatible = is_pg_compatible
+        self.since_mz_version = since_mz_version
 
     def to_pattern(self, args_count: int) -> str:
         raise NotImplementedError
@@ -157,6 +160,7 @@ class DbFunction(DbOperationOrFunction):
         relevance: OperationRelevance = OperationRelevance.DEFAULT,
         is_enabled: bool = True,
         is_pg_compatible: bool = True,
+        since_mz_version: MzVersion | None = None,
     ):
         self.validate_params(params)
 
@@ -170,6 +174,7 @@ class DbFunction(DbOperationOrFunction):
             relevance=relevance,
             is_enabled=is_enabled,
             is_pg_compatible=is_pg_compatible,
+            since_mz_version=since_mz_version,
         )
         self.function_name_in_lower_case = function_name.lower()
 

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -34,7 +34,7 @@ class MzVersion(Version):
     """Version of Materialize, can be parsed from version string, SQL, cargo"""
 
     @classmethod
-    def parse_mz(cls, version: str) -> "MzVersion":
+    def parse_mz(cls, version: str, drop_dev_suffix: bool = False) -> "MzVersion":
         """Parses a Mz version string, for example:  v0.45.0-dev (f01773cb1)"""
         if not version[0] == "v":
             raise ValueError(f"Invalid mz version string: {version}")
@@ -44,6 +44,10 @@ class MzVersion(Version):
             if not git_hash[0] == "(" or not git_hash[-1] == ")":
                 raise ValueError(f"Invalid mz version string: {version}")
             # Hash ignored
+
+        if drop_dev_suffix:
+            version = version.replace("-dev", "")
+
         return cls.parse(version)
 
     @classmethod

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -28,8 +28,8 @@ from materialize.util import MzVersion
 class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
     def __init__(self, mz1_version: str, mz2_version: str):
         super().__init__()
-        self.mz1_version = MzVersion.parse_mz(mz1_version)
-        self.mz2_version = MzVersion.parse_mz(mz2_version)
+        self.mz1_version = MzVersion.parse_mz(mz1_version, drop_dev_suffix=True)
+        self.mz2_version = MzVersion.parse_mz(mz2_version, drop_dev_suffix=True)
 
     def shall_ignore_expression(
         self, expression: Expression, row_selection: DataRowSelection


### PR DESCRIPTION
This addresses https://buildkite.com/materialize/nightlies/builds/5066#018baeea-07d6-4a88-9c14-a089d24c257d and https://buildkite.com/materialize/nightlies/builds/5066#018baeea-07dc-4200-93de-1c86d4c923d3.

**Commits:**
ef0031ef98 output consistency: also ignore success mismatch on eager evaluations
592a4ac6f4 version consistency: ignore unavailable features
dfa2692ae7 version consistency: specify version of constant_time_eq
54ccdf8cde version consistency: ignore dev suffix

**Nightly:**
https://buildkite.com/materialize/nightlies/builds/5069
