### PR TITLE
optimizer: use the right key in `OptimizePeek`

### DIFF
--- a/test/sqllogictest/github-23015.slt
+++ b/test/sqllogictest/github-23015.slt
@@ -1,0 +1,16 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# Regression test for #23015.
+
+query TT
+select distinct 'postgres', current_user() from mz_internal.mz_cluster_replica_metrics;
+----
+postgres
+materialize


### PR DESCRIPTION
### Motivation

  * This PR fixes a recognized bug.

Fixes #23015.

### Tips for reviewer

It turns out that the `RelationType` (and more specifically its `keys` property) might change between the end of the local MIR optimization phase and the end of the global MIR optimization phase.

Consequently, the key that is attached to the exported index might be different than the type of the fully optimized dataflow. This can cause messed up plan construction because we use the key in the

```rust
permutation_for_arrangement(&key, arity);
```

call when constructing a `PeekPlan::SlowPath` in `plan_peek`. This commit fixes the issue by passing the original type as a separate field in the `GlobalMirPlan` result for `OptimizePeek`.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
