### PR TITLE
32b offsets in arrangements

### DIFF
--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -13,13 +13,15 @@
 
 use differential_dataflow::operators::arrange::TraceAgent;
 use differential_dataflow::trace::implementations::ord::{ColKeySpine, ColValSpine};
+
+use mz_ore::num::Overflowing;
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_types::errors::DataflowError;
 
-pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R, u32>;
-pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R, u32>;
-pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R, u32>;
-pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R, u32>;
+pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R, Overflowing<u32>>;
+pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R, Overflowing<u32>>;
+pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R, Overflowing<u32>>;
+pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R, Overflowing<u32>>;
 pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
 pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
 pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -16,10 +16,10 @@ use differential_dataflow::trace::implementations::ord::{ColKeySpine, ColValSpin
 use mz_repr::{Diff, Row, Timestamp};
 use mz_storage_types::errors::DataflowError;
 
-pub type RowSpine<K, V, T, R, O = usize> = ColValSpine<K, V, T, R, O>;
-pub type RowKeySpine<K, T, R, O = usize> = ColKeySpine<K, T, R, O>;
-pub type ErrSpine<K, T, R, O = usize> = ColKeySpine<K, T, R, O>;
-pub type ErrValSpine<K, T, R, O = usize> = ColValSpine<K, DataflowError, T, R, O>;
+pub type RowSpine<K, V, T, R> = ColValSpine<K, V, T, R, u32>;
+pub type RowKeySpine<K, T, R> = ColKeySpine<K, T, R, u32>;
+pub type ErrSpine<K, T, R> = ColKeySpine<K, T, R, u32>;
+pub type ErrValSpine<K, T, R> = ColValSpine<K, DataflowError, T, R, u32>;
 pub type TraceRowHandle<K, V, T, R> = TraceAgent<RowSpine<K, V, T, R>>;
 pub type TraceErrHandle<K, T, R> = TraceAgent<ErrSpine<K, T, R>>;
 pub type KeysValsHandle = TraceRowHandle<Row, Row, Timestamp, Diff>;

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -125,6 +125,7 @@ pub mod metrics;
 #[cfg(feature = "network")]
 pub mod netio;
 pub mod now;
+pub mod num;
 pub mod option;
 pub mod panic;
 pub mod path;

--- a/src/ore/src/num.rs
+++ b/src/ore/src/num.rs
@@ -16,11 +16,10 @@
 
 //! Number utilities
 
-use crate::cast::CastFrom;
 use std::fmt::{Display, Formatter};
 use std::ops::{Add, Sub};
 
-/// Overflowing number
+/// Overflowing number. Operations panic on overflow, even in release mode.
 #[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
 pub struct Overflowing<T>(pub T);
 
@@ -52,14 +51,18 @@ impl Sub<Self> for Overflowing<u32> {
     }
 }
 
-impl From<usize> for Overflowing<u32> {
-    fn from(value: usize) -> Self {
-        Self(u32::try_from(value).expect("Overflow"))
+impl TryFrom<usize> for Overflowing<u32> {
+    type Error = <u32 as TryFrom<usize>>::Error;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u32::try_from(value).map(Self)
     }
 }
 
-impl From<Overflowing<u32>> for usize {
-    fn from(value: Overflowing<u32>) -> Self {
-        Self::cast_from(value.0)
+impl TryFrom<Overflowing<u32>> for usize {
+    type Error = <usize as TryFrom<u32>>::Error;
+
+    fn try_from(value: Overflowing<u32>) -> Result<Self, Self::Error> {
+        Self::try_from(value.0)
     }
 }

--- a/src/ore/src/num.rs
+++ b/src/ore/src/num.rs
@@ -1,0 +1,65 @@
+// Copyright 2019 The Rust Project Contributors
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License in the LICENSE file at the
+// root of this repository, or online at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Number utilities
+
+use crate::cast::CastFrom;
+use std::fmt::{Display, Formatter};
+use std::ops::{Add, Sub};
+
+/// Overflowing number
+#[derive(Debug, Ord, PartialOrd, Eq, PartialEq, Copy, Clone)]
+pub struct Overflowing<T>(pub T);
+
+impl<T: Display> Display for Overflowing<T> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl Add<Self> for Overflowing<u32> {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        match self.0.overflowing_add(rhs.0) {
+            (_, true) => panic!("Overflow {self} + {rhs}"),
+            (result, false) => Self(result),
+        }
+    }
+}
+
+impl Sub<Self> for Overflowing<u32> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        match self.0.overflowing_sub(rhs.0) {
+            (_, true) => panic!("Overflow {self} - {rhs}"),
+            (result, false) => Self(result),
+        }
+    }
+}
+
+impl From<usize> for Overflowing<u32> {
+    fn from(value: usize) -> Self {
+        Self(u32::try_from(value).expect("Overflow"))
+    }
+}
+
+impl From<Overflowing<u32>> for usize {
+    fn from(value: Overflowing<u32>) -> Self {
+        Self::cast_from(value.0)
+    }
+}

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -265,8 +265,8 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
 # Under arrangement specialization of only empty values, a single-column relation
-# should demand 64 bytes per tuple instead of 96.
-> SELECT records >= 300, size >= 300*64, capacity >= 300*64 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+# should demand 56 bytes per tuple instead of 88.
+> SELECT records >= 300, size >= 300*56, capacity >= 300*56 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
 true true true
 true true true
 
@@ -295,7 +295,7 @@ true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 64*1000 AND size < 2*64*1000, capacity > 64*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 56*1000 AND size < 2*56*1000, capacity > 56*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 true true true true true
 
 > DROP INDEX ii_t4


### PR DESCRIPTION
### Motivation

Change the offsets in arrangements to a 32-bit offset. This limits the amount of rows we can store in a batch to 2^32 rows (ca. 4~M~billion), which currently would mean to store 384GiB of data in a single batch. We don't have any example of such a large batch in Materialize (TODO: validate). Note that the allocations are sharded across workers, so the only possibility for this to happen is a highly skewed relation or a cross join. I don't think we could construct such a batch at the moment because we'd likely have more than the margin of memory already in use, discounting made-up examples that cause an empty key and large values without large inputs.

This saves us 4 bytes per key and value, reducing the size of records in arrangements from 96 to 88 bytes. The downside is that we can only store 4~M~ billion distinct keys/values-per-key in an arrangement batch. If we ever try to store, we'd panic. (We add a `Overflowing` type that also panics on release builds.)

It's not possible to move this behind a feature flag because the type is set at compile time.

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
