### PR TITLE
storage: metric for count of in-memory remap bindings

### DIFF
--- a/src/storage/src/source/metrics.rs
+++ b/src/storage/src/source/metrics.rs
@@ -39,6 +39,7 @@ pub(super) struct SourceSpecificMetrics {
     pub(super) error_retractions: IntCounterVec,
     pub(super) persist_sink_processed_batches: IntCounterVec,
     pub(super) offset_commit_failures: IntCounterVec,
+    pub(super) inmemory_remap_bindings: UIntGaugeVec,
 }
 
 impl SourceSpecificMetrics {
@@ -92,6 +93,11 @@ impl SourceSpecificMetrics {
                 name: "mz_source_offset_commit_failures",
                 help: "A counter representing how many times we have failed to commit offsets for a source",
                 var_labels: ["source_id"],
+            )),
+            inmemory_remap_bindings: registry.register(metric!(
+                name: "mz_source_inmemory_remap_bindings",
+                help: "The number of in-memory remap bindings that reclocking a time needs to iterate over.",
+                var_labels: ["source_id", "worker_id"],
             )),
         }
     }

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -390,6 +390,11 @@ where
             inner: Rc::clone(&self.inner),
         }
     }
+
+    /// The number of remap bindings in the trace
+    pub fn size(&self) -> usize {
+        self.inner.borrow().remap_trace.len()
+    }
 }
 
 impl<FromTime: Timestamp, IntoTime: Timestamp + Lattice + Display> Drop

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -691,6 +691,8 @@ where
                     }
                 },
                 _ = work_to_do.notified(), if timestamper.initialized() => {
+                    source_metrics.inmemory_remap_bindings.set(u64::cast_from(timestamper.size()));
+
                     // Drain all messages that can be reclocked from all the batches
                     let total_buffered: usize = untimestamped_batches.iter().map(|(_, b)| b.len()).sum();
                     let reclock_source_upper = timestamper.source_upper();

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -254,6 +254,8 @@ pub struct SourceMetrics {
     pub(crate) resume_upper: DeleteOnDropGauge<'static, AtomicI64, Vec<String>>,
     /// Per-partition Prometheus metrics.
     pub(crate) partition_metrics: BTreeMap<PartitionId, PartitionMetrics>,
+    /// The number of in-memory remap bindings that reclocking a time needs to iterate over.
+    pub(crate) inmemory_remap_bindings: DeleteOnDropGauge<'static, AtomicU64, Vec<String>>,
     source_name: String,
     source_id: GlobalId,
     base_metrics: SourceBaseMetrics,
@@ -281,6 +283,10 @@ impl SourceMetrics {
                 .source_specific
                 .resume_upper
                 .get_delete_on_drop_gauge(vec![source_id.to_string()]),
+            inmemory_remap_bindings: base
+                .source_specific
+                .inmemory_remap_bindings
+                .get_delete_on_drop_gauge(vec![source_id.to_string(), worker_id.to_string()]),
             partition_metrics: Default::default(),
             source_name: source_name.to_string(),
             source_id,


### PR DESCRIPTION
### Motivation

During incident 75 we observed the CPU spending all its time in reclocking. At the time the only theory we could come up with was that the in-memory trace of the remap shard had not been compacted leading to the slowdown of each reclock operation.

We couldn't confirm this was the case by neither observing the machines during the incident nor by benchmarking, whose results were inconclusive.

This PR adds a metric for the value in question (size of in-memory remap trace) that will help us prove or disprove the theory if the issue happens again in the future.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
