### PR TITLE
github action: Notify on Slack about risky PRs

### DIFF
--- a/.github/workflows/slack_notify_qa_risky.yml
+++ b/.github/workflows/slack_notify_qa_risky.yml
@@ -1,0 +1,107 @@
+# Copyright 2020 The Actions Ecosystem Authors
+# Modifications Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Portions of this file are derived from the README examples in the Action
+# Slack Notifier project. The original source code was retrieved on
+# January 5, 2022 from:
+#
+#     https://github.com/actions-ecosystem/action-slack-notifier/blob/fc778468d09c43a6f4d1b8cccaca59766656996a/README.md
+
+# Send a notification to the #team-testing-risky Slack channel when a risky change is made.
+
+name: Slack QA Risky Notifications
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+    paths:
+      - src/environmentd/tests/server.rs
+      - src/pgwire/src/message.rs
+      - src/sql/src/plan/statement.rs
+      - src/catalog/src/builtin.rs
+      - src/sql/src/rbac.rs
+      - src/sqllogictest/src/runner.rs
+      - src/adapter/src/coord/command_handler.rs
+      - src/expr/src/relation/mod.rs
+      - src/adapter/src/coord.rs
+      - src/sql-parser/src/ast/defs/statement.rs
+      - src/adapter/src/catalog.rs
+      - src/sql/src/catalog.rs
+      - src/environmentd/tests/sql.rs
+      - src/pgwire/src/protocol.rs
+      - src/expr/src/scalar/mod.rs
+      - src/adapter/src/coord/sequencer.rs
+      - src/sql/src/func.rs
+      - src/sql/src/plan.rs
+      - src/adapter/src/coord/sequencer/inner.rs
+      - src/expr/src/scalar/func.rs
+      - src/sql/src/plan/statement/ddl.rs
+      - src/adapter/src/catalog.rs
+      - src/adapter/src/coord.rs
+      - src/sql/src/plan/query.rs
+      - src/sql-parser/src/parser.rs
+
+jobs:
+  notify:
+    name: "Notify about risky PRs"
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+      - name: "Long change filter"
+        id: long
+        run: |
+          num_lines=$(git diff --diff-filter=AM ${{ github.event.before }} ${{ github.event.after }} -- '*.rs' | grep "^+" | grep -v "^+++" | wc -l)
+          if [[ $num_lines -gt 300 ]]; then
+            echo "long=true" >> $GITHUB_OUTPUT
+          fi
+      - name: "Push to Slack"
+        if: steps.long.outputs.long == 'true'
+        uses: actions-ecosystem/action-slack-notifier@fc778468d09c43a6f4d1b8cccaca59766656996a
+        with:
+          slack_token: ${{ secrets.SLACK_TOKEN }}
+          channel: team-testing-risky
+          custom_payload: |
+            {
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new risky change is ready for review!"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *PR:* <${{ github.event.pull_request.html_url }}|${{ github.event.pull_request.title }}>"
+                  }
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "• *Author:* <${{ github.event.pull_request.user.html_url }}|${{ github.event.pull_request.user.login }}>"
+                  }
+                }
+              ]
+            }


### PR DESCRIPTION
Most risky files via `git log --all --raw --grep='(close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved) #' -i -E | grep "^:100644" | grep " M" | grep "\.rs$" | cut -f2 | sort | uniq -c | sort -n`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
