### PR TITLE
environmentd: macOS Codesigning for all Built Programs

### DIFF
--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -140,14 +140,15 @@ def main() -> int:
         del args.args[0]
 
     if args.program in KNOWN_PROGRAMS:
-        build_retcode = _build(args, extra_programs=[args.program])
+        (build_retcode, built_programs) = _build(args, extra_programs=[args.program])
         if args.build_only:
             return build_retcode
 
         if args.release:
-            path = MZ_ROOT / "target" / "release" / args.program
+            artifact_path = MZ_ROOT / "target" / "release"
         else:
-            path = MZ_ROOT / "target" / "debug" / args.program
+            artifact_path = MZ_ROOT / "target" / "debug"
+        program_path = artifact_path / args.program
 
         if args.disable_mac_codesigning:
             if sys.platform != "darwin":
@@ -155,13 +156,15 @@ def main() -> int:
             else:
                 print("Disabled macOS Codesigning")
         elif sys.platform == "darwin":
-            _macos_codesign(path)
+            for program in built_programs:
+                path = artifact_path / program
+                _macos_codesign(str(path))
 
         if args.wrapper:
             command = shlex.split(args.wrapper)
         else:
             command = []
-        command.append(str(path))
+        command.append(str(program_path))
         if args.tokio_console:
             command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "environmentd":
@@ -230,7 +233,7 @@ def main() -> int:
             _run_sql(args.postgres, f"CREATE DATABASE IF NOT EXISTS {db}")
             command += [f"--postgres-url={args.postgres}", *args.args]
     elif args.program == "test":
-        build_retcode = _build(args)
+        (build_retcode, _) = _build(args)
         if args.build_only:
             return build_retcode
 
@@ -301,10 +304,13 @@ def _set_foreground_process(pid: int) -> None:
         os.tcsetpgrp(tty.fileno(), os.getpgrp())
 
 
-def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
+def _build(
+    args: argparse.Namespace, extra_programs: list[str] = []
+) -> tuple[int, list[str]]:
     env = dict(os.environ)
     command = _cargo_command(args, "build")
     features = []
+
     if args.coverage:
         env["RUSTFLAGS"] = (
             env.get("RUSTFLAGS", "") + " " + " ".join(rustc_flags.coverage)
@@ -313,10 +319,13 @@ def _build(args: argparse.Namespace, extra_programs: list[str] = []) -> int:
         features.extend(args.features.split(","))
     if features:
         command += [f"--features={','.join(features)}"]
-    for program in [*REQUIRED_SERVICES, *extra_programs]:
+
+    programs = [*REQUIRED_SERVICES, *extra_programs]
+    for program in programs:
         command += ["--bin", program]
     completed_proc = spawn.runv(command, env=env)
-    return completed_proc.returncode
+
+    return (completed_proc.returncode, programs)
 
 
 def _macos_codesign(path: str) -> None:

--- a/misc/python/materialize/cli/run.py
+++ b/misc/python/materialize/cli/run.py
@@ -148,7 +148,6 @@ def main() -> int:
             artifact_path = MZ_ROOT / "target" / "release"
         else:
             artifact_path = MZ_ROOT / "target" / "debug"
-        program_path = artifact_path / args.program
 
         if args.disable_mac_codesigning:
             if sys.platform != "darwin":
@@ -164,7 +163,7 @@ def main() -> int:
             command = shlex.split(args.wrapper)
         else:
             command = []
-        command.append(str(program_path))
+        command.append(str(artifact_path / args.program))
         if args.tokio_console:
             command += ["--tokio-console-listen-addr=127.0.0.1:6669"]
         if args.program == "environmentd":


### PR DESCRIPTION
This PR extends the existing macOS codesigning when building `environmentd` for local development, to also codesign all built programs, i.e. `clusterd`. This self signing is necessary to use macOS Instruments on the built programs.

### Motivation

Use macOS Instruments to investigate memory usage in `clusterd`

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
