### PR TITLE
testdrive: Add quickstart guide with unified cluster

### DIFF
--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -1,0 +1,129 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This test verifies the Quickstart page works: https://materialize.com/docs/get-started/quickstart/
+# Uses shared compute+storage cluster
+
+> CREATE SOURCE auction_house
+  IN CLUSTER default
+  FROM LOAD GENERATOR AUCTION
+  (TICK INTERVAL '0.01s')
+  FOR ALL TABLES
+
+> SHOW SOURCES
+name                   type           size                         cluster
+--------------------------------------------------------------------------
+accounts               subsource      <null>                       <null>
+bids                   subsource      <null>                       <null>
+auction_house          load-generator <null>                       default
+auction_house_progress progress       <null>                       <null>
+auctions               subsource      <null>                       <null>
+organizations          subsource      <null>                       <null>
+users                  subsource      <null>                       <null>
+
+> SELECT id, seller, item FROM auctions WHERE id = 1
+1 1824 "Best Pizza in Town"
+
+> SELECT id, buyer, auction_id, amount FROM bids WHERE id = 10
+10 3844 1 59
+
+> CREATE VIEW winning_bids AS
+  SELECT DISTINCT ON (auctions.id) bids.*, auctions.item, auctions.seller
+  FROM auctions, bids
+  WHERE auctions.id = bids.auction_id
+    AND bids.bid_time < auctions.end_time
+    AND mz_now() >= auctions.end_time
+  ORDER BY auctions.id,
+    bids.bid_time DESC,
+    bids.amount,
+    bids.buyer
+
+> SELECT id, buyer, auction_id, amount, item, seller FROM winning_bids WHERE id = 18
+18 1036 1 86 "Best Pizza in Town" 1824
+
+> CREATE INDEX wins_by_item ON winning_bids (item)
+> CREATE INDEX wins_by_bidder ON winning_bids (buyer)
+> CREATE INDEX wins_by_seller ON winning_bids (seller)
+
+? EXPLAIN SELECT * FROM winning_bids WHERE item = 'Best Pizza in Town' ORDER BY bid_time DESC
+Explained Query (fast path):
+  Finish order_by=[#4 desc nulls_first] output=[#0..=#6]
+    Project (#1..=#5, #0, #6)
+      ReadIndex on=materialize.public.winning_bids wins_by_item=[lookup value=("Best Pizza in Town")]
+
+Used Indexes:
+  - materialize.public.wins_by_item (lookup)
+
+> SELECT id, buyer, auction_id, amount, item, seller FROM winning_bids WHERE item = 'Best Pizza in Town' AND id < 100 ORDER BY bid_time DESC
+62 3016 6 77 "Best Pizza in Town" 2500
+46 2530 4 49 "Best Pizza in Town" 2822
+18 1036 1 86 "Best Pizza in Town" 1824
+
+> CREATE VIEW fraud_activity AS
+  SELECT w2.seller,
+         w2.item AS seller_item,
+         w2.amount AS seller_amount,
+         w1.item buyer_item,
+         w1.amount buyer_amount
+  FROM winning_bids w1,
+       winning_bids w2
+  WHERE w1.buyer = w2.seller
+    AND w2.amount > w1.amount
+
+> SELECT * FROM fraud_activity where seller_item = 'Gift Basket' and seller = 100
+100 "Gift Basket" 63 "Gift Basket" 51
+
+> CREATE TABLE fraud_accounts (id bigint)
+
+$ set-regex match=\d{13,20} replacement=<TIMESTAMP>
+
+> BEGIN
+
+> DECLARE c CURSOR FOR SUBSCRIBE TO (
+    SELECT buyer
+    FROM winning_bids
+    WHERE buyer NOT IN (SELECT id FROM fraud_accounts) AND buyer = 71
+    GROUP BY buyer
+    ORDER BY 1 ASC LIMIT 5
+  )
+
+> FETCH 1 c WITH (timeout='1s')
+<TIMESTAMP> 1 71
+
+$ postgres-execute connection=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
+INSERT INTO fraud_accounts VALUES (71)
+
+> FETCH 1 c WITH (timeout='1s')
+<TIMESTAMP> -1 71
+
+> COMMIT
+
+> CREATE VIEW funds_movement AS
+  SELECT id, SUM(credits) as credits, SUM(debits) as debits
+  FROM (
+    SELECT seller as id, amount as credits, 0 as debits
+    FROM winning_bids
+    UNION ALL
+    SELECT buyer as id, 0 as credits, amount as debits
+    FROM winning_bids
+  )
+  GROUP BY id
+
+# > SELECT SUM(credits), SUM(debits) FROM funds_movement
+# 37529 37529
+#
+# > BEGIN
+# > DECLARE c CURSOR FOR SUBSCRIBE TO (
+#     SELECT SUM(credits), SUM(debits) FROM funds_movement
+#   )
+# > FETCH 1 c WITH (timeout='1s')
+
+> DROP SOURCE auction_house CASCADE
+
+> DROP TABLE fraud_accounts


### PR DESCRIPTION
Currently blocked by https://github.com/MaterializeInc/materialize/issues/23037

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
