### PR TITLE
test: Fix flaky auto_run_on_introspection test

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -3000,11 +3000,15 @@ fn test_auto_run_on_introspection_feature_disabled() {
         .unwrap();
     assert_introspection_notice(None);
 
-    let _row = client
-        .query_one(
-            "SELECT * FROM mz_internal.mz_cluster_replica_heartbeats LIMIT 1",
-            &[],
-        )
+    // We add a retry here since it might take a moment to get a replica heartbeat.
+    let _row = Retry::default()
+        .max_tries(5)
+        .retry(|_state| {
+            client.query_one(
+                "SELECT * FROM mz_internal.mz_cluster_replica_heartbeats LIMIT 1",
+                &[],
+            )
+        })
         .unwrap();
     assert_introspection_notice(None);
 


### PR DESCRIPTION
This PR fixes a flaky test by adding a retry. The test is making sure we don't auto route introspection queries that need to get run on a specific replica. The issue is the replica might not have fully started yet, so the query could fail. Adding the retry should make the test stable.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23026

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Test only change
