### PR TITLE
test: Add debug info to webhook parallel-action

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1291,7 +1291,9 @@ class HttpPostAction(Action):
         try:
             result = requests.post(url, data=payload.encode("utf-8"), headers=headers)
             if result.status_code != 200:
-                raise ValueError(f"POST failed: {result.status_code}, {result.text}\nURL: {url}")
+                raise ValueError(
+                    f"POST failed: {result.status_code}, {result.text}\nURL: {url}"
+                )
         except (requests.exceptions.ConnectionError):
             # Expected when Mz is killed
             if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1291,7 +1291,7 @@ class HttpPostAction(Action):
         try:
             result = requests.post(url, data=payload.encode("utf-8"), headers=headers)
             if result.status_code != 200:
-                raise ValueError(f"POST failed: {result.status_code}, {result.text}")
+                raise ValueError(f"POST failed: {result.status_code}, {result.text}\nURL: {url}")
         except (requests.exceptions.ConnectionError):
             # Expected when Mz is killed
             if exe.db.scenario not in (Scenario.Kill, Scenario.BackupRestore):


### PR DESCRIPTION
This PR adds some debug info to the webhook parallel action, so when we get an error we know what URL we were attempting to POST to. It also adds a Rust test that reproduces the behavior seen in https://github.com/MaterializeInc/materialize/issues/23027

### Motivation

Related to https://github.com/MaterializeInc/materialize/issues/23027

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Test only
