### PR TITLE
func: Limit number of columns in csv_extract

### DIFF
--- a/misc/python/materialize/sqlsmith.py
+++ b/misc/python/materialize/sqlsmith.py
@@ -109,7 +109,7 @@ known_errors = [
     "regex parse error",
     "out of valid range",
     '" does not exist',  # role does not exist
-    "csv_extract number of columns too large",
+    "attempt to create relation with too many columns",
     "target replica failed or was dropped",  # expected on replica OoMs with #21587
     "cannot materialize call to",  # create materialized view on some internal views
     "arrays must not contain null values",  # aclexplode, mz_aclexplode

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3455,8 +3455,11 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
                         sql_bail!("csv_extract number of columns must be a positive integer literal");
                     },
                     Some(ncols @ 1..=MAX_EXTRACT_COLUMNS) => ncols,
-                    Some(TOO_MANY_EXTRACT_COLUMNS..) => {
-                        sql_bail!("csv_extract number of columns too large, must be less than or equal to {MAX_EXTRACT_COLUMNS}");
+                    Some(ncols @ TOO_MANY_EXTRACT_COLUMNS..) => {
+                        return Err(PlanError::TooManyColumns {
+                            max_num_columns: usize::try_from(MAX_EXTRACT_COLUMNS).unwrap_or(usize::MAX),
+                            req_num_columns: usize::try_from(ncols).unwrap_or(usize::MAX),
+                        });
                     },
                 };
                 let ncols = usize::try_from(ncols).expect("known to be greater than zero");

--- a/test/sqllogictest/extract.slt
+++ b/test/sqllogictest/extract.slt
@@ -43,3 +43,9 @@ SELECT * FROM data, (VALUES (2)) ncols, csv_extract(ncols.column1, data.input)
 
 query error db error: ERROR: csv_extract number of columns must be a positive integer literal
 SELECT * FROM data, csv_extract((SELECT 2), data.input)
+
+query error db error: ERROR: csv_extract number of columns must be less than or equal to 8192
+SELECT * FROM data, csv_extract(8193, data.input)
+
+statement ok
+SELECT * FROM data, csv_extract(8192, data.input)

--- a/test/sqllogictest/extract.slt
+++ b/test/sqllogictest/extract.slt
@@ -44,7 +44,7 @@ SELECT * FROM data, (VALUES (2)) ncols, csv_extract(ncols.column1, data.input)
 query error db error: ERROR: csv_extract number of columns must be a positive integer literal
 SELECT * FROM data, csv_extract((SELECT 2), data.input)
 
-query error db error: ERROR: csv_extract number of columns must be less than or equal to 8192
+query error db error: ERROR: attempt to create relation with too many columns, 8193 max: 8192
 SELECT * FROM data, csv_extract(8193, data.input)
 
 statement ok

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -109,4 +109,4 @@ $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET max_result_size
 
 ! SELECT csv_extract(9223372036854775807, '');
-contains:csv_extract number of columns too large
+contains:attempt to create relation with too many columns, 9223372036854775807 max: 8192


### PR DESCRIPTION
This PR limits the absolute number of columns that can be extracted with `csv_extract` to 8192. Given the [maximum number of columns Postgres supports is 1600](https://www.postgresql.org/docs/current/limits.html), 8192 seems like a good limit.

Currently we do limit the number of columns to just how much memory we can allocate, but this leads to issues like https://github.com/MaterializeInc/materialize/issues/22735, and realistically we should restrict the number of columns much more than just the number of column names we can fit in memory. 

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/22735

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
