### PR TITLE
mzexplore,optbench: minor fixes

### DIFF
--- a/misc/python/materialize/cli/optbench.py
+++ b/misc/python/materialize/cli/optbench.py
@@ -239,11 +239,11 @@ def compare(
 
     try:
         base_df = pd.read_csv(base, quoting=csv.QUOTE_MINIMAL).agg(
-            [np.min, np.median, np.max]
+            ["min", "median", "max"]
         )
 
         diff_df = pd.read_csv(diff, quoting=csv.QUOTE_MINIMAL).agg(
-            [np.min, np.median, np.max]
+            ["min", "median", "max"]
         )
 
         # compute diff/base quotient for all (metric, query) pairs

--- a/misc/python/materialize/mzexplore/catalog/items.sql
+++ b/misc/python/materialize/mzexplore/catalog/items.sql
@@ -21,9 +21,9 @@ FROM
   mz_databases AS d ON (s.database_id = d.id)
 WHERE
   o.id like 'u%' AND
-  o.name like {name} AND
-  s.name like {schema} AND
-  d.name like {database}
+  o.name ilike {name} AND
+  s.name ilike {schema} AND
+  d.name ilike {database}
 ORDER BY
   o.type,
   d.name,

--- a/misc/python/materialize/mzexplore/sql/keywords.txt
+++ b/misc/python/materialize/mzexplore/sql/keywords.txt
@@ -1,0 +1,1 @@
+../../../../../src/sql-lexer/src/keywords.txt


### PR DESCRIPTION
It turns out that [pg8000.native.identifier](https://github.com/tlocke/pg8000/blob/017959e97751c35a3d58bc8bd5722cee5c10b656/pg8000/converters.py#L739-L761) is not compatible with [the Postgres code](https://github.com/postgres/postgres/blob/b0f7dd915bca6243f3daf52a81b8d0682a38ee3b/src/backend/utils/adt/ruleutils.c#L11968-L12050
), so we need to roll our own modified `identifier` version.

I'm using the occasion to also make the `mzexplore` code a bit more robust and fix a warning in `optbench`.

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

In `mzexplore`:
- Fix `identifier` quotation.
- Make `items.sql` query case-insensitive.
- Skip failing `CREATE` or `EXPLAIN` commands with warning.

In `optbench`:
- Adress pandas deprecation warning.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
