### PR TITLE
docs: Release `COMMENT ON` to public preview

### DIFF
--- a/doc/user/content/sql/comment-on.md
+++ b/doc/user/content/sql/comment-on.md
@@ -6,7 +6,7 @@ menu:
     parent: 'commands'
 ---
 
-{{< private-preview />}}
+{{< public-preview />}}
 
 `COMMENT ON ...` adds or updates the comment of an object.
 


### PR DESCRIPTION
I got sign off from Product ([Slack](https://materializeinc.slack.com/archives/C02FWJ94HME/p1699480397235819?thread_ts=1699036729.368979&cid=C02FWJ94HME)) and the LaunchDarkly flag is set to 100%. The last step is to update the docs!

### Motivation

Closes https://github.com/MaterializeInc/materialize/issues/22109

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates our documentation to reflect that `COMMENT ON` is in Public Preview
