### PR TITLE
parallel-workload refinement

### DIFF
--- a/misc/python/materialize/data_ingest/definition.py
+++ b/misc/python/materialize/data_ingest/definition.py
@@ -22,6 +22,7 @@ rng = random.Random()
 class Records(Enum):
     ALL = 0  #  Only applies to DELETE operations
     ONE = 1
+    HUNDRED = 100
     SOME = 1_000
     MANY = 1_000_000
 

--- a/misc/python/materialize/data_ingest/executor.py
+++ b/misc/python/materialize/data_ingest/executor.py
@@ -176,7 +176,6 @@ class KafkaExecutor(Executor):
         )
         for topic, f in fs.items():
             f.result()
-            print(f"Topic {topic} created")
 
         # NOTE: this _could_ be refactored, but since we are fairly certain at
         # this point there will be exactly one topic it should be fine.

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1269,7 +1269,7 @@ class HttpPostAction(Action):
                 return
 
             source = self.rng.choice(exe.db.webhook_sources)
-        url = f"http://{exe.db.host}:{exe.db.ports['http']}/api/webhook/{exe.db}/public/{source}"
+        url = f"http://{exe.db.host}:{exe.db.ports['http']}/api/webhook/{source.schema.db.name()}/{source.schema.name()}/{source.name()}"
 
         payload = source.body_format.to_data_type().random_value(self.rng)
 
@@ -1289,6 +1289,7 @@ class HttpPostAction(Action):
             f"POST Headers: {', '.join(headers_strs)} Body: {payload.encode('utf-8')}"
         )
         try:
+            source.num_rows += 1
             result = requests.post(url, data=payload.encode("utf-8"), headers=headers)
             if result.status_code != 200:
                 raise ValueError(f"POST failed: {result.status_code}, {result.text}")

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -368,11 +368,6 @@ class CommentAction(Action):
         exe.execute(query)
 
 
-class SleepAction(Action):
-    def run(self, exe: Executor) -> None:
-        time.sleep(1)
-
-
 class CreateIndexAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         return [
@@ -1358,7 +1353,6 @@ dml_nontrans_action_list = ActionList(
 
 ddl_action_list = ActionList(
     [
-        (SleepAction, 100),  # DDLs easily starve Mz, don't run them too often
         (CreateIndexAction, 2),
         (DropIndexAction, 1),
         (CreateTableAction, 2),
@@ -1397,3 +1391,11 @@ ddl_action_list = ActionList(
     ],
     autocommit=True,
 )
+
+action_lists = [
+    read_action_list,
+    fetch_action_list,
+    write_action_list,
+    dml_nontrans_action_list,
+    ddl_action_list,
+]

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -55,6 +55,7 @@ class Executor:
     def commit(self) -> None:
         self.insert_table = None
         try:
+            self.log("commit")
             self.cur._c.commit()
         except Exception as e:
             raise QueryError(str(e), "commit")
@@ -62,6 +63,7 @@ class Executor:
     def rollback(self) -> None:
         self.insert_table = None
         try:
+            self.log("rollback")
             self.cur._c.rollback()
         except Exception as e:
             raise QueryError(str(e), "rollback")

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -26,7 +26,7 @@ class Worker:
     actions: list[Action]
     weights: list[float]
     end_time: float
-    num_queries: int
+    num_queries: Counter[type[Action]]
     autocommit: bool
     system: bool
     exe: Executor | None
@@ -47,7 +47,7 @@ class Worker:
         self.actions = actions
         self.weights = weights
         self.end_time = end_time
-        self.num_queries = 0
+        self.num_queries = Counter()
         self.autocommit = autocommit
         self.system = system
         self.ignored_errors = defaultdict(Counter)
@@ -67,7 +67,7 @@ class Worker:
 
         while time.time() < self.end_time:
             action = self.rng.choices(self.actions, self.weights)[0]
-            self.num_queries += 1
+            self.num_queries[type(action)] += 1
             try:
                 if self.exe.rollback_next:
                     try:

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -91,6 +91,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         Scenario(args.scenario),
         args.threads,
         args.naughty_identifiers,
+        args.fast_startup,
         c,
     )
     # TODO: Only ignore errors that will be handled by parallel-workload, not others


### PR DESCRIPTION
Noticed problems with webhook sources and tables being mostly empty, fixed those issues and did some work to make it easier to find such issues in the future.

Hopefully gets parallel-workload green again after yesterday's webhook change.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
