### PR TITLE
output consistency: fixes and further ignores

### DIFF
--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -46,7 +46,7 @@ def matches_fun_by_name(
 
 
 def matches_fun_by_any_name(
-    expression: Expression, function_names_in_lower_case: list[str]
+    expression: Expression, function_names_in_lower_case: set[str]
 ) -> bool:
     for function_name in function_names_in_lower_case:
         if matches_fun_by_name(expression, function_name):

--- a/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/expression_matchers.py
@@ -63,6 +63,14 @@ def matches_op_by_pattern(expression: Expression, pattern: str) -> bool:
     return False
 
 
+def matches_op_by_any_pattern(expression: Expression, patterns: set[str]) -> bool:
+    for pattern in patterns:
+        if matches_op_by_pattern(expression, pattern):
+            return True
+
+    return False
+
+
 def matches_expression_with_only_plain_arguments(expression: Expression) -> bool:
     if isinstance(expression, ExpressionWithArgs):
         for arg in expression.args:

--- a/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
+++ b/misc/python/materialize/output_consistency/ignore_filter/inconsistency_ignore_filter.py
@@ -257,7 +257,7 @@ class PostExecutionInconsistencyIgnoreFilter(
     def _uses_eager_evaluation(self, query_template: QueryTemplate) -> bool:
         # note that these functions do not necessarily require an aggregation
 
-        functions_with_eager_evaluation = ["coalesce"]
+        functions_with_eager_evaluation = {"coalesce"}
 
         return query_template.matches_any_expression(
             partial(

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -82,4 +82,6 @@ class PostgresResultComparator(ResultComparator):
             value1 = last_second_and_milliseconds_pattern.sub("0", value1)
             value2 = last_second_and_milliseconds_pattern.sub("0", value2)
 
+        assert self.is_timestamp(value1)
+        assert self.is_timestamp(value2)
         return value1 == value2

--- a/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
+++ b/misc/python/materialize/postgres_consistency/validation/pg_result_comparator.py
@@ -79,7 +79,7 @@ class PostgresResultComparator(ResultComparator):
 
         if milliseconds_pattern.search(value1) and milliseconds_pattern.search(value2):
             # drop milliseconds and trunc last digit of second
-            value1 = milliseconds_pattern.sub(value1, "0")
-            value2 = milliseconds_pattern.sub(value2, "0")
+            value1 = last_second_and_milliseconds_pattern.sub("0", value1)
+            value2 = last_second_and_milliseconds_pattern.sub("0", value2)
 
         return value1 == value2

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -6,11 +6,15 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
+from functools import partial
 
 from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
+)
+from materialize.output_consistency.ignore_filter.expression_matchers import (
+    matches_fun_by_any_name,
+    matches_op_by_any_pattern,
 )
 from materialize.output_consistency.ignore_filter.ignore_verdict import YesIgnore
 from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter import (
@@ -24,12 +28,19 @@ from materialize.output_consistency.validation.validation_message import (
 )
 from materialize.util import MzVersion
 
+MZ_VERSION_0_77_0 = MzVersion.parse_mz("v0.77.0")
+
 
 class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
     def __init__(self, mz1_version: str, mz2_version: str):
         super().__init__()
         self.mz1_version = MzVersion.parse_mz(mz1_version, drop_dev_suffix=True)
         self.mz2_version = MzVersion.parse_mz(mz2_version, drop_dev_suffix=True)
+        self.lower_version, self.higher_version = (
+            (self.mz1_version, self.mz2_version)
+            if self.mz1_version < self.mz2_version
+            else (self.mz2_version, self.mz1_version)
+        )
 
     def shall_ignore_expression(
         self, expression: Expression, row_selection: DataRowSelection
@@ -39,6 +50,27 @@ class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
 
         if not self._contains_only_available_operations(expression, self.mz2_version):
             return YesIgnore(f"Feature is not available in {self.mz2_version}")
+
+        if self.lower_version < MZ_VERSION_0_77_0 <= self.higher_version:
+            if expression.matches(
+                partial(
+                    matches_fun_by_any_name,
+                    function_names_in_lower_case={
+                        "date_trunc",
+                        "date_part",
+                        "timezone",
+                        "try_parse_monotonic_iso8601_timestamp",
+                    },
+                ),
+                True,
+            ) or expression.matches(
+                partial(
+                    matches_op_by_any_pattern,
+                    patterns={"EXTRACT($ FROM $)", "$ AT TIME ZONE $::TEXT"},
+                ),
+                True,
+            ):
+                return YesIgnore("Fixed issue regarding time zone handling")
 
         return NoIgnore()
 


### PR DESCRIPTION
I hope this will turn the output consistency checks green and keeps them that way for some time...

This
* adds ignores in the version-consistency check to account for the fix conducted in https://github.com/MaterializeInc/materialize/pull/22944
* fixes the timestamp precision reduction
* ensures that the timestamp precision also gets reduced at the last second digit if not milliseconds are present

I will trigger a [nightly build](https://buildkite.com/materialize/nightlies/builds/5077) but we can unfortunately not appropriately test the version-consistency ignores because the check will be run against the merge base in this pull request (unlike in a nightly on main).