### PR TITLE
zippy: Add balancerd as a first-class citizen

### DIFF
--- a/misc/python/materialize/zippy/balancerd_capabilities.py
+++ b/misc/python/materialize/zippy/balancerd_capabilities.py
@@ -1,0 +1,14 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.zippy.framework import Capability
+
+
+class BalancerdIsRunning(Capability):
+    pass

--- a/misc/python/materialize/zippy/debezium_actions.py
+++ b/misc/python/materialize/zippy/debezium_actions.py
@@ -12,6 +12,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.debezium_capabilities import (
     DebeziumRunning,
     DebeziumSourceExists,
@@ -53,7 +54,13 @@ class CreateDebeziumSource(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, StoragedRunning, KafkaRunning, PostgresTableExists}
+        return {
+            BalancerdIsRunning,
+            MzIsRunning,
+            StoragedRunning,
+            KafkaRunning,
+            PostgresTableExists,
+        }
 
     def __init__(self, capabilities: Capabilities) -> None:
         # To avoid conflicts, we make sure the postgres table and the debezium source have matching names

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -106,6 +106,11 @@ class Action:
         """Compute the capability classes that this action requires."""
         return set()
 
+    @classmethod
+    def incompatible_with(cls) -> set[type[Capability]]:
+        """The capability classes that this action is not compatible with."""
+        return set()
+
     def withholds(self) -> set[type[Capability]]:
         """Compute the capability classes that this action will make unavailable."""
         return set()
@@ -136,6 +141,11 @@ class ActionFactory:
     @classmethod
     def requires(cls) -> set[type[Capability]] | list[set[type[Capability]]]:
         """Compute the capability classes that this Action Factory requires."""
+        return set()
+
+    @classmethod
+    def incompatible_with(cls) -> set[type[Capability]]:
+        """The capability classes that this action is not compatible with."""
         return set()
 
 
@@ -234,8 +244,13 @@ class Test:
         return random.choices(actions_or_factories, weights=class_weights, k=1)[0]
 
     def _can_run(self, action: ActionOrFactory) -> bool:
-        requires = action.requires()
+        if any(
+            self._capabilities.provides(dislike)
+            for dislike in action.incompatible_with()
+        ):
+            return False
 
+        requires = action.requires()
         if isinstance(requires, set):
             return all(self._capabilities.provides(req) for req in requires)
         else:

--- a/misc/python/materialize/zippy/peek_actions.py
+++ b/misc/python/materialize/zippy/peek_actions.py
@@ -10,6 +10,7 @@
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 
@@ -19,7 +20,7 @@ class PeekCancellation(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning}
+        return {BalancerdIsRunning, MzIsRunning}
 
     def run(self, c: Composition) -> None:
         c.testdrive(

--- a/misc/python/materialize/zippy/pg_cdc_actions.py
+++ b/misc/python/materialize/zippy/pg_cdc_actions.py
@@ -12,6 +12,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.pg_cdc_capabilities import PostgresCdcTableExists
@@ -25,7 +26,13 @@ class CreatePostgresCdcTable(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, StoragedRunning, PostgresRunning, PostgresTableExists}
+        return {
+            BalancerdIsRunning,
+            MzIsRunning,
+            StoragedRunning,
+            PostgresRunning,
+            PostgresTableExists,
+        }
 
     def __init__(self, capabilities: Capabilities) -> None:
         postgres_table = random.choice(capabilities.get(PostgresTableExists))

--- a/misc/python/materialize/zippy/postgres_actions.py
+++ b/misc/python/materialize/zippy/postgres_actions.py
@@ -11,6 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.postgres_capabilities import PostgresRunning, PostgresTableExists
@@ -53,7 +54,7 @@ class CreatePostgresTable(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, PostgresRunning}
+        return {BalancerdIsRunning, MzIsRunning, PostgresRunning}
 
     def __init__(self, capabilities: Capabilities) -> None:
         this_postgres_table = PostgresTableExists(
@@ -106,7 +107,7 @@ class PostgresDML(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, PostgresRunning, PostgresTableExists}
+        return {BalancerdIsRunning, MzIsRunning, PostgresRunning, PostgresTableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.postgres_table = random.choice(capabilities.get(PostgresTableExists))

--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -8,6 +8,11 @@
 # by the Apache License, Version 2.0.
 
 
+from materialize.zippy.balancerd_actions import (
+    BalancerdRestart,
+    BalancerdStart,
+    BalancerdStop,
+)
 from materialize.zippy.crdb_actions import CockroachRestart, CockroachStart
 from materialize.zippy.debezium_actions import CreateDebeziumSource, DebeziumStart
 from materialize.zippy.framework import ActionOrFactory, Scenario
@@ -49,6 +54,7 @@ DEFAULT_BOOTSTRAP: list[ActionOrFactory] = [
     MinioStart,
     MzStart,
     StoragedStart,
+    BalancerdStart,
 ]
 
 
@@ -83,8 +89,11 @@ class UserTables(Scenario):
 
     def config(self) -> dict[ActionOrFactory, float]:
         return {
-            MzStart: 1,
-            MzStop: 15,
+            MzStart: 5,
+            BalancerdStart: 1,
+            MzStop: 10,
+            BalancerdStop: 1,
+            BalancerdRestart: 1,
             KillClusterd: 10,
             StoragedRestart: 5,
             CreateTableParameterized(): 10,

--- a/misc/python/materialize/zippy/sink_actions.py
+++ b/misc/python/materialize/zippy/sink_actions.py
@@ -11,6 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.replica_capabilities import source_capable_clusters
@@ -24,7 +25,7 @@ class CreateSinkParameterized(ActionFactory):
 
     @classmethod
     def requires(cls) -> list[set[type[Capability]]]:
-        return [{MzIsRunning, StoragedRunning, ViewExists}]
+        return [{BalancerdIsRunning, MzIsRunning, StoragedRunning, ViewExists}]
 
     def __init__(self, max_sinks: int = 10) -> None:
         self.max_sinks = max_sinks

--- a/misc/python/materialize/zippy/source_actions.py
+++ b/misc/python/materialize/zippy/source_actions.py
@@ -11,6 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.kafka_capabilities import KafkaRunning, TopicExists
 from materialize.zippy.mz_capabilities import MzIsRunning
@@ -24,7 +25,13 @@ class CreateSourceParameterized(ActionFactory):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, StoragedRunning, KafkaRunning, TopicExists}
+        return {
+            BalancerdIsRunning,
+            MzIsRunning,
+            StoragedRunning,
+            KafkaRunning,
+            TopicExists,
+        }
 
     def __init__(self, max_sources: int = 10) -> None:
         self.max_sources = max_sources

--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -11,6 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
 from materialize.zippy.table_capabilities import TableExists
@@ -27,7 +28,7 @@ class CreateTableParameterized(ActionFactory):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning}
+        return {BalancerdIsRunning, MzIsRunning}
 
     def new(self, capabilities: Capabilities) -> list[Action]:
         new_table_name = capabilities.get_free_capability_name(
@@ -51,6 +52,10 @@ class CreateTableParameterized(ActionFactory):
 
 class CreateTable(Action):
     """Creates a table on the Mz instance. 50% of the tables have a default index."""
+
+    @classmethod
+    def requires(cls) -> set[type[Capability]]:
+        return {BalancerdIsRunning, MzIsRunning}
 
     def __init__(self, table: TableExists, capabilities: Capabilities) -> None:
         assert (
@@ -84,7 +89,7 @@ class ValidateTable(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, TableExists}
+        return {BalancerdIsRunning, MzIsRunning, TableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.table = random.choice(capabilities.get(TableExists))
@@ -122,7 +127,7 @@ class DML(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, TableExists}
+        return {BalancerdIsRunning, MzIsRunning, TableExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.table = random.choice(capabilities.get(TableExists))

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -11,6 +11,7 @@ import random
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
+from materialize.zippy.balancerd_capabilities import BalancerdIsRunning
 from materialize.zippy.debezium_capabilities import DebeziumSourceExists
 from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
 from materialize.zippy.mz_capabilities import MzIsRunning
@@ -27,10 +28,10 @@ class CreateViewParameterized(ActionFactory):
     @classmethod
     def requires(cls) -> list[set[type[Capability]]]:
         return [
-            {MzIsRunning, SourceExists},
-            {MzIsRunning, TableExists},
-            {MzIsRunning, DebeziumSourceExists},
-            {MzIsRunning, PostgresCdcTableExists},
+            {BalancerdIsRunning, MzIsRunning, SourceExists},
+            {BalancerdIsRunning, MzIsRunning, TableExists},
+            {BalancerdIsRunning, MzIsRunning, DebeziumSourceExists},
+            {BalancerdIsRunning, MzIsRunning, PostgresCdcTableExists},
         ]
 
     def __init__(
@@ -126,7 +127,7 @@ class ValidateView(Action):
 
     @classmethod
     def requires(cls) -> set[type[Capability]]:
-        return {MzIsRunning, StoragedRunning, ViewExists}
+        return {BalancerdIsRunning, MzIsRunning, StoragedRunning, ViewExists}
 
     def __init__(self, capabilities: Capabilities) -> None:
         self.view = random.choice(capabilities.get(ViewExists))

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -13,6 +13,7 @@ from datetime import timedelta
 from enum import Enum
 
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
+from materialize.mzcompose.services.balancerd import Balancerd
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.debezium import Debezium
@@ -36,6 +37,7 @@ SERVICES = [
     Postgres(),
     Cockroach(),
     Minio(setup_materialize=True),
+    Balancerd(),
     # Those two are overriden below
     Materialized(),
     Clusterd(name="storaged"),
@@ -141,6 +143,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             setup_materialize=True,
         ),
         Testdrive(
+            materialize_url="postgres://materialize@balancerd:6875",
             no_reset=True,
             seed=1,
             default_timeout="600s",


### PR DESCRIPTION
- Add balancerd as an entity in Zippy that can be started, killed and restarted
- Direct all testdrive traffic in Zippy through balancerd
- Add balancerd restarts to the UserTables scenario, as it has the largest ammount of SQL traffic going through
- enable actions in Zippy to define what capabilities they dislike. This way, we do not attempt to start a service that is already running.
- Make sure materialized will be restarted soon after any kill.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Balancerd needs to be exercised, especially in the ReleaseQualification tests

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
