### PR TITLE
version consistency: catch all date-time operations

### DIFF
--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -8,7 +8,11 @@
 # by the Apache License, Version 2.0.
 from functools import partial
 
-from materialize.output_consistency.expression.expression import Expression
+from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
+from materialize.output_consistency.expression.expression import (
+    Expression,
+    LeafExpression,
+)
 from materialize.output_consistency.expression.expression_with_args import (
     ExpressionWithArgs,
 )
@@ -21,6 +25,13 @@ from materialize.output_consistency.ignore_filter.inconsistency_ignore_filter im
     IgnoreVerdict,
     InconsistencyIgnoreFilter,
     NoIgnore,
+)
+from materialize.output_consistency.input_data.operations.date_time_operations_provider import (
+    DATE_TIME_OPERATION_TYPES,
+)
+from materialize.output_consistency.operation.operation import (
+    DbFunction,
+    DbOperation,
 )
 from materialize.output_consistency.selection.selection import DataRowSelection
 from materialize.output_consistency.validation.validation_message import (
@@ -51,26 +62,11 @@ class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
         if not self._contains_only_available_operations(expression, self.mz2_version):
             return YesIgnore(f"Feature is not available in {self.mz2_version}")
 
-        if self.lower_version < MZ_VERSION_0_77_0 <= self.higher_version:
-            if expression.matches(
-                partial(
-                    matches_fun_by_any_name,
-                    function_names_in_lower_case={
-                        "date_trunc",
-                        "date_part",
-                        "timezone",
-                        "try_parse_monotonic_iso8601_timestamp",
-                    },
-                ),
-                True,
-            ) or expression.matches(
-                partial(
-                    matches_op_by_any_pattern,
-                    patterns={"EXTRACT($ FROM $)", "$ AT TIME ZONE $::TEXT"},
-                ),
-                True,
-            ):
-                return YesIgnore("Fixed issue regarding time zone handling")
+        if (
+            self.lower_version < MZ_VERSION_0_77_0 <= self.higher_version
+            and self._is_any_date_time_expression(expression)
+        ):
+            return YesIgnore("Fixed issue regarding time zone handling")
 
         return NoIgnore()
 
@@ -92,3 +88,39 @@ class VersionConsistencyIgnoreFilter(InconsistencyIgnoreFilter):
             return feature_version > mz_version
 
         return not expression.matches(is_newer_operation, True)
+
+    def _is_any_date_time_expression(self, expression: Expression) -> bool:
+        all_date_time_function_names = {
+            function.function_name_in_lower_case
+            for function in DATE_TIME_OPERATION_TYPES
+            if isinstance(function, DbFunction)
+        }
+        all_date_time_operation_patterns = {
+            operation.pattern
+            for operation in DATE_TIME_OPERATION_TYPES
+            if isinstance(operation, DbOperation)
+        }
+
+        def is_date_time_leaf_expression(expression: Expression) -> bool:
+            return (
+                isinstance(expression, LeafExpression)
+                and expression.data_type.category == DataTypeCategory.DATE_TIME
+            )
+
+        return (
+            expression.matches(is_date_time_leaf_expression, True)
+            or expression.matches(
+                partial(
+                    matches_fun_by_any_name,
+                    function_names_in_lower_case=all_date_time_function_names,
+                ),
+                True,
+            )
+            or expression.matches(
+                partial(
+                    matches_op_by_any_pattern,
+                    patterns=all_date_time_operation_patterns,
+                ),
+                True,
+            )
+        )


### PR DESCRIPTION
Some stuff still slipped through: https://buildkite.com/materialize/nightlies/builds/5089#018bb445-b5fe-42c2-a931-b951f3937238 😢 