### PR TITLE
compute-types: teach is_single_time about max as_of

### DIFF
--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -345,6 +345,10 @@ impl GlobalMirPlan<Unresolved> {
         // Use the the opportunity to name an `until` frontier that will prevent
         // work we needn't perform. By default, `until` will be
         // `Antichain::new()`, which prevents no updates and is safe.
+        //
+        // If `timestamp_ctx.antichain()` is empty, `timestamp_ctx.timestamp()`
+        // will return `None` and we use the default (empty) `until`. Otherwise,
+        // we expect to be able to set `until = as_of + 1` without an overflow.
         if let Some(as_of) = timestamp_ctx.timestamp() {
             if let Some(until) = as_of.checked_add(1) {
                 self.df_desc.until = Antichain::from_elem(until);

--- a/src/compute-types/src/dataflows.rs
+++ b/src/compute-types/src/dataflows.rs
@@ -14,6 +14,7 @@ use std::fmt;
 use std::time::Duration;
 
 use mz_expr::{CollectionPlan, MirRelationExpr, MirScalarExpr, OptimizedMirRelationExpr};
+use mz_ore::soft_assert_or_log;
 use mz_proto::{IntoRustIfSome, ProtoMapEntry, ProtoType, RustType, TryFromProtoError};
 use mz_repr::{GlobalId, RelationType};
 use mz_storage_types::controller::CollectionMetadata;
@@ -67,19 +68,35 @@ pub struct DataflowDescription<P, S: 'static = (), T = mz_repr::Timestamp> {
 impl<T> DataflowDescription<Plan<T>, (), mz_repr::Timestamp> {
     /// Tests if the dataflow refers to a single timestamp, namely
     /// that `as_of` has a single coordinate and that the `until`
-    /// value corresponds to the `as_of` value plus one.
+    /// value corresponds to the `as_of` value plus one, or `as_of`
+    /// is the maximum timestamp and is thus single.
     pub fn is_single_time(&self) -> bool {
         // TODO: this would be much easier to check if `until` was a strict lower bound,
         // and we would be testing that `until == as_of`.
+
+        let until = &self.until;
+
+        // IF `as_of` is not set at all this can't be a single time dataflow.
         let Some(as_of) = self.as_of.as_ref() else {
             return false;
         };
-        !as_of.is_empty()
-            && as_of
-                .as_option()
-                .and_then(|as_of| as_of.checked_add(1))
-                .as_ref()
-                == self.until.as_option()
+        // Ensure that as_of <= until.
+        soft_assert_or_log!(
+            timely::PartialOrder::less_equal(as_of, until),
+            "expected empty `as_of ≤ until`, got `{as_of:?} ≰ {until:?}`",
+        );
+        // IF `as_of` is not a single timestamp this can't be a single time dataflow.
+        let Some(as_of) = as_of.as_option() else {
+            return false;
+        };
+        // Ensure that `as_of = MAX` implies `until.is_empty()`.
+        soft_assert_or_log!(
+            as_of != &mz_repr::Timestamp::MAX || until.is_empty(),
+            "expected `until = {{}}` due to `as_of = MAX`, got `until = {until:?}`",
+        );
+        // Note that the `(as_of = MAX, until = {})` case also returns `true`
+        // here (as expected) since we are going to compare two `None` values.
+        as_of.try_step_forward().as_ref() == until.as_option()
     }
 }
 

--- a/src/repr/src/timestamp.rs
+++ b/src/repr/src/timestamp.rs
@@ -49,6 +49,13 @@ pub trait TimestampManipulation:
     /// Advance a timestamp forward by the given `amount`. Panic if unable to do so.
     fn step_forward_by(&self, amount: &Self) -> Self;
 
+    /// Advance a timestamp forward by the given `amount`. Return `None` if unable to do so.
+    fn try_step_forward_by(&self, amount: &Self) -> Option<Self>;
+
+    /// Advance a timestamp by the least amount possible such that `ts.less_than(ts.step_forward())`
+    /// is true. Return `None` if unable to do so.
+    fn try_step_forward(&self) -> Option<Self>;
+
     /// Retreat a timestamp by the least amount possible such that
     /// `ts.step_back().unwrap().less_than(ts)` is true. Return `None` if unable,
     /// which must only happen if the timestamp is `Timestamp::minimum()`.
@@ -65,6 +72,14 @@ impl TimestampManipulation for Timestamp {
 
     fn step_forward_by(&self, amount: &Self) -> Self {
         self.step_forward_by(amount)
+    }
+
+    fn try_step_forward(&self) -> Option<Self> {
+        self.try_step_forward()
+    }
+
+    fn try_step_forward_by(&self, amount: &Self) -> Option<Self> {
+        self.try_step_forward_by(amount)
     }
 
     fn step_back(&self) -> Option<Self> {
@@ -147,6 +162,17 @@ impl Timestamp {
             Some(ts) => ts,
             None => panic!("could not step {self} forward by {amount}"),
         }
+    }
+
+    /// Advance a timestamp by the least amount possible such that `ts.less_than(ts.step_forward())`
+    /// is true. Return `None` if unable to do so.
+    pub fn try_step_forward(&self) -> Option<Self> {
+        self.checked_add(1)
+    }
+
+    /// Advance a timestamp forward by the given `amount`. Return `None` if unable to do so.
+    pub fn try_step_forward_by(&self, amount: &Self) -> Option<Self> {
+        self.checked_add(*amount)
     }
 
     /// Retreat a timestamp by the least amount possible such that


### PR DESCRIPTION
If as_of is the max timestamp, the dataflow cannot contain other timestamps, so avoid the `until - as_of = 1` check. This will result in more optimizations being applied to constant (no timestamp) queries.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a