### PR TITLE
storage: avoid rendering sources with empty as_of's

### DIFF
--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -782,8 +782,14 @@ impl<'w, A: Allocate> Worker<'w, A> {
                     }
                 }
 
-                // If all subsources of the source are finished, we can skip rendering.
-                if resume_uppers.values().all(|frontier| frontier.is_empty()) {
+                // If all subsources of the source are finished, we can skip rendering entirely.
+                // Also, if `as_of` is empty, the dataflow has been finalized, so we can skip it as
+                // well.
+                //
+                // TODO(guswynn|petrosagg): this is a bit hacky, and is a consequence of storage state
+                // management being a bit of a mess. we should clean this up and remove weird if
+                // statements like this.
+                if resume_uppers.values().all(|frontier| frontier.is_empty()) || as_of.is_empty() {
                     return;
                 }
 


### PR DESCRIPTION
We believe this fixes https://github.com/MaterializeInc/materialize/issues/20320. The original bug appears to be a race condition when a source is created and dropped quickly, but other conditions might trigger it


### Motivation


  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
