### PR TITLE
adapter: remove noisy warn for as_of and untils

### DIFF
--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -24,7 +24,7 @@ use mz_transform::normalize_lets::normalize_lets;
 use mz_transform::typecheck::{empty_context, SharedContext as TypecheckContext};
 use mz_transform::{Optimizer as TransformOptimizer, StatisticsOracle};
 use timely::progress::Antichain;
-use tracing::{span, warn, Level};
+use tracing::{span, Level};
 
 use crate::catalog::Catalog;
 use crate::coord::dataflows::{
@@ -347,8 +347,6 @@ impl GlobalMirPlan<Unresolved> {
         if let Some(as_of) = as_of.as_option() {
             if let Some(until) = as_of.checked_add(1) {
                 self.df_desc.until = Antichain::from_elem(until);
-            } else {
-                warn!(as_of = %as_of, "as_of + 1 overflow");
             }
         }
 


### PR DESCRIPTION
This is an alternate solution than the one in #23051.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a