### PR TITLE
storage: do not add subsources to dropped IDs set

### DIFF
--- a/test/testdrive/github-23037.td
+++ b/test/testdrive/github-23037.td
@@ -1,0 +1,46 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+> CREATE SOURCE auction_house
+  IN CLUSTER default
+  FROM LOAD GENERATOR AUCTION
+  (TICK INTERVAL '0.01s')
+  FOR ALL TABLES
+
+> CREATE VIEW winning_bids AS
+  SELECT DISTINCT ON (auctions.id) bids.*, auctions.item, auctions.seller
+  FROM auctions, bids
+  WHERE auctions.id = bids.auction_id
+    AND bids.bid_time < auctions.end_time
+    AND mz_now() >= auctions.end_time
+  ORDER BY auctions.id,
+    bids.bid_time DESC,
+    bids.amount,
+    bids.buyer
+
+> CREATE INDEX wins_by_item ON winning_bids (item)
+> CREATE INDEX wins_by_bidder ON winning_bids (buyer)
+> CREATE INDEX wins_by_seller ON winning_bids (seller)
+
+> CREATE VIEW fraud_activity AS
+  SELECT w2.seller,
+         w2.item AS seller_item,
+         w2.amount AS seller_amount,
+         w1.item buyer_item,
+         w1.amount buyer_amount
+  FROM winning_bids w1,
+       winning_bids w2
+  WHERE w1.buyer = w2.seller
+    AND w2.amount > w1.amount
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+DROP DATABASE materialize
+
+$ postgres-execute connection=postgres://mz_system@${testdrive.materialize-internal-sql-addr}/materialize
+CREATE DATABASE materialize


### PR DESCRIPTION
Reverting part of #22705 -- however, this leaves in a "leak" of sorts where we leave subsource IDs in the set of source uppers/reported frontiers, though they're never meaningfully used. Additionally, this also means that we do not successfully/completely drop subsources until MZ restarts.

I propose merging this PR despite those shortcomings to fix #23037, and then take on a refactor of subsource frontier reporting/state management as a follow-on refactor.

### Motivation

Fixes #23037

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
