### PR TITLE
sql-pretty: fix and improve DISTINCT

### DIFF
--- a/src/sql-parser/tests/testdata/select
+++ b/src/sql-parser/tests/testdata/select
@@ -1595,3 +1595,10 @@ select 2 OPERATOR(*) 2 + 2
 SELECT 2 OPERATOR(*) 2 + 2
 =>
 Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Op { op: Op { namespace: Some([]), op: "*" }, expr1: Value(Number("2")), expr2: Some(Op { op: Op { namespace: None, op: "+" }, expr1: Value(Number("2")), expr2: Some(Value(Number("2"))) }) }, alias: None }], from: [], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })
+
+parse-statement
+select count(distinct s) from y
+----
+SELECT count(DISTINCT s) FROM y
+=>
+Select(SelectStatement { query: Query { ctes: Simple([]), body: Select(Select { distinct: None, projection: [Expr { expr: Function(Function { name: Name(UnresolvedItemName([Ident("count")])), args: Args { args: [Identifier([Ident("s")])], order_by: [] }, filter: None, over: None, distinct: true }), alias: None }], from: [TableWithJoins { relation: Table { name: Name(UnresolvedItemName([Ident("y")])), alias: None }, joins: [] }], selection: None, group_by: [], having: None, options: [] }), order_by: [], limit: None, offset: None }, as_of: None })

--- a/src/sql-pretty/src/util.rs
+++ b/src/sql-pretty/src/util.rs
@@ -35,8 +35,15 @@ where
     if v.is_empty() {
         title
     } else {
-        nest(title, comma_separate(f, v))
+        nest_comma_separate(title, f, v)
     }
+}
+
+pub(crate) fn nest_comma_separate<'a, F, T>(title: RcDoc<'a, ()>, f: F, v: &'a [T]) -> RcDoc<'a, ()>
+where
+    F: Fn(&'a T) -> RcDoc<'a, ()>,
+{
+    nest(title, comma_separate(f, v))
 }
 
 pub(crate) fn comma_separate<'a, F, T>(f: F, v: &'a [T]) -> RcDoc<'a, ()>


### PR DESCRIPTION
This was broken in functions due to no testing in the parser. While here improve DISTINCT in SELECT as well.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/pull/22386#issuecomment-1804400891

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a