### PR TITLE
storage: fix small persist descriptions in storage persist_sink

### DIFF
--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -454,7 +454,7 @@ where
                     Diagnostics {
                         shard_name: collection_id.to_string(),
                         handle_purpose: format!(
-                            "compute::persist_sink::mint_batch_descriptions {}",
+                            "storage::persist_sink::mint_batch_descriptions {}",
                             collection_id
                         ),
                     },
@@ -618,7 +618,7 @@ where
                 Arc::new(UnitSchema),
                 Diagnostics {
                     shard_name: collection_id.to_string(),
-                    handle_purpose: format!("compute::persist_sink::write_batches {}", collection_id),
+                    handle_purpose: format!("storage::persist_sink::write_batches {}", collection_id),
                 },
             )
             .await


### PR DESCRIPTION
oopsie

### Motivation
   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
