### PR TITLE
feature-benchmark: Use all_subclasses

### DIFF
--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -54,6 +54,7 @@ from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
+from materialize.util import all_subclasses
 from materialize.version_list import VersionsFromDocs
 
 #
@@ -355,19 +356,12 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     # Build the list of scenarios to run
     root_scenario = globals()[args.root_scenario]
-    initial_scenarios = {}
+    scenarios = []
 
     if root_scenario.__subclasses__():
-        for scenario in root_scenario.__subclasses__():
-            has_children = False
-            for s in scenario.__subclasses__():
-                has_children = True
-                initial_scenarios[s] = 1
-
-            if not has_children:
-                initial_scenarios[scenario] = 1
+        scenarios = [s for s in all_subclasses(root_scenario) if not s.__subclasses__()]
     else:
-        initial_scenarios[root_scenario] = 1
+        scenarios = [root_scenario]
 
     dependencies = ["postgres"]
 
@@ -378,31 +372,31 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     c.up(*dependencies)
 
-    scenarios = initial_scenarios.copy()
-
     for cycle in range(0, args.max_retries):
         print(
-            f"Cycle {cycle+1} with scenarios: {', '.join([scenario.__name__ for scenario in scenarios.keys()])}"
+            f"Cycle {cycle+1} with scenarios: {', '.join([scenario.__name__ for scenario in scenarios])}"
         )
 
         report = Report()
 
-        for scenario in list(scenarios.keys()):
+        scenarios_with_regressions = []
+        for scenario in scenarios:
             comparators = run_one_scenario(c, scenario, args)
             report.extend(comparators)
 
             # Do not retry the scenario if no regressions
-            if all([not c.is_regression() for c in comparators]):
-                del scenarios[scenario]
+            if any([c.is_regression() for c in comparators]):
+                scenarios_with_regressions.append(scenario)
 
             print(f"+++ Benchmark Report for cycle {cycle+1}:")
             report.dump()
 
-        if len(scenarios.keys()) == 0:
+        scenarios = scenarios_with_regressions
+        if not scenarios:
             break
 
-    if len(scenarios.keys()) > 0:
+    if scenarios:
         print(
-            f"ERROR: The following scenarios have regressions: {', '.join([scenario.__name__ for scenario in scenarios.keys()])}"
+            f"ERROR: The following scenarios have regressions: {', '.join([scenario.__name__ for scenario in scenarios])}"
         )
         sys.exit(1)

--- a/test/feature-benchmark/scenarios.py
+++ b/test/feature-benchmark/scenarios.py
@@ -1484,7 +1484,7 @@ ALTER SYSTEM SET max_tables = {self.n() * 2};
         ]
 
 
-class HydrateIndex(ScenarioBig):
+class HydrateIndex(Scenario):
     """Measure the time it takes for an index to hydrate when a cluster comes online."""
 
     def init(self) -> list[Action]:


### PR DESCRIPTION
This was currently not missing any tests but it could have if someone created a deeper nesting of subclasses.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
