### PR TITLE
adapter: avoid more tracing ref panics in explain codepaths

### DIFF
--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -3434,6 +3434,7 @@ impl Coordinator {
                     &source_ids,
                     None, // no real-time recency
                 )
+                .with_subscriber(root_dispatch.clone())
                 .await?
                 .timestamp_context;
 

--- a/src/adapter/src/coord/sequencer/old_optimizer_api.rs
+++ b/src/adapter/src/coord/sequencer/old_optimizer_api.rs
@@ -1024,6 +1024,7 @@ impl Coordinator {
                 &source_ids,
                 None, // no real-time recency
             )
+            .with_subscriber(root_dispatch.clone())
             .await?
             .timestamp_context;
 


### PR DESCRIPTION
I cant find where these `.await` points were added (these were refactored and move multiple times recently, but any use of tokio sync objects can cause this issue

@aljoscha @aalexandrov do you know if these calls to `sequence_peek_timestamp` were originally added long enough ago that its in this weeks release? if so this needs to be backported

### Motivation


  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
