### PR TITLE
ci: Make error detection in logs faster

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -22,29 +22,10 @@ from materialize import ci_util, spawn, ui
 
 CI_RE = re.compile("ci-regexp: (.*)")
 CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
+
+# Unexpected failures, report them
 ERROR_RE = re.compile(
     r"""
-    # This block contains expected failures, don't report them
-    ^((?!.*
-    # Expected in restart test
-    ( restart-materialized-1\ \ \|\ thread\ 'coordinator'\ panicked\ at\ 'can't\ persist\ timestamp
-    # Expected in cluster test
-    | cluster-clusterd[12]-1\ .*\ halting\ process:\ new\ timely\ configuration\ does\ not\ match\ existing\ timely\ configuration
-    # Emitted by tests employing explicit mz_panic()
-    | forced\ panic
-    # Expected once compute cluster has panicked, brings no new information
-    | timely\ communication\ error:
-    # Expected once compute cluster has panicked, only happens in CI
-    | aborting\ because\ propagate_crashes\ is\ enabled
-    # Expected when CRDB is corrupted
-    | restart-materialized-1\ .*relation\ \\"fence\\"\ does\ not\ exist
-    # Expected when CRDB is corrupted
-    | restart-materialized-1\ .*relation\ "consensus"\ does\ not\ exist
-    # Will print a separate panic line which will be handled and contains the relevant information
-    | internal\ error:\ panic\ at\ the\ `.*`\ optimization\ stage
-    ))
-    .)*
-    # This block contains unexpected failures, report them
     ( panicked\ at
     | segfault\ at
     | trap\ invalid\ opcode
@@ -73,6 +54,30 @@ ERROR_RE = re.compile(
     | error:\ Found\ argument\ '.*'\ which\ wasn't\ expected,\ or\ isn't\ valid\ in\ this\ context
     | unrecognized\ configuration\ parameter
     | Coordinator is stuck
+    )
+    """,
+    re.VERBOSE,
+)
+
+# Expected failures, don't report them
+IGNORE_RE = re.compile(
+    r"""
+    # Expected in restart test
+    ( restart-materialized-1\ \ \|\ thread\ 'coordinator'\ panicked\ at\ 'can't\ persist\ timestamp
+    # Expected in cluster test
+    | cluster-clusterd[12]-1\ .*\ halting\ process:\ new\ timely\ configuration\ does\ not\ match\ existing\ timely\ configuration
+    # Emitted by tests employing explicit mz_panic()
+    | forced\ panic
+    # Expected once compute cluster has panicked, brings no new information
+    | timely\ communication\ error:
+    # Expected once compute cluster has panicked, only happens in CI
+    | aborting\ because\ propagate_crashes\ is\ enabled
+    # Expected when CRDB is corrupted
+    | restart-materialized-1\ .*relation\ \\"fence\\"\ does\ not\ exist
+    # Expected when CRDB is corrupted
+    | restart-materialized-1\ .*relation\ "consensus"\ does\ not\ exist
+    # Will print a separate panic line which will be handled and contains the relevant information
+    | internal\ error:\ panic\ at\ the\ `.*`\ optimization\ stage
     )
     """,
     re.VERBOSE,
@@ -229,8 +234,7 @@ def get_error_logs(log_files: list[str]) -> list[ErrorLog]:
     for log_file in log_files:
         with open(log_file) as f:
             for line_nr, line in enumerate(f):
-                match = ERROR_RE.search(line)
-                if match:
+                if ERROR_RE.search(line) and not IGNORE_RE.search(line):
                     # environmentd segfaults during normal shutdown in coverage builds, see #20016
                     # Ignoring this in regular ways would still be quite spammy.
                     if (


### PR DESCRIPTION
The regex with includes could take multiple minutes, on the same sample it runs in 1 s now. Seen in https://buildkite.com/materialize/nightlies/builds/5111#018bb6a3-a076-4891-8b47-8ab602e952d6

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
