### PR TITLE
ci: Enable parallelism in nightly testdrive

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -103,6 +103,7 @@ steps:
       - id: redpanda-testdrive
         label: ":panda_face: :racing_car: testdrive"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -115,6 +116,7 @@ steps:
       - id: redpanda-testdrive-aarch64
         label: ":panda_face: :racing_car: testdrive aarch64"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-aarch64
         artifact_paths: junit_*.xml
@@ -128,6 +130,7 @@ steps:
       - id: testdrive-partitions-5
         label: ":racing_car: testdrive with --kafka-default-partitions 5"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -140,6 +143,7 @@ steps:
       - id: testdrive-replicas-4
         label: ":racing_car: testdrive 4 replicas"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -152,6 +156,7 @@ steps:
       - id: testdrive-size-1
         label: ":racing_car: testdrive with SIZE 1"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -164,6 +169,7 @@ steps:
       - id: testdrive-size-8
         label: ":racing_car: testdrive with SIZE 8"
         timeout_in_minutes: 600
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml
@@ -187,6 +193,7 @@ steps:
       - id: persistence-testdrive
         label: ":racing_car: testdrive with --persistent-user-tables"
         timeout_in_minutes: 30
+        parallelism: 2
         agents:
           queue: linux-x86_64
         artifact_paths: junit_*.xml


### PR DESCRIPTION
Might be a workaround for the currently hanging testdrive runs in nightly (which I will still investigate)

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
