### PR TITLE
docs: Update EXPLAIN plans and other minor fixes/updates

### DIFF
--- a/doc/user/content/sql/explain-plan.md
+++ b/doc/user/content/sql/explain-plan.md
@@ -171,7 +171,7 @@ With
   cte l0 =
     Project (#0, #1)
       Filter (#0 > #2)
-        Get materialize.public.t
+        ReadStorage materialize.public.t
 ```
 
 Many operators need to refer to columns in their input. These are displayed like
@@ -185,15 +185,15 @@ about the implementation in the `Join` operator can be requested with [the `join
 ```text
 Join on=(#1 = #2 AND #3 = #4) type=delta
   implementation
-    %0:t » %1:u[#0]KA » %2:v[#0]KA
-    %1:u » %0:t[#1]KA » %2:v[#0]KA
-    %2:v » %1:u[#1]KA » %0:t[#1]KA
+    %0:t » %1:u[#0]K » %2:v[#0]K
+    %1:u » %0:t[#1]K » %2:v[#0]K
+    %2:v » %1:u[#1]K » %0:t[#1]K
   ArrangeBy keys=[[#1]]
-    Get materialize.public.t
+    ReadStorage materialize.public.t
   ArrangeBy keys=[[#0], [#1]]
-    Get materialize.public.u
+    ReadStorage materialize.public.u
   ArrangeBy keys=[[#0]]
-    Get materialize.public.v
+    ReadStorage materialize.public.v
 ```
 The `%0`, `%1`, etc. refer to each of the join inputs.
 A *differential* join shows one join path, which is simply a sequence of binary
@@ -219,8 +219,8 @@ that implements the rest of the plan.
 ```
 Finish order_by=[#1 asc nulls_last, #0 desc nulls_first] limit=5 output=[#0, #1]
   CrossJoin
-    Get materialize.public.r
-    Get materialize.public.s
+    ReadStorage materialize.public.r
+    ReadStorage materialize.public.s
 ```
 
 Below the plan, a "Used indexes" section indicates which indexes will be used by the query, [and in what way](/transform-data/optimization/#use-explain-to-verify-index-usage).

--- a/doc/user/content/sql/explain-timestamp.md
+++ b/doc/user/content/sql/explain-timestamp.md
@@ -6,7 +6,7 @@ menu:
     parent: commands
 ---
 
-`EXPLAIN TIMESTAMP` displays the timestamps used for a `SELECT` statement -- valuable information to acknowledge query delays.
+`EXPLAIN TIMESTAMP` displays the timestamps used for a `SELECT` statement -- valuable information to investigate query delays.
 
 {{< warning >}}
 `EXPLAIN` is not part of Materialize's stable interface and is not subject to
@@ -63,8 +63,8 @@ A timeline value of `None` means the query is known to be constant across all ti
 Every source has a beginning _read frontier_ and an ending _write frontier_.
 They stand for a source’s limits to return a correct result immediately:
 
-* Read frontier: Indicates the minimum logical timestamp to return a correct result (known as _compaction_)
-* Write frontier: Indicates the maximum timestamp to build a correct result without waiting unprocessed data.
+* Read frontier: Indicates the minimum logical timestamp to return a correct result (advanced by _compaction_)
+* Write frontier: Indicates the maximum timestamp to build a correct result without waiting for unprocessed data.
 
 Each source has its own output section consisting of the following fields:
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -72,7 +72,7 @@ sampling rate than the one set in this variable.
 | `prepared_statement_name` | [`text`]                     | The name given by the client library to the prepared statement.                                                                                                                                                                                                               |
 | `session_id`              | [`uuid`]                     | An ID that is unique for each session.                                                                                                                                                                                                                                        |
 | `redacted_sql`            | [`text`]                     | The SQL text of the statement, in a normalized form, with all string and numeric literals hidden.                                                                                                                                                                             |
-| `prepared_at`             | [`timestamp with time zone`] | The time at which the statement was prepared                                                                                                                                                                                                                                  |
+| `prepared_at`             | [`timestamp with time zone`] | The time at which the statement was prepared.                                                                                                                                                                                                                                 |
 
 ### `mz_cluster_replica_frontiers`
 
@@ -379,7 +379,7 @@ referenced from
 | `id`                 | [`uuid`]                     | The globally unique ID of this history entry. Does **not** correspond to [`mz_sessions.id`](#mz_sessions), which can be recycled. |
 | `connected_at`       | [`timestamp with time zone`] | The time at which the session was established.                                                                                    |
 | `application_name`   | [`text`]                     | The `application_name` session metadata field.                                                                                    |
-| `authenticated_user` | [`text`]                     | The name of the user for wish the session was established.                                                                        |
+| `authenticated_user` | [`text`]                     | The name of the user for which the session was established.                                                                       |
 -->
 
 ### `mz_sessions`


### PR DESCRIPTION
`EXPLAIN` output have been changing a bit, but we (mostly me) forgot to update some doc pages.

Also, various minor text fixes.

Also note that `EXPLAIN VIEW` is not supported anymore. This is because it was not clear whether we want to explain it as an ad-hoc query, or as a standing query (which apply different optimizations), and it often did the opposite of what people expected. Now you can instead EXPLAIN the `SELECT *` from the view, or `EXPLAIN CREATE INDEX` on the view, etc.

### Motivation

Minor doc fixes.

### Tips for reviewer

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
