### PR TITLE
scalability framework: remove scatterplot variant for duration

### DIFF
--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -59,46 +59,6 @@ def scatterplot_tps_per_connections(
     plot.legend(legend)
 
 
-def scatterplot_duration_per_connections(
-    workload_name: str,
-    figure: SubFigure,
-    df_details_by_endpoint_name: dict[str, DfDetails],
-    baseline_version_name: str | None,
-    include_zero_in_y_axis: bool,
-    include_workload_in_title: bool = False,
-) -> None:
-    legend = []
-    plot: Axes = figure.subplots(1, 1)
-
-    i = 0
-    for endpoint_version_name, df_details in df_details_by_endpoint_name.items():
-        endpoint_offset = i / 40.0
-        legend.append(endpoint_name_to_description(endpoint_version_name))
-
-        plot.scatter(
-            [
-                concurrency + endpoint_offset
-                for concurrency in df_details.get_concurrency_values()
-            ],
-            df_details.get_wallclock_values(),
-            alpha=0.25,
-            marker=_get_plot_marker(endpoint_version_name, baseline_version_name),
-        )
-
-        i = i + 1
-
-    plot.set_ylabel("Duration in Seconds")
-    plot.set_xlabel("Concurrent SQL Connections")
-
-    if include_zero_in_y_axis:
-        plot.set_ylim(ymin=0)
-
-    if include_workload_in_title:
-        plot.set_title(workload_name)
-
-    plot.legend(legend)
-
-
 def boxplot_duration_by_connections_for_workload(
     workload_name: str,
     figure: SubFigure,

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -18,11 +18,8 @@ from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
     boxplot_duration_by_connections_for_workload,
     boxplot_duration_by_endpoints_for_workload,
-    scatterplot_duration_per_connections,
     scatterplot_tps_per_connections,
 )
-
-USE_BOXPLOT = True
 
 
 def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
@@ -45,27 +42,18 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
         include_zero_in_y_axis=include_zero_in_y_axis,
     )
 
-    if USE_BOXPLOT:
-        boxplot_duration_by_connections_for_workload(
-            workload_name,
-            duration_per_connections_figure,
-            df_details_by_endpoint_name,
-            include_zero_in_y_axis=include_zero_in_y_axis,
-        )
-        boxplot_duration_by_endpoints_for_workload(
-            workload_name,
-            duration_per_endpoints_figure,
-            df_details_by_endpoint_name,
-            include_zero_in_y_axis=include_zero_in_y_axis,
-        )
-    else:
-        scatterplot_duration_per_connections(
-            workload_name,
-            duration_per_connections_figure,
-            df_details_by_endpoint_name,
-            baseline_version_name=None,
-            include_zero_in_y_axis=include_zero_in_y_axis,
-        )
+    boxplot_duration_by_connections_for_workload(
+        workload_name,
+        duration_per_connections_figure,
+        df_details_by_endpoint_name,
+        include_zero_in_y_axis=include_zero_in_y_axis,
+    )
+    boxplot_duration_by_endpoints_for_workload(
+        workload_name,
+        duration_per_endpoints_figure,
+        df_details_by_endpoint_name,
+        include_zero_in_y_axis=include_zero_in_y_axis,
+    )
 
 
 def load_data_from_filesystem(


### PR DESCRIPTION
This removes the scatterplot for duration values, which was available as an option but not used lately. I believe that the boxplot and violin plot ([next PR](https://github.com/MaterializeInc/materialize/pull/23098)) clearly outperform it.