### PR TITLE
scalability framework: introduce violin plots

### DIFF
--- a/misc/python/materialize/scalability/df/df_wrapper_base.py
+++ b/misc/python/materialize/scalability/df/df_wrapper_base.py
@@ -23,6 +23,9 @@ class DfWrapperBase:
     def length(self) -> int:
         return len(self.data.index)
 
+    def has_values(self) -> bool:
+        return self.length() > 0
+
     def to_csv(self, file_path: Path) -> None:
         self.data.to_csv(file_path)
 

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -11,6 +11,7 @@
 import math
 from typing import Any
 
+import numpy as np
 from matplotlib.axes import Axes
 from matplotlib.figure import SubFigure
 from matplotlib.markers import MarkerStyle
@@ -21,6 +22,11 @@ from materialize.scalability.endpoints import endpoint_name_to_description
 
 PLOT_MARKER_POINT = MarkerStyle("o")
 PLOT_MARKER_SQUARE = MarkerStyle(",")
+PLOT_MARKER_HLINE = MarkerStyle("_")
+
+PLOT_COLOR_DARK_BLUE = "darkblue"
+
+USE_VIOLINPLOT_INSTEAD_OF_BOXPLOT = True
 
 
 def plot_tps_per_connections(
@@ -234,7 +240,41 @@ def _get_subplot_in_grid(
 
 
 def _plot_distribution(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
-    _plot_boxplot(plot, data, labels)
+    if USE_VIOLINPLOT_INSTEAD_OF_BOXPLOT:
+        _plot_violinplot(plot, data, labels)
+    else:
+        _plot_boxplot(plot, data, labels)
+
+
+def _plot_violinplot(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
+    xpos = np.arange(1, len(data) + 1)
+
+    plot.violinplot(data)
+    plot.set_xticks(xpos, labels=labels)
+
+    for i, data_col in enumerate(data):
+        quartile1, medians, quartile3 = np.percentile(
+            data[i],
+            [25, 50, 75],
+        )
+        # plot median line
+        plot.scatter(
+            xpos[i],
+            medians,
+            marker=PLOT_MARKER_HLINE,
+            color=PLOT_COLOR_DARK_BLUE,
+            s=300,
+        )
+        # plot 25% - 75% area
+        plot.vlines(
+            xpos[i],
+            quartile1,
+            quartile3,
+            color=PLOT_COLOR_DARK_BLUE,
+            linestyle="-",
+            lw=5,
+        )
+
 
 def _plot_boxplot(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
     plot.boxplot(data, labels=labels)

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -107,7 +107,7 @@ def plot_duration_by_connections_for_workload(
             )
             legend.append(formatted_endpoint_name)
 
-        plot.boxplot(durations, labels=legend)
+        _plot_distribution(plot, data=durations, labels=legend)
 
         if is_in_first_column:
             plot.set_ylabel("Duration (seconds)")
@@ -160,7 +160,7 @@ def plot_duration_by_endpoints_for_workload(
 
             legend.append(concurrency)
 
-        plot.boxplot(durations, labels=legend)
+        _plot_distribution(plot, data=durations, labels=legend)
 
         if is_in_first_column and is_in_last_row:
             plot.set_ylabel("Duration (seconds)")
@@ -231,3 +231,10 @@ def _get_subplot_in_grid(
     assert type(plot) == Axes
 
     return plot, is_in_first_column, is_in_last_row
+
+
+def _plot_distribution(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
+    _plot_boxplot(plot, data, labels)
+
+def _plot_boxplot(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
+    plot.boxplot(data, labels=labels)

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -6,9 +6,8 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
-
 import math
+from enum import Enum
 from typing import Any
 
 import numpy as np
@@ -26,7 +25,13 @@ PLOT_MARKER_HLINE = MarkerStyle("_")
 
 PLOT_COLOR_DARK_BLUE = "darkblue"
 
-USE_VIOLINPLOT_INSTEAD_OF_BOXPLOT = True
+
+class DistributionPlotType(Enum):
+    VIOLIN = 1
+    BOX = 2
+
+
+DEFAULT_DISTRIBUTION_PLOT_TYPE = DistributionPlotType.VIOLIN
 
 
 def plot_tps_per_connections(
@@ -72,6 +77,7 @@ def plot_duration_by_connections_for_workload(
     df_details_by_endpoint_name: dict[str, DfDetails],
     include_zero_in_y_axis: bool,
     include_workload_in_title: bool = False,
+    plot_type: DistributionPlotType = DEFAULT_DISTRIBUTION_PLOT_TYPE,
 ) -> None:
     """This uses a boxplot or violin plot for the distribution of the duration."""
     if len(df_details_by_endpoint_name) == 0:
@@ -113,7 +119,7 @@ def plot_duration_by_connections_for_workload(
             )
             legend.append(formatted_endpoint_name)
 
-        _plot_distribution(plot, data=durations, labels=legend)
+        _plot_distribution(plot, data=durations, labels=legend, plot_type=plot_type)
 
         if is_in_first_column:
             plot.set_ylabel("Duration (seconds)")
@@ -133,6 +139,7 @@ def plot_duration_by_endpoints_for_workload(
     df_details_by_endpoint_name: dict[str, DfDetails],
     include_zero_in_y_axis: bool,
     include_workload_in_title: bool = False,
+    plot_type: DistributionPlotType = DEFAULT_DISTRIBUTION_PLOT_TYPE,
 ) -> None:
     """This uses a boxplot or violin plot for the distribution of the duration."""
 
@@ -166,7 +173,7 @@ def plot_duration_by_endpoints_for_workload(
 
             legend.append(concurrency)
 
-        _plot_distribution(plot, data=durations, labels=legend)
+        _plot_distribution(plot, data=durations, labels=legend, plot_type=plot_type)
 
         if is_in_first_column and is_in_last_row:
             plot.set_ylabel("Duration (seconds)")
@@ -239,11 +246,18 @@ def _get_subplot_in_grid(
     return plot, is_in_first_column, is_in_last_row
 
 
-def _plot_distribution(plot: Axes, data: list[list[float]], labels: list[str]) -> None:
-    if USE_VIOLINPLOT_INSTEAD_OF_BOXPLOT:
+def _plot_distribution(
+    plot: Axes,
+    data: list[list[float]],
+    labels: list[str],
+    plot_type: DistributionPlotType,
+) -> None:
+    if plot_type == DistributionPlotType.VIOLIN:
         _plot_violinplot(plot, data, labels)
-    else:
+    elif plot_type == DistributionPlotType.BOX:
         _plot_boxplot(plot, data, labels)
+    else:
+        raise RuntimeError(f"Unexpected plot type: {plot_type}")
 
 
 def _plot_violinplot(plot: Axes, data: list[list[float]], labels: list[str]) -> None:

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -23,7 +23,7 @@ PLOT_MARKER_POINT = MarkerStyle("o")
 PLOT_MARKER_SQUARE = MarkerStyle(",")
 
 
-def scatterplot_tps_per_connections(
+def plot_tps_per_connections(
     workload_name: str,
     figure: SubFigure,
     df_totals_by_endpoint_name: dict[str, DfTotals],
@@ -31,6 +31,7 @@ def scatterplot_tps_per_connections(
     include_zero_in_y_axis: bool,
     include_workload_in_title: bool = False,
 ) -> None:
+    """This uses a scatter plot to plot the TPS per connections."""
     legend = []
     plot: Axes = figure.subplots(1, 1)
     max_concurrency = 1
@@ -59,13 +60,14 @@ def scatterplot_tps_per_connections(
     plot.legend(legend)
 
 
-def boxplot_duration_by_connections_for_workload(
+def plot_duration_by_connections_for_workload(
     workload_name: str,
     figure: SubFigure,
     df_details_by_endpoint_name: dict[str, DfDetails],
     include_zero_in_y_axis: bool,
     include_workload_in_title: bool = False,
 ) -> None:
+    """This uses a boxplot or violin plot for the distribution of the duration."""
     if len(df_details_by_endpoint_name) == 0:
         return
 
@@ -115,13 +117,15 @@ def boxplot_duration_by_connections_for_workload(
         plot.set_title(title)
 
 
-def boxplot_duration_by_endpoints_for_workload(
+def plot_duration_by_endpoints_for_workload(
     workload_name: str,
     figure: SubFigure,
     df_details_by_endpoint_name: dict[str, DfDetails],
     include_zero_in_y_axis: bool,
     include_workload_in_title: bool = False,
 ) -> None:
+    """This uses a boxplot or violin plot for the distribution of the duration."""
+
     if len(df_details_by_endpoint_name) == 0:
         return
 

--- a/misc/python/materialize/scalability/plot/plot.py
+++ b/misc/python/materialize/scalability/plot/plot.py
@@ -91,17 +91,21 @@ def plot_duration_by_connections_for_workload(
         durations: list[list[float]] = []
 
         for endpoint_version_name, df_details in df_details_by_endpoint_name.items():
+            df_details_of_concurrency = df_details.to_filtered_by_concurrency(
+                concurrency
+            )
+
+            if not df_details_of_concurrency.has_values():
+                continue
+
+            durations.append(df_details_of_concurrency.get_wallclock_values())
+
             formatted_endpoint_name = (
                 endpoint_version_name
                 if not use_short_names
                 else _shorten_endpoint_version_name(endpoint_version_name)
             )
             legend.append(formatted_endpoint_name)
-
-            df_details_of_concurrency = df_details.to_filtered_by_concurrency(
-                concurrency
-            )
-            durations.append(df_details_of_concurrency.get_wallclock_values())
 
         plot.boxplot(durations, labels=legend)
 
@@ -145,12 +149,16 @@ def plot_duration_by_endpoints_for_workload(
         durations: list[list[float]] = []
 
         for concurrency in concurrencies:
-            legend.append(concurrency)
-
             df_details_of_concurrency = df_details.to_filtered_by_concurrency(
                 concurrency
             )
+
+            if not df_details_of_concurrency.has_values():
+                continue
+
             durations.append(df_details_of_concurrency.get_wallclock_values())
+
+            legend.append(concurrency)
 
         plot.boxplot(durations, labels=legend)
 

--- a/test/scalability/README.md
+++ b/test/scalability/README.md
@@ -110,8 +110,16 @@ This diagram show the transactions per second per concurrency. Higher values are
 
 ## Duration per transaction
 
-These boxplots show the duration of the individual statements per concurrency. They provide information about the mean
+These plots show the duration of the individual statements per concurrency. They provide information about the mean
 duration of an operation and their timing reliability. Lower values are better.
+Violin plots are used by default, boxplots are available as alternative.
+
+### How to interpret the violin plots
+The violin plots show the distribution of the data.
+The dark blue bar shows the interquartile range, which contains 75% of the measurements.
+The horizontal dark blue line shows the median.
+
+See also: https://en.wikipedia.org/wiki/Violin_plot
 
 ### How to interpret a boxplot
 The most important things in a nutshell:

--- a/test/scalability/lib.py
+++ b/test/scalability/lib.py
@@ -16,9 +16,9 @@ from materialize.scalability.df.df_details import DfDetails
 from materialize.scalability.df.df_totals import DfTotals
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_duration_by_connections_for_workload,
-    boxplot_duration_by_endpoints_for_workload,
-    scatterplot_tps_per_connections,
+    plot_duration_by_connections_for_workload,
+    plot_duration_by_endpoints_for_workload,
+    plot_tps_per_connections,
 )
 
 
@@ -34,7 +34,7 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
         workload_name
     )
 
-    scatterplot_tps_per_connections(
+    plot_tps_per_connections(
         workload_name,
         tps_figure,
         df_totals_by_endpoint_name,
@@ -42,13 +42,13 @@ def plotit(workload_name: str, include_zero_in_y_axis: bool = True) -> None:
         include_zero_in_y_axis=include_zero_in_y_axis,
     )
 
-    boxplot_duration_by_connections_for_workload(
+    plot_duration_by_connections_for_workload(
         workload_name,
         duration_per_connections_figure,
         df_details_by_endpoint_name,
         include_zero_in_y_axis=include_zero_in_y_axis,
     )
-    boxplot_duration_by_endpoints_for_workload(
+    plot_duration_by_endpoints_for_workload(
         workload_name,
         duration_per_endpoints_figure,
         df_details_by_endpoint_name,

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -32,9 +32,9 @@ from materialize.scalability.endpoints import (
 )
 from materialize.scalability.io import paths
 from materialize.scalability.plot.plot import (
-    boxplot_duration_by_connections_for_workload,
-    boxplot_duration_by_endpoints_for_workload,
-    scatterplot_tps_per_connections,
+    plot_duration_by_connections_for_workload,
+    plot_duration_by_endpoints_for_workload,
+    plot_tps_per_connections,
 )
 from materialize.scalability.regression_outcome import RegressionOutcome
 from materialize.scalability.result_analyzer import ResultAnalyzer
@@ -307,7 +307,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
     ) in result.get_df_total_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 6))
         (subfigure) = fig.subfigures(1, 1)
-        scatterplot_tps_per_connections(
+        plot_tps_per_connections(
             workload_name,
             subfigure,
             results_by_endpoint,
@@ -325,7 +325,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
     ) in result.get_df_details_by_workload_and_endpoint().items():
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
-        boxplot_duration_by_connections_for_workload(
+        plot_duration_by_connections_for_workload(
             workload_name,
             subfigure,
             results_by_endpoint,
@@ -340,7 +340,7 @@ def create_plots(result: BenchmarkResult, baseline_endpoint: Endpoint | None) ->
 
         fig = plt.figure(layout="constrained", figsize=(16, 10))
         (subfigure) = fig.subfigures(1, 1)
-        boxplot_duration_by_endpoints_for_workload(
+        plot_duration_by_endpoints_for_workload(
             workload_name,
             subfigure,
             results_by_endpoint,


### PR DESCRIPTION
Introduce violin plots as alternative to boxplots and make them default for distribution plots.
Violin plots perform better in terms of outliers.

Nightly: https://buildkite.com/materialize/nightlies/builds/5119

<img width="1483" alt="Bildschirmfoto 2023-11-10 um 12 33 33" src="https://github.com/MaterializeInc/materialize/assets/129728240/d4f0baf4-df3e-4bad-aee2-eb18b5c22c7d">