### PR TITLE
docstrings: fix "redundant explicit link target"

### DIFF
--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -76,9 +76,9 @@ type IntrospectionUpdates = (IntrospectionType, Vec<(Row, Diff)>);
 /// Responses from the compute controller.
 #[derive(Debug)]
 pub enum ComputeControllerResponse<T> {
-    /// See [`ComputeResponse::PeekResponse`](crate::protocol::response::ComputeResponse::PeekResponse).
+    /// See [`ComputeResponse::PeekResponse`].
     PeekResponse(Uuid, PeekResponse, OpenTelemetryContext),
-    /// See [`ComputeResponse::SubscribeResponse`](crate::protocol::response::ComputeResponse::SubscribeResponse).
+    /// See [`ComputeResponse::SubscribeResponse`].
     SubscribeResponse(GlobalId, SubscribeResponse<T>),
 }
 

--- a/src/ore/src/future.rs
+++ b/src/ore/src/future.rs
@@ -16,7 +16,7 @@
 //! Future and stream utilities.
 //!
 //! This module provides future and stream combinators that are missing from
-//! the [`futures`](futures) crate.
+//! the [`futures`] crate.
 
 use std::any::Any;
 use std::error::Error;

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -22,7 +22,7 @@ pub use crate::relation_and_scalar::{
 };
 use crate::{Datum, ScalarType};
 
-/// The type of a [`Datum`](crate::Datum).
+/// The type of a [`Datum`].
 ///
 /// [`ColumnType`] bundles information about the scalar type of a datum (e.g.,
 /// Int32 or String) with its nullability.

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -15,9 +15,9 @@
 //!
 //! A worker receives _external_ [`StorageCommands`](StorageCommand) from the
 //! storage controller, via a channel. Storage workers also share an _internal_
-//! control/command fabric ([`internal_control`](crate::internal_control)).
-//! Internal commands go through a `Sequencer` dataflow that ensures that all
-//! workers receive all commands in the same consistent order.
+//! control/command fabric ([`internal_control`]). Internal commands go through
+//! a `Sequencer` dataflow that ensures that all workers receive all commands in
+//! the same consistent order.
 //!
 //! We need to make sure that commands that cause dataflows to be rendered are
 //! processed in the same consistent order across all workers because timely


### PR DESCRIPTION
This PR fixes "redundant explicit link target" warnings produced by cargo-doc.

### Motivation

   * This PR refactors docstrings.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  -  N/A
