### PR TITLE
tests: use new user timeline per test and testdrive invocation

### DIFF
--- a/test/testdrive/timelines.td
+++ b/test/testdrive/timelines.td
@@ -27,7 +27,7 @@ $ kafka-create-topic topic=input-system
 > CREATE SOURCE source_system_user
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-system-${testdrive.seed}')
   FORMAT BYTES
-  WITH (TIMELINE 'user')
+  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 $ set schema=[
   {
@@ -140,7 +140,7 @@ contains:unacceptable timeline name "mz_foo"
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-input-cdcv2-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}'
   ENVELOPE MATERIALIZE
-  WITH (TIMELINE 'user')
+  WITH (TIMELINE '${testdrive.seed}-timelines')
 
 > CREATE TABLE input_table (a bigint);
 

--- a/test/testdrive/timestamps-debezium-kafka.td
+++ b/test/testdrive/timestamps-debezium-kafka.td
@@ -103,12 +103,12 @@ $ kafka-ingest format=avro topic=bar schema=${schema}
 > CREATE SOURCE data_foo
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-foo-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
-  WITH (TIMELINE 'user')
+  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE SOURCE data_bar
   FROM KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-bar-${testdrive.seed}')
   FORMAT AVRO USING SCHEMA '${schema}' ENVELOPE MATERIALIZE
-  WITH (TIMELINE 'user')
+  WITH (TIMELINE '${testdrive.seed}-timestamps-debezium-kafka')
 
 > CREATE MATERIALIZED VIEW foo AS SELECT b, sum(a) FROM data_foo GROUP BY b
 


### PR DESCRIPTION
Before, it could happen that tests that thought they had sole control over the read/write timestamp of a timeline would interact at a distance. For example, a test might create a CDCv2 source and advance it's upper to `2`, but another test might already have advanced that shared timeline's read/write timetamp to `3`, meaning queries that are expected to return in the first test would block forever.

User timelines are not available in production, so I'm hesitant to put in more work than this quick fix.

Fixes #23096

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
