### PR TITLE
testdrive: kafka-ingest headers: Support bytes as int arrays

### DIFF
--- a/doc/developer/testdrive.md
+++ b/doc/developer/testdrive.md
@@ -802,7 +802,7 @@ for the specified consumer group, topic, and partition.
 #### `headers=<list or object>`
 
 `headers` is a parameter that takes a json map (or list of maps) with string key-value pairs
-sent as headers for every message for the given action.
+sent as headers for every message for the given action. To represent a value of bytes (instead of string) an int array with each value representing a byte can be passed.
 
 ## Actions on Confluent Schema Registry
 

--- a/src/testdrive/src/action/kafka/ingest.rs
+++ b/src/testdrive/src/action/kafka/ingest.rs
@@ -256,13 +256,22 @@ pub async fn run_ingest(
 
         for headers_map in headers_maps {
             for (k, v) in headers_map.iter() {
-                if let Value::String(val) = v {
-                    headers.push((k.clone(), Some(val.clone())));
-                } else if let Value::Null = v {
-                    headers.push((k.clone(), None));
-                } else {
-                    bail!("`headers` must have string or null values")
-                }
+                headers.push((k.clone(), match v {
+                    Value::String(val) => Some(val.as_bytes().to_vec()),
+                    Value::Array(val) => {
+                        let mut values = Vec::new();
+                        for value in val {
+                            if let Value::Number(int) = value {
+                                values.push(u8::try_from(int.as_i64().unwrap()).unwrap())
+                            } else {
+                                bail!("`headers` value arrays must only contain numbers (to represent bytes)")
+                            }
+                        }
+                        Some(values.clone())
+                    },
+                    Value::Null => None,
+                    _ => bail!("`headers` must have string, int array or null values")
+                }));
             }
         }
         Some(headers)

--- a/test/testdrive/kafka-headers.td
+++ b/test/testdrive/kafka-headers.td
@@ -25,7 +25,8 @@ $ set schema={
 
 $ kafka-create-topic topic=headers_src
 
-$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus": "gusfive", "gus2": "gus3"}
+# [103, 117, 115, 51] = "gus3"
+$ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema} headers={"gus": "gusfive", "gus2": [103, 117, 115, 51]}
 {"key": "fish"} {"f1": "fishval", "f2": 1000}
 
 $ kafka-ingest format=avro topic=headers_src key-format=avro key-schema=${keyschema} schema=${schema}


### PR DESCRIPTION
As suggested in https://materializeinc.slack.com/archives/C01LKF361MZ/p1699625220133889

@sthm Does this work for you?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
