### PR TITLE
storage: change spill2disk db path to <scratch_dir>/storage/upsert/<source_id>/<worker_id> over just <scratch_dir>/<source_id>/<worker_id>

### DIFF
--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -295,6 +295,9 @@ where
     /// serialize and deserialize the keys and values.
     pub async fn new<M, O, IM>(
         instance_path: &Path,
+        // An old path to the db that we should cleanup. Used to migrate paths.
+        // TODO(guswynn): remove this once a release with it goes out.
+        legacy_instance_path: &Path,
         options: InstanceOptions,
         tuning_config: RocksDBConfig,
         shared_metrics: M,
@@ -309,6 +312,7 @@ where
         let dynamic_config = tuning_config.dynamic.clone();
         if options.cleanup_on_new && instance_path.exists() {
             let instance_path_owned = instance_path.to_owned();
+            let legacy_instance_path_owned = legacy_instance_path.to_owned();
             mz_ore::task::spawn_blocking(
                 || {
                     format!(
@@ -324,6 +328,15 @@ where
                             e.display_with_causes(),
                         );
                     }
+                    if let Err(e) =
+                        DB::destroy(&RocksDBOptions::default(), &*legacy_instance_path_owned)
+                    {
+                        tracing::warn!(
+                            "failed to cleanup legacy rocksdb dir on creation {}: {}",
+                            legacy_instance_path_owned.display(),
+                            e.display_with_causes(),
+                        );
+                    }
                 },
             )
             .await?;
@@ -333,12 +346,14 @@ where
         let (tx, rx): (mpsc::Sender<Command<K, V>>, _) = mpsc::channel(10);
 
         let instance_path = instance_path.to_owned();
+        let legacy_instance_path = legacy_instance_path.to_owned();
         let (creation_error_tx, creation_error_rx) = oneshot::channel();
         std::thread::spawn(move || {
             rocksdb_core_loop(
                 options,
                 tuning_config,
                 instance_path,
+                legacy_instance_path,
                 rx,
                 shared_metrics,
                 instance_metrics,
@@ -528,6 +543,7 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
     options: InstanceOptions,
     tuning_config: RocksDBConfig,
     instance_path: PathBuf,
+    legacy_instance_path: PathBuf,
     mut cmd_rx: mpsc::Receiver<Command<K, V>>,
     shared_metrics: M,
     instance_metrics: IM,
@@ -786,6 +802,13 @@ fn rocksdb_core_loop<K, V, M, O, IM>(
         tracing::warn!(
             "failed to cleanup rocksdb dir at {}: {}",
             instance_path.display(),
+            e.display_with_causes(),
+        );
+    }
+    if let Err(e) = DB::destroy(&RocksDBOptions::default(), &*legacy_instance_path) {
+        tracing::warn!(
+            "failed to cleanup legacy rocksdb dir at {}: {}",
+            legacy_instance_path.display(),
             e.display_with_causes(),
         );
     }

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -117,6 +117,7 @@ async fn basic() -> Result<(), anyhow::Error> {
 
     let mut instance = RocksDBInstance::<String, String>::new(
         t.path(),
+        t.path(),
         InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
         RocksDBConfig::new(Default::default(), None),
         shared_metrics_for_tests()?,
@@ -208,6 +209,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
 
     let instance1 = RocksDBInstance::<String, String>::new(
         t.path().join("1").as_path(),
+        t.path().join("1").as_path(),
         InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
         rocksdb_config.clone(),
         shared_metrics_for_tests()?,
@@ -229,6 +231,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
     rocksdb_config.apply(tuning_parameters);
 
     let instance2 = RocksDBInstance::<String, String>::new(
+        t.path().join("2").as_path(),
         t.path().join("2").as_path(),
         InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
         rocksdb_config.clone(),
@@ -254,6 +257,7 @@ async fn shared_write_buffer_manager() -> Result<(), anyhow::Error> {
     assert!(shared_write_buffer_manager.get().is_none());
 
     let instance3 = RocksDBInstance::<String, String>::new(
+        t.path().join("3").as_path(),
         t.path().join("3").as_path(),
         InstanceOptions::defaults_with_env(rocksdb::Env::new()?),
         rocksdb_config,

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -234,6 +234,11 @@ where
         let rocksdb_shared_metrics = Arc::clone(&upsert_metrics.rocksdb_shared);
         let rocksdb_instance_metrics = Arc::clone(&upsert_metrics.rocksdb_instance_metrics);
         let rocksdb_dir = scratch_directory
+            .join("storage")
+            .join("upsert")
+            .join(source_config.id.to_string())
+            .join(source_config.worker_id.to_string());
+        let legacy_rocksdb_dir = scratch_directory
             .join(source_config.id.to_string())
             .join(source_config.worker_id.to_string());
 
@@ -254,6 +259,7 @@ where
                     AutoSpillBackend::new(
                         RocksDBParams {
                             instance_path: rocksdb_dir,
+                            legacy_instance_path: legacy_rocksdb_dir,
                             env,
                             tuning_config: tuning,
                             shared_metrics: rocksdb_shared_metrics,
@@ -278,6 +284,7 @@ where
                     rocksdb::RocksDB::new(
                         mz_rocksdb::RocksDBInstance::new(
                             &rocksdb_dir,
+                            &legacy_rocksdb_dir,
                             mz_rocksdb::InstanceOptions::defaults_with_env(env),
                             tuning,
                             rocksdb_shared_metrics,

--- a/src/storage/src/render/upsert/types.rs
+++ b/src/storage/src/render/upsert/types.rs
@@ -533,6 +533,7 @@ pub enum BackendType {
 /// Params required to create rocksdb instance
 pub(crate) struct RocksDBParams {
     pub(crate) instance_path: PathBuf,
+    pub(crate) legacy_instance_path: PathBuf,
     pub(crate) env: rocksdb::Env,
     pub(crate) tuning_config: RocksDBConfig,
     pub(crate) shared_metrics: Arc<mz_rocksdb::RocksDBSharedMetrics>,
@@ -565,6 +566,7 @@ impl AutoSpillBackend {
     async fn init_rocksdb(rocksdb_params: &RocksDBParams) -> RocksDB {
         let RocksDBParams {
             instance_path,
+            legacy_instance_path,
             env,
             tuning_config,
             shared_metrics,
@@ -575,6 +577,7 @@ impl AutoSpillBackend {
         RocksDB::new(
             mz_rocksdb::RocksDBInstance::new(
                 instance_path,
+                legacy_instance_path,
                 mz_rocksdb::InstanceOptions::defaults_with_env(env.clone()),
                 tuning_config.clone(),
                 Arc::clone(shared_metrics),

--- a/test/cloudtest/test_disk.py
+++ b/test/cloudtest/test_disk.py
@@ -75,6 +75,6 @@ def test_disk_replica(mz: MaterializeApplication) -> None:
         "--",
         "bash",
         "-c",
-        "ls /scratch",
+        "ls /scratch/storage/upsert",
     )
     assert source_global_id in on_disk_sources

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -361,7 +361,11 @@ def workflow_rocksdb_cleanup(c: Composition) -> None:
         )[0]
         prefix = "/scratch"
         cluster_prefix = f"cluster-{cluster_id}-replica-{replica_id}"
-        return f"{prefix}/{cluster_prefix}", f"{prefix}/{cluster_prefix}/{source_id}"
+        postfix = "storage/upsert"
+        return (
+            f"{prefix}/{cluster_prefix}/{postfix}",
+            f"{prefix}/{cluster_prefix}/{postfix}/{source_id}",
+        )
 
     # Returns the number of files recursive in a given directory
     def num_files(dir: str) -> int:


### PR DESCRIPTION
I noticed in https://github.com/MaterializeInc/materialize/pull/22723 that we shouldn't be using the top-level scratch dir for storage/upsert without namespacing

Note that the migration code is not strictly necessary, as we never preserve pods while upgrading them, but i added it just in case.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
