### PR TITLE
*: get clippy passing on 1.73

### DIFF
--- a/src/mz/src/server.rs
+++ b/src/mz/src/server.rs
@@ -62,10 +62,10 @@ async fn request(
 
     let client_id = client_id.parse::<Uuid>();
     let secret = secret.parse::<Uuid>();
-    if client_id.is_ok() && secret.is_ok() {
+    if let (Ok(client_id), Ok(secret)) = (client_id, secret) {
         let app_password = AppPassword {
-            client_id: client_id.unwrap(),
-            secret_key: secret.unwrap(),
+            client_id,
+            secret_key: secret,
         };
         tx.send(Ok(app_password))
             .unwrap_or_else(|_| panic!("Error handling login details."));

--- a/src/ssh-util/src/keys.rs
+++ b/src/ssh-util/src/keys.rs
@@ -87,9 +87,7 @@ impl Eq for SshKeyPair {}
 
 impl PartialOrd for SshKeyPair {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.key_pair
-            .fingerprint(HashAlg::default())
-            .partial_cmp(&other.key_pair.fingerprint(HashAlg::default()))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/storage-controller/src/persist_handles.rs
+++ b/src/storage-controller/src/persist_handles.rs
@@ -12,6 +12,7 @@
 
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fmt::Debug;
+use std::fmt::Write;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
@@ -628,11 +629,13 @@ impl<T: Timestamp + Lattice + Codec64 + TimestampManipulation> TxnsTableWorker<T
                 .iter()
                 .map(|(x, _)| x.to_string())
                 .collect::<BTreeSet<_>>(),
-            updates
-                .iter()
-                .filter(|(_, v)| !v.is_empty())
-                .map(|(k, v)| format!("\n  {}: {:?}", k, v.first()))
-                .collect::<String>(),
+            updates.iter().filter(|(_, v)| !v.is_empty()).fold(
+                String::new(),
+                |mut output, (k, v)| {
+                    let _ = write!(output, "\n  {}: {:?}", k, v.first());
+                    output
+                }
+            )
         );
         // TODO: persist-txn doesn't take an advance_to yet, it uses
         // timestamp.step_forward. This is the same in all cases, so just assert that


### PR DESCRIPTION
`clippy::incorrect_partial_ord_impl_on_ord_type` found a real fragile piece of code in `mz-ssh-util`, but was quite annoying to work around in `mz-expr`

`clippy::format_collect` was pretty annoying in `mz-storage-controller`, we may consider just allowing that one

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
