### PR TITLE
storage-types: trait-ify AlterCompatible

### DIFF
--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -331,8 +331,7 @@ impl ShouldHalt for StorageError {
             | StorageError::ExportInstanceMissing { .. }
             | StorageError::Generic(_)
             | StorageError::DataflowError(_)
-            | StorageError::InvalidAlterSource { .. }
-            | StorageError::IncompatibleSinkDescriptions { .. }
+            | StorageError::InvalidAlter { .. }
             | StorageError::ShuttingDown(_) => false,
             StorageError::IOError(e) => e.is_unrecoverable(),
         }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -135,6 +135,7 @@ use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::parameters::StorageParameters;
 use mz_storage_types::sinks::{ProtoDurableExportMetadata, SinkAsOf, StorageSinkDesc};
 use mz_storage_types::sources::{IngestionDescription, SourceData, SourceExport};
+use mz_storage_types::AlterCompatible;
 use proptest::prelude::{any, Arbitrary, BoxedStrategy, Strategy};
 use prost::Message;
 use serde::{Deserialize, Serialize};
@@ -3001,7 +3002,7 @@ where
                     "{id:?} inalterable because its data source is {:?} and not an ingestion",
                     o
                 );
-                return Err(StorageError::InvalidAlterSource { id });
+                return Err(StorageError::InvalidAlter { id });
             }
         };
 
@@ -3013,7 +3014,7 @@ where
                     prev_storage_dependencies,
                     new_storage_dependencies
                 );
-            return Err(StorageError::InvalidAlterSource { id });
+            return Err(StorageError::InvalidAlter { id });
         }
 
         Ok(())

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -85,3 +85,23 @@ pub mod parameters;
 pub mod shim;
 pub mod sinks;
 pub mod sources;
+
+/// Explicitly states the contract between storage and higher levels of
+/// Materialize w/r/t which facets of objects managed by storage (e.g. sources,
+/// sinks, connections) may be altered.
+///
+/// n.b. when implementing this trait, leave a warning log with more details as
+/// to what the problem was, given that the returned error is scant on details.
+pub trait AlterCompatible: std::fmt::Debug + PartialEq {
+    fn alter_compatible(
+        &self,
+        id: mz_repr::GlobalId,
+        other: &Self,
+    ) -> Result<(), controller::StorageError> {
+        if self == other {
+            Ok(())
+        } else {
+            Err(controller::StorageError::InvalidAlter { id })
+        }
+    }
+}

--- a/src/storage-types/src/sinks.rs
+++ b/src/storage-types/src/sinks.rs
@@ -46,7 +46,7 @@ pub struct StorageSinkDesc<S: StorageSinkDescFillState, T = mz_repr::Timestamp> 
 }
 
 impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + PartialOrder>
-    StorageSinkDesc<S, T>
+    crate::AlterCompatible for StorageSinkDesc<S, T>
 {
     /// Determines if `self` is compatible with another `StorageSinkDesc`, in
     /// such a way that it is possible to turn `self` into `other` through a
@@ -55,7 +55,7 @@ impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + Par
     /// Currently, the only "valid transformation" is the passage of time such
     /// that the sink's as ofs may differ. However, this will change once we
     /// support `ALTER CONNECTION` or `ALTER SINK`.
-    pub fn alter_compatible(
+    fn alter_compatible(
         &self,
         id: GlobalId,
         other: &StorageSinkDesc<S, T>,
@@ -86,15 +86,15 @@ impl<S: Debug + StorageSinkDescFillState + PartialEq, T: Debug + PartialEq + Par
             ),
         ];
 
-        for (compatible, desc) in compatibility_checks {
+        for (compatible, field) in compatibility_checks {
             if !compatible {
                 tracing::warn!(
-                    "StorageSinkDesc incompatible at {desc}:\nself:\n{:#?}\n\nother\n{:#?}",
+                    "StorageSinkDesc incompatible at {field}:\nself:\n{:#?}\n\nother\n{:#?}",
                     self,
                     other
                 );
 
-                return Err(StorageError::IncompatibleSinkDescriptions { id });
+                return Err(StorageError::InvalidAlter { id });
             }
         }
 

--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -58,6 +58,7 @@ use crate::instances::StorageInstanceId;
 use crate::sources::encoding::{DataEncoding, DataEncodingInner, SourceDataEncoding};
 use crate::sources::proto_ingestion_description::{ProtoSourceExport, ProtoSourceImport};
 use crate::sources::proto_load_generator_source_connection::Generator as ProtoGenerator;
+use crate::AlterCompatible;
 
 pub mod encoding;
 
@@ -107,12 +108,10 @@ impl<S> IngestionDescription<S> {
     }
 }
 
-impl<S: Debug + Eq + PartialEq> IngestionDescription<S> {
-    /// Determines if `self` is compatible with another `IngestionDescription`,
-    /// in such a way that it is possible to turn `self` into `other` through a
-    /// valid series of transformations (e.g. no transformation or `ALTER
-    /// SOURCE`).
-    pub fn alter_compatible(
+impl<S: Debug + Eq + PartialEq + crate::AlterCompatible> AlterCompatible
+    for IngestionDescription<S>
+{
+    fn alter_compatible(
         &self,
         id: GlobalId,
         other: &IngestionDescription<S>,
@@ -132,48 +131,59 @@ impl<S: Debug + Eq + PartialEq> IngestionDescription<S> {
         self.desc.alter_compatible(id, desc)?;
 
         let compatibility_checks = [
-            source_imports == &other.source_imports,
-            ingestion_metadata == &other.ingestion_metadata,
-            source_exports
-                .iter()
-                .merge_join_by(&other.source_exports, |(l_key, _), (r_key, _)| {
-                    l_key.cmp(r_key)
-                })
-                .all(|r| match r {
-                    Both(
-                        (
-                            _,
-                            SourceExport {
-                                output_index: _,
-                                storage_metadata: l_metadata,
-                            },
-                        ),
-                        (
-                            _,
-                            SourceExport {
-                                output_index: _,
-                                storage_metadata: r_metadata,
-                            },
-                        ),
-                    ) => {
-                        // the output index may change, but the table's metadata
-                        // may not
-                        l_metadata == r_metadata
-                    }
-                    _ => true,
-                }),
-            instance_id == &other.instance_id,
-            remap_collection_id == &other.remap_collection_id,
+            (source_imports == &other.source_imports, "source_imports"),
+            (
+                ingestion_metadata
+                    .alter_compatible(id, &other.ingestion_metadata)
+                    .is_ok(),
+                "ingestion_metadata",
+            ),
+            (
+                source_exports
+                    .iter()
+                    .merge_join_by(&other.source_exports, |(l_key, _), (r_key, _)| {
+                        l_key.cmp(r_key)
+                    })
+                    .all(|r| match r {
+                        Both(
+                            (
+                                _,
+                                SourceExport {
+                                    output_index: _,
+                                    storage_metadata: l_metadata,
+                                },
+                            ),
+                            (
+                                _,
+                                SourceExport {
+                                    output_index: _,
+                                    storage_metadata: r_metadata,
+                                },
+                            ),
+                        ) => {
+                            // the output index may change, but the table's metadata
+                            // may not
+                            l_metadata == r_metadata
+                        }
+                        _ => true,
+                    }),
+                "source_exports",
+            ),
+            (instance_id == &other.instance_id, "instance_id"),
+            (
+                remap_collection_id == &other.remap_collection_id,
+                "remap_collection_id",
+            ),
         ];
-        for compatible in compatibility_checks {
+        for (compatible, field) in compatibility_checks {
             if !compatible {
                 tracing::warn!(
-                    "IngestionDescription incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                    "IngestionDescription incompatible at {field}:\nself:\n{:#?}\n\nother\n{:#?}",
                     self,
                     other
                 );
 
-                return Err(StorageError::InvalidAlterSource { id });
+                return Err(StorageError::InvalidAlter { id });
             }
         }
 
@@ -1354,7 +1364,7 @@ impl UnplannedSourceEnvelope {
 }
 
 /// A connection to an external system
-pub trait SourceConnection: Debug + Clone + PartialEq {
+pub trait SourceConnection: Debug + Clone + PartialEq + crate::AlterCompatible {
     /// The name of the external system (e.g kafka, postgres, etc).
     fn name(&self) -> &'static str;
 
@@ -1372,27 +1382,6 @@ pub trait SourceConnection: Debug + Clone + PartialEq {
     /// Returns metadata columns that this connection *instance* will produce once rendered. The
     /// columns are returned in the order specified by the user.
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)>;
-
-    /// Determines if `self` is compatible with another `SourceConnection`, in
-    /// such a way that it is possible to turn `self` into `other` through a
-    /// valid series of transformations (e.g. no transformation or `ALTER
-    /// SOURCE`).
-    ///
-    /// Note that the default implementation errors unless the two are equal. To
-    /// support any modifying transformations, you must specify the
-    /// implementation.
-    fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), StorageError> {
-        if self == other {
-            Ok(())
-        } else {
-            tracing::warn!(
-                "SourceConnection incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
-                self,
-                other
-            );
-            Err(StorageError::InvalidAlterSource { id })
-        }
-    }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1522,6 +1511,8 @@ impl<C: ConnectionAccess> SourceConnection for KafkaSourceConnection<C> {
             .collect()
     }
 }
+
+impl<C: ConnectionAccess> crate::AlterCompatible for KafkaSourceConnection<C> {}
 
 impl<C: ConnectionAccess> Arbitrary for KafkaSourceConnection<C>
 where
@@ -1776,11 +1767,13 @@ impl<C: ConnectionAccess> SourceDesc<C> {
     pub fn envelope(&self) -> &SourceEnvelope {
         &self.envelope
     }
+}
 
+impl<C: ConnectionAccess> crate::AlterCompatible for SourceDesc<C> {
     /// Determines if `self` is compatible with another `SourceDesc`, in such a
     /// way that it is possible to turn `self` into `other` through a valid
     /// series of transformations (e.g. no transformation or `ALTER SOURCE`).
-    pub fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), StorageError> {
+    fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), StorageError> {
         if self == other {
             return Ok(());
         }
@@ -1793,21 +1786,24 @@ impl<C: ConnectionAccess> SourceDesc<C> {
         connection.alter_compatible(id, &other.connection)?;
 
         let compatibility_checks = [
-            connection == &other.connection,
-            encoding == &other.encoding,
-            envelope == &other.envelope,
-            timestamp_interval == &other.timestamp_interval,
+            (connection == &other.connection, "connection"),
+            (encoding == &other.encoding, "encoding"),
+            (envelope == &other.envelope, "envelope"),
+            (
+                timestamp_interval == &other.timestamp_interval,
+                "timestamp_interval",
+            ),
         ];
 
-        for compatible in compatibility_checks {
+        for (compatible, field) in compatibility_checks {
             if !compatible {
                 tracing::warn!(
-                    "SourceDesc incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                    "SourceDesc incompatible {field}:\nself:\n{:#?}\n\nother\n{:#?}",
                     self,
                     other
                 );
 
-                return Err(StorageError::InvalidAlterSource { id });
+                return Err(StorageError::InvalidAlter { id });
             }
         }
 
@@ -1911,20 +1907,32 @@ impl<C: ConnectionAccess> SourceConnection for GenericSourceConnection<C> {
             Self::TestScript(conn) => conn.metadata_columns(),
         }
     }
+}
 
+impl<C: ConnectionAccess> crate::AlterCompatible for GenericSourceConnection<C> {
     fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), StorageError> {
         if self == other {
             return Ok(());
         }
-        match (self, other) {
+        let r = match (self, other) {
             (Self::Kafka(conn), Self::Kafka(other)) => conn.alter_compatible(id, other),
             (Self::Postgres(conn), Self::Postgres(other)) => conn.alter_compatible(id, other),
             (Self::LoadGenerator(conn), Self::LoadGenerator(other)) => {
                 conn.alter_compatible(id, other)
             }
             (Self::TestScript(conn), Self::TestScript(other)) => conn.alter_compatible(id, other),
-            _ => Err(StorageError::InvalidAlterSource { id }),
+            _ => Err(StorageError::InvalidAlter { id }),
+        };
+
+        if r.is_err() {
+            tracing::warn!(
+                "GenericSourceConnection incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                self,
+                other
+            );
         }
+
+        r
     }
 }
 
@@ -2048,7 +2056,9 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
     fn metadata_columns(&self) -> Vec<(&str, ColumnType)> {
         vec![]
     }
+}
 
+impl<C: ConnectionAccess> crate::AlterCompatible for PostgresSourceConnection<C> {
     fn alter_compatible(&self, id: GlobalId, other: &Self) -> Result<(), StorageError> {
         if self == other {
             return Ok(());
@@ -2063,30 +2073,36 @@ impl<C: ConnectionAccess> SourceConnection for PostgresSourceConnection<C> {
         } = self;
 
         let compatibility_checks = [
-            connection_id == &other.connection_id,
-            connection == &other.connection,
-            table_casts
-                .iter()
-                .merge_join_by(&other.table_casts, |(l_key, _), (r_key, _)| {
-                    l_key.cmp(r_key)
-                })
-                .all(|r| match r {
-                    Both((_, l_val), (_, r_val)) => l_val == r_val,
-                    _ => true,
-                }),
-            publication == &other.publication,
-            publication_details == &other.publication_details,
+            (connection_id == &other.connection_id, "connection_id"),
+            (connection == &other.connection, "connection"),
+            (
+                table_casts
+                    .iter()
+                    .merge_join_by(&other.table_casts, |(l_key, _), (r_key, _)| {
+                        l_key.cmp(r_key)
+                    })
+                    .all(|r| match r {
+                        Both((_, l_val), (_, r_val)) => l_val == r_val,
+                        _ => true,
+                    }),
+                "table_casts",
+            ),
+            (publication == &other.publication, "publication"),
+            (
+                publication_details == &other.publication_details,
+                "publication_details",
+            ),
         ];
 
-        for compatible in compatibility_checks {
+        for (compatible, field) in compatibility_checks {
             if !compatible {
                 tracing::warn!(
-                    "PostgresSourceConnection incompatible:\nself:\n{:#?}\n\nother\n{:#?}",
+                    "PostgresSourceConnection incompatible at {field}:\nself:\n{:#?}\n\nother\n{:#?}",
                     self,
                     other
                 );
 
-                return Err(StorageError::InvalidAlterSource { id });
+                return Err(StorageError::InvalidAlter { id });
             }
         }
 
@@ -2218,6 +2234,8 @@ impl SourceConnection for LoadGeneratorSourceConnection {
         vec![]
     }
 }
+
+impl crate::AlterCompatible for LoadGeneratorSourceConnection {}
 
 #[derive(Arbitrary, Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub enum LoadGenerator {
@@ -2633,6 +2651,8 @@ impl SourceConnection for TestScriptSourceConnection {
         vec![]
     }
 }
+
+impl crate::AlterCompatible for TestScriptSourceConnection {}
 
 impl RustType<ProtoTestScriptSourceConnection> for TestScriptSourceConnection {
     fn into_proto(&self) -> ProtoTestScriptSourceConnection {

--- a/src/storage/src/storage_state.rs
+++ b/src/storage/src/storage_state.rs
@@ -102,6 +102,7 @@ use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::sinks::{MetadataFilled, StorageSinkDesc};
 use mz_storage_types::sources::{IngestionDescription, SourceData};
+use mz_storage_types::AlterCompatible;
 use timely::communication::Allocate;
 use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;


### PR DESCRIPTION
To express "alter compatibility" for structs w/ generic fields in ways more complex than relying on the PartialEq impl, we need a trait.

This commit does that, in addition to expressing that a CollectionMetadata's persist location may change.

### Motivation

Fixes #22948 -- this does not _need_ to panic because if the persist URI meaningfully changes (i.e. we are unexpectedly connected to a new cockroach cluster), there will be other more serious symptoms than this check.

Further, Cockroach allows you to connect to query many replicas in the cluster, so querying some new replica does not necessarily imply that anything has meaningfully changed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
