### PR TITLE
catalog: Move const to catalog crate

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -38,6 +38,7 @@ pub use mz_catalog::memory::objects::{
     DefaultPrivileges, Func, Index, Log, MaterializedView, Role, Schema, Secret, Sink, Source,
     Table, Type, View,
 };
+use mz_catalog::SYSTEM_CONN_ID;
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_controller::clusters::{
     ClusterEvent, ManagedReplicaLocation, ReplicaConfig, ReplicaLocation,
@@ -105,12 +106,6 @@ mod migrate;
 mod inner;
 mod open;
 mod state;
-
-pub static SYSTEM_CONN_ID: ConnectionId = ConnectionId::Static(0);
-
-const CREATE_SQL_TODO: &str = "TODO";
-
-pub const LINKED_CLUSTER_REPLICA_NAME: &str = "linked";
 
 /// A `Catalog` keeps track of the SQL objects known to the planner.
 ///

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -25,6 +25,7 @@ use mz_catalog::builtin::{
     MZ_WEBHOOKS_SOURCES,
 };
 use mz_catalog::memory::error::{Error, ErrorKind};
+use mz_catalog::SYSTEM_CONN_ID;
 use mz_controller::clusters::{
     ClusterStatus, ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ProcessId,
     ReplicaAllocation, ReplicaLocation,
@@ -54,7 +55,6 @@ use mz_storage_types::sources::{
 use crate::catalog::{
     AwsPrincipalContext, CatalogItem, CatalogState, ClusterVariant, Connection, DataSourceDesc,
     Database, DefaultPrivilegeObject, Func, Index, MaterializedView, Sink, Type, View,
-    SYSTEM_CONN_ID,
 };
 use crate::coord::ConnMeta;
 use crate::subscribe::ActiveSubscribe;

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -32,6 +32,7 @@ use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, CommentsMap, DataSourceDesc, Database, DefaultPrivileges, Func, Log,
     Role, Schema, Source, Table, Type,
 };
+use mz_catalog::{CREATE_SQL_TODO, SYSTEM_CONN_ID};
 use mz_cluster_client::ReplicaId;
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_compute_client::logging::LogVariant;
@@ -65,7 +66,6 @@ use mz_storage_types::sources::Timeline;
 
 use crate::catalog::{
     is_reserved_name, migrate, BuiltinTableUpdate, Catalog, CatalogPlans, CatalogState, Config,
-    CREATE_SQL_TODO, SYSTEM_CONN_ID,
 };
 use crate::config::{SynchronizedParameters, SystemParameterFrontend, SystemParameterSyncConfig};
 use crate::coord::timestamp_oracle;

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -30,6 +30,7 @@ use mz_catalog::memory::objects::{
     CommentsMap, Connection, DataSourceDesc, Database, DefaultPrivileges, Index, MaterializedView,
     Role, Schema, Secret, Sink, Source, Table, Type, View,
 };
+use mz_catalog::{LINKED_CLUSTER_REPLICA_NAME, SYSTEM_CONN_ID};
 use mz_controller::clusters::{
     ClusterStatus, ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ProcessId,
     ReplicaAllocation, ReplicaConfig, ReplicaLocation, UnmanagedReplicaLocation,
@@ -71,10 +72,7 @@ use mz_storage_types::connections::inline::{
 };
 use mz_transform::Optimizer;
 
-use crate::catalog::{
-    AwsPrincipalContext, BuiltinTableUpdate, ClusterReplicaSizeMap, ConnCatalog,
-    LINKED_CLUSTER_REPLICA_NAME, SYSTEM_CONN_ID,
-};
+use crate::catalog::{AwsPrincipalContext, BuiltinTableUpdate, ClusterReplicaSizeMap, ConnCatalog};
 use crate::coord::ConnMeta;
 use crate::optimize::{self, Optimize};
 use crate::session::Session;

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 use fail::fail_point;
 use mz_adapter_types::connection::ConnectionId;
 use mz_audit_log::VersionedEvent;
+use mz_catalog::SYSTEM_CONN_ID;
 use mz_compute_client::protocol::response::PeekResponse;
 use mz_controller::clusters::ReplicaLocation;
 use mz_controller_types::{ClusterId, ReplicaId};
@@ -43,9 +44,7 @@ use serde_json::json;
 use timely::progress::Antichain;
 use tracing::{event, warn, Level};
 
-use crate::catalog::{
-    CatalogItem, CatalogState, DataSourceDesc, Op, Sink, TransactionResult, SYSTEM_CONN_ID,
-};
+use crate::catalog::{CatalogItem, CatalogState, DataSourceDesc, Op, Sink, TransactionResult};
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::{TimelineContext, TimelineState};
 use crate::coord::{Coordinator, ReplicaMetadata};

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -9,6 +9,7 @@
 
 //! Coordinator functionality to sequence linked-cluster-related plans
 
+use mz_catalog::LINKED_CLUSTER_REPLICA_NAME;
 use std::time::Duration;
 
 use mz_compute_client::controller::ComputeReplicaConfig;
@@ -20,7 +21,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::SourceSinkClusterConfig;
 
-use crate::catalog::{self, ClusterConfig, ClusterVariant, LINKED_CLUSTER_REPLICA_NAME};
+use crate::catalog::{self, ClusterConfig, ClusterVariant};
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 use crate::session::Session;

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -89,8 +89,9 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use mz_adapter::catalog::{Catalog, CatalogItem, Op, Table, SYSTEM_CONN_ID};
+use mz_adapter::catalog::{Catalog, CatalogItem, Op, Table};
 use mz_adapter::session::{Session, DEFAULT_DATABASE_NAME};
+use mz_catalog::SYSTEM_CONN_ID;
 use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;
 use mz_sql::ast::{Expr, Statement};

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -79,6 +79,14 @@
 
 //! Persistent metadata storage for the coordinator.
 
+use mz_adapter_types::connection::ConnectionId;
+
 pub mod builtin;
 pub mod durable;
 pub mod memory;
+
+pub static SYSTEM_CONN_ID: ConnectionId = ConnectionId::Static(0);
+
+pub const CREATE_SQL_TODO: &str = "TODO";
+
+pub const LINKED_CLUSTER_REPLICA_NAME: &str = "linked";


### PR DESCRIPTION
This commit moves `const`s and `static`s in adapter::catalog.rs to the catalog crate.

Works towards resolving #22593

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
