### PR TITLE
mzcompose: use name for Materialized service hostname

### DIFF
--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -99,7 +99,7 @@ class ServiceConfig(TypedDict, total=False):
     hostname: str
     """The hostname to use.
 
-    By default, the name of the service is used as the hostname.
+    By default, the container's ID is used as the hostname.
     """
 
     extra_hosts: list[str]

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -154,7 +154,15 @@ class Materialized(Service):
 
         command += options
 
-        config: ServiceConfig = {}
+        config: ServiceConfig = {
+            # Use the service name as the hostname so that it is stable across
+            # container recreation. (The default hostname is the container ID,
+            # which changes when the container is recreated.) This is important
+            # when using `external_cockroach=False`, as the consensus/blob URLs
+            # refer to the container's hostname, and we don't want those URLs to
+            # change when the container is recreated.
+            "hostname": name,
+        }
 
         if image:
             config["image"] = image


### PR DESCRIPTION
By default, docker compose uses the container's ID for its hostname, however that isn't stable and makes inconsistent any state that depends on the hostname. In our experience, this means that the persist location's URI is unstable, which causes some of our internal asserts to fire.

This commit attempts to stabilize the hostname by making it match the service's name.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
