### PR TITLE
parallel-workload: Reduce number of columns

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -881,11 +881,11 @@ class RevokePrivilegesAction(Action):
             if not exe.db.roles:
                 return
             role = self.rng.choice(exe.db.roles)
-        privilege = self.rng.choice(["SELECT", "INSERT", "UPDATE", "ALL"])
-        tables_views: list[DBObject] = [*exe.db.tables, *exe.db.views]
-        table = self.rng.choice(tables_views)
-        query = f"REVOKE {privilege} ON {table} FROM {role}"
-        exe.execute(query)
+            privilege = self.rng.choice(["SELECT", "INSERT", "UPDATE", "ALL"])
+            tables_views: list[DBObject] = [*exe.db.tables, *exe.db.views]
+            table = self.rng.choice(tables_views)
+            query = f"REVOKE {privilege} ON {table} FROM {role}"
+            exe.execute(query)
 
 
 # TODO: Should factor this out so can easily use it without action

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -34,7 +34,7 @@ from materialize.parallel_workload.executor import Executor
 from materialize.parallel_workload.settings import Complexity, Scenario
 from materialize.util import naughty_strings
 
-MAX_COLUMNS = 100
+MAX_COLUMNS = 10
 MAX_INCLUDE_HEADERS = 5
 MAX_ROWS = 100
 MAX_CLUSTERS = 10


### PR DESCRIPTION
"statement batch size cannot exceed 1000.0 KB" error seen in https://buildkite.com/materialize/nightlies/builds/5125#018bb936-da2f-4864-b793-c6001d6cba0a

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
