### PR TITLE
catalog: add mz_timezone_names and abbrevs

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_catalog.md
+++ b/doc/user/content/sql/system-catalog/mz_catalog.md
@@ -458,6 +458,32 @@ Field        | Type                 | Meaning
 `owner_id`   | [`text`]             | The role ID of the owner of the table. Corresponds to [`mz_roles.id`](/sql/system-catalog/mz_catalog/#mz_roles).
 `privileges` | [`mz_aclitem array`] | The privileges belonging to the table.
 
+### `mz_timezone_abbreviations`
+
+The `mz_timezone_abbreviations` view contains a row for each supported timezone abbreviation.
+A "fixed" abbreviation does not change its offset or daylight status based on the current time.
+A non-"fixed" abbreviation is dependent on the current time for its offset, and must use the [`timezone_offset`](/sql/functions/#timezone_offset) function to find its properties.
+These correspond to the `pg_catalog.pg_timezone_abbrevs` table, but can be materialized as they do not depend on the current time.
+
+<!-- RELATION_SPEC mz_catalog.mz_timezone_abbreviations -->
+Field           | Type         | Meaning
+----------------|--------------|----------
+`abbreviation`  | [`text`]     | The timezone abbreviation.
+`utc_offset`    | [`interval`] | The UTC offset of the timezone or `NULL` if fixed.
+`dst`           | [`boolean`]  | Whether the timezone is in daylight savings or `NULL` if fixed.
+`timezone_name` | [`text`]     | The full name of the non-fixed timezone or `NULL` if not fixed.
+
+### `mz_timezone_names`
+
+The `mz_timezone_names` view contains a row for each supported timezone.
+Use the [`timezone_offset`](/sql/functions/#timezone_offset) function for properties of a timezone at a certain timestamp.
+These correspond to the `pg_catalog.pg_timezone_names` table, but can be materialized as they do not depend on the current time.
+
+<!-- RELATION_SPEC mz_catalog.mz_timezone_names -->
+Field        | Type                 | Meaning
+-------------|----------------------|----------
+`name`       | [`text`]             | The timezone name.
+
 ### `mz_types`
 
 The `mz_types` table contains a row for each type in the system.
@@ -500,5 +526,6 @@ Field          | Type                 | Meaning
 [`uint8`]: /sql/types/uint8
 [`uint4`]: /sql/types/uint4
 [`mz_aclitem array`]: /sql/types/mz_aclitem
+[`interval`]: /sql/types/interval
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_catalog.mz_operators -->

--- a/src/pgtz/src/abbrev.rs
+++ b/src/pgtz/src/abbrev.rs
@@ -55,6 +55,6 @@ const fn make_fixed_offset(utc_offset_secs: i32) -> FixedOffset {
 
 include!(concat!(env!("OUT_DIR"), "/abbrev.gen.rs"));
 
-/// The SQL definition of the contents of the `pg_timezone_abbrevs` view.
-pub const PG_CATALOG_TIMEZONE_ABBREVS_SQL: &str =
+/// The SQL definition of the contents of the `mz_timezone_abbreviations` view.
+pub const MZ_CATALOG_TIMEZONE_ABBREVIATIONS_SQL: &str =
     include_str!(concat!(env!("OUT_DIR"), "/abbrev.gen.sql"));

--- a/src/pgtz/src/timezone.rs
+++ b/src/pgtz/src/timezone.rs
@@ -23,8 +23,8 @@ use crate::abbrev::TIMEZONE_ABBREVS;
 
 include!(concat!(env!("OUT_DIR"), "/mz_pgtz.timezone.rs"));
 
-/// The SQL definition of the contents of the `pg_timezone_names` view.
-pub const PG_CATALOG_TIMEZONE_NAMES_SQL: &str =
+/// The SQL definition of the contents of the `mz_timezone_names` view.
+pub const MZ_CATALOG_TIMEZONE_NAMES_SQL: &str =
     include_str!(concat!(env!("OUT_DIR"), "/timezone.gen.sql"));
 
 /// Parsed timezone.

--- a/test/sqllogictest/autogenerated/mz_catalog.slt
+++ b/test/sqllogictest/autogenerated/mz_catalog.slt
@@ -321,6 +321,19 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object 
 6  privileges  mz_aclitem[]
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_timezone_abbreviations' ORDER BY position
+----
+1  abbreviation  text
+2  utc_offset  interval
+3  dst  boolean
+4  timezone_name  text
+
+query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_timezone_names' ORDER BY position
+----
+1  name  text
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_catalog' AND object = 'mz_types' ORDER BY position
 ----
 1  id  text
@@ -378,5 +391,7 @@ mz_ssh_tunnel_connections
 mz_storage_usage
 mz_system_privileges
 mz_tables
+mz_timezone_abbreviations
+mz_timezone_names
 mz_types
 mz_views

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -225,6 +225,14 @@ mz_tables
 BASE TABLE
 materialize
 mz_catalog
+mz_timezone_abbreviations
+VIEW
+materialize
+mz_catalog
+mz_timezone_names
+VIEW
+materialize
+mz_catalog
 mz_types
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -505,6 +505,8 @@ name
 mz_objects
 mz_relations
 mz_storage_usage
+mz_timezone_abbreviations
+mz_timezone_names
 
 # Check default sources, tables, and views in mz_internal.
 


### PR DESCRIPTION
This will allow for materializing things related to timezones.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Add `mz_timezone_names` and `mz_timezone_abbrevs` views to `mz_catalog`.