### PR TITLE
test/lang: add ruby language tests

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -48,6 +48,7 @@ copyright_files=$(grep -vE \
     -e '(^|/)Cargo\.lock$' \
     -e '^about\.toml$' \
     -e '^deny\.toml$' \
+    -e '(^|/)Gemfile\.lock$' \
     -e '^netlify\.toml$' \
     -e '^rustfmt\.toml$' \
     -e '^clippy\.toml$' \

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -710,6 +710,18 @@ steps:
         agents:
           queue: linux-x86_64
 
+      - id: lang-ruby
+        label: ":ruby: tests"
+        depends_on: build-x86_64
+        timeout_in_minutes: 10
+        inputs: [test/lang/ruby]
+        artifact_paths: junit_*.xml
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: ruby
+        agents:
+          queue: linux-x86_64
+
   - id: deploy-website
     label: Deploy website
     depends_on: lint-docs

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -407,7 +407,7 @@ impl Catalog {
             details: CatalogTypeDetails {
                 array_id: builtin.details.array_id,
                 typ,
-                typreceive_oid: builtin.details.typreceive_oid,
+                pg_metadata: builtin.details.pg_metadata.clone(),
             },
         }
     }
@@ -4865,7 +4865,8 @@ mod tests {
                 ty: String,
                 elem: u32,
                 array: u32,
-                receive: Option<u32>,
+                input: u32,
+                receive: u32,
             }
 
             struct PgOper {
@@ -4902,7 +4903,7 @@ mod tests {
 
             let pg_type: BTreeMap<_, _> = client
                 .query(
-                    "SELECT oid, typname, typtype::text, typelem, typarray, nullif(typreceive::oid, 0) as typreceive FROM pg_type",
+                    "SELECT oid, typname, typtype::text, typelem, typarray, typinput::oid, typreceive::oid as typreceive FROM pg_type",
                     &[],
                 )
                 .await
@@ -4915,6 +4916,7 @@ mod tests {
                         ty: row.get("typtype"),
                         elem: row.get("typelem"),
                         array: row.get("typarray"),
+                        input: row.get("typinput"),
                         receive: row.get("typreceive"),
                     };
                     (oid, pg_type)
@@ -5004,13 +5006,31 @@ mod tests {
                             ty.oid, pg_ty.name, ty.name,
                         );
 
+                        let (typinput_oid, typreceive_oid) = match &ty.details.pg_metadata {
+                            None => (0, 0),
+                            Some(pgmeta) => (pgmeta.typinput_oid, pgmeta.typreceive_oid),
+                        };
                         assert_eq!(
-                            ty.details.typreceive_oid, pg_ty.receive,
-                            "type {} has typreceive OID {:?} in mz but {:?} in pg",
-                            ty.name, ty.details.typreceive_oid, pg_ty.receive,
+                            typinput_oid,
+                            pg_ty.input,
+                            "type {} has typinput OID {:?} in mz but {:?} in pg",
+                            ty.name, typinput_oid, pg_ty.input,
                         );
-
-                        if let Some(typreceive_oid) = ty.details.typreceive_oid {
+                        assert_eq!(
+                            typreceive_oid,
+                            pg_ty.receive,
+                            "type {} has typreceive OID {:?} in mz but {:?} in pg",
+                            ty.name, typreceive_oid, pg_ty.receive,
+                        );
+                        if typinput_oid != 0 {
+                            assert!(
+                                func_oids.contains(&typinput_oid),
+                                "type {} has typinput OID {} that does not exist in pg_proc",
+                                ty.name,
+                                typinput_oid,
+                            );
+                        }
+                        if typreceive_oid != 0 {
                             assert!(
                                 func_oids.contains(&typreceive_oid),
                                 "type {} has typreceive OID {} that does not exist in pg_proc",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -5011,14 +5011,12 @@ mod tests {
                             Some(pgmeta) => (pgmeta.typinput_oid, pgmeta.typreceive_oid),
                         };
                         assert_eq!(
-                            typinput_oid,
-                            pg_ty.input,
+                            typinput_oid, pg_ty.input,
                             "type {} has typinput OID {:?} in mz but {:?} in pg",
                             ty.name, typinput_oid, pg_ty.input,
                         );
                         assert_eq!(
-                            typreceive_oid,
-                            pg_ty.receive,
+                            typreceive_oid, pg_ty.receive,
                             "type {} has typreceive OID {:?} in mz but {:?} in pg",
                             ty.name, typreceive_oid, pg_ty.receive,
                         );

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -964,12 +964,13 @@ impl CatalogState {
             diff,
         });
 
-        if let Some(typreceive_oid) = typ.details.typreceive_oid {
+        if let Some(pg_metadata) = &typ.details.pg_metadata {
             out.push(BuiltinTableUpdate {
                 id: self.resolve_builtin_table(&MZ_TYPE_PG_METADATA),
                 row: Row::pack_slice(&[
                     Datum::String(&id.to_string()),
-                    Datum::UInt32(typreceive_oid),
+                    Datum::UInt32(pg_metadata.typinput_oid),
+                    Datum::UInt32(pg_metadata.typreceive_oid),
                 ]),
                 diff,
             });

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -1001,7 +1001,7 @@ impl CatalogState {
                 details: CatalogTypeDetails {
                     array_id: None,
                     typ: typ.inner,
-                    typreceive_oid: None,
+                    pg_metadata: None,
                 },
                 resolved_ids,
             }),

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1239,7 +1239,7 @@ impl Coordinator {
             details: CatalogTypeDetails {
                 array_id: None,
                 typ: plan.typ.inner,
-                typreceive_oid: None,
+                pg_metadata: None,
             },
             resolved_ids,
         };

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -34,8 +34,8 @@ use mz_repr::namespaces::{
 use mz_repr::role_id::RoleId;
 use mz_repr::{RelationDesc, RelationType, ScalarType};
 use mz_sql::catalog::{
-    CatalogItemType, CatalogType, CatalogTypeDetails, NameReference, ObjectType, RoleAttributes,
-    TypeReference,
+    CatalogItemType, CatalogType, CatalogTypeDetails, CatalogTypePgMetadata, NameReference,
+    ObjectType, RoleAttributes, TypeReference,
 };
 use mz_sql::rbac;
 use mz_sql::session::user::{
@@ -315,7 +315,10 @@ pub const TYPE_BOOL: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Bool,
         array_id: None,
-        typreceive_oid: Some(2436),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1242,
+            typreceive_oid: 2436,
+        }),
     },
 };
 
@@ -326,7 +329,10 @@ pub const TYPE_BYTEA: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Bytes,
         array_id: None,
-        typreceive_oid: Some(2412),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1244,
+            typreceive_oid: 2412,
+        }),
     },
 };
 
@@ -337,7 +343,10 @@ pub const TYPE_INT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int64,
         array_id: None,
-        typreceive_oid: Some(2408),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 460,
+            typreceive_oid: 2408,
+        }),
     },
 };
 
@@ -348,7 +357,10 @@ pub const TYPE_INT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int32,
         array_id: None,
-        typreceive_oid: Some(2406),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 42,
+            typreceive_oid: 2406,
+        }),
     },
 };
 
@@ -359,7 +371,10 @@ pub const TYPE_TEXT: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::String,
         array_id: None,
-        typreceive_oid: Some(2414),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 46,
+            typreceive_oid: 2414,
+        }),
     },
 };
 
@@ -370,7 +385,10 @@ pub const TYPE_OID: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Oid,
         array_id: None,
-        typreceive_oid: Some(2418),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1798,
+            typreceive_oid: 2418,
+        }),
     },
 };
 
@@ -381,7 +399,10 @@ pub const TYPE_FLOAT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Float32,
         array_id: None,
-        typreceive_oid: Some(2424),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 200,
+            typreceive_oid: 2424,
+        }),
     },
 };
 
@@ -392,7 +413,10 @@ pub const TYPE_FLOAT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Float64,
         array_id: None,
-        typreceive_oid: Some(2426),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 214,
+            typreceive_oid: 2426,
+        }),
     },
 };
 
@@ -405,7 +429,10 @@ pub const TYPE_BOOL_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BOOL.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -418,7 +445,10 @@ pub const TYPE_BYTEA_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BYTEA.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -431,7 +461,10 @@ pub const TYPE_INT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -444,7 +477,10 @@ pub const TYPE_TEXT_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TEXT.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -457,7 +493,10 @@ pub const TYPE_INT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -470,7 +509,10 @@ pub const TYPE_FLOAT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_FLOAT4.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -483,7 +525,10 @@ pub const TYPE_FLOAT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_FLOAT8.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -496,7 +541,10 @@ pub const TYPE_OID_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_OID.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -507,7 +555,10 @@ pub const TYPE_DATE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Date,
         array_id: None,
-        typreceive_oid: Some(2468),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1084,
+            typreceive_oid: 2468,
+        }),
     },
 };
 
@@ -518,7 +569,10 @@ pub const TYPE_TIME: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Time,
         array_id: None,
-        typreceive_oid: Some(2470),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1143,
+            typreceive_oid: 2470,
+        }),
     },
 };
 
@@ -529,7 +583,10 @@ pub const TYPE_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Timestamp,
         array_id: None,
-        typreceive_oid: Some(2474),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1312,
+            typreceive_oid: 2474,
+        }),
     },
 };
 
@@ -542,7 +599,10 @@ pub const TYPE_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMP.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -555,7 +615,10 @@ pub const TYPE_DATE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -568,7 +631,10 @@ pub const TYPE_TIME_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIME.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -579,7 +645,10 @@ pub const TYPE_TIMESTAMPTZ: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::TimestampTz,
         array_id: None,
-        typreceive_oid: Some(2476),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1150,
+            typreceive_oid: 2476,
+        }),
     },
 };
 
@@ -592,7 +661,10 @@ pub const TYPE_TIMESTAMPTZ_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMPTZ.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -603,7 +675,10 @@ pub const TYPE_INTERVAL: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Interval,
         array_id: None,
-        typreceive_oid: Some(2478),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1160,
+            typreceive_oid: 2478,
+        }),
     },
 };
 
@@ -616,7 +691,10 @@ pub const TYPE_INTERVAL_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INTERVAL.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -627,7 +705,10 @@ pub const TYPE_NAME: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::PgLegacyName,
         array_id: None,
-        typreceive_oid: Some(2422),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 34,
+            typreceive_oid: 2422,
+        }),
     },
 };
 
@@ -640,7 +721,10 @@ pub const TYPE_NAME_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NAME.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -651,7 +735,10 @@ pub const TYPE_NUMERIC: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Numeric,
         array_id: None,
-        typreceive_oid: Some(2460),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1701,
+            typreceive_oid: 2460,
+        }),
     },
 };
 
@@ -664,7 +751,10 @@ pub const TYPE_NUMERIC_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUMERIC.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -675,7 +765,10 @@ pub const TYPE_RECORD: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: Some(2402),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2290,
+            typreceive_oid: 2402,
+        }),
     },
 };
 
@@ -688,7 +781,10 @@ pub const TYPE_RECORD_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_RECORD.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -699,7 +795,10 @@ pub const TYPE_UUID: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Uuid,
         array_id: None,
-        typreceive_oid: Some(2961),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2952,
+            typreceive_oid: 2961,
+        }),
     },
 };
 
@@ -712,7 +811,10 @@ pub const TYPE_UUID_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UUID.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -723,7 +825,10 @@ pub const TYPE_JSONB: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Jsonb,
         array_id: None,
-        typreceive_oid: Some(3805),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3806,
+            typreceive_oid: 3805,
+        }),
     },
 };
 
@@ -736,7 +841,10 @@ pub const TYPE_JSONB_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_JSONB.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -747,7 +855,10 @@ pub const TYPE_ANY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2294,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -758,7 +869,10 @@ pub const TYPE_ANYARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: Some(2502),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2296,
+            typreceive_oid: 2502,
+        }),
     },
 };
 
@@ -769,7 +883,10 @@ pub const TYPE_ANYELEMENT: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2312,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -780,7 +897,10 @@ pub const TYPE_ANYNONARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2777,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -791,7 +911,10 @@ pub const TYPE_ANYRANGE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3832,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -802,7 +925,10 @@ pub const TYPE_CHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::PgLegacyChar,
         array_id: None,
-        typreceive_oid: Some(2434),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1245,
+            typreceive_oid: 2434,
+        }),
     },
 };
 
@@ -813,7 +939,10 @@ pub const TYPE_VARCHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::VarChar,
         array_id: None,
-        typreceive_oid: Some(2432),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1046,
+            typreceive_oid: 2432,
+        }),
     },
 };
 
@@ -824,7 +953,10 @@ pub const TYPE_INT2: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int16,
         array_id: None,
-        typreceive_oid: Some(2404),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 38,
+            typreceive_oid: 2404,
+        }),
     },
 };
 
@@ -837,7 +969,10 @@ pub const TYPE_INT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT2.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -848,7 +983,10 @@ pub const TYPE_BPCHAR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Char,
         array_id: None,
-        typreceive_oid: Some(2430),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1044,
+            typreceive_oid: 2430,
+        }),
     },
 };
 
@@ -861,7 +999,10 @@ pub const TYPE_CHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_CHAR.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -874,7 +1015,10 @@ pub const TYPE_VARCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_VARCHAR.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -887,7 +1031,10 @@ pub const TYPE_BPCHAR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_BPCHAR.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -898,7 +1045,10 @@ pub const TYPE_REGPROC: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegProc,
         array_id: None,
-        typreceive_oid: Some(2444),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 44,
+            typreceive_oid: 2444,
+        }),
     },
 };
 
@@ -911,7 +1061,10 @@ pub const TYPE_REGPROC_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGPROC.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -922,7 +1075,10 @@ pub const TYPE_REGTYPE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegType,
         array_id: None,
-        typreceive_oid: Some(2454),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2220,
+            typreceive_oid: 2454,
+        }),
     },
 };
 
@@ -935,7 +1091,10 @@ pub const TYPE_REGTYPE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGTYPE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -946,7 +1105,10 @@ pub const TYPE_REGCLASS: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::RegClass,
         array_id: None,
-        typreceive_oid: Some(2452),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2218,
+            typreceive_oid: 2452,
+        }),
     },
 };
 
@@ -959,7 +1121,10 @@ pub const TYPE_REGCLASS_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_REGCLASS.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -970,7 +1135,10 @@ pub const TYPE_INT2_VECTOR: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Int2Vector,
         array_id: None,
-        typreceive_oid: Some(2410),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 40,
+            typreceive_oid: 2410,
+        }),
     },
 };
 
@@ -983,7 +1151,10 @@ pub const TYPE_INT2_VECTOR_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT2_VECTOR.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -994,7 +1165,10 @@ pub const TYPE_ANYCOMPATIBLE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 5086,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -1005,7 +1179,10 @@ pub const TYPE_ANYCOMPATIBLEARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: Some(5090),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 5088,
+            typreceive_oid: 5090,
+        }),
     },
 };
 
@@ -1016,7 +1193,10 @@ pub const TYPE_ANYCOMPATIBLENONARRAY: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 5092,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -1027,7 +1207,10 @@ pub const TYPE_ANYCOMPATIBLERANGE: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 5094,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -1038,7 +1221,7 @@ pub const TYPE_LIST: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1049,7 +1232,7 @@ pub const TYPE_MAP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1060,7 +1243,7 @@ pub const TYPE_ANYCOMPATIBLELIST: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1071,7 +1254,7 @@ pub const TYPE_ANYCOMPATIBLEMAP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1082,7 +1265,7 @@ pub const TYPE_UINT2: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt16,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1095,7 +1278,7 @@ pub const TYPE_UINT2_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT2.name,
         },
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1106,7 +1289,7 @@ pub const TYPE_UINT4: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt32,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1119,7 +1302,7 @@ pub const TYPE_UINT4_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT4.name,
         },
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1130,7 +1313,7 @@ pub const TYPE_UINT8: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::UInt64,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1143,7 +1326,7 @@ pub const TYPE_UINT8_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_UINT8.name,
         },
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1154,7 +1337,7 @@ pub const TYPE_MZ_TIMESTAMP: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::MzTimestamp,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1167,7 +1350,7 @@ pub const TYPE_MZ_TIMESTAMP_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_MZ_TIMESTAMP.name,
         },
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1180,7 +1363,10 @@ pub const TYPE_INT4_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1193,7 +1379,10 @@ pub const TYPE_INT4_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT4_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1206,7 +1395,10 @@ pub const TYPE_INT8_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1219,7 +1411,10 @@ pub const TYPE_INT8_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_INT8_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1232,7 +1427,10 @@ pub const TYPE_DATE_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1245,7 +1443,10 @@ pub const TYPE_DATE_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_DATE_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1258,7 +1459,10 @@ pub const TYPE_NUM_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUMERIC.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1271,7 +1475,10 @@ pub const TYPE_NUM_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_NUM_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1284,7 +1491,10 @@ pub const TYPE_TS_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMP.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1297,7 +1507,10 @@ pub const TYPE_TS_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TS_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1310,7 +1523,10 @@ pub const TYPE_TSTZ_RANGE: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TIMESTAMPTZ.name,
         },
         array_id: None,
-        typreceive_oid: Some(3836),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 3834,
+            typreceive_oid: 3836,
+        }),
     },
 };
 
@@ -1323,7 +1539,10 @@ pub const TYPE_TSTZ_RANGE_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_TSTZ_RANGE.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1334,7 +1553,7 @@ pub const TYPE_MZ_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::MzAclItem,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: None,
     },
 };
 
@@ -1347,7 +1566,10 @@ pub const TYPE_MZ_ACL_ITEM_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_MZ_ACL_ITEM.name,
         },
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1358,7 +1580,10 @@ pub const TYPE_ACL_ITEM: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::AclItem,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 1031,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -1371,7 +1596,10 @@ pub const TYPE_ACL_ITEM_ARRAY: BuiltinType<NameReference> = BuiltinType {
             element_reference: TYPE_ACL_ITEM.name,
         },
         array_id: None,
-        typreceive_oid: Some(2400),
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 750,
+            typreceive_oid: 2400,
+        }),
     },
 };
 
@@ -1382,7 +1610,10 @@ pub const TYPE_INTERNAL: BuiltinType<NameReference> = BuiltinType {
     details: CatalogTypeDetails {
         typ: CatalogType::Pseudo,
         array_id: None,
-        typreceive_oid: None,
+        pg_metadata: Some(CatalogTypePgMetadata {
+            typinput_oid: 2304,
+            typreceive_oid: 0,
+        }),
     },
 };
 
@@ -1833,6 +2064,7 @@ pub static MZ_TYPE_PG_METADATA: Lazy<BuiltinTable> = Lazy::new(|| BuiltinTable {
     schema: MZ_INTERNAL_SCHEMA,
     desc: RelationDesc::empty()
         .with_column("id", ScalarType::String.nullable(false))
+        .with_column("typinput", ScalarType::Oid.nullable(false))
         .with_column("typreceive", ScalarType::Oid.nullable(false)),
     is_retained_metrics_object: false,
     sensitivity: DataSensitivity::Public,
@@ -3119,7 +3351,7 @@ pub const PG_TYPE: BuiltinView = BuiltinView {
         0
     )
         AS typarray,
-    (CASE mztype WHEN 'a' THEN 'array_in' ELSE NULL END)::pg_catalog.regproc AS typinput,
+    mz_internal.mz_type_pg_metadata.typinput::pg_catalog.regproc AS typinput,
     COALESCE(mz_internal.mz_type_pg_metadata.typreceive, 0) AS typreceive,
     false::pg_catalog.bool AS typnotnull,
     0::pg_catalog.oid AS typbasetype,

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -783,8 +783,17 @@ pub struct CatalogTypeDetails<T: TypeReference> {
     pub array_id: Option<GlobalId>,
     /// The description of this type.
     pub typ: CatalogType<T>,
-    /// The OID of the `typreceive` function in PostgreSQL, if available.
-    pub typreceive_oid: Option<u32>,
+    /// Additional metadata about the type in PostgreSQL, if relevant.
+    pub pg_metadata: Option<CatalogTypePgMetadata>,
+}
+
+/// Additional PostgreSQL metadata about a type.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CatalogTypePgMetadata {
+    /// The OID of the `typinput` function in PostgreSQL.
+    pub typinput_oid: u32,
+    /// The OID of the `typreceive` function in PostgreSQL.
+    pub typreceive_oid: u32,
 }
 
 /// Represents a reference to type in the catalog

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -127,6 +127,7 @@ impl TypeCategory {
             | ParamType::ListElementAnyCompatible
             | ParamType::Internal
             | ParamType::NonVecAny
+            | ParamType::NonVecAnyCompatible
             | ParamType::MapAny
             | ParamType::MapAnyCompatible
             | ParamType::RecordAny => Self::Pseudo,
@@ -702,6 +703,10 @@ pub enum ParamType {
     /// `ScalarType::Array`, requiring other "Any"-type
     /// parameters to be of the same type.
     NonVecAny,
+    /// A pseudotype permitting any type except `ScalarType::List` and
+    /// `ScalarType::Array`, requiring other "Compatibility"-type
+    /// parameters to be of the same type.
+    NonVecAnyCompatible,
     /// A standard parameter that accepts arguments that match its embedded
     /// `ScalarType`.
     Plain(ScalarType),
@@ -735,7 +740,7 @@ impl ParamType {
             ListAny | ListAnyCompatible => matches!(t, List { .. }),
             MapAny | MapAnyCompatible => matches!(t, Map { .. }),
             RangeAny | RangeAnyCompatible => matches!(t, Range { .. }),
-            NonVecAny => !t.is_vec(),
+            NonVecAny | NonVecAnyCompatible => !t.is_vec(),
             Internal => false,
             Plain(to) => typeconv::can_cast(ecx, CastContext::Implicit, t, to),
             RecordAny => matches!(t, Record { .. }),
@@ -784,6 +789,7 @@ impl ParamType {
             | MapAny
             | MapAnyCompatible
             | NonVecAny
+            | NonVecAnyCompatible
             // In PG, RecordAny isn't polymorphic even though it offers
             // polymorphic behavior. For more detail, see
             // `PolymorphicCompatClass::StructuralEq`.
@@ -816,6 +822,7 @@ impl ParamType {
             ParamType::MapAny => "map",
             ParamType::MapAnyCompatible => "anycompatiblemap",
             ParamType::NonVecAny => "anynonarray",
+            ParamType::NonVecAnyCompatible => "anycompatiblenonarray",
             ParamType::RecordAny => "record",
             ParamType::RangeAny => "anyrange",
             ParamType::RangeAnyCompatible => "anycompatiblerange",
@@ -1304,7 +1311,7 @@ impl TryFrom<&ParamType> for PolymorphicCompatClass {
             AnyElement | ArrayAny | ListAny | MapAny | NonVecAny | RangeAny => {
                 PolymorphicCompatClass::Any
             }
-            ArrayAnyCompatible | AnyCompatible | RangeAnyCompatible => {
+            ArrayAnyCompatible | AnyCompatible | RangeAnyCompatible | NonVecAnyCompatible => {
                 PolymorphicCompatClass::BestCommonAny
             }
             ListAnyCompatible | ListElementAnyCompatible => PolymorphicCompatClass::BestCommonList,
@@ -1803,10 +1810,6 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
 
                 Ok(HirScalarExpr::CallVariadic { func: VariadicFunc::ArrayFill { elem_type }, exprs })
             }) => ArrayAny, 1286;
-        },
-        "array_in" => Scalar {
-            params!(String, Oid, Int32) =>
-                Operation::variadic(|_ecx, _exprs| bail_unsupported!("array_in")) => ArrayAny, 750;
         },
         "array_length" => Scalar {
             params![ArrayAny, Int64] => BinaryFunc::ArrayLength => Int32, 2176;
@@ -2746,6 +2749,124 @@ pub static PG_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         },
 
         // Internal conversion stubs.
+        "aclitemin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("aclitemin")) => AclItem, 1031;
+        },
+        "any_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("any_in")) => Any, 2294;
+        },
+        "anyarray_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anyarray_in")) => ArrayAny, 2296;
+        },
+        "anycompatible_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anycompatible_in")) => AnyCompatible, 5086;
+        },
+        "anycompatiblearray_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anycompatiblearray_in")) => ArrayAnyCompatible, 5088;
+        },
+        "anycompatiblenonarray_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anycompatiblenonarray_in")) => NonVecAnyCompatible, 5092;
+        },
+        "anycompatiblerange_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anycompatiblerange_in")) => RangeAnyCompatible, 5094;
+        },
+        "anyelement_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anyelement_in")) => AnyElement, 2312;
+        },
+        "anynonarray_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anynonarray_in")) => NonVecAny, 2777;
+        },
+        "anyrange_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("anyrange_in")) => RangeAny, 3832;
+        },
+        "array_in" => Scalar {
+            params!(String, Oid, Int32) =>
+                Operation::variadic(|_ecx, _exprs| bail_unsupported!("array_in")) => ArrayAny, 750;
+        },
+        "boolin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("boolin")) => Bool, 1242;
+        },
+        "bpcharin" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("bpcharin")) => Char, 1044;
+        },
+        "byteain" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("byteain")) => Bytes, 1244;
+        },
+        "charin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("charin")) => PgLegacyChar, 1245;
+        },
+        "date_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("date_in")) => Date, 1084;
+        },
+        "float4in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("float4in")) => Float32, 200;
+        },
+        "float8in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("float8in")) => Float64, 214;
+        },
+        "int2in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("int2in")) => Int16, 38;
+        },
+        "int2vectorin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("int2vectorin")) => Int2Vector, 40;
+        },
+        "int4in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("int4in")) => Int32, 42;
+        },
+        "int8in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("int8in")) => Int64, 460;
+        },
+        "internal_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("internal_in")) => Internal, 2304;
+        },
+        "interval_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("interval_in")) => Interval, 1160;
+        },
+        "jsonb_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("jsonb_in")) => Jsonb, 3806;
+        },
+        "namein" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("namein")) => PgLegacyName, 34;
+        },
+        "numeric_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("numeric_in")) => Numeric, 1701;
+        },
+        "oidin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("oidin")) => Oid, 1798;
+        },
+        "range_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("range_in")) => RangeAny, 3834;
+        },
+        "record_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("record_in")) => RecordAny, 2290;
+        },
+        "regclassin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("regclassin")) => RegClass, 2218;
+        },
+        "regprocin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("regprocin")) => RegProc, 44;
+        },
+        "regtypein" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("regtypein")) => RegType, 2220;
+        },
+        "textin" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("textin")) => String, 46;
+        },
+        "time_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("time_in")) => Time, 1143;
+        },
+        "timestamp_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("timestamp_in")) => Timestamp, 1312;
+        },
+        "timestamptz_in" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("timestamptz_in")) => TimestampTz, 1150;
+        },
+        "varcharin" => Scalar {
+            params!(String, Oid, Int32) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("varcharin")) => VarChar, 1046;
+        },
+        "uuid_in" => Scalar {
+            params!(String) => Operation::variadic(|_ecx, _exprs| bail_unsupported!("uuid_in")) => Uuid, 2952;
+        },
         "boolrecv" => Scalar {
             params!(Internal) => Operation::nullary(|_ecx| catalog_name_only!("boolrecv")) => Bool, 2436;
         },

--- a/test/lang/ruby/.gitignore
+++ b/test/lang/ruby/.gitignore
@@ -1,0 +1,2 @@
+.bundle
+vendor

--- a/test/lang/ruby/Gemfile
+++ b/test/lang/ruby/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem "pg", "~> 1.5.4"
+gem "test-unit", "~> 3.6.1"

--- a/test/lang/ruby/Gemfile.lock
+++ b/test/lang/ruby/Gemfile.lock
@@ -1,0 +1,18 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    pg (1.5.4)
+    power_assert (2.0.3)
+    test-unit (3.6.1)
+      power_assert
+
+PLATFORMS
+  aarch64-linux
+  arm64-darwin-22
+
+DEPENDENCIES
+  pg (~> 1.5.4)
+  test-unit (~> 3.6.1)
+
+BUNDLED WITH
+   2.4.10

--- a/test/lang/ruby/mzcompose
+++ b/test/lang/ruby/mzcompose
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# mzcompose — runs Docker Compose with Materialize customizations.
+
+exec "$(dirname "$0")"/../../../bin/pyactivate -m materialize.cli.mzcompose "$@"

--- a/test/lang/ruby/mzcompose.py
+++ b/test/lang/ruby/mzcompose.py
@@ -1,0 +1,32 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+from materialize.mzcompose.composition import Composition, Service
+from materialize.mzcompose.services.materialized import Materialized
+
+SERVICES = [
+    Materialized(),
+    Service(
+        name="ruby",
+        config={
+            "image": "ruby:3.2.2-bookworm",
+            "volumes": [
+                "../../../:/workdir",
+            ],
+            "environment": [
+                "PGHOST=materialized",
+            ],
+        },
+    ),
+]
+
+
+def workflow_default(c: Composition) -> None:
+    c.up("materialized")
+    c.run("ruby", "/workdir/test/lang/ruby/test.sh")

--- a/test/lang/ruby/test.rb
+++ b/test/lang/ruby/test.rb
@@ -1,0 +1,45 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+require "bundler/setup"
+require "pg"
+require "test/unit"
+
+
+class MaterializeTest < Test::Unit::TestCase
+  def connect
+    PG.connect(
+      host: ENV["PGHOST"] || "localhost",
+      port: (ENV["PGPORT"] || 6875).to_i,
+      dbname: ENV["PGDATABASE"] || "materialize",
+      user: ENV["PGUSER"] || "materialize",
+    )
+  end
+
+  def test_type_map_all_strings
+    conn = connect
+    conn.exec("VALUES ('a'::text, 1::integer, '2023-01-01T01:23:45'::timestamp), ('b', NULL, NULL) ORDER BY 1") do |result|
+      assert_equal(result.collect.to_a, [
+          {"column1" => "a", "column2" => "1", "column3" => "2023-01-01 01:23:45"},
+          {"column1" => "b", "column2" => nil, "column3" => nil}
+      ])
+    end
+  end
+
+  def test_type_map_basic_type_map
+    conn = connect
+    conn.type_map_for_results = PG::BasicTypeMapForResults.new(conn)
+    conn.exec("VALUES ('a'::text, 1::integer, '2023-01-01T01:23:45'::timestamp), ('b', NULL, NULL) ORDER BY 1") do |result|
+      assert_equal(result.collect.to_a, [
+          {"column1" => "a", "column2" => 1, "column3" => Time.new(2023, 1, 1, 1, 23, 45)},
+          {"column1" => "b", "column2" => nil, "column3" => nil}
+      ])
+    end
+  end
+end

--- a/test/lang/ruby/test.sh
+++ b/test/lang/ruby/test.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# test.sh — run Ruby language tests.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/../../.."
+
+. misc/shlib/shlib.bash
+
+cd test/lang/ruby
+
+bundle install
+
+try ruby test.rb
+
+try_status_report


### PR DESCRIPTION
To ensure that type mapping with the pg gem works as desired.

### Motivation

  * This PR fixes a previously unreported bug.

    Type mapping with the Ruby `pg` gem (see enclosed test) did not work.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
