### PR TITLE
Re-use a thread-local row allocation

### DIFF
--- a/src/compute/src/render/flat_map.rs
+++ b/src/compute/src/render/flat_map.rs
@@ -8,7 +8,7 @@
 // by the Apache License, Version 2.0.
 
 use mz_expr::{MapFilterProject, MirScalarExpr, TableFunc};
-use mz_repr::{DatumVec, Row, RowArena};
+use mz_repr::{DatumVec, RowArena, SharedRow};
 use mz_timely_util::operator::StreamExt;
 use timely::dataflow::Scope;
 
@@ -33,7 +33,6 @@ where
         let (ok_collection, err_collection) = input.as_specific_collection(input_key.as_deref());
         let (oks, errs) = ok_collection.inner.flat_map_fallible("FlatMapStage", {
             let mut datums = DatumVec::new();
-            let mut row_builder = Row::default();
             move |(input_row, mut time, diff)| {
                 let temp_storage = RowArena::new();
                 // Unpack datums and capture its length (to rewind MFP eval).
@@ -61,6 +60,8 @@ where
                 let temp_storage = &temp_storage;
                 let mfp_plan = &mfp_plan;
                 let output_rows_vec: Vec<_> = output_rows.collect();
+                let binding = SharedRow::get();
+                let mut row_builder = binding.borrow_mut();
                 let row_builder = &mut row_builder;
                 output_rows_vec
                     .iter()

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1480,11 +1480,11 @@ pub mod plan {
         /// The `row` is not cleared first, but emptied if the function
         /// returns `Ok(Some(row)).
         #[inline(always)]
-        pub fn evaluate_into<'a>(
+        pub fn evaluate_into<'a, 'row>(
             &'a self,
             datums: &mut Vec<Datum<'a>>,
             arena: &'a RowArena,
-            row_buf: &'a mut Row,
+            row_buf: &'row mut Row,
         ) -> Result<Option<Row>, EvalError> {
             let passed_predicates = self.evaluate_inner(datums, arena)?;
             if !passed_predicates {

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -123,7 +123,7 @@ pub use crate::row::encoding::{
 };
 pub use crate::row::{
     datum_list_size, datum_size, datums_size, row_size, DatumList, DatumMap, ProtoRow, Row,
-    RowArena, RowPacker, RowRef,
+    RowArena, RowPacker, RowRef, SharedRow,
 };
 pub use crate::scalar::{
     arb_datum, arb_range_type, ArrayRustType, AsColumnType, Datum, DatumType, PropArray, PropDatum,


### PR DESCRIPTION
This changes our row reuse to share a single row per thread, instead of retaining an allocation per dataflow operator.

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
