### PR TITLE
version consistency: drop function id suffix from error message before comparison

### DIFF
--- a/misc/python/materialize/output_consistency/validation/result_comparator.py
+++ b/misc/python/materialize/output_consistency/validation/result_comparator.py
@@ -36,9 +36,13 @@ from materialize.output_consistency.validation.validation_outcome import (
 class ResultComparator:
     """Compares the outcome (result or failure) of multiple query executions"""
 
-    def __init__(self, ignore_filter: GenericInconsistencyIgnoreFilter):
+    def __init__(
+        self,
+        ignore_filter: GenericInconsistencyIgnoreFilter,
+        error_message_normalizer: ErrorMessageNormalizer = ErrorMessageNormalizer(),
+    ):
         self.ignore_filter = ignore_filter
-        self.error_message_normalizer = ErrorMessageNormalizer()
+        self.error_message_normalizer = error_message_normalizer
 
     def compare_results(self, query_execution: QueryExecution) -> ValidationOutcome:
         validation_outcome = ValidationOutcome()

--- a/misc/python/materialize/version_consistency/validation/version_consistency_error_message_normalizer.py
+++ b/misc/python/materialize/version_consistency/validation/version_consistency_error_message_normalizer.py
@@ -1,0 +1,23 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import re
+
+from materialize.output_consistency.validation.error_message_normalizer import (
+    ErrorMessageNormalizer,
+)
+
+FUNCTION_ID_SUFFIX_PATTERN = re.compile(r" \(function \[s\d+ AS pg_catalog\.\w+\]\)")
+
+
+class VersionConsistencyErrorMessageNormalizer(ErrorMessageNormalizer):
+    def normalize(self, error_message: str) -> str:
+        error_message = re.sub(FUNCTION_ID_SUFFIX_PATTERN, "", error_message)
+
+        return error_message

--- a/misc/python/materialize/version_consistency/version_consistency_test.py
+++ b/misc/python/materialize/version_consistency/version_consistency_test.py
@@ -40,6 +40,9 @@ from materialize.version_consistency.execution.multi_version_executors import (
 from materialize.version_consistency.ignore_filter.version_consistency_ignore_filter import (
     VersionConsistencyIgnoreFilter,
 )
+from materialize.version_consistency.validation.version_consistency_error_message_normalizer import (
+    VersionConsistencyErrorMessageNormalizer,
+)
 
 EVALUATION_STRATEGY_NAME_DFR = "dataflow_rendering"
 EVALUATION_STRATEGY_NAME_CTF = "constant_folding"
@@ -79,7 +82,9 @@ class VersionConsistencyTest(OutputConsistencyTest):
     def create_result_comparator(
         self, ignore_filter: GenericInconsistencyIgnoreFilter
     ) -> ResultComparator:
-        return ResultComparator(ignore_filter)
+        return ResultComparator(
+            ignore_filter, VersionConsistencyErrorMessageNormalizer()
+        )
 
     def create_inconsistency_ignore_filter(
         self, sql_executors: SqlExecutors


### PR DESCRIPTION
This addresses the failure in https://buildkite.com/materialize/nightlies/builds/5151#018bc618-2054-4717-9239-64944e5724ec.