### PR TITLE
ci: Bump CRDB/Redpanda/Kafka versions

### DIFF
--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,7 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM cockroachdb/cockroach:v23.1.10 AS crdb
+FROM cockroachdb/cockroach:v23.1.11 AS crdb
 
 MZFROM ubuntu-base
 

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -78,6 +78,8 @@ IGNORE_RE = re.compile(
     | restart-materialized-1\ .*relation\ "consensus"\ does\ not\ exist
     # Will print a separate panic line which will be handled and contains the relevant information
     | internal\ error:\ panic\ at\ the\ `.*`\ optimization\ stage
+    # redpanda INFO logging
+    | larger\ sizes\ prevent\ running\ out\ of\ memory
     )
     """,
     re.VERBOSE,

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -33,7 +33,7 @@ T = TypeVar("T")
 say = ui.speaker("C> ")
 
 
-DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.0.5"
+DEFAULT_CONFLUENT_PLATFORM_VERSION = "7.5.0"
 
 DEFAULT_MZ_VOLUMES = [
     "mzdata:/mzdata",

--- a/misc/python/materialize/mzcompose/services/cockroach.py
+++ b/misc/python/materialize/mzcompose/services/cockroach.py
@@ -21,7 +21,7 @@ from materialize.mzcompose.service import (
 
 
 class Cockroach(Service):
-    DEFAULT_COCKROACH_TAG = "v23.1.10"
+    DEFAULT_COCKROACH_TAG = "v23.1.11"
 
     def __init__(
         self,

--- a/misc/python/materialize/mzcompose/services/redpanda.py
+++ b/misc/python/materialize/mzcompose/services/redpanda.py
@@ -18,7 +18,7 @@ class Redpanda(Service):
     def __init__(
         self,
         name: str = "redpanda",
-        version: str = "v23.1.9",
+        version: str = "v23.2.15",
         auto_create_topics: bool = False,
         image: str | None = None,
         aliases: list[str] | None = None,

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -16,14 +16,15 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
-REDPANDA_VERSIONS = ["v23.1.2", "v22.2.11", "v22.1.11"]
+REDPANDA_VERSIONS = ["v23.2.15", "v23.1.20", "v22.3.25", "v22.2.13", "v22.1.11"]
 
 CONFLUENT_PLATFORM_VERSIONS = [
-    "6.2.8",
-    "7.0.7",
-    "7.1.5",
-    "7.2.3",
-    "7.3.2",
+    "6.2.12",
+    "7.0.11",
+    "7.1.9",
+    "7.2.7",
+    "7.3.5",
+    "7.4.2",
     "latest",
 ]
 

--- a/test/kafka-ssl/smoketest.td
+++ b/test/kafka-ssl/smoketest.td
@@ -34,7 +34,7 @@ $ kafka-ingest format=avro topic=data schema=${schema} timestamp=1
     SSL CERTIFICATE = '${arg.materialized-kafka1-crt}',
     SSL CERTIFICATE AUTHORITY = '${arg.ca-crt}'
   );
-contains:Connection reset: error:1408F119:SSL routines:ssl3_get_record:decryption failed or bad record mac
+contains:Connection reset: error:14094416:SSL routines:ssl3_read_bytes:sslv3 alert certificate unknown: SSL alert number 46
 
 # Attempt to connect with the wrong CA
 ! CREATE CONNECTION kafka_ssl TO KAFKA (


### PR DESCRIPTION
Is there a reason to stay on older versions?

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
