### PR TITLE
parallel-workload: Disable postgres sources in backup+restore scenario

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1177,6 +1177,10 @@ class CreatePostgresSourceAction(Action):
         return result
 
     def run(self, exe: Executor) -> None:
+        # TODO: Reenable when #22770 is fixed
+        if exe.db.scenario == Scenario.BackupRestore:
+            return
+
         with exe.db.lock:
             if len(exe.db.postgres_sources) > MAX_POSTGRES_SOURCES:
                 return

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -807,16 +807,20 @@ class Database:
                 )
                 for i in range(rng.randint(0, MAX_INITIAL_KAFKA_SOURCES))
             ]
-            self.postgres_sources = [
-                PostgresSource(
-                    i,
-                    rng.choice(self.clusters),
-                    rng.choice(self.schemas),
-                    ports,
-                    rng,
-                )
-                for i in range(rng.randint(0, MAX_INITIAL_POSTGRES_SOURCES))
-            ]
+            # TODO: Reenable when #22770 is fixed
+            if self.scenario == Scenario.BackupRestore:
+                self.postgres_sources = []
+            else:
+                self.postgres_sources = [
+                    PostgresSource(
+                        i,
+                        rng.choice(self.clusters),
+                        rng.choice(self.schemas),
+                        ports,
+                        rng,
+                    )
+                    for i in range(rng.randint(0, MAX_INITIAL_POSTGRES_SOURCES))
+                ]
             self.kafka_sinks = [
                 KafkaSink(
                     i,


### PR DESCRIPTION
Until 22770 is resolved

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
