### PR TITLE
 ci: reduce git fetch operations 

### DIFF
--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -200,6 +200,7 @@ def fetch(
 
     fetch_tags = (
         include_tags == YesNoOnce.YES
+        # fetch tags again if used with force (tags might have changed)
         or (include_tags == YesNoOnce.ONCE and force)
         or (
             include_tags == YesNoOnce.ONCE

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -178,10 +178,10 @@ def fetch(
 ) -> str:
     """Fetch from remotes"""
 
-    if remote and all_remotes:
+    if remote is not None and all_remotes:
         raise RuntimeError("all_remotes must be false when a remote is specified")
 
-    if branch and not remote:
+    if branch is not None and remote is None:
         raise RuntimeError("remote must be specified when a branch is specified")
 
     if branch is not None and only_tags:

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import random
+from enum import Enum
 from pathlib import Path
 from typing import TypeVar
 
@@ -44,3 +45,9 @@ def naughty_strings() -> list[str]:
         with open(MZ_ROOT / "misc" / "python" / "materialize" / "blns.json") as f:
             NAUGHTY_STRINGS = json.load(f)
     return NAUGHTY_STRINGS
+
+
+class YesNoOnce(Enum):
+    YES = 1
+    NO = 2
+    ONCE = 3

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -43,7 +43,7 @@ from materialize.scalability.schema import Schema, TransactionIsolation
 from materialize.scalability.workload import Workload, WorkloadSelfTest
 from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
-from materialize.util import all_subclasses
+from materialize.util import YesNoOnce, all_subclasses
 
 SERVICES = [
     Materialized(
@@ -167,7 +167,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         print(f"* {other_endpoint}")
 
     # fetch main branch and git tags so that their commit messages can be resolved
-    git.fetch(remote=git.get_remote(), branch="main", include_tags=True)
+    git.fetch(remote=git.get_remote(), branch="main", include_tags=YesNoOnce.ONCE)
 
     schema = Schema(
         create_index=args.create_index,


### PR DESCRIPTION
This reduces git fetch operations that are only triggered to fetch the tags. For that, `include_tags` in the fetch method is changed from boolean to `YesNoOnce`. `YesNoOnce.ONCE` only fetches tags if this is the first fetch request for the given remote. In addition, `only_tags` does not perform a fetch operation if no tags need to be fetched.