### PR TITLE
Revert "[skunkworks] row: Use CompactBytes as backing store (#22760)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1199,16 +1199,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "compact_bytes"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de71a0422a777179ab4baef92325e56396443df4a680bc443b11f63d644ca019"
-dependencies = [
- "serde",
- "static_assertions",
-]
-
-[[package]]
 name = "compile-time-run"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4652,7 +4642,6 @@ dependencies = [
  "bytes",
  "chrono",
  "clap",
- "compact_bytes",
  "console-subscriber",
  "ctor",
  "either",
@@ -5106,7 +5095,6 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "columnation",
- "compact_bytes",
  "criterion",
  "dec",
  "differential-dataflow",
@@ -5137,7 +5125,6 @@ dependencies = [
  "serde",
  "serde_json",
  "smallvec",
- "static_assertions",
  "thiserror",
  "timely",
  "tokio-postgres",

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -21,7 +21,6 @@ chrono = { version = "0.4.23", default-features = false, features = [
   "std",
 ], optional = true }
 clap = { version = "3.2.24", features = ["env"], optional = true }
-compact_bytes = { version = "0.1.1", optional = true }
 ctor = { version = "0.1.26", optional = true }
 either = "1.8.0"
 futures = { version = "0.3.25", optional = true }
@@ -96,7 +95,7 @@ async = [
   "tokio",
   "tracing",
 ]
-bytes_ = ["bytes", "compact_bytes", "smallvec", "smallvec/const_generics"]
+bytes_ = ["bytes", "smallvec", "smallvec/const_generics"]
 network = ["async", "bytes", "hyper", "smallvec", "tonic", "tracing"]
 region = ["lgalloc"]
 tracing_ = [

--- a/src/ore/src/vec.rs
+++ b/src/ore/src/vec.rs
@@ -78,17 +78,6 @@ where
     }
 }
 
-#[cfg(feature = "compact_bytes")]
-impl Vector<u8> for compact_bytes::CompactBytes {
-    fn push(&mut self, value: u8) {
-        self.push(value)
-    }
-
-    fn extend_from_slice(&mut self, other: &[u8]) {
-        self.extend_from_slice(other)
-    }
-}
-
 /// Extension methods for `std::vec::Vec`
 pub trait VecExt<T> {
     /// Creates an iterator which uses a closure to determine if an element should be removed.

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -22,7 +22,6 @@ cfg-if = "1.0.0"
 columnation = { git = "https://github.com/frankmcsherry/columnation" }
 chrono = { version = "0.4.23", default-features = false, features = ["serde", "std"] }
 chrono-tz = { version = "0.8.1", features = ["serde", "case-insensitive"] }
-compact_bytes = "0.1.1"
 dec = "0.4.8"
 differential-dataflow = "0.12.0"
 enum_dispatch = "0.3.11"
@@ -32,7 +31,7 @@ hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 mz-lowertest = { path = "../lowertest" }
-mz-ore = { path = "../ore", features = ["bytes_", "smallvec", "region", "stack", "test", "serde"] }
+mz-ore = { path = "../ore", features = ["bytes", "smallvec", "region", "stack", "test", "serde"] }
 mz-persist-types = { path = "../persist-types" }
 mz-pgtz = { path = "../pgtz" }
 mz-proto = { path = "../proto", features = ["chrono"] }
@@ -46,14 +45,13 @@ ryu = "1.0.12"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
-static_assertions = "1.1"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"
 url = { version = "2.3.1", features = ["serde"] }
 uuid = { version = "1.2.2", features = ["serde"] }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
-proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
+proptest-derive = { version = "0.3.0", features = ["boxed_union"]}
 thiserror = "1.0.37"
 
 # for the tracing_ feature

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -17,7 +17,6 @@ use std::str;
 use std::sync::atomic::{self, AtomicBool};
 
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
-use compact_bytes::CompactBytes;
 use mz_ore::cast::{CastFrom, ReinterpretCast};
 use mz_ore::soft_assert;
 use mz_ore::vec::Vector;
@@ -27,6 +26,7 @@ use ordered_float::OrderedFloat;
 use proptest::prelude::*;
 use proptest::strategy::{BoxedStrategy, Strategy};
 use serde::{Deserialize, Serialize};
+use smallvec::SmallVec;
 use uuid::Uuid;
 
 use crate::adt::array::{
@@ -112,22 +112,7 @@ pub static VARIABLE_LENGTH_ENCODING: AtomicBool = AtomicBool::new(false);
 /// avoids the allocations involved in `Row::new()`.
 #[derive(Default, Eq, PartialEq, Hash, Serialize, Deserialize)]
 pub struct Row {
-    data: CompactBytes,
-}
-
-// Nothing depends on Row being exactly 24, we just want to add visibility to the size.
-static_assertions::const_assert_eq!(std::mem::size_of::<Row>(), 24);
-
-impl Clone for Row {
-    fn clone(&self) -> Self {
-        Row {
-            data: self.data.clone(),
-        }
-    }
-
-    fn clone_from(&mut self, source: &Self) {
-        self.data.clone_from(&source.data);
-    }
+    data: SmallVec<[u8; Self::SIZE]>,
 }
 
 impl Arbitrary for Row {
@@ -149,8 +134,18 @@ impl Arbitrary for Row {
     }
 }
 
+// Implement Clone manually to use SmallVec's more efficient from_slice.
+// TODO: Revisit once Rust supports specialization: https://github.com/rust-lang/rust/issues/31844
+impl Clone for Row {
+    fn clone(&self) -> Self {
+        Self {
+            data: SmallVec::from_slice(self.data.as_slice()),
+        }
+    }
+}
+
 impl Row {
-    const SIZE: usize = CompactBytes::MAX_INLINE;
+    const SIZE: usize = 24;
 }
 
 /// These implementations order first by length, and then by slice contents.
@@ -216,7 +211,7 @@ mod columnation {
             if item.data.spilled() {
                 let bytes = self.region.copy_slice(&item.data[..]);
                 Row {
-                    data: compact_bytes::CompactBytes::from_raw_parts(
+                    data: smallvec::SmallVec::from_raw_parts(
                         bytes.as_mut_ptr(),
                         item.data.len(),
                         item.data.capacity(),
@@ -1518,7 +1513,7 @@ impl Row {
     #[inline]
     pub fn with_capacity(cap: usize) -> Self {
         Self {
-            data: CompactBytes::with_capacity(cap),
+            data: SmallVec::with_capacity(cap),
         }
     }
 
@@ -1663,7 +1658,7 @@ impl RowPacker<'_> {
 
     /// Appends the datums of an entire `Row`.
     pub fn extend_by_row(&mut self, row: &Row) {
-        self.row.data.extend_from_slice(row.data.as_slice());
+        self.row.data.extend(row.data.iter().copied());
     }
 
     /// Pushes a [`DatumList`] that is built from a closure.
@@ -2780,5 +2775,15 @@ mod tests {
 
         let e = test_range_errors_inner(vec![vec![Datum::Int32(2)], vec![Datum::Int32(1)]]);
         assert_eq!(e, Err(InvalidRangeError::MisorderedRangeBounds));
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[mz_ore::test]
+    fn row_size_is_stable() {
+        // nothing depends on this being exactly 32, we just want it to be an active decision if we
+        // change it
+        assert_eq!(std::mem::size_of::<super::Row>(), 32);
     }
 }

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1549,24 +1549,13 @@ NULL
 query III
 SELECT mz_row_size((1, 2)), mz_row_size((1, 2, 3, 4)), mz_row_size((1, 2, 3, 4, 5))
 ----
-24  24  24
-
-statement ok
-CREATE TABLE ts_size (t TEXT)
-
-statement ok
-INSERT INTO ts_size VALUES ('2023-10-30T13:47:11Z')
-
-query I
-SELECT mz_row_size(ts_size.*) FROM ts_size
-----
-24
+32  32  32
 
 query III
 SELECT a, b, mz_row_size(col_size.*) FROM col_size ORDER BY a
 ----
-1  2  63
-NULL  NULL  24
+1  2  71
+NULL  NULL  32
 
 query error mz_errored
 SELECT mz_internal.mz_error_if_null(NULL, 'mz_errored')

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -265,8 +265,8 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
 # Under arrangement specialization of only empty values, a single-column relation
-# should demand 48 bytes per tuple instead of 96.
-> SELECT records >= 300, size >= 300*48, capacity >= 300*48 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+# should demand 56 bytes per tuple instead of 88.
+> SELECT records >= 300, size >= 300*56, capacity >= 300*56 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
 true true true
 true true true
 
@@ -295,7 +295,7 @@ true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 48*1000 AND size < 2*48*1000, capacity > 48*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 56*1000 AND size < 2*56*1000, capacity > 56*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 true true true true true
 
 > DROP INDEX ii_t4

--- a/test/testdrive/oom.td
+++ b/test/testdrive/oom.td
@@ -14,23 +14,23 @@ $ postgres-connect name=mz_system url=postgres://mz_system:materialize@${testdri
 $ postgres-execute connection=mz_system
 ALTER SYSTEM SET max_result_size = 128
 
-# Each inline row takes 24 bytes of memory, 23 for the inline array and 1 for the length.
+# Each inline row takes 32 bytes of memory. 24 bytes for the inline array and 8 bytes
+# for the capacity.
 
-> SELECT 1::int4 FROM generate_series(1, 5);
-1
+> SELECT 1::int4 FROM generate_series(1, 4);
 1
 1
 1
 1
 
-! SELECT 1::int4 FROM generate_series(1, 6);
+! SELECT 1::int4 FROM generate_series(1, 5);
 contains:result exceeds max size of 128 B
 
 > CREATE TABLE t1 (a int4)
 
-> INSERT INTO t1 SELECT 1::int4 FROM generate_series(1, 5);
+> INSERT INTO t1 SELECT 1::int4 FROM generate_series(1, 4);
 
-> INSERT INTO t1 VALUES (6);
+> INSERT INTO t1 VALUES (5);
 
 ! SELECT * FROM t1
 contains:result exceeds max size of 128 B
@@ -54,7 +54,7 @@ contains:result exceeds max size of 128 B
 # be sent to computed to be executed. Therefore, we need to set the size high enough such that it will be evaluated by
 # computed to test the computed side of things.
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 240000;
+ALTER SYSTEM SET max_result_size = 320000;
 
 > SELECT generate_series::int4 FROM generate_series(1, 4);
 1
@@ -63,35 +63,35 @@ ALTER SYSTEM SET max_result_size = 240000;
 4
 
 ! SELECT generate_series::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 320.0 KB
 
 ! SELECT 1::int4 FROM generate_series(1, 10001)
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 320.0 KB
 
 > CREATE TABLE t2 (a int4)
 
 ! INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10001);
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 320.0 KB
 
 > INSERT INTO t2 SELECT generate_series::int4 FROM generate_series(1, 10000);
 
 > INSERT INTO t2 VALUES (10000);
 
 ! SELECT * FROM t2
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 320.0 KB
 
 ! INSERT INTO t2 SELECT * FROM t2;
-contains:result exceeds max size of 240.0 KB
+contains:result exceeds max size of 320.0 KB
 
-# Rows keep 23 bytes inline, after that the row is spilled to the heap. int4 takes 5 bytes,
+# Rows keep 24 bytes inline, after that the row is spilled to the heap. int4 takes 5 bytes,
 # 4 for the int and 1 for the tag. A row of 5 int4's will spill to the heap, but any less will
-# be kept inline. A row of 5 int4's should then take 25 + 24 = 49 bytes.
+# be kept inline. A row of 5 int4's should then take 25 + 32 = 57 bytes.
 #
 # Large numbers are used to avoid this test being defeated
 # by the optimization in https://github.com/MaterializeInc/materialize/pull/21016
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 49
+ALTER SYSTEM SET max_result_size = 57
 
 > SELECT 17000000, 17000001, 17000002, 17000003;
 17000000 17000001 17000002 17000003
@@ -100,10 +100,10 @@ ALTER SYSTEM SET max_result_size = 49
 17000000 17000001 17000002 17000003 17000004
 
 $ postgres-execute connection=mz_system
-ALTER SYSTEM SET max_result_size = 48
+ALTER SYSTEM SET max_result_size = 56
 
 ! SELECT 17000000, 17000001, 17000002, 17000003, 17000004;
-contains:result exceeds max size of 48 B
+contains:result exceeds max size of 56 B
 
 $ postgres-execute connection=mz_system
 ALTER SYSTEM RESET max_result_size


### PR DESCRIPTION
This reverts commit 8e6836f2d55781a0a5e53edd73eaadfa7d1d3335.

### Motivation

This PR is a precautionary revert of the new `Row` impl. There is no way to feature gate the new implementation, so I'm putting up this revert which we'll apply to a point fix in the next release, just incase something goes bad we have a build we can deploy.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
