### PR TITLE
Revert "Merge pull request #23022 from aljoscha/adapter-never-remove-…

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2233,6 +2233,9 @@ impl Catalog {
                         }
                     }
                 }
+                Op::DropTimeline(timeline) => {
+                    tx.remove_timestamp(timeline);
+                }
                 Op::GrantRole {
                     role_id,
                     member_id,
@@ -3676,6 +3679,7 @@ pub enum Op {
         comment: Option<String>,
     },
     DropObject(ObjectId),
+    DropTimeline(Timeline),
     GrantRole {
         role_id: RoleId,
         member_id: RoleId,

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -25,7 +25,7 @@ use mz_repr::{GlobalId, Timestamp};
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaSpecifier};
 use mz_storage_types::sources::Timeline;
 use timely::progress::Timestamp as TimelyTimestamp;
-use tracing::{debug, error};
+use tracing::error;
 
 use crate::catalog::CatalogItem;
 use crate::coord::id_bundle::CollectionIdBundle;
@@ -280,6 +280,11 @@ impl Coordinator {
             }
         }
         let became_empty = read_holds.is_empty();
+
+        // Finally, remove the Timeline if it's empty.
+        if became_empty {
+            self.global_timelines.remove(&timeline);
+        }
 
         became_empty
     }
@@ -632,22 +637,9 @@ impl Coordinator {
                 // advance of any object's upper. This is the largest timestamp that is closed
                 // to writes.
                 let id_bundle = self.ids_in_timeline(&timeline);
-
-                // Advance the timeline if-and-only-if there are objects in it.
-                // Otherwise we'd advance to the empty frontier, meaning we
-                // close it off for ever.
-                if !id_bundle.is_empty() {
-                    let least_valid_write = self.least_valid_write(&id_bundle);
-                    let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
-                    oracle.apply_write(now).await;
-                    debug!(
-                        least_valid_write = ?least_valid_write,
-                        oracle_read_ts = ?oracle.read_ts().await,
-                        "advanced {:?} to {}",
-                        timeline,
-                        now,
-                    );
-                }
+                let now =
+                    Self::largest_not_in_advance_of_upper(&self.least_valid_write(&id_bundle));
+                oracle.apply_write(now).await;
             };
             let read_ts = oracle.read_ts().await;
             if read_holds.times().any(|time| time.less_than(&read_ts)) {

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1096,6 +1096,15 @@ impl<'a> Transaction<'a> {
         self.system_configurations.delete(|_k, _v| true);
     }
 
+    pub fn remove_timestamp(&mut self, timeline: Timeline) {
+        let timeline_str = timeline.to_string();
+        let prev = self
+            .timestamps
+            .set(TimestampKey { id: timeline_str }, None)
+            .expect("cannot have uniqueness violation");
+        assert!(prev.is_some());
+    }
+
     pub(crate) fn insert_config(&mut self, key: String, value: u64) -> Result<(), CatalogError> {
         match self
             .configs


### PR DESCRIPTION
Fixes #23087

Revert of #23022 

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
