### PR TITLE
test: Fix a flaky test

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -2905,11 +2905,15 @@ fn test_auto_run_on_introspection_feature_enabled() {
         .unwrap();
     assert_introspection_notice(true);
 
-    let _row = client
-        .query_one(
-            "SELECT * FROM mz_internal.mz_cluster_replica_heartbeats LIMIT 1",
-            &[],
-        )
+    // We add a retry here since it might take a moment to get a replica heartbeat.
+    let _row = Retry::default()
+        .max_tries(5)
+        .retry(|_state| {
+            client.query_one(
+                "SELECT * FROM mz_internal.mz_cluster_replica_heartbeats LIMIT 1",
+                &[],
+            )
+        })
         .unwrap();
     assert_introspection_notice(true);
 


### PR DESCRIPTION
This PR adds a retry around a flaky SQL call in a test.

Note: I recently fixed a very similar test in https://github.com/MaterializeInc/materialize/pull/23042, but this is a different test case than that PR. I checked the integration test suite for other calls to this flaky source, and this is indeed the only other one.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23110

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
