### PR TITLE
Update Differential Dataflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1729,7 +1729,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#40fbd33810198116f7a3562e86495233184acbd4"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#cccb1e2f2723fdefc4f2a992c86dcf0f9e4c6cc7"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1786,7 +1786,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#40fbd33810198116f7a3562e86495233184acbd4"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#cccb1e2f2723fdefc4f2a992c86dcf0f9e4c6cc7"
 dependencies = [
  "abomonation",
  "abomonation_derive",


### PR DESCRIPTION
### Motivation


  * This PR adds a feature that has not yet been specified.

Update our dependency on Differential Dataflow.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
