### PR TITLE
test: Disable shadow catalog in parallel tests

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -46,8 +46,13 @@ SERVICES = [
     Clusterd(name="clusterd2"),
     Clusterd(name="clusterd3"),
     Clusterd(name="clusterd4"),
-    # We use mz_panic() in some test scenarios, so environmentd must stay up.
-    Materialized(propagate_crashes=False, external_cockroach=True),
+    Materialized(
+        # We use mz_panic() in some test scenarios, so environmentd must stay up.
+        propagate_crashes=False,
+        external_cockroach=True,
+        # Kills make the shadow catalog not work properly
+        catalog_store="stash",
+    ),
     Redpanda(),
     Toxiproxy(),
     Testdrive(

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -64,7 +64,21 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "minio",
         "materialized",
     ]
-    c.up(*service_names)
+    catalog_store = (
+        "stash"
+        if args.scenario in (Scenario.Kill, Scenario.BackupRestore)
+        else "shadow"
+    )
+    with c.override(
+        Materialized(
+            external_cockroach=True,
+            restart="on-failure",
+            external_minio=True,
+            ports=["6975:6875", "6976:6876", "6977:6877"],
+            catalog_store=catalog_store,
+        )
+    ):
+        c.up(*service_names)
     c.up("mc", persistent=True)
     c.exec(
         "mc",

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -88,6 +88,7 @@ SERVICES = [
         external_minio=True,
         sanity_restart=False,
         volumes_extra=["secrets:/share/secrets"],
+        catalog_store="stash",
     ),
     TestdriveService(
         default_timeout="300s",


### PR DESCRIPTION
The Shadow catalog does the following on every catalog operation:

  1. Execute the operation on catalog A.
  2. Execute the operation on catalog B.
  3. Compare the results.

The parallel-workload tests will randomly kill Materialize, so we could end up in a situation where the operation happens on catalog A but not on catalog B, and we will see an inconsistency between the two catalogs. The shadow catalog is meant to be used to compare two catalog implementations, so it's OK that it has this deficiency. Given that, this commit disables the shadow catalog in parallel-workload tests.

Fixes #23146

### Motivation
This PR fixes a recognized bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
