### PR TITLE
adapter: improve dependency tracking

### DIFF
--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -418,7 +418,8 @@ impl CatalogState {
 
         if !entry.item().is_temporary() {
             // Populate or clean up the `mz_object_dependencies` table.
-            for dependee in &entry.item().uses().0 {
+            // TODO(jkosh44) Unclear if this table wants to include all uses or only references.
+            for dependee in &entry.item().references().0 {
                 updates.push(self.pack_depends_update(id, *dependee, diff))
             }
         }

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1167,7 +1167,7 @@ impl Coordinator {
             .entries()
             .cloned()
             .map(|entry| {
-                let remaining_deps = entry.uses().0.iter().copied().collect::<Vec<_>>();
+                let remaining_deps = entry.uses().into_iter().collect::<Vec<_>>();
                 (entry, remaining_deps)
             })
             .collect();

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4100,10 +4100,9 @@ impl Coordinator {
                             && (
                                 // empty `uses` indicates either system func or
                                 // view created from constants
-                                entry.uses().0.is_empty()
+                                entry.uses().is_empty()
                                     || entry
                                         .uses()
-                                        .0
                                         .iter()
                                         .all(|id| validate_read_dependencies(catalog, id))
                             )

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -270,7 +270,7 @@ impl Fingerprint for &BuiltinTable {
 
 impl Fingerprint for &BuiltinView {
     fn fingerprint(&self) -> String {
-        self.sql.to_string()
+        format!("\n\n{}\n\n", self.sql)
     }
 }
 

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -23,6 +23,8 @@
 //! <https://materialize.com/docs/sql/system-catalog/>.
 
 use std::hash::Hash;
+use std::string::ToString;
+use std::sync::Mutex;
 
 use const_format::concatcp;
 use mz_compute_client::logging::{ComputeLog, DifferentialLog, LogVariant, TimelyLog};
@@ -268,9 +270,26 @@ impl Fingerprint for &BuiltinTable {
     }
 }
 
+/// Allows tests to inject arbitrary amounts of whitespace to forcibly change the fingerprint and
+/// trigger a builtin migration. Ideally this would be guarded by a `#[cfg(test)]` but unfortunately,
+/// the builtin migrations are in a different crate and would not be able to modify this value.
+/// There is an open issue to move builtin migrations to this crate:
+/// <https://github.com/MaterializeInc/materialize/issues/22593>
+pub static REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE: Mutex<
+    Option<String>,
+> = Mutex::new(None);
 impl Fingerprint for &BuiltinView {
     fn fingerprint(&self) -> String {
-        format!("\n\n{}\n\n", self.sql)
+        // This is only called during bootstrapping so it's not that big of a deal to lock a mutex,
+        // though it's not great.
+        let guard = REALLY_DANGEROUS_DO_NOT_CALL_THIS_IN_PRODUCTION_VIEW_FINGERPRINT_WHITESPACE
+            .lock()
+            .expect("lock poisoned");
+        if let Some(whitespace) = &*guard {
+            format!("{}{}", self.sql, whitespace)
+        } else {
+            self.sql.to_string()
+        }
     }
 }
 

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -850,14 +850,14 @@ impl CatalogItem {
                 .0
                 .clone()
                 .into_iter()
-                .chain(view.raw_expr.depends_on().into_iter())
+                .chain(view.raw_expr.depends_on())
                 .collect(),
             CatalogItem::MaterializedView(mview) => mview
                 .resolved_ids
                 .0
                 .clone()
                 .into_iter()
-                .chain(mview.raw_expr.depends_on().into_iter())
+                .chain(mview.raw_expr.depends_on())
                 .collect(),
             CatalogItem::Secret(_) => BTreeSet::new(),
             CatalogItem::Connection(connection) => connection.resolved_ids.0.clone(),

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -829,39 +829,23 @@ impl CatalogItem {
     /// referenced. For example this will include any catalog objects used to implement functions
     /// and casts in the item.
     pub fn uses(&self) -> BTreeSet<GlobalId> {
+        let mut uses = self.references().0.clone();
         match self {
             // TODO(jkosh44) This isn't really correct for functions. They may use other objects in
             // their implementation. However, currently there's no way to get that information.
-            CatalogItem::Func(_) => BTreeSet::new(),
-            CatalogItem::Index(idx) => idx
-                .resolved_ids
-                .0
-                .clone()
-                .into_iter()
-                .chain(idx.keys.iter().flat_map(|key| key.depends_on().into_iter()))
-                .collect(),
-            CatalogItem::Sink(sink) => sink.resolved_ids.0.clone(),
-            CatalogItem::Source(source) => source.resolved_ids.0.clone(),
-            CatalogItem::Log(_) => BTreeSet::new(),
-            CatalogItem::Table(table) => table.resolved_ids.0.clone(),
-            CatalogItem::Type(typ) => typ.resolved_ids.0.clone(),
-            CatalogItem::View(view) => view
-                .resolved_ids
-                .0
-                .clone()
-                .into_iter()
-                .chain(view.raw_expr.depends_on())
-                .collect(),
-            CatalogItem::MaterializedView(mview) => mview
-                .resolved_ids
-                .0
-                .clone()
-                .into_iter()
-                .chain(mview.raw_expr.depends_on())
-                .collect(),
-            CatalogItem::Secret(_) => BTreeSet::new(),
-            CatalogItem::Connection(connection) => connection.resolved_ids.0.clone(),
+            CatalogItem::Func(_) => {}
+            CatalogItem::Index(_) => {}
+            CatalogItem::Sink(_) => {}
+            CatalogItem::Source(_) => {}
+            CatalogItem::Log(_) => {}
+            CatalogItem::Table(_) => {}
+            CatalogItem::Type(_) => {}
+            CatalogItem::View(view) => uses.extend(view.raw_expr.depends_on()),
+            CatalogItem::MaterializedView(mview) => uses.extend(mview.raw_expr.depends_on()),
+            CatalogItem::Secret(_) => {}
+            CatalogItem::Connection(_) => {}
         }
+        uses
     }
 
     /// Returns the connection ID that this item belongs to, if this item is

--- a/src/expr/src/scalar/mod.rs
+++ b/src/expr/src/scalar/mod.rs
@@ -29,7 +29,7 @@ use mz_repr::adt::range::InvalidRangeError;
 use mz_repr::adt::regex::Regex;
 use mz_repr::adt::timestamp::TimestampError;
 use mz_repr::strconv::{ParseError, ParseHexError};
-use mz_repr::{arb_datum, ColumnType, Datum, Row, RowArena, ScalarType};
+use mz_repr::{arb_datum, ColumnType, Datum, GlobalId, Row, RowArena, ScalarType};
 use proptest::prelude::*;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
@@ -1898,6 +1898,40 @@ impl MirScalarExpr {
             size += 1;
         })?;
         Ok(size)
+    }
+
+    /// Extract all dependencies of `self`.
+    pub fn depends_on(&self) -> BTreeSet<GlobalId> {
+        let mut dependencies = BTreeSet::new();
+        #[allow(deprecated)]
+        self.visit_post_nolimit(&mut |e| {
+            // TODO(jkosh44) There's no way to extract the dependencies from functions that may be used.
+            match e {
+                MirScalarExpr::Column(_) => {}
+                MirScalarExpr::Literal(_, _) => {}
+                MirScalarExpr::CallUnmaterializable(_) => {}
+                MirScalarExpr::CallUnary { func: _, expr } => {
+                    dependencies.extend(expr.depends_on());
+                }
+                MirScalarExpr::CallBinary {
+                    func: _,
+                    expr1,
+                    expr2,
+                } => {
+                    dependencies.extend(expr1.depends_on());
+                    dependencies.extend(expr2.depends_on());
+                }
+                MirScalarExpr::CallVariadic { func: _, exprs } => {
+                    dependencies.extend(exprs.iter().flat_map(|expr| expr.depends_on()));
+                }
+                MirScalarExpr::If { cond, then, els } => {
+                    dependencies.extend(cond.depends_on());
+                    dependencies.extend(then.depends_on());
+                    dependencies.extend(els.depends_on());
+                }
+            }
+        });
+        dependencies
     }
 }
 

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -576,8 +576,15 @@ pub trait CatalogItem {
     fn create_sql(&self) -> &str;
 
     /// Returns the IDs of the catalog items upon which this catalog item
+    /// directly references.
+    fn references(&self) -> &ResolvedIds;
+
+    /// Returns the IDs of the catalog items upon which this catalog item
     /// depends.
-    fn uses(&self) -> ResolvedIds;
+    fn uses(&self) -> BTreeSet<GlobalId>;
+
+    /// Returns the IDs of the catalog items that directly reference this catalog item.
+    fn referenced_by(&self) -> &[GlobalId];
 
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -577,7 +577,7 @@ pub trait CatalogItem {
 
     /// Returns the IDs of the catalog items upon which this catalog item
     /// depends.
-    fn uses(&self) -> &ResolvedIds;
+    fn uses(&self) -> ResolvedIds;
 
     /// Returns the IDs of the catalog items that depend upon this catalog item.
     fn used_by(&self) -> &[GlobalId];

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -177,7 +177,7 @@ pub(crate) fn add_materialize_comments(
     if catalog.system_vars().enable_sink_doc_on_option() {
         let from_id = stmt.from.item_id();
         let from = catalog.get_item(from_id);
-        let object_ids = from.uses().0.iter().map(|id| *id).chain_one(from.id());
+        let object_ids = from.uses().0.into_iter().map(|id| id).chain_one(from.id());
 
         // add comments to the avro doc comments
         if let Some(Format::Avro(AvroSchema::Csr {

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -177,7 +177,7 @@ pub(crate) fn add_materialize_comments(
     if catalog.system_vars().enable_sink_doc_on_option() {
         let from_id = stmt.from.item_id();
         let from = catalog.get_item(from_id);
-        let object_ids = from.uses().0.into_iter().map(|id| id).chain_one(from.id());
+        let object_ids = from.references().0.clone().into_iter().chain_one(from.id());
 
         // add comments to the avro doc comments
         if let Some(Format::Avro(AvroSchema::Csr {

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -1471,7 +1471,7 @@ fn generate_read_privileges_inner(
             match item.item_type() {
                 CatalogItemType::View | CatalogItemType::MaterializedView => {
                     privileges.push((SystemObjectId::Object(id.into()), AclMode::SELECT, role_id));
-                    views.push((item.uses().0.into_iter(), item.owner_id()));
+                    views.push((item.references().0.clone().into_iter(), item.owner_id()));
                 }
                 CatalogItemType::Table | CatalogItemType::Source => {
                     privileges.push((SystemObjectId::Object(id.into()), AclMode::SELECT, role_id));

--- a/src/sql/src/rbac.rs
+++ b/src/sql/src/rbac.rs
@@ -1471,7 +1471,7 @@ fn generate_read_privileges_inner(
             match item.item_type() {
                 CatalogItemType::View | CatalogItemType::MaterializedView => {
                     privileges.push((SystemObjectId::Object(id.into()), AclMode::SELECT, role_id));
-                    views.push((item.uses().0.iter().cloned(), item.owner_id()));
+                    views.push((item.uses().0.into_iter(), item.owner_id()));
                 }
                 CatalogItemType::Table | CatalogItemType::Source => {
                     privileges.push((SystemObjectId::Object(id.into()), AclMode::SELECT, role_id));


### PR DESCRIPTION
Improve dependency tracking for views that have un-named dependencies.

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a