### PR TITLE
platform-checks: Workaround for broken v0.75.3

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -118,8 +118,15 @@ class UpgradeEntireMzFourVersions(Scenario):
         return minor_versions[-4]
 
     def actions(self) -> list[Action]:
+        minor_minus_2 = minor_versions[-2]
+        minor_minus_1 = minor_versions[-1]
+        # TODO(def-) This version was bad, see #23160, can be removed after the next release
+        if minor_minus_2 == MzVersion.parse("0.75.3"):
+            minor_minus_2 = None
+            minor_minus_1 = None
+
         print(
-            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {minor_versions[-2]} -> {minor_versions[-1]}"
+            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {minor_minus_2} -> {minor_minus_1}"
         )
         return [
             StartMz(self, tag=minor_versions[-4]),
@@ -128,10 +135,10 @@ class UpgradeEntireMzFourVersions(Scenario):
             StartMz(self, tag=minor_versions[-3]),
             Manipulate(self, phase=1),
             KillMz(),
-            StartMz(self, tag=minor_versions[-2]),
+            StartMz(self, tag=minor_minus_2),
             Manipulate(self, phase=2),
             KillMz(),
-            StartMz(self, tag=minor_versions[-1]),
+            StartMz(self, tag=minor_minus_1),
             KillMz(),
             StartMz(self, tag=None),
             Validate(self),


### PR DESCRIPTION
https://github.com/MaterializeInc/materialize/issues/23160

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
