### PR TITLE
ci: move MzVersion to own file

### DIFF
--- a/misc/python/materialize/checks/all_checks/array_type.py
+++ b/misc/python/materialize/checks/all_checks/array_type.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class ArrayType(Check):

--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -10,7 +10,7 @@
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class UnifiedCluster(Check):

--- a/misc/python/materialize/checks/all_checks/comment.py
+++ b/misc/python/materialize/checks/all_checks/comment.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class Comment(Check):

--- a/misc/python/materialize/checks/all_checks/default_privileges.py
+++ b/misc/python/materialize/checks/all_checks/default_privileges.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class DefaultPrivileges(Check):

--- a/misc/python/materialize/checks/all_checks/identifiers.py
+++ b/misc/python/materialize/checks/all_checks/identifiers.py
@@ -16,7 +16,8 @@ from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion, naughty_strings
+from materialize.mz_version import MzVersion
+from materialize.util import naughty_strings
 
 
 def dq(ident: str) -> str:

--- a/misc/python/materialize/checks/all_checks/json_source.py
+++ b/misc/python/materialize/checks/all_checks/json_source.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class JsonSource(Check):

--- a/misc/python/materialize/checks/all_checks/kafka_protocols.py
+++ b/misc/python/materialize/checks/all_checks/kafka_protocols.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class KafkaProtocols(Check):

--- a/misc/python/materialize/checks/all_checks/managed_cluster.py
+++ b/misc/python/materialize/checks/all_checks/managed_cluster.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class CreateManagedCluster(Check):

--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class MaterializedViews(Check):

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class Owners(Check):

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check, disabled
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class PgCdcBase:

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class Privileges(Check):

--- a/misc/python/materialize/checks/all_checks/rename_cluster.py
+++ b/misc/python/materialize/checks/all_checks/rename_cluster.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class RenameCluster(Check):

--- a/misc/python/materialize/checks/all_checks/rename_replica.py
+++ b/misc/python/materialize/checks/all_checks/rename_replica.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class RenameReplica(Check):

--- a/misc/python/materialize/checks/all_checks/rename_schema.py
+++ b/misc/python/materialize/checks/all_checks/rename_schema.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class RenameSchema(Check):

--- a/misc/python/materialize/checks/all_checks/replica.py
+++ b/misc/python/materialize/checks/all_checks/replica.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import TESTDRIVE_NOP, Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class CreateReplica(Check):

--- a/misc/python/materialize/checks/all_checks/roles.py
+++ b/misc/python/materialize/checks/all_checks/roles.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import TESTDRIVE_NOP, Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class CreateRole(Check):

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -12,7 +12,7 @@ from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 def schemas() -> str:

--- a/misc/python/materialize/checks/all_checks/statement_logging.py
+++ b/misc/python/materialize/checks/all_checks/statement_logging.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class StatementLogging(Check):

--- a/misc/python/materialize/checks/all_checks/swap_cluster.py
+++ b/misc/python/materialize/checks/all_checks/swap_cluster.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class SwapCluster(Check):

--- a/misc/python/materialize/checks/all_checks/swap_schema.py
+++ b/misc/python/materialize/checks/all_checks/swap_schema.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class SwapSchema(Check):

--- a/misc/python/materialize/checks/all_checks/temporal_types.py
+++ b/misc/python/materialize/checks/all_checks/temporal_types.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class TemporalTypes(Check):

--- a/misc/python/materialize/checks/all_checks/uuid.py
+++ b/misc/python/materialize/checks/all_checks/uuid.py
@@ -11,7 +11,7 @@ from textwrap import dedent
 from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class UUID(Check):

--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -12,7 +12,7 @@ from materialize.checks.actions import Testdrive
 from materialize.checks.checks import Check
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 def schemas() -> str:

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.executors import Executor
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 TESTDRIVE_NOP = "$ nop"
 

--- a/misc/python/materialize/checks/cloudtest_actions.py
+++ b/misc/python/materialize/checks/cloudtest_actions.py
@@ -11,7 +11,7 @@
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
 from materialize.cloudtest.k8s.environmentd import EnvironmentdStatefulSet
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class ReplaceEnvironmentdStatefulSet(Action):

--- a/misc/python/materialize/checks/executors.py
+++ b/misc/python/materialize/checks/executors.py
@@ -13,8 +13,8 @@ from inspect import Traceback
 from typing import Any
 
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition
-from materialize.util import MzVersion
 
 
 class Executor:

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Any
 
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.services.clusterd import Clusterd
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.util import MzVersion
 
 if TYPE_CHECKING:
     from materialize.checks.scenarios import Scenario

--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -36,7 +36,7 @@ from materialize.checks.mzcompose_actions import (
 from materialize.checks.mzcompose_actions import (
     RestartSourcePostgres as RestartSourcePostgresAction,
 )
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class Scenario:

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -17,7 +17,7 @@ from materialize.checks.mzcompose_actions import (
     UseClusterdCompute,
 )
 from materialize.checks.scenarios import Scenario
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 from materialize.version_list import VersionsFromDocs
 
 version_list = VersionsFromDocs()

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -11,7 +11,7 @@
 import subprocess
 
 from materialize import buildkite, git
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 try:
     from semver.version import Version

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -14,7 +14,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 from materialize.version_list import INVALID_VERSIONS
 
 try:

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -1,0 +1,86 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Various utilities"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+try:
+    from semver.version import Version
+except ImportError:
+    from semver import VersionInfo as Version  # type: ignore
+
+
+class MzVersion(Version):
+    """Version of Materialize, can be parsed from version string, SQL, cargo"""
+
+    @classmethod
+    def create_mz(
+        cls, major: int, minor: int, patch: int, prerelease: str | None = None
+    ) -> MzVersion:
+        prerelease_suffix = f"-{prerelease}" if prerelease is not None else ""
+        return cls.parse_mz(f"v{major}.{minor}.{patch}{prerelease_suffix}")
+
+    @classmethod
+    def parse_mz(cls, version: str, drop_dev_suffix: bool = False) -> MzVersion:
+        """Parses a Mz version string, for example:  v0.45.0-dev (f01773cb1)"""
+        if not version[0] == "v":
+            raise ValueError(f"Invalid mz version string: {version}")
+        version = version[1:]
+        if " " in version:
+            version, git_hash = version.split(" ")
+            if not git_hash[0] == "(" or not git_hash[-1] == ")":
+                raise ValueError(f"Invalid mz version string: {version}")
+            # Hash ignored
+
+        if drop_dev_suffix:
+            version = version.replace("-dev", "")
+
+        return cls.parse(version)
+
+    @classmethod
+    def try_parse_mz(
+        cls, version: str, drop_dev_suffix: bool = False
+    ) -> MzVersion | None:
+        """Parses a Mz version string but returns empty if that fails"""
+        try:
+            return cls.parse_mz(version, drop_dev_suffix=drop_dev_suffix)
+        except ValueError:
+            return None
+
+    @classmethod
+    def is_mz_version_string(cls, version: str) -> bool:
+        return cls.try_parse_mz(version) is not None
+
+    @classmethod
+    def parse_cargo(cls) -> MzVersion:
+        """Uses the cargo mz-environmentd package info to get the version of current source code state"""
+        metadata = json.loads(
+            subprocess.check_output(
+                ["cargo", "metadata", "--no-deps", "--format-version=1"]
+            )
+        )
+        for package in metadata["packages"]:
+            if package["name"] == "mz-environmentd":
+                return cls.parse(package["version"])
+        else:
+            raise ValueError("No mz-environmentd version found in cargo metadata")
+
+    @classmethod
+    def from_semver(cls, version: Version) -> MzVersion:
+        return cls.parse(str(version))
+
+    def to_semver(self) -> Version:
+        return Version.parse(str(self).lstrip("v"))
+
+    def __str__(self) -> str:
+        return "v" + super().__str__()

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -10,6 +10,7 @@
 
 from copy import copy
 
+from materialize.mz_version import MzVersion
 from materialize.mzcompose import (
     DEFAULT_CRDB_ENVIRONMENT,
     DEFAULT_MZ_ENVIRONMENT_ID,
@@ -22,7 +23,6 @@ from materialize.mzcompose.service import (
     ServiceDependency,
 )
 from materialize.mzcompose.services.minio import MINIO_BLOB_URI
-from materialize.util import MzVersion
 
 
 class Materialized(Service):

--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+from materialize.mz_version import MzVersion
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.enum.enum_constant import EnumConstant
 from materialize.output_consistency.expression.expression import Expression
@@ -46,7 +47,6 @@ from materialize.output_consistency.operation.operation import (
     DbOperationOrFunction,
     OperationRelevance,
 )
-from materialize.util import MzVersion
 
 TEXT_OPERATION_TYPES: list[DbOperationOrFunction] = []
 

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -9,6 +9,7 @@
 
 from enum import Enum
 
+from materialize.mz_version import MzVersion
 from materialize.output_consistency.data_type.data_type import DataType
 from materialize.output_consistency.expression.expression import Expression
 from materialize.output_consistency.expression.expression_characteristics import (
@@ -19,7 +20,6 @@ from materialize.output_consistency.operation.operation_args_validator import (
 )
 from materialize.output_consistency.operation.operation_param import OperationParam
 from materialize.output_consistency.operation.return_type_spec import ReturnTypeSpec
-from materialize.util import MzVersion
 
 EXPRESSION_PLACEHOLDER = "$"
 

--- a/misc/python/materialize/util.py
+++ b/misc/python/materialize/util.py
@@ -14,87 +14,14 @@ from __future__ import annotations
 import json
 import os
 import random
-import subprocess
 from pathlib import Path
 from typing import TypeVar
-
-try:
-    from semver.version import Version
-except ImportError:
-    from semver import VersionInfo as Version  # type: ignore
-
 
 MZ_ROOT = Path(os.environ["MZ_ROOT"])
 
 
 def nonce(digits: int) -> str:
     return "".join(random.choice("0123456789abcdef") for _ in range(digits))
-
-
-class MzVersion(Version):
-    """Version of Materialize, can be parsed from version string, SQL, cargo"""
-
-    @classmethod
-    def create_mz(
-        cls, major: int, minor: int, patch: int, prerelease: str | None = None
-    ) -> MzVersion:
-        prerelease_suffix = f"-{prerelease}" if prerelease is not None else ""
-        return cls.parse_mz(f"v{major}.{minor}.{patch}{prerelease_suffix}")
-
-    @classmethod
-    def parse_mz(cls, version: str, drop_dev_suffix: bool = False) -> MzVersion:
-        """Parses a Mz version string, for example:  v0.45.0-dev (f01773cb1)"""
-        if not version[0] == "v":
-            raise ValueError(f"Invalid mz version string: {version}")
-        version = version[1:]
-        if " " in version:
-            version, git_hash = version.split(" ")
-            if not git_hash[0] == "(" or not git_hash[-1] == ")":
-                raise ValueError(f"Invalid mz version string: {version}")
-            # Hash ignored
-
-        if drop_dev_suffix:
-            version = version.replace("-dev", "")
-
-        return cls.parse(version)
-
-    @classmethod
-    def try_parse_mz(
-        cls, version: str, drop_dev_suffix: bool = False
-    ) -> MzVersion | None:
-        """Parses a Mz version string but returns empty if that fails"""
-        try:
-            return cls.parse_mz(version, drop_dev_suffix=drop_dev_suffix)
-        except ValueError:
-            return None
-
-    @classmethod
-    def is_mz_version_string(cls, version: str) -> bool:
-        return cls.try_parse_mz(version) is not None
-
-    @classmethod
-    def parse_cargo(cls) -> MzVersion:
-        """Uses the cargo mz-environmentd package info to get the version of current source code state"""
-        metadata = json.loads(
-            subprocess.check_output(
-                ["cargo", "metadata", "--no-deps", "--format-version=1"]
-            )
-        )
-        for package in metadata["packages"]:
-            if package["name"] == "mz-environmentd":
-                return cls.parse(package["version"])
-        else:
-            raise ValueError("No mz-environmentd version found in cargo metadata")
-
-    @classmethod
-    def from_semver(cls, version: Version) -> MzVersion:
-        return cls.parse(str(version))
-
-    def to_semver(self) -> Version:
-        return Version.parse(str(self).lstrip("v"))
-
-    def __str__(self) -> str:
-        return "v" + super().__str__()
 
 
 T = TypeVar("T")

--- a/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
+++ b/misc/python/materialize/version_consistency/ignore_filter/version_consistency_ignore_filter.py
@@ -8,6 +8,7 @@
 # by the Apache License, Version 2.0.
 from functools import partial
 
+from materialize.mz_version import MzVersion
 from materialize.output_consistency.data_type.data_type_category import DataTypeCategory
 from materialize.output_consistency.expression.expression import (
     Expression,
@@ -37,7 +38,6 @@ from materialize.output_consistency.operation.operation import (
     DbOperation,
 )
 from materialize.output_consistency.selection.selection import DataRowSelection
-from materialize.util import MzVersion
 
 MZ_VERSION_0_77_0 = MzVersion.parse_mz("v0.77.0")
 MZ_VERSION_0_78_0 = MzVersion.parse_mz("v0.78.0")

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import frontmatter
 
 from materialize import git
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 MZ_ROOT = Path(os.environ["MZ_ROOT"])
 

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -21,7 +21,8 @@ from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.wait import wait
-from materialize.util import MzVersion, all_subclasses
+from materialize.mz_version import MzVersion
+from materialize.util import all_subclasses
 from materialize.version_list import VersionsFromDocs
 
 LOGGER = logging.getLogger(__name__)

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -13,6 +13,7 @@ operational after an upgrade.
 
 import random
 
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.kafka import Kafka
@@ -22,7 +23,6 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
-from materialize.util import MzVersion
 from materialize.version_list import VersionsFromDocs
 
 version_list = VersionsFromDocs()

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -15,6 +15,8 @@ from collections.abc import Generator
 
 import networkx as nx
 
+from materialize.util import all_subclasses
+
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
 sys.path.append(os.path.dirname(__file__))
@@ -37,6 +39,7 @@ from materialize.checks.checks import Check
 from materialize.checks.executors import MzcomposeExecutor
 from materialize.checks.scenarios import *  # noqa: F401 F403
 from materialize.checks.scenarios import Scenario
+from materialize.mz_version import MzVersion
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.debezium import Debezium
@@ -46,7 +49,6 @@ from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.ssh_bastion_host import SshBastionHost
 from materialize.mzcompose.services.testdrive import Testdrive as TestdriveService
-from materialize.util import MzVersion, all_subclasses
 from materialize.version_list import VersionsFromDocs
 
 SERVICES = [

--- a/test/upgrade-matrix/nodes.py
+++ b/test/upgrade-matrix/nodes.py
@@ -11,7 +11,7 @@
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.mzcompose_actions import ConfigureMz, KillMz, StartMz
 from materialize.checks.scenarios import Scenario
-from materialize.util import MzVersion
+from materialize.mz_version import MzVersion
 
 
 class Node:


### PR DESCRIPTION
Further isolate the class `MzVersion` to reduce its dependencies to a minimum.