### PR TITLE
adapter: never remove timeline state

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2222,9 +2222,6 @@ impl Catalog {
                         }
                     }
                 }
-                Op::DropTimeline(timeline) => {
-                    tx.remove_timestamp(timeline);
-                }
                 Op::GrantRole {
                     role_id,
                     member_id,
@@ -3664,7 +3661,6 @@ pub enum Op {
         comment: Option<String>,
     },
     DropObject(ObjectId),
-    DropTimeline(Timeline),
     GrantRole {
         role_id: RoleId,
         member_id: RoleId,

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -158,7 +158,7 @@ impl Coordinator {
     pub(crate) async fn catalog_transact_with<'a, F, R>(
         &mut self,
         conn_id: Option<&ConnectionId>,
-        mut ops: Vec<catalog::Op>,
+        ops: Vec<catalog::Op>,
         f: F,
     ) -> Result<R, AdapterError>
     where
@@ -174,7 +174,6 @@ impl Coordinator {
         let mut views_to_drop = vec![];
         let mut replication_slots_to_drop: Vec<(mz_postgres_util::Config, String)> = vec![];
         let mut secrets_to_drop = vec![];
-        let mut timelines_to_drop = vec![];
         let mut vpc_endpoints_to_drop = vec![];
         let mut clusters_to_drop = vec![];
         let mut cluster_replicas_to_drop = vec![];
@@ -401,18 +400,6 @@ impl Coordinator {
                 Some((timeline, (empty, bundle)))
             })
             .collect();
-        timelines_to_drop.extend(
-            timeline_associations
-                .iter()
-                .filter_map(|(timeline, (is_empty, _))| is_empty.then_some(timeline))
-                .cloned(),
-        );
-        ops.extend(
-            timelines_to_drop
-                .iter()
-                .cloned()
-                .map(catalog::Op::DropTimeline),
-        );
 
         self.validate_resource_limits(&ops, conn_id.unwrap_or(&SYSTEM_CONN_ID))?;
 
@@ -1119,7 +1106,6 @@ impl Coordinator {
                 | Op::AlterSink { .. }
                 | Op::AlterSource { .. }
                 | Op::AlterSetCluster { .. }
-                | Op::DropTimeline(_)
                 | Op::UpdatePrivilege { .. }
                 | Op::UpdateDefaultPrivilege { .. }
                 | Op::GrantRole { .. }

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -25,7 +25,7 @@ use mz_repr::{GlobalId, Timestamp};
 use mz_sql::names::{ResolvedDatabaseSpecifier, SchemaSpecifier};
 use mz_storage_types::sources::Timeline;
 use timely::progress::Timestamp as TimelyTimestamp;
-use tracing::error;
+use tracing::{debug, error};
 
 use crate::catalog::CatalogItem;
 use crate::coord::id_bundle::CollectionIdBundle;
@@ -637,9 +637,22 @@ impl Coordinator {
                 // advance of any object's upper. This is the largest timestamp that is closed
                 // to writes.
                 let id_bundle = self.ids_in_timeline(&timeline);
-                let now =
-                    Self::largest_not_in_advance_of_upper(&self.least_valid_write(&id_bundle));
-                oracle.apply_write(now).await;
+
+                // Advance the timeline if-and-only-if there are objects in it.
+                // Otherwise we'd advance to the empty frontier, meaning we
+                // close it off for ever.
+                if !id_bundle.is_empty() {
+                    let least_valid_write = self.least_valid_write(&id_bundle);
+                    let now = Self::largest_not_in_advance_of_upper(&least_valid_write);
+                    oracle.apply_write(now).await;
+                    debug!(
+                        least_valid_write = ?least_valid_write,
+                        oracle_read_ts = ?oracle.read_ts().await,
+                        "advanced {:?} to {}",
+                        timeline,
+                        now,
+                    );
+                }
             };
             let read_ts = oracle.read_ts().await;
             if read_holds.times().any(|time| time.less_than(&read_ts)) {

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -281,11 +281,6 @@ impl Coordinator {
         }
         let became_empty = read_holds.is_empty();
 
-        // Finally, remove the Timeline if it's empty.
-        if became_empty {
-            self.global_timelines.remove(&timeline);
-        }
-
         became_empty
     }
 

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -1096,15 +1096,6 @@ impl<'a> Transaction<'a> {
         self.system_configurations.delete(|_k, _v| true);
     }
 
-    pub fn remove_timestamp(&mut self, timeline: Timeline) {
-        let timeline_str = timeline.to_string();
-        let prev = self
-            .timestamps
-            .set(TimestampKey { id: timeline_str }, None)
-            .expect("cannot have uniqueness violation");
-        assert!(prev.is_some());
-    }
-
     pub(crate) fn insert_config(&mut self, key: String, value: u64) -> Result<(), CatalogError> {
         match self
             .configs


### PR DESCRIPTION
For now, mostly so I can run nightly tests and present the "fix" to folks.

Second attempt at https://github.com/MaterializeInc/materialize/pull/23022, with more bugs fixed.

### Motivation

The motivation from the first PR still holds:

> 
> This is motivated by the addition of an external, distributed timestamp oracle which makes it harder to remove timeline state atomically with the DDL/catalog/stash changes that cause said removal.
> 
> Additionally, it seems incorrect that a timelines' timestamp state can vanish and then be re-created in the future, potentially at a lower timestamp, which would violate linearizability.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
