### PR TITLE
fix: Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,9 +3093,9 @@ dependencies = [
 
 [[package]]
 name = "lgalloc"
-version = "0.1.5"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914567ecbb55c70b5a8d3009c45dd684619b5e5d1e8d84eff140b53b8e136e60"
+checksum = "22763659eca028d9bf872e5cdf978c87dfaa4a379ba50abb8e94b48c9869e18e"
 dependencies = [
  "crossbeam-deque",
  "libc",


### PR DESCRIPTION
It seems like our Cargo.lock file became out of date

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
