### PR TITLE
storage: use AlterCompatible for source exports

### DIFF
--- a/src/storage-types/src/sources.rs
+++ b/src/storage-types/src/sources.rs
@@ -163,7 +163,7 @@ impl<S: Debug + Eq + PartialEq + crate::AlterCompatible> AlterCompatible
                         ) => {
                             // the output index may change, but the table's metadata
                             // may not
-                            l_metadata == r_metadata
+                            l_metadata.alter_compatible(id, r_metadata).is_ok()
                         }
                         _ => true,
                     }),


### PR DESCRIPTION
When adding the alter compatible checks, I missed that the source exports (`SourceExport`) should have used this instead of `PartialEq`.

### Motivation

 This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
