### PR TITLE
Fuse MFPs into `Reduce` stage

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -78,6 +78,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "default_arrangement_exert_proportionality": "16",
     "persist_txn_tables": "eager",
     "enable_expressions_in_limit_syntax": "true",
+    "enable_reduce_mfp_fusion": "true",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/src/adapter/src/optimize/index.rs
+++ b/src/adapter/src/optimize/index.rs
@@ -218,6 +218,7 @@ impl Optimize<GlobalMirPlan> for Optimizer {
             df_desc,
             self.config.enable_consolidate_after_union_negate,
             self.config.enable_specialized_arrangements,
+            self.config.enable_reduce_mfp_fusion,
         )
         .map_err(OptimizerError::Internal)?;
 

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -252,6 +252,7 @@ impl Optimize<GlobalMirPlan> for Optimizer {
             df_desc,
             self.config.enable_consolidate_after_union_negate,
             self.config.enable_specialized_arrangements,
+            self.config.enable_reduce_mfp_fusion,
         )
         .map_err(OptimizerError::Internal)?;
 

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -126,6 +126,10 @@ pub struct OptimizerConfig {
     pub persist_fast_path_limit: usize,
     /// Enable outer join lowering implemented in #22343.
     pub enable_new_outer_join_lowering: bool,
+    /// Enable fusion of MFPs in reductions.
+    ///
+    /// The fusion happens in MIR ⇒ LIR lowering.
+    pub enable_reduce_mfp_fusion: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -144,6 +148,7 @@ impl From<&SystemVars> for OptimizerConfig {
             enable_specialized_arrangements: vars.enable_specialized_arrangements(),
             persist_fast_path_limit: vars.persist_fast_path_limit(),
             enable_new_outer_join_lowering: vars.enable_new_outer_join_lowering(),
+            enable_reduce_mfp_fusion: vars.enable_reduce_mfp_fusion(),
         }
     }
 }

--- a/src/adapter/src/optimize/peek.rs
+++ b/src/adapter/src/optimize/peek.rs
@@ -429,6 +429,7 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
                         df_desc,
                         self.config.enable_consolidate_after_union_negate,
                         self.config.enable_specialized_arrangements,
+                        self.config.enable_reduce_mfp_fusion,
                     )
                     .map_err(OptimizerError::Internal)?;
                 }
@@ -449,6 +450,7 @@ impl<'s> Optimize<GlobalMirPlan<ResolvedGlobal<'s>>> for Optimizer {
                     df_desc,
                     self.config.enable_consolidate_after_union_negate,
                     self.config.enable_specialized_arrangements,
+                    self.config.enable_reduce_mfp_fusion,
                 )
                 .map_err(OptimizerError::Internal)?;
 

--- a/src/adapter/src/optimize/subscribe.rs
+++ b/src/adapter/src/optimize/subscribe.rs
@@ -310,6 +310,7 @@ impl Optimize<GlobalMirPlan<Resolved>> for Optimizer {
             df_desc,
             self.config.enable_consolidate_after_union_negate,
             self.config.enable_specialized_arrangements,
+            self.config.enable_reduce_mfp_fusion,
         )
         .map_err(OptimizerError::Internal)?;
 

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -219,6 +219,7 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                 key_val_plan,
                 plan,
                 input_key,
+                mfp_after,
             } => {
                 use crate::plan::reduce::ReducePlan;
                 match plan {
@@ -259,6 +260,12 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         let key = CompactScalarSeq(key);
                         writeln!(f, "{}input_key={}", ctx.indent, key)?;
                     }
+                    // ATTENTION: This is probably incorrect; have someone fix.
+                    if !mfp_after.is_identity() {
+                        writeln!(f, "{}mfp_after", ctx.indent)?;
+                        ctx.indented(|ctx| mfp_after.fmt_text(f, ctx))?;
+                    }
+
                     input.fmt_text(f, ctx)
                 })?;
             }

--- a/src/compute-types/src/explain/text.rs
+++ b/src/compute-types/src/explain/text.rs
@@ -260,7 +260,6 @@ impl DisplayText<PlanRenderingContext<'_, Plan>> for Plan {
                         let key = CompactScalarSeq(key);
                         writeln!(f, "{}input_key={}", ctx.indent, key)?;
                     }
-                    // ATTENTION: This is probably incorrect; have someone fix.
                     if !mfp_after.is_identity() {
                         writeln!(f, "{}mfp_after", ctx.indent)?;
                         ctx.indented(|ctx| mfp_after.fmt_text(f, ctx))?;

--- a/src/compute-types/src/plan.proto
+++ b/src/compute-types/src/plan.proto
@@ -126,6 +126,7 @@ message ProtoPlan {
         mz_compute_types.plan.reduce.ProtoKeyValPlan key_val_plan = 2;
         mz_compute_types.plan.reduce.ProtoReducePlan plan = 3;
         ProtoPlanInputKey input_key = 4;
+        mz_expr.linear.ProtoMapFilterProject mfp_after = 5;
    }
 
    message ProtoPlanTopK {

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -94,6 +94,7 @@ pub trait Interpreter<T = mz_repr::Timestamp> {
         key_val_plan: &KeyValPlan,
         plan: &ReducePlan,
         input_key: &Option<Vec<MirScalarExpr>>,
+        mfp_after: &MapFilterProject,
     ) -> Self::Domain;
 
     fn top_k(
@@ -374,14 +375,19 @@ where
                     key_val_plan,
                     plan,
                     input_key,
-                    mfp_after: _,
+                    mfp_after,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
                     // Interpret the current node.
-                    Ok(self
-                        .interpret
-                        .reduce(&self.ctx, input, key_val_plan, plan, input_key))
+                    Ok(self.interpret.reduce(
+                        &self.ctx,
+                        input,
+                        key_val_plan,
+                        plan,
+                        input_key,
+                        mfp_after,
+                    ))
                 }
                 TopK { input, top_k_plan } => {
                     // Descend recursively into all children.
@@ -650,7 +656,7 @@ where
                     key_val_plan,
                     plan,
                     input_key,
-                    mfp_after: _,
+                    mfp_after,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -661,6 +667,7 @@ where
                         key_val_plan,
                         plan,
                         input_key,
+                        mfp_after,
                     );
                     // Mutate the current node using the given `action`.
                     (self.action)(expr, &result, &[input]);

--- a/src/compute-types/src/plan/interpret/api.rs
+++ b/src/compute-types/src/plan/interpret/api.rs
@@ -374,6 +374,7 @@ where
                     key_val_plan,
                     plan,
                     input_key,
+                    mfp_after: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;
@@ -649,6 +650,7 @@ where
                     key_val_plan,
                     plan,
                     input_key,
+                    mfp_after: _,
                 } => {
                     // Descend recursively into all children.
                     let input = self.apply_rec(input, rg)?;

--- a/src/compute-types/src/plan/interpret/physically_monotonic.rs
+++ b/src/compute-types/src/plan/interpret/physically_monotonic.rs
@@ -174,6 +174,7 @@ impl<T> Interpreter<T> for SingleTimeMonotonic<'_, T> {
         _key_val_plan: &KeyValPlan,
         _plan: &ReducePlan,
         _input_key: &Option<Vec<MirScalarExpr>>,
+        _mfp_after: &MapFilterProject,
     ) -> Self::Domain {
         // In a recursive context, reduce will advance across timestamps
         // and may need to retract. Outside of a recursive context, the

--- a/src/compute-types/src/plan/mod.rs
+++ b/src/compute-types/src/plan/mod.rs
@@ -1564,8 +1564,10 @@ This is not expected to cause incorrect results, but could indicate a performanc
                     (mfp_after, mfp, output_arity) =
                         reduce_plan.extract_mfp_after(mfp, group_key.len());
                 } else {
-                    mfp_after = MapFilterProject::new(mfp.input_arity);
-                    output_arity = group_key.len() + aggregates.len();
+                    (mfp_after, output_arity) = (
+                        MapFilterProject::new(mfp.input_arity),
+                        group_key.len() + aggregates.len(),
+                    );
                     soft_assert_eq_or_log!(
                         mfp.input_arity,
                         output_arity,

--- a/src/compute-types/src/plan/mod.rs
+++ b/src/compute-types/src/plan/mod.rs
@@ -317,7 +317,8 @@ pub enum Plan<T = mz_repr::Timestamp> {
         input_key: Option<Vec<MirScalarExpr>>,
         /// An MFP that must be applied to results. The projection part of this
         /// MFP must preserve the key for the reduction; otherwise, the results
-        /// become undefined.
+        /// become undefined. Additionally, the MFP must be free from temporal
+        /// predicates so that it can be readily evaluated.
         mfp_after: MapFilterProject,
     },
     /// Key-based "Top K" operator, retaining the first K records in each group.

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -888,9 +888,15 @@ where
                 key_val_plan,
                 plan,
                 input_key,
+                mfp_after,
             } => {
                 let input = self.render_plan(*input);
-                self.render_reduce(input, key_val_plan, plan, input_key)
+                let mfp_option = if mfp_after.is_identity() {
+                    None
+                } else {
+                    Some(mfp_after)
+                };
+                self.render_reduce(input, key_val_plan, plan, input_key, mfp_option)
             }
             Plan::TopK { input, top_k_plan } => {
                 let input = self.render_plan(*input);

--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -891,11 +891,7 @@ where
                 mfp_after,
             } => {
                 let input = self.render_plan(*input);
-                let mfp_option = if mfp_after.is_identity() {
-                    None
-                } else {
-                    Some(mfp_after)
-                };
+                let mfp_option = (!mfp_after.is_identity()).then_some(mfp_after);
                 self.render_reduce(input, key_val_plan, plan, input_key, mfp_option)
             }
             Plan::TopK { input, top_k_plan } => {

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -1534,11 +1534,10 @@ fn evaluate_mfp_after<'a, 'b>(
         // The `mfp_after` must preserve the key columns,
         // so we can skip them to form aggregation results.
         row_packer.extend(iter.skip(key_len));
-        Some(row_builder.clone())
     } else {
         row_packer.extend(&datums_local[key_len..]);
-        Some(row_builder.clone())
     }
+    Some(row_builder.clone())
 }
 
 fn accumulable_zero(aggr_func: &AggregateFunc) -> Accum {

--- a/src/expr/src/linear.rs
+++ b/src/expr/src/linear.rs
@@ -1546,6 +1546,11 @@ pub mod plan {
             self.mfp.predicates.iter().any(|(_pos, e)| e.could_error())
                 || self.mfp.expressions.iter().any(|e| e.could_error())
         }
+
+        /// Returns true when `Self` is the identity.
+        pub fn is_identity(&self) -> bool {
+            self.mfp.is_identity()
+        }
     }
 
     impl std::ops::Deref for SafeMfpPlan {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2204,6 +2204,13 @@ feature_flags!(
         internal: true,
         enable_for_item_parsing: true,
     },
+    {
+        name: enable_reduce_mfp_fusion,
+        desc: "fusion of MFPs in reductions",
+        default: false,
+        internal: true,
+        enable_for_item_parsing: false,
+    },
 );
 
 /// Represents the input to a variable.

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1153,11 +1153,14 @@ impl<'a> RunnerInner<'a> {
     /// Set features that should be enabled regardless of whether reset-server was
     /// called. These features may be set conditionally depending on the run configuration.
     async fn ensure_fixed_features(&self) -> Result<(), anyhow::Error> {
-        // We turn on enable_specialized_arrangements, as we wish to get
-        // as much coverage of this feature as we can.
+        // We turn on enable_specialized_arrangements and enable_reduce_mfp_fusion, as we wish
+        // to get as much coverage of these features as we can.
         // TODO(vmarcos): Remove this code when we retire these feature flags.
         self.system_client
             .execute("ALTER SYSTEM SET enable_specialized_arrangements = on", &[])
+            .await?;
+        self.system_client
+            .execute("ALTER SYSTEM SET enable_reduce_mfp_fusion = on", &[])
             .await?;
 
         // Dangerous functions are useful for tests so we enable it for all tests.

--- a/test/sqllogictest/explain/physical_plan_as_json.slt
+++ b/test/sqllogictest/explain/physical_plan_as_json.slt
@@ -1669,7 +1669,16 @@ SELECT DISTINCT a, b FROM t
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1
+            ],
+            "input_arity": 2
+          }
         }
       }
     }
@@ -1806,7 +1815,17 @@ GROUP BY a
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1,
+              2
+            ],
+            "input_arity": 3
+          }
         }
       }
     }
@@ -1955,7 +1974,16 @@ FROM t
                   ]
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
             }
           },
           "body": {
@@ -2216,7 +2244,17 @@ SELECT * FROM hierarchical_group_by
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1,
+              2
+            ],
+            "input_arity": 3
+          }
         }
       }
     }
@@ -2339,7 +2377,16 @@ MATERIALIZED VIEW hierarchical_global_mv
                   }
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
             }
           },
           "body": {
@@ -2614,7 +2661,16 @@ SELECT * FROM hierarchical_global
                   }
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
             }
           },
           "body": {
@@ -3194,7 +3250,17 @@ GROUP BY a
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1,
+              2
+            ],
+            "input_arity": 3
+          }
         }
       }
     }
@@ -3626,7 +3692,16 @@ FROM t
                   ]
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1
+                ],
+                "input_arity": 2
+              }
             }
           },
           "body": {
@@ -4280,7 +4355,21 @@ MATERIALIZED VIEW collated_group_by_mv
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "input_arity": 7
+          }
         }
       }
     }
@@ -4766,7 +4855,21 @@ SELECT * FROM collated_group_by
             {
               "Column": 0
             }
-          ]
+          ],
+          "mfp_after": {
+            "expressions": [],
+            "predicates": [],
+            "projection": [
+              0,
+              1,
+              2,
+              3,
+              4,
+              5,
+              6
+            ],
+            "input_arity": 7
+          }
         }
       }
     }
@@ -5274,7 +5377,20 @@ MATERIALIZED VIEW collated_global_mv
                   ]
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "input_arity": 6
+              }
             }
           },
           "body": {
@@ -6018,7 +6134,20 @@ SELECT * FROM collated_global
                   ]
                 }
               },
-              "input_key": null
+              "input_key": null,
+              "mfp_after": {
+                "expressions": [],
+                "predicates": [],
+                "projection": [
+                  0,
+                  1,
+                  2,
+                  3,
+                  4,
+                  5
+                ],
+                "input_arity": 6
+              }
             }
           },
           "body": {

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -12,6 +12,8 @@
 # PR https://github.com/MaterializeInc/materialize/pull/23197
 #
 
+mode cockroach
+
 statement ok
 CREATE TABLE t (a int, b int);
 
@@ -30,8 +32,7 @@ HAVING ((COUNT(b) + 1) - a) > 2 AND (COUNT(b) + 1) / (1 + a) >= 1;
 query II
 SELECT * FROM mv_complex_mfp_accumulable;
 ----
-1
-7
+1 7
 
 query T multiline
 EXPLAIN PHYSICAL PLAN FOR
@@ -56,3 +57,138 @@ materialize.public.mv_complex_mfp_accumulable:
         raw=true
 
 EOF
+
+# Check that we treat errors properly.
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_accumulable;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query II
+SELECT * FROM mv_complex_mfp_accumulable;
+----
+1 7
+
+# We test variations of the scenario above to cover reduction types.
+statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_basic_single AS
+SELECT a, LIST_AGG(b ORDER BY b DESC)::text
+FROM t
+GROUP BY a
+HAVING
+  ((LIST_AGG(b ORDER BY b DESC)[1] + 1) - a) > 2 AND
+  (LIST_AGG(b ORDER BY b DESC)[1] + 1) / (1 + a) >= 1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_single;
+----
+1  {3,2,1}
+
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_basic_single;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_single;
+----
+1  {3,2,1}
+
+statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_basic_multiple AS
+SELECT a, LIST_AGG(b ORDER BY b DESC)::text
+FROM t
+GROUP BY a
+HAVING
+  ((ARRAY_AGG(b ORDER BY b DESC)[1] + 1) - a) > 2 AND
+  (ARRAY_AGG(b ORDER BY b DESC)[1] + 1) / (1 + a) >= 1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_multiple;
+----
+1  {3,2,1}
+
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_basic_multiple;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_multiple;
+----
+1  {3,2,1}
+
+statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_bucketed AS
+SELECT a, MAX(b) + 1
+FROM t
+GROUP BY a
+HAVING ((MAX(b) + 1) - a) > 2 AND (MAX(b) + 1) / (1 + a) >= 1;
+
+query II
+SELECT * FROM mv_complex_mfp_bucketed;
+----
+1 4
+
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_bucketed;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query II
+SELECT * FROM mv_complex_mfp_bucketed;
+----
+1 4
+
+statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_collation AS
+SELECT a, MAX(b) + 1
+FROM t
+GROUP BY a
+HAVING ((COUNT(b) + 1) - a) > 2 AND (COUNT(b) + 1) / (1 + a) >= 1;
+
+query II
+SELECT * FROM mv_complex_mfp_collation;
+----
+1 4
+
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_collation;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query II
+SELECT * FROM mv_complex_mfp_collation;
+----
+1 4
+
+# NOTE(vmarcos): Even though placement of an Mfp that has parts that can be
+# fused on top of a Reduce::Distinct is valid LIR, we should not at present produce
+# this pattern via SQL. To see why, note that if the MFP has parts that could be fused,
+# then it must preserve the reduction key, i.e., all columns for the distinct, and
+# the fusable parts need to be: (a) free of temporal filters; (b) only contain map
+# and filter (i.e., essentially be a predicate). So, these fusable parts could just as
+# well be applied to the input to the Reduce::Distinct, and the optimizer will just
+# perform predicate pushdown to filter the input before it gets arranged. Additionally,
+# if it were the case that we would lift the predicate to enable reuse, then that would
+# mean that we could not fuse it into the reduction anyway.

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -151,6 +151,34 @@ SELECT * FROM mv_complex_mfp_basic_single;
 1  {3,2,1}
 
 statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_basic_distinct_single AS
+SELECT a, LIST_AGG(DISTINCT b ORDER BY b DESC)::text
+FROM t
+GROUP BY a
+HAVING
+  ((LIST_AGG(DISTINCT b ORDER BY b DESC)[1] + 1) - a) > 2 AND
+  (LIST_AGG(DISTINCT b ORDER BY b DESC)[1] + 1) / (1 + a) >= 1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_distinct_single;
+----
+1  {3,2,1}
+
+statement ok
+INSERT INTO t VALUES (-1, 3);
+
+query error division by zero
+SELECT * FROM mv_complex_mfp_basic_distinct_single;
+
+statement ok
+DELETE FROM t WHERE a = -1;
+
+query IT
+SELECT * FROM mv_complex_mfp_basic_distinct_single;
+----
+1  {3,2,1}
+
+statement ok
 CREATE MATERIALIZED VIEW mv_complex_mfp_basic_multiple AS
 SELECT a, LIST_AGG(b ORDER BY b DESC)::text
 FROM t
@@ -190,17 +218,40 @@ SELECT * FROM mv_complex_mfp_bucketed;
 ----
 1 4
 
+# Note we use a one-shot SELECT to cover the monotonic case.
+query II
+SELECT a, MAX(b) + 1
+FROM t
+GROUP BY a
+HAVING ((MAX(b) + 1) - a) > 2 AND (MAX(b) + 1) / (1 + a) >= 1;
+----
+1 4
+
 statement ok
 INSERT INTO t VALUES (-1, 3);
 
 query error division by zero
 SELECT * FROM mv_complex_mfp_bucketed;
 
+query error division by zero
+SELECT a, MAX(b) + 1
+FROM t
+GROUP BY a
+HAVING ((MAX(b) + 1) - a) > 2 AND (MAX(b) + 1) / (1 + a) >= 1;
+
 statement ok
 DELETE FROM t WHERE a = -1;
 
 query II
 SELECT * FROM mv_complex_mfp_bucketed;
+----
+1 4
+
+query II
+SELECT a, MAX(b) + 1
+FROM t
+GROUP BY a
+HAVING ((MAX(b) + 1) - a) > 2 AND (MAX(b) + 1) / (1 + a) >= 1;
 ----
 1 4
 

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -1,0 +1,58 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+#
+# Test proper fusion of MFPs in Reduce.
+# PR https://github.com/MaterializeInc/materialize/pull/23197
+#
+
+statement ok
+CREATE TABLE t (a int, b int);
+
+statement ok
+INSERT INTO t VALUES (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1);
+
+# Illustrates a complex MFP scenario with all three components
+# active in the fused MFP.
+statement ok
+CREATE MATERIALIZED VIEW mv_complex_mfp_accumulable AS
+SELECT a, SUM(b) + 1
+FROM t
+GROUP BY a
+HAVING ((COUNT(b) + 1) - a) > 2 AND (COUNT(b) + 1) / (1 + a) >= 1;
+
+query II
+SELECT * FROM mv_complex_mfp_accumulable;
+----
+1
+7
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+MATERIALIZED VIEW mv_complex_mfp_accumulable;
+----
+materialize.public.mv_complex_mfp_accumulable:
+  Mfp
+    project=(#0, #3)
+    map=((#1 + 1))
+    input_key=#0
+    Reduce::Accumulable
+      simple_aggrs[0]=(0, 0, sum(#1))
+      simple_aggrs[1]=(1, 1, count(#1))
+      val_plan
+        project=(#1, #1)
+      key_plan
+        project=(#0)
+      mfp_after
+        filter=(((#3 - integer_to_bigint(#0)) > 2) AND ((#3 / integer_to_bigint((1 + #0))) >= 1))
+        map=((#2 + 1))
+      Get::PassArrangements materialize.public.t
+        raw=true
+
+EOF

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -14,6 +14,11 @@
 
 mode cockroach
 
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_reduce_mfp_fusion TO true;
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t (a int, b int);
 

--- a/test/sqllogictest/reduce_mfp.slt
+++ b/test/sqllogictest/reduce_mfp.slt
@@ -25,6 +25,41 @@ CREATE TABLE t (a int, b int);
 statement ok
 INSERT INTO t VALUES (1, 1), (1, 2), (1, 3), (2, 1), (2, 2), (3, 1);
 
+# Illustrates a special-case MFP where we can completely absorb all
+# components, including a projection.
+statement ok
+CREATE MATERIALIZED VIEW mv_fusable_mfp_accumulable AS
+SELECT a, SUM(b)
+FROM t
+GROUP BY a
+HAVING ((COUNT(b) + 1) - a) > 2 AND (COUNT(b) + 1) / (1 + a) >= 1;
+
+query II
+SELECT * FROM mv_fusable_mfp_accumulable;
+----
+1 6
+
+query T multiline
+EXPLAIN PHYSICAL PLAN FOR
+MATERIALIZED VIEW mv_fusable_mfp_accumulable;
+----
+materialize.public.mv_fusable_mfp_accumulable:
+  Reduce::Accumulable
+    simple_aggrs[0]=(0, 0, sum(#1))
+    simple_aggrs[1]=(1, 1, count(#1))
+    val_plan
+      project=(#1, #1)
+    key_plan
+      project=(#0)
+    mfp_after
+      project=(#0, #1)
+      filter=(((#3 - integer_to_bigint(#0)) > 2) AND ((#3 / integer_to_bigint((1 + #0))) >= 1))
+      map=((#2 + 1))
+    Get::PassArrangements materialize.public.t
+      raw=true
+
+EOF
+
 # Illustrates a complex MFP scenario with all three components
 # active in the fused MFP.
 statement ok
@@ -68,10 +103,18 @@ statement ok
 INSERT INTO t VALUES (-1, 3);
 
 query error division by zero
+SELECT * FROM mv_fusable_mfp_accumulable;
+
+query error division by zero
 SELECT * FROM mv_complex_mfp_accumulable;
 
 statement ok
 DELETE FROM t WHERE a = -1;
+
+query II
+SELECT * FROM mv_fusable_mfp_accumulable;
+----
+1 6
 
 query II
 SELECT * FROM mv_complex_mfp_accumulable;

--- a/test/sqllogictest/transform/relax_must_consolidate.slt
+++ b/test/sqllogictest/transform/relax_must_consolidate.slt
@@ -665,7 +665,7 @@ Explained Query:
 
 EOF
 
-# Mfp, Get, Union, FlatMap chained from Reduce enforcer, no must_consolidate
+# Get, Union, FlatMap chained from Reduce enforcer, no must_consolidate
 statement ok
 CREATE VIEW single_time_monotonic_t AS
     SELECT b, a, COUNT(*) AS c FROM t GROUP BY b, a;
@@ -756,27 +756,30 @@ Explained Query:
           mfp_after
             project=(#0, #2)
           Union
-            Get::Collection l0
+            Get::Arrangement l0
               project=(#0, #1)
               filter=((1 = (#1 % 2)))
-              raw=true
-            Get::Collection l0
+              key=#0, #1
+              raw=false
+              arrangements[0]={ key=[#0, #1], permutation=id, thinning=(#2) }
+            Get::Arrangement l0
               project=(#0, #1)
               filter=((1 = (#2 % 2)))
-              raw=true
+              key=#0, #1
+              raw=false
+              arrangements[0]={ key=[#0, #1], permutation=id, thinning=(#2) }
     cte l0 =
-      Mfp
-        filter=((2 = (#2 + 1)))
-        input_key=#0, #1
-        Reduce::Accumulable
-          simple_aggrs[0]=(0, 0, count(*))
-          val_plan
-            project=(#2)
-            map=(true)
-          key_plan
-            project=(#1, #0)
-          Get::Collection materialize.public.t
-            raw=true
+      Reduce::Accumulable
+        simple_aggrs[0]=(0, 0, count(*))
+        val_plan
+          project=(#2)
+          map=(true)
+        key_plan
+          project=(#1, #0)
+        mfp_after
+          filter=((2 = (#2 + 1)))
+        Get::Collection materialize.public.t
+          raw=true
 
 Source materialize.public.t
   filter=((6 = (#0 + 1)))
@@ -948,7 +951,9 @@ Explained Query:
 
 EOF
 
-# Top-k can have no must_consolidate, not only min/max
+# Top-k can have no must_consolidate, not only min/max.
+# In addition, the lack of need for must_consolidate
+# propagates through Mfp to a higher-level min/max.
 query I
 SELECT MAX(max_a)
 FROM (

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -359,8 +359,8 @@ true true true true true
 true true true true true true true
 
 > SELECT
-    records > 2 * 1000,
-    records < 2 * 2 * 1000,
+    records > 1000,
+    records < 2 * 1000,
     size > 0.025 * 100 * 1024,
     size < 4 * 100 * 1024,
     capacity > 0.25 * 100 * 1024,


### PR DESCRIPTION
This is a work-in-progress branch showing of fusing `MapFilterProject` operators into `Reduce` stages. This has the potential to allow data reduction in the output arrangements maintained by `Reduce` stages, when these stages are followed by transformations, projections, and filtering of the results. When they are not, there is some additional logic that occurs in determining this, but it should be light. In the worst case, ineffective predicates are pushed down, but we will need to evaluate them at some point (we evaluate them twice in this PR; to determine valid outputs, and separately to look for errors).