### PR TITLE
*: fix some more 1.73 clippy lints

### DIFF
--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -2314,7 +2314,7 @@ impl SharedRow {
     ///
     /// Panics when the row is already borrowed elsewhere.
     pub fn get() -> Self {
-        let row = Self::SHARED_ROW.with(|cell| Rc::clone(cell));
+        let row = Self::SHARED_ROW.with(Rc::clone);
         // Clear row
         row.borrow_mut().packer();
         Self(row)


### PR DESCRIPTION
just another i found

i am not pushing people to 1.73 yet because i want to sit with it for a bit longer

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
