### PR TITLE
Fix inconsistent SQL statements for `BuiltinView`s

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2758,7 +2758,7 @@ UNION ALL
 pub const MZ_OBJECT_FULLY_QUALIFIED_NAMES: BuiltinView = BuiltinView {
     name: "mz_object_fully_qualified_names",
     schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE VIEW mz_catalog.mz_object_fully_qualified_names (id, name, object_type, schema_name, database_name) AS
+    sql: "CREATE VIEW mz_internal.mz_object_fully_qualified_names (id, name, object_type, schema_name, database_name) AS
     SELECT o.id, o.name, o.type, sc.name as schema_name, db.name as database_name
     FROM mz_catalog.mz_objects o
     INNER JOIN mz_catalog.mz_schemas sc ON sc.id = o.schema_id
@@ -4032,7 +4032,7 @@ FROM
 pub const MZ_DATAFLOW_OPERATOR_PARENTS_PER_WORKER: BuiltinView = BuiltinView {
     name: "mz_dataflow_operator_parents_per_worker",
     schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE VIEW mz_internal.mz_operator_parents_per_worker AS
+    sql: "CREATE VIEW mz_internal.mz_dataflow_operator_parents_per_worker AS
 WITH operator_addrs AS(
     SELECT
         id, address, worker_id
@@ -4058,7 +4058,7 @@ FROM parent_addrs AS pa
 pub const MZ_DATAFLOW_OPERATOR_PARENTS: BuiltinView = BuiltinView {
     name: "mz_dataflow_operator_parents",
     schema: MZ_INTERNAL_SCHEMA,
-    sql: "CREATE VIEW mz_internal.mz_operator_parents AS
+    sql: "CREATE VIEW mz_internal.mz_dataflow_operator_parents AS
 SELECT id, parent_id
 FROM mz_internal.mz_dataflow_operator_parents_per_worker
 WHERE worker_id = 0",


### PR DESCRIPTION
Fixes: https://github.com/MaterializeInc/materialize/issues/23201
Following: https://github.com/MaterializeInc/materialize/pull/23125#issuecomment-1807238403

I used the `name` and `schema` fields as the source of truth, this means changing the SQL statements to align with those fields.