### PR TITLE
balancerd: Fortify the balancerd mzcompose test

### DIFF
--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -167,7 +167,10 @@ def workflow_mz_not_running(c: Composition) -> None:
         c.sql_cursor(service="balancerd")
         assert False, "connect() expected to fail"
     except ProgrammingError as e:
-        assert "No route to host" in str(e)
+        assert any(
+            expected in str(e)
+            for expected in ["No route to host", "Connection timed out"]
+        )
     except:
         assert False, "connect() threw an unexpected exception"
 


### PR DESCRIPTION
The mz-not-running workflow should accept different error messages as a valid outcome.

### Motivation

Nightly was failing.