### PR TITLE
platform-checks: Simplify disabled decorator

### DIFF
--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 
 from random import Random
-from typing import Any
 
 from materialize.checks.actions import Testdrive
 from materialize.checks.executors import Executor
@@ -79,14 +78,8 @@ class Check:
 
 
 def disabled(ignore_reason: str):
-    class ClassWrapper:
-        def __init__(self, cls: type[Check]):
-            assert issubclass(cls, Check)
-            self.check_class = cls
-            self.check_class.enabled = False
+    def decorator(cls):
+        cls.enabled = False
+        return cls
 
-        def __call__(self, *cls_ars: Any):
-            check = self.check_class(*cls_ars)
-            return check
-
-    return ClassWrapper
+    return decorator


### PR DESCRIPTION
Works for subclasses now

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
