### PR TITLE
backup: Add additional scenarios for backup+restore

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -398,6 +398,28 @@ steps:
               composition: platform-checks
               args: [--scenario=BackupAndRestoreAfterManipulate, "--seed=$BUILDKITE_JOB_ID"]
 
+      - id: checks-backup-multi
+        label: "Checks + multiple backups/restores"
+        timeout_in_minutes: 60
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=BackupAndRestoreMulti, "--seed=$BUILDKITE_JOB_ID"]
+
+      - id: checks-backup-rollback
+        label: "Checks + backup + rollback to previous"
+        timeout_in_minutes: 60
+        artifact_paths: junit_*.xml
+        agents:
+          queue: builder-linux-x86_64
+        plugins:
+          - ./ci/plugins/mzcompose:
+              composition: platform-checks
+              args: [--scenario=BackupAndRestoreToPreviousState, "--seed=$BUILDKITE_JOB_ID"]
+
       - id: checks-parallel-drop-create-default-replica
         label: "Checks parallel + DROP/CREATE replica"
         skip: "Affected by #21317"

--- a/doc/developer/platform-checks.md
+++ b/doc/developer/platform-checks.md
@@ -108,6 +108,13 @@ same resource type.
 ## Ignoring a Check
 To ignore a `Check`, annotate it with `@disabled(ignore_reason="due to #...")`.
 
+## Externally-idempotent Checks
+
+If a check performs non-idempotent actions against third-party services, such as ingesting non-UPSERT data into a
+Kafka or Postgres source, it needs to be annotated with `@external_idempotence(False)`. This Check will not be run
+in Scenarios, such as some Backup+Restore scenarios, that may need to run a `manipulate()` phase twice.
+
+
 # Writing a Scenario
 
 A Scenario is a list of sequential Actions that the framework will perform one after another:

--- a/misc/python/materialize/checks/actions.py
+++ b/misc/python/materialize/checks/actions.py
@@ -80,7 +80,6 @@ class Manipulate(Action):
         self.phase = phase - 1
 
         self.checks = scenario.check_objects
-        assert len(self.checks) >= self.phase
 
     def execute(self, e: Executor) -> None:
         assert self.phase is not None

--- a/misc/python/materialize/checks/all_checks/alter_index.py
+++ b/misc/python/materialize/checks/all_checks/alter_index.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 
 
@@ -17,6 +17,7 @@ def schema() -> str:
     return dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
 
 
+@externally_idempotent(False)
 class AlterIndex(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/debezium.py
+++ b/misc/python/materialize/checks/all_checks/debezium.py
@@ -10,9 +10,10 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 
+@externally_idempotent(False)
 class DebeziumPostgres(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/kafka_formats.py
+++ b/misc/python/materialize/checks/all_checks/kafka_formats.py
@@ -87,6 +87,7 @@ class KafkaFormats(Check):
                   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
+                  ENVELOPE UPSERT
             """
             )
         )
@@ -132,6 +133,7 @@ class KafkaFormats(Check):
                   KEY FORMAT PROTOBUF MESSAGE '.Key' USING SCHEMA '${test-schema}'
                   VALUE FORMAT PROTOBUF MESSAGE '.Value' USING SCHEMA '${test-schema}'
                   INCLUDE KEY
+                  ENVELOPE UPSERT
 
                 $ kafka-ingest format=bytes key-format=bytes key-terminator=: topic=format-bytes
                 key2A,key2B:value2A,value2B

--- a/misc/python/materialize/checks/all_checks/kafka_protocols.py
+++ b/misc/python/materialize/checks/all_checks/kafka_protocols.py
@@ -9,11 +9,12 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
 
 
+@externally_idempotent(False)
 class KafkaProtocols(Check):
     def _can_run(self, e: Executor) -> bool:
         return self.base_version >= MzVersion.parse("0.78.0-dev")

--- a/misc/python/materialize/checks/all_checks/multiple_partitions.py
+++ b/misc/python/materialize/checks/all_checks/multiple_partitions.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 
 
@@ -17,6 +17,7 @@ def schemas() -> str:
     return dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
 
 
+@externally_idempotent(False)
 class MultiplePartitions(Check):
     """Test that adds new partitions to a Kafka source"""
 

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 from typing import Any
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check, disabled
+from materialize.checks.checks import Check, disabled, externally_idempotent
 from materialize.mz_version import MzVersion
 
 
@@ -215,17 +215,20 @@ class PgCdcBase:
         )
 
 
+@externally_idempotent(False)
 class PgCdc(PgCdcBase, Check):
     def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
         super().__init__(wait=True, base_version=base_version, rng=rng)
 
 
 @disabled("requires #18940 to be fixed")
+@externally_idempotent(False)
 class PgCdcNoWait(PgCdcBase, Check):
     def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
         super().__init__(wait=False, base_version=base_version, rng=rng)
 
 
+@externally_idempotent(False)
 class PgCdcMzNow(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/rename_source.py
+++ b/misc/python/materialize/checks/all_checks/rename_source.py
@@ -9,9 +9,10 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 
+@externally_idempotent(False)
 class RenameSource(Check):
     def _source_schema(self) -> str:
         return dedent(

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
@@ -42,6 +42,7 @@ def schemas_null() -> str:
     )
 
 
+@externally_idempotent(False)
 class SinkUpsert(Check):
     """Basic Check on sinks from an upsert source"""
 
@@ -203,6 +204,7 @@ class SinkUpsert(Check):
         )
 
 
+@externally_idempotent(False)
 class SinkTables(Check):
     """Sink and re-ingest a large transaction from a table source"""
 
@@ -298,6 +300,7 @@ class SinkTables(Check):
         )
 
 
+@externally_idempotent(False)
 class SinkNullDefaults(Check):
     """Check on an Avro sink with NULL DEFAULTS"""
 
@@ -546,6 +549,7 @@ class SinkNullDefaults(Check):
         )
 
 
+@externally_idempotent(False)
 class SinkComments(Check):
     """Check on an Avro sink with comments"""
 

--- a/misc/python/materialize/checks/all_checks/source_errors.py
+++ b/misc/python/materialize/checks/all_checks/source_errors.py
@@ -10,9 +10,10 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 
+@externally_idempotent(False)
 class SourceErrors(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -72,12 +73,12 @@ class SourceErrors(Check):
             for s in [
                 """
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
-                DROP PUBLICATION source_errors_publicationA;
+                DROP PUBLICATION IF EXISTS source_errors_publicationA;
                 INSERT INTO source_errors_table VALUES (3);
                 """,
                 """
                 $ postgres-execute connection=postgres://postgres:postgres@postgres
-                DROP PUBLICATION source_errors_publicationB;
+                DROP PUBLICATION IF EXISTS source_errors_publicationB;
                 INSERT INTO source_errors_table VALUES (4);
                 """,
             ]

--- a/misc/python/materialize/checks/all_checks/ssh.py
+++ b/misc/python/materialize/checks/all_checks/ssh.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 
 
@@ -17,6 +17,7 @@ def schemas() -> str:
     return dedent(KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD)
 
 
+@externally_idempotent(False)
 class SshPg(Check):
     """
     Testing Postgres CDC source with SSH tunnel
@@ -123,6 +124,7 @@ class SshPg(Check):
         )
 
 
+@externally_idempotent(False)
 class SshKafka(Check):
     """
     Testing Kafka source with SSH tunnel

--- a/misc/python/materialize/checks/all_checks/top_k.py
+++ b/misc/python/materialize/checks/all_checks/top_k.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 
 def schema() -> str:
@@ -26,6 +26,7 @@ def schema() -> str:
     )
 
 
+@externally_idempotent(False)
 class BasicTopK(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -76,6 +77,7 @@ class BasicTopK(Check):
         )
 
 
+@externally_idempotent(False)
 class MonotonicTopK(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -138,6 +140,7 @@ class MonotonicTopK(Check):
         )
 
 
+@externally_idempotent(False)
 class MonotonicTop1(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -20,6 +20,7 @@ class Check:
     # Has to be set for the class already, not just in the constructor, so that
     # we can change the value for the entire class in the decorator
     enabled: bool = True
+    externally_idempotent: bool = True
 
     def __init__(self, base_version: MzVersion, rng: Random | None) -> None:
         self.base_version = base_version
@@ -80,6 +81,14 @@ class Check:
 def disabled(ignore_reason: str):
     def decorator(cls):
         cls.enabled = False
+        return cls
+
+    return decorator
+
+
+def externally_idempotent(externally_idempotent: bool = True):
+    def decorator(cls):
+        cls.externally_idempotent = externally_idempotent
         return cls
 
     return decorator

--- a/misc/python/materialize/checks/scenarios_backup_restore.py
+++ b/misc/python/materialize/checks/scenarios_backup_restore.py
@@ -54,3 +54,56 @@ class BackupAndRestoreBeforeManipulate(Scenario):
             Manipulate(self, phase=2),
             Validate(self),
         ]
+
+
+class BackupAndRestoreToPreviousState(Scenario):
+    """Backup, run more workloads, and then Restore to a previous state."""
+
+    def requires_external_idempotence(self) -> bool:
+        # This scenario will run manipulate(#2) twice, so only compatible
+        # Checks are allowed to participate
+        return True
+
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(self),
+            Initialize(self),
+            Manipulate(self, phase=1),
+            Backup(),
+            Manipulate(self, phase=2),  # Those updates will be lost here ..
+            KillMz(),
+            Restore(),
+            StartMz(self),
+            Manipulate(self, phase=2),  # ... and redone here
+            Validate(self),
+        ]
+
+
+class BackupAndRestoreMulti(Scenario):
+    """Repeated Backup and Restore operations."""
+
+    def actions(self) -> list[Action]:
+        return [
+            StartMz(self),
+            Initialize(self),
+            Backup(),
+            KillMz(),
+            Restore(),
+            StartMz(self),
+            Manipulate(self, phase=1),
+            Backup(),
+            KillMz(),
+            Restore(),
+            StartMz(self),
+            Manipulate(self, phase=2),
+            Backup(),
+            KillMz(),
+            Restore(),
+            StartMz(self),
+            Validate(self),
+            Backup(),
+            KillMz(),
+            Restore(),
+            StartMz(self),
+            Validate(self),
+        ]


### PR DESCRIPTION
Add additional backup+restore scenarios, including one where Mz is allowed to continue to run and execute queries after the backup has been taken.

To accomodate the scenario, which needs to run the manipulate(#2) phase once again after the restore, the `@externally_idempotent(False)` decorator is introduced to annotate Checks that perform actions against third-party services that are not idempotent.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Existing backup + restore tests take a backup and then immediately restore it. This is not a realistic scenario as in real life Mz would "advance" after a backup has been taken and then would be "rolled back in time" on a restore.