### PR TITLE
Upload sources to Polar Signals 

### DIFF
--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -144,7 +144,7 @@ RUN curl -fsSL https://github.com/benesch/autouseradd/releases/download/1.3.0/au
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-compose \
     && curl -fsSL https://github.com/christian-korneck/docker-pushrm/releases/download/v1.9.0/docker-pushrm_linux_$ARCH_GO > /usr/local/lib/docker/cli-plugins/docker-pushrm \
     && chmod +x /usr/local/lib/docker/cli-plugins/docker-pushrm \
-    && curl -fsSL https://github.com/parca-dev/parca-debuginfo/releases/download/v0.7.0/parca-debuginfo_0.7.0_Linux_$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/").tar.gz \
+    && curl -fsSL https://github.com/parca-dev/parca-debuginfo/releases/download/v0.9.0/parca-debuginfo_0.9.0_Linux_$(echo "$ARCH_GCC" | sed "s/aarch64/arm64/").tar.gz \
     | tar xz -C /usr/local/bin parca-debuginfo
 
 ENTRYPOINT ["autouseradd", "--user", "materialize"]

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -240,11 +240,13 @@ class PSUploadSources(PreImage):
             "--ignore-failed-read",
         ]
 
-        p1 = subprocess.Popen(cmd1, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        p2 = subprocess.Popen(
-            cmd2, stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
+        p1 = subprocess.Popen(cmd1, stdout=subprocess.PIPE)
+        p2 = subprocess.Popen(cmd2, stdin=p1.stdout, stdout=subprocess.PIPE)
+
+        # This causes p1 to receive SIGPIPE if p2 exits early,
+        # like in the shell
         p1.stdout.close()
+
         for p in [p1, p2]:
             if p.returncode:
                 raise subprocess.CalledProcessError(p.returncode, p.args)

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -212,6 +212,63 @@ class Copy(PreImage):
         return set(git.expand_globs(self.rd.root, f"{self.source}/{self.matching}"))
 
 
+class PSUploadSources(PreImage):
+    """A `PreImage` action which uploads a source tarball to S3."""
+
+    def __init__(self, rd: RepositoryDetails, path: Path, config: dict[str, Any]):
+        super().__init__(rd, path)
+
+        bin = config.pop("bin", None)
+        if bin is None:
+            raise ValueError("mzbuild config is missing 'bin' argument")
+        self.bin_path = path / bin
+        self.out_path = path / "sources.tar.zstd"
+
+    def run(self) -> None:
+        super().run()
+        with open(self.bin_path, "rb") as bin:
+            build_id = get_build_id(bin)
+
+        cmd1 = ["/usr/bin/llvm-dwarfdump", "--show-sources", self.bin_path]
+        cmd2 = [
+            "/usr/bin/tar",
+            "-cf",
+            self.out_path,
+            "--zstd",
+            "-T",
+            "-",
+            "--ignore-failed-read",
+        ]
+
+        p1 = subprocess.Popen(cmd1, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        p2 = subprocess.Popen(
+            cmd2, stdin=p1.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        p1.stdout.close()
+        for p in [p1, p2]:
+            if p.returncode:
+                raise subprocess.CalledProcessError(p.returncode, p.args)
+
+        polar_signals_api_token = os.getenv("POLAR_SIGNALS_API_TOKEN")
+        if self.rd.stable and polar_signals_api_token is not None:
+            print("Attempting to upload sources to polar signals")
+            spawn.runv(
+                [
+                    "/usr/local/bin/parca-debuginfo",
+                    "upload",
+                    "--store-address=grpc.polarsignals.com:443",
+                    "--type=sources",
+                    f"--build-id={build_id}",
+                    self.out_path,
+                ],
+                cwd=self.rd.root,
+                env={"PARCA_DEBUGINFO_BEARER_TOKEN": polar_signals_api_token},
+            )
+
+    def inputs(self) -> set[str]:
+        return {self.bin_path}
+
+
 class S3UploadDebuginfo(PreImage):
     """A `PreImage` action which uploads an executable and its debuginfo to S3.
 
@@ -543,6 +600,10 @@ class Image:
                 elif typ == "s3-upload-debuginfo":
                     self.pre_images.append(
                         S3UploadDebuginfo(self.rd, self.path, pre_image)
+                    )
+                elif typ == "ps-upload-sources":
+                    self.pre_images.append(
+                        PSUploadSources(self.rd, self.path, pre_image)
                     )
                 else:
                     raise ValueError(

--- a/src/clusterd/ci/mzbuild.yml
+++ b/src/clusterd/ci/mzbuild.yml
@@ -16,3 +16,5 @@ pre-image:
   - type: s3-upload-debuginfo
     bin: clusterd
     bucket: materialize-debuginfo
+  - type: ps-upload-sources
+    bin: clusterd.debug

--- a/src/environmentd/ci/mzbuild.yml
+++ b/src/environmentd/ci/mzbuild.yml
@@ -16,3 +16,5 @@ pre-image:
   - type: s3-upload-debuginfo
     bin: environmentd
     bucket: materialize-debuginfo
+  - type: ps-upload-sources
+    bin: environmentd.debug

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -80,6 +80,7 @@
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
+
 //! Internal utility libraries for Materialize.
 //!
 //! **ore** (_n_): the raw material from which more valuable materials are extracted.

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -80,7 +80,6 @@
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
 // END LINT CONFIG
-
 //! Internal utility libraries for Materialize.
 //!
 //! **ore** (_n_): the raw material from which more valuable materials are extracted.


### PR DESCRIPTION
This will be nice for us to have, as it'll allow us to see source-level profiling info in PS. @brancz is going to demo this during the weekly demo tomorrow.

The size is about 15 MiB for clusterd; I haven't checked for environmentd but I doubt it's substantially more. 30 MiB extra storage per released build shouldn't move the needle for us on PS cost.

### Motivation

  * This PR adds a known-desirable feature.

    Upload sources to PolarSignals.



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
     I will test manually that the thing got uploaded properly once CI runs for this build.

- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - None