### PR TITLE
adapter: Box several very large `Future`s

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -13,9 +13,10 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use futures::future::{BoxFuture, FutureExt};
 use once_cell::sync::Lazy;
 use regex::Regex;
-use tracing::{info, warn};
+use tracing::{info, warn, Instrument};
 use uuid::Uuid;
 
 use mz_catalog::builtin::{
@@ -180,359 +181,368 @@ impl CatalogItemRebuilder {
 impl Catalog {
     /// Initializes a CatalogState. Separate from [`Catalog::open`] to avoid depending on state
     /// external to a [mz_catalog::durable::DurableCatalogState] (for example: no [mz_secrets::SecretsReader]).
-    #[tracing::instrument(name = "catalog::initialize_state", level = "info", skip_all)]
-    pub async fn initialize_state(
+    ///
+    /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 7.5KB. This would
+    /// get stored on the stack which is bad for runtime performance, and blow up our stack usage.
+    /// Because of that we purposefully move this Future onto the heap (i.e. Box it).
+    pub fn initialize_state<'a>(
         config: StateConfig,
-        storage: &mut Box<dyn mz_catalog::durable::DurableCatalogState>,
-    ) -> Result<
-        (
-            CatalogState,
-            mz_repr::Timestamp,
-            BuiltinMigrationMetadata,
-            String,
-        ),
-        AdapterError,
+        storage: &'a mut Box<dyn mz_catalog::durable::DurableCatalogState>,
+    ) -> BoxFuture<
+        'a,
+        Result<
+            (
+                CatalogState,
+                mz_repr::Timestamp,
+                BuiltinMigrationMetadata,
+                String,
+            ),
+            AdapterError,
+        >,
     > {
-        for builtin_role in BUILTIN_ROLES {
-            assert!(
+        async move {
+            for builtin_role in BUILTIN_ROLES {
+                assert!(
                 is_reserved_name(builtin_role.name),
                 "builtin role {builtin_role:?} must start with one of the following prefixes {}",
                 BUILTIN_PREFIXES.join(", ")
             );
-        }
-        for builtin_cluster in BUILTIN_CLUSTERS {
-            assert!(
+            }
+            for builtin_cluster in BUILTIN_CLUSTERS {
+                assert!(
                 is_reserved_name(builtin_cluster.name),
                 "builtin cluster {builtin_cluster:?} must start with one of the following prefixes {}",
                 BUILTIN_PREFIXES.join(", ")
             );
-        }
-
-        let mut state = CatalogState {
-            database_by_name: BTreeMap::new(),
-            database_by_id: BTreeMap::new(),
-            entry_by_id: BTreeMap::new(),
-            ambient_schemas_by_name: BTreeMap::new(),
-            ambient_schemas_by_id: BTreeMap::new(),
-            temporary_schemas: BTreeMap::new(),
-            clusters_by_id: BTreeMap::new(),
-            clusters_by_name: BTreeMap::new(),
-            clusters_by_linked_object_id: BTreeMap::new(),
-            roles_by_name: BTreeMap::new(),
-            roles_by_id: BTreeMap::new(),
-            config: mz_sql::catalog::CatalogConfig {
-                start_time: to_datetime((config.now)()),
-                start_instant: Instant::now(),
-                nonce: rand::random(),
-                environment_id: config.environment_id,
-                session_id: Uuid::new_v4(),
-                build_info: config.build_info,
-                timestamp_interval: Duration::from_secs(1),
-                now: config.now.clone(),
-            },
-            oid_counter: FIRST_USER_OID,
-            cluster_replica_sizes: config.cluster_replica_sizes,
-            default_storage_cluster_size: config.default_storage_cluster_size,
-            availability_zones: config.availability_zones,
-            system_configuration: {
-                let mut s =
-                    SystemVars::new(config.active_connection_count).set_unsafe(config.unsafe_mode);
-                if config.all_features {
-                    s.enable_all_feature_flags_by_default();
-                }
-                s
-            },
-            egress_ips: config.egress_ips,
-            aws_principal_context: config.aws_principal_context,
-            aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
-            http_host_name: config.http_host_name,
-            default_privileges: DefaultPrivileges::default(),
-            system_privileges: PrivilegeMap::default(),
-            comments: CommentsMap::default(),
-        };
-
-        let is_read_only = storage.is_read_only();
-        let mut txn = storage.transaction().await?;
-        // Choose a time at which to boot. This is the time at which we will run
-        // internal migrations.
-        //
-        // This time is usually the current system time, but with protection
-        // against backwards time jumps, even across restarts.
-        let boot_ts = {
-            let previous_ts = txn
-                .get_timestamp(&Timeline::EpochMilliseconds)
-                .expect("missing EpochMilliseconds timeline");
-            let boot_ts =
-                timestamp_oracle::catalog_oracle::monotonic_now(config.now.clone(), previous_ts);
-            if !is_read_only {
-                // IMPORTANT: we durably record the new timestamp before using it.
-                txn.set_timestamp(Timeline::EpochMilliseconds, boot_ts)?;
             }
 
-            boot_ts
-        };
-
-        state.create_temporary_schema(&SYSTEM_CONN_ID, MZ_SYSTEM_ROLE_ID)?;
-
-        let databases = txn.get_databases();
-        for mz_catalog::durable::Database {
-            id,
-            name,
-            owner_id,
-            privileges,
-        } in databases
-        {
-            let oid = state.allocate_oid()?;
-            state.database_by_id.insert(
-                id.clone(),
-                Database {
-                    name: name.clone(),
-                    id,
-                    oid,
-                    schemas_by_id: BTreeMap::new(),
-                    schemas_by_name: BTreeMap::new(),
-                    owner_id,
-                    privileges: PrivilegeMap::from_mz_acl_items(privileges),
+            let mut state = CatalogState {
+                database_by_name: BTreeMap::new(),
+                database_by_id: BTreeMap::new(),
+                entry_by_id: BTreeMap::new(),
+                ambient_schemas_by_name: BTreeMap::new(),
+                ambient_schemas_by_id: BTreeMap::new(),
+                temporary_schemas: BTreeMap::new(),
+                clusters_by_id: BTreeMap::new(),
+                clusters_by_name: BTreeMap::new(),
+                clusters_by_linked_object_id: BTreeMap::new(),
+                roles_by_name: BTreeMap::new(),
+                roles_by_id: BTreeMap::new(),
+                config: mz_sql::catalog::CatalogConfig {
+                    start_time: to_datetime((config.now)()),
+                    start_instant: Instant::now(),
+                    nonce: rand::random(),
+                    environment_id: config.environment_id,
+                    session_id: Uuid::new_v4(),
+                    build_info: config.build_info,
+                    timestamp_interval: Duration::from_secs(1),
+                    now: config.now.clone(),
                 },
-            );
-            state.database_by_name.insert(name.clone(), id.clone());
-        }
-
-        let schemas = txn.get_schemas();
-        for mz_catalog::durable::Schema {
-            id,
-            name,
-            database_id,
-            owner_id,
-            privileges,
-        } in schemas
-        {
-            let oid = state.allocate_oid()?;
-            let (schemas_by_id, schemas_by_name, database_spec) = match &database_id {
-                Some(database_id) => {
-                    let db = state
-                        .database_by_id
-                        .get_mut(database_id)
-                        .expect("catalog out of sync");
-                    (
-                        &mut db.schemas_by_id,
-                        &mut db.schemas_by_name,
-                        ResolvedDatabaseSpecifier::Id(*database_id),
-                    )
-                }
-                None => (
-                    &mut state.ambient_schemas_by_id,
-                    &mut state.ambient_schemas_by_name,
-                    ResolvedDatabaseSpecifier::Ambient,
-                ),
+                oid_counter: FIRST_USER_OID,
+                cluster_replica_sizes: config.cluster_replica_sizes,
+                default_storage_cluster_size: config.default_storage_cluster_size,
+                availability_zones: config.availability_zones,
+                system_configuration: {
+                    let mut s = SystemVars::new(config.active_connection_count)
+                        .set_unsafe(config.unsafe_mode);
+                    if config.all_features {
+                        s.enable_all_feature_flags_by_default();
+                    }
+                    s
+                },
+                egress_ips: config.egress_ips,
+                aws_principal_context: config.aws_principal_context,
+                aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
+                http_host_name: config.http_host_name,
+                default_privileges: DefaultPrivileges::default(),
+                system_privileges: PrivilegeMap::default(),
+                comments: CommentsMap::default(),
             };
-            schemas_by_id.insert(
-                id.clone(),
-                Schema {
-                    name: QualifiedSchemaName {
-                        database: database_spec,
-                        schema: name.clone(),
-                    },
-                    id: SchemaSpecifier::Id(id.clone()),
-                    oid,
-                    items: BTreeMap::new(),
-                    functions: BTreeMap::new(),
-                    owner_id,
-                    privileges: PrivilegeMap::from_mz_acl_items(privileges),
-                },
-            );
-            schemas_by_name.insert(name.clone(), id);
-        }
 
-        let roles = txn.get_roles();
-        for mz_catalog::durable::Role {
-            id,
-            name,
-            attributes,
-            membership,
-            vars,
-        } in roles
-        {
-            let oid = state.allocate_oid()?;
-            state.roles_by_name.insert(name.clone(), id);
-            state.roles_by_id.insert(
+            let is_read_only = storage.is_read_only();
+            let mut txn = storage.transaction().await?;
+            // Choose a time at which to boot. This is the time at which we will run
+            // internal migrations.
+            //
+            // This time is usually the current system time, but with protection
+            // against backwards time jumps, even across restarts.
+            let boot_ts = {
+                let previous_ts = txn
+                    .get_timestamp(&Timeline::EpochMilliseconds)
+                    .expect("missing EpochMilliseconds timeline");
+                let boot_ts = timestamp_oracle::catalog_oracle::monotonic_now(
+                    config.now.clone(),
+                    previous_ts,
+                );
+                if !is_read_only {
+                    // IMPORTANT: we durably record the new timestamp before using it.
+                    txn.set_timestamp(Timeline::EpochMilliseconds, boot_ts)?;
+                }
+
+                boot_ts
+            };
+
+            state.create_temporary_schema(&SYSTEM_CONN_ID, MZ_SYSTEM_ROLE_ID)?;
+
+            let databases = txn.get_databases();
+            for mz_catalog::durable::Database {
                 id,
-                Role {
-                    name,
-                    id,
-                    oid,
-                    attributes,
-                    membership,
-                    vars,
-                },
-            );
-        }
-
-        let default_privileges = txn.get_default_privileges();
-        for mz_catalog::durable::DefaultPrivilege { object, acl_item } in default_privileges {
-            state.default_privileges.grant(object, acl_item);
-        }
-
-        let system_privileges = txn.get_system_privileges();
-        state.system_privileges.grant_all(system_privileges);
-
-        Catalog::load_system_configuration(
-            &mut state,
-            &mut txn,
-            is_read_only,
-            config.system_parameter_defaults,
-            config.system_parameter_sync_config,
-        )
-        .await?;
-
-        // Now that LD is loaded, set the intended catalog timeout.
-        // TODO: Move this into the catalog constructor.
-        txn.set_connection_timeout(state.system_config().crdb_connect_timeout());
-
-        // Add any new builtin Clusters or Cluster Replicas that may be newly defined.
-        if !is_read_only {
-            add_new_builtin_clusters_migration(&mut txn)?;
-            add_new_builtin_cluster_replicas_migration(
-                &mut txn,
-                config.builtin_cluster_replica_size,
-            )?;
-        }
-
-        let comments = txn.get_comments();
-        for mz_catalog::durable::Comment {
-            object_id,
-            sub_component,
-            comment,
-        } in comments
-        {
-            state
-                .comments
-                .update_comment(object_id, sub_component, Some(comment));
-        }
-
-        Catalog::load_builtin_types(&mut state, &mut txn)?;
-
-        let persisted_builtin_ids: BTreeMap<_, _> = txn
-            .get_system_items()
-            .map(|mapping| (mapping.description, mapping.unique_identifier))
-            .collect();
-        let AllocatedBuiltinSystemIds {
-            all_builtins,
-            new_builtins,
-            migrated_builtins,
-        } = Catalog::allocate_system_ids(
-            &mut txn,
-            BUILTINS::iter()
-                .filter(|builtin| !matches!(builtin, Builtin::Type(_)))
-                .collect(),
-            |builtin| {
-                persisted_builtin_ids
-                    .get(&SystemObjectDescription {
-                        schema_name: builtin.schema().to_string(),
-                        object_type: builtin.catalog_item_type(),
-                        object_name: builtin.name().to_string(),
-                    })
-                    .cloned()
-            },
-        )?;
-
-        let id_fingerprint_map: BTreeMap<GlobalId, String> = all_builtins
-            .iter()
-            .map(|(builtin, id)| (*id, builtin.fingerprint()))
-            .collect();
-        let (builtin_indexes, builtin_non_indexes): (Vec<_>, Vec<_>) = all_builtins
-            .into_iter()
-            .partition(|(builtin, _)| matches!(builtin, Builtin::Index(_)));
-
-        {
-            let span = tracing::span!(tracing::Level::DEBUG, "builtin_non_indexes");
-            let _enter = span.enter();
-            for (builtin, id) in builtin_non_indexes {
-                let schema_id = state.ambient_schemas_by_name[builtin.schema()];
-                let name = QualifiedItemName {
-                    qualifiers: ItemQualifiers {
-                        database_spec: ResolvedDatabaseSpecifier::Ambient,
-                        schema_spec: SchemaSpecifier::Id(schema_id),
+                name,
+                owner_id,
+                privileges,
+            } in databases
+            {
+                let oid = state.allocate_oid()?;
+                state.database_by_id.insert(
+                    id.clone(),
+                    Database {
+                        name: name.clone(),
+                        id,
+                        oid,
+                        schemas_by_id: BTreeMap::new(),
+                        schemas_by_name: BTreeMap::new(),
+                        owner_id,
+                        privileges: PrivilegeMap::from_mz_acl_items(privileges),
                     },
-                    item: builtin.name().into(),
+                );
+                state.database_by_name.insert(name.clone(), id.clone());
+            }
+
+            let schemas = txn.get_schemas();
+            for mz_catalog::durable::Schema {
+                id,
+                name,
+                database_id,
+                owner_id,
+                privileges,
+            } in schemas
+            {
+                let oid = state.allocate_oid()?;
+                let (schemas_by_id, schemas_by_name, database_spec) = match &database_id {
+                    Some(database_id) => {
+                        let db = state
+                            .database_by_id
+                            .get_mut(database_id)
+                            .expect("catalog out of sync");
+                        (
+                            &mut db.schemas_by_id,
+                            &mut db.schemas_by_name,
+                            ResolvedDatabaseSpecifier::Id(*database_id),
+                        )
+                    }
+                    None => (
+                        &mut state.ambient_schemas_by_id,
+                        &mut state.ambient_schemas_by_name,
+                        ResolvedDatabaseSpecifier::Ambient,
+                    ),
                 };
-                match builtin {
-                    Builtin::Log(log) => {
-                        let oid = state.allocate_oid()?;
-                        let mut acl_items = vec![rbac::owner_privilege(
-                            mz_sql::catalog::ObjectType::Source,
-                            MZ_SYSTEM_ROLE_ID,
-                        )];
-                        match log.sensitivity {
-                            DataSensitivity::Public => {
-                                acl_items.push(rbac::default_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Source,
-                                ));
-                            }
-                            DataSensitivity::SuperuserAndSupport => {
-                                acl_items.push(rbac::support_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Source,
-                                ));
-                            }
-                            DataSensitivity::Superuser => {}
-                        }
-                        state.insert_item(
-                            id,
-                            oid,
-                            name.clone(),
-                            CatalogItem::Log(Log {
-                                variant: log.variant.clone(),
-                                has_storage_collection: false,
-                            }),
-                            MZ_SYSTEM_ROLE_ID,
-                            PrivilegeMap::from_mz_acl_items(acl_items),
-                        );
-                    }
+                schemas_by_id.insert(
+                    id.clone(),
+                    Schema {
+                        name: QualifiedSchemaName {
+                            database: database_spec,
+                            schema: name.clone(),
+                        },
+                        id: SchemaSpecifier::Id(id.clone()),
+                        oid,
+                        items: BTreeMap::new(),
+                        functions: BTreeMap::new(),
+                        owner_id,
+                        privileges: PrivilegeMap::from_mz_acl_items(privileges),
+                    },
+                );
+                schemas_by_name.insert(name.clone(), id);
+            }
 
-                    Builtin::Table(table) => {
-                        let oid = state.allocate_oid()?;
-                        let mut acl_items = vec![rbac::owner_privilege(
-                            mz_sql::catalog::ObjectType::Table,
-                            MZ_SYSTEM_ROLE_ID,
-                        )];
-                        match table.sensitivity {
-                            DataSensitivity::Public => {
-                                acl_items.push(rbac::default_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Table,
-                                ));
+            let roles = txn.get_roles();
+            for mz_catalog::durable::Role {
+                id,
+                name,
+                attributes,
+                membership,
+                vars,
+            } in roles
+            {
+                let oid = state.allocate_oid()?;
+                state.roles_by_name.insert(name.clone(), id);
+                state.roles_by_id.insert(
+                    id,
+                    Role {
+                        name,
+                        id,
+                        oid,
+                        attributes,
+                        membership,
+                        vars,
+                    },
+                );
+            }
+
+            let default_privileges = txn.get_default_privileges();
+            for mz_catalog::durable::DefaultPrivilege { object, acl_item } in default_privileges {
+                state.default_privileges.grant(object, acl_item);
+            }
+
+            let system_privileges = txn.get_system_privileges();
+            state.system_privileges.grant_all(system_privileges);
+
+            Catalog::load_system_configuration(
+                &mut state,
+                &mut txn,
+                is_read_only,
+                config.system_parameter_defaults,
+                config.system_parameter_sync_config,
+            )
+            .await?;
+
+            // Now that LD is loaded, set the intended catalog timeout.
+            // TODO: Move this into the catalog constructor.
+            txn.set_connection_timeout(state.system_config().crdb_connect_timeout());
+
+            // Add any new builtin Clusters or Cluster Replicas that may be newly defined.
+            if !is_read_only {
+                add_new_builtin_clusters_migration(&mut txn)?;
+                add_new_builtin_cluster_replicas_migration(
+                    &mut txn,
+                    config.builtin_cluster_replica_size,
+                )?;
+            }
+
+            let comments = txn.get_comments();
+            for mz_catalog::durable::Comment {
+                object_id,
+                sub_component,
+                comment,
+            } in comments
+            {
+                state
+                    .comments
+                    .update_comment(object_id, sub_component, Some(comment));
+            }
+
+            Catalog::load_builtin_types(&mut state, &mut txn)?;
+
+            let persisted_builtin_ids: BTreeMap<_, _> = txn
+                .get_system_items()
+                .map(|mapping| (mapping.description, mapping.unique_identifier))
+                .collect();
+            let AllocatedBuiltinSystemIds {
+                all_builtins,
+                new_builtins,
+                migrated_builtins,
+            } = Catalog::allocate_system_ids(
+                &mut txn,
+                BUILTINS::iter()
+                    .filter(|builtin| !matches!(builtin, Builtin::Type(_)))
+                    .collect(),
+                |builtin| {
+                    persisted_builtin_ids
+                        .get(&SystemObjectDescription {
+                            schema_name: builtin.schema().to_string(),
+                            object_type: builtin.catalog_item_type(),
+                            object_name: builtin.name().to_string(),
+                        })
+                        .cloned()
+                },
+            )?;
+
+            let id_fingerprint_map: BTreeMap<GlobalId, String> = all_builtins
+                .iter()
+                .map(|(builtin, id)| (*id, builtin.fingerprint()))
+                .collect();
+            let (builtin_indexes, builtin_non_indexes): (Vec<_>, Vec<_>) = all_builtins
+                .into_iter()
+                .partition(|(builtin, _)| matches!(builtin, Builtin::Index(_)));
+
+            {
+                let span = tracing::span!(tracing::Level::DEBUG, "builtin_non_indexes");
+                let _enter = span.enter();
+                for (builtin, id) in builtin_non_indexes {
+                    let schema_id = state.ambient_schemas_by_name[builtin.schema()];
+                    let name = QualifiedItemName {
+                        qualifiers: ItemQualifiers {
+                            database_spec: ResolvedDatabaseSpecifier::Ambient,
+                            schema_spec: SchemaSpecifier::Id(schema_id),
+                        },
+                        item: builtin.name().into(),
+                    };
+                    match builtin {
+                        Builtin::Log(log) => {
+                            let oid = state.allocate_oid()?;
+                            let mut acl_items = vec![rbac::owner_privilege(
+                                mz_sql::catalog::ObjectType::Source,
+                                MZ_SYSTEM_ROLE_ID,
+                            )];
+                            match log.sensitivity {
+                                DataSensitivity::Public => {
+                                    acl_items.push(rbac::default_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Source,
+                                    ));
+                                }
+                                DataSensitivity::SuperuserAndSupport => {
+                                    acl_items.push(rbac::support_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Source,
+                                    ));
+                                }
+                                DataSensitivity::Superuser => {}
                             }
-                            DataSensitivity::SuperuserAndSupport => {
-                                acl_items.push(rbac::support_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Table,
-                                ));
-                            }
-                            DataSensitivity::Superuser => {}
+                            state.insert_item(
+                                id,
+                                oid,
+                                name.clone(),
+                                CatalogItem::Log(Log {
+                                    variant: log.variant.clone(),
+                                    has_storage_collection: false,
+                                }),
+                                MZ_SYSTEM_ROLE_ID,
+                                PrivilegeMap::from_mz_acl_items(acl_items),
+                            );
                         }
 
-                        state.insert_item(
-                            id,
-                            oid,
-                            name.clone(),
-                            CatalogItem::Table(Table {
-                                create_sql: CREATE_SQL_TODO.to_string(),
-                                desc: table.desc.clone(),
-                                defaults: vec![Expr::null(); table.desc.arity()],
-                                conn_id: None,
-                                resolved_ids: ResolvedIds(BTreeSet::new()),
-                                custom_logical_compaction_window: table
-                                    .is_retained_metrics_object
-                                    .then(|| state.system_config().metrics_retention()),
-                                is_retained_metrics_object: table.is_retained_metrics_object,
-                            }),
-                            MZ_SYSTEM_ROLE_ID,
-                            PrivilegeMap::from_mz_acl_items(acl_items),
-                        );
-                    }
-                    Builtin::Index(_) => {
-                        unreachable!("handled later once clusters have been created")
-                    }
-                    Builtin::View(view) => {
-                        let item = state
+                        Builtin::Table(table) => {
+                            let oid = state.allocate_oid()?;
+                            let mut acl_items = vec![rbac::owner_privilege(
+                                mz_sql::catalog::ObjectType::Table,
+                                MZ_SYSTEM_ROLE_ID,
+                            )];
+                            match table.sensitivity {
+                                DataSensitivity::Public => {
+                                    acl_items.push(rbac::default_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Table,
+                                    ));
+                                }
+                                DataSensitivity::SuperuserAndSupport => {
+                                    acl_items.push(rbac::support_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Table,
+                                    ));
+                                }
+                                DataSensitivity::Superuser => {}
+                            }
+
+                            state.insert_item(
+                                id,
+                                oid,
+                                name.clone(),
+                                CatalogItem::Table(Table {
+                                    create_sql: CREATE_SQL_TODO.to_string(),
+                                    desc: table.desc.clone(),
+                                    defaults: vec![Expr::null(); table.desc.arity()],
+                                    conn_id: None,
+                                    resolved_ids: ResolvedIds(BTreeSet::new()),
+                                    custom_logical_compaction_window: table
+                                        .is_retained_metrics_object
+                                        .then(|| state.system_config().metrics_retention()),
+                                    is_retained_metrics_object: table.is_retained_metrics_object,
+                                }),
+                                MZ_SYSTEM_ROLE_ID,
+                                PrivilegeMap::from_mz_acl_items(acl_items),
+                            );
+                        }
+                        Builtin::Index(_) => {
+                            unreachable!("handled later once clusters have been created")
+                        }
+                        Builtin::View(view) => {
+                            let item = state
                             .parse_item(
                                 id,
                                 view.sql.into(),
@@ -550,200 +560,200 @@ impl Catalog {
                                     view.name, e
                                 )
                             });
-                        let oid = state.allocate_oid()?;
-                        let mut acl_items = vec![rbac::owner_privilege(
-                            mz_sql::catalog::ObjectType::View,
-                            MZ_SYSTEM_ROLE_ID,
-                        )];
-                        match view.sensitivity {
-                            DataSensitivity::Public => {
-                                acl_items.push(rbac::default_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::View,
-                                ));
+                            let oid = state.allocate_oid()?;
+                            let mut acl_items = vec![rbac::owner_privilege(
+                                mz_sql::catalog::ObjectType::View,
+                                MZ_SYSTEM_ROLE_ID,
+                            )];
+                            match view.sensitivity {
+                                DataSensitivity::Public => {
+                                    acl_items.push(rbac::default_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::View,
+                                    ));
+                                }
+                                DataSensitivity::SuperuserAndSupport => {
+                                    acl_items.push(rbac::support_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::View,
+                                    ));
+                                }
+                                DataSensitivity::Superuser => {}
                             }
-                            DataSensitivity::SuperuserAndSupport => {
-                                acl_items.push(rbac::support_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::View,
-                                ));
-                            }
-                            DataSensitivity::Superuser => {}
+
+                            state.insert_item(
+                                id,
+                                oid,
+                                name,
+                                item,
+                                MZ_SYSTEM_ROLE_ID,
+                                PrivilegeMap::from_mz_acl_items(acl_items),
+                            );
                         }
 
-                        state.insert_item(
-                            id,
-                            oid,
-                            name,
-                            item,
-                            MZ_SYSTEM_ROLE_ID,
-                            PrivilegeMap::from_mz_acl_items(acl_items),
-                        );
-                    }
+                        Builtin::Type(_) => unreachable!("loaded separately"),
 
-                    Builtin::Type(_) => unreachable!("loaded separately"),
-
-                    Builtin::Func(func) => {
-                        let oid = state.allocate_oid()?;
-                        state.insert_item(
-                            id,
-                            oid,
-                            name.clone(),
-                            CatalogItem::Func(Func { inner: func.inner }),
-                            MZ_SYSTEM_ROLE_ID,
-                            PrivilegeMap::default(),
-                        );
-                    }
-
-                    Builtin::Source(coll) => {
-                        let introspection_type = match &coll.data_source {
-                            Some(i) => i.clone(),
-                            None => continue,
-                        };
-
-                        let oid = state.allocate_oid()?;
-                        let mut acl_items = vec![rbac::owner_privilege(
-                            mz_sql::catalog::ObjectType::Source,
-                            MZ_SYSTEM_ROLE_ID,
-                        )];
-                        match coll.sensitivity {
-                            DataSensitivity::Public => {
-                                acl_items.push(rbac::default_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Source,
-                                ));
-                            }
-                            DataSensitivity::SuperuserAndSupport => {
-                                acl_items.push(rbac::support_builtin_object_privilege(
-                                    mz_sql::catalog::ObjectType::Source,
-                                ));
-                            }
-                            DataSensitivity::Superuser => {}
+                        Builtin::Func(func) => {
+                            let oid = state.allocate_oid()?;
+                            state.insert_item(
+                                id,
+                                oid,
+                                name.clone(),
+                                CatalogItem::Func(Func { inner: func.inner }),
+                                MZ_SYSTEM_ROLE_ID,
+                                PrivilegeMap::default(),
+                            );
                         }
 
-                        state.insert_item(
-                            id,
-                            oid,
-                            name.clone(),
-                            CatalogItem::Source(Source {
-                                create_sql: CREATE_SQL_TODO.to_string(),
-                                data_source: DataSourceDesc::Introspection(introspection_type),
-                                desc: coll.desc.clone(),
-                                timeline: Timeline::EpochMilliseconds,
-                                resolved_ids: ResolvedIds(BTreeSet::new()),
-                                custom_logical_compaction_window: coll
-                                    .is_retained_metrics_object
-                                    .then(|| state.system_config().metrics_retention()),
-                                is_retained_metrics_object: coll.is_retained_metrics_object,
-                            }),
-                            MZ_SYSTEM_ROLE_ID,
-                            PrivilegeMap::from_mz_acl_items(acl_items),
-                        );
+                        Builtin::Source(coll) => {
+                            let introspection_type = match &coll.data_source {
+                                Some(i) => i.clone(),
+                                None => continue,
+                            };
+
+                            let oid = state.allocate_oid()?;
+                            let mut acl_items = vec![rbac::owner_privilege(
+                                mz_sql::catalog::ObjectType::Source,
+                                MZ_SYSTEM_ROLE_ID,
+                            )];
+                            match coll.sensitivity {
+                                DataSensitivity::Public => {
+                                    acl_items.push(rbac::default_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Source,
+                                    ));
+                                }
+                                DataSensitivity::SuperuserAndSupport => {
+                                    acl_items.push(rbac::support_builtin_object_privilege(
+                                        mz_sql::catalog::ObjectType::Source,
+                                    ));
+                                }
+                                DataSensitivity::Superuser => {}
+                            }
+
+                            state.insert_item(
+                                id,
+                                oid,
+                                name.clone(),
+                                CatalogItem::Source(Source {
+                                    create_sql: CREATE_SQL_TODO.to_string(),
+                                    data_source: DataSourceDesc::Introspection(introspection_type),
+                                    desc: coll.desc.clone(),
+                                    timeline: Timeline::EpochMilliseconds,
+                                    resolved_ids: ResolvedIds(BTreeSet::new()),
+                                    custom_logical_compaction_window: coll
+                                        .is_retained_metrics_object
+                                        .then(|| state.system_config().metrics_retention()),
+                                    is_retained_metrics_object: coll.is_retained_metrics_object,
+                                }),
+                                MZ_SYSTEM_ROLE_ID,
+                                PrivilegeMap::from_mz_acl_items(acl_items),
+                            );
+                        }
                     }
                 }
             }
-        }
 
-        let clusters = txn.get_clusters();
-        let mut cluster_azs = BTreeMap::new();
-        for mz_catalog::durable::Cluster {
-            id,
-            name,
-            linked_object_id,
-            owner_id,
-            privileges,
-            config,
-        } in clusters
-        {
-            let introspection_source_index_gids = txn.get_introspection_source_indexes(id);
-
-            let AllocatedBuiltinSystemIds {
-                all_builtins: all_indexes,
-                new_builtins: new_indexes,
-                ..
-            } = Catalog::allocate_system_ids(&mut txn, BUILTINS::logs().collect(), |log| {
-                introspection_source_index_gids
-                    .get(log.name)
-                    .cloned()
-                    // We migrate introspection sources later so we can hardcode the fingerprint as ""
-                    .map(|id| SystemObjectUniqueIdentifier {
-                        id,
-                        fingerprint: "".to_string(),
-                    })
-            })?;
-
-            let new_indexes = new_indexes
-                .iter()
-                .map(|(log, index_id)| IntrospectionSourceIndex {
-                    cluster_id: id,
-                    name: log.name.to_string(),
-                    index_id: *index_id,
-                })
-                .collect();
-            txn.set_introspection_source_indexes(new_indexes)?;
-
-            if let mz_catalog::durable::ClusterVariant::Managed(managed) = &config.variant {
-                cluster_azs.insert(id, managed.availability_zones.clone());
-            }
-
-            state.insert_cluster(
+            let clusters = txn.get_clusters();
+            let mut cluster_azs = BTreeMap::new();
+            for mz_catalog::durable::Cluster {
                 id,
                 name,
                 linked_object_id,
-                all_indexes,
                 owner_id,
-                PrivilegeMap::from_mz_acl_items(privileges),
-                config.into(),
-            );
-        }
+                privileges,
+                config,
+            } in clusters
+            {
+                let introspection_source_index_gids = txn.get_introspection_source_indexes(id);
 
-        let replicas = txn.get_cluster_replicas();
-        let mut allocated_replicas = Vec::new();
-        for mz_catalog::durable::ClusterReplica {
-            cluster_id,
-            replica_id,
-            name,
-            config,
-            owner_id,
-        } in replicas
-        {
-            let logging = ReplicaLogging {
-                log_logging: config.logging.log_logging,
-                interval: config.logging.interval,
-            };
-            let config = ReplicaConfig {
-                location: state.concretize_replica_location(
-                    config.location,
-                    &vec![],
-                    cluster_azs.get(&cluster_id).map(|zones| &**zones),
-                )?,
-                compute: ComputeReplicaConfig {
-                    logging,
-                    idle_arrangement_merge_effort: config.idle_arrangement_merge_effort,
-                },
-            };
+                let AllocatedBuiltinSystemIds {
+                    all_builtins: all_indexes,
+                    new_builtins: new_indexes,
+                    ..
+                } = Catalog::allocate_system_ids(&mut txn, BUILTINS::logs().collect(), |log| {
+                    introspection_source_index_gids
+                        .get(log.name)
+                        .cloned()
+                        // We migrate introspection sources later so we can hardcode the fingerprint as ""
+                        .map(|id| SystemObjectUniqueIdentifier {
+                            id,
+                            fingerprint: "".to_string(),
+                        })
+                })?;
 
-            allocated_replicas.push(mz_catalog::durable::ClusterReplica {
+                let new_indexes = new_indexes
+                    .iter()
+                    .map(|(log, index_id)| IntrospectionSourceIndex {
+                        cluster_id: id,
+                        name: log.name.to_string(),
+                        index_id: *index_id,
+                    })
+                    .collect();
+                txn.set_introspection_source_indexes(new_indexes)?;
+
+                if let mz_catalog::durable::ClusterVariant::Managed(managed) = &config.variant {
+                    cluster_azs.insert(id, managed.availability_zones.clone());
+                }
+
+                state.insert_cluster(
+                    id,
+                    name,
+                    linked_object_id,
+                    all_indexes,
+                    owner_id,
+                    PrivilegeMap::from_mz_acl_items(privileges),
+                    config.into(),
+                );
+            }
+
+            let replicas = txn.get_cluster_replicas();
+            let mut allocated_replicas = Vec::new();
+            for mz_catalog::durable::ClusterReplica {
                 cluster_id,
                 replica_id,
-                name: name.clone(),
-                config: config.clone().into(),
-                owner_id: owner_id.clone(),
-            });
+                name,
+                config,
+                owner_id,
+            } in replicas
+            {
+                let logging = ReplicaLogging {
+                    log_logging: config.logging.log_logging,
+                    interval: config.logging.interval,
+                };
+                let config = ReplicaConfig {
+                    location: state.concretize_replica_location(
+                        config.location,
+                        &vec![],
+                        cluster_azs.get(&cluster_id).map(|zones| &**zones),
+                    )?,
+                    compute: ComputeReplicaConfig {
+                        logging,
+                        idle_arrangement_merge_effort: config.idle_arrangement_merge_effort,
+                    },
+                };
 
-            state.insert_cluster_replica(cluster_id, name, replica_id, config, owner_id);
-        }
-        txn.set_replicas(allocated_replicas)?;
+                allocated_replicas.push(mz_catalog::durable::ClusterReplica {
+                    cluster_id,
+                    replica_id,
+                    name: name.clone(),
+                    config: config.clone().into(),
+                    owner_id: owner_id.clone(),
+                });
 
-        for (builtin, id) in builtin_indexes {
-            let schema_id = state.ambient_schemas_by_name[builtin.schema()];
-            let name = QualifiedItemName {
-                qualifiers: ItemQualifiers {
-                    database_spec: ResolvedDatabaseSpecifier::Ambient,
-                    schema_spec: SchemaSpecifier::Id(schema_id),
-                },
-                item: builtin.name().into(),
-            };
-            match builtin {
-                Builtin::Index(index) => {
-                    let mut item = state
+                state.insert_cluster_replica(cluster_id, name, replica_id, config, owner_id);
+            }
+            txn.set_replicas(allocated_replicas)?;
+
+            for (builtin, id) in builtin_indexes {
+                let schema_id = state.ambient_schemas_by_name[builtin.schema()];
+                let name = QualifiedItemName {
+                    qualifiers: ItemQualifiers {
+                        database_spec: ResolvedDatabaseSpecifier::Ambient,
+                        schema_spec: SchemaSpecifier::Id(schema_id),
+                    },
+                    item: builtin.name().into(),
+                };
+                match builtin {
+                    Builtin::Index(index) => {
+                        let mut item = state
                         .parse_item(
                             id,
                             index.sql.into(),
@@ -761,86 +771,92 @@ impl Catalog {
                                 index.name, e
                             )
                         });
-                    let CatalogItem::Index(_) = &mut item else {
-                        panic!("internal error: builtin index {}'s SQL does not begin with \"CREATE INDEX\".", index.name);
-                    };
+                        let CatalogItem::Index(_) = &mut item else {
+                            panic!("internal error: builtin index {}'s SQL does not begin with \"CREATE INDEX\".", index.name);
+                        };
 
-                    let oid = state.allocate_oid()?;
-                    state.insert_item(
-                        id,
-                        oid,
-                        name,
-                        item,
-                        MZ_SYSTEM_ROLE_ID,
-                        PrivilegeMap::default(),
-                    );
-                }
-                Builtin::Log(_)
-                | Builtin::Table(_)
-                | Builtin::View(_)
-                | Builtin::Type(_)
-                | Builtin::Func(_)
-                | Builtin::Source(_) => {
-                    unreachable!("handled above")
+                        let oid = state.allocate_oid()?;
+                        state.insert_item(
+                            id,
+                            oid,
+                            name,
+                            item,
+                            MZ_SYSTEM_ROLE_ID,
+                            PrivilegeMap::default(),
+                        );
+                    }
+                    Builtin::Log(_)
+                    | Builtin::Table(_)
+                    | Builtin::View(_)
+                    | Builtin::Type(_)
+                    | Builtin::Func(_)
+                    | Builtin::Source(_) => {
+                        unreachable!("handled above")
+                    }
                 }
             }
+
+            let new_system_id_mappings = new_builtins
+                .iter()
+                .map(|(builtin, id)| SystemObjectMapping {
+                    description: SystemObjectDescription {
+                        schema_name: builtin.schema().to_string(),
+                        object_type: builtin.catalog_item_type(),
+                        object_name: builtin.name().to_string(),
+                    },
+                    unique_identifier: SystemObjectUniqueIdentifier {
+                        id: *id,
+                        fingerprint: builtin.fingerprint(),
+                    },
+                })
+                .collect();
+            txn.set_system_object_mappings(new_system_id_mappings)?;
+
+            let last_seen_version = txn
+                .get_catalog_content_version()
+                .unwrap_or_else(|| "new".to_string());
+
+            if !config.skip_migrations {
+                migrate::migrate(&mut state, &mut txn, config.now, config.connection_context)
+                    .await
+                    .map_err(|e| {
+                        Error::new(ErrorKind::FailedMigration {
+                            last_seen_version: last_seen_version.clone(),
+                            this_version: config.build_info.version,
+                            cause: e.to_string(),
+                        })
+                    })?;
+                txn.set_catalog_content_version(config.build_info.version.to_string())?;
+            }
+
+            let mut state = Catalog::load_catalog_items(&mut txn, &state)?;
+
+            let mut builtin_migration_metadata = Catalog::generate_builtin_migration_metadata(
+                &state,
+                &mut txn,
+                migrated_builtins,
+                id_fingerprint_map,
+            )?;
+            Catalog::apply_in_memory_builtin_migration(
+                &mut state,
+                &mut builtin_migration_metadata,
+            )?;
+            Catalog::apply_persisted_builtin_migration(
+                &state,
+                &mut txn,
+                &mut builtin_migration_metadata,
+            )?;
+
+            txn.commit().await?;
+            Ok((
+                state,
+                boot_ts,
+                builtin_migration_metadata,
+                last_seen_version,
+            ))
         }
-
-        let new_system_id_mappings = new_builtins
-            .iter()
-            .map(|(builtin, id)| SystemObjectMapping {
-                description: SystemObjectDescription {
-                    schema_name: builtin.schema().to_string(),
-                    object_type: builtin.catalog_item_type(),
-                    object_name: builtin.name().to_string(),
-                },
-                unique_identifier: SystemObjectUniqueIdentifier {
-                    id: *id,
-                    fingerprint: builtin.fingerprint(),
-                },
-            })
-            .collect();
-        txn.set_system_object_mappings(new_system_id_mappings)?;
-
-        let last_seen_version = txn
-            .get_catalog_content_version()
-            .unwrap_or_else(|| "new".to_string());
-
-        if !config.skip_migrations {
-            migrate::migrate(&mut state, &mut txn, config.now, config.connection_context)
-                .await
-                .map_err(|e| {
-                    Error::new(ErrorKind::FailedMigration {
-                        last_seen_version: last_seen_version.clone(),
-                        this_version: config.build_info.version,
-                        cause: e.to_string(),
-                    })
-                })?;
-            txn.set_catalog_content_version(config.build_info.version.to_string())?;
-        }
-
-        let mut state = Catalog::load_catalog_items(&mut txn, &state)?;
-
-        let mut builtin_migration_metadata = Catalog::generate_builtin_migration_metadata(
-            &state,
-            &mut txn,
-            migrated_builtins,
-            id_fingerprint_map,
-        )?;
-        Catalog::apply_in_memory_builtin_migration(&mut state, &mut builtin_migration_metadata)?;
-        Catalog::apply_persisted_builtin_migration(
-            &state,
-            &mut txn,
-            &mut builtin_migration_metadata,
-        )?;
-
-        txn.commit().await?;
-        Ok((
-            state,
-            boot_ts,
-            builtin_migration_metadata,
-            last_seen_version,
-        ))
+        .instrument(tracing::info_span!("catalog::initialize_state"))
+        .boxed()
     }
 
     /// Opens or creates a catalog that stores data at `path`.
@@ -849,62 +865,57 @@ impl Catalog {
     /// schemas since last restart, a list of updates to builtin tables that
     /// describe the initial state of the catalog, and the version of the
     /// catalog before any migrations were performed.
-    #[tracing::instrument(name = "catalog::open", level = "info", skip_all)]
-    pub async fn open(
+    ///
+    /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 17KB. This would
+    /// get stored on the stack which is bad for runtime performance, and blow up our stack usage.
+    /// Because of that we purposefully move this Future onto the heap (i.e. Box it).
+    pub fn open(
         config: Config<'_>,
-    ) -> Result<
-        (
-            Catalog,
-            BuiltinMigrationMetadata,
-            Vec<BuiltinTableUpdate>,
-            String,
-        ),
-        AdapterError,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            (
+                Catalog,
+                BuiltinMigrationMetadata,
+                Vec<BuiltinTableUpdate>,
+                String,
+            ),
+            AdapterError,
+        >,
     > {
-        let mut storage = config.storage;
-        let (state, boot_ts, builtin_migration_metadata, last_seen_version) =
-            Self::initialize_state(config.state, &mut storage).await?;
+        async move {
+            let mut storage = config.storage;
+            let (state, boot_ts, builtin_migration_metadata, last_seen_version) =
+                Self::initialize_state(config.state, &mut storage).await?;
 
-        let mut catalog = Catalog {
-            state,
-            plans: CatalogPlans {
-                optimized_plan_by_id: Default::default(),
-                physical_plan_by_id: Default::default(),
-                dataflow_metainfos: BTreeMap::new(),
-            },
-            transient_revision: 1,
-            storage: Arc::new(tokio::sync::Mutex::new(storage)),
-        };
+            let mut catalog = Catalog {
+                state,
+                plans: CatalogPlans {
+                    optimized_plan_by_id: Default::default(),
+                    physical_plan_by_id: Default::default(),
+                    dataflow_metainfos: BTreeMap::new(),
+                },
+                transient_revision: 1,
+                storage: Arc::new(tokio::sync::Mutex::new(storage)),
+            };
 
-        // Load public keys for SSH connections from the secrets store to the catalog
-        for (id, entry) in catalog.state.entry_by_id.iter_mut() {
-            if let CatalogItem::Connection(ref mut connection) = entry.item {
-                if let mz_storage_types::connections::Connection::Ssh(ref mut ssh) =
-                    connection.connection
-                {
-                    let secret = config.secrets_reader.read(*id).await?;
-                    let keyset = SshKeyPairSet::from_bytes(&secret)?;
-                    let public_key_pair = keyset.public_keys();
-                    ssh.public_keys = Some(public_key_pair);
+            // Load public keys for SSH connections from the secrets store to the catalog
+            for (id, entry) in catalog.state.entry_by_id.iter_mut() {
+                if let CatalogItem::Connection(ref mut connection) = entry.item {
+                    if let mz_storage_types::connections::Connection::Ssh(ref mut ssh) =
+                        connection.connection
+                    {
+                        let secret = config.secrets_reader.read(*id).await?;
+                        let keyset = SshKeyPairSet::from_bytes(&secret)?;
+                        let public_key_pair = keyset.public_keys();
+                        ssh.public_keys = Some(public_key_pair);
+                    }
                 }
             }
-        }
 
-        let mut builtin_table_updates = vec![];
-        for (schema_id, schema) in &catalog.state.ambient_schemas_by_id {
-            let db_spec = ResolvedDatabaseSpecifier::Ambient;
-            builtin_table_updates.push(catalog.state.pack_schema_update(&db_spec, schema_id, 1));
-            for (_item_name, item_id) in &schema.items {
-                builtin_table_updates.extend(catalog.state.pack_item_update(*item_id, 1));
-            }
-            for (_item_name, function_id) in &schema.functions {
-                builtin_table_updates.extend(catalog.state.pack_item_update(*function_id, 1));
-            }
-        }
-        for (_id, db) in &catalog.state.database_by_id {
-            builtin_table_updates.push(catalog.state.pack_database_update(db, 1));
-            let db_spec = ResolvedDatabaseSpecifier::Id(db.id.clone());
-            for (schema_id, schema) in &db.schemas_by_id {
+            let mut builtin_table_updates = vec![];
+            for (schema_id, schema) in &catalog.state.ambient_schemas_by_id {
+                let db_spec = ResolvedDatabaseSpecifier::Ambient;
                 builtin_table_updates
                     .push(catalog.state.pack_schema_update(&db_spec, schema_id, 1));
                 for (_item_name, item_id) in &schema.items {
@@ -914,116 +925,135 @@ impl Catalog {
                     builtin_table_updates.extend(catalog.state.pack_item_update(*function_id, 1));
                 }
             }
-        }
-        for (id, sub_component, comment) in catalog.state.comments.iter() {
-            builtin_table_updates.push(catalog.state.pack_comment_update(
-                id,
-                sub_component,
-                comment,
-                1,
-            ));
-        }
-        for (_id, role) in &catalog.state.roles_by_id {
-            if let Some(builtin_update) = catalog.state.pack_role_update(role.id, 1) {
-                builtin_table_updates.push(builtin_update);
+            for (_id, db) in &catalog.state.database_by_id {
+                builtin_table_updates.push(catalog.state.pack_database_update(db, 1));
+                let db_spec = ResolvedDatabaseSpecifier::Id(db.id.clone());
+                for (schema_id, schema) in &db.schemas_by_id {
+                    builtin_table_updates
+                        .push(catalog.state.pack_schema_update(&db_spec, schema_id, 1));
+                    for (_item_name, item_id) in &schema.items {
+                        builtin_table_updates.extend(catalog.state.pack_item_update(*item_id, 1));
+                    }
+                    for (_item_name, function_id) in &schema.functions {
+                        builtin_table_updates
+                            .extend(catalog.state.pack_item_update(*function_id, 1));
+                    }
+                }
             }
-            for group_id in role.membership.map.keys() {
+            for (id, sub_component, comment) in catalog.state.comments.iter() {
+                builtin_table_updates.push(catalog.state.pack_comment_update(
+                    id,
+                    sub_component,
+                    comment,
+                    1,
+                ));
+            }
+            for (_id, role) in &catalog.state.roles_by_id {
+                if let Some(builtin_update) = catalog.state.pack_role_update(role.id, 1) {
+                    builtin_table_updates.push(builtin_update);
+                }
+                for group_id in role.membership.map.keys() {
+                    builtin_table_updates.push(
+                        catalog
+                            .state
+                            .pack_role_members_update(*group_id, role.id, 1),
+                    )
+                }
+            }
+            for (default_privilege_object, default_privilege_acl_items) in
+                catalog.state.default_privileges.iter()
+            {
+                for default_privilege_acl_item in default_privilege_acl_items {
+                    builtin_table_updates.push(catalog.state.pack_default_privileges_update(
+                        default_privilege_object,
+                        &default_privilege_acl_item.grantee,
+                        &default_privilege_acl_item.acl_mode,
+                        1,
+                    ));
+                }
+            }
+            for system_privilege in catalog.state.system_privileges.all_values_owned() {
                 builtin_table_updates.push(
                     catalog
                         .state
-                        .pack_role_members_update(*group_id, role.id, 1),
-                )
+                        .pack_system_privileges_update(system_privilege, 1),
+                );
             }
-        }
-        for (default_privilege_object, default_privilege_acl_items) in
-            catalog.state.default_privileges.iter()
-        {
-            for default_privilege_acl_item in default_privilege_acl_items {
-                builtin_table_updates.push(catalog.state.pack_default_privileges_update(
-                    default_privilege_object,
-                    &default_privilege_acl_item.grantee,
-                    &default_privilege_acl_item.acl_mode,
-                    1,
-                ));
-            }
-        }
-        for system_privilege in catalog.state.system_privileges.all_values_owned() {
-            builtin_table_updates.push(
-                catalog
-                    .state
-                    .pack_system_privileges_update(system_privilege, 1),
-            );
-        }
-        for (id, cluster) in &catalog.state.clusters_by_id {
-            builtin_table_updates.push(catalog.state.pack_cluster_update(&cluster.name, 1));
-            if let Some(linked_object_id) = cluster.linked_object_id {
-                builtin_table_updates.push(catalog.state.pack_cluster_link_update(
-                    &cluster.name,
-                    linked_object_id,
-                    1,
-                ));
-            }
-            for (replica_name, replica_id) in cluster.replicas().map(|r| (&r.name, r.replica_id)) {
-                builtin_table_updates.extend(catalog.state.pack_cluster_replica_update(
-                    *id,
-                    replica_name,
-                    1,
-                ));
-                let replica = catalog.state.get_cluster_replica(*id, replica_id);
-                for process_id in 0..replica.config.location.num_processes() {
-                    let update = catalog.state.pack_cluster_replica_status_update(
-                        *id,
-                        replica_id,
-                        u64::cast_from(process_id),
+            for (id, cluster) in &catalog.state.clusters_by_id {
+                builtin_table_updates.push(catalog.state.pack_cluster_update(&cluster.name, 1));
+                if let Some(linked_object_id) = cluster.linked_object_id {
+                    builtin_table_updates.push(catalog.state.pack_cluster_link_update(
+                        &cluster.name,
+                        linked_object_id,
                         1,
-                    );
-                    builtin_table_updates.push(update);
+                    ));
                 }
-            }
-        }
-        // Operators aren't stored in the catalog, but we would like them in
-        // introspection views.
-        for (op, func) in OP_IMPLS.iter() {
-            match func {
-                mz_sql::func::Func::Scalar(impls) => {
-                    for imp in impls {
-                        builtin_table_updates.push(catalog.state.pack_op_update(
-                            op,
-                            imp.details(),
+                for (replica_name, replica_id) in
+                    cluster.replicas().map(|r| (&r.name, r.replica_id))
+                {
+                    builtin_table_updates.extend(catalog.state.pack_cluster_replica_update(
+                        *id,
+                        replica_name,
+                        1,
+                    ));
+                    let replica = catalog.state.get_cluster_replica(*id, replica_id);
+                    for process_id in 0..replica.config.location.num_processes() {
+                        let update = catalog.state.pack_cluster_replica_status_update(
+                            *id,
+                            replica_id,
+                            u64::cast_from(process_id),
                             1,
-                        ));
+                        );
+                        builtin_table_updates.push(update);
                     }
                 }
-                _ => unreachable!("all operators must be scalar functions"),
             }
-        }
-        let audit_logs = catalog.storage().await.get_audit_logs().await?;
-        for event in audit_logs {
-            builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
-        }
+            // Operators aren't stored in the catalog, but we would like them in
+            // introspection views.
+            for (op, func) in OP_IMPLS.iter() {
+                match func {
+                    mz_sql::func::Func::Scalar(impls) => {
+                        for imp in impls {
+                            builtin_table_updates.push(catalog.state.pack_op_update(
+                                op,
+                                imp.details(),
+                                1,
+                            ));
+                        }
+                    }
+                    _ => unreachable!("all operators must be scalar functions"),
+                }
+            }
+            let audit_logs = catalog.storage().await.get_audit_logs().await?;
+            for event in audit_logs {
+                builtin_table_updates.push(catalog.state.pack_audit_log_update(&event)?);
+            }
 
-        // To avoid reading over storage_usage events multiple times, do both
-        // the table updates and delete calculations in a single read over the
-        // data.
-        let storage_usage_events = catalog
-            .storage()
-            .await
-            .get_and_prune_storage_usage(config.storage_usage_retention_period, boot_ts)
-            .await?;
-        for event in storage_usage_events {
-            builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
-        }
+            // To avoid reading over storage_usage events multiple times, do both
+            // the table updates and delete calculations in a single read over the
+            // data.
+            let storage_usage_events = catalog
+                .storage()
+                .await
+                .get_and_prune_storage_usage(config.storage_usage_retention_period, boot_ts)
+                .await?;
+            for event in storage_usage_events {
+                builtin_table_updates.push(catalog.state.pack_storage_usage_update(&event)?);
+            }
 
-        for ip in &catalog.state.egress_ips {
-            builtin_table_updates.push(catalog.state.pack_egress_ip_update(ip)?);
-        }
+            for ip in &catalog.state.egress_ips {
+                builtin_table_updates.push(catalog.state.pack_egress_ip_update(ip)?);
+            }
 
-        Ok((
-            catalog,
-            builtin_migration_metadata,
-            builtin_table_updates,
-            last_seen_version,
-        ))
+            Ok((
+                catalog,
+                builtin_migration_metadata,
+                builtin_table_updates,
+                last_seen_version,
+            ))
+        }
+        .instrument(tracing::info_span!("catalog::open"))
+        .boxed()
     }
 
     /// Loads the system configuration from the various locations in which its

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -12,6 +12,8 @@
 
 //! Logic for executing a planned SQL query.
 
+use futures::future::LocalBoxFuture;
+use futures::FutureExt;
 use inner::return_if_err;
 use mz_controller_types::ClusterId;
 use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr, RowSetFinishing};
@@ -62,537 +64,550 @@ mod linked_cluster;
 pub(super) mod old_optimizer_api;
 
 impl Coordinator {
-    #[tracing::instrument(level = "debug", skip_all)]
-    pub(crate) async fn sequence_plan(
+    /// BOXED FUTURE: As of Nov 2023 the returned Future from this function was 34KB. This would
+    /// get stored on the stack which is bad for runtime performance, and blow up our stack usage.
+    /// Because of that we purposefully move this Future onto the heap (i.e. Box it).
+    pub(crate) fn sequence_plan(
         &mut self,
         mut ctx: ExecuteContext,
         plan: Plan,
         resolved_ids: ResolvedIds,
-    ) {
-        event!(Level::TRACE, plan = format!("{:?}", plan));
-        let mut responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
-        responses.push(ExecuteResponseKind::Canceled);
-        ctx.tx_mut().set_allowed(responses);
+    ) -> LocalBoxFuture<'_, ()> {
+        async move {
+            event!(Level::TRACE, plan = format!("{:?}", plan));
+            let mut responses = ExecuteResponse::generated_from(PlanKind::from(&plan));
+            responses.push(ExecuteResponseKind::Canceled);
+            ctx.tx_mut().set_allowed(responses);
 
-        // Scope the borrow of the Catalog because we need to mutate the Coordinator state below.
-        let (target_cluster_id, target_cluster) = {
+            // Scope the borrow of the Catalog because we need to mutate the Coordinator state below.
+            let (target_cluster_id, target_cluster) = {
+                let session_catalog = self.catalog.for_session(ctx.session());
+                // If our query only depends on system tables, a LaunchDarkly flag is enabled, and a
+                // session var is set, then we automatically run the query on the mz_introspection cluster.
+                let target_cluster = introspection::auto_run_on_introspection(
+                    &session_catalog,
+                    ctx.session(),
+                    &plan,
+                );
+                let target_cluster_id = self
+                    .catalog()
+                    .resolve_target_cluster(target_cluster, ctx.session())
+                    .ok()
+                    .map(|cluster| cluster.id());
+                (target_cluster_id, target_cluster)
+            };
+            if let (Some(cluster_id), Some(statement_id)) =
+                (target_cluster_id, ctx.extra().contents())
+            {
+                self.set_statement_execution_cluster(statement_id, cluster_id);
+            }
+
             let session_catalog = self.catalog.for_session(ctx.session());
-            // If our query only depends on system tables, a LaunchDarkly flag is enabled, and a
-            // session var is set, then we automatically run the query on the mz_introspection cluster.
-            let target_cluster =
-                introspection::auto_run_on_introspection(&session_catalog, ctx.session(), &plan);
-            let target_cluster_id = self
+
+            if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &plan) {
+                return ctx.retire(Err(e));
+            }
+
+            if let Err(e) = rbac::check_plan(
+                &session_catalog,
+                &self
+                    .active_conns()
+                    .into_iter()
+                    .map(|(conn_id, conn_meta)| {
+                        (conn_id.unhandled(), *conn_meta.authenticated_role_id())
+                    })
+                    .collect(),
+                ctx.session().role_metadata(),
+                ctx.session().vars(),
+                &plan,
+                target_cluster_id,
+                &resolved_ids,
+            ) {
+                return ctx.retire(Err(e.into()));
+            }
+
+            let enable_unified_optimizer_api = self
                 .catalog()
-                .resolve_target_cluster(target_cluster, ctx.session())
-                .ok()
-                .map(|cluster| cluster.id());
-            (target_cluster_id, target_cluster)
-        };
-        if let (Some(cluster_id), Some(statement_id)) = (target_cluster_id, ctx.extra().contents())
-        {
-            self.set_statement_execution_cluster(statement_id, cluster_id);
-        }
-
-        let session_catalog = self.catalog.for_session(ctx.session());
-
-        if let Err(e) = introspection::check_cluster_restrictions(&session_catalog, &plan) {
-            return ctx.retire(Err(e));
-        }
-
-        if let Err(e) = rbac::check_plan(
-            &session_catalog,
-            &self
-                .active_conns()
-                .into_iter()
-                .map(|(conn_id, conn_meta)| {
-                    (conn_id.unhandled(), *conn_meta.authenticated_role_id())
+                .system_config()
+                .enable_unified_optimizer_api();
+            match plan {
+                Plan::CreateSource(plan) => {
+                    let source_id =
+                        return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
+                    let result = self
+                        .sequence_create_source(
+                            ctx.session_mut(),
+                            vec![CreateSourcePlans {
+                                source_id,
+                                plan,
+                                resolved_ids,
+                            }],
+                        )
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSources(plans) => {
+                    assert!(
+                        resolved_ids.0.is_empty(),
+                        "each plan has separate resolved_ids"
+                    );
+                    let result = self.sequence_create_source(ctx.session_mut(), plans).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateConnection(plan) => {
+                    self.sequence_create_connection(ctx, plan, resolved_ids)
+                        .await;
+                }
+                Plan::CreateDatabase(plan) => {
+                    let result = self.sequence_create_database(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSchema(plan) => {
+                    let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateRole(plan) => {
+                    let result = self
+                        .sequence_create_role(Some(ctx.session().conn_id()), plan)
+                        .await;
+                    if result.is_ok() {
+                        self.maybe_send_rbac_notice(ctx.session());
+                    }
+                    ctx.retire(result);
+                }
+                Plan::CreateCluster(plan) => {
+                    let result = self.sequence_create_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateClusterReplica(plan) => {
+                    let result = self
+                        .sequence_create_cluster_replica(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateTable(plan) => {
+                    let result = self
+                        .sequence_create_table(&mut ctx, plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSecret(plan) => {
+                    let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::CreateSink(plan) => {
+                    self.sequence_create_sink(ctx, plan, resolved_ids).await;
+                }
+                Plan::CreateView(plan) => {
+                    let result = self
+                        .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateMaterializedView(plan) => {
+                    let result = self
+                        .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateIndex(plan) => {
+                    let result = self
+                        .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::CreateType(plan) => {
+                    let result = self
+                        .sequence_create_type(ctx.session(), plan, resolved_ids)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::Comment(plan) => {
+                    let result = self.sequence_comment_on(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::DropObjects(plan) => {
+                    let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::DropOwned(plan) => {
+                    let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::EmptyQuery => {
+                    ctx.retire(Ok(ExecuteResponse::EmptyQuery));
+                }
+                Plan::ShowAllVariables => {
+                    let result = self.sequence_show_all_variables(ctx.session());
+                    ctx.retire(result);
+                }
+                Plan::ShowVariable(plan) => {
+                    let result = self.sequence_show_variable(ctx.session(), plan);
+                    ctx.retire(result);
+                }
+                Plan::InspectShard(plan) => {
+                    // TODO: Ideally, this await would happen off the main thread.
+                    let result = self.sequence_inspect_shard(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::SetVariable(plan) => {
+                    let result = self.sequence_set_variable(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::ResetVariable(plan) => {
+                    let result = self.sequence_reset_variable(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::SetTransaction(plan) => {
+                    let result = self.sequence_set_transaction(ctx.session_mut(), plan);
+                    ctx.retire(result);
+                }
+                Plan::StartTransaction(plan) => {
+                    if matches!(
+                        ctx.session().transaction(),
+                        TransactionStatus::InTransaction(_)
+                    ) {
+                        ctx.session()
+                            .add_notice(AdapterNotice::ExistingTransactionInProgress);
+                    }
+                    let result = ctx.session_mut().start_transaction(
+                        self.now_datetime(),
+                        plan.access,
+                        plan.isolation_level,
+                    );
+                    ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
+                }
+                Plan::CommitTransaction(CommitTransactionPlan {
+                    ref transaction_type,
                 })
-                .collect(),
-            ctx.session().role_metadata(),
-            ctx.session().vars(),
-            &plan,
-            target_cluster_id,
-            &resolved_ids,
-        ) {
-            return ctx.retire(Err(e.into()));
-        }
-
-        let enable_unified_optimizer_api = self
-            .catalog()
-            .system_config()
-            .enable_unified_optimizer_api();
-        match plan {
-            Plan::CreateSource(plan) => {
-                let source_id = return_if_err!(self.catalog_mut().allocate_user_id().await, ctx);
-                let result = self
-                    .sequence_create_source(
-                        ctx.session_mut(),
-                        vec![CreateSourcePlans {
-                            source_id,
-                            plan,
-                            resolved_ids,
-                        }],
-                    )
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateSources(plans) => {
-                assert!(
-                    resolved_ids.0.is_empty(),
-                    "each plan has separate resolved_ids"
-                );
-                let result = self.sequence_create_source(ctx.session_mut(), plans).await;
-                ctx.retire(result);
-            }
-            Plan::CreateConnection(plan) => {
-                self.sequence_create_connection(ctx, plan, resolved_ids)
-                    .await;
-            }
-            Plan::CreateDatabase(plan) => {
-                let result = self.sequence_create_database(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateSchema(plan) => {
-                let result = self.sequence_create_schema(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateRole(plan) => {
-                let result = self
-                    .sequence_create_role(Some(ctx.session().conn_id()), plan)
-                    .await;
-                if result.is_ok() {
-                    self.maybe_send_rbac_notice(ctx.session());
+                | Plan::AbortTransaction(AbortTransactionPlan {
+                    ref transaction_type,
+                }) => {
+                    let action = match &plan {
+                        Plan::CommitTransaction(_) => EndTransactionAction::Commit,
+                        Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
+                        _ => unreachable!(),
+                    };
+                    if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit()
+                    {
+                        // In Postgres, if a user sends a COMMIT or ROLLBACK in an
+                        // implicit transaction, a warning is sent warning them.
+                        // (The transaction is still closed and a new implicit
+                        // transaction started, though.)
+                        ctx.session().add_notice(
+                            AdapterNotice::ExplicitTransactionControlInImplicitTransaction,
+                        );
+                    }
+                    self.sequence_end_transaction(ctx, action).await;
                 }
-                ctx.retire(result);
-            }
-            Plan::CreateCluster(plan) => {
-                let result = self.sequence_create_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateClusterReplica(plan) => {
-                let result = self
-                    .sequence_create_cluster_replica(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateTable(plan) => {
-                let result = self
-                    .sequence_create_table(&mut ctx, plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateSecret(plan) => {
-                let result = self.sequence_create_secret(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::CreateSink(plan) => {
-                self.sequence_create_sink(ctx, plan, resolved_ids).await;
-            }
-            Plan::CreateView(plan) => {
-                let result = self
-                    .sequence_create_view(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateMaterializedView(plan) => {
-                let result = self
-                    .sequence_create_materialized_view(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateIndex(plan) => {
-                let result = self
-                    .sequence_create_index(ctx.session_mut(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::CreateType(plan) => {
-                let result = self
-                    .sequence_create_type(ctx.session(), plan, resolved_ids)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::Comment(plan) => {
-                let result = self.sequence_comment_on(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::DropObjects(plan) => {
-                let result = self.sequence_drop_objects(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::DropOwned(plan) => {
-                let result = self.sequence_drop_owned(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::EmptyQuery => {
-                ctx.retire(Ok(ExecuteResponse::EmptyQuery));
-            }
-            Plan::ShowAllVariables => {
-                let result = self.sequence_show_all_variables(ctx.session());
-                ctx.retire(result);
-            }
-            Plan::ShowVariable(plan) => {
-                let result = self.sequence_show_variable(ctx.session(), plan);
-                ctx.retire(result);
-            }
-            Plan::InspectShard(plan) => {
-                // TODO: Ideally, this await would happen off the main thread.
-                let result = self.sequence_inspect_shard(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::SetVariable(plan) => {
-                let result = self.sequence_set_variable(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::ResetVariable(plan) => {
-                let result = self.sequence_reset_variable(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::SetTransaction(plan) => {
-                let result = self.sequence_set_transaction(ctx.session_mut(), plan);
-                ctx.retire(result);
-            }
-            Plan::StartTransaction(plan) => {
-                if matches!(
-                    ctx.session().transaction(),
-                    TransactionStatus::InTransaction(_)
-                ) {
-                    ctx.session()
-                        .add_notice(AdapterNotice::ExistingTransactionInProgress);
+                Plan::Select(plan) => {
+                    self.sequence_peek(ctx, plan, target_cluster).await;
                 }
-                let result = ctx.session_mut().start_transaction(
-                    self.now_datetime(),
-                    plan.access,
-                    plan.isolation_level,
-                );
-                ctx.retire(result.map(|_| ExecuteResponse::StartedTransaction))
-            }
-            Plan::CommitTransaction(CommitTransactionPlan {
-                ref transaction_type,
-            })
-            | Plan::AbortTransaction(AbortTransactionPlan {
-                ref transaction_type,
-            }) => {
-                let action = match &plan {
-                    Plan::CommitTransaction(_) => EndTransactionAction::Commit,
-                    Plan::AbortTransaction(_) => EndTransactionAction::Rollback,
-                    _ => unreachable!(),
-                };
-                if ctx.session().transaction().is_implicit() && !transaction_type.is_implicit() {
-                    // In Postgres, if a user sends a COMMIT or ROLLBACK in an
-                    // implicit transaction, a warning is sent warning them.
-                    // (The transaction is still closed and a new implicit
-                    // transaction started, though.)
-                    ctx.session()
-                        .add_notice(AdapterNotice::ExplicitTransactionControlInImplicitTransaction);
+                Plan::Subscribe(plan) => {
+                    if enable_unified_optimizer_api {
+                        let result = self
+                            .sequence_subscribe(&mut ctx, plan, target_cluster)
+                            .await;
+                        ctx.retire(result);
+                    } else {
+                        // Allow while the introduction of the new optimizer API in
+                        // #20569 is in progress.
+                        #[allow(deprecated)]
+                        let result = self
+                            .sequence_subscribe_deprecated(&mut ctx, plan, target_cluster)
+                            .await;
+                        ctx.retire(result);
+                    }
                 }
-                self.sequence_end_transaction(ctx, action).await;
-            }
-            Plan::Select(plan) => {
-                self.sequence_peek(ctx, plan, target_cluster).await;
-            }
-            Plan::Subscribe(plan) => {
-                if enable_unified_optimizer_api {
-                    let result = self
-                        .sequence_subscribe(&mut ctx, plan, target_cluster)
+                Plan::SideEffectingFunc(plan) => {
+                    ctx.retire(self.sequence_side_effecting_func(plan));
+                }
+                Plan::ShowCreate(plan) => {
+                    ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
+                }
+                Plan::ShowColumns(show_columns_plan) => {
+                    self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster)
                         .await;
+                }
+                Plan::CopyFrom(plan) => {
+                    let (tx, _, session, ctx_extra) = ctx.into_parts();
+                    tx.send(
+                        Ok(ExecuteResponse::CopyFrom {
+                            id: plan.id,
+                            columns: plan.columns,
+                            params: plan.params,
+                            ctx_extra,
+                        }),
+                        session,
+                    );
+                }
+                Plan::ExplainPlan(plan) => {
+                    self.sequence_explain_plan(ctx, plan, target_cluster).await;
+                }
+                Plan::ExplainSinkSchema(plan) => {
+                    let result = self.sequence_explain_schema(plan);
                     ctx.retire(result);
-                } else {
-                    // Allow while the introduction of the new optimizer API in
-                    // #20569 is in progress.
-                    #[allow(deprecated)]
+                }
+                Plan::ExplainTimestamp(plan) => {
+                    self.sequence_explain_timestamp(ctx, plan, target_cluster)
+                        .await;
+                }
+                Plan::Insert(plan) => {
+                    self.sequence_insert(ctx, plan).await;
+                }
+                Plan::ReadThenWrite(plan) => {
+                    self.sequence_read_then_write(ctx, plan).await;
+                }
+                Plan::AlterNoop(plan) => {
+                    ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
+                }
+                Plan::AlterCluster(plan) => {
+                    let result = self.sequence_alter_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterClusterRename(plan) => {
                     let result = self
-                        .sequence_subscribe_deprecated(&mut ctx, plan, target_cluster)
+                        .sequence_alter_cluster_rename(ctx.session_mut(), plan)
                         .await;
                     ctx.retire(result);
                 }
-            }
-            Plan::SideEffectingFunc(plan) => {
-                ctx.retire(self.sequence_side_effecting_func(plan));
-            }
-            Plan::ShowCreate(plan) => {
-                ctx.retire(Ok(Self::send_immediate_rows(vec![plan.row])));
-            }
-            Plan::ShowColumns(show_columns_plan) => {
-                self.sequence_peek(ctx, show_columns_plan.select_plan, target_cluster)
-                    .await;
-            }
-            Plan::CopyFrom(plan) => {
-                let (tx, _, session, ctx_extra) = ctx.into_parts();
-                tx.send(
-                    Ok(ExecuteResponse::CopyFrom {
-                        id: plan.id,
-                        columns: plan.columns,
-                        params: plan.params,
-                        ctx_extra,
-                    }),
-                    session,
-                );
-            }
-            Plan::ExplainPlan(plan) => {
-                self.sequence_explain_plan(ctx, plan, target_cluster).await;
-            }
-            Plan::ExplainSinkSchema(plan) => {
-                let result = self.sequence_explain_schema(plan);
-                ctx.retire(result);
-            }
-            Plan::ExplainTimestamp(plan) => {
-                self.sequence_explain_timestamp(ctx, plan, target_cluster)
-                    .await;
-            }
-            Plan::Insert(plan) => {
-                self.sequence_insert(ctx, plan).await;
-            }
-            Plan::ReadThenWrite(plan) => {
-                self.sequence_read_then_write(ctx, plan).await;
-            }
-            Plan::AlterNoop(plan) => {
-                ctx.retire(Ok(ExecuteResponse::AlteredObject(plan.object_type)));
-            }
-            Plan::AlterCluster(plan) => {
-                let result = self.sequence_alter_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterClusterRename(plan) => {
-                let result = self
-                    .sequence_alter_cluster_rename(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterClusterSwap(plan) => {
-                let result = self
-                    .sequence_alter_cluster_swap(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterClusterReplicaRename(plan) => {
-                let result = self
-                    .sequence_alter_cluster_replica_rename(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterSetCluster(plan) => {
-                let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterItemRename(plan) => {
-                let result = self
-                    .sequence_alter_item_rename(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterItemSwap(_plan) => {
-                // Note: we should never reach this point because we return an unsupported error in
-                // planning.
-                ctx.retire(Err(AdapterError::Unsupported("ALTER ... SWAP ...")));
-            }
-            Plan::AlterSchemaRename(plan) => {
-                let result = self
-                    .sequence_alter_schema_rename(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterSchemaSwap(plan) => {
-                let result = self
-                    .sequence_alter_schema_swap(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterIndexSetOptions(plan) => {
-                let result = self.sequence_alter_index_set_options(plan);
-                ctx.retire(result);
-            }
-            Plan::AlterIndexResetOptions(plan) => {
-                let result = self.sequence_alter_index_reset_options(plan);
-                ctx.retire(result);
-            }
-            Plan::AlterRole(plan) => {
-                let result = self.sequence_alter_role(ctx.session_mut(), plan).await;
-                if result.is_ok() {
-                    self.maybe_send_rbac_notice(ctx.session());
+                Plan::AlterClusterSwap(plan) => {
+                    let result = self
+                        .sequence_alter_cluster_swap(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
                 }
-                ctx.retire(result);
-            }
-            Plan::AlterSecret(plan) => {
-                let result = self.sequence_alter_secret(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSink(plan) => {
-                let result = self.sequence_alter_sink(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::PurifiedAlterSource {
-                alter_source,
-                subsources,
-            } => {
-                let result = self
-                    .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterSource(_) => {
-                unreachable!("ALTER SOURCE must be purified")
-            }
-            Plan::AlterSystemSet(plan) => {
-                let result = self.sequence_alter_system_set(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSystemReset(plan) => {
-                let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterSystemResetAll(plan) => {
-                let result = self
-                    .sequence_alter_system_reset_all(ctx.session(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::DiscardTemp => {
-                self.drop_temp_items(ctx.session().conn_id()).await;
-                ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
-            }
-            Plan::DiscardAll => {
-                let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
-                    self.clear_transaction(ctx.session_mut());
+                Plan::AlterClusterReplicaRename(plan) => {
+                    let result = self
+                        .sequence_alter_cluster_replica_rename(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSetCluster(plan) => {
+                    let result = self.sequence_alter_set_cluster(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterItemRename(plan) => {
+                    let result = self
+                        .sequence_alter_item_rename(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterItemSwap(_plan) => {
+                    // Note: we should never reach this point because we return an unsupported error in
+                    // planning.
+                    ctx.retire(Err(AdapterError::Unsupported("ALTER ... SWAP ...")));
+                }
+                Plan::AlterSchemaRename(plan) => {
+                    let result = self
+                        .sequence_alter_schema_rename(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSchemaSwap(plan) => {
+                    let result = self
+                        .sequence_alter_schema_swap(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterIndexSetOptions(plan) => {
+                    let result = self.sequence_alter_index_set_options(plan);
+                    ctx.retire(result);
+                }
+                Plan::AlterIndexResetOptions(plan) => {
+                    let result = self.sequence_alter_index_reset_options(plan);
+                    ctx.retire(result);
+                }
+                Plan::AlterRole(plan) => {
+                    let result = self.sequence_alter_role(ctx.session_mut(), plan).await;
+                    if result.is_ok() {
+                        self.maybe_send_rbac_notice(ctx.session());
+                    }
+                    ctx.retire(result);
+                }
+                Plan::AlterSecret(plan) => {
+                    let result = self.sequence_alter_secret(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSink(plan) => {
+                    let result = self.sequence_alter_sink(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::PurifiedAlterSource {
+                    alter_source,
+                    subsources,
+                } => {
+                    let result = self
+                        .sequence_alter_source(ctx.session_mut(), alter_source, subsources)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSource(_) => {
+                    unreachable!("ALTER SOURCE must be purified")
+                }
+                Plan::AlterSystemSet(plan) => {
+                    let result = self.sequence_alter_system_set(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSystemReset(plan) => {
+                    let result = self.sequence_alter_system_reset(ctx.session(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterSystemResetAll(plan) => {
+                    let result = self
+                        .sequence_alter_system_reset_all(ctx.session(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::DiscardTemp => {
                     self.drop_temp_items(ctx.session().conn_id()).await;
-                    ctx.session_mut().reset();
-                    Ok(ExecuteResponse::DiscardedAll)
-                } else {
-                    Err(AdapterError::OperationProhibitsTransaction(
-                        "DISCARD ALL".into(),
-                    ))
-                };
-                ctx.retire(ret);
-            }
-            Plan::Declare(plan) => {
-                self.declare(ctx, plan.name, plan.stmt, plan.sql, plan.params);
-            }
-            Plan::Fetch(FetchPlan {
-                name,
-                count,
-                timeout,
-            }) => {
-                let ctx_extra = std::mem::take(ctx.extra_mut());
-                ctx.retire(Ok(ExecuteResponse::Fetch {
+                    ctx.retire(Ok(ExecuteResponse::DiscardedTemp));
+                }
+                Plan::DiscardAll => {
+                    let ret = if let TransactionStatus::Started(_) = ctx.session().transaction() {
+                        self.clear_transaction(ctx.session_mut());
+                        self.drop_temp_items(ctx.session().conn_id()).await;
+                        ctx.session_mut().reset();
+                        Ok(ExecuteResponse::DiscardedAll)
+                    } else {
+                        Err(AdapterError::OperationProhibitsTransaction(
+                            "DISCARD ALL".into(),
+                        ))
+                    };
+                    ctx.retire(ret);
+                }
+                Plan::Declare(plan) => {
+                    self.declare(ctx, plan.name, plan.stmt, plan.sql, plan.params);
+                }
+                Plan::Fetch(FetchPlan {
                     name,
                     count,
                     timeout,
-                    ctx_extra,
-                }));
-            }
-            Plan::Close(plan) => {
-                if ctx.session_mut().remove_portal(&plan.name) {
-                    ctx.retire(Ok(ExecuteResponse::ClosedCursor));
-                } else {
-                    ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
+                }) => {
+                    let ctx_extra = std::mem::take(ctx.extra_mut());
+                    ctx.retire(Ok(ExecuteResponse::Fetch {
+                        name,
+                        count,
+                        timeout,
+                        ctx_extra,
+                    }));
                 }
-            }
-            Plan::Prepare(plan) => {
-                if ctx
-                    .session()
-                    .get_prepared_statement_unverified(&plan.name)
-                    .is_some()
-                {
-                    ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
-                } else {
-                    ctx.session_mut().set_prepared_statement(
-                        plan.name,
-                        Some(plan.stmt),
-                        plan.sql,
-                        plan.desc,
-                        self.catalog().transient_revision(),
-                        self.now(),
-                    );
-                    ctx.retire(Ok(ExecuteResponse::Prepare));
-                }
-            }
-            Plan::Execute(plan) => {
-                match self.sequence_execute(ctx.session_mut(), plan) {
-                    Ok(portal_name) => {
-                        let (tx, _, session, extra) = ctx.into_parts();
-                        self.internal_cmd_tx
-                            .send(Message::Command(Command::Execute {
-                                portal_name,
-                                session,
-                                tx: tx.take(),
-                                outer_ctx_extra: Some(extra),
-                                span: tracing::debug_span!("execute_plan"),
-                            }))
-                            .expect("sending to self.internal_cmd_tx cannot fail");
-                    }
-                    Err(err) => ctx.retire(Err(err)),
-                };
-            }
-            Plan::Deallocate(plan) => match plan.name {
-                Some(name) => {
-                    if ctx.session_mut().remove_prepared_statement(&name) {
-                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
+                Plan::Close(plan) => {
+                    if ctx.session_mut().remove_portal(&plan.name) {
+                        ctx.retire(Ok(ExecuteResponse::ClosedCursor));
                     } else {
-                        ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
+                        ctx.retire(Err(AdapterError::UnknownCursor(plan.name)));
                     }
                 }
-                None => {
-                    ctx.session_mut().remove_all_prepared_statements();
-                    ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
+                Plan::Prepare(plan) => {
+                    if ctx
+                        .session()
+                        .get_prepared_statement_unverified(&plan.name)
+                        .is_some()
+                    {
+                        ctx.retire(Err(AdapterError::PreparedStatementExists(plan.name)));
+                    } else {
+                        ctx.session_mut().set_prepared_statement(
+                            plan.name,
+                            Some(plan.stmt),
+                            plan.sql,
+                            plan.desc,
+                            self.catalog().transient_revision(),
+                            self.now(),
+                        );
+                        ctx.retire(Ok(ExecuteResponse::Prepare));
+                    }
                 }
-            },
-            Plan::Raise(RaisePlan { severity }) => {
-                ctx.session()
-                    .add_notice(AdapterNotice::UserRequested { severity });
-                ctx.retire(Ok(ExecuteResponse::Raised));
-            }
-            Plan::RotateKeys(RotateKeysPlan { id }) => {
-                let result = self.sequence_rotate_keys(ctx.session(), id).await;
-                ctx.retire(result);
-            }
-            Plan::GrantPrivileges(plan) => {
-                let result = self
-                    .sequence_grant_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::RevokePrivileges(plan) => {
-                let result = self
-                    .sequence_revoke_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::AlterDefaultPrivileges(plan) => {
-                let result = self
-                    .sequence_alter_default_privileges(ctx.session_mut(), plan)
-                    .await;
-                ctx.retire(result);
-            }
-            Plan::GrantRole(plan) => {
-                let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::RevokeRole(plan) => {
-                let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::AlterOwner(plan) => {
-                let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::ReassignOwned(plan) => {
-                let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
-                ctx.retire(result);
-            }
-            Plan::ValidateConnection(plan) => {
-                let connection_context = self.connection_context.clone();
-                let connection = plan
-                    .connection
-                    .into_inline_connection(self.catalog().state());
-                mz_ore::task::spawn(|| "coord::validate_connection", async move {
-                    let res = match connection.validate(plan.id, &connection_context).await {
-                        Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
-                        Err(err) => Err(err.into()),
+                Plan::Execute(plan) => {
+                    match self.sequence_execute(ctx.session_mut(), plan) {
+                        Ok(portal_name) => {
+                            let (tx, _, session, extra) = ctx.into_parts();
+                            self.internal_cmd_tx
+                                .send(Message::Command(Command::Execute {
+                                    portal_name,
+                                    session,
+                                    tx: tx.take(),
+                                    outer_ctx_extra: Some(extra),
+                                    span: tracing::debug_span!("execute_plan"),
+                                }))
+                                .expect("sending to self.internal_cmd_tx cannot fail");
+                        }
+                        Err(err) => ctx.retire(Err(err)),
                     };
-                    ctx.retire(res);
-                });
+                }
+                Plan::Deallocate(plan) => match plan.name {
+                    Some(name) => {
+                        if ctx.session_mut().remove_prepared_statement(&name) {
+                            ctx.retire(Ok(ExecuteResponse::Deallocate { all: false }));
+                        } else {
+                            ctx.retire(Err(AdapterError::UnknownPreparedStatement(name)));
+                        }
+                    }
+                    None => {
+                        ctx.session_mut().remove_all_prepared_statements();
+                        ctx.retire(Ok(ExecuteResponse::Deallocate { all: true }));
+                    }
+                },
+                Plan::Raise(RaisePlan { severity }) => {
+                    ctx.session()
+                        .add_notice(AdapterNotice::UserRequested { severity });
+                    ctx.retire(Ok(ExecuteResponse::Raised));
+                }
+                Plan::RotateKeys(RotateKeysPlan { id }) => {
+                    let result = self.sequence_rotate_keys(ctx.session(), id).await;
+                    ctx.retire(result);
+                }
+                Plan::GrantPrivileges(plan) => {
+                    let result = self
+                        .sequence_grant_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::RevokePrivileges(plan) => {
+                    let result = self
+                        .sequence_revoke_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::AlterDefaultPrivileges(plan) => {
+                    let result = self
+                        .sequence_alter_default_privileges(ctx.session_mut(), plan)
+                        .await;
+                    ctx.retire(result);
+                }
+                Plan::GrantRole(plan) => {
+                    let result = self.sequence_grant_role(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::RevokeRole(plan) => {
+                    let result = self.sequence_revoke_role(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::AlterOwner(plan) => {
+                    let result = self.sequence_alter_owner(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::ReassignOwned(plan) => {
+                    let result = self.sequence_reassign_owned(ctx.session_mut(), plan).await;
+                    ctx.retire(result);
+                }
+                Plan::ValidateConnection(plan) => {
+                    let connection_context = self.connection_context.clone();
+                    let connection = plan
+                        .connection
+                        .into_inline_connection(self.catalog().state());
+                    mz_ore::task::spawn(|| "coord::validate_connection", async move {
+                        let res = match connection.validate(plan.id, &connection_context).await {
+                            Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
+                            Err(err) => Err(err.into()),
+                        };
+                        ctx.retire(res);
+                    });
+                }
             }
         }
+        .instrument(tracing::debug_span!("coord::sequencer::sequence_plan"))
+        .boxed_local()
     }
 
     #[tracing::instrument(level = "debug", skip(self))]


### PR DESCRIPTION
This PR updates a few functions in the adapter to return Box-ed Futures instead of a Future that is put on the stack, i.e. `async fn` gets changed to `fn ... -> BoxFuture`.

### Motivation

While working on improving our environmentd Rust tests, e.g. https://github.com/MaterializeInc/materialize/issues/22432, I ran into a few stack overflows. It's known that the [coordinator stores a lot of state on its stack](https://github.com/MaterializeInc/materialize/blob/main/src/adapter/src/coord.rs#L2094-L2097), but it wasn't the coordinator thread that was panicking, it was the thread created by the test framework to run the test case. Increasing our `STACK_RED_ZONE` size allowed the tests to pass, but that didn't feel like a good solution.

Using `RUSTFLAGS=-Zprint-type-sizes` I was able to see the sizes for all compiled types, and I found that we have several Futures returned by `async fn`s that are 10s of KB in size! The Coordinator's main `async fn serve` returned a Future that was `92KB`! Based on the sizes reported and some hot loops in the code base, I replaced a few `async fn` with `fn -> BoxFuture`. Even though these Futures are now stored on the heap and not the stack, there is a good chance we could see a performance improvement from this change, because previously these very large Futures could get memcopy-d when we run them, but now they'd stay on the heap and we'd be passing around a pointer.

Ideally we'd have a proc macro like `#[box_future]` that would do this boxing automatically and then we can enable the [large_futures](https://rust-lang.github.io/rust-clippy/master/#/large_futures) clippy lint, but that's out of scope for this PR.

### Tips for reviewer

The diff is **much** smaller if viewed with whitespace hidden.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
