### PR TITLE
catalog: Fix read-only shadow ts discrepancies

### DIFF
--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -76,8 +76,9 @@
 // END LINT CONFIG
 
 use mz_catalog::durable::{
-    persist_backed_catalog_state, stash_backed_catalog_state, test_bootstrap_args,
-    test_stash_backed_catalog_state, CatalogError, Epoch, OpenableDurableCatalogState, StashConfig,
+    persist_backed_catalog_state, shadow_catalog_state, stash_backed_catalog_state,
+    test_bootstrap_args, test_stash_backed_catalog_state, CatalogError, Epoch,
+    OpenableDurableCatalogState, StashConfig,
 };
 use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
 use mz_persist_client::PersistClient;
@@ -380,6 +381,36 @@ async fn test_persist_open_read_only() {
     .await;
 }
 
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_shadow_read_only_open() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let organization_id = Uuid::new_v4();
+    let (debug_factory, stash_config) = stash_config().await;
+
+    let shadow_openable_state1 = shadow_catalog_state(
+        stash_config.clone(),
+        persist_client.clone(),
+        organization_id,
+    )
+    .await;
+    let shadow_openable_state2 = shadow_catalog_state(
+        stash_config.clone(),
+        persist_client.clone(),
+        organization_id,
+    )
+    .await;
+    let shadow_openable_state3 =
+        shadow_catalog_state(stash_config.clone(), persist_client, organization_id).await;
+    test_open_read_only(
+        shadow_openable_state1,
+        shadow_openable_state2,
+        shadow_openable_state3,
+    )
+    .await;
+    debug_factory.drop().await;
+}
+
 async fn test_open_read_only(
     openable_state1: impl OpenableDurableCatalogState,
     openable_state2: impl OpenableDurableCatalogState,
@@ -469,6 +500,36 @@ async fn test_persist_open() {
         persist_openable_state3,
     )
     .await;
+}
+
+#[mz_ore::test(tokio::test)]
+#[cfg_attr(miri, ignore)] //  unsupported operation: can't call foreign function `TLS_client_method` on OS `linux`
+async fn test_shadow_open() {
+    let persist_client = PersistClient::new_for_tests().await;
+    let organization_id = Uuid::new_v4();
+    let (debug_factory, stash_config) = stash_config().await;
+
+    let shadow_openable_state1 = shadow_catalog_state(
+        stash_config.clone(),
+        persist_client.clone(),
+        organization_id,
+    )
+    .await;
+    let shadow_openable_state2 = shadow_catalog_state(
+        stash_config.clone(),
+        persist_client.clone(),
+        organization_id,
+    )
+    .await;
+    let shadow_openable_state3 =
+        shadow_catalog_state(stash_config.clone(), persist_client, organization_id).await;
+    test_open(
+        shadow_openable_state1,
+        shadow_openable_state2,
+        shadow_openable_state3,
+    )
+    .await;
+    debug_factory.drop().await;
 }
 
 async fn test_open(


### PR DESCRIPTION
The shadow catalog is a catalog implementation used for testing. Internally it has a stash and persist catalog implementation. On every operation it compares the results of each implementation and panics if there's a difference.

The Coordinator will update the timestamps of every timeline on a set interval, currently set to 10 seconds. Timestamps are currently stored in the catalog. If the Coordinator is shut down during this interval, then it's possible that only one of the catalog implementations updated the timestamps, while the other didn't. Writeable catalogs will fix any timestamp discrepancies during startup. However, read-only catalogs cannot fix this discrepancy because they cannot write.

This commit fixes this issue by having the shadow catalog ignore any timestamp discrepancies during read-only mode.

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
