### PR TITLE
Enable jemalloc profiling by default

### DIFF
--- a/src/prof/src/jemalloc.rs
+++ b/src/prof/src/jemalloc.rs
@@ -39,7 +39,7 @@ pub const LG_PROF_SAMPLE: size_t = 19;
 #[allow(non_upper_case_globals)]
 #[export_name = "malloc_conf"]
 // if you change this, also change `LG_PROF_SAMPLE`
-pub static malloc_conf: &[u8] = b"prof:true,prof_active:false,lg_prof_sample:19\0";
+pub static malloc_conf: &[u8] = b"prof:true,prof_active:true,lg_prof_sample:19\0";
 
 pub static PROF_CTL: Lazy<Option<Arc<Mutex<JemallocProfCtl>>>> = Lazy::new(|| {
     if let Some(ctl) = JemallocProfCtl::get() {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1989,7 +1989,7 @@ feature_flags!(
     {
         name: enable_jemalloc_profiling,
         desc: "jemalloc heap memory profiling",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },


### PR DESCRIPTION
This PR enables jemalloc profiling by default. It is already enabled everywhere in staging and prod via feature flag, but the part of process startup that occurs before the process gets access to the dynamic configuration value still has memory profiling disabled due to the default. This may cause us to miss memory events that happen early in process startup, so we want profiling to be enabled by default.

### Motivation

  * This PR fixes a hole in our internal observability.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
