### PR TITLE
storage: fix yet another shutdown bug

### DIFF
--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -165,8 +165,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
         let table_info = reader_table_info;
         Box::pin(async move {
             let (id, worker_id) = (config.id, config.worker_id);
-            let [data_cap, upper_cap]: &mut [_; 2] = caps.try_into().unwrap();
-            let (data_cap, upper_cap) = (data_cap.as_mut().unwrap(), upper_cap.as_mut().unwrap());
+            let [data_cap_set, upper_cap_set]: &mut [_; 2] = caps.try_into().unwrap();
 
             if !config.responsible_for("slot") {
                 return Ok(());
@@ -197,8 +196,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let Some(resume_lsn) = resume_upper.into_option() else {
                 return Ok(());
             };
-            data_cap.downgrade(&resume_lsn);
-            upper_cap.downgrade(&resume_lsn);
+            data_cap_set.downgrade([&resume_lsn]);
+            upper_cap_set.downgrade([&resume_lsn]);
             trace!(%id, "timely-{worker_id} replication reader started lsn={}", resume_lsn);
 
 
@@ -237,7 +236,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     // (in practice) never conflict any previously revealed
                     // portions of the TVC.
                     let update = ((oid, Err(err.clone())), MzOffset::from(u64::MAX), 1);
-                    data_output.give(data_cap, update).await;
+                    data_output.give(&data_cap_set[0], update).await;
                 }
                 return Ok(());
             }
@@ -250,7 +249,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 client,
                 slot,
                 &connection.publication,
-                *data_cap.time(),
+                *data_cap_set[0].time(),
                 committed_uppers.as_mut()
             )
             .peekable());
@@ -262,7 +261,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             while let Some(event) = stream.as_mut().next().await {
                 use LogicalReplicationMessage::*;
                 use ReplicationMessage::*;
-                let mut new_upper = *data_cap.time();
+                let mut new_upper = *data_cap_set[0].time();
                 match event {
                     Ok(XLogData(data)) => match data.data() {
                         Begin(begin) => {
@@ -296,9 +295,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                             }
                             new_upper = commit_lsn + 1;
                             if container.len() > max_capacity {
-                                data_output.give_container(data_cap, &mut container).await;
-                                upper_cap.downgrade(&new_upper);
-                                data_cap.downgrade(&new_upper);
+                                data_output.give_container(&data_cap_set[0], &mut container).await;
+                                upper_cap_set.downgrade([&new_upper]);
+                                data_cap_set.downgrade([&new_upper]);
                             }
                         },
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -313,10 +312,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
                 let will_yield = stream.as_mut().peek().now_or_never().is_none();
                 if will_yield {
-                    data_output.give_container(data_cap, &mut container).await;
-                    upper_cap.downgrade(&new_upper);
-                    data_cap.downgrade(&new_upper);
-                    rewinds.retain(|_, (_, req)| data_cap.time() <= &req.snapshot_lsn);
+                    data_output.give_container(&data_cap_set[0], &mut container).await;
+                    upper_cap_set.downgrade([&new_upper]);
+                    data_cap_set.downgrade([&new_upper]);
+                    rewinds.retain(|_, (_, req)| data_cap_set[0].time() <= &req.snapshot_lsn);
                 }
             }
             // We never expect the replication stream to gracefully end

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -141,7 +141,7 @@ use std::str::FromStr;
 use differential_dataflow::{AsCollection, Collection};
 use futures::TryStreamExt;
 use timely::dataflow::channels::pact::Pipeline;
-use timely::dataflow::operators::{Broadcast, ConnectLoop, Feedback};
+use timely::dataflow::operators::{Broadcast, CapabilitySet, ConnectLoop, Feedback};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::types::PgLsn;
@@ -231,8 +231,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let id = config.id;
             let worker_id = config.worker_id;
 
-            let [data_cap, rewind_cap, snapshot_cap]: &mut [_; 3] = caps.try_into().unwrap();
-            let data_cap = data_cap.as_mut().unwrap();
+            let [data_cap_set, rewind_cap_set, snapshot_cap_set]: &mut [_; 3] = caps.try_into().unwrap();
             trace!(
                 %id,
                 "timely-{worker_id} initializing table reader with {} tables to snapshot",
@@ -263,8 +262,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
 
                 let snapshot_info = export_snapshot(&client).await?;
                 trace!(%id, "timely-{worker_id} exporting snapshot info {snapshot_info:?}");
-                let cap = snapshot_cap.as_ref().unwrap();
-                snapshot_handle.give(cap, snapshot_info).await;
+                snapshot_handle.give(&snapshot_cap_set[0], snapshot_info).await;
 
                 client
             } else {
@@ -317,9 +315,9 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             for &oid in reader_snapshot_table_info.keys() {
                 trace!(%id, "timely-{worker_id} producing rewind request for {oid}");
                 let req = RewindRequest { oid, snapshot_lsn };
-                rewinds_handle.give(rewind_cap.as_ref().unwrap(), req).await;
+                rewinds_handle.give(&rewind_cap_set[0], req).await;
             }
-            *rewind_cap = None;
+            *rewind_cap_set = CapabilitySet::new();
 
             let upstream_info = mz_postgres_util::publication_info(
                 &context.ssh_tunnel_manager,
@@ -334,7 +332,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 let desc = match verify_schema(oid, expected_desc, &upstream_info) {
                     Ok(()) => expected_desc,
                     Err(err) => {
-                        raw_handle.give(data_cap, ((oid, Err(err)), MzOffset::minimum(), 1)).await;
+                        raw_handle.give(&data_cap_set[0], ((oid, Err(err)), MzOffset::minimum(), 1)).await;
                         continue;
                     }
                 };
@@ -350,7 +348,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 let mut stream = pin!(client.copy_out_simple(&query).await?);
 
                 while let Some(bytes) = stream.try_next().await? {
-                    raw_handle.give(data_cap, ((oid, Ok(bytes)), MzOffset::minimum(), 1)).await;
+                    raw_handle.give(&data_cap_set[0], ((oid, Ok(bytes)), MzOffset::minimum(), 1)).await;
                 }
             }
             // Failure scenario after we have produced the snapshot, but before a successful COMMIT
@@ -360,14 +358,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             // its client since this is what holds the exported transaction alive.
             if is_snapshot_leader {
                 trace!(%id, "timely-{worker_id} waiting for all workers to finish");
-                *snapshot_cap = None;
+                *snapshot_cap_set = CapabilitySet::new();
                 while snapshot_input.next().await.is_some() {}
                 trace!(%id, "timely-{worker_id} (leader) comitting COPY transaction");
                 client.simple_query("COMMIT").await?;
             } else {
                 trace!(%id, "timely-{worker_id} comitting COPY transaction");
                 client.simple_query("COMMIT").await?;
-                *snapshot_cap = None;
+                *snapshot_cap_set = CapabilitySet::new();
             }
             drop(client);
             Ok(())


### PR DESCRIPTION
As part of #20150 I changed the decode operator to use the `AsyncOperatorBuilder::build_fallible` construction so that we could use the ergonomic `?` operator and trigger safe dataflow restarts when transient errors were hit.

The way `build_fallible` makes using `?` shutdown-safe is by not giving you access to owned `Capability` values like the normal builder. Instead, it gives out mutable references to capabilities which can be used for all the normal things (sending data/downgrades) but when a `?` triggers an error and the future returns we only drop a reference, which doesn't have any side effects. The actual capability is kept alive by the `build_fallible` machinery until dataflow shutdown has been initiated by all workers.

Unfortunately that pattern completely breaks down with operators that don't want to keep around any initial capabilities and instead just want to react on input capabilities, which is exactly what the decode operator wants to do. Traditionally, operators that just transform their input in some way want to immediately drop their initial capabilities and produce data to their outputs using the input capabilities received. In the fallible operator land this is not shutdown-safe! This is because the capabilities received by calling `input_handle.next_mut()` are normal, owned `InputCapability` values, and if an error is hit which causes the return of the operator's `Future` then that capability will be dropped without waiting for all workers to initiate shutdown.

I have verified that this can happen and can lead to data loss. I created a source that read a single avro record from kafka but when it tried to decode it it hit a schema registry error (because I had stopped the CSR container). This led to the decode operator to drop the `InputCapability` of that message as part of erroring out, which caused the frontier to advance, which caused the persist sink to happily advance the source upper with no data. When the dataflow eventually restarted the resume upper had moved past the offset of the original message and that message was permanently lost.

This PR fixes the issue by keeping around the initial capabilities and driving them around every time the input frontier advances.

PS: This is yet another subtle bug on the big pile of shutdown bugs that we've had to deal with. Both this issue and all the previous ones would not have manifested if we had been using `Worker::drop_dataflow` to drop dataflows.

Fixes #23225
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
