### PR TITLE
sql-pretty: add LATERAL and various exprs

### DIFF
--- a/src/sql-pretty/src/util.rs
+++ b/src/sql-pretty/src/util.rs
@@ -28,7 +28,7 @@ where
 
 pub(crate) fn title_comma_separate<'a, F, T, S>(title: S, f: F, v: &'a [T]) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc<'a, ()>,
+    F: Fn(&'a T) -> RcDoc,
     S: Into<String>,
 {
     let title = RcDoc::text(title.into());
@@ -39,22 +39,31 @@ where
     }
 }
 
-pub(crate) fn nest_comma_separate<'a, F, T>(title: RcDoc<'a, ()>, f: F, v: &'a [T]) -> RcDoc<'a, ()>
+pub(crate) fn nest_comma_separate<'a, F, T: 'a, I>(
+    title: RcDoc<'a, ()>,
+    f: F,
+    v: I,
+) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc<'a, ()>,
+    F: Fn(&'a T) -> RcDoc,
+    I: IntoIterator<Item = &'a T>,
 {
     nest(title, comma_separate(f, v))
 }
 
-pub(crate) fn comma_separate<'a, F, T>(f: F, v: &'a [T]) -> RcDoc<'a, ()>
+pub(crate) fn comma_separate<'a, F, T: 'a, I>(f: F, v: I) -> RcDoc<'a, ()>
 where
-    F: Fn(&'a T) -> RcDoc<'a, ()>,
+    F: Fn(&'a T) -> RcDoc,
+    I: IntoIterator<Item = &'a T>,
 {
-    let docs = v.iter().map(f).collect();
+    let docs = v.into_iter().map(f);
     comma_separated(docs)
 }
 
-pub(crate) fn comma_separated(v: Vec<RcDoc>) -> RcDoc {
+pub(crate) fn comma_separated<'a, I>(v: I) -> RcDoc<'a, ()>
+where
+    I: IntoIterator<Item = RcDoc<'a, ()>>,
+{
     RcDoc::intersperse(v, RcDoc::concat([RcDoc::text(","), RcDoc::line()])).group()
 }
 


### PR DESCRIPTION
### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a