### PR TITLE
testdrive: Drop load generator sources at end of test

### DIFF
--- a/test/testdrive/audit-log.td
+++ b/test/testdrive/audit-log.td
@@ -33,3 +33,5 @@ create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"kafka
 create  cluster "{\"id\":\"<GID>\",\"name\":\"materialize_public_counter_src\"}"  materialize
 create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_counter_src\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
 create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"counter_src\",\"schema\":\"public\",\"size\":\"${arg.default-storage-size}\",\"type\":\"load-generator\"}"  materialize
+
+> DROP SOURCE counter_src

--- a/test/testdrive/dataflow-cleanup.td
+++ b/test/testdrive/dataflow-cleanup.td
@@ -103,3 +103,4 @@ true
 
 # Clean up.
 > DROP CLUSTER test CASCADE
+> DROP SOURCE lgtpch CASCADE

--- a/test/testdrive/expected_group_size_tuning.td
+++ b/test/testdrive/expected_group_size_tuning.td
@@ -147,3 +147,5 @@
 > SELECT COUNT(savings > 0)
   FROM mz_internal.mz_expected_group_size_advice;
 6
+
+> DROP SOURCE lgtpch CASCADE

--- a/test/testdrive/load-generator.td
+++ b/test/testdrive/load-generator.td
@@ -103,3 +103,8 @@ $ set-regex match=(\s{12}0|\d{13,20}|u\d{1,5}|\(\d+-\d\d-\d\d\s\d\d:\d\d:\d\d\.\
   FROM LOAD GENERATOR COUNTER (MAX CARDINALITY 8, TICK INTERVAL '0.001s')
   FOR ALL TABLES;
 contains: FOR ALL TABLES is only valid for multi-output sources
+
+> DROP SOURCE auction_house CASCADE
+> DROP SOURCE another.auction_house CASCADE
+> DROP SOURCE counter CASCADE
+> DROP SOURCE counter3 CASCADE

--- a/test/testdrive/mz-arrangement-sharing.td
+++ b/test/testdrive/mz-arrangement-sharing.td
@@ -898,4 +898,3 @@ CREATE CLUSTER REPLICA default.replica SIZE = '2', INTROSPECTION DEBUGGING = tru
 # Reset default cluster into its previous state so that other tests can expect it to be unchanged
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 DROP CLUSTER REPLICA default.replica
-ALTER CLUSTER default SET (MANAGED = true)

--- a/test/testdrive/mz-support-privileges.td
+++ b/test/testdrive/mz-support-privileges.td
@@ -44,3 +44,5 @@ EXPLAIN TIMESTAMP FOR SELECT b.auction_id, b.buyer, b.amount, b.bid_time, u.org_
 # The mz_support user can filter SHOW commands on user objects.
 $ postgres-execute connection=mz_support
 SHOW INDEXES ON bids;
+
+> DROP SOURCE auction_house CASCADE;

--- a/test/testdrive/quickstart.td
+++ b/test/testdrive/quickstart.td
@@ -10,10 +10,12 @@
 # This test verifies the Quickstart page works: https://materialize.com/docs/get-started/quickstart/
 # Uses shared compute+storage cluster
 
-# TODO(def-): Reenable when #23242 is fixed
+> CREATE CLUSTER quickstart REPLICAS (r1 (SIZE '4-4'));
+
+> SET CLUSTER = quickstart
 
 > CREATE SOURCE auction_house
-  IN CLUSTER default
+  IN CLUSTER quickstart
   FROM LOAD GENERATOR AUCTION
   (TICK INTERVAL '0.05s')
   FOR ALL TABLES
@@ -23,7 +25,7 @@ name                   type           size                         cluster
 --------------------------------------------------------------------------
 accounts               subsource      <null>                       <null>
 bids                   subsource      <null>                       <null>
-auction_house          load-generator <null>                       default
+auction_house          load-generator <null>                       quickstart
 auction_house_progress progress       <null>                       <null>
 auctions               subsource      <null>                       <null>
 organizations          subsource      <null>                       <null>
@@ -101,7 +103,7 @@ $ set-regex match=\d{13,20} replacement=<TIMESTAMP>
 $ postgres-execute connection=postgres://materialize:materialize@${testdrive.materialize-sql-addr}
 INSERT INTO fraud_accounts VALUES (12)
 
-> FETCH 1 c WITH (timeout='1s')
+> FETCH 1 c WITH (timeout='30s')
 <TIMESTAMP> -1 12
 
 > COMMIT
@@ -129,3 +131,5 @@ INSERT INTO fraud_accounts VALUES (12)
 > DROP SOURCE auction_house CASCADE
 
 > DROP TABLE fraud_accounts
+
+> DROP CLUSTER quickstart CASCADE

--- a/test/testdrive/show-subsources.td
+++ b/test/testdrive/show-subsources.td
@@ -77,3 +77,5 @@ contains:Cannot specify both FROM and ON
 > CREATE TABLE t (a int)
 ! SHOW SUBSOURCES ON t
 contains:cannot show subsources on materialize.other.t because it is a table
+
+> DROP SOURCE other.lgo CASCADE

--- a/test/testdrive/timestamp-interval.td
+++ b/test/testdrive/timestamp-interval.td
@@ -44,3 +44,6 @@ $ kafka-ingest format=avro topic=top1 schema=${schema} timestamp=1
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
   ENVELOPE NONE
   WITH (TIMESTAMP INTERVAL '500ms')
+
+> DROP SOURCE quick_counter CASCADE
+> DROP SOURCE slow_counter CASCADE

--- a/test/testdrive/tpch.td
+++ b/test/testdrive/tpch.td
@@ -1497,3 +1497,5 @@ true
   ORDER BY
       cntrycode;
 7 values hashing to 3782c67124c71b5bcb3460934dec46de
+
+> DROP SOURCE gen CASCADE


### PR DESCRIPTION
Better alternative to https://github.com/MaterializeInc/materialize/pull/23237 Sorry for the bunch of chaos, hopefully this also makes testdrive faster. Nightly: https://buildkite.com/materialize/nightlies/builds/5242

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
