### PR TITLE
[persist/clusterd] Shift Persist-backed peeks to happen in `clusterd`

### DIFF
--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -803,11 +803,11 @@ Per-worker relations expose the same data as their global counterparts, but have
 The `mz_active_peeks` view describes all read queries ("peeks") that are pending in the [dataflow] layer.
 
 <!-- RELATION_SPEC mz_internal.mz_active_peeks -->
-| Field       | Type               | Meaning                                                                                                           |
-| ----------- | ------------------ | --------                                                                                                          |
-| `id`        | [`uuid`]           | The ID of the peek request.                                                                                       |
-| `index_id`  | [`text`]           | The ID of the index the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes). |
-| `time`      | [`mz_timestamp`]   | The timestamp the peek has requested.                                                                             |
+| Field       | Type               | Meaning                                                                                                                                              |
+| ----------- | ------------------ |------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `id`        | [`uuid`]           | The ID of the peek request.                                                                                                                          |
+| `index_id`  | [`text`]           | The ID of the collection the peek is targeting. When targeting an index, this corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes). |
+| `time`      | [`mz_timestamp`]   | The timestamp the peek has requested.                                                                                                                |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_active_peeks_per_worker -->
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -806,7 +806,7 @@ The `mz_active_peeks` view describes all read queries ("peeks") that are pending
 | Field       | Type               | Meaning                                                                                                                                              |
 | ----------- | ------------------ |------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `id`        | [`uuid`]           | The ID of the peek request.                                                                                                                          |
-| `index_id`  | [`text`]           | The ID of the collection the peek is targeting. When targeting an index, this corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes). |
+| `index_id`  | [`text`]           | The ID of the collection the peek is targeting. Corresponds to [`mz_catalog.mz_indexes.id`](../mz_catalog#mz_indexes), [`mz_catalog.mz_materialized_views.id`](../mz_catalog#mz_materialized_views), [`mz_catalog.mz_sources.id`](../mz_catalog#mz_sources), or [`mz_catalog.mz_tables.id`](../mz_catalog#mz_tables). |
 | `time`      | [`mz_timestamp`]   | The timestamp the peek has requested.                                                                                                                |
 
 <!-- RELATION_SPEC_UNDOCUMENTED mz_internal.mz_active_peeks_per_worker -->

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -12,15 +12,15 @@
 //! This module determines if a dataflow can be short-cut, by returning constant values
 //! or by reading out of existing arrangements, and implements the appropriate plan.
 
-use differential_dataflow::consolidation::consolidate;
 use std::collections::{BTreeMap, BTreeSet};
+use std::fmt;
 use std::num::NonZeroUsize;
-use std::time::{Duration, Instant};
-use std::{fmt, mem};
 
+use differential_dataflow::consolidation::consolidate;
 use futures::TryFutureExt;
 use mz_adapter_types::connection::ConnectionId;
 use mz_cluster_client::ReplicaId;
+use mz_compute_client::protocol::command::PeekTarget;
 use mz_compute_client::protocol::response::PeekResponse;
 use mz_compute_types::dataflows::{DataflowDescription, IndexImport};
 use mz_compute_types::ComputeInstanceId;
@@ -33,16 +33,13 @@ use mz_ore::str::{separated, Indent, StrExt};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{CompactScalarSeq, ExprHumanizer, IndexUsageType, Indices, UsedIndexes};
-use mz_repr::{DatumVec, Diff, GlobalId, RelationType, Row, RowArena};
+use mz_repr::{Diff, GlobalId, RelationType, Row};
 use serde::{Deserialize, Serialize};
 use timely::progress::Timestamp;
 use tokio::sync::oneshot;
-use tokio::task::JoinHandle;
-use tracing::{info, warn};
 use uuid::Uuid;
 
 use crate::coord::timestamp_selection::TimestampDetermination;
-use crate::coord::Message;
 use crate::statement_logging::{StatementEndedExecutionReason, StatementExecutionStrategy};
 use crate::util::ResultExt;
 use crate::{AdapterError, ExecuteContextExtra, ExecuteResponse};
@@ -455,109 +452,13 @@ impl crate::coord::Coordinator {
             self.set_statement_execution_timestamp(id, timestamp)
         }
 
-        if let PeekPlan::FastPath(FastPathPlan::PeekPersist(id, mfp_plan)) = fast_path {
-            let mut cursor = self
-                .controller
-                .storage
-                .snapshot_cursor(id, timestamp)
-                .await?;
-
-            let metrics = self.metrics.clone();
-            let handle: JoinHandle<Result<PeekResponseUnary, String>> =
-                mz_ore::task::spawn(|| "persist::peek", async move {
-                    let mut limit_remaining =
-                        finishing.limit.unwrap_or(usize::MAX) + finishing.offset;
-
-                    // Re-used state for processing and building rows.
-                    let mut accum = vec![];
-                    let mut datum_vec = DatumVec::new();
-                    let mut row_builder = Row::default();
-                    let arena = RowArena::new();
-
-                    let start = Instant::now();
-                    let mut last_fetch = Duration::ZERO;
-                    while limit_remaining > 0 {
-                        let Some(batch) = cursor.next().await else {
-                            break;
-                        };
-                        last_fetch = start.elapsed();
-                        for ((k, v), _, d) in batch {
-                            let row = k?.0.map_err(|e| e.to_string())?;
-                            let () = v?;
-                            let count: usize = d
-                                .try_into()
-                                .map_err(|_| "Negative count for thing in snapshot".to_owned())?;
-                            let Some(count) = NonZeroUsize::new(count) else {
-                                continue;
-                            };
-                            let mut datum_local = datum_vec.borrow_with(&row);
-                            let eval_result = mfp_plan
-                                .evaluate_into(&mut datum_local, &arena, &mut row_builder)
-                                .map_err(|e| e.to_string())?;
-                            if let Some(row) = eval_result {
-                                accum.push((row, count));
-                                limit_remaining = limit_remaining.saturating_sub(count.get());
-                                if limit_remaining == 0 {
-                                    break;
-                                }
-                            }
-                        }
-                    }
-
-                    let res = finishing.finish(accum, max_result_size)?;
-                    let total_duration = start.elapsed();
-                    metrics
-                        .persist_peek_seconds
-                        .observe(total_duration.as_secs_f64());
-                    info!(
-                        collection =? id,
-                        fetch_duration =? last_fetch,
-                        total_duration =? total_duration,
-                        "persist peek success"
-                    );
-                    Ok(PeekResponseUnary::Rows(res))
-                });
-            let internal_cmd_tx = self.internal_cmd_tx.clone();
-            let ctx_extra = mem::take(ctx_extra);
-            return Ok(ExecuteResponse::SendingRows {
-                future: Box::pin(async move {
-                    let res = match handle.await {
-                        Ok(Ok(res)) => res,
-                        Ok(Err(err)) => PeekResponseUnary::Error(err.to_string()),
-                        Err(_join_error) => PeekResponseUnary::Canceled,
-                    };
-
-                    let reason = match &res {
-                        PeekResponseUnary::Rows(rows) => StatementEndedExecutionReason::Success {
-                            rows_returned: Some(u64::cast_from(rows.len())),
-                            execution_strategy: Some(StatementExecutionStrategy::PersistFastPath),
-                        },
-                        PeekResponseUnary::Error(e) => {
-                            StatementEndedExecutionReason::Errored { error: e.clone() }
-                        }
-                        PeekResponseUnary::Canceled => StatementEndedExecutionReason::Canceled,
-                    };
-
-                    if let Err(e) = internal_cmd_tx.send(Message::RetireExecute {
-                        data: ctx_extra,
-                        reason,
-                    }) {
-                        warn!("internal_cmd_rx dropped before we could send: {:?}", e);
-                    }
-
-                    res
-                }),
-                span: tracing::Span::current(),
-            });
-        }
-
         // The remaining cases are a peek into a maintained arrangement, or building a dataflow.
         // In both cases we will want to peek, and the main difference is that we might want to
         // build a dataflow and drop it once the peek is issued. The peeks are also constructed
         // differently.
 
         // If we must build the view, ship the dataflow.
-        let (peek_command, drop_dataflow, is_fast_path) = match fast_path {
+        let (peek_command, drop_dataflow, is_fast_path, peek_target) = match fast_path {
             PeekPlan::FastPath(FastPathPlan::PeekExisting(
                 _coll_id,
                 idx_id,
@@ -567,7 +468,19 @@ impl crate::coord::Coordinator {
                 (idx_id, literal_constraints, timestamp, map_filter_project),
                 None,
                 true,
+                PeekTarget::Index,
             ),
+            PeekPlan::FastPath(FastPathPlan::PeekPersist(coll_id, map_filter_project)) => {
+                let peek_command = (coll_id, None, timestamp, map_filter_project);
+                let metadata = self
+                    .controller
+                    .storage
+                    .collection(coll_id)
+                    .expect("storage collection for fast-path peek")
+                    .collection_metadata
+                    .clone();
+                (peek_command, None, true, PeekTarget::Persist { metadata })
+            }
             PeekPlan::SlowPath(PeekDataflowPlan {
                 desc: dataflow,
                 // n.b. this index_id identifies a transient index the
@@ -608,6 +521,7 @@ impl crate::coord::Coordinator {
                     ),
                     Some(index_id),
                     false,
+                    PeekTarget::Index,
                 )
             }
             _ => {
@@ -655,6 +569,7 @@ impl crate::coord::Coordinator {
                 finishing.clone(),
                 map_filter_project,
                 target_replica,
+                peek_target,
             )
             .unwrap_or_terminate("cannot fail to peek");
 

--- a/src/adapter/src/coord/peek.rs
+++ b/src/adapter/src/coord/peek.rs
@@ -468,7 +468,7 @@ impl crate::coord::Coordinator {
                 (idx_id, literal_constraints, timestamp, map_filter_project),
                 None,
                 true,
-                PeekTarget::Index,
+                PeekTarget::Index { id: idx_id },
             ),
             PeekPlan::FastPath(FastPathPlan::PeekPersist(coll_id, map_filter_project)) => {
                 let peek_command = (coll_id, None, timestamp, map_filter_project);
@@ -479,7 +479,15 @@ impl crate::coord::Coordinator {
                     .expect("storage collection for fast-path peek")
                     .collection_metadata
                     .clone();
-                (peek_command, None, true, PeekTarget::Persist { metadata })
+                (
+                    peek_command,
+                    None,
+                    true,
+                    PeekTarget::Persist {
+                        id: coll_id,
+                        metadata,
+                    },
+                )
             }
             PeekPlan::SlowPath(PeekDataflowPlan {
                 desc: dataflow,
@@ -521,7 +529,7 @@ impl crate::coord::Coordinator {
                     ),
                     Some(index_id),
                     false,
-                    PeekTarget::Index,
+                    PeekTarget::Index { id: index_id },
                 )
             }
             _ => {

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -13,7 +13,7 @@ use mz_ore::stats::{histogram_milliseconds_buckets, histogram_seconds_buckets};
 use mz_sql::ast::{AstInfo, Statement, StatementKind, SubscribeOutput};
 use mz_sql::session::user::User;
 use mz_sql_parser::ast::statement_kind_label_value;
-use prometheus::{Histogram, HistogramVec, IntCounterVec, IntGaugeVec};
+use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
@@ -27,7 +27,6 @@ pub struct Metrics {
     pub storage_usage_collection_time_seconds: HistogramVec,
     pub subscribe_outputs: IntCounterVec,
     pub canceled_peeks: IntCounterVec,
-    pub persist_peek_seconds: Histogram,
     pub linearize_message_seconds: HistogramVec,
     pub time_to_first_row_seconds: HistogramVec,
     pub statement_logging_unsampled_bytes: IntCounterVec,
@@ -90,11 +89,6 @@ impl Metrics {
             canceled_peeks: registry.register(metric!(
                 name: "mz_canceled_peeks_total",
                 help: "The total number of canceled peeks since process start.",
-            )),
-            persist_peek_seconds: registry.register(metric!(
-                name: "mz_persist_peek_seconds",
-                help: "Time spent in (experimental) Persist fast-path peeks.",
-                buckets: histogram_seconds_buckets(0.000_128, 8.0),
             )),
             linearize_message_seconds: registry.register(metric!(
                 name: "mz_linearize_message_seconds",

--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -108,6 +108,7 @@ fn main() {
         .extern_path(".mz_compute_types", "::mz_compute_types")
         .extern_path(".mz_cluster_client", "::mz_cluster_client")
         .extern_path(".mz_storage_client", "::mz_storage_client")
+        .extern_path(".mz_storage_types", "::mz_storage_types")
         .extern_path(".mz_tracing", "::mz_tracing")
         .extern_path(".mz_service", "::mz_service")
         .compile_with_config(

--- a/src/compute-client/src/controller.rs
+++ b/src/compute-client/src/controller.rs
@@ -60,7 +60,7 @@ use crate::controller::instance::{ActiveInstance, Instance};
 use crate::controller::replica::ReplicaConfig;
 use crate::logging::{LogVariant, LoggingConfig};
 use crate::metrics::ComputeControllerMetrics;
-use crate::protocol::command::ComputeParameters;
+use crate::protocol::command::{ComputeParameters, PeekTarget};
 use crate::protocol::response::{ComputeResponse, PeekResponse, SubscribeResponse};
 use crate::service::{ComputeClient, ComputeGrpcClient};
 
@@ -520,6 +520,7 @@ where
         finishing: RowSetFinishing,
         map_filter_project: mz_expr::SafeMfpPlan,
         target_replica: Option<ReplicaId>,
+        peek_target: PeekTarget,
     ) -> Result<(), PeekError> {
         self.instance(instance_id)?.peek(
             collection_id,
@@ -529,6 +530,7 @@ where
             finishing,
             map_filter_project,
             target_replica,
+            peek_target,
         )?;
         Ok(())
     }

--- a/src/compute-client/src/controller/error.rs
+++ b/src/compute-client/src/controller/error.rs
@@ -164,7 +164,7 @@ impl From<instance::PeekError> for PeekError {
         match error {
             CollectionMissing(id) => Self::CollectionMissing(id),
             ReplicaMissing(id) => Self::ReplicaMissing(id),
-            SinceViolation(id) => Self::CollectionMissing(id),
+            SinceViolation(id) => Self::SinceViolation(id),
         }
     }
 }

--- a/src/compute-client/src/controller/instance.rs
+++ b/src/compute-client/src/controller/instance.rs
@@ -883,10 +883,17 @@ where
         map_filter_project: mz_expr::SafeMfpPlan,
         target_replica: Option<ReplicaId>,
     ) -> Result<(), PeekError> {
-        let since = self.compute.collection(id)?.read_capabilities.frontier();
-        if !since.less_equal(&timestamp) {
-            Err(PeekError::SinceViolation(id))?;
-        }
+        let collection_meta = if let Ok(state) = self.compute.collection(id) {
+            let since = state.read_capabilities.frontier();
+            if !since.less_equal(&timestamp) {
+                Err(PeekError::SinceViolation(id))?;
+            }
+            None
+        } else if let Ok(state) = self.storage_controller.collection(id) {
+            Some(state.collection_metadata.clone())
+        } else {
+            return Err(PeekError::CollectionMissing(id));
+        };
 
         if let Some(target) = target_replica {
             if !self.compute.replica_exists(target) {
@@ -922,6 +929,7 @@ where
             // Obtain an `OpenTelemetryContext` from the thread-local tracing
             // tree to forward it on to the compute worker.
             otel_ctx,
+            collection_meta,
         }));
 
         Ok(())

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -51,6 +51,10 @@ message ProtoInstanceConfig {
     logging.ProtoLoggingConfig logging = 1;
 }
 
+message ProtoPersistTarget {
+    mz_storage_types.controller.ProtoCollectionMetadata metadata = 8;
+}
+
 message ProtoPeek {
     mz_repr.global_id.ProtoGlobalId id = 1;
     repeated mz_repr.row.ProtoRow key = 2;
@@ -59,7 +63,9 @@ message ProtoPeek {
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
     map<string, string> otel_ctx = 7;
-    mz_storage_types.controller.ProtoCollectionMetadata collection_meta = 8;
+    oneof target {
+        ProtoPersistTarget persist = 8;
+    }
 }
 
 message ProtoComputeParameters {

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -22,7 +22,7 @@ import "repr/src/row.proto";
 import "cluster-client/src/client.proto";
 import "service/src/params.proto";
 import "storage-client/src/client.proto";
-import "storage-types/src/parameters.proto";
+import "storage-types/src/controller.proto";
 import "tracing/src/params.proto";
 
 import "google/protobuf/empty.proto";
@@ -59,6 +59,7 @@ message ProtoPeek {
     mz_expr.relation.ProtoRowSetFinishing finishing = 5;
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
     map<string, string> otel_ctx = 7;
+    mz_storage_types.controller.ProtoCollectionMetadata collection_meta = 8;
 }
 
 message ProtoComputeParameters {

--- a/src/compute-client/src/protocol/command.proto
+++ b/src/compute-client/src/protocol/command.proto
@@ -51,11 +51,17 @@ message ProtoInstanceConfig {
     logging.ProtoLoggingConfig logging = 1;
 }
 
+message ProtoIndexTarget {
+    mz_repr.global_id.ProtoGlobalId id = 1;
+}
+
 message ProtoPersistTarget {
-    mz_storage_types.controller.ProtoCollectionMetadata metadata = 8;
+    mz_repr.global_id.ProtoGlobalId id = 1;
+    mz_storage_types.controller.ProtoCollectionMetadata metadata = 2;
 }
 
 message ProtoPeek {
+    // TODO(bkirwi) remove this now-redundant field once persist peeks are locked in
     mz_repr.global_id.ProtoGlobalId id = 1;
     repeated mz_repr.row.ProtoRow key = 2;
     mz_proto.ProtoU128 uuid = 3;
@@ -64,7 +70,8 @@ message ProtoPeek {
     mz_expr.linear.ProtoSafeMfpPlan map_filter_project = 6;
     map<string, string> otel_ctx = 7;
     oneof target {
-        ProtoPersistTarget persist = 8;
+        ProtoIndexTarget index = 8;
+        ProtoPersistTarget persist = 9;
     }
 }
 

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -171,11 +171,12 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
         frontier: Antichain<T>,
     },
 
-    /// `Peek` instructs the replica to perform a peek at an index.
+    /// `Peek` instructs the replica to perform a peek on a collection: either an index or a
+    /// Persist-backed collection.
     ///
     /// The [`Peek`] description must have the following properties:
     ///
-    ///   * The target index has previously been created by a corresponding `CreateDataflow`
+    ///   * If targeting an index, it has previously been created by a corresponding `CreateDataflow`
     ///     command.
     ///   * The [`Peek::uuid`] is unique, i.e., the UUIDs of peeks a replica gets instructed to
     ///     perform do not repeat (within a single protocol iteration).
@@ -492,8 +493,8 @@ pub enum PeekTarget {
 
 /// Peek a collection, either in an arrangement or Persist.
 ///
-/// This request elicits data from the worker, by naming an
-/// arrangement and some actions to apply to the results before
+/// This request elicits data from the worker, by naming the
+/// collection and some actions to apply to the results before
 /// returning them.
 ///
 /// The `timestamp` member must be valid for the arrangement that
@@ -504,9 +505,9 @@ pub enum PeekTarget {
 /// correctly answer the `Peek`.
 #[derive(Arbitrary, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Peek<T = mz_repr::Timestamp> {
-    /// The identifier of the arrangement.
+    /// The identifier of the collection.
     pub id: GlobalId,
-    /// If `Some`, then look up only the given keys from the arrangement (instead of a full scan).
+    /// If `Some`, then look up only the given keys from the collection (instead of a full scan).
     /// The vector is never empty.
     #[proptest(strategy = "proptest::option::of(proptest::collection::vec(any::<Row>(), 1..5))")]
     pub literal_constraints: Option<Vec<Row>>,
@@ -515,7 +516,7 @@ pub struct Peek<T = mz_repr::Timestamp> {
     /// Used in responses and cancellation requests.
     #[proptest(strategy = "any_uuid()")]
     pub uuid: Uuid,
-    /// The logical timestamp at which the arrangement is queried.
+    /// The logical timestamp at which the collection is queried.
     pub timestamp: T,
     /// Actions to apply to the result set before returning them.
     pub finishing: RowSetFinishing,

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -513,6 +513,9 @@ pub struct Peek<T = mz_repr::Timestamp> {
     /// the compute controller and the compute worker.
     #[proptest(strategy = "empty_otel_ctx()")]
     pub otel_ctx: OpenTelemetryContext,
+    /// If this peek is for a Persist shard, the collection metadata for that shard.
+    /// (If absent, this is a standard peek against an arrangement.)
+    pub collection_meta: Option<CollectionMetadata>,
 }
 
 impl RustType<ProtoPeek> for Peek {
@@ -533,6 +536,7 @@ impl RustType<ProtoPeek> for Peek {
             finishing: Some(self.finishing.into_proto()),
             map_filter_project: Some(self.map_filter_project.into_proto()),
             otel_ctx: self.otel_ctx.clone().into(),
+            collection_meta: self.collection_meta.into_proto(),
         }
     }
 
@@ -554,6 +558,7 @@ impl RustType<ProtoPeek> for Peek {
                 .map_filter_project
                 .into_rust_if_some("ProtoPeek::map_filter_project")?,
             otel_ctx: x.otel_ctx.into(),
+            collection_meta: x.collection_meta.into_rust()?,
         })
     }
 }

--- a/src/compute-client/src/protocol/command.rs
+++ b/src/compute-client/src/protocol/command.rs
@@ -177,7 +177,7 @@ pub enum ComputeCommand<T = mz_repr::Timestamp> {
     /// The [`Peek`] description must have the following properties:
     ///
     ///   * If targeting an index, it has previously been created by a corresponding `CreateDataflow`
-    ///     command.
+    ///     command. (If targeting a persist collection, that collection should exist.)
     ///   * The [`Peek::uuid`] is unique, i.e., the UUIDs of peeks a replica gets instructed to
     ///     perform do not repeat (within a single protocol iteration).
     ///

--- a/src/compute-client/src/protocol/history.rs
+++ b/src/compute-client/src/protocol/history.rs
@@ -130,10 +130,13 @@ where
 
         // Determine the required antichains to support live peeks;
         let mut live_peek_frontiers = std::collections::BTreeMap::new();
-        for Peek { id, timestamp, .. } in live_peeks.values() {
+        for Peek {
+            target, timestamp, ..
+        } in live_peeks.values()
+        {
             // Introduce `time` as a constraint on the `as_of` frontier of `id`.
             live_peek_frontiers
-                .entry(id)
+                .entry(target.id())
                 .or_insert_with(Antichain::new)
                 .insert(timestamp.clone());
         }

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -661,6 +661,9 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
 }
 
 /// A peek against either an index or a Persist collection.
+///
+/// Note that `PendingPeek` intentionally does not implement or derive `Clone`,
+/// as each `PendingPeek` is meant to be dropped after it's responded to.
 pub enum PendingPeek {
     /// A peek against an index. (Possibly a temporary index created for the purpose.)
     Index(IndexPeek),
@@ -838,9 +841,6 @@ impl PersistPeek {
 }
 
 /// An in-progress index-backed peek, and data to eventually fulfill it.
-///
-/// Note that `PendingPeek` intentionally does not implement or derive `Clone`,
-/// as each `PendingPeek` is meant to be dropped after it's responded to.
 pub struct IndexPeek {
     peek: Peek,
     /// The data from which the trace derives.

--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -54,6 +54,8 @@ pub struct ComputeMetrics {
 
     /// Heap capacity of the shared row
     pub(crate) shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
+
+    pub(crate) persist_peek_seconds: Histogram,
 }
 
 impl ComputeMetrics {
@@ -105,7 +107,13 @@ impl ComputeMetrics {
                 name: "mz_dataflow_shared_row_heap_capacity_bytes",
                 help: "The heap capacity of the shared row.",
                 var_labels: ["worker_id"],
-            ))
+            )),
+
+            persist_peek_seconds: registry.register(metric!(
+                name: "mz_persist_peek_seconds",
+                help: "Time spent in (experimental) Persist fast-path peeks.",
+                buckets: mz_ore::stats::histogram_seconds_buckets(0.000_128, 8.0),
+            )),
         }
     }
 


### PR DESCRIPTION
This shifts the actual peeking in our new Persist-backed peeks to happen in `clusterd`, piggybacking off the existing Peek protocol.

### Motivation

Epic link: https://github.com/MaterializeInc/materialize/issues/21265

Our new Persist-backed peek code can OOM on very large shards that were written "all at once". (As happens in some loadgen sources, for example.) These will also OOM the old peek code, as it happens... but the old peek code runs in `clusterd` and the new code runs in `environmentd`, which makes the new version worse.

To avoid introducing a brand-new failure mode with the new peeks, this moves the reading to happen in `clusterd`. This makes comparisons between the two codepaths more "apples to apples". (It also has some minor side-effect improvements, like making fast-path peeks cancellable.)

### Tips for reviewer

This code is flagged off outside a few selected tests. Given that, I'd prefer to defer larger followup changes to followup PRs... as long as this feels like a step in the right direction.

One upshot of this is that lots of things that worked for index-backed peeks now worked for Persist peeks: cancellation, observability in the catalog... I think this is mostly great news, but it is a change. There's an argument that we'd want to add a new column / tag to the peek collections to discriminate between types. I'm open to it... but I would rather defer that until we're closer to releasing this in production, to avoid churn in user-visible schemas.

We have pretty good test coverage for the persist peek path now. This is currently disabled in main... but I will run the full CI for this branch, and consider re-enabling it if things are looking sufficiently good.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
