### PR TITLE
[persist/storage] Wrap the u64 part number in an opaque type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5757,6 +5757,7 @@ dependencies = [
  "mz-timely-util",
  "prometheus",
  "proptest",
+ "serde",
  "timely",
  "tokio",
  "tracing",

--- a/src/storage-operators/Cargo.toml
+++ b/src/storage-operators/Cargo.toml
@@ -20,6 +20,7 @@ mz-storage-types = { path = "../storage-types" }
 mz-timely-util = { path = "../timely-util" }
 prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
+serde = { version = "1.0.152", features = ["derive"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.24.2", features = ["fs", "rt", "sync", "test-util", "time"] }
 tracing = "0.1.37"

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -22,6 +22,7 @@ use mz_ore::metrics::{CounterVecExt, GaugeVecExt};
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_storage_operators::metrics::BackpressureMetrics;
 use mz_storage_operators::persist_source;
+use mz_storage_operators::persist_source::Subtime;
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::{
     DataflowError, DecodeError, EnvelopeError, UpsertError, UpsertNullKeyError, UpsertValueError,
@@ -461,7 +462,7 @@ where
                                                         progress_stream: feedback_data,
                                                         max_inflight_bytes:
                                                             storage_dataflow_max_inflight_bytes,
-                                                        summary: (Default::default(), 1),
+                                                        summary: (Default::default(), Subtime::least_summary()),
                                                         metrics: backpressure_metrics.clone(),
                                                     }),
                                                     backpressure_metrics,


### PR DESCRIPTION
### Motivation

Refactoring!

We've talked about changing the meaning of the sub-timestamp here: for example, it may reflect progress through the keyspace for a future consolidating source. This bundles it up in an opaque type, so that we don't accidentally grow any dependencies on the exact representation of the data.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
