### PR TITLE
Enroll `balancerd` in the "upload debuginfo" program

### DIFF
--- a/misc/images/balancerd/mzbuild.yml
+++ b/misc/images/balancerd/mzbuild.yml
@@ -15,7 +15,7 @@ pre-image:
     strip: true
     split_debuginfo: true
   - type: s3-upload-debuginfo
-    bin: balancerd
+    bin: mz-balancerd
     bucket: materialize-debuginfo
   - type: ps-upload-sources
-    bin: balancerd.debug
+    bin: mz-balancerd.debug

--- a/misc/images/balancerd/mzbuild.yml
+++ b/misc/images/balancerd/mzbuild.yml
@@ -12,4 +12,10 @@ description: Ingress balancer.
 pre-image:
   - type: cargo-build
     bin: [mz-balancerd]
-    strip: false
+    strip: true
+    split_debuginfo: true
+  - type: s3-upload-debuginfo
+    bin: balancerd
+    bucket: materialize-debuginfo
+  - type: ps-upload-sources
+    bin: balancerd.debug


### PR DESCRIPTION
Make debuginfo collection and uploading for balancerd work the same way as it does for environmentd/clusterd

### Motivation

  * This PR adds a known-desirable feature.

    Discussed [here](https://github.com/MaterializeInc/materialize/pull/23223#discussion_r1395677320)
