### PR TITLE
[sources] Postgres LSN tests

### DIFF
--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -77,6 +77,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use bytes::Bytes;
+use differential_dataflow::difference::Semigroup;
 use differential_dataflow::{AsCollection, Collection};
 use futures::{future, future::select, FutureExt, Stream as AsyncStream, StreamExt, TryStreamExt};
 use once_cell::sync::Lazy;
@@ -190,8 +191,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 subsource_resume_uppers
                     .values()
                     .flat_map(|f| f.elements())
-                    // Advance any upper as far as the slot_lsn.
-                    .map(|t|std::cmp::max(*t, slot_lsn))
+                    // When snapshotting tables, the resume LSN wants to move to 0;
+                    // however, we want to ensure it is at least the slot's LSN, so
+                    // ensure that any 0 resume upper is treated as the slot's LSN.
+                    .map(|t| if t.is_zero() { slot_lsn } else { *t })
             );
 
             let Some(resume_lsn) = resume_upper.into_option() else {


### PR DESCRIPTION
Our postgres source has a check that makes sure our LSN is not ahead of what it's supposed to be:

https://github.com/MaterializeInc/materialize/blob/09ab50f10e9fa99c7f539762ef0aee726935c660/src/storage/src/source/postgres/replication.rs#L391-L404

However, we base our expectation on the current contents of the LSN:

https://github.com/MaterializeInc/materialize/blob/09ab50f10e9fa99c7f539762ef0aee726935c660/src/storage/src/source/postgres/replication.rs#L186-L194

Which means this check is unlikely to actually spot bad LSNs in practice. Instead, let's only advance the LSN in the case that the original commit message called out: when the offset is zero, during I guess a snapshot.

### Motivation

Possible fix for: https://github.com/MaterializeInc/materialize/issues/22982

(Restoring a backup is a case where the stored LSN is very likely to fall out of sync with the external system.)

### Tips for reviewer

I don't understand the Postgres source... please check my work!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
