### PR TITLE
scalability framework: fix computation of transaction ID

### DIFF
--- a/misc/python/materialize/scalability/benchmark_executor.py
+++ b/misc/python/materialize/scalability/benchmark_executor.py
@@ -206,7 +206,7 @@ class BenchmarkExecutor:
                         local,
                         cursor_pool,
                         operations[i % len(operations)],
-                        i,
+                        int(i / len(operations)),
                     )
                     for i in range(count)
                 ],


### PR DESCRIPTION
This is the ID that identifies the operations of a workload (e.g. when executing `InsertAndSelectStarWorkload` once, each pair of `InsertDefaultValues` and `SelectStar` will share the same transaction ID).

This transaction ID is only used for distribution plots.