### PR TITLE
fgviz: use new prof-http path

### DIFF
--- a/bin/fgviz
+++ b/bin/fgviz
@@ -11,11 +11,11 @@
 #
 # fgviz — generate and launch flamegraph visualizer
 
-cargo run --bin fgviz > "$( dirname "$0" )"/../src/prof/src/http/flamegraph.html -- "$@"
+cargo run --bin fgviz > "$( dirname "$0" )"/../src/prof-http/src/http/flamegraph.html -- "$@"
 
 if ! command -v open &> /dev/null
 then
-    echo "Open 'src/prof/src/http/static/flamegraph.html' in your favorite browser."
+    echo "Open 'src/prof-http/src/http/flamegraph.html' in your favorite browser."
 else
-    open "$( dirname "$0" )"/../src/prof/src/http/flamegraph.html
+    open "$( dirname "$0" )"/../src/prof-http/src/http/flamegraph.html
 fi


### PR DESCRIPTION
Update the paths used by fgviz after #22786 changed them.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
