### PR TITLE
parallel-workload: Limit number of indexes

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -37,12 +37,13 @@ from materialize.util import naughty_strings
 MAX_COLUMNS = 10
 MAX_INCLUDE_HEADERS = 5
 MAX_ROWS = 100
-MAX_CLUSTERS = 10
-MAX_CLUSTER_REPLICAS = 4
+MAX_CLUSTERS = 5
+MAX_CLUSTER_REPLICAS = 2
 MAX_DBS = 10
 MAX_SCHEMAS = 20
-MAX_TABLES = 100
+MAX_TABLES = 40
 MAX_VIEWS = 100
+MAX_INDEXES = 100
 MAX_ROLES = 100
 MAX_WEBHOOK_SOURCES = 20
 MAX_KAFKA_SOURCES = 20
@@ -224,8 +225,6 @@ class Table(DBObject):
         query += ",\n    ".join(column.create() for column in self.columns)
         query += ")"
         exe.execute(query)
-        query = f"CREATE DEFAULT INDEX ON {self}"
-        exe.execute(query)
 
 
 class View(DBObject):
@@ -329,8 +328,6 @@ class View(DBObject):
             else:
                 query += " ON TRUE"
 
-        exe.execute(query)
-        query = f"CREATE DEFAULT INDEX ON {self}"
         exe.execute(query)
 
 
@@ -780,7 +777,7 @@ class Database:
             Cluster(
                 i,
                 managed=rng.choice([True, False]),
-                size=rng.choice(["1", "2", "4"]),
+                size=rng.choice(["1", "2"]),
                 replication_factor=1,
                 introspection_interval=rng.choice(["0", "1s", "10s"]),
             )

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -302,7 +302,7 @@ def run(
             if thread.is_alive():
                 print(f"{thread.name} still running: {worker.exe.last_log}")
         print("Threads have not stopped within 5 minutes, exiting hard")
-        # TODO(def-): Switch to failing exit code when https://github.com/MaterializeInc/materialize/issues/22717 is fixed
+        # TODO(def-): Switch to failing exit code when #23254 is fixed
         os._exit(0)
 
     conn = pg8000.connect(host=host, port=ports["materialized"], user="materialize")

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -79,39 +79,39 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         )
     ):
         c.up(*service_names)
-    c.up("mc", persistent=True)
-    c.exec(
-        "mc",
-        "mc",
-        "alias",
-        "set",
-        "persist",
-        "http://minio:9000/",
-        "minioadmin",
-        "minioadmin",
-    )
-    c.exec("mc", "mc", "version", "enable", "persist/persist")
+        c.up("mc", persistent=True)
+        c.exec(
+            "mc",
+            "mc",
+            "alias",
+            "set",
+            "persist",
+            "http://minio:9000/",
+            "minioadmin",
+            "minioadmin",
+        )
+        c.exec("mc", "mc", "version", "enable", "persist/persist")
 
-    ports = {s: c.default_port(s) for s in service_names}
-    ports["http"] = c.port("materialized", 6876)
-    ports["mz_system"] = c.port("materialized", 6877)
-    # try:
-    run(
-        "localhost",
-        ports,
-        args.seed,
-        args.runtime,
-        Complexity(args.complexity),
-        Scenario(args.scenario),
-        args.threads,
-        args.naughty_identifiers,
-        args.fast_startup,
-        c,
-    )
-    # TODO: Only ignore errors that will be handled by parallel-workload, not others
-    # except Exception:
-    #     print("--- Execution of parallel-workload failed")
-    #     print_exc()
-    #     # Don't fail the entire run. We ran into a crash,
-    #     # ci-logged-errors-detect will handle this if it's an unknown failure.
-    #     return
+        ports = {s: c.default_port(s) for s in service_names}
+        ports["http"] = c.port("materialized", 6876)
+        ports["mz_system"] = c.port("materialized", 6877)
+        # try:
+        run(
+            "localhost",
+            ports,
+            args.seed,
+            args.runtime,
+            Complexity(args.complexity),
+            Scenario(args.scenario),
+            args.threads,
+            args.naughty_identifiers,
+            args.fast_startup,
+            c,
+        )
+        # TODO: Only ignore errors that will be handled by parallel-workload, not others
+        # except Exception:
+        #     print("--- Execution of parallel-workload failed")
+        #     print_exc()
+        #     # Don't fail the entire run. We ran into a crash,
+        #     # ci-logged-errors-detect will handle this if it's an unknown failure.
+        #     return


### PR DESCRIPTION
Seems to cause #22717

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
