### PR TITLE
balancerd: bump versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3686,7 +3686,7 @@ dependencies = [
 
 [[package]]
 name = "mz-balancerd"
-version = "0.0.0"
+version = "0.78.0-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/bin/bump-version
+++ b/bin/bump-version
@@ -29,7 +29,7 @@ version=${1#v}
 
 sed -i.bak \
     "s/^version = .*/version = \"$version\"/" \
-    src/{clusterd,environmentd,persist-client,testdrive,stash-debug,catalog-debug}/Cargo.toml
+    src/{clusterd,environmentd,persist-client,testdrive,stash-debug,catalog-debug,balancerd}/Cargo.toml
 
 if ! [[ "$version" = *dev ]]; then
     sed -i.bak \
@@ -49,7 +49,7 @@ else
     done
 fi
 
-rm -f src/{clusterd,environmentd,persist-client,testdrive,stash-debug,catalog-debug}/Cargo.toml.bak LICENSE.bak
+rm -f src/{clusterd,environmentd,persist-client,testdrive,stash-debug,catalog-debug,balancerd}/Cargo.toml.bak LICENSE.bak
 
 cargo check
 

--- a/src/balancerd/Cargo.toml
+++ b/src/balancerd/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "mz-balancerd"
 description = "Balancer service."
-version = "0.0.0"
+version = "0.78.0-dev"
 edition.workspace = true
 rust-version.workspace = true
 publish = false


### PR DESCRIPTION
Fixes #23249

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a