### PR TITLE
adapter: fix index as-of bootstrapping

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2843,3 +2843,50 @@ def workflow_test_github_cloud_7998(
         c.kill("materialized")
         c.up("materialized")
         c.run("testdrive", "github-cloud-7998/check.td")
+
+
+def workflow_test_github_23246(c: Composition, parser: WorkflowArgumentParser) -> None:
+    """Regression test for #23246."""
+
+    c.down(destroy_volumes=True)
+
+    with c.override(
+        Testdrive(no_reset=True),
+    ):
+        c.up("testdrive", persistent=True)
+        c.up("materialized")
+
+        # Create an MV reading from an index. Make sure it doesn't produce its
+        # snapshot by installing it in a cluster without replicas.
+        c.sql(
+            """
+            CREATE CLUSTER test SIZE '1', REPLICATION FACTOR 0;
+            SET cluster = test;
+
+            CREATE TABLE t (a int);
+            INSERT INTO t VALUES (1);
+
+            CREATE DEFAULT INDEX ON t;
+            CREATE MATERIALIZED VIEW mv AS SELECT * FROM t;
+            """
+        )
+
+        # Verify that the MV's upper is zero, which is what caused the bug.
+        # This ensures that the test doesn't break in the future because we
+        # start initializing frontiers differently.
+        c.testdrive(
+            input=dedent(
+                """
+                > SELECT write_frontier
+                  FROM mz_internal.mz_frontiers
+                  JOIN mz_materialized_views ON (object_id = id)
+                  WHERE name = 'mv'
+                0
+                """
+            )
+        )
+
+        # Trigger an environment bootstrap, and see if envd comes up without
+        # panicking.
+        c.kill("materialized")
+        c.up("materialized")


### PR DESCRIPTION
This PR fixes the as-of selection for indexes during bootstrapping (again) by ensuring that applying the `max_as_of` constraint doesn't move the final `as_of` before the `min_as_of`. `max_as_of`, which is informed by the requirements of dependent MVs, should never be less than `min_as_of`, which is informed by the read frontiers of inputs. This was only possible before because we didn't consider dependent MVs that hadn't produced their snapshot yet and therefore could have an `upper` before their `since`.

### Motivation

  * This PR fixes a recognized bug.

Fixes #23246

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
