### PR TITLE
mzcompose: Work around label lists being broken in docker compose v2.23.0

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -422,9 +422,9 @@ class Composition:
                     not in self.compose["services"]["materialized"]["labels"]
                 ):
                     print("sanity_restart disabled by override(), keeping it disabled")
-                    old_compose["services"]["materialized"]["labels"].remove(
+                    del old_compose["services"]["materialized"]["labels"][
                         "sanity_restart"
-                    )
+                    ]
 
             # Restore the old composition.
             self.compose = old_compose

--- a/misc/python/materialize/mzcompose/service.py
+++ b/misc/python/materialize/mzcompose/service.py
@@ -159,7 +159,7 @@ class ServiceConfig(TypedDict, total=False):
     restart: str
     """Restart policy."""
 
-    labels: list[str]
+    labels: dict[str, Any]
     """Container labels."""
 
 

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -181,7 +181,8 @@ class Materialized(Service):
             config["deploy"] = {"resources": {"limits": {"memory": memory}}}
 
         if sanity_restart:
-            config.setdefault("labels", []).append("sanity_restart")
+            # Workaround for https://bytemeta.vip/repo/docker/compose/issues/11133
+            config["labels"] = {"sanity_restart": True}
 
         volumes = []
         if use_default_volumes:


### PR DESCRIPTION
See https://materializeinc.slack.com/archives/C01LKF361MZ/p1700170484444259

Verified that this still works on older docker compose versions.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
