### PR TITLE
parallel-workload: Another attempt at fine-grained locking

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -143,12 +143,11 @@ class FetchAction(Action):
 class SelectAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
-        if exe.db.complexity in (Complexity.DML, Complexity.DDL):
-            result.extend(
-                [
-                    "in the same timedomain",
-                ]
-            )
+        result.extend(
+            [
+                "in the same timedomain",
+            ]
+        )
         if exe.db.complexity == Complexity.DDL:
             result.extend(
                 [
@@ -220,13 +219,11 @@ class SQLsmithAction(Action):
     def errors_to_ignore(self, exe: Executor) -> list[str]:
         result = super().errors_to_ignore(exe)
         result.extend(known_errors)
-
-        if exe.db.complexity in (Complexity.DML, Complexity.DDL):
-            result.extend(
-                [
-                    "in the same timedomain",
-                ]
-            )
+        result.extend(
+            [
+                "in the same timedomain",
+            ]
+        )
         if exe.db.complexity == Complexity.DDL:
             result.extend(
                 [

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -59,8 +59,8 @@ def run(
     ports: dict[str, int],
     seed: str,
     runtime: int,
-    complexity: Complexity,
-    scenario: Scenario,
+    complexity_str: str,
+    scenario_str: str,
     num_threads: int | None,
     naughty_identifiers: bool,
     fast_startup: bool,
@@ -68,6 +68,19 @@ def run(
 ) -> None:
     num_threads = num_threads or os.cpu_count() or 10
     random.seed(seed)
+
+    rng = random.Random(random.randrange(SEED_RANGE))
+
+    complexity = (
+        Complexity(rng.choice([elem.value for elem in Complexity]))
+        if complexity_str == "random"
+        else Complexity(complexity_str)
+    )
+    scenario = (
+        Scenario(rng.choice([elem.value for elem in Scenario]))
+        if scenario_str == "random"
+        else Scenario(scenario_str)
+    )
 
     print(
         f"+++ Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''} {'--fast-startup' if fast_startup else ''}(--host={host})"
@@ -78,7 +91,6 @@ def run(
         datetime.datetime.now() + datetime.timedelta(seconds=runtime)
     ).timestamp()
 
-    rng = random.Random(random.randrange(SEED_RANGE))
     database = Database(
         rng, seed, host, ports, complexity, scenario, naughty_identifiers, fast_startup
     )
@@ -361,13 +373,13 @@ def parse_common_args(parser: argparse.ArgumentParser) -> None:
         "--complexity",
         default="ddl",
         type=str,
-        choices=[elem.value for elem in Complexity],
+        choices=[elem.value for elem in Complexity] + ["random"],
     )
     parser.add_argument(
         "--scenario",
         default="regression",
         type=str,
-        choices=[elem.value for elem in Scenario],
+        choices=[elem.value for elem in Scenario] + ["random"],
     )
     parser.add_argument(
         "--threads",
@@ -428,8 +440,8 @@ def main() -> int:
         ports,
         args.seed,
         args.runtime,
-        Complexity(args.complexity),
-        Scenario(args.scenario),
+        args.complexity,
+        args.scenario,
         args.threads,
         args.naughty_identifiers,
         args.fast_startup,

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -90,19 +90,29 @@ def run(
     with system_conn.cursor() as system_cur:
         system_exe = Executor(rng, system_cur, database)
         system_exe.execute(
-            f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 2}"
+            f"ALTER SYSTEM SET max_schemas_per_database = {MAX_SCHEMAS * 2 + num_threads}"
         )
         # The presence of ALTER TABLE RENAME can cause the total number of tables to exceed MAX_TABLES
-        system_exe.execute(f"ALTER SYSTEM SET max_tables = {MAX_TABLES * 2}")
-        system_exe.execute(f"ALTER SYSTEM SET max_materialized_views = {MAX_VIEWS * 2}")
         system_exe.execute(
-            f"ALTER SYSTEM SET max_sources = {(MAX_WEBHOOK_SOURCES + MAX_KAFKA_SOURCES + MAX_POSTGRES_SOURCES) * 2}"
+            f"ALTER SYSTEM SET max_tables = {MAX_TABLES * 2 + num_threads}"
         )
-        system_exe.execute(f"ALTER SYSTEM SET max_sinks = {MAX_KAFKA_SINKS * 2}")
-        system_exe.execute(f"ALTER SYSTEM SET max_roles = {MAX_ROLES * 2}")
-        system_exe.execute(f"ALTER SYSTEM SET max_clusters = {MAX_CLUSTERS * 2}")
         system_exe.execute(
-            f"ALTER SYSTEM SET max_replicas_per_cluster = {MAX_CLUSTER_REPLICAS * 2}"
+            f"ALTER SYSTEM SET max_materialized_views = {MAX_VIEWS * 2 + num_threads}"
+        )
+        system_exe.execute(
+            f"ALTER SYSTEM SET max_sources = {(MAX_WEBHOOK_SOURCES + MAX_KAFKA_SOURCES + MAX_POSTGRES_SOURCES) * 2 + num_threads}"
+        )
+        system_exe.execute(
+            f"ALTER SYSTEM SET max_sinks = {MAX_KAFKA_SINKS * 2 + num_threads}"
+        )
+        system_exe.execute(
+            f"ALTER SYSTEM SET max_roles = {MAX_ROLES * 2 + num_threads}"
+        )
+        system_exe.execute(
+            f"ALTER SYSTEM SET max_clusters = {MAX_CLUSTERS * 2 + num_threads}"
+        )
+        system_exe.execute(
+            f"ALTER SYSTEM SET max_replicas_per_cluster = {MAX_CLUSTER_REPLICAS * 2 + num_threads}"
         )
         # Most queries should not fail because of privileges
         for object_type in [

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -67,7 +67,6 @@ class Worker:
 
         while time.time() < self.end_time:
             action = self.rng.choices(self.actions, self.weights)[0]
-            self.num_queries[type(action)] += 1
             try:
                 if self.exe.rollback_next:
                     try:
@@ -88,7 +87,8 @@ class Worker:
                         self.exe
                     )
                     self.exe.reconnect_next = False
-                action.run(self.exe)
+                if action.run(self.exe):
+                    self.num_queries[type(action)] += 1
             except QueryError as e:
                 for error in action.errors_to_ignore(self.exe):
                     if error in e.msg:

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -18,7 +18,7 @@ from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.parallel_workload.parallel_workload import parse_common_args, run
-from materialize.parallel_workload.settings import Complexity, Scenario
+from materialize.parallel_workload.settings import Scenario
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -101,8 +101,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ports,
             args.seed,
             args.runtime,
-            Complexity(args.complexity),
-            Scenario(args.scenario),
+            args.complexity,
+            args.scenario,
             args.threads,
             args.naughty_identifiers,
             args.fast_startup,


### PR DESCRIPTION
This increases parallelism, and thus is in the spirit of the framework

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
