### PR TITLE
ci: bounded memory for table-index-hydration

### DIFF
--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -379,7 +379,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="6.1Gb",
+        clusterd_memory="7.1Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -379,7 +379,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="3.5Gb",
+        clusterd_memory="4.1Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -379,7 +379,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="4.1Gb",
+        clusterd_memory="4.6Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -379,7 +379,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="4.6Gb",
+        clusterd_memory="5.1Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",

--- a/test/bounded-memory/mzcompose.py
+++ b/test/bounded-memory/mzcompose.py
@@ -379,7 +379,7 @@ SCENARIOS = [
             """
         ),
         materialized_memory="10Gb",
-        clusterd_memory="5.1Gb",
+        clusterd_memory="6.1Gb",
     ),
     KafkaScenario(
         name="upsert-index-hydration",


### PR DESCRIPTION
Nightlies:
* table-index-hydration with 4.1Gb: https://buildkite.com/materialize/nightlies/builds/5274
* table-index-hydration with 4.6Gb: https://buildkite.com/materialize/nightlies/builds/5275
* table-index-hydration with 5.1Gb: https://buildkite.com/materialize/nightlies/builds/5276
* table-index-hydration with 6.1Gb: https://buildkite.com/materialize/nightlies/builds/5277
* table-index-hydration with 7.1Gb: https://buildkite.com/materialize/nightlies/builds/5278
* table-index-hydration with original memory: https://buildkite.com/materialize/nightlies/builds/5279