### PR TITLE
adapter: Refactor environmentd test

### DIFF
--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -126,7 +126,6 @@ async fn test_balancer() {
         None,
     )
     .unwrap();
-    task::spawn(|| "test_balancer-frontegg_future", frontegg_future);
 
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -89,15 +89,14 @@ use mz_frontegg_auth::{
 use mz_frontegg_mock::FronteggMockServer;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
-use mz_ore::task::RuntimeExt;
+use mz_ore::task;
 use mz_server_core::TlsCertConfig;
 use openssl::ssl::{SslConnectorBuilder, SslVerifyMode};
-use postgres::Client;
 use uuid::Uuid;
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // too slow
-fn test_balancer() {
+async fn test_balancer() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -127,6 +126,8 @@ fn test_balancer() {
         None,
     )
     .unwrap();
+    task::spawn(|| "test_balancer-frontegg_future", frontegg_future);
+
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
             admin_api_token_url: frontegg_server.url.clone(),
@@ -141,21 +142,28 @@ fn test_balancer() {
     let frontegg_user = "user@_.com";
     let frontegg_password = format!("mzp_{client_id}{secret}");
 
-    let config = test_util::Config::default()
+    let envd_server = test_util::TestHarness::default()
         // Enable SSL on the main port. There should be a balancerd port with no SSL.
         .with_tls(server_cert.clone(), server_key.clone())
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let envd_server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
     // Ensure we could connect directly to envd without SSL on the balancer port.
-    let mut pg_client_envd = envd_server
-        .pg_config_balancer()
+    let pg_client_envd = envd_server
+        .connect()
+        .balancer()
         .user(frontegg_user)
         .password(&frontegg_password)
-        .connect(tokio_postgres::NoTls)
+        .await
         .unwrap();
-    let res: i32 = pg_client_envd.query_one("SELECT 4", &[]).unwrap().get(0);
+
+    let res: i32 = pg_client_envd
+        .query_one("SELECT 4", &[])
+        .await
+        .unwrap()
+        .get(0);
     assert_eq!(res, 4);
 
     let resolvers = vec![
@@ -181,15 +189,13 @@ fn test_balancer() {
             cert_config.clone(),
             MetricsRegistry::new(),
         );
-        let balancer_server = envd_server
-            .runtime
-            .block_on(async { BalancerService::new(balancer_cfg).await.unwrap() });
+        let balancer_server = BalancerService::new(balancer_cfg).await.unwrap();
         let balancer_pgwire_listen = balancer_server.pgwire.0.local_addr();
-        envd_server.runtime.spawn_named(|| "balancer", async {
+        task::spawn(|| "balancer", async {
             balancer_server.serve().await.unwrap();
         });
 
-        let mut pg_client = Client::connect(
+        let (pg_client, conn) = tokio_postgres::connect(
             &format!(
                 "user={frontegg_user} password={frontegg_password} host={} port={} sslmode=require",
                 balancer_pgwire_listen.ip(),
@@ -199,9 +205,13 @@ fn test_balancer() {
                 Ok(b.set_verify(SslVerifyMode::NONE))
             })),
         )
+        .await
         .unwrap();
+        task::spawn(|| "balancer-pg_client", async move {
+            conn.await.expect("balancer-pg_client")
+        });
 
-        let res: i32 = pg_client.query_one("SELECT 2", &[]).unwrap().get(0);
+        let res: i32 = pg_client.query_one("SELECT 2", &[]).await.unwrap().get(0);
         assert_eq!(res, 2);
     }
 }

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -1051,7 +1051,7 @@ pub async fn create_postgres_source_with_table<'a>(
     let password = pg_config.get_password();
 
     mz_ore::task::spawn(|| "postgres-source-connection", async move {
-        while let Err(e) = connection.await {
+        if let Err(e) = connection.await {
             panic!("connection error: {}", e);
         }
     });

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -515,7 +515,6 @@ async fn test_auth_expiry() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
 
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -667,7 +666,6 @@ async fn test_auth_base_require_tls_frontegg() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
 
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -1423,7 +1421,6 @@ async fn test_auth_admin_non_superuser() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
 
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
@@ -1535,7 +1532,6 @@ async fn test_auth_admin_superuser() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
 
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
@@ -1647,7 +1643,6 @@ async fn test_auth_admin_superuser_revoked() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
 
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
@@ -1753,7 +1748,6 @@ async fn test_auth_deduplication() {
         Some(2),
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mz_cloud-frontegg", frontegg_future);
 
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -1871,7 +1865,6 @@ async fn test_refresh_task_metrics() {
         None,
     )
     .unwrap();
-    mz_ore::task::spawn(|| "mz_cloud-frontegg", frontegg_future);
 
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -79,6 +79,7 @@
 
 use std::collections::BTreeMap;
 use std::fs::{self, File};
+use std::future::IntoFuture;
 use std::io::{Read, Write};
 use std::net::{IpAddr, Ipv4Addr, TcpStream};
 use std::sync::atomic::Ordering;
@@ -102,7 +103,6 @@ use mz_ore::assert_contains;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NowFn, SYSTEM_TIME};
 use mz_ore::retry::Retry;
-use mz_ore::task::RuntimeExt;
 use mz_sql::names::PUBLIC_ROLE_NAME;
 use mz_sql::session::user::{HTTP_DEFAULT_USER, SYSTEM_USER};
 use openssl::error::ErrorStack;
@@ -111,7 +111,6 @@ use postgres::config::SslMode;
 use postgres::error::SqlState;
 use serde::Deserialize;
 use serde_json::json;
-use tokio::runtime::Runtime;
 use tungstenite::protocol::frame::coding::CloseCode;
 use tungstenite::Message;
 use uuid::Uuid;
@@ -205,9 +204,8 @@ fn assert_http_rejected() -> Assert<Box<dyn Fn(Option<StatusCode>, String)>> {
     }))
 }
 
-fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>]) {
+async fn run_tests<'a>(header: &str, server: &test_util::TestServer, tests: &[TestCase<'a>]) {
     println!("==> {}", header);
-    let runtime = Runtime::new().unwrap();
     for test in tests {
         match test {
             TestCase::Pgwire {
@@ -224,23 +222,30 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                 );
 
                 let tls = make_pg_tls(configure);
-                let mut pg_client = server.pg_config();
-                pg_client
+                let conn_config = server
+                    .connect()
                     .ssl_mode(*ssl_mode)
                     .user(user_to_auth_as)
                     .password(password.unwrap_or(""));
 
                 match assert {
                     Assert::Success => {
-                        let mut pg_client = pg_client.connect(tls).unwrap();
-                        let row = pg_client.query_one("SELECT current_user", &[]).unwrap();
+                        let pg_client = conn_config.with_tls(tls).await.unwrap();
+                        let row = pg_client
+                            .query_one("SELECT current_user", &[])
+                            .await
+                            .unwrap();
                         assert_eq!(row.get::<_, String>(0), *user_reported_by_system);
                     }
                     Assert::SuccessSuperuserCheck(is_superuser) => {
-                        let mut pg_client = pg_client.connect(tls.clone()).unwrap();
-                        let row = pg_client.query_one("SELECT current_user", &[]).unwrap();
+                        let pg_client = conn_config.with_tls(tls).await.unwrap();
+                        let row = pg_client
+                            .query_one("SELECT current_user", &[])
+                            .await
+                            .unwrap();
                         assert_eq!(row.get::<_, String>(0), *user_reported_by_system);
-                        let row = pg_client.query_one("SHOW is_superuser", &[]).unwrap();
+
+                        let row = pg_client.query_one("SHOW is_superuser", &[]).await.unwrap();
                         let expected = if *is_superuser { "on" } else { "off" };
                         assert_eq!(row.get::<_, String>(0), *expected);
                     }
@@ -248,12 +253,17 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                         // This sometimes returns a network error, so retry until we get a db error.
                         Retry::default()
                             .max_duration(Duration::from_secs(10))
-                            .retry(|_| {
+                            .retry_async(|_| async {
                                 // Due to delayed startup, we must attempt a query to
                                 // check if there was a login error.
-                                let err = match pg_client.connect(tls.clone()) {
-                                    Ok(mut pg_client) => {
-                                        pg_client.query_one("SELECT 1", &[]).unwrap_err()
+                                let pg_client = server
+                                    .connect()
+                                    .with_config(conn_config.as_pg_config().clone())
+                                    .with_tls(tls.clone())
+                                    .await;
+                                let err = match pg_client {
+                                    Ok(pg_client) => {
+                                        pg_client.query_one("SELECT 1", &[]).await.unwrap_err()
                                     }
                                     Err(err) => err,
                                 };
@@ -263,13 +273,17 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                                 check(err);
                                 Ok(())
                             })
+                            .await
                             .unwrap();
                     }
                     Assert::Err(check) => {
                         // Due to delayed startup, we must attempt a query to
                         // check if there was a login error.
-                        let err = match pg_client.connect(tls.clone()) {
-                            Ok(mut pg_client) => pg_client.query_one("SELECT 1", &[]).unwrap_err(),
+                        let pg_client = conn_config.with_tls(tls.clone()).await;
+                        let err = match pg_client {
+                            Ok(pg_client) => {
+                                pg_client.query_one("SELECT 1", &[]).await.unwrap_err()
+                            }
                             Err(err) => err,
                         };
                         check(&err);
@@ -284,37 +298,34 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                 configure,
                 assert,
             } => {
-                fn query_http_api<'a>(
+                async fn query_http_api<'a>(
                     query: &str,
                     uri: &Uri,
                     headers: &'a HeaderMap,
                     configure: &Box<
                         dyn Fn(&mut SslConnectorBuilder) -> Result<(), ErrorStack> + 'a,
                     >,
-                    runtime: &Runtime,
                 ) -> hyper::Result<Response<Body>> {
-                    runtime.block_on(
-                        hyper::Client::builder()
-                            .build::<_, Body>(make_http_tls(configure))
-                            .request({
-                                let mut req = Request::post(uri);
-                                for (k, v) in headers.iter() {
-                                    req.headers_mut().unwrap().insert(k, v.clone());
-                                }
-                                req.headers_mut().unwrap().insert(
-                                    "Content-Type",
-                                    HeaderValue::from_static("application/json"),
-                                );
-                                req.body(Body::from(json!({ "query": query }).to_string()))
-                                    .unwrap()
-                            }),
-                    )
+                    hyper::Client::builder()
+                        .build::<_, Body>(make_http_tls(configure))
+                        .request({
+                            let mut req = Request::post(uri);
+                            for (k, v) in headers.iter() {
+                                req.headers_mut().unwrap().insert(k, v.clone());
+                            }
+                            req.headers_mut().unwrap().insert(
+                                "Content-Type",
+                                HeaderValue::from_static("application/json"),
+                            );
+                            req.body(Body::from(json!({ "query": query }).to_string()))
+                                .unwrap()
+                        })
+                        .await
                 }
 
-                fn assert_success_response(
+                async fn assert_success_response(
                     res: hyper::Result<Response<Body>>,
                     expected_rows: Vec<Vec<String>>,
-                    runtime: &Runtime,
                 ) {
                     #[derive(Deserialize)]
                     struct Result {
@@ -324,9 +335,7 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                     struct Response {
                         results: Vec<Result>,
                     }
-                    let body = runtime
-                        .block_on(body::to_bytes(res.unwrap().into_body()))
-                        .unwrap();
+                    let body = body::to_bytes(res.unwrap().into_body()).await.unwrap();
                     let res: Response = serde_json::from_slice(&body).unwrap();
                     assert_eq!(res.results[0].rows, expected_rows)
                 }
@@ -343,40 +352,34 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                     .path_and_query("/api/sql")
                     .build()
                     .unwrap();
-                let res = query_http_api(
-                    "SELECT pg_catalog.current_user()",
-                    &uri,
-                    headers,
-                    configure,
-                    &runtime,
-                );
+                let res =
+                    query_http_api("SELECT pg_catalog.current_user()", &uri, headers, configure)
+                        .await;
 
                 match assert {
                     Assert::Success => {
                         assert_success_response(
                             res,
                             vec![vec![user_reported_by_system.to_string()]],
-                            &runtime,
-                        );
+                        )
+                        .await;
                     }
                     Assert::SuccessSuperuserCheck(is_superuser) => {
                         assert_success_response(
                             res,
                             vec![vec![user_reported_by_system.to_string()]],
-                            &runtime,
-                        );
+                        )
+                        .await;
                         let res =
-                            query_http_api("SHOW is_superuser", &uri, headers, configure, &runtime);
+                            query_http_api("SHOW is_superuser", &uri, headers, configure).await;
                         let expected = if *is_superuser { "on" } else { "off" };
-                        assert_success_response(res, vec![vec![expected.to_string()]], &runtime);
+                        assert_success_response(res, vec![vec![expected.to_string()]]).await;
                     }
                     Assert::Err(check) => {
                         let (code, message) = match res {
                             Ok(mut res) => {
-                                let body = String::from_utf8_lossy(
-                                    &runtime.block_on(body::to_bytes(res.body_mut())).unwrap(),
-                                )
-                                .into_owned();
+                                let body = body::to_bytes(res.body_mut()).await.unwrap();
+                                let body = String::from_utf8_lossy(&body[..]).into_owned();
                                 (Some(res.status()), body)
                             }
                             Err(e) => (None, e.to_string()),
@@ -405,7 +408,7 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
                     .unwrap();
                 let stream = make_ws_tls(&uri, configure);
                 let (mut ws, _resp) = tungstenite::client(uri, stream).unwrap();
-                //  let (mut ws, _resp) = tungstenite::connect(uri).unwrap();
+
                 ws.send(Message::Text(serde_json::to_string(&auth).unwrap()))
                     .unwrap();
 
@@ -477,9 +480,9 @@ fn run_tests<'a>(header: &str, server: &test_util::Server, tests: &[TestCase<'a>
     }
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_expiry() {
+async fn test_auth_expiry() {
     // This function verifies that the background expiry refresh task runs. This
     // is done by starting a web server that awaits the refresh request, which the
     // test waits for.
@@ -512,6 +515,8 @@ fn test_auth_expiry() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
+
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
             admin_api_token_url: frontegg_server.url.clone(),
@@ -526,25 +531,28 @@ fn test_auth_expiry() {
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("mzp_{client_id}{secret}");
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
-    let mut pg_client = server
-        .pg_config()
+    let pg_client = server
+        .connect()
         .ssl_mode(SslMode::Require)
         .user(frontegg_user)
         .password(frontegg_password)
-        .connect(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
         })))
+        .await
         .unwrap();
 
     assert_eq!(
         pg_client
             .query_one("SELECT current_user", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         frontegg_user
@@ -556,6 +564,7 @@ fn test_auth_expiry() {
     assert_eq!(
         pg_client
             .query_one("SELECT current_user", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         frontegg_user
@@ -567,14 +576,17 @@ fn test_auth_expiry() {
         .store(false, Ordering::Relaxed);
     frontegg_server.wait_for_refresh(EXPIRES_IN_SECS);
     // Sleep until the expiry future should resolve.
-    std::thread::sleep(Duration::from_secs(EXPIRES_IN_SECS + 1));
-    assert!(pg_client.query_one("SELECT current_user", &[]).is_err());
+    tokio::time::sleep(Duration::from_secs(EXPIRES_IN_SECS + 1)).await;
+    assert!(pg_client
+        .query_one("SELECT current_user", &[])
+        .await
+        .is_err());
 }
 
 #[allow(clippy::unit_arg)]
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_base_require_tls_frontegg() {
+async fn test_auth_base_require_tls_frontegg() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -655,6 +667,8 @@ fn test_auth_base_require_tls_frontegg() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
+
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
             admin_api_token_url: frontegg_server.url,
@@ -684,11 +698,13 @@ fn test_auth_base_require_tls_frontegg() {
 
     // Test connecting to a server that requires TLS and uses Materialize Cloud for
     // authentication.
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
+
     run_tests(
         "TlsMode::Require, MzCloud",
         &server,
@@ -1048,17 +1064,18 @@ fn test_auth_base_require_tls_frontegg() {
                 })),
             },
         ],
-    );
+    )
+    .await;
 }
 
 #[allow(clippy::unit_arg)]
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_base_disable_tls() {
+async fn test_auth_base_disable_tls() {
     let no_headers = HeaderMap::new();
 
     // Test TLS modes with a server that does not support TLS.
-    let server = test_util::start_server(test_util::Config::default()).unwrap();
+    let server = test_util::TestHarness::default().start().await;
     run_tests(
         "TlsMode::Disable",
         &server,
@@ -1129,13 +1146,14 @@ fn test_auth_base_disable_tls() {
                 })),
             },
         ],
-    );
+    )
+    .await;
 }
 
 #[allow(clippy::unit_arg)]
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_base_require_tls() {
+async fn test_auth_base_require_tls() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1151,8 +1169,11 @@ fn test_auth_base_require_tls() {
     let no_headers = HeaderMap::new();
 
     // Test TLS modes with a server that requires TLS.
-    let config = test_util::Config::default().with_tls(server_cert, server_key);
-    let server = test_util::start_server(config).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert, server_key)
+        .start()
+        .await;
+
     run_tests(
         "TlsMode::Require",
         &server,
@@ -1237,13 +1258,13 @@ fn test_auth_base_require_tls() {
                 })),
             },
         ],
-    );
-    drop(server);
+    )
+    .await;
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_intermediate_ca_no_intermediary() {
+async fn test_auth_intermediate_ca_no_intermediary() {
     // Create a CA, an intermediate CA, and a server key pair signed by the
     // intermediate CA.
     let ca = Ca::new_root("test ca").unwrap();
@@ -1254,8 +1275,11 @@ fn test_auth_intermediate_ca_no_intermediary() {
 
     // When the server presents only its own certificate, without the
     // intermediary, the client should fail to verify the chain.
-    let config = test_util::Config::default().with_tls(server_cert, server_key);
-    let server = test_util::start_server(config).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert, server_key)
+        .start()
+        .await;
+
     run_tests(
         "TlsMode::Require",
         &server,
@@ -1282,12 +1306,13 @@ fn test_auth_intermediate_ca_no_intermediary() {
                 })),
             },
         ],
-    );
+    )
+    .await;
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_intermediate_ca() {
+async fn test_auth_intermediate_ca() {
     // Create a CA, an intermediate CA, and a server key pair signed by the
     // intermediate CA.
     let ca = Ca::new_root("test ca").unwrap();
@@ -1316,8 +1341,11 @@ fn test_auth_intermediate_ca() {
     // When the server is configured to present the entire certificate chain,
     // the client should be able to verify the chain even though it only knows
     // about the root CA.
-    let config = test_util::Config::default().with_tls(server_cert_chain, server_key);
-    let server = test_util::start_server(config).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_tls(server_cert_chain, server_key)
+        .start()
+        .await;
+
     run_tests(
         "TlsMode::Require",
         &server,
@@ -1339,12 +1367,13 @@ fn test_auth_intermediate_ca() {
                 assert: Assert::Success,
             },
         ],
-    );
+    )
+    .await;
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_admin_non_superuser() {
+async fn test_auth_admin_non_superuser() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1394,6 +1423,8 @@ fn test_auth_admin_non_superuser() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
+
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -1411,11 +1442,12 @@ fn test_auth_admin_non_superuser() {
     let frontegg_basic = Authorization::basic(frontegg_user, frontegg_password);
     let frontegg_header_basic = make_header(frontegg_basic);
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
     run_tests(
         "Non-superuser",
@@ -1447,12 +1479,13 @@ fn test_auth_admin_non_superuser() {
                 assert: Assert::SuccessSuperuserCheck(false),
             },
         ],
-    );
+    )
+    .await;
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_admin_superuser() {
+async fn test_auth_admin_superuser() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1502,6 +1535,8 @@ fn test_auth_admin_superuser() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
+
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -1519,11 +1554,12 @@ fn test_auth_admin_superuser() {
     let admin_frontegg_basic = Authorization::basic(admin_frontegg_user, admin_frontegg_password);
     let admin_frontegg_header_basic = make_header(admin_frontegg_basic);
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
     run_tests(
         "Superuser",
@@ -1555,12 +1591,13 @@ fn test_auth_admin_superuser() {
                 assert: Assert::SuccessSuperuserCheck(true),
             },
         ],
-    );
+    )
+    .await;
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_admin_superuser_revoked() {
+async fn test_auth_admin_superuser_revoked() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1610,6 +1647,8 @@ fn test_auth_admin_superuser_revoked() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mzcloud-frontegg", frontegg_future);
+
     let password_prefix = "mzp_";
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
@@ -1625,25 +1664,28 @@ fn test_auth_admin_superuser_revoked() {
 
     let frontegg_password = &format!("{password_prefix}{client_id}{secret}");
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
-    let mut pg_client = server
-        .pg_config()
+    let pg_client = server
+        .connect()
         .ssl_mode(SslMode::Require)
         .user(frontegg_user)
         .password(frontegg_password)
-        .connect(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
         })))
+        .await
         .unwrap();
 
     assert_eq!(
         pg_client
             .query_one("SHOW is_superuser", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         "off"
@@ -1658,6 +1700,7 @@ fn test_auth_admin_superuser_revoked() {
     assert_eq!(
         pg_client
             .query_one("SHOW is_superuser", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         "on"
@@ -1672,15 +1715,16 @@ fn test_auth_admin_superuser_revoked() {
     assert_eq!(
         pg_client
             .query_one("SHOW is_superuser", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         "off"
     );
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_auth_deduplication() {
+async fn test_auth_deduplication() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1709,6 +1753,8 @@ fn test_auth_deduplication() {
         Some(2),
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mz_cloud-frontegg", frontegg_future);
+
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
             admin_api_token_url: frontegg_server.url.clone(),
@@ -1723,54 +1769,50 @@ fn test_auth_deduplication() {
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("mzp_{client_id}{secret}");
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
     assert_eq!(*frontegg_server.auth_requests.lock().unwrap(), 0);
 
-    let mut pg_client_1_config = server.pg_config_async();
-    let pg_client_1_fut = pg_client_1_config
+    let pg_client_1_fut = server
+        .connect()
         .ssl_mode(SslMode::Require)
         .user(frontegg_user)
         .password(frontegg_password)
-        .connect(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
-        })));
+        })))
+        .into_future();
 
-    let mut pg_client_2_config = server.pg_config_async();
-    let pg_client_2_fut = pg_client_2_config
+    let pg_client_2_fut = server
+        .connect()
         .ssl_mode(SslMode::Require)
         .user(frontegg_user)
         .password(frontegg_password)
-        .connect(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
-        })));
-    let client_fut = futures::future::join(pg_client_1_fut, pg_client_2_fut);
-    let (client_1_result, client_2_result) = server.runtime.block_on(client_fut);
+        })))
+        .into_future();
 
-    let (pg_client_1, pg_client_1_conn) = client_1_result.unwrap();
-    let (pg_client_2, pg_client_2_conn) = client_2_result.unwrap();
+    let (client_1_result, client_2_result) =
+        futures::future::join(pg_client_1_fut, pg_client_2_fut).await;
+    let pg_client_1 = client_1_result.unwrap();
+    let pg_client_2 = client_2_result.unwrap();
 
-    server.runtime.spawn_named(|| "pg-client-1", async move {
-        pg_client_1_conn.await.expect("connection 1 failed");
-    });
-    server.runtime.spawn_named(|| "pg-client-2", async move {
-        pg_client_2_conn.await.expect("connection 2 failed");
-    });
-
-    let frontegg_user_client_1 = server
-        .runtime
-        .block_on(pg_client_1.query_one("SELECT current_user", &[]))
+    let frontegg_user_client_1 = pg_client_1
+        .query_one("SELECT current_user", &[])
+        .await
         .unwrap()
         .get::<_, String>(0);
     assert_eq!(frontegg_user_client_1, frontegg_user);
 
-    let frontegg_user_client_2 = server
-        .runtime
-        .block_on(pg_client_2.query_one("SELECT current_user", &[]))
+    let frontegg_user_client_2 = pg_client_2
+        .query_one("SELECT current_user", &[])
+        .await
         .unwrap()
         .get::<_, String>(0);
     assert_eq!(frontegg_user_client_2, frontegg_user);
@@ -1783,24 +1825,24 @@ fn test_auth_deduplication() {
     assert_eq!(*frontegg_server.refreshes.lock().unwrap(), 1);
 
     // Both clients should still be queryable.
-    let frontegg_user_client_1_post_refresh = server
-        .runtime
-        .block_on(pg_client_1.query_one("SELECT current_user", &[]))
+    let frontegg_user_client_1_post_refresh = pg_client_1
+        .query_one("SELECT current_user", &[])
+        .await
         .unwrap()
         .get::<_, String>(0);
     assert_eq!(frontegg_user_client_1_post_refresh, frontegg_user);
 
-    let frontegg_user_client_2_post_refresh = server
-        .runtime
-        .block_on(pg_client_2.query_one("SELECT current_user", &[]))
+    let frontegg_user_client_2_post_refresh = pg_client_2
+        .query_one("SELECT current_user", &[])
+        .await
         .unwrap()
         .get::<_, String>(0);
     assert_eq!(frontegg_user_client_2_post_refresh, frontegg_user);
 }
 
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(miri, ignore)] // unsupported operation: can't call foreign function `OPENSSL_init_ssl` on OS `linux`
-fn test_refresh_task_metrics() {
+async fn test_refresh_task_metrics() {
     let ca = Ca::new_root("test ca").unwrap();
     let (server_cert, server_key) = ca
         .request_cert("server", vec![IpAddr::V4(Ipv4Addr::LOCALHOST)])
@@ -1829,6 +1871,8 @@ fn test_refresh_task_metrics() {
         None,
     )
     .unwrap();
+    mz_ore::task::spawn(|| "mz_cloud-frontegg", frontegg_future);
+
     let frontegg_auth = FronteggAuthentication::new(
         FronteggConfig {
             admin_api_token_url: frontegg_server.url.clone(),
@@ -1843,25 +1887,28 @@ fn test_refresh_task_metrics() {
     let frontegg_user = "user@_.com";
     let frontegg_password = &format!("mzp_{client_id}{secret}");
 
-    let config = test_util::Config::default()
+    let server = test_util::TestHarness::default()
         .with_tls(server_cert, server_key)
         .with_frontegg(&frontegg_auth)
-        .with_metrics_registry(metrics_registry);
-    let server = test_util::start_server(config).unwrap();
+        .with_metrics_registry(metrics_registry)
+        .start()
+        .await;
 
-    let mut pg_client = server
-        .pg_config()
+    let pg_client = server
+        .connect()
         .ssl_mode(SslMode::Require)
         .user(frontegg_user)
         .password(frontegg_password)
-        .connect(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
+        .with_tls(make_pg_tls(Box::new(|b: &mut SslConnectorBuilder| {
             Ok(b.set_verify(SslVerifyMode::NONE))
         })))
+        .await
         .unwrap();
 
     assert_eq!(
         pg_client
             .query_one("SELECT current_user", &[])
+            .await
             .unwrap()
             .get::<_, String>(0),
         frontegg_user

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -162,162 +162,167 @@ impl MockHttpServer {
     }
 }
 
-#[mz_ore::test]
-fn test_no_block() {
-    // This is better than relying on CI to time out, because an actual failure
-    // (as opposed to a CI timeout) causes `services.log` to be uploaded.
-    mz_ore::test::timeout(Duration::from_secs(120), || {
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_no_block() {
+    // We manually time out the test because it's better than relying on CI to time out, because
+    // an actual failure (as opposed to a CI timeout) causes `services.log` to be uploaded.
+    let test_case = async move {
         println!("test_no_block: starting server");
-        let server = test_util::start_server(test_util::Config::default()).unwrap();
-        server.enable_feature_flags(&["enable_connection_validation_syntax"]);
+        let server = test_util::TestHarness::default().start().await;
+        server
+            .enable_feature_flags(&["enable_connection_validation_syntax"])
+            .await;
 
-        server.runtime.block_on(async {
-            println!("test_no_block: starting mock HTTP server");
-            let mut schema_registry_server = MockHttpServer::new();
+        println!("test_no_block: starting mock HTTP server");
+        let mut schema_registry_server = MockHttpServer::new();
 
-            println!("test_no_block: connecting to server");
-            let (client, _conn) = server.connect_async(postgres::NoTls).await.unwrap();
+        println!("test_no_block: connecting to server");
+        let client = server.connect().await.unwrap();
 
-            let slow_task = task::spawn(|| "slow_client", async move {
-                println!("test_no_block: in thread; executing create source");
-                let result = client
+        let slow_task = task::spawn(|| "slow_client", async move {
+            println!("test_no_block: in thread; executing create source");
+            let result = client
                 .batch_execute(&format!(
                     "CREATE CONNECTION IF NOT EXISTS csr_conn TO CONFLUENT SCHEMA REGISTRY (URL 'http://{}') WITH (VALIDATE = false);",
                     schema_registry_server.addr,
                 ))
                 .await;
-                println!("test_no_block: in thread; create CSR conn done");
-                let _ = result.unwrap();
+            println!("test_no_block: in thread; create CSR conn done");
+            let _ = result.unwrap();
 
-                let result = client
+            let result = client
                     .batch_execute(&format!(
                         "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}', SECURITY PROTOCOL PLAINTEXT) WITH (VALIDATE = false)",
                         &*KAFKA_ADDRS,
                     ))
                     .await;
-                println!("test_no_block: in thread; create Kafka conn done");
-                let _ = result.unwrap();
+            println!("test_no_block: in thread; create Kafka conn done");
+            let _ = result.unwrap();
 
-                let result = client
-                    .batch_execute(
-                        "CREATE SOURCE foo \
+            let result = client
+                .batch_execute(
+                    "CREATE SOURCE foo \
                         FROM KAFKA CONNECTION kafka_conn (TOPIC 'foo') \
                         FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn",
-                    )
-                    .await;
-                println!("test_no_block: in thread; create source done");
-                // Verify that the schema registry error was returned to the client, for
-                // good measure.
-                assert_contains!(result.unwrap_err().to_string(), "server error 503");
-            });
+                )
+                .await;
+            println!("test_no_block: in thread; create source done");
+            // Verify that the schema registry error was returned to the client, for
+            // good measure.
+            assert_contains!(result.unwrap_err().to_string(), "server error 503");
+        });
 
-            // Wait for Materialize to contact the schema registry, which
-            // indicates the adapter is processing the CREATE SOURCE command. It
-            // will be unable to complete the query until we respond.
-            println!("test_no_block: accepting fake schema registry connection");
-            let response_tx = schema_registry_server.accept().await;
+        // Wait for Materialize to contact the schema registry, which
+        // indicates the adapter is processing the CREATE SOURCE command. It
+        // will be unable to complete the query until we respond.
+        println!("test_no_block: accepting fake schema registry connection");
+        let response_tx = schema_registry_server.accept().await;
 
-            // Verify that the adapter can still process other requests from
-            // other sessions.
-            println!("test_no_block: connecting to server again");
-            let (client, _conn) = server.connect_async(postgres::NoTls).await.unwrap();
-            println!("test_no_block: executing query");
-            let answer: i32 = client.query_one("SELECT 1 + 1", &[]).await.unwrap().get(0);
-            assert_eq!(answer, 2);
+        // Verify that the adapter can still process other requests from
+        // other sessions.
+        println!("test_no_block: connecting to server again");
+        let client = server.connect().await.unwrap();
+        println!("test_no_block: executing query");
+        let answer: i32 = client.query_one("SELECT 1 + 1", &[]).await.unwrap().get(0);
+        assert_eq!(answer, 2);
 
-            // Return an error to the adapter, so that we can shutdown cleanly.
-            println!("test_no_block: writing fake schema registry error");
-            response_tx
-                .send(StatusCode::SERVICE_UNAVAILABLE.into_response())
-                .expect("server unexpectedly closed channel");
+        // Return an error to the adapter, so that we can shutdown cleanly.
+        println!("test_no_block: writing fake schema registry error");
+        response_tx
+            .send(StatusCode::SERVICE_UNAVAILABLE.into_response())
+            .expect("server unexpectedly closed channel");
 
-            println!("test_no_block: joining task");
-            slow_task.await.unwrap();
+        println!("test_no_block: joining task");
+        slow_task.await.unwrap();
+    };
 
-            Ok(())
-        })
-    }).expect("Test timed out");
+    tokio::time::timeout(Duration::from_secs(120), test_case)
+        .await
+        .expect("Test timed out");
 }
 
 /// Test that dropping a connection while a source is undergoing purification
 /// does not crash the server.
-#[mz_ore::test]
-fn test_drop_connection_race() {
-    let server = test_util::start_server(test_util::Config::default().unsafe_mode()).unwrap();
-    server.enable_feature_flags(&["enable_connection_validation_syntax"]);
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_drop_connection_race() {
+    let server = test_util::TestHarness::default()
+        .unsafe_mode()
+        .start()
+        .await;
+    server
+        .enable_feature_flags(&["enable_connection_validation_syntax"])
+        .await;
     info!("test_drop_connection_race: server started");
 
-    server.runtime.block_on(async {
-        info!("test_drop_connection_race: starting mock HTTP server");
-        let mut schema_registry_server = MockHttpServer::new();
+    info!("test_drop_connection_race: starting mock HTTP server");
+    let mut schema_registry_server = MockHttpServer::new();
 
-        // Construct a source that depends on a schema registry connection.
-        let (client, _conn) = server.connect_async(postgres::NoTls).await.unwrap();
-        client
-            .batch_execute(&format!(
-                "CREATE CONNECTION conn TO CONFLUENT SCHEMA REGISTRY (URL 'http://{}') WITH (VALIDATE = false)",
-                schema_registry_server.addr,
-            ))
-            .await
-            .unwrap();
-        client
-            .batch_execute(&format!(
-                "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}', SECURITY PROTOCOL PLAINTEXT) WITH (VALIDATE = false)",
-                &*KAFKA_ADDRS,
-            ))
-            .await
-            .unwrap();
-        let source_task = task::spawn(|| "source_client", async move {
-            info!("test_drop_connection_race: in task; creating connection and source");
-            let result = client
-                .batch_execute(
-                    "CREATE SOURCE foo \
+    // Construct a source that depends on a schema registry connection.
+    let client = server.connect().await.unwrap();
+    client
+        .batch_execute(&format!(
+            "CREATE CONNECTION conn TO CONFLUENT SCHEMA REGISTRY (URL 'http://{}') WITH (VALIDATE = false)",
+            schema_registry_server.addr,
+        ))
+        .await
+        .unwrap();
+    client
+        .batch_execute(&format!(
+            "CREATE CONNECTION kafka_conn TO KAFKA (BROKER '{}', SECURITY PROTOCOL PLAINTEXT) WITH (VALIDATE = false)",
+            &*KAFKA_ADDRS,
+        ))
+        .await
+        .unwrap();
+    let source_task = task::spawn(|| "source_client", async move {
+        info!("test_drop_connection_race: in task; creating connection and source");
+        let result = client
+            .batch_execute(
+                "CREATE SOURCE foo \
                      FROM KAFKA CONNECTION kafka_conn (TOPIC 'foo') \
                      FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION conn",
-                )
-                .await;
-            info!(
-                "test_drop_connection_race: in task; create source done: {:?}",
-                result
-            );
+            )
+            .await;
+        info!(
+            "test_drop_connection_race: in task; create source done: {:?}",
             result
-        });
-
-        // Wait for Materialize to contact the schema registry, which indicates
-        // the adapter is processing the CREATE SOURCE command. It will be
-        // unable to complete the query until we respond.
-        info!("test_drop_connection_race: accepting fake schema registry connection");
-        let response_tx = schema_registry_server.accept().await;
-
-        // Drop the connection on which the source depends.
-        info!("test_drop_connection_race: dropping connection");
-        let (client, _conn) = server.connect_async(postgres::NoTls).await.unwrap();
-        client.batch_execute("DROP CONNECTION conn").await.unwrap();
-
-        let schema = Json(json!({
-            "id": 1_i64,
-            "subject": "foo-value",
-            "version": 1_i64,
-            "schema": r#"{"type": "long"}"#,
-        }));
-
-        info!("test_drop_connection_race: sending fake schema registry response");
-        response_tx
-            .send(schema.clone().into_response())
-            .expect("server unexpectedly closed channel");
-        info!("test_drop_connection_race: sending fake schema registry response again");
-        let response_tx = schema_registry_server.accept().await;
-        response_tx
-            .send(schema.into_response())
-            .expect("server unexpectedly closed channel");
-
-        info!("test_drop_connection_race: asserting response");
-        let source_res = source_task.await.unwrap();
-        assert_contains!(
-            source_res.unwrap_err().to_string(),
-            "unknown catalog item 'conn'"
         );
+        result
     });
+
+    // Wait for Materialize to contact the schema registry, which indicates
+    // the adapter is processing the CREATE SOURCE command. It will be
+    // unable to complete the query until we respond.
+    info!("test_drop_connection_race: accepting fake schema registry connection");
+    let response_tx = schema_registry_server.accept().await;
+
+    // Drop the connection on which the source depends.
+    info!("test_drop_connection_race: dropping connection");
+    let client = server.connect().await.unwrap();
+    client.batch_execute("DROP CONNECTION conn").await.unwrap();
+
+    let schema = Json(json!({
+        "id": 1_i64,
+        "subject": "foo-value",
+        "version": 1_i64,
+        "schema": r#"{"type": "long"}"#,
+    }));
+
+    info!("test_drop_connection_race: sending fake schema registry response");
+    response_tx
+        .send(schema.clone().into_response())
+        .expect("server unexpectedly closed channel");
+    info!("test_drop_connection_race: sending fake schema registry response again");
+    let response_tx = schema_registry_server.accept().await;
+    response_tx
+        .send(schema.into_response())
+        .expect("server unexpectedly closed channel");
+
+    info!("test_drop_connection_race: asserting response");
+    let source_res = source_task.await.unwrap();
+    assert_contains!(
+        source_res.unwrap_err().to_string(),
+        "unknown catalog item 'conn'"
+    );
 }
 
 #[mz_ore::test]
@@ -446,22 +451,30 @@ fn test_subscribe_negative_diffs() {
     assert_eq!(row.get::<_, i64>("count"), 2);
 }
 
-#[mz_ore::test]
-fn test_empty_subscribe_notice() {
-    let config = test_util::Config::default().with_now(NOW_ZERO.clone());
-    let server = test_util::start_server(config).unwrap();
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_empty_subscribe_notice() {
+    let server = test_util::TestHarness::default()
+        .with_now(NOW_ZERO.clone())
+        .start()
+        .await;
+
     let (tx, mut rx) = futures::channel::mpsc::unbounded();
-    let mut client = server
-        .pg_config()
+    let client = server
+        .connect()
         .notice_callback(move |notice| tx.unbounded_send(notice).unwrap())
-        .connect(postgres::NoTls)
+        .await
         .unwrap();
 
-    client.batch_execute("CREATE TABLE t (a int)").unwrap();
-    let now = test_util::get_explain_timestamp("t", &mut client);
+    client
+        .batch_execute("CREATE TABLE t (a int)")
+        .await
+        .unwrap();
+    let now = test_util::get_explain_timestamp("t", &client).await;
     client
         .batch_execute(&format!("SUBSCRIBE TO t AS OF {now} UP TO {now}"))
+        .await
         .unwrap();
+
     Retry::default()
         .max_duration(Duration::from_secs(10))
         .retry(|_| {
@@ -477,16 +490,22 @@ fn test_empty_subscribe_notice() {
         .unwrap();
 }
 
-#[mz_ore::test]
-fn test_empty_subscribe_error() {
-    let config = test_util::Config::default().with_now(NOW_ZERO.clone());
-    let server = test_util::start_server(config).unwrap();
-    let mut client = server.connect(postgres::NoTls).unwrap();
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_empty_subscribe_error() {
+    let server = test_util::TestHarness::default()
+        .with_now(NOW_ZERO.clone())
+        .start()
+        .await;
+    let client = server.connect().await.unwrap();
 
-    client.batch_execute("CREATE TABLE t (a int)").unwrap();
-    let now = test_util::get_explain_timestamp("t", &mut client);
+    client
+        .batch_execute("CREATE TABLE t (a int)")
+        .await
+        .unwrap();
+    let now = test_util::get_explain_timestamp("t", &client).await;
     let e = client
         .batch_execute(&format!("SUBSCRIBE TO t AS OF {now} UP TO {}", now - 1))
+        .await
         .expect_err("expected DB error");
     let e = e.as_db_error().expect("expected DB error");
     assert!(e.code().code() == "22000")
@@ -1098,38 +1117,28 @@ fn test_subscribe_empty_upper_frontier() {
 
 // Tests that a client that launches a non-terminating SUBSCRIBE and disconnects
 // does not keep the server alive forever.
-#[mz_ore::test]
-fn test_subscribe_shutdown() {
-    let server = test_util::start_server(test_util::Config::default()).unwrap();
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn test_subscribe_shutdown() {
+    let server = test_util::TestHarness::default().start().await;
 
-    // We have to use the async PostgreSQL client so that we can ungracefully
-    // abort the connection task.
-    // See: https://github.com/sfackler/rust-postgres/issues/725
-    server
-        .runtime
-        .block_on(async {
-            let (client, conn_task) = server.connect_async(tokio_postgres::NoTls).await.unwrap();
+    let (client, conn_task) = server.connect().with_handle().await.unwrap();
 
-            // Create a table with no data that we can SUBSCRIBE. This is the simplest
-            // way to cause a SUBSCRIBE to never terminate.
-            client.batch_execute("CREATE TABLE t ()").await.unwrap();
+    // Create a table with no data that we can SUBSCRIBE. This is the simplest
+    // way to cause a SUBSCRIBE to never terminate.
+    client.batch_execute("CREATE TABLE t ()").await.unwrap();
 
-            // Launch the ill-fated subscribe.
-            client
-                .copy_out("COPY (SUBSCRIBE t) TO STDOUT")
-                .await
-                .unwrap();
-
-            // Un-gracefully abort the connection.
-            conn_task.abort();
-
-            // Need to await `conn_task` to actually deliver the `abort`. We don't
-            // care about the result though (it's probably `JoinError` with `is_cancelled` being true).
-            let _ = conn_task.await;
-
-            Ok::<_, Box<dyn Error>>(())
-        })
+    // Launch the ill-fated subscribe.
+    client
+        .copy_out("COPY (SUBSCRIBE t) TO STDOUT")
+        .await
         .unwrap();
+
+    // Un-gracefully abort the connection.
+    conn_task.abort();
+
+    // Need to await `conn_task` to actually deliver the `abort`. We don't
+    // care about the result though (it's probably `JoinError` with `is_cancelled` being true).
+    let _ = conn_task.await;
 
     // Dropping the server will initiate a graceful shutdown. We previously had
     // a bug where the server would fail to notice that the client running
@@ -1421,9 +1430,9 @@ fn test_transactional_explain_timestamps() {
 //
 // Feel free to modify this test if that product requirement changes,
 // but please at least keep _something_ that tests that custom compaction windows are working.
-#[mz_ore::test]
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
 #[cfg_attr(coverage, ignore)] // https://github.com/MaterializeInc/materialize/issues/18934
-fn test_utilization_hold() {
+async fn test_utilization_hold() {
     const THIRTY_DAYS_MS: u64 = 30 * 24 * 60 * 60 * 1000;
     // `mz_introspection` tests indexes, `default` tests tables.
     // The bool determines whether we are testing indexes.
@@ -1440,26 +1449,28 @@ fn test_utilization_hold() {
         NowFn::from(move || *timestamp.lock().unwrap())
     };
     let data_dir = tempfile::tempdir().unwrap();
-    let config = test_util::Config::default()
-        .with_now(now_fn)
-        .data_directory(data_dir.path());
 
     // Create the server with the past time, to make sure the table is created.
-    let server = test_util::start_server(config).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_now(now_fn)
+        .data_directory(data_dir.path())
+        .start()
+        .await;
 
     // Fast-forward time to make sure the table is still readable at the old time.
     *now.lock().unwrap() = now_millis;
 
-    let mut client = server.connect(postgres::NoTls).unwrap();
+    let client = server.connect().await.unwrap();
 
     for q in QUERIES_TO_TRY {
         let explain_q = &format!("EXPLAIN TIMESTAMP AS JSON FOR {q}");
         for cluster in CLUSTERS_TO_TRY {
             client
                 .execute(&format!("SET cluster={cluster}"), &[])
+                .await
                 .unwrap();
 
-            let row = client.query_one(explain_q, &[]).unwrap();
+            let row = client.query_one(explain_q, &[]).await.unwrap();
             let explain: String = row.get(0);
             let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
 
@@ -1489,22 +1500,25 @@ fn test_utilization_hold() {
     }
 
     // Check that we can turn off retention
-    let mut sys_client = server
-        .pg_config_internal()
+    let sys_client = server
+        .connect()
+        .internal()
         .user(&SYSTEM_USER.name)
-        .connect(postgres::NoTls)
+        .await
         .unwrap();
 
     sys_client
         .execute("ALTER SYSTEM SET metrics_retention='1s'", &[])
+        .await
         .unwrap();
     for q in QUERIES_TO_TRY {
         let explain_q = &format!("EXPLAIN TIMESTAMP AS JSON FOR {q}");
         for cluster in CLUSTERS_TO_TRY {
             client
                 .execute(&format!("SET cluster={cluster}"), &[])
+                .await
                 .unwrap();
-            let row = client.query_one(explain_q, &[]).unwrap();
+            let row = client.query_one(explain_q, &[]).await.unwrap();
             let explain: String = row.get(0);
             let explain: TimestampExplanation<Timestamp> = serde_json::from_str(&explain).unwrap();
             let since = explain
@@ -1524,57 +1538,54 @@ fn test_utilization_hold() {
 // forever) when a client is terminated (disconnects from the server) instead
 // of cancelled (sends a pgwire cancel request on a new connection).
 #[ignore] // TODO(necaris): Re-enable this as soon as possible
-#[mz_ore::test]
-fn test_github_12546() {
-    let config = test_util::Config::default().with_propagate_crashes(false);
-    let server = test_util::start_server(config).unwrap();
-    server.enable_feature_flags(&["enable_dangerous_functions"]);
-
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn test_github_12546() {
+    let server = test_util::TestHarness::default()
+        .with_propagate_crashes(false)
+        .start()
+        .await;
     server
-        .runtime
-        .block_on(async {
-            let (client, conn_task) = server.connect_async(tokio_postgres::NoTls).await.unwrap();
+        .enable_feature_flags(&["enable_dangerous_functions"])
+        .await;
 
-            client
-                .batch_execute("CREATE TABLE test(a text);")
-                .await
-                .unwrap();
-            client
-                .batch_execute("INSERT INTO test VALUES ('a');")
-                .await
-                .unwrap();
+    let (client, conn_task) = server.connect().with_handle().await.unwrap();
 
-            let query = client.query("SELECT mz_internal.mz_panic(a) FROM test", &[]);
-            let timeout = tokio::time::timeout(Duration::from_secs(2), query);
-            // We expect the timeout to trigger because the query should be crashing the
-            // compute instance.
-            assert_eq!(
-                timeout.await.unwrap_err().to_string(),
-                "deadline has elapsed"
-            );
-
-            // Aborting the connection should cause its pending queries to be cancelled,
-            // allowing the compute instances to stop crashing while trying to execute
-            // them.
-            conn_task.abort();
-
-            // Need to await `conn_task` to actually deliver the `abort`.
-            let _ = conn_task.await;
-
-            // Make a new connection to verify the compute instance can now start.
-            let (client, _conn_task) = server.connect_async(tokio_postgres::NoTls).await.unwrap();
-            assert_eq!(
-                client
-                    .query_one("SELECT count(*) FROM test", &[])
-                    .await
-                    .unwrap()
-                    .get::<_, i64>(0),
-                1,
-            );
-
-            Ok::<_, Box<dyn Error>>(())
-        })
+    client
+        .batch_execute("CREATE TABLE test(a text);")
+        .await
         .unwrap();
+    client
+        .batch_execute("INSERT INTO test VALUES ('a');")
+        .await
+        .unwrap();
+
+    let query = client.query("SELECT mz_internal.mz_panic(a) FROM test", &[]);
+    let timeout = tokio::time::timeout(Duration::from_secs(2), query);
+    // We expect the timeout to trigger because the query should be crashing the
+    // compute instance.
+    assert_eq!(
+        timeout.await.unwrap_err().to_string(),
+        "deadline has elapsed"
+    );
+
+    // Aborting the connection should cause its pending queries to be cancelled,
+    // allowing the compute instances to stop crashing while trying to execute
+    // them.
+    conn_task.abort();
+
+    // Need to await `conn_task` to actually deliver the `abort`.
+    let _ = conn_task.await;
+
+    // Make a new connection to verify the compute instance can now start.
+    let client = server.connect().await.unwrap();
+    assert_eq!(
+        client
+            .query_one("SELECT count(*) FROM test", &[])
+            .await
+            .unwrap()
+            .get::<_, i64>(0),
+        1,
+    );
 }
 
 #[mz_ore::test]
@@ -1723,120 +1734,136 @@ fn test_read_then_write_serializability() {
     }
 }
 
-#[mz_ore::test]
-fn test_timestamp_recovery() {
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_timestamp_recovery() {
     let now = Arc::new(Mutex::new(1));
     let now_fn = {
         let timestamp = Arc::clone(&now);
         NowFn::from(move || *timestamp.lock().unwrap())
     };
     let data_dir = tempfile::tempdir().unwrap();
-    let config = test_util::Config::default()
+    let harness = test_util::TestHarness::default()
         .with_now(now_fn)
         .data_directory(data_dir.path());
 
     // Start a server and get the current global timestamp
     let global_timestamp = {
-        let server = test_util::start_server(config.clone()).unwrap();
-        let mut client = server.connect(postgres::NoTls).unwrap();
+        let server = harness.clone().start().await;
+        let client = server.connect().await.unwrap();
 
-        client.batch_execute("CREATE TABLE t1 (i1 INT)").unwrap();
-        test_util::get_explain_timestamp("t1", &mut client)
+        client
+            .batch_execute("CREATE TABLE t1 (i1 INT)")
+            .await
+            .unwrap();
+        test_util::get_explain_timestamp("t1", &client).await
     };
 
     // Rollback the current time and ensure that a value larger than the old global timestamp is
     // recovered
     {
         *now.lock().expect("lock poisoned") = 0;
-        let server = test_util::start_server(config).unwrap();
-        let mut client = server.connect(postgres::NoTls).unwrap();
-        let recovered_timestamp = test_util::get_explain_timestamp("t1", &mut client);
+        let server = harness.clone().start().await;
+        let client = server.connect().await.unwrap();
+        let recovered_timestamp = test_util::get_explain_timestamp("t1", &client).await;
         assert!(recovered_timestamp > global_timestamp);
     }
 }
 
-#[mz_ore::test]
-fn test_timeline_read_holds() {
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 1))]
+async fn test_timeline_read_holds() {
     // Set the timestamp to zero for deterministic initial timestamps.
     let now = Arc::new(Mutex::new(0));
     let now_fn = {
         let now = Arc::clone(&now);
         NowFn::from(move || *now.lock().unwrap())
     };
-    let config = test_util::Config::default().with_now(now_fn).unsafe_mode();
-    let server = test_util::start_server(config).unwrap();
-    let mut mz_client = server.connect(postgres::NoTls).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_now(now_fn)
+        .unsafe_mode()
+        .start()
+        .await;
+    let mz_client = server.connect().await.unwrap();
 
     let view_name = "v_hold";
     let source_name = "source_hold";
-    let (mut pg_client, cleanup_fn) = test_util::create_postgres_source_with_table(
-        &server.runtime,
-        &mut mz_client,
-        view_name,
-        "(a INT)",
-        source_name,
-    )
-    .unwrap();
+    let (pg_client, cleanup_fn) =
+        test_util::create_postgres_source_with_table(&mz_client, view_name, "(a INT)", source_name)
+            .await
+            .unwrap();
 
     // Create user table in Materialize.
-    mz_client.batch_execute("DROP TABLE IF EXISTS t;").unwrap();
-    mz_client.batch_execute("CREATE TABLE t (a INT);").unwrap();
+    mz_client
+        .batch_execute("DROP TABLE IF EXISTS t;")
+        .await
+        .unwrap();
+    mz_client
+        .batch_execute("CREATE TABLE t (a INT);")
+        .await
+        .unwrap();
     test_util::insert_with_deterministic_timestamps("t", "(42)", &server, Arc::clone(&now))
+        .await
         .unwrap();
 
     // Insert data into source.
     let source_rows: i64 = 10;
     for _ in 0..source_rows {
-        let _ = server
-            .runtime
-            .block_on(pg_client.execute(&format!("INSERT INTO {view_name} VALUES (42);"), &[]))
+        let _ = pg_client
+            .execute(&format!("INSERT INTO {view_name} VALUES (42);"), &[])
+            .await
             .unwrap();
     }
 
-    test_util::wait_for_view_population(&mut mz_client, view_name, source_rows).unwrap();
+    test_util::wait_for_view_population(&mz_client, view_name, source_rows)
+        .await
+        .unwrap();
 
     // Make sure that the table and view are joinable immediately at some timestamp.
-    let mut mz_join_client = server.connect(postgres::NoTls).unwrap();
-    let _ = mz_ore::test::timeout(Duration::from_millis(2_000), move || {
-        Ok(mz_join_client
-            .query_one(&format!("SELECT COUNT(t.a) FROM t, {view_name};"), &[])
-            .unwrap()
-            .get::<_, i64>(0))
+    let mz_join_client = server.connect().await.unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(2_000), async move {
+        Ok::<_, anyhow::Error>(
+            mz_join_client
+                .query_one(&format!("SELECT COUNT(t.a) FROM t, {view_name};"), &[])
+                .await
+                .unwrap()
+                .get::<_, i64>(0),
+        )
     })
+    .await
     .unwrap();
 
-    cleanup_fn(&mut mz_client, &mut pg_client, &server.runtime).unwrap();
+    cleanup_fn(&mz_client, &pg_client).await.unwrap();
 }
 
-#[mz_ore::test]
-fn test_linearizability() {
+#[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+async fn test_linearizability() {
     // Set the timestamp to zero for deterministic initial timestamps.
     let now = Arc::new(Mutex::new(0));
     let now_fn = {
         let now = Arc::clone(&now);
         NowFn::from(move || *now.lock().unwrap())
     };
-    let config = test_util::Config::default().with_now(now_fn).unsafe_mode();
-    let server = test_util::start_server(config).unwrap();
-    let mut mz_client = server.connect(postgres::NoTls).unwrap();
+    let server = test_util::TestHarness::default()
+        .with_now(now_fn)
+        .unsafe_mode()
+        .start()
+        .await;
+    let mz_client = server.connect().await.unwrap();
 
     let view_name = "v_lin";
     let source_name = "source_lin";
-    let (mut pg_client, cleanup_fn) = test_util::create_postgres_source_with_table(
-        &server.runtime,
-        &mut mz_client,
-        view_name,
-        "(a INT)",
-        source_name,
-    )
-    .unwrap();
+    let (pg_client, cleanup_fn) =
+        test_util::create_postgres_source_with_table(&mz_client, view_name, "(a INT)", source_name)
+            .await
+            .unwrap();
     // Insert value into postgres table.
-    let _ = server
-        .runtime
-        .block_on(pg_client.execute(&format!("INSERT INTO {view_name} VALUES (42);"), &[]))
+    let _ = pg_client
+        .execute(&format!("INSERT INTO {view_name} VALUES (42);"), &[])
+        .await
         .unwrap();
 
-    test_util::wait_for_view_population(&mut mz_client, view_name, 1).unwrap();
+    test_util::wait_for_view_population(&mz_client, view_name, 1)
+        .await
+        .unwrap();
 
     // The user table's write frontier will be close to zero because we use a deterministic
     // now function in this test. It may be slightly higher than zero because bootstrapping
@@ -1849,33 +1876,48 @@ fn test_linearizability() {
 
     mz_client
         .batch_execute("SET transaction_isolation = serializable")
+        .await
         .unwrap();
-    let view_ts = test_util::get_explain_timestamp(view_name, &mut mz_client);
+    let view_ts = test_util::get_explain_timestamp(view_name, &mz_client).await;
+
     // Create user table in Materialize.
-    mz_client.batch_execute("DROP TABLE IF EXISTS t;").unwrap();
-    mz_client.batch_execute("CREATE TABLE t (a INT);").unwrap();
-    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
+    mz_client
+        .batch_execute("DROP TABLE IF EXISTS t;")
+        .await
+        .unwrap();
+    mz_client
+        .batch_execute("CREATE TABLE t (a INT);")
+        .await
+        .unwrap();
+    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mz_client).await;
+
     // In serializable transaction isolation, read timestamps can go backwards.
     assert!(join_ts < view_ts);
 
     mz_client
         .batch_execute("SET transaction_isolation = 'strict serializable'")
+        .await
         .unwrap();
-    let view_ts = test_util::get_explain_timestamp(view_name, &mut mz_client);
-    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
+
+    let view_ts = test_util::get_explain_timestamp(view_name, &mz_client).await;
+    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mz_client).await;
+
     // Since the query on the join was done after the query on the view, it should have a higher or
     // equal timestamp in strict serializable mode.
     assert!(join_ts >= view_ts);
 
     mz_client
         .batch_execute("SET transaction_isolation = serializable")
+        .await
         .unwrap();
-    let view_ts = test_util::get_explain_timestamp(view_name, &mut mz_client);
-    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mut mz_client);
+
+    let view_ts = test_util::get_explain_timestamp(view_name, &mz_client).await;
+    let join_ts = test_util::get_explain_timestamp(&format!("{view_name}, t"), &mz_client).await;
+
     // If we go back to serializable, then timestamps can revert again.
     assert!(join_ts < view_ts);
 
-    cleanup_fn(&mut mz_client, &mut pg_client, &server.runtime).unwrap();
+    cleanup_fn(&mz_client, &pg_client).await.unwrap();
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
This PR only touches test code.

In this PR we refactor the `environmentd` (and `balancerd`) tests to be "async by default". There are a couple of key changes:

1. All helpers in `test_utils.rs` are refactored to be async. They no longer take a runtime as an argument, or create a runtime themselves.
2. The test `Config` has been refactored to `TestHarness`, which is a struct that handles test configuration and starting the `enviromentd` server. There are two modes a `TestHarness` can be created in, either `async fn start()` or `fn start_blocking()`.
    * `async fn start()` returns a `TestServer`, where all of the helper methods return `tokio_postgres` types, and thus are `async`.
    * `fn start_blocking()` returns a `TestServerWithRuntime`, where all of the helper methods return `postgres` types, and thus are synchronous/blocking.

The goal with the `TestHarness` change was to make migrating existing synchronous tests easy. The first part of that is the split between sync and async types, the other part is code refactoring. For example a sync test might look like:

```
let server = TestHarness::default().start_blocking();
```

to refactor it to the async variant all you need to do is:

```
let server = TestHarness::default().start().await;
```

3. The async version, i.e. `TestServer`, has a single `fn connect(...)` method which returns a `ConnectBuilder`. Instead of multiple different methods to configure how we want to connect to the running `environmentd` server, it's now bundled into this builder. The goal here was to reduce boilerplate and make it just as easy to use an async client as it is the sync client, e.g. handling notices with a `tokio_postgres` client isn't very straight forward.

For example, if you just want to run some queries against the test server:

```
let client = server.connect().await.unwrap();
``` 

or if you want to configure the TLS used:

```
let client = server.connect().with_tls(...).await.unwrap();
```

and much more:

```
let (client, conn_handle) = server.connect()
    .user("parker")
    .password("1234")
    .dbname("test")
    .notice_callback(move |notice| notice_tx.send(notice))
    .with_tls(...)
    .with_handle()
    .await
    .unwrap();
```

### Motivation

Making changes to our `environmentd` tests was painful because our tests and test utils were split between async and synchronous. For example, making changes to fix issues like https://github.com/MaterializeInc/materialize/issues/22432 would end up being more complicated than necessary because some tests would rely on both async and sync test helpers.

### Tips for reviewer

Removing white space would be useful, and this PR is split into 3 commits which can be reviewed independently:

1. Changes to `test_utils.rs` to make all helpers async, and introduce the split between `TestServer` and `TestServerWithRuntime`, as well as introduce `ConnectBuilder`.
2. Refactoring a number of tests to be async, i.e. use `#[mz_ore::test(tokio::test)]`. Any tests that now relied on an async helper, or was already spawning futures on a runtime, were refactored.
3. Refactoring all remaining tests to use the new `let server = TestHarness::default().start_blocking()` API. There are no functional changes in this commit, just code movement.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a, only changes testing code
