### PR TITLE
adapter: upgrade parameter sync logging to INFO

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1155,13 +1155,13 @@ impl Catalog {
                     .map(|param| {
                         let name = param.name;
                         let value = param.value;
-                        tracing::debug!(name, value, "sync parameter");
+                        tracing::info!(name, value, initial = true, "sync parameter");
                         (name, OwnedVarInput::Flat(value))
                     })
                     .chain(std::iter::once({
                         let name = CONFIG_HAS_SYNCED_ONCE.name().to_string();
                         let value = true.to_string();
-                        tracing::debug!(name, value, "sync parameter");
+                        tracing::info!(name, value, initial = true, "sync parameter");
                         (name, OwnedVarInput::Flat(value))
                     }))
                     .collect::<Vec<_>>();

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -10,7 +10,7 @@
 use std::collections::BTreeMap;
 
 use mz_sql::session::user::SYSTEM_USER;
-use tracing::{debug, error};
+use tracing::{error, info};
 
 use crate::config::SynchronizedParameters;
 use crate::{AdapterError, Client, SessionClient};
@@ -40,7 +40,7 @@ impl SystemParameterBackend {
             vars.insert(param.name.clone(), param.value.clone());
             match self.session_client.set_system_vars(vars).await {
                 Ok(()) => {
-                    debug!(name = param.name, value = param.value, "sync parameter");
+                    info!(name = param.name, value = param.value, "sync parameter");
                 }
                 Err(error) => {
                     error!(


### PR DESCRIPTION
This allows us to discover which configs were active on a given environment at a given time when debugging a past incident. The volume of these log lines should be pretty low given that we don't update LD flags all the time.

### Motivation

  * This PR improves internal observability.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A
