### PR TITLE
balancerd: re-resolve each request with static

### DIFF
--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -159,7 +159,7 @@ fn test_balancer() {
     assert_eq!(res, 4);
 
     let resolvers = vec![
-        Resolver::Static(envd_server.inner.balancer_sql_local_addr()),
+        Resolver::Static(envd_server.inner.balancer_sql_local_addr().to_string()),
         Resolver::Frontegg(FronteggResolver {
             auth: frontegg_auth,
             addr_template: envd_server.inner.balancer_sql_local_addr().to_string(),


### PR DESCRIPTION
Teach the static resolver (not used in production, tests only) to re-resolve on each connection. This allows a restarting envd to be found.

Fixes #23271

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a