### PR TITLE
rbac: Allow mz_support to read progress sources

### DIFF
--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -817,7 +817,7 @@ impl Catalog {
                 .unwrap_or_else(|| "new".to_string());
 
             if !config.skip_migrations {
-                migrate::migrate(&mut state, &mut txn, config.now, config.connection_context)
+                migrate::migrate(&state, &mut txn, config.now, config.connection_context)
                     .await
                     .map_err(|e| {
                         Error::new(ErrorKind::FailedMigration {

--- a/src/catalog/src/memory/objects.rs
+++ b/src/catalog/src/memory/objects.rs
@@ -791,6 +791,17 @@ impl CatalogItem {
         }
     }
 
+    /// Reports whether this catalog entry is a progress source.
+    pub fn is_progress_source(&self) -> bool {
+        matches!(
+            self,
+            CatalogItem::Source(Source {
+                data_source: DataSourceDesc::Progress,
+                ..
+            })
+        )
+    }
+
     /// Collects the identifiers of the objects that were encountered when
     /// resolving names in the item's DDL statement.
     pub fn uses(&self) -> &ResolvedIds {
@@ -1237,6 +1248,11 @@ impl CatalogEntry {
             ),
             _ => false,
         }
+    }
+
+    /// Reports whether this catalog entry is a progress source.
+    pub fn is_progress_source(&self) -> bool {
+        self.item().is_progress_source()
     }
 
     /// Returns the `GlobalId` of all of this entry's subsources.
@@ -1953,6 +1969,10 @@ impl mz_sql::catalog::CatalogItem for CatalogEntry {
 
     fn is_subsource(&self) -> bool {
         self.is_subsource()
+    }
+
+    fn is_progress_source(&self) -> bool {
+        self.is_progress_source()
     }
 
     fn subsources(&self) -> BTreeSet<GlobalId> {

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -585,6 +585,9 @@ pub trait CatalogItem {
     /// Reports whether this catalog item is a subsource.
     fn is_subsource(&self) -> bool;
 
+    /// Reports whether this catalog item is a progress source.
+    fn is_progress_source(&self) -> bool;
+
     /// If this catalog item is a source, it return the IDs of its subsources.
     fn subsources(&self) -> BTreeSet<GlobalId>;
 

--- a/test/sqllogictest/object_ownership.slt
+++ b/test/sqllogictest/object_ownership.slt
@@ -1246,6 +1246,7 @@ DROP ROLE owner
 ----
 db error: ERROR: role "owner" cannot be dropped because some objects depend on it
 DETAIL: owner: owner of SOURCE "materialize.public.s_progress"
+owner: privileges granted on SOURCE "materialize.public.s_progress" to mz_support
 owner: privileges on SOURCE "materialize.public.s_progress" granted by owner
 owner: privileges granted on SOURCE "materialize.public.s_progress" to owner
 owner: owner of SOURCE "materialize.public.s"

--- a/test/sqllogictest/privilege_checks.slt
+++ b/test/sqllogictest/privilege_checks.slt
@@ -489,6 +489,33 @@ REVOKE CREATE ON CLUSTER source_cluster FROM joe;
 ----
 COMPLETE 0
 
+# mz_support reading from progress source
+
+simple conn=mz_system,user=mz_system
+CREATE SOURCE s FROM LOAD GENERATOR COUNTER WITH (SIZE '1');
+----
+COMPLETE 0
+
+simple conn=mz_support,user=mz_support
+SET CLUSTER TO "default";
+----
+COMPLETE 0
+
+simple conn=mz_support,user=mz_support
+SELECT * FROM s_progress LIMIT 0;
+----
+COMPLETE 0
+
+simple conn=mz_support,user=mz_support
+SET CLUSTER TO mz_introspection;
+----
+COMPLETE 0
+
+simple conn=mz_system,user=mz_system
+DROP SOURCE s;
+----
+COMPLETE 0
+
 # CREATE SECRET
 
 simple conn=joe,user=joe

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -4714,7 +4714,7 @@ mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 17
+COMPLETE 18
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.table_privileges WHERE grantee = 'PUBLIC'
@@ -4761,7 +4761,7 @@ mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_prepared_statement_history_redacted,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_statement_execution_history_redacted,SELECT,NO,YES
-COMPLETE 17
+COMPLETE 18
 
 simple conn=mz_system,user=mz_system
 SELECT COUNT(*) >= 166 FROM information_schema.role_table_grants WHERE grantee = 'PUBLIC'

--- a/test/sqllogictest/privilege_grants.slt
+++ b/test/sqllogictest/privilege_grants.slt
@@ -4708,6 +4708,7 @@ materialize,materialize,materialize,public,t,UPDATE,NO,NO
 materialize,materialize,materialize,public,s,SELECT,NO,YES
 materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
+materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES
@@ -4754,6 +4755,7 @@ materialize,materialize,materialize,public,t,UPDATE,NO,NO
 materialize,materialize,materialize,public,s,SELECT,NO,YES
 materialize,materialize,materialize,public,t,SELECT,NO,YES
 materialize,materialize,materialize,public,v,SELECT,NO,YES
+materialize,mz_support,materialize,public,s_progress,SELECT,NO,YES
 materialize,materialize,materialize,public,s_progress,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_session_history,SELECT,NO,YES
 mz_system,mz_support,materialize,mz_internal,mz_activity_log_redacted,SELECT,NO,YES


### PR DESCRIPTION
This commit updates the default privileges such that mz_support can read all progress sources. The default privilege framework is not granular enough to create default privileges for specific types of sources, so this default privilege is hardcoded into the binary and not visible via mz_default_privileges.

This commit also adds a migration to grant SELECT on all existing progress sources to mz_support.

Resolves #23199

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
