### PR TITLE
.*: Box all Futures that are larger than 8KiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3794,6 +3794,7 @@ version = "0.78.0-dev"
 dependencies = [
  "anyhow",
  "clap",
+ "futures",
  "mz-adapter",
  "mz-build-info",
  "mz-catalog",
@@ -5334,6 +5335,7 @@ dependencies = [
  "datadriven",
  "enum-kinds",
  "fail",
+ "futures",
  "globset",
  "hex",
  "http",

--- a/clippy.toml
+++ b/clippy.toml
@@ -83,3 +83,5 @@ disallowed-types = [
     { path = "std::collections::HashMap", reason = "use `std::collections::BTreeMap` or `mz_ore::collections::HashMap` instead" },
     { path = "std::collections::HashSet", reason = "use `std::collections::BTreeSet` or `mz_ore::collections::HashSet` instead" },
 ]
+
+future-size-threshold = 8192

--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -176,6 +176,9 @@ WARN_LINTS = [
     # Implementing `From` gives you `Into` for free, but the reverse is not
     # true.
     "clippy::from_over_into",
+    # Futures get compiled into state machines, which can end up being very large (10's of KB).
+    # It's inefficient to moves these around on the stack, so require that they get boxed.
+    "clippy::large_futures",
 ]
 
 

--- a/src/adapter-types/src/lib.rs
+++ b/src/adapter-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Types for the adapter.

--- a/src/adapter/benches/catalog.rs
+++ b/src/adapter/benches/catalog.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::str::FromStr;

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -4272,6 +4272,7 @@ mod tests {
     use std::time::{Duration, Instant};
     use std::{env, iter};
 
+    use futures::future::FutureExt;
     use itertools::Itertools;
     use tokio_postgres::types::Type;
     use tokio_postgres::NoTls;
@@ -4384,6 +4385,7 @@ mod tests {
             }
             catalog.expire().await;
         })
+        .boxed()
         .await
     }
 
@@ -4582,6 +4584,7 @@ mod tests {
             );
             catalog.expire().await;
         })
+        .boxed()
         .await
     }
 
@@ -4608,6 +4611,7 @@ mod tests {
             );
             catalog.expire().await;
         })
+        .boxed()
         .await;
     }
 
@@ -4787,6 +4791,7 @@ mod tests {
             );
             catalog.expire().await;
         })
+        .boxed()
         .await;
     }
 
@@ -4810,6 +4815,7 @@ mod tests {
             );
             catalog.expire().await;
         })
+        .boxed()
         .await;
     }
 
@@ -5208,7 +5214,7 @@ mod tests {
             catalog.expire().await;
         }
 
-        Catalog::with_debug(NOW_ZERO.clone(), inner).await
+        Catalog::with_debug(NOW_ZERO.clone(), inner).boxed().await
     }
 
     // Execute all builtin functions with all combinations of arguments from interesting datums.
@@ -5358,8 +5364,9 @@ mod tests {
             handles
         }
 
-        let handles =
-            Catalog::with_debug(NOW_ZERO.clone(), |catalog| async { inner(catalog) }).await;
+        let handles = Catalog::with_debug(NOW_ZERO.clone(), |catalog| async { inner(catalog) })
+            .boxed()
+            .await;
         for handle in handles {
             handle.await.expect("must succeed");
         }
@@ -5578,6 +5585,7 @@ mod tests {
             }
             catalog.expire().await;
         })
+        .boxed()
         .await
     }
 }

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -1854,6 +1854,7 @@ fn default_logging_config() -> ReplicaLogging {
 mod builtin_migration_tests {
     use std::collections::{BTreeMap, BTreeSet};
 
+    use futures::FutureExt;
     use itertools::Itertools;
     use mz_catalog::memory::objects::Table;
 
@@ -2152,6 +2153,7 @@ mod builtin_migration_tests {
             );
             catalog.expire().await;
         })
+        .boxed()
         .await
     }
 

--- a/src/adapter/src/config/sync.rs
+++ b/src/adapter/src/config/sync.rs
@@ -9,6 +9,7 @@
 
 use std::time::Duration;
 
+use futures::FutureExt;
 use tokio::time;
 
 use crate::config::{
@@ -32,7 +33,9 @@ pub async fn system_parameter_sync(
 
     // Ensure the frontend client is initialized.
     let mut frontend = Option::<SystemParameterFrontend>::None; // lazy initialize the frontend below
-    let mut backend = SystemParameterBackend::new(adapter_client).await?;
+
+    // Note: the Future is intentionally boxed because it is very large.
+    let mut backend = SystemParameterBackend::new(adapter_client).boxed().await?;
 
     // Tick every `tick_duration` ms, skipping missed ticks.
     let mut interval = time::interval(tick_interval);

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -106,6 +106,8 @@ impl Coordinator {
 
                     self.handle_execute(portal_name, session, tx, outer_ctx_extra)
                         .instrument(span)
+                        // Note: the Future is intentionally boxed because it is very large.
+                        .boxed_local()
                         .await;
                 }
 
@@ -445,7 +447,10 @@ impl Coordinator {
             _ => {}
         }
 
-        self.handle_execute_inner(stmt, params, ctx).await
+        self.handle_execute_inner(stmt, params, ctx)
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed_local()
+            .await
     }
 
     #[tracing::instrument(level = "debug", skip(self, ctx))]

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::anyhow;
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, FutureExt};
 use itertools::Itertools;
 use maplit::{btreemap, btreeset};
 use mz_cloud_resources::VpcEndpointConfig;
@@ -2171,6 +2171,8 @@ impl Coordinator {
                     target_cluster,
                 }),
             )
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed_local()
             .await;
         } else {
             // Allow while the introduction of the new optimizer API in
@@ -2183,6 +2185,8 @@ impl Coordinator {
                     target_cluster,
                 }),
             )
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed_local()
             .await;
         }
     }
@@ -4060,6 +4064,8 @@ impl Coordinator {
                 };
 
                 self.sequence_read_then_write(ctx, read_then_write_plan)
+                    // Note: the Future is intentionally boxed because it is very large.
+                    .boxed_local()
                     .await;
             }
         }
@@ -4178,6 +4184,8 @@ impl Coordinator {
             },
             TargetCluster::Active,
         )
+        // Note: the Future is intentionally boxed because it is very large.
+        .boxed_local()
         .await;
 
         let internal_cmd_tx = self.internal_cmd_tx.clone();

--- a/src/adapter/src/lib.rs
+++ b/src/adapter/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 // Disallow usage of `unwrap()`.
 #![warn(clippy::unwrap_used)]

--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -76,6 +76,7 @@
 #![warn(clippy::large_futures)]
 // END LINT CONFIG
 
+use futures::FutureExt;
 use mz_adapter::catalog::Catalog;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::NOW_ZERO;
@@ -187,5 +188,6 @@ async fn test_parameter_type_inference() {
         }
         catalog.expire().await;
     })
+    .boxed()
     .await
 }

--- a/src/adapter/tests/parameters.rs
+++ b/src/adapter/tests/parameters.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_adapter::catalog::Catalog;

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -90,6 +90,7 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
+use futures::FutureExt;
 use mz_adapter::catalog::{Catalog, CatalogItem, Op, Table};
 use mz_adapter::session::{Session, DEFAULT_DATABASE_NAME};
 use mz_catalog::SYSTEM_CONN_ID;
@@ -205,7 +206,9 @@ async fn datadriven() {
             }
             f
         })
+        .boxed()
         .await
     })
+    .boxed()
     .await;
 }

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -84,6 +84,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeSet;

--- a/src/adapter/tests/timestamp_selection.rs
+++ b/src/adapter/tests/timestamp_selection.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 // Test determine_timestamp.

--- a/src/alloc/src/lib.rs
+++ b/src/alloc/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_ore::metrics::MetricsRegistry;

--- a/src/audit-log/src/lib.rs
+++ b/src/audit-log/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Audit log data structures.

--- a/src/avro-derive/src/lib.rs
+++ b/src/avro-derive/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 /// Derive decoders for Rust structs from Avro values.

--- a/src/avro/examples/benchmark.rs
+++ b/src/avro/examples/benchmark.rs
@@ -87,6 +87,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 // TODO(benesch): remove this once this module no longer makes use of

--- a/src/avro/src/lib.rs
+++ b/src/avro/src/lib.rs
@@ -87,6 +87,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! # avro

--- a/src/avro/tests/io.rs
+++ b/src/avro/tests/io.rs
@@ -87,6 +87,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Port of https://github.com/apache/avro/blob/master/lang/py/test/test_io.py

--- a/src/avro/tests/schema.rs
+++ b/src/avro/tests/schema.rs
@@ -87,6 +87,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Port of tests from:

--- a/src/aws-s3-util/src/lib.rs
+++ b/src/aws-s3-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use aws_sdk_s3::config::Builder;

--- a/src/aws-secrets-controller/src/lib.rs
+++ b/src/aws-secrets-controller/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/balancerd/src/lib.rs
+++ b/src/balancerd/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! The balancerd service is a horizontally scalable, stateless, multi-tenant ingress router for

--- a/src/balancerd/src/main.rs
+++ b/src/balancerd/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Manages a single Materialize environment.

--- a/src/balancerd/tests/server.rs
+++ b/src/balancerd/tests/server.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration tests for balancerd.

--- a/src/build-info/build.rs
+++ b/src/build-info/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/build-info/src/lib.rs
+++ b/src/build-info/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Metadata about a Materialize build.

--- a/src/catalog-debug/Cargo.toml
+++ b/src/catalog-debug/Cargo.toml
@@ -9,6 +9,7 @@ publish = false
 [dependencies]
 anyhow = "1.0.66"
 clap = { version = "3.2.24", features = ["derive", "env"] }
+futures = "0.3.25"
 mz-adapter = { path = "../adapter" }
 mz-build-info = { path = "../build-info" }
 mz-catalog = { path = "../catalog" }

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Debug utility for stashes.

--- a/src/catalog/build.rs
+++ b/src/catalog/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -10,6 +10,8 @@
 //! This crate is responsible for durably storing and modifying the catalog contents.
 
 use async_trait::async_trait;
+use futures::future::{BoxFuture, FutureExt};
+
 use std::fmt::Debug;
 use std::num::NonZeroI64;
 use std::time::Duration;
@@ -268,11 +270,11 @@ pub fn test_stash_backed_catalog_state(
 }
 
 /// Creates an openable durable catalog state implemented using persist.
-pub async fn persist_backed_catalog_state(
+pub fn persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,
-) -> PersistHandle {
-    PersistHandle::new(persist_client, organization_id).await
+) -> BoxFuture<'static, PersistHandle> {
+    PersistHandle::new(persist_client, organization_id).boxed()
 }
 
 /// Creates an openable durable catalog state implemented using both the stash and persist, that

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_ore::now::EpochMillis;
@@ -349,6 +349,8 @@ impl OpenableDurableCatalogState for PersistHandle {
         deploy_generation: Option<u64>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Savepoint, boot_ts, bootstrap_args, deploy_generation)
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed()
             .await
     }
 
@@ -359,6 +361,8 @@ impl OpenableDurableCatalogState for PersistHandle {
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Readonly, boot_ts, bootstrap_args, None)
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed()
             .await
     }
 
@@ -370,6 +374,8 @@ impl OpenableDurableCatalogState for PersistHandle {
         deploy_generation: Option<u64>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Writable, boot_ts, bootstrap_args, deploy_generation)
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed()
             .await
     }
 

--- a/src/catalog/src/lib.rs
+++ b/src/catalog/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 // Disallow usage of `unwrap()`.
 #![warn(clippy::unwrap_used)]

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_catalog::durable::debug::SettingCollection;

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -76,6 +76,7 @@
 #![warn(clippy::large_futures)]
 // END LINT CONFIG
 
+use futures::FutureExt;
 use mz_catalog::durable::debug::SettingCollection;
 use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::{
@@ -101,6 +102,7 @@ async fn test_stash_debug() {
         debug_openable_state2,
         debug_openable_state3,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }
@@ -123,6 +125,7 @@ async fn test_persist_debug() {
         persist_openable_state2,
         persist_openable_state3,
     )
+    .boxed()
     .await;
 }
 

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_catalog::durable::{

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -76,6 +76,7 @@
 #![warn(clippy::large_futures)]
 // END LINT CONFIG
 
+use futures::FutureExt;
 use mz_catalog::durable::{
     persist_backed_catalog_state, shadow_catalog_state, stash_backed_catalog_state,
     test_bootstrap_args, test_stash_backed_catalog_state, CatalogError, Epoch,
@@ -94,7 +95,9 @@ async fn test_stash_is_initialized() {
     let (debug_factory, stash_config) = stash_config().await;
     let openable_state1 = stash_backed_catalog_state(stash_config.clone());
     let openable_state2 = stash_backed_catalog_state(stash_config);
-    test_is_initialized(openable_state1, openable_state2).await;
+    test_is_initialized(openable_state1, openable_state2)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -104,7 +107,9 @@ async fn test_debug_stash_is_initialized() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state1 = test_stash_backed_catalog_state(&debug_factory);
     let debug_openable_state2 = test_stash_backed_catalog_state(&debug_factory);
-    test_is_initialized(debug_openable_state1, debug_openable_state2).await;
+    test_is_initialized(debug_openable_state1, debug_openable_state2)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -117,7 +122,9 @@ async fn test_persist_is_initialized() {
         persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state2 =
         persist_backed_catalog_state(persist_client, organization_id).await;
-    test_is_initialized(persist_openable_state1, persist_openable_state2).await;
+    test_is_initialized(persist_openable_state1, persist_openable_state2)
+        .boxed()
+        .await;
 }
 
 async fn test_is_initialized(
@@ -152,7 +159,9 @@ async fn test_stash_get_deployment_generation() {
     let (debug_factory, stash_config) = stash_config().await;
     let openable_state1 = stash_backed_catalog_state(stash_config.clone());
     let openable_state2 = stash_backed_catalog_state(stash_config);
-    test_get_deployment_generation(openable_state1, openable_state2).await;
+    test_get_deployment_generation(openable_state1, openable_state2)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -162,7 +171,9 @@ async fn test_debug_stash_get_deployment_generation() {
     let debug_factory = DebugStashFactory::new().await;
     let debug_openable_state1 = test_stash_backed_catalog_state(&debug_factory);
     let debug_openable_state2 = test_stash_backed_catalog_state(&debug_factory);
-    test_get_deployment_generation(debug_openable_state1, debug_openable_state2).await;
+    test_get_deployment_generation(debug_openable_state1, debug_openable_state2)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -175,7 +186,9 @@ async fn test_persist_get_deployment_generation() {
         persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state2 =
         persist_backed_catalog_state(persist_client, organization_id).await;
-    test_get_deployment_generation(persist_openable_state1, persist_openable_state2).await;
+    test_get_deployment_generation(persist_openable_state1, persist_openable_state2)
+        .boxed()
+        .await;
 }
 
 async fn test_get_deployment_generation(
@@ -221,6 +234,7 @@ async fn test_stash_open_savepoint() {
         openable_state3,
         openable_state4,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }
@@ -239,6 +253,7 @@ async fn test_debug_stash_open_savepoint() {
         debug_openable_state3,
         debug_openable_state4,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }
@@ -262,6 +277,7 @@ async fn test_persist_open_savepoint() {
         persist_openable_state3,
         persist_openable_state4,
     )
+    .boxed()
     .await;
 }
 
@@ -344,7 +360,9 @@ async fn test_stash_open_read_only() {
     let openable_state1 = stash_backed_catalog_state(stash_config.clone());
     let openable_state2 = stash_backed_catalog_state(stash_config.clone());
     let openable_state3 = stash_backed_catalog_state(stash_config);
-    test_open_read_only(openable_state1, openable_state2, openable_state3).await;
+    test_open_read_only(openable_state1, openable_state2, openable_state3)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -360,6 +378,7 @@ async fn test_debug_stash_open_read_only() {
         debug_openable_state2,
         debug_openable_state3,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }
@@ -380,6 +399,7 @@ async fn test_persist_open_read_only() {
         persist_openable_state2,
         persist_openable_state3,
     )
+    .boxed()
     .await;
 }
 
@@ -487,7 +507,9 @@ async fn test_stash_open() {
     let openable_state1 = stash_backed_catalog_state(stash_config.clone());
     let openable_state2 = stash_backed_catalog_state(stash_config.clone());
     let openable_state3 = stash_backed_catalog_state(stash_config);
-    test_open(openable_state1, openable_state2, openable_state3).await;
+    test_open(openable_state1, openable_state2, openable_state3)
+        .boxed()
+        .await;
     debug_factory.drop().await;
 }
 
@@ -503,6 +525,7 @@ async fn test_debug_stash_open() {
         debug_openable_state2,
         debug_openable_state3,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }
@@ -523,6 +546,7 @@ async fn test_persist_open() {
         persist_openable_state2,
         persist_openable_state3,
     )
+    .boxed()
     .await;
 }
 
@@ -552,6 +576,7 @@ async fn test_shadow_open() {
         shadow_openable_state2,
         shadow_openable_state3,
     )
+    .boxed()
     .await;
     debug_factory.drop().await;
 }

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use itertools::Itertools;

--- a/src/ccsr/src/lib.rs
+++ b/src/ccsr/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_debug_implementations)]
 

--- a/src/ccsr/tests/client.rs
+++ b/src/ccsr/tests/client.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/cloud-api/src/lib.rs
+++ b/src/cloud-api/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_docs)]
 

--- a/src/cloud-resources/src/lib.rs
+++ b/src/cloud-resources/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Abstractions for management of cloud resources that have no equivalent when running

--- a/src/cluster-client/build.rs
+++ b/src/cluster-client/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/cluster-client/src/lib.rs
+++ b/src/cluster-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! The public API for both compute and storage.

--- a/src/cluster/src/lib.rs
+++ b/src/cluster/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Tools for storage and compute.

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -84,7 +84,7 @@ use anyhow::Context;
 use axum::http::StatusCode;
 use axum::routing;
 use fail::FailScenario;
-use futures::future;
+use futures::{future, FutureExt};
 use mz_build_info::{build_info, BuildInfo};
 use mz_cloud_resources::AwsExternalIdPrefix;
 use mz_compute::server::ComputeInstanceContext;
@@ -200,7 +200,8 @@ async fn main() {
         env_prefix: Some("CLUSTERD_"),
         enable_version_flag: true,
     });
-    if let Err(err) = run(args).await {
+    // Note: the Future is intentionally boxed because it is very large.
+    if let Err(err) = run(args).boxed_local().await {
         eprintln!("clusterd: fatal: {}", err.display_with_causes());
         process::exit(1);
     }

--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/compute-client/build.rs
+++ b/src/compute-client/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/compute-client/src/lib.rs
+++ b/src/compute-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 // This appears to be defective at the moment, with false positives

--- a/src/compute-types/build.rs
+++ b/src/compute-types/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/compute-types/src/lib.rs
+++ b/src/compute-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Shared types for the `mz-compute*` crates

--- a/src/compute/src/lib.rs
+++ b/src/compute/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_docs)]
 

--- a/src/controller-types/src/lib.rs
+++ b/src/controller-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Shared types for the `mz-controller` crate

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -96,7 +96,7 @@ use std::num::NonZeroI64;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
-use futures::future::BoxFuture;
+use futures::future::{BoxFuture, FutureExt};
 use futures::stream::{Peekable, StreamExt};
 use mz_build_info::BuildInfo;
 use mz_cluster_client::ReplicaId;
@@ -394,6 +394,8 @@ where
             config.metrics_registry.clone(),
             enable_persist_txn_tables,
         )
+        // Note: the Future is intentionally boxed because it is very large.
+        .boxed()
         .await;
 
         let compute_controller = ComputeController::new(

--- a/src/controller/src/lib.rs
+++ b/src/controller/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A representative of STORAGE and COMPUTE that maintains summaries of the involved objects.

--- a/src/environmentd/build.rs
+++ b/src/environmentd/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Manages a single Materialize environment.

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -92,6 +92,7 @@ use std::{cmp, env, iter, process, thread};
 use anyhow::{bail, Context};
 use clap::{ArgEnum, Parser};
 use fail::FailScenario;
+use futures::FutureExt;
 use http::header::HeaderValue;
 use itertools::Itertools;
 use mz_adapter::catalog::ClusterReplicaSizeMap;
@@ -998,6 +999,8 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 internal_console_redirect_url: args.internal_console_redirect_url,
                 enable_persist_txn_tables_cli: args.enable_persist_txn_tables,
             })
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed()
             .await
     })?;
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A SQL stream processor built on top of [timely dataflow] and

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -92,6 +92,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
+use futures::FutureExt;
 use mz_adapter::catalog::ClusterReplicaSizeMap;
 use mz_adapter::config::{system_parameter_sync, SystemParameterSyncConfig};
 use mz_adapter::webhook::WebhookConcurrencyLimiter;
@@ -403,6 +404,8 @@ impl Listeners {
                 &config.controller,
                 &config.environment_id,
             )
+            // Note: the Future is intentionally boxed because it is very large.
+            .boxed()
             .await?;
 
             if !openable_adapter_storage.is_initialized().await? {
@@ -459,6 +462,8 @@ impl Listeners {
             &config.controller,
             &config.environment_id,
         )
+        // Note: the Future is intentionally boxed because it is very large.
+        .boxed()
         .await?;
         // Get the value from Launch Darkly as of the last time this environment
         // was running. (Ideally it would be the current value, but that's
@@ -733,6 +738,8 @@ async fn catalog_opener(
                     persist_client,
                     environment_id.organization_id(),
                 )
+                // Note: the Future is intentionally boxed because it is very large.
+                .boxed()
                 .await,
             )
         }

--- a/src/environmentd/src/telemetry.rs
+++ b/src/environmentd/src/telemetry.rs
@@ -77,6 +77,7 @@
 // environment in real time:
 // https://app.segment.com/materializeinc/sources/cloud_dev/debugger.
 
+use futures::FutureExt;
 use mz_adapter::telemetry::SegmentClientExt;
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
@@ -136,37 +137,41 @@ async fn report_loop(
                     .active_subscribes
                     .with_label_values(&["user"])
                     .get();
-                let rows = adapter_client.introspection_execute_one(&format!("
-                    SELECT jsonb_build_object(
-                        'active_aws_privatelink_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'aws-privatelink')::int4,
-                        'active_clusters', (SELECT count(*) FROM mz_clusters WHERE id LIKE 'u%')::int4,
-                        'active_cluster_replicas', (
-                            SELECT jsonb_object_agg(base.size, coalesce(count, 0))
-                            FROM mz_internal.mz_cluster_replica_sizes base
-                            LEFT JOIN (
-                                SELECT r.size, count(*)::int4
-                                FROM mz_cluster_replicas r
-                                JOIN mz_clusters c ON c.id = r.cluster_id
-                                WHERE c.id LIKE 'u%'
-                                GROUP BY r.size
-                            ) extant ON base.size = extant.size
-                        ),
-                        'active_confluent_schema_registry_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'confluent-schema-registry')::int4,
-                        'active_materialized_views', (SELECT count(*) FROM mz_materialized_views WHERE id LIKE 'u%')::int4,
-                        'active_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type <> 'subsource')::int4,
-                        'active_kafka_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'kafka')::int4,
-                        'active_kafka_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'kafka')::int4,
-                        'active_load_generator_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'load-generator')::int4,
-                        'active_postgres_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'postgres')::int4,
-                        'active_postgres_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'postgres')::int4,
-                        'active_sinks', (SELECT count(*) FROM mz_sinks WHERE id LIKE 'u%')::int4,
-                        'active_ssh_tunnel_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'ssh-tunnel')::int4,
-                        'active_kafka_sinks', (SELECT count(*) FROM mz_sinks WHERE id LIKE 'u%' AND type = 'kafka')::int4,
-                        'active_tables', (SELECT count(*) FROM mz_tables WHERE id LIKE 'u%')::int4,
-                        'active_views', (SELECT count(*) FROM mz_views WHERE id LIKE 'u%')::int4,
-                        'active_subscribes', {active_subscribes}
-                    )",
-                )).await?;
+                let rows = adapter_client
+                    .introspection_execute_one(&format!("
+                        SELECT jsonb_build_object(
+                            'active_aws_privatelink_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'aws-privatelink')::int4,
+                            'active_clusters', (SELECT count(*) FROM mz_clusters WHERE id LIKE 'u%')::int4,
+                            'active_cluster_replicas', (
+                                SELECT jsonb_object_agg(base.size, coalesce(count, 0))
+                                FROM mz_internal.mz_cluster_replica_sizes base
+                                LEFT JOIN (
+                                    SELECT r.size, count(*)::int4
+                                    FROM mz_cluster_replicas r
+                                    JOIN mz_clusters c ON c.id = r.cluster_id
+                                    WHERE c.id LIKE 'u%'
+                                    GROUP BY r.size
+                                ) extant ON base.size = extant.size
+                            ),
+                            'active_confluent_schema_registry_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'confluent-schema-registry')::int4,
+                            'active_materialized_views', (SELECT count(*) FROM mz_materialized_views WHERE id LIKE 'u%')::int4,
+                            'active_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type <> 'subsource')::int4,
+                            'active_kafka_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'kafka')::int4,
+                            'active_kafka_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'kafka')::int4,
+                            'active_load_generator_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'load-generator')::int4,
+                            'active_postgres_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'postgres')::int4,
+                            'active_postgres_sources', (SELECT count(*) FROM mz_sources WHERE id LIKE 'u%' AND type = 'postgres')::int4,
+                            'active_sinks', (SELECT count(*) FROM mz_sinks WHERE id LIKE 'u%')::int4,
+                            'active_ssh_tunnel_connections', (SELECT count(*) FROM mz_connections WHERE id LIKE 'u%' AND type = 'ssh-tunnel')::int4,
+                            'active_kafka_sinks', (SELECT count(*) FROM mz_sinks WHERE id LIKE 'u%' AND type = 'kafka')::int4,
+                            'active_tables', (SELECT count(*) FROM mz_tables WHERE id LIKE 'u%')::int4,
+                            'active_views', (SELECT count(*) FROM mz_views WHERE id LIKE 'u%')::int4,
+                            'active_subscribes', {active_subscribes}
+                        )",
+                    ))
+                    // Note: the Future is intentionally boxed because it is very large.
+                    .boxed()
+                    .await?;
                 let row = rows.into_element();
                 let jsonb = Jsonb::from_row(row);
                 Ok::<_, anyhow::Error>(jsonb.as_ref().to_serde_json())

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -87,6 +87,7 @@ use std::time::Duration;
 use std::{env, fs, iter, thread};
 
 use anyhow::anyhow;
+use futures::future::FutureExt;
 use headers::{Header, HeaderMapExt};
 use hyper::http::header::HeaderMap;
 use hyper::service::{make_service_fn, service_fn};
@@ -521,6 +522,7 @@ impl Listeners {
                     // TODO(txn): Get this flipped to true before turning anything on in prod.
                     enable_persist_txn_tables_cli: None,
                 })
+                .boxed()
                 .await
         })?;
         let server = Server {

--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration tests for TLS encryption and authentication.

--- a/src/environmentd/tests/cli.rs
+++ b/src/environmentd/tests/cli.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::time::Duration;

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration tests for pgwire functionality.

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration tests for Materialize server.

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration tests for SQL functionality.

--- a/src/environmentd/tests/timezones.rs
+++ b/src/environmentd/tests/timezones.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 // This file does comparison tests between postgres and materialize for the pg_timezone_abbrevs and

--- a/src/expr-parser/src/lib.rs
+++ b/src/expr-parser/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 mod catalog;

--- a/src/expr-parser/tests/test_mir_parser.rs
+++ b/src/expr-parser/tests/test_mir_parser.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_expr_parser::{handle_define, handle_roundtrip, TestCatalog};

--- a/src/expr-test-util/src/lib.rs
+++ b/src/expr-test-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/expr-test-util/tests/test_runner.rs
+++ b/src/expr-test-util/tests/test_runner.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 mod test {

--- a/src/expr/benches/like_pattern.rs
+++ b/src/expr/benches/like_pattern.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};

--- a/src/expr/build.rs
+++ b/src/expr/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/expr/src/lib.rs
+++ b/src/expr/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Core expression language.

--- a/src/expr/tests/test_runner.rs
+++ b/src/expr/tests/test_runner.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 mod test {

--- a/src/frontegg-auth/src/lib.rs
+++ b/src/frontegg-auth/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 mod app_password;

--- a/src/frontegg-client/src/lib.rs
+++ b/src/frontegg-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_docs)]
 

--- a/src/http-util/src/lib.rs
+++ b/src/http-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! HTTP utilities.

--- a/src/interchange/benches/avro.rs
+++ b/src/interchange/benches/avro.rs
@@ -72,6 +72,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use byteorder::{NetworkEndian, WriteBytesExt};

--- a/src/interchange/benches/benches.rs
+++ b/src/interchange/benches/benches.rs
@@ -75,6 +75,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use criterion::{criterion_group, criterion_main};

--- a/src/interchange/benches/protobuf.rs
+++ b/src/interchange/benches/protobuf.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use criterion::{black_box, Criterion, Throughput};

--- a/src/interchange/build.rs
+++ b/src/interchange/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/interchange/src/bin/avro-decode.rs
+++ b/src/interchange/src/bin/avro-decode.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/interchange/src/lib.rs
+++ b/src/interchange/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Translations for various data serialization formats.

--- a/src/kafka-util/src/bin/kgen.rs
+++ b/src/kafka-util/src/bin/kgen.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/kafka-util/src/lib.rs
+++ b/src/kafka-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Utilities for working with Kafka.

--- a/src/lowertest-derive/src/lib.rs
+++ b/src/lowertest-derive/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Macros needed by the `mz_lowertest` crate.

--- a/src/lowertest/src/lib.rs
+++ b/src/lowertest/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Utilities for testing lower layers of the Materialize stack.

--- a/src/lowertest/tests/test_runner.rs
+++ b/src/lowertest/tests/test_runner.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 #[cfg(test)]

--- a/src/lsp-server/src/lib.rs
+++ b/src/lsp-server/src/lib.rs
@@ -74,6 +74,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_docs)]
 

--- a/src/lsp-server/src/main.rs
+++ b/src/lsp-server/src/main.rs
@@ -82,6 +82,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_lsp_server::backend::{Backend, DEFAULT_FORMATTING_WIDTH};

--- a/src/lsp-server/tests/test.rs
+++ b/src/lsp-server/tests/test.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 #[cfg(test)]

--- a/src/metabase/src/lib.rs
+++ b/src/metabase/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! An API client for [Metabase].

--- a/src/metrics/src/lib.rs
+++ b/src/metrics/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Internal metrics libraries for Materialize.

--- a/src/mz/src/bin/mz/main.rs
+++ b/src/mz/src/bin/mz/main.rs
@@ -81,6 +81,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/mz/src/lib.rs
+++ b/src/mz/src/lib.rs
@@ -80,6 +80,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_docs)]
 

--- a/src/mz/tests/local.rs
+++ b/src/mz/tests/local.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 #[cfg(test)]

--- a/src/npm/src/lib.rs
+++ b/src/npm/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A lightweight JavaScript package manager, like npm.

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/orchestrator-process/src/lib.rs
+++ b/src/orchestrator-process/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/orchestrator-tracing/src/lib.rs
+++ b/src/orchestrator-tracing/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Service orchestration for tracing-aware services.

--- a/src/orchestrator/src/lib.rs
+++ b/src/orchestrator/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/ore/src/lib.rs
+++ b/src/ore/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Internal utility libraries for Materialize.

--- a/src/ore/tests/future.rs
+++ b/src/ore/tests/future.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::panic;

--- a/src/ore/tests/panic.rs
+++ b/src/ore/tests/panic.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::panic;

--- a/src/ore/tests/task.rs
+++ b/src/ore/tests/task.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_ore::task::{AbortHandleExt, JoinSetExt};

--- a/src/persist-cli/src/main.rs
+++ b/src/persist-cli/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 #![warn(missing_debug_implementations)]
 #![warn(

--- a/src/persist-cli/src/open_loop.rs
+++ b/src/persist-cli/src/open_loop.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use anyhow::bail;
+use futures::FutureExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
@@ -150,6 +151,7 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
                 args.num_writers,
                 args.num_readers,
             )
+            .boxed()
             .await?
         }
         BenchmarkType::MzSourceModel => panic!("source model"),

--- a/src/persist-cli/src/txns.rs
+++ b/src/persist-cli/src/txns.rs
@@ -12,7 +12,7 @@ use std::time::Instant;
 
 use anyhow::anyhow;
 use futures::stream::FuturesUnordered;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::cache::PersistClientCache;
@@ -70,6 +70,8 @@ pub async fn run(args: Args) -> Result<(), anyhow::Error> {
         Arc::new(StringSchema),
         Arc::new(UnitSchema),
     )
+    // Note: the Future is intentionally boxed because it is very large.
+    .boxed()
     .await;
 
     let data_ids = (0..args.num_datas)

--- a/src/persist-client/benches/benches.rs
+++ b/src/persist-client/benches/benches.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::sync::Arc;

--- a/src/persist-client/build.rs
+++ b/src/persist-client/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/persist-client/src/internal/datadriven.rs
+++ b/src/persist-client/src/internal/datadriven.rs
@@ -143,6 +143,8 @@ impl<'a> DirectiveArgs<'a> {
 }
 
 mod tests {
+    use futures::future::FutureExt;
+
     use super::*;
 
     #[mz_ore::test]
@@ -180,7 +182,8 @@ mod tests {
         use crate::internal::machine::datadriven as machine_dd;
 
         ::datadriven::walk_async("tests/machine", |mut f| {
-            let initial_state_fut = machine_dd::MachineState::new();
+            // Note: the Future is intentionally boxed because it is very large.
+            let initial_state_fut = machine_dd::MachineState::new().boxed_local();
             async move {
                 let state = Arc::new(Mutex::new(initial_state_fut.await));
                 f.run_async(move |tc| {
@@ -262,10 +265,14 @@ mod tests {
                         }
                     }
                 })
+                // Note: the Future is intentionally boxed because it is very large.
+                .boxed_local()
                 .await;
                 f
             }
         })
+        // Note: the Future is intentionally boxed because it is very large.
+        .boxed_local()
         .await;
     }
 }

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! An abstraction presenting as a durable time-varying collection (aka shard)

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Atomic multi-shard [persist] writes.

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -420,6 +420,8 @@ impl DataSubscribe {
 
 #[cfg(test)]
 mod tests {
+    use futures::FutureExt;
+
     use crate::tests::writer;
     use crate::txns::TxnsHandle;
 
@@ -447,7 +449,10 @@ mod tests {
 
         // Now register the shard. Also start a new subscription and step the
         // previous one (plus repeat this for ever later step).
-        txns.register(1, [writer(&client, d0).await]).await.unwrap();
+        txns.register(1, [writer(&client, d0).await])
+            .boxed()
+            .await
+            .unwrap();
         subs.push(txns.read_cache().expect_subscribe(&client, d0, 5));
         step(&mut subs);
 

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -283,7 +283,7 @@ mod tests {
     use std::time::{Duration, SystemTime};
 
     use futures::stream::FuturesUnordered;
-    use futures::StreamExt;
+    use futures::{FutureExt, StreamExt};
     use mz_persist_client::PersistClient;
 
     use crate::tests::writer;
@@ -432,7 +432,7 @@ mod tests {
                 let mut register_ts = 1;
                 loop {
                     let data_write = writer(&client, d0).await;
-                    match txns.register(register_ts, [data_write]).await {
+                    match txns.register(register_ts, [data_write]).boxed().await {
                         Ok(()) => {
                             debug!("{} registered at {}", idx, register_ts);
                             break;

--- a/src/persist-types/build.rs
+++ b/src/persist-types/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/persist-types/src/lib.rs
+++ b/src/persist-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Types for the persist crate.

--- a/src/persist/build.rs
+++ b/src/persist/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/persist/src/lib.rs
+++ b/src/persist/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Persistence for differential dataflow collections

--- a/src/pgcopy/src/lib.rs
+++ b/src/pgcopy/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Encoding and decoding for PostgreSQL COPY data format

--- a/src/pgrepr-consts/src/lib.rs
+++ b/src/pgrepr-consts/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Constants used in the representation of and serialization for PostgreSQL datums.

--- a/src/pgrepr/src/lib.rs
+++ b/src/pgrepr/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Representation of and serialization for PostgreSQL datums.

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! pgtest is a Postgres wire protocol tester using datadriven test files. It

--- a/src/pgtest/src/main.rs
+++ b/src/pgtest/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_ore::cli::{self, CliConfig};

--- a/src/pgtz/build.rs
+++ b/src/pgtz/build.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/pgtz/src/lib.rs
+++ b/src/pgtz/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 pub mod abbrev;

--- a/src/pgwire-common/src/lib.rs
+++ b/src/pgwire-common/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Common PostgreSQL network ("wire") protocol logic.

--- a/src/pgwire/src/lib.rs
+++ b/src/pgwire/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! PostgreSQL network ("wire") protocol.

--- a/src/pgwire/src/server.rs
+++ b/src/pgwire/src/server.rs
@@ -13,6 +13,7 @@ use std::pin::Pin;
 use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
+use futures::FutureExt;
 use mz_frontegg_auth::Authentication as FronteggAuthentication;
 use mz_ore::netio::AsyncReady;
 use mz_pgwire_common::{
@@ -137,6 +138,8 @@ impl Server {
                                     internal,
                                     active_connection_count,
                                 })
+                                // Note: the Future is intentionally boxed because it is very large.
+                                .boxed()
                                 .await?;
                                 conn.flush().await?;
                                 return Ok(());

--- a/src/pid-file/build.rs
+++ b/src/pid-file/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 fn main() {

--- a/src/pid-file/src/lib.rs
+++ b/src/pid-file/src/lib.rs
@@ -87,6 +87,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! PID file management for daemons.

--- a/src/pid-file/tests/pid_file.rs
+++ b/src/pid-file/tests/pid_file.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::error::Error;

--- a/src/postgres-client/src/lib.rs
+++ b/src/postgres-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A Postgres client that uses deadpool as a connection pool and comes with

--- a/src/postgres-util/build.rs
+++ b/src/postgres-util/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/postgres-util/src/lib.rs
+++ b/src/postgres-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! PostgreSQL utility library.

--- a/src/proc/src/lib.rs
+++ b/src/proc/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Utility crate to extract information about the running process.

--- a/src/prof-http/build.rs
+++ b/src/prof-http/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 fn main() -> Result<(), anyhow::Error> {

--- a/src/prof-http/src/bin/fgviz.rs
+++ b/src/prof-http/src/bin/fgviz.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use askama::Template;

--- a/src/prof-http/src/lib.rs
+++ b/src/prof-http/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Profiling HTTP endpoints.

--- a/src/prof/build.rs
+++ b/src/prof/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 fn main() -> Result<(), anyhow::Error> {

--- a/src/prof/src/lib.rs
+++ b/src/prof/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeMap;

--- a/src/proto/build.rs
+++ b/src/proto/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/proto/src/lib.rs
+++ b/src/proto/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Generated protobuf code and companion impls.

--- a/src/regexp/src/lib.rs
+++ b/src/regexp/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_repr::adt::regex::Regex;

--- a/src/repr-test-util/src/lib.rs
+++ b/src/repr-test-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Utilities to build objects from the `repr` crate for unit testing.

--- a/src/repr-test-util/tests/test_runner.rs
+++ b/src/repr-test-util/tests/test_runner.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 #[cfg(test)]

--- a/src/repr/benches/row.rs
+++ b/src/repr/benches/row.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::cmp::Ordering;

--- a/src/repr/benches/strconv.rs
+++ b/src/repr/benches/strconv.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};

--- a/src/repr/build.rs
+++ b/src/repr/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/repr/src/lib.rs
+++ b/src/repr/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Fundamental data representation.

--- a/src/repr/tests/strconv.rs
+++ b/src/repr/tests/strconv.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, TimeZone, Utc};

--- a/src/rocksdb-types/build.rs
+++ b/src/rocksdb-types/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/rocksdb-types/src/lib.rs
+++ b/src/rocksdb-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! An async wrapper around RocksDB, that does IO on a separate thread.

--- a/src/rocksdb/src/lib.rs
+++ b/src/rocksdb/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! An async wrapper around RocksDB, that does IO on a separate thread.

--- a/src/rocksdb/tests/basic.rs
+++ b/src/rocksdb/tests/basic.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_ore::metrics::{CounterVecExt, HistogramVecExt};

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -82,6 +82,7 @@ use aws_sdk_s3::operation::create_bucket::CreateBucketError;
 use aws_sdk_s3::types::{BucketLocationConstraint, CreateBucketConfiguration};
 use clap::Parser;
 use futures::stream::{self, StreamExt, TryStreamExt};
+use futures::FutureExt;
 use mz_ore::cast::CastFrom;
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::error::ErrorExt;
@@ -132,7 +133,8 @@ struct Args {
 
 #[tokio::main]
 async fn main() {
-    if let Err(e) = run().await {
+    // Note: the Future is intentionally boxed because it is very large.
+    if let Err(e) = run().boxed().await {
         error!("{}", e.display_with_causes());
         std::process::exit(1);
     }

--- a/src/s3-datagen/src/main.rs
+++ b/src/s3-datagen/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::{io, iter};

--- a/src/secrets/src/lib.rs
+++ b/src/secrets/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Abstractions for secure management of user secrets.

--- a/src/segment/src/lib.rs
+++ b/src/segment/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Segment library for Rust.

--- a/src/server-core/src/lib.rs
+++ b/src/server-core/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Methods common to servers listening for TCP connections.

--- a/src/service/build.rs
+++ b/src/service/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/service/src/lib.rs
+++ b/src/service/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Common code for services orchestrated by environmentd.

--- a/src/sql-lexer/build.rs
+++ b/src/sql-lexer/build.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/sql-lexer/src/lib.rs
+++ b/src/sql-lexer/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 pub mod keywords;

--- a/src/sql-parser/build.rs
+++ b/src/sql-parser/build.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::path::PathBuf;

--- a/src/sql-parser/src/lib.rs
+++ b/src/sql-parser/src/lib.rs
@@ -84,6 +84,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! SQL parser.

--- a/src/sql-parser/tests/sqlparser_common.rs
+++ b/src/sql-parser/tests/sqlparser_common.rs
@@ -84,6 +84,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::error::Error;

--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 mod doc;

--- a/src/sql-pretty/tests/parser.rs
+++ b/src/sql-pretty/tests/parser.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use datadriven::walk;

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -21,6 +21,7 @@ globset = "0.4.9"
 hex = "0.4.3"
 http = "0.2.8"
 itertools = "0.10.5"
+futures = "0.3.25"
 once_cell = "1.16.0"
 maplit = "1.0.2"
 mz-build-info = { path = "../build-info" }

--- a/src/sql/src/lib.rs
+++ b/src/sql/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! SQL-dataflow translation.

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -84,6 +84,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use chrono::Utc;
+use futures::FutureExt;
 use mz_orchestrator_tracing::{StaticTracingConfig, TracingCliArgs};
 use mz_ore::cli::{self, CliConfig, KeyValueArg};
 use mz_ore::metrics::MetricsRegistry;
@@ -224,7 +225,7 @@ async fn main() -> ExitCode {
     }
 
     if args.rewrite_results {
-        return rewrite(&config, args).await;
+        return rewrite(&config, args).boxed_local().await;
     }
 
     let mut junit = match args.junit_report {

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::cell::RefCell;

--- a/src/sqllogictest/src/lib.rs
+++ b/src/sqllogictest/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A driver for sqllogictest, a SQL correctness testing framework.

--- a/src/sqllogictest/tests/parser.rs
+++ b/src/sqllogictest/tests/parser.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use mz_sqllogictest::ast::{Location, Record};

--- a/src/ssh-util/src/lib.rs
+++ b/src/ssh-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! SSH utility library.

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -90,7 +90,7 @@ use std::time::Duration;
 
 use anyhow::Context;
 use clap::Parser;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use once_cell::sync::Lazy;
 use tracing_subscriber::filter::EnvFilter;
 
@@ -170,7 +170,7 @@ async fn main() {
         env_prefix: Some("MZ_STASH_DEBUG_"),
         enable_version_flag: true,
     });
-    if let Err(err) = run(args).await {
+    if let Err(err) = run(args).boxed_local().await {
         eprintln!("stash: fatal: {}", err.display_with_causes());
         process::exit(1);
     }

--- a/src/stash-debug/src/main.rs
+++ b/src/stash-debug/src/main.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Debug utility for stashes.

--- a/src/stash-types/src/lib.rs
+++ b/src/stash-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Shared types for the `mz-stash*` crates

--- a/src/stash/benches/postgres.rs
+++ b/src/stash/benches/postgres.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::str::FromStr;

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Durable metadata storage.

--- a/src/storage-client/build.rs
+++ b/src/storage-client/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/storage-client/src/lib.rs
+++ b/src/storage-client/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Materialize's storage layer.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Implementation of the storage controller trait.

--- a/src/storage-operators/src/lib.rs
+++ b/src/storage-operators/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Shared Storage dataflow operators

--- a/src/storage-types/build.rs
+++ b/src/storage-types/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Shared types for the `mz-storage*` crates

--- a/src/storage/examples/upsert_open_loop.rs
+++ b/src/storage/examples/upsert_open_loop.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Open-loop benchmark for measuring UPSERT performance.

--- a/src/storage/src/lib.rs
+++ b/src/storage/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Materialize's storage layer.

--- a/src/storage/src/source/reclock.rs
+++ b/src/storage/src/source/reclock.rs
@@ -716,6 +716,7 @@ mod tests {
             PROGRESS_DESC.clone(),
             GlobalId::Explain,
         )
+        .boxed_local()
         .await
         .unwrap();
 
@@ -762,7 +763,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_basic_usage() {
         let (mut operator, mut follower) =
-            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Reclock offsets 1 and 3 to timestamp 1000
         let batch = vec![
@@ -837,7 +840,9 @@ mod tests {
             .expect("error opening persist shard");
 
         let (mut operator, mut follower) =
-            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(remap_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         let query = Antichain::from_elem(Partitioned::minimum());
         // This is the initial source frontier so we should get the initial ts upper
@@ -985,7 +990,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_reclock() {
         let (mut operator, mut follower) =
-            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Reclock offsets 1 and 2 to timestamp 1000
         let batch = vec![
@@ -1074,7 +1081,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_reclock_gh16318() {
         let (mut operator, mut follower) =
-            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // First mint bindings for 0 at timestamp 1000
         let source_upper = partitioned_frontier([(0, MzOffset::from(50))]);
@@ -1125,7 +1134,9 @@ mod tests {
             .expect("error opening persist shard");
 
         let (mut operator, mut follower) =
-            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(remap_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Reclock offsets 1 and 2 to timestamp 1000
         let batch = vec![
@@ -1185,7 +1196,9 @@ mod tests {
 
         // Starting a new operator with an `as_of` is the same as having compacted
         let (_operator, follower) =
-            make_test_operator(remap_shard, Antichain::from_elem(1000.into())).await;
+            make_test_operator(remap_shard, Antichain::from_elem(1000.into()))
+                .boxed_local()
+                .await;
 
         // Reclocking offsets 3 and 4 should succeed
         let batch = vec![
@@ -1213,7 +1226,9 @@ mod tests {
     #[cfg_attr(miri, ignore)] // error: unsupported operation: can't call foreign function `decNumberFromInt32` on OS `linux`
     async fn test_sharing() {
         let (mut operator, mut follower) =
-            make_test_operator(ShardId::new(), Antichain::from_elem(0.into())).await;
+            make_test_operator(ShardId::new(), Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Install a since hold
         let shared_follower = follower.share();
@@ -1246,9 +1261,13 @@ mod tests {
         // Create two operators pointing to the same shard
         let shared_shard = ShardId::new();
         let (mut op_a, mut follower_a) =
-            make_test_operator(shared_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(shared_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
         let (mut op_b, mut follower_b) =
-            make_test_operator(shared_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(shared_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Reclock a batch from one of the operators
         // Reclock offsets 1 and 2 to timestamp 1000 from operator A
@@ -1322,7 +1341,9 @@ mod tests {
             .expect("error opening persist shard");
 
         let (mut operator, mut follower) =
-            make_test_operator(remap_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(remap_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // SETUP
         // Reclock offsets 1 and 2 to timestamp 1000
@@ -1463,7 +1484,9 @@ mod tests {
         let binding_shard = ShardId::new();
 
         let (mut operator, _follower) =
-            make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(binding_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // We do multiple rounds of minting. This will downgrade the since of
         // the internal listen. If we didn't make sure to also heartbeat the
@@ -1490,7 +1513,9 @@ mod tests {
         // Starting a new operator with an `as_of` of `0`, to verify that
         // holding back the `since` of the remap shard works as expected.
         let (_operator, _follower) =
-            make_test_operator(binding_shard, Antichain::from_elem(0.into())).await;
+            make_test_operator(binding_shard, Antichain::from_elem(0.into()))
+                .boxed_local()
+                .await;
 
         // Also manually assert the since of the remap shard.
         let persist_location = PersistLocation {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -41,6 +41,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use futures::stream::StreamExt;
+use futures::FutureExt;
 use itertools::Itertools;
 use mz_expr::PartitionId;
 use mz_ore::cast::CastFrom;
@@ -467,6 +468,8 @@ where
             remap_relation_desc,
             remap_collection_id,
         )
+        // The Future is intentionally boxed because it is very large.
+        .boxed_local()
         .await
         .unwrap_or_else(|e| panic!("Failed to create remap handle for source {}: {}", name, e.display_with_causes()));
         let clock = RemapClock::new(now.clone(), timestamp_interval);

--- a/src/storage/src/storage_state/async_storage_worker.rs
+++ b/src/storage/src/storage_state/async_storage_worker.rs
@@ -18,6 +18,7 @@ use std::fmt::Display;
 use std::sync::Arc;
 
 use differential_dataflow::lattice::Lattice;
+use futures::future::FutureExt;
 use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::read::ListenEvent;
 use mz_persist_client::Diagnostics;
@@ -345,6 +346,8 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                     as_of.clone(),
                                     &resume_uppers,
                                 )
+                                // Note: We intentionally box the Future because it is very large.
+                                .boxed()
                                 .await;
                                 to_vec_row(uppers)
                             }
@@ -356,6 +359,8 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                     as_of.clone(),
                                     &resume_uppers,
                                 )
+                                // Note: We intentionally box the Future because it is very large.
+                                .boxed()
                                 .await;
                                 to_vec_row(uppers)
                             }
@@ -368,6 +373,8 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                         as_of.clone(),
                                         &resume_uppers,
                                     )
+                                    // Note: We intentionally box the Future because it is very large.
+                                    .boxed()
                                     .await;
                                 to_vec_row(uppers)
                             }
@@ -380,6 +387,8 @@ impl<T: Timestamp + Lattice + Codec64 + Display> AsyncStorageWorker<T> {
                                         as_of.clone(),
                                         &resume_uppers,
                                     )
+                                    // Note: We intentionally box the Future because it is very large.
+                                    .boxed()
                                     .await;
                                 to_vec_row(uppers)
                             }

--- a/src/storage/tests/setup.rs
+++ b/src/storage/tests/setup.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Unit tests for sources.

--- a/src/storage/tests/sources.rs
+++ b/src/storage/tests/sources.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Basic unit tests for sources.

--- a/src/test-macro/src/lib.rs
+++ b/src/test-macro/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! test macro with auto-initialized logging

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::{BTreeMap, BTreeSet};

--- a/src/testdrive/src/lib.rs
+++ b/src/testdrive/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Integration test driver for Materialize.

--- a/src/timely-util/src/lib.rs
+++ b/src/timely-util/src/lib.rs
@@ -79,6 +79,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Utilities for working with Timely.

--- a/src/tls-util/src/lib.rs
+++ b/src/tls-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! A tiny utility library for making TLS connectors.

--- a/src/tracing/build.rs
+++ b/src/tracing/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::env;

--- a/src/tracing/src/lib.rs
+++ b/src/tracing/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Mz-specific library for interacting with `tracing`.

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Transformations for relation expressions.

--- a/src/transform/tests/test_runner.rs
+++ b/src/transform/tests/test_runner.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! This module defines a small language for directly constructing RelationExprs and running

--- a/src/transform/tests/test_transforms.rs
+++ b/src/transform/tests/test_transforms.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::collections::BTreeSet;

--- a/src/walkabout/src/lib.rs
+++ b/src/walkabout/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! Visitor generation for Rust structs and enums.

--- a/src/walkabout/tests/walkabout.rs
+++ b/src/walkabout/tests/walkabout.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::io::Write;

--- a/src/workspace-hack/build.rs
+++ b/src/workspace-hack/build.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 // A build script is required for Cargo to honor build dependencies.

--- a/src/workspace-hack/src/lib.rs
+++ b/src/workspace-hack/src/lib.rs
@@ -73,4 +73,5 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG

--- a/test/metabase/smoketest/src/bin/metabase-smoketest.rs
+++ b/test/metabase/smoketest/src/bin/metabase-smoketest.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 use std::time::Duration;

--- a/test/test-util/src/lib.rs
+++ b/test/test-util/src/lib.rs
@@ -73,6 +73,7 @@
 #![warn(clippy::disallowed_macros)]
 #![warn(clippy::disallowed_types)]
 #![warn(clippy::from_over_into)]
+#![warn(clippy::large_futures)]
 // END LINT CONFIG
 
 //! `test_util` provides utilities for test programs and demos that run against Materialize.


### PR DESCRIPTION
This PR boxes (aka moves to the heap) all Rust Futures that are larger than 8KiB, and enables the [large_futures](https://rust-lang.github.io/rust-clippy/master/#/large_futures) clippy lint.

### Motivation

Calling Rust Futures currently can result in inefficient code with excessive memcpy's, as documented by this issue: https://github.com/rust-lang/rust/issues/99504. There are a number of Futures in our codebase which are quite large >8KiB, and thus could see poor performance. By Box-ing the Futures we'd end up memcpy-ing only a fat pointer, which is 16 bytes, which should be a good performance improvement.

Discussed this in [Slack](https://materializeinc.slack.com/archives/CMH6PG4CW/p1700235579916409)

### Tips for reviewer

This PR is split into two commits that can be reviewed separately:

1. Enabling the new `large_futures` lint.
2. Boxing all of the Futures.

When boxing a Future there are two possible approaches, either changing the `async fn` to `fn -> BoxFuture` or using `.boxed()` at the callsite. I generally used `.boxed()` and only when a function was called multiple times, didn't use generics, and it didn't complicate the return type too much, would I update from `async fn` to `fn -> BoxFuture`.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
