### PR TITLE
Implement PrivateLink Connection Status History Table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2257,6 +2257,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
+
+[[package]]
 name = "futures-util"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2343,6 +2349,24 @@ dependencies = [
  "log",
  "regex",
  "serde",
+]
+
+[[package]]
+name = "governor"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "821239e5672ff23e2a7060901fa622950bbd80b649cdaadd78d1c1767ed14eb4"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures",
+ "futures-timer",
+ "no-std-compat",
+ "nonzero_ext",
+ "parking_lot",
+ "quanta",
+ "rand",
+ "smallvec",
 ]
 
 [[package]]
@@ -3159,6 +3183,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3437,6 +3470,7 @@ dependencies = [
  "enum-kinds",
  "fail",
  "futures",
+ "governor",
  "hex",
  "itertools",
  "launchdarkly-server-sdk",
@@ -3782,6 +3816,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "chrono",
+ "futures",
  "k8s-openapi",
  "kube",
  "mz-ore",
@@ -5990,6 +6026,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "no-std-compat"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
+
+[[package]]
 name = "nom"
 version = "7.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5998,6 +6040,12 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "normalize-line-endings"
@@ -7064,6 +7112,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7133,6 +7197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -731,6 +731,20 @@ messages and additional metadata helpful for debugging.
 | `error`        | [`text`]                        | If the source is in an error state, the error message.                                                             |
 | `details`      | [`jsonb`]                       | Additional metadata provided by the source. In case of error, may contain a `hint` field with helpful suggestions. |
 
+
+### `mz_aws_privatelink_connection_status_history`
+
+The `mz_aws_privatelink_connection_status_history` table contains a row describing
+the historical status for each PrivateLink connection.
+
+<!-- RELATION_SPEC mz_internal.mz_aws_privatelink_connection_status_history -->
+| Field             | Type                       | Meaning                                                    |
+|-------------------|----------------------------|------------------------------------------------------------|
+| `occurred_at`     | `timestamp with time zone` | Wall-clock timestamp of the status change.       |
+| `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections)   |
+| `status`          | `text`                     | The status: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, `unknown`                        |
+
+
 <!--
 ### `mz_statement_execution_history`
 

--- a/doc/user/content/sql/system-catalog/mz_internal.md
+++ b/doc/user/content/sql/system-catalog/mz_internal.md
@@ -735,14 +735,14 @@ messages and additional metadata helpful for debugging.
 ### `mz_aws_privatelink_connection_status_history`
 
 The `mz_aws_privatelink_connection_status_history` table contains a row describing
-the historical status for each PrivateLink connection.
+the historical status for each AWS PrivateLink connection in the system.
 
 <!-- RELATION_SPEC mz_internal.mz_aws_privatelink_connection_status_history -->
 | Field             | Type                       | Meaning                                                    |
 |-------------------|----------------------------|------------------------------------------------------------|
 | `occurred_at`     | `timestamp with time zone` | Wall-clock timestamp of the status change.       |
-| `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections)   |
-| `status`          | `text`                     | The status: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, `unknown`                        |
+| `connection_id`   | `text`                     | The unique identifier of the AWS PrivateLink connection. Corresponds to [`mz_catalog.mz_connections.id`](../mz_catalog#mz_connections).   |
+| `status`          | `text`                     | The status of the connection: one of `pending-service-discovery`, `creating-endpoint`, `recreating-endpoint`, `updating-endpoint`, `available`, `deleted`, `deleting`, `expired`, `failed`, `pending`, `pending-acceptance`, `rejected`, or `unknown`.                        |
 
 
 <!--

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -25,6 +25,31 @@ who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
 version = "0.12.0@git:fca940b40e7827a9a639f99af45806100ef14954"
 
+[[audits.futures-timer]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "3.0.2"
+
+[[audits.governor]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.6.0"
+
+[[audits.nonzero_ext]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.3.0"
+
+[[audits.quanta]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.11.1"
+
+[[audits.raw-cpuid]]
+who = "Roshan Jobanputra <roshan@materialize.com>"
+criteria = "safe-to-deploy"
+version = "10.7.0"
+
 [[audits.timely]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"

--- a/misc/cargo-vet/imports.lock
+++ b/misc/cargo-vet/imports.lock
@@ -1072,6 +1072,17 @@ criteria = "safe-to-deploy"
 version = "1.0.1"
 notes = "No unsafe usage or ambient capabilities"
 
+[[audits.embark-studios.audits.no-std-compat]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+version = "0.2.0"
+notes = "No unsafe usage or ambient capabilities"
+
+[[audits.embark-studios.audits.no-std-compat]]
+who = "Johan Andersson <opensource@embark-studios.com>"
+criteria = "safe-to-deploy"
+delta = "0.2.0 -> 0.4.1"
+
 [[audits.embark-studios.audits.similar]]
 who = "Johan Andersson <opensource@embark-studios.com>"
 criteria = "safe-to-deploy"
@@ -1440,6 +1451,12 @@ aggregated-from = "https://raw.githubusercontent.com/mozilla/cargo-vet/main/supp
 who = "Mike Hommey <mh+mozilla@glandium.org>"
 criteria = "safe-to-deploy"
 version = "0.4.17"
+aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
+
+[[audits.mozilla.audits.mach2]]
+who = "Gabriele Svelto <gsvelto@mozilla.com>"
+criteria = "safe-to-deploy"
+version = "0.4.1"
 aggregated-from = "https://hg.mozilla.org/mozilla-central/raw-file/tip/supply-chain/audits.toml"
 
 [[audits.mozilla.audits.matches]]

--- a/src/adapter/Cargo.toml
+++ b/src/adapter/Cargo.toml
@@ -19,6 +19,7 @@ differential-dataflow = "0.12.0"
 enum-kinds = "0.5.1"
 fail = { version = "0.5.1", features = ["failpoints"] }
 futures = "0.3.25"
+governor = "0.6.0"
 hex = "0.4.3"
 itertools = "0.10.5"
 once_cell = "1.16.0"

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -137,6 +137,9 @@ impl Coordinator {
                 Message::DrainStatementLog => {
                     self.drain_statement_log().await;
                 }
+                Message::PrivateLinkVpcEndpointEvents(events) => {
+                    self.write_privatelink_status_updates(events).await;
+                }
             }
         }
         .boxed_local()

--- a/src/adapter/src/coord/privatelink_status.rs
+++ b/src/adapter/src/coord/privatelink_status.rs
@@ -1,0 +1,90 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::num::NonZeroU32;
+use std::{collections::BTreeMap, sync::Arc};
+
+use futures::stream::StreamExt;
+use futures::FutureExt;
+use governor::{Quota, RateLimiter};
+
+use mz_cloud_resources::VpcEndpointEvent;
+use mz_ore::task::spawn;
+use mz_repr::{Datum, GlobalId, Row};
+use mz_storage_client::controller::IntrospectionType;
+
+use crate::coord::Coordinator;
+
+use super::Message;
+
+impl Coordinator {
+    pub(crate) fn spawn_privatelink_vpc_endpoints_watch_task(&self) {
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        let rate_quota: i32 = self
+            .catalog
+            .system_config()
+            .privatelink_status_update_quota_per_minute()
+            .try_into()
+            .expect("value coouldn't be converted to i32");
+        if let Some(controller) = &self.cloud_resource_controller {
+            let controller = Arc::clone(controller);
+            spawn(|| "privatelink_vpc_endpoint_watch", async move {
+                let mut stream = controller.watch_vpc_endpoints().await;
+                // Using a per-minute quota implies a burst-size of the same amount
+                let rate_limiter = RateLimiter::direct(Quota::per_minute(
+                    NonZeroU32::new(rate_quota).expect("will be non-zero"),
+                ));
+
+                loop {
+                    // Wait for an event to become available
+                    if let Some(event) = stream.next().await {
+                        // Wait until we're permitted to tell the coordinator about the event
+                        rate_limiter.until_ready().await;
+
+                        // Drain any additional events from the queue that accumulated while
+                        // waiting for the rate limiter, deduplicating by connection_id.
+                        let mut events = BTreeMap::new();
+                        events.insert(event.connection_id, event);
+                        while let Some(event) = stream.next().now_or_never().and_then(|e| e) {
+                            events.insert(event.connection_id, event);
+                        }
+
+                        // Send the event batch to the coordinator.
+                        let _ = internal_cmd_tx.send(Message::PrivateLinkVpcEndpointEvents(events));
+                    }
+                }
+            });
+        }
+    }
+
+    pub(crate) async fn write_privatelink_status_updates(
+        &mut self,
+        events: BTreeMap<GlobalId, VpcEndpointEvent>,
+    ) {
+        let mut updates = Vec::new();
+        for value in events.into_values() {
+            updates.push((
+                Row::pack_slice(&[
+                    Datum::TimestampTz(value.time.try_into().expect("must fit")),
+                    Datum::String(&value.connection_id.to_string()),
+                    Datum::String(&value.status.to_string()),
+                ]),
+                1,
+            ));
+        }
+
+        self.controller
+            .storage
+            .record_introspection_updates(
+                IntrospectionType::PrivatelinkConnectionStatusHistory,
+                updates,
+            )
+            .await;
+    }
+}

--- a/src/adapter/src/flags.rs
+++ b/src/adapter/src/flags.rs
@@ -84,7 +84,9 @@ pub fn storage_config(config: &SystemVars) -> StorageParameters {
         },
         pg_source_snapshot_statement_timeout: config.pg_source_snapshot_statement_timeout(),
         keep_n_source_status_history_entries: config.keep_n_source_status_history_entries(),
-        keep_n_sink_status_history_entries: config.keep_n_source_status_history_entries(),
+        keep_n_sink_status_history_entries: config.keep_n_sink_status_history_entries(),
+        keep_n_privatelink_status_history_entries: config
+            .keep_n_privatelink_status_history_entries(),
         upsert_rocksdb_tuning_config: {
             match mz_rocksdb_types::RocksDBTuningParameters::from_parameters(
                 config.upsert_rocksdb_compaction_style(),

--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -44,8 +44,9 @@ use mz_sql::session::user::{
 };
 use mz_storage_client::controller::IntrospectionType;
 use mz_storage_client::healthcheck::{
-    MZ_PREPARED_STATEMENT_HISTORY_DESC, MZ_SESSION_HISTORY_DESC, MZ_SINK_STATUS_HISTORY_DESC,
-    MZ_SOURCE_STATUS_HISTORY_DESC, MZ_STATEMENT_EXECUTION_HISTORY_DESC,
+    MZ_PREPARED_STATEMENT_HISTORY_DESC, MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC,
+    MZ_SESSION_HISTORY_DESC, MZ_SINK_STATUS_HISTORY_DESC, MZ_SOURCE_STATUS_HISTORY_DESC,
+    MZ_STATEMENT_EXECUTION_HISTORY_DESC,
 };
 use once_cell::sync::Lazy;
 use serde::Serialize;
@@ -2411,6 +2412,16 @@ pub static MZ_SOURCE_STATUS_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinS
     is_retained_metrics_object: false,
     sensitivity: DataSensitivity::Public,
 });
+
+pub static MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY: Lazy<BuiltinSource> =
+    Lazy::new(|| BuiltinSource {
+        name: "mz_aws_privatelink_connection_status_history",
+        schema: MZ_INTERNAL_SCHEMA,
+        data_source: Some(IntrospectionType::PrivatelinkConnectionStatusHistory),
+        desc: MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC.clone(),
+        is_retained_metrics_object: false,
+        sensitivity: DataSensitivity::Public,
+    });
 
 pub static MZ_STATEMENT_EXECUTION_HISTORY: Lazy<BuiltinSource> = Lazy::new(|| BuiltinSource {
     name: "mz_statement_execution_history",
@@ -6211,6 +6222,7 @@ pub static BUILTINS_STATIC: Lazy<Vec<Builtin<NameReference>>> = Lazy::new(|| {
         Builtin::Source(&MZ_SINK_STATUS_HISTORY),
         Builtin::View(&MZ_SINK_STATUSES),
         Builtin::Source(&MZ_SOURCE_STATUS_HISTORY),
+        Builtin::Source(&MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY),
         Builtin::Source(&MZ_STATEMENT_EXECUTION_HISTORY),
         Builtin::View(&MZ_STATEMENT_EXECUTION_HISTORY_REDACTED),
         Builtin::Source(&MZ_PREPARED_STATEMENT_HISTORY),

--- a/src/cloud-resources/Cargo.toml
+++ b/src/cloud-resources/Cargo.toml
@@ -11,6 +11,8 @@ anyhow = "1.0.66"
 async-trait = "0.1.68"
 k8s-openapi = { version = "0.20.0", features = ["schemars", "v1_26"] }
 kube = { version = "0.87.1", default-features = false, features = ["client", "derive", "openssl-tls", "ws"] }
+chrono = { version = "0.4.23", default-features = false }
+futures = "0.3.25"
 mz-ore = { path = "../ore", features = [] }
 mz-repr = { path = "../repr" }
 schemars = { version = "0.8", features = ["uuid1"] }

--- a/src/cloud-resources/src/crd/vpc_endpoint.rs
+++ b/src/cloud-resources/src/crd/vpc_endpoint.rs
@@ -9,6 +9,7 @@
 
 //! VpcEndpoint custom resource, to be reconciled into an AWS VPC Endpoint by the
 //! environment-controller.
+use std::fmt;
 
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use kube::CustomResource;
@@ -77,6 +78,27 @@ pub mod v1 {
         PendingAcceptance,
         Rejected,
         Unknown,
+    }
+
+    impl fmt::Display for VpcEndpointState {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            let repr = match self {
+                VpcEndpointState::PendingServiceDiscovery => "pending-service-discovery",
+                VpcEndpointState::CreatingEndpoint => "creating-endpoint",
+                VpcEndpointState::RecreatingEndpoint => "recreating-endpoint",
+                VpcEndpointState::UpdatingEndpoint => "updating-endpoint",
+                VpcEndpointState::Available => "available",
+                VpcEndpointState::Deleted => "deleted",
+                VpcEndpointState::Deleting => "deleting",
+                VpcEndpointState::Expired => "expired",
+                VpcEndpointState::Failed => "failed",
+                VpcEndpointState::Pending => "pending",
+                VpcEndpointState::PendingAcceptance => "pending-acceptance",
+                VpcEndpointState::Rejected => "rejected",
+                VpcEndpointState::Unknown => "unknown",
+            };
+            write!(f, "{}", repr)
+        }
     }
 }
 

--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -10,17 +10,24 @@
 //! Management of K8S objects, such as VpcEndpoints.
 
 use std::collections::BTreeMap;
-use std::str::FromStr;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::Utc;
+use futures::stream::BoxStream;
+use futures::StreamExt;
 use kube::api::{DeleteParams, ListParams, ObjectMeta, Patch, PatchParams};
+use kube::runtime::{watcher, WatchStreamExt};
 use kube::{Api, ResourceExt};
 use maplit::btreemap;
 use mz_repr::GlobalId;
 
-use mz_cloud_resources::crd::vpc_endpoint::v1::{VpcEndpoint, VpcEndpointSpec, VpcEndpointStatus};
-use mz_cloud_resources::{CloudResourceController, CloudResourceReader, VpcEndpointConfig};
+use mz_cloud_resources::crd::vpc_endpoint::v1::{
+    VpcEndpoint, VpcEndpointSpec, VpcEndpointState, VpcEndpointStatus,
+};
+use mz_cloud_resources::{
+    CloudResourceController, CloudResourceReader, VpcEndpointConfig, VpcEndpointEvent,
+};
 
 use crate::{util, KubernetesOrchestrator, FIELD_MANAGER};
 
@@ -89,11 +96,7 @@ impl CloudResourceController for KubernetesOrchestrator {
         let objects = self.vpc_endpoint_api.list(&ListParams::default()).await?;
         let mut endpoints = BTreeMap::new();
         for object in objects {
-            let maybe_id = object
-                .name_any()
-                .split_once('-')
-                .and_then(|(_, id_str)| GlobalId::from_str(id_str).ok());
-            let id = match maybe_id {
+            let id = match mz_cloud_resources::id_from_vpc_endpoint_name(&object.name_any()) {
                 Some(id) => id,
                 // Ignore any object whose name can't be parsed as a GlobalId
                 None => continue,
@@ -101,6 +104,63 @@ impl CloudResourceController for KubernetesOrchestrator {
             endpoints.insert(id, object.status.unwrap_or_default());
         }
         Ok(endpoints)
+    }
+
+    async fn watch_vpc_endpoints(&self) -> BoxStream<'static, VpcEndpointEvent> {
+        let stream = watcher(self.vpc_endpoint_api.clone(), watcher::Config::default())
+            .touched_objects()
+            .filter_map(|object| async move {
+                match object {
+                    Ok(vpce) => {
+                        if let Some(connection_id) =
+                            mz_cloud_resources::id_from_vpc_endpoint_name(&vpce.name_any())
+                        {
+                            if let Some(state) =
+                                vpce.status.as_ref().and_then(|st| st.state.to_owned())
+                            {
+                                return Some(VpcEndpointEvent {
+                                    connection_id,
+                                    status: state,
+                                    // Use the 'Available' Condition on the VPCE Status to set the event-time, falling back
+                                    // to now if it's not set
+                                    time: vpce
+                                        .status
+                                        .unwrap()
+                                        .conditions
+                                        .and_then(|c| {
+                                            c.into_iter().find(|c| &c.type_ == "Available")
+                                        })
+                                        .and_then(|condition| {
+                                            Some(condition.last_transition_time.0)
+                                        })
+                                        .unwrap_or_else(Utc::now),
+                                });
+                            } else {
+                                // The Status/State is not yet populated on the VpcEndpoint, which means it was just
+                                // initialized and hasn't yet been reconciled by the environment-controller
+                                // We return an event with an 'unknown' state so that watchers know the VpcEndpoint was created
+                                // even if we don't yet have an accurate status
+                                return Some(VpcEndpointEvent {
+                                    connection_id,
+                                    status: VpcEndpointState::Unknown,
+                                    time: vpce.creation_timestamp().expect("Will exist").0,
+                                });
+                            }
+                            // TODO: Should we also check for the deletion_timestamp on the vpce? That would indicate that the
+                            // resource is about to be deleted; however there is already a 'deleted' enum val on VpcEndpointState
+                            // which refers to the state of the customer's VPC Endpoint Service, so we'd need to introduce a new state val
+                        }
+                        None
+                    }
+                    Err(error) => {
+                        // We assume that errors returned by Kubernetes are usually transient, so we
+                        // just log a warning and ignore them otherwise.
+                        tracing::warn!("vpc endpoint watch error: {error}");
+                        None
+                    }
+                }
+            });
+        Box::pin(stream)
     }
 
     fn reader(&self) -> Arc<dyn CloudResourceReader> {

--- a/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
+++ b/src/orchestrator-kubernetes/src/cloud_resource_controller.rs
@@ -112,45 +112,38 @@ impl CloudResourceController for KubernetesOrchestrator {
             .filter_map(|object| async move {
                 match object {
                     Ok(vpce) => {
-                        if let Some(connection_id) =
-                            mz_cloud_resources::id_from_vpc_endpoint_name(&vpce.name_any())
+                        let connection_id =
+                            mz_cloud_resources::id_from_vpc_endpoint_name(&vpce.name_any())?;
+
+                        if let Some(state) = vpce.status.as_ref().and_then(|st| st.state.to_owned())
                         {
-                            if let Some(state) =
-                                vpce.status.as_ref().and_then(|st| st.state.to_owned())
-                            {
-                                return Some(VpcEndpointEvent {
-                                    connection_id,
-                                    status: state,
-                                    // Use the 'Available' Condition on the VPCE Status to set the event-time, falling back
-                                    // to now if it's not set
-                                    time: vpce
-                                        .status
-                                        .unwrap()
-                                        .conditions
-                                        .and_then(|c| {
-                                            c.into_iter().find(|c| &c.type_ == "Available")
-                                        })
-                                        .and_then(|condition| {
-                                            Some(condition.last_transition_time.0)
-                                        })
-                                        .unwrap_or_else(Utc::now),
-                                });
-                            } else {
-                                // The Status/State is not yet populated on the VpcEndpoint, which means it was just
-                                // initialized and hasn't yet been reconciled by the environment-controller
-                                // We return an event with an 'unknown' state so that watchers know the VpcEndpoint was created
-                                // even if we don't yet have an accurate status
-                                return Some(VpcEndpointEvent {
-                                    connection_id,
-                                    status: VpcEndpointState::Unknown,
-                                    time: vpce.creation_timestamp().expect("Will exist").0,
-                                });
-                            }
-                            // TODO: Should we also check for the deletion_timestamp on the vpce? That would indicate that the
-                            // resource is about to be deleted; however there is already a 'deleted' enum val on VpcEndpointState
-                            // which refers to the state of the customer's VPC Endpoint Service, so we'd need to introduce a new state val
+                            Some(VpcEndpointEvent {
+                                connection_id,
+                                status: state,
+                                // Use the 'Available' Condition on the VPCE Status to set the event-time, falling back
+                                // to now if it's not set
+                                time: vpce
+                                    .status
+                                    .unwrap()
+                                    .conditions
+                                    .and_then(|c| c.into_iter().find(|c| &c.type_ == "Available"))
+                                    .and_then(|condition| Some(condition.last_transition_time.0))
+                                    .unwrap_or_else(Utc::now),
+                            })
+                        } else {
+                            // The Status/State is not yet populated on the VpcEndpoint, which means it was just
+                            // initialized and hasn't yet been reconciled by the environment-controller
+                            // We return an event with an 'unknown' state so that watchers know the VpcEndpoint was created
+                            // even if we don't yet have an accurate status
+                            Some(VpcEndpointEvent {
+                                connection_id,
+                                status: VpcEndpointState::Unknown,
+                                time: vpce.creation_timestamp()?.0,
+                            })
                         }
-                        None
+                        // TODO: Should we also check for the deletion_timestamp on the vpce? That would indicate that the
+                        // resource is about to be deleted; however there is already a 'deleted' enum val on VpcEndpointState
+                        // which refers to the state of the customer's VPC Endpoint Service, so we'd need to introduce a new state val
                     }
                     Err(error) => {
                         // We assume that errors returned by Kubernetes are usually transient, so we

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1433,6 +1433,15 @@ const KEEP_N_SINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
     internal: true
 };
 
+/// Controls [`mz_storage_types::parameters::StorageParameters::keep_n_privatelink_status_history_entries`].
+const KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES: ServerVar<usize> = ServerVar {
+    name: UncasedStr::new("keep_n_privatelink_status_history_entries"),
+    value: &5,
+    description: "On reboot, truncate all but the last n entries per ID in the mz_aws_privatelink_connection_status_history \
+    collection (Materialize).",
+    internal: true
+};
+
 const ENABLE_STORAGE_SHARD_FINALIZATION: ServerVar<bool> = ServerVar {
     name: UncasedStr::new("enable_storage_shard_finalization"),
     value: &true,
@@ -2792,6 +2801,7 @@ impl SystemVars {
             .with_var(&MAX_CONNECTIONS)
             .with_var(&KEEP_N_SOURCE_STATUS_HISTORY_ENTRIES)
             .with_var(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
+            .with_var(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
             .with_var(&ENABLE_MZ_JOIN_CORE)
             .with_var(&LINEAR_JOIN_YIELDING)
             .with_var(&DEFAULT_IDLE_ARRANGEMENT_MERGE_EFFORT)
@@ -3459,6 +3469,10 @@ impl SystemVars {
 
     pub fn keep_n_sink_status_history_entries(&self) -> usize {
         *self.expect_value(&KEEP_N_SINK_STATUS_HISTORY_ENTRIES)
+    }
+
+    pub fn keep_n_privatelink_status_history_entries(&self) -> usize {
+        *self.expect_value(&KEEP_N_PRIVATELINK_STATUS_HISTORY_ENTRIES)
     }
 
     /// Returns the `enable_mz_join_core` configuration parameter.

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1325,6 +1325,14 @@ const OPTIMIZER_ONESHOT_STATS_TIMEOUT: ServerVar<Duration> = ServerVar {
     internal: true,
 };
 
+const PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE: ServerVar<u32> = ServerVar {
+    name: UncasedStr::new("privatelink_status_update_quota_per_minute"),
+    value: &20,
+    description: "Sets the per-minute quota for privatelink vpc status updates to be written to \
+    the storage-collection-backed system table. This value implies the total and burst quota per-minute.",
+    internal: true,
+};
+
 static DEFAULT_STATEMENT_LOGGING_SAMPLE_RATE: Lazy<Numeric> = Lazy::new(|| 0.1.into());
 pub static STATEMENT_LOGGING_SAMPLE_RATE: Lazy<ServerVar<Numeric>> = Lazy::new(|| {
     ServerVar {
@@ -2839,6 +2847,7 @@ impl SystemVars {
             )
             .with_var(&OPTIMIZER_STATS_TIMEOUT)
             .with_var(&OPTIMIZER_ONESHOT_STATS_TIMEOUT)
+            .with_var(&PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE)
             .with_var(&WEBHOOK_CONCURRENT_REQUEST_LIMIT)
             .with_var(&ENABLE_COLUMNATION_LGALLOC)
             .with_var(&TIMESTAMP_ORACLE_IMPL);
@@ -3584,6 +3593,11 @@ impl SystemVars {
 
     pub fn cluster_soften_az_affinity_weight(&self) -> i32 {
         *self.expect_value(&cluster_scheduling::CLUSTER_SOFTEN_AZ_AFFINITY_WEIGHT)
+    }
+
+    /// Returns the `privatelink_status_update_quota_per_minute` configuration parameter.
+    pub fn privatelink_status_update_quota_per_minute(&self) -> u32 {
+        *self.expect_value(&PRIVATELINK_STATUS_UPDATE_QUOTA_PER_MINUTE)
     }
 
     /// Returns the `statement_logging_max_sample_rate` configuration parameter.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -69,6 +69,9 @@ pub enum IntrospectionType {
     // Collections written by the compute controller.
     ComputeDependencies,
     ComputeReplicaHeartbeats,
+
+    // Written by the Adapter for tracking AWS PrivateLink Connection Status History
+    PrivatelinkConnectionStatusHistory,
 }
 
 /// Describes how data is written to the collection.

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -23,6 +23,7 @@ use std::fmt::Debug;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use differential_dataflow::lattice::Lattice;
 use itertools::Itertools;
@@ -531,6 +532,10 @@ pub trait StorageController: Debug + Send {
     /// good and there is no possibility of the old code running concurrently
     /// with the new code.
     async fn init_txns(&mut self, init_ts: Self::Timestamp) -> Result<(), StorageError>;
+
+    /// Returns the timestamp of the latest row for each id in the
+    /// privatelink_connection_status_history table seen on startup
+    fn get_privatelink_status_table_latest(&self) -> &Option<BTreeMap<GlobalId, DateTime<Utc>>>;
 }
 
 /// Compaction policies for collections maintained by `Controller`.

--- a/src/storage-client/src/healthcheck.rs
+++ b/src/storage-client/src/healthcheck.rs
@@ -104,3 +104,13 @@ pub static MZ_SINK_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
         .with_column("error", ScalarType::String.nullable(true))
         .with_column("details", ScalarType::Jsonb.nullable(true))
 });
+
+pub static MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC: Lazy<RelationDesc> = Lazy::new(|| {
+    RelationDesc::empty()
+        .with_column(
+            "occurred_at",
+            ScalarType::TimestampTz { precision: None }.nullable(false),
+        )
+        .with_column("connection_id", ScalarType::String.nullable(false))
+        .with_column("status", ScalarType::String.nullable(false))
+});

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -917,6 +917,12 @@ where
                             )
                             .await;
                         }
+                        IntrospectionType::PrivatelinkConnectionStatusHistory => {
+                            self.partially_truncate_status_history(
+                                IntrospectionType::PrivatelinkConnectionStatusHistory,
+                            )
+                            .await;
+                        }
 
                         // Truncate compute-maintained collections.
                         IntrospectionType::ComputeDependencies
@@ -2631,6 +2637,17 @@ where
                     .0,
                 healthcheck::MZ_SINK_STATUS_HISTORY_DESC
                     .get_by_name(&ColumnName::from("sink_id"))
+                    .expect("schema has not changed")
+                    .0,
+            ),
+            IntrospectionType::PrivatelinkConnectionStatusHistory => (
+                self.config.keep_n_privatelink_status_history_entries,
+                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("occurred_at"))
+                    .expect("schema has not changed")
+                    .0,
+                healthcheck::MZ_PRIVATELINK_CONNECTION_STATUS_HISTORY_DESC
+                    .get_by_name(&ColumnName::from("connection_id"))
                     .expect("schema has not changed")
                     .0,
             ),

--- a/src/storage-types/src/parameters.proto
+++ b/src/storage-types/src/parameters.proto
@@ -34,6 +34,7 @@ message ProtoStorageParameters {
     ProtoPgSourceTcpTimeouts pg_source_tcp_timeouts = 16;
     mz_proto.ProtoDuration pg_source_snapshot_statement_timeout = 17;
     bool record_namespaced_errors = 18;
+    uint64 keep_n_privatelink_status_history_entries = 19;
 }
 
 

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -32,6 +32,7 @@ pub struct StorageParameters {
     pub pg_source_snapshot_statement_timeout: Duration,
     pub keep_n_source_status_history_entries: usize,
     pub keep_n_sink_status_history_entries: usize,
+    pub keep_n_privatelink_status_history_entries: usize,
     /// A set of parameters used to tune RocksDB when used with `UPSERT` sources.
     pub upsert_rocksdb_tuning_config: mz_rocksdb_types::RocksDBTuningParameters,
     /// Whether or not to allow shard finalization to occur. Note that this will
@@ -65,6 +66,7 @@ impl Default for StorageParameters {
             pg_source_snapshot_statement_timeout: Default::default(),
             keep_n_source_status_history_entries: Default::default(),
             keep_n_sink_status_history_entries: Default::default(),
+            keep_n_privatelink_status_history_entries: Default::default(),
             upsert_rocksdb_tuning_config: Default::default(),
             finalize_shards: Default::default(),
             tracing: Default::default(),
@@ -152,6 +154,7 @@ impl StorageParameters {
             pg_source_snapshot_statement_timeout,
             keep_n_source_status_history_entries,
             keep_n_sink_status_history_entries,
+            keep_n_privatelink_status_history_entries,
             upsert_rocksdb_tuning_config,
             finalize_shards,
             tracing,
@@ -168,6 +171,7 @@ impl StorageParameters {
         self.pg_source_snapshot_statement_timeout = pg_source_snapshot_statement_timeout;
         self.keep_n_source_status_history_entries = keep_n_source_status_history_entries;
         self.keep_n_sink_status_history_entries = keep_n_sink_status_history_entries;
+        self.keep_n_privatelink_status_history_entries = keep_n_privatelink_status_history_entries;
         self.upsert_rocksdb_tuning_config = upsert_rocksdb_tuning_config;
         self.finalize_shards = finalize_shards;
         self.tracing.update(tracing);
@@ -195,6 +199,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             ),
             keep_n_sink_status_history_entries: u64::cast_from(
                 self.keep_n_sink_status_history_entries,
+            ),
+            keep_n_privatelink_status_history_entries: u64::cast_from(
+                self.keep_n_privatelink_status_history_entries,
             ),
             upsert_rocksdb_tuning_config: Some(self.upsert_rocksdb_tuning_config.into_proto()),
             finalize_shards: self.finalize_shards,
@@ -230,6 +237,9 @@ impl RustType<ProtoStorageParameters> for StorageParameters {
             ),
             keep_n_sink_status_history_entries: usize::cast_from(
                 proto.keep_n_sink_status_history_entries,
+            ),
+            keep_n_privatelink_status_history_entries: usize::cast_from(
+                proto.keep_n_privatelink_status_history_entries,
             ),
             upsert_rocksdb_tuning_config: proto
                 .upsert_rocksdb_tuning_config

--- a/test/cloudtest/test_privatelink_connection.py
+++ b/test/cloudtest/test_privatelink_connection.py
@@ -58,6 +58,13 @@ def test_create_privatelink_connection(mz: MaterializeApplication) -> None:
 
     exists(resource=f"vpcendpoint/connection-{aws_connection_id}")
 
+    assert (
+        "unknown"
+        == mz.environmentd.sql_query(
+            f"SELECT status FROM mz_internal.mz_aws_privatelink_connection_status_history WHERE connection_id = '{aws_connection_id}'"
+        )[0][0]
+    )
+
     # TODO: validate the contents of the VPC endpoint resource, rather than just
     # its existence.
 

--- a/test/sqllogictest/autogenerated/mz_internal.slt
+++ b/test/sqllogictest/autogenerated/mz_internal.slt
@@ -413,6 +413,13 @@ SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object
 5  details  jsonb
 
 query ITT
+SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_aws_privatelink_connection_status_history' ORDER BY position
+----
+1  occurred_at  timestamp␠with␠time␠zone
+2  connection_id  text
+3  status  text
+
+query ITT
 SELECT position, name, type FROM objects WHERE schema = 'mz_internal' AND object = 'mz_subscriptions' ORDER BY position
 ----
 1  id  text
@@ -639,6 +646,7 @@ mz_arrangement_sharing_per_worker
 mz_arrangement_sharing_raw
 mz_arrangement_sizes
 mz_arrangement_sizes_per_worker
+mz_aws_privatelink_connection_status_history
 mz_cluster_links
 mz_cluster_replica_frontiers
 mz_cluster_replica_heartbeats

--- a/test/sqllogictest/information_schema_tables.slt
+++ b/test/sqllogictest/information_schema_tables.slt
@@ -301,6 +301,10 @@ mz_arrangement_sizes_per_worker
 VIEW
 materialize
 mz_internal
+mz_aws_privatelink_connection_status_history
+SOURCE
+materialize
+mz_internal
 mz_cluster_links
 BASE TABLE
 materialize

--- a/test/testdrive/catalog.td
+++ b/test/testdrive/catalog.td
@@ -524,6 +524,7 @@ mz_arrangement_sharing_raw                   log   <null>   <null>
 mz_arrangement_heap_size_raw                 log   <null>   <null>
 mz_arrangement_heap_capacity_raw             log   <null>   <null>
 mz_arrangement_heap_allocations_raw          log   <null>   <null>
+mz_aws_privatelink_connection_status_history source <null>  <null>
 mz_cluster_replica_frontiers                 source <null>  <null>
 mz_cluster_replica_heartbeats                source <null>  <null>
 mz_compute_delays_histogram_raw              log   <null>   <null>


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a known-desirable feature: Fixes https://github.com/MaterializeInc/materialize/issues/19022
  * [Design Doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20231103_privatelink_status_table.md#solution-proposal)


<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]


    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

* Best reviewed commit-by-commit
* I added a basic check to the cloudtest `test_privatelink_connection` test case, but this is not comprehensive since cloudtest doesn't run the environment-controller and validate a real privatelink connection set up
* To do e2e validation I'm working on extending the cloud repo's [`test_privatelink`](https://github.com/MaterializeInc/cloud/blob/main/tests/k8s/test_privatelink.py)  test-case to confirm that the system table correctly reflects the up-to-date status of the VPC Endpoint CRD as a real connection is bootstrapped
* There is one TODO I left in the `watch_vpc_endpoints` function that I'm curious to get an opinion on from someone more familiar with k8s watch & privatelink status semantics

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  - https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/20231103_privatelink_status_table.md
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Implement a new `mz_internal` table `mz_aws_privatelink_connection_status_history` to expose the connection status history of PrivateLink connections to users.
