### PR TITLE
sqllogictest: support rewrite with colnames

### DIFF
--- a/src/sqllogictest/src/parser.rs
+++ b/src/sqllogictest/src/parser.rs
@@ -259,6 +259,10 @@ impl<'a> Parser<'a> {
                 &DOUBLE_LINE_REGEX
             })?
             .trim_start();
+        // We don't want to advance the expected output past the column names so rewriting works,
+        // but need to be able to parse past them, so remember the position before possible column
+        // names.
+        let query_output_str = output_str;
         let column_names = if check_column_names {
             Some(
                 split_at(&mut output_str, &LINE_REGEX)?
@@ -321,7 +325,7 @@ impl<'a> Parser<'a> {
                 column_names,
                 mode: self.mode,
                 output,
-                output_str,
+                output_str: query_output_str,
             }),
             location,
         })


### PR DESCRIPTION
Previously this would silently create incorrect output that would fail on a non-rewrite run.

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a