### PR TITLE
storage: speed up sink creation when `DescribeConfigs` is banned

### DIFF
--- a/src/kafka-util/src/admin.rs
+++ b/src/kafka-util/src/admin.rs
@@ -102,13 +102,18 @@ where
                 .iter()
                 .find(|t| t.name() == new_topic.name)
                 .ok_or(CreateTopicError::MissingMetadata)?;
-            let num_partitions = i32::try_from(topic.partitions().len())
-                .map_err(|_| CreateTopicError::TooManyPartitions)?;
-            if num_partitions != new_topic.num_partitions {
-                return Err(CreateTopicError::PartitionCountMismatch {
-                    expected: new_topic.num_partitions,
-                    actual: num_partitions,
-                });
+            // If the desired number of partitions is not "use the broker
+            // default", wait for the topic to have the correct number of
+            // partitions.
+            if new_topic.num_partitions != -1 {
+                let num_partitions = i32::try_from(topic.partitions().len())
+                    .map_err(|_| CreateTopicError::TooManyPartitions)?;
+                if num_partitions != new_topic.num_partitions {
+                    return Err(CreateTopicError::PartitionCountMismatch {
+                        expected: new_topic.num_partitions,
+                        actual: num_partitions,
+                    });
+                }
             }
             Ok(())
         })

--- a/src/storage-client/src/sink.rs
+++ b/src/storage-client/src/sink.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use anyhow::{anyhow, bail, Context};
 use maplit::btreemap;
 use mz_kafka_util::client::{
-    MzClientContext, TunnelingClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
+    GetPartitionsError, MzClientContext, TunnelingClientContext, DEFAULT_FETCH_METADATA_TIMEOUT,
 };
 use mz_ore::collections::CollectionExt;
 use mz_ore::retry::Retry;
@@ -420,17 +420,24 @@ pub async fn determine_latest_progress_record(
         C: ConsumerContext,
     {
         // ensure the progress topic has exactly one partition
-        let partitions = mz_kafka_util::client::get_partitions(
+        let partitions = match mz_kafka_util::client::get_partitions(
             progress_client.client(),
             progress_topic,
             timeout,
-        )
-        .with_context(|| {
-            format!(
-                "Unable to fetch metadata about progress topic {}",
-                progress_topic
-            )
-        })?;
+        ) {
+            Ok(partitions) => partitions,
+            Err(GetPartitionsError::TopicDoesNotExist) => {
+                // The progress topic doesn't exist, which indicates there is
+                // no committed timestamp.
+                return Ok(None);
+            }
+            e => e.with_context(|| {
+                format!(
+                    "Unable to fetch metadata about progress topic {}",
+                    progress_topic
+                )
+            })?,
+        };
 
         if partitions.len() != 1 {
             bail!(

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -391,6 +391,13 @@ impl KafkaConnection {
         T: FromClientConfigAndContext<TunnelingClientContext<C>>,
     {
         let mut options = self.options.clone();
+
+        // Ensure that Kafka topics are *not* automatically created when
+        // consuming, producing, or fetching metadata for a topic. This ensures
+        // that we don't accidentally create topics with the wrong number of
+        // partitions.
+        options.insert("allow.auto.create.topics".into(), "false".into());
+
         options.insert(
             "bootstrap.servers".into(),
             self.brokers.iter().map(|b| &b.address).join(",").into(),

--- a/test/kafka-auth/test-kafka-acl-no-describe-configs.td
+++ b/test/kafka-auth/test-kafka-acl-no-describe-configs.td
@@ -22,7 +22,9 @@
     SECURITY PROTOCOL SASL_PLAINTEXT
   );
 
-> CREATE MATERIALIZED VIEW mv AS SELECT DISTINCT column1 FROM (VALUES (1), (2));
+> CREATE TABLE t (column1 integer)
+> INSERT INTO t VALUES (1), (2)
+> CREATE MATERIALIZED VIEW mv AS SELECT DISTINCT column1 FROM t
 
 # ==> Test. <==
 
@@ -39,6 +41,15 @@ $ kafka-verify-data format=json key=false sink=materialize.public.nonexisting so
 {"column1": 1}
 {"column1": 2}
 
+# Ensure that the sink never entered the `stalled` status. Previously we had a
+# glitch where the sink would stall once before becoming healthy due to a glitch
+# in the topic creation code path when access to `DescribeConfigs` is banned.
+> SELECT DISTINCT status FROM mz_sinks
+  JOIN mz_internal.mz_sink_status_history ON mz_sinks.id = mz_sink_status_history.sink_id
+  WHERE mz_sinks.name = 'nonexisting'
+starting
+running
+
 # Creating the sink after creating the topic outside of Materialize should
 # succeed, because Materialize no longer needs to run DescribeConfigs to
 # determine the replication factor/number of partitions to use.
@@ -53,3 +64,12 @@ $ kafka-create-topic topic=no-describe-configs
 $ kafka-verify-data format=json key=false sink=materialize.public.preexisting sort-messages=true
 {"column1": 1}
 {"column1": 2}
+
+# Ensure that the sink never entered the `stalled` status. Previously we had a
+# glitch where the sink would stall once before becoming healthy due to a glitch
+# in the topic creation code path when access to `DescribeConfigs` is banned.
+> SELECT DISTINCT status FROM mz_sinks
+  JOIN mz_internal.mz_sink_status_history ON mz_sinks.id = mz_sink_status_history.sink_id
+  WHERE mz_sinks.name = 'preexisting'
+starting
+running

--- a/test/testdrive/kafka-time-offset.td
+++ b/test/testdrive/kafka-time-offset.td
@@ -31,7 +31,7 @@ $ kafka-create-topic topic=t0
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, TOPIC 'missing_topic')
   FORMAT TEXT
   INCLUDE OFFSET
-contains:UnknownTopicOrPartition (Broker: Unknown topic or partition)
+contains:Topic does not exist
 
 ! CREATE SOURCE pick_one
   FROM KAFKA CONNECTION kafka_conn (START TIMESTAMP=1, START OFFSET=[1], TOPIC 'testdrive-t0-${testdrive.seed}')


### PR DESCRIPTION
Creating a Kafka sink was previously slow when the Kafka cluster prohibited Materialize from using the `DescribeConfigs` operation. There were two problems:

 1. The code to check whether the progress topic referenced a deleted data topic was racing with the code to create the progress topic. The reference check would win the race, then choke on the fact that the progress topic did not yet exist. Materialize would suspend and resume the sink after 30s, at which point the progress topic would already exist and the reference check would succeed, but then...

 2. Materialize's topic creation code path would attempt to create the sink's data topic with -1 partitions, indicating that the broker's default number of partitions should be used, but then Materialize would *wait* for the topic to have -1 partitions, which of course never happened. Topic creation would eventually time out, at which point Materialize would suspend and resume the sink, at which point the data topic would already exist and so Materialize wouldn't wait for it to have -1 partitions.

This commit fixes (1) by teaching the reference check to handle missing progress topics and (2) by teaching the topic creation code not to wait for the topic to have any particular number of partitions if the number of requested partitions was -1. It also adds a test that ensures Kafka sinks are created without ever entering the `stalled` status.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a bug reported on Slack.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
