### PR TITLE
explain: support `disable_${feature}`

### DIFF
--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -95,6 +95,9 @@ pub struct DataflowBuilder<'a> {
     /// This can also be used to grab a handle to the storage abstraction, through
     /// its `storage_mut()` method.
     pub compute: ComputeInstanceSnapshot,
+    /// Indexes to be ignored even if they are present in the catalog.
+    pub ignored_indexes: BTreeSet<GlobalId>,
+    /// A guard for recursive operations in this [`DataflowBuilder`] instance.
     recursion_guard: RecursionGuard,
 }
 
@@ -279,8 +282,13 @@ impl<'a> DataflowBuilder<'a> {
         Self {
             catalog,
             compute,
+            ignored_indexes: Default::default(),
             recursion_guard: RecursionGuard::with_limit(RECURSION_LIMIT),
         }
+    }
+
+    pub fn ignore_indexes(&mut self, indexes: impl Iterator<Item = GlobalId>) {
+        self.ignored_indexes.extend(indexes);
     }
 
     /// Imports the view, source, or table with `id` into the provided

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -86,6 +86,7 @@ impl DataflowBuilder<'_> {
         self.catalog
             .get_indexes_on(id, self.compute.instance_id())
             .filter(|(idx_id, _idx)| self.compute.contains_collection(idx_id))
+            .filter(|(idx_id, _idx)| !self.ignored_indexes.contains(idx_id))
     }
 }
 

--- a/src/adapter/src/optimize/mod.rs
+++ b/src/adapter/src/optimize/mod.rs
@@ -157,7 +157,9 @@ impl From<(&SystemVars, &ExplainConfig)> for OptimizerConfig {
         // We are calling this constructor from an 'Explain' mode context.
         config.mode = OptimizeMode::Explain;
         // Override feature flags that can be enabled in the EXPLAIN config.
-        config.enable_new_outer_join_lowering |= explain_config.enable_new_outer_join_lowering;
+        if let Some(explain_flag) = explain_config.enable_new_outer_join_lowering {
+            config.enable_new_outer_join_lowering = explain_flag;
+        }
         // Return final result.
         config
     }

--- a/src/sql/src/plan/lowering.rs
+++ b/src/sql/src/plan/lowering.rs
@@ -148,7 +148,9 @@ impl From<(&SystemVars, &ExplainConfig)> for Config {
         // Construct base config from vars.
         let mut config = Self::from(vars);
         // Override feature flags that can be enabled in the EXPLAIN config.
-        config.enable_new_outer_join_lowering |= explain_config.enable_new_outer_join_lowering;
+        if let Some(explain_flag) = explain_config.enable_new_outer_join_lowering {
+            config.enable_new_outer_join_lowering = explain_flag;
+        }
         // Return final result.
         config
     }

--- a/test/sqllogictest/explain/bad_explain_statements.slt
+++ b/test/sqllogictest/explain/bad_explain_statements.slt
@@ -13,5 +13,5 @@ CREATE VIEW v as SELECT (1, 2)
 statement error db error: ERROR: EXPLAIN \.\.\. VIEW <view_name> is not supported, for more information consult the documentation at https://materialize\.com/docs/sql/explain\-plan
 EXPLAIN VIEW v
 
-statement error unsupported 'EXPLAIN ... WITH' flags: \{"foo"\}
+statement error unsupported 'EXPLAIN ... WITH' unknown flags: \{"foo"\}
 EXPLAIN RAW PLAN WITH (foo, types) AS TEXT FOR SELECT 1

--- a/test/sqllogictest/outer_join_lowering.slt
+++ b/test/sqllogictest/outer_join_lowering.slt
@@ -194,6 +194,65 @@ With
 
 EOF
 
+# ON predicates with non-trivial equi-join conjuncts were previously planned using
+# the fallback lowering strategy.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(disable_new_outer_join_lowering, humanized_exprs, arity) FOR
+SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
+  SELECT
+    facts.facts_k01,
+    facts.facts_d01,
+    facts.dim01_k01,
+    dim01.dim01_d01
+  FROM
+    left_joins_raw.facts LEFT JOIN
+    left_joins_raw.dim01 ON(facts.dim01_k01 + x = dim01.dim01_k01 + y)
+);
+----
+Return // { arity: 6 }
+  Filter true // { arity: 6 }
+    Project (#0, #1, #4..=#7) // { arity: 6 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+        Get l0 // { arity: 2 }
+        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+          Union // { arity: 17 }
+            Get l3 // { arity: 17 }
+            CrossJoin // { arity: 17 }
+              Project (#0..=#10) // { arity: 11 }
+                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                  Union // { arity: 11 }
+                    Negate // { arity: 11 }
+                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                        Get l3 // { arity: 17 }
+                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                      Get l2 // { arity: 11 }
+                  Get l2 // { arity: 11 }
+              Constant // { arity: 6 }
+                - (null, null, null, null, null, null)
+With
+  cte l3 =
+    Filter ((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) // { arity: 17 }
+      Project (#0..=#10, #13..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+
+EOF
+
 # ON predicates with non-trivial equi-join conjuncts are planned using the
 # optimized lowering strategy.
 query T multiline
@@ -296,6 +355,69 @@ With
             Get l1 // { arity: 2 }
             Get materialize.left_joins_raw.dim01 // { arity: 6 }
           Get l2 // { arity: 11 }
+  cte l2 =
+    CrossJoin // { arity: 11 }
+      Get l1 // { arity: 2 }
+      Get materialize.left_joins_raw.facts // { arity: 9 }
+  cte l1 =
+    Distinct project=[#0{x}, #1{y}] // { arity: 2 }
+      Get l0 // { arity: 2 }
+  cte l0 =
+    CrossJoin // { arity: 2 }
+      Constant // { arity: 0 }
+        - ()
+      Get materialize.left_joins.outer // { arity: 2 }
+
+EOF
+
+# ON predicates with at least one equi-join conjunct were previouisly planned
+# using the fallback lowering strategy.
+query T multiline
+EXPLAIN DECORRELATED PLAN WITH(disable_new_outer_join_lowering, humanized_exprs, arity) FOR
+SELECT * FROM left_joins.outer CROSS JOIN LATERAL (
+  SELECT
+    facts.facts_k01,
+    facts.facts_d01,
+    facts.dim01_k01,
+    dim01.dim01_d01
+  FROM
+    left_joins_raw.facts LEFT JOIN
+    left_joins_raw.dim01 ON(
+      facts.dim01_k01 + x = dim01.dim01_k01 + y AND
+      facts_d02 = 42 AND
+      dim01_d02 = 24
+    )
+);
+----
+Return // { arity: 6 }
+  Filter true // { arity: 6 }
+    Project (#0, #1, #4..=#7) // { arity: 6 }
+      Join on=(#0{x} = #2{x} AND #1{y} = #3{y}) // { arity: 8 }
+        Get l0 // { arity: 2 }
+        Project (#0..=#2, #6, #3, #12) // { arity: 6 }
+          Union // { arity: 17 }
+            Get l3 // { arity: 17 }
+            CrossJoin // { arity: 17 }
+              Project (#0..=#10) // { arity: 11 }
+                Join on=(#0{x} = #11{x} AND #1{y} = #12{y} AND #2{facts_k01} = #13{facts_k01} AND #3{dim01_k01} = #14{dim01_k01} AND #4{dim02_k01} = #15{dim02_k01} AND #5{dim03_k01} = #16{dim03_k01} AND #6{facts_d01} = #17{facts_d01} AND #7{facts_d02} = #18{facts_d02} AND #8{facts_d03} = #19{facts_d03} AND #9{facts_d04} = #20{facts_d04} AND #10{facts_d05} = #21{facts_d05}) // { arity: 22 }
+                  Union // { arity: 11 }
+                    Negate // { arity: 11 }
+                      Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                        Get l3 // { arity: 17 }
+                    Distinct project=[#0{x}, #1{y}, #2{facts_k01}, #3{dim01_k01}, #4{dim02_k01}, #5{dim03_k01}, #6{facts_d01}, #7{facts_d02}, #8{facts_d03}, #9{facts_d04}, #10{facts_d05}] // { arity: 11 }
+                      Get l2 // { arity: 11 }
+                  Get l2 // { arity: 11 }
+              Constant // { arity: 6 }
+                - (null, null, null, null, null, null)
+With
+  cte l3 =
+    Filter ((((#3{dim01_k01} + #0{x}) = (#11{dim01_k01} + #1{y})) AND (#7{facts_d02} = 42)) AND (#13{dim01_d02} = 24)) // { arity: 17 }
+      Project (#0..=#10, #13..=#18) // { arity: 17 }
+        Join on=(#0{x} = #11{x} AND #1{y} = #12{y}) // { arity: 19 }
+          Get l2 // { arity: 11 }
+          CrossJoin // { arity: 8 }
+            Get l1 // { arity: 2 }
+            Get materialize.left_joins_raw.dim01 // { arity: 6 }
   cte l2 =
     CrossJoin // { arity: 11 }
       Get l1 // { arity: 2 }

--- a/test/sqllogictest/tpch_create_index.slt
+++ b/test/sqllogictest/tpch_create_index.slt
@@ -187,6 +187,11 @@ ORDER BY
 	l_returnflag,
 	l_linestatus;
 
+# Create a default index on Q01 in order to ensure that the EXPLAIN CREATE INDEX
+# output does not produce a plan that just reads from the explained index if it
+# already exists.
+statement ok
+CREATE DEFAULT INDEX ON Q01;
 
 query T multiline
 -- Explain index on Q01


### PR DESCRIPTION
Fix `EXPLAIN` glitches that prevented us from catching plan regressions in the latest production deployment.

### Motivation

  * This PR fixes a previously unreported bug.

This fixes the following two bugs.

First: `ExplainConfig` flags that override feature flags should be able to work in both directions:

1. When the feature flag value is `off` one should be able to turn it
   `on` with an `ExplainConfig` override.
2. When the feature flag value is `on` one should be able to turn it
   `off` with an `ExplainConfig` override.

Currently, we only do (1). The first commit adds (2) and some reusable infrastructure that we can use for future feature flags.

Second: fix `EXPLAIN CREATE INDEX`

At the moment `EXPLAIN CREATE INDEX` will report a trivial plan that just reads from an index if an index identical to the explained one exists in the catalog.

The second commit changes this behavior by excluding structurally identical indexes from the `EXPLAIN` optimization pass.

### Tips for reviewer

1. The first commit works by:
    1. Changing the `ExplainConfig::enable_new_outer_join_lowering` type from `bool` to `Option<bool>`.
    1. Adding a `parse_flag` function for parsing `ExplainConfig` values that override feature flags.
2. The second commit works by:
    1. Adding an `ignored_indexes: BTreeSet<GlobalId>` field to `DataflowBuilder`.
    2. Filtering out ignored indexes in `DataflowBuilder::indexes_on`.
    3. Ignoring indexes on the same item that use the same keys in the `index::Optimizer` in `Explain` mode.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix a bug in `EXPLAIN CREATE INDEX` when an identical index already exists in the catalog.
