### PR TITLE
persist: Mark fetch_recent_upper as linearizable

### DIFF
--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -823,8 +823,6 @@ fn diagnostics() -> Diagnostics {
 }
 
 /// Fetch the current upper of the catalog state.
-// TODO(jkosh44) This isn't actually guaranteed to be linearizable. Before enabling this in
-//  production we need a new linearizable solution.
 async fn current_upper(
     write_handle: &mut WriteHandle<StateUpdateKind, (), Timestamp, Diff>,
 ) -> Timestamp {


### PR DESCRIPTION
This commit updates the documentation for fetch_recent_upper to indicate that it is linearizable with other writes and adds a test for linearizability.

### Motivation
This PR adds a feature that has not yet been specified.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
