### PR TITLE
sql: use common fn for show create

### DIFF
--- a/test/sqllogictest/show_create_system_objects.slt
+++ b/test/sqllogictest/show_create_system_objects.slt
@@ -9,8 +9,8 @@
 
 mode cockroach
 
-query error cannot show create for system object mz_internal.mz_storage_shards
-SHOW CREATE SOURCE mz_internal.mz_storage_shards
+query error db error: ERROR: cannot show create for system object mz_internal\.mz_source_statistics
+SHOW CREATE SOURCE mz_internal.mz_source_statistics
 
-query error cannot show create for system object mz_catalog.mz_tables
+query error db error: ERROR: cannot show create for system object mz_catalog\.mz_tables
 SHOW CREATE TABLE mz_tables


### PR DESCRIPTION
Refactor to use common logic for `SHOW CREATE`; no logic change.

### Motivation

   * This PR refactors existing code.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a