### PR TITLE
zippy: Add Backup + Restore to scenarios

### DIFF
--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -100,6 +100,18 @@ steps:
           composition: zippy
           args: [--scenario=DebeziumPostgres, --actions=1000000]
 
+  - id: zippy-backup-and-restore-large
+    label: "Large-scale backup+restore"
+    timeout_in_minutes: 2880
+    agents:
+      queue: linux-x86_64
+    artifact_paths: junit_*.xml
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: zippy
+          args: [--scenario=BackupAndRestoreLarge, --actions=1000000]
+
+
   - id: zippy-kafka-parallel-insert
     label: "Longer Zippy Kafka Parallel Insert"
     timeout_in_minutes: 2880

--- a/misc/python/materialize/checks/backup_actions.py
+++ b/misc/python/materialize/checks/backup_actions.py
@@ -10,25 +10,12 @@
 
 from materialize.checks.actions import Action
 from materialize.checks.executors import Executor
-from materialize.mzcompose.services.minio import MINIO_BLOB_URI
 
 
 class Backup(Action):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
-        c.exec("mc", "mc", "mb", "--ignore-existing", "persist/crdb-backup")
-        c.exec(
-            "cockroach",
-            "cockroach",
-            "sql",
-            "--insecure",
-            "-e",
-            """
-           CREATE EXTERNAL CONNECTION backup_bucket AS 's3://persist/crdb-backup?AWS_ENDPOINT=http://minio:9000/&AWS_REGION=minio&AWS_ACCESS_KEY_ID=minioadmin&AWS_SECRET_ACCESS_KEY=minioadmin';
-           BACKUP INTO 'external://backup_bucket';
-           DROP EXTERNAL CONNECTION backup_bucket;
-        """,
-        )
+        c.backup_crdb()
 
     def join(self, e: Executor) -> None:
         # Action is blocking
@@ -38,27 +25,7 @@ class Backup(Action):
 class Restore(Action):
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
-        c.exec(
-            "cockroach",
-            "cockroach",
-            "sql",
-            "--insecure",
-            "-e",
-            """
-            DROP DATABASE defaultdb;
-            CREATE EXTERNAL CONNECTION backup_bucket AS 's3://persist/crdb-backup?AWS_ENDPOINT=http://minio:9000/&AWS_REGION=minio&AWS_ACCESS_KEY_ID=minioadmin&AWS_SECRET_ACCESS_KEY=minioadmin';
-            RESTORE DATABASE defaultdb FROM LATEST IN 'external://backup_bucket';
-            DROP EXTERNAL CONNECTION backup_bucket;
-        """,
-        )
-        c.run(
-            "persistcli",
-            "admin",
-            "--commit",
-            "restore-blob",
-            f"--blob-uri={MINIO_BLOB_URI}",
-            "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
-        )
+        c.restore_mz()
 
     def join(self, e: Executor) -> None:
         # Action is blocking

--- a/misc/python/materialize/checks/scenarios_backup_restore.py
+++ b/misc/python/materialize/checks/scenarios_backup_restore.py
@@ -34,7 +34,6 @@ class BackupAndRestoreAfterManipulate(Scenario):
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Validate(self),
         ]
 
@@ -50,7 +49,6 @@ class BackupAndRestoreBeforeManipulate(Scenario):
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Manipulate(self, phase=2),
             Validate(self),
         ]
@@ -73,7 +71,6 @@ class BackupAndRestoreToPreviousState(Scenario):
             Manipulate(self, phase=2),  # Those updates will be lost here ..
             KillMz(),
             Restore(),
-            StartMz(self),
             Manipulate(self, phase=2),  # ... and redone here
             Validate(self),
         ]
@@ -89,21 +86,17 @@ class BackupAndRestoreMulti(Scenario):
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Manipulate(self, phase=1),
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Manipulate(self, phase=2),
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Validate(self),
             Backup(),
             KillMz(),
             Restore(),
-            StartMz(self),
             Validate(self),
         ]

--- a/misc/python/materialize/mzcompose/services/persistcli.py
+++ b/misc/python/materialize/mzcompose/services/persistcli.py
@@ -1,0 +1,14 @@
+from materialize.mzcompose.service import Service
+
+
+class Persistcli(Service):
+    def __init__(
+        self,
+    ) -> None:
+        super().__init__(
+            name="persistcli",
+            config={
+                # TODO: depends!
+                "mzbuild": "jobs"
+            },
+        )

--- a/misc/python/materialize/mzcompose/services/persistcli.py
+++ b/misc/python/materialize/mzcompose/services/persistcli.py
@@ -1,3 +1,13 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
 from materialize.mzcompose.service import Service
 
 

--- a/misc/python/materialize/zippy/all_actions.py
+++ b/misc/python/materialize/zippy/all_actions.py
@@ -1,0 +1,38 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.zippy.balancerd_actions import BalancerdIsRunning
+from materialize.zippy.framework import Action, ActionFactory, Capabilities, Capability
+from materialize.zippy.mz_actions import MzIsRunning
+from materialize.zippy.table_actions import ValidateTable
+from materialize.zippy.table_capabilities import TableExists
+from materialize.zippy.view_actions import ValidateView
+from materialize.zippy.view_capabilities import ViewExists
+
+
+class ValidateAll(ActionFactory):
+    """Emits ValidateView and ValidateTable for all eligible objects."""
+
+    @classmethod
+    def requires(cls) -> list[set[type[Capability]]]:
+        return [
+            {BalancerdIsRunning, MzIsRunning, TableExists},
+            {BalancerdIsRunning, MzIsRunning, ViewExists},
+        ]
+
+    def new(self, capabilities: Capabilities) -> list[Action]:
+        validations = []
+        for view in capabilities.get(ViewExists):
+            validations.append(ValidateView(capabilities=capabilities, view=view))
+
+        for table in capabilities.get(TableExists):
+            validations.append(ValidateTable(capabilities=capabilities, table=table))
+
+        return validations

--- a/misc/python/materialize/zippy/backup_and_restore_actions.py
+++ b/misc/python/materialize/zippy/backup_and_restore_actions.py
@@ -1,0 +1,29 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+
+from materialize.mzcompose.composition import Composition
+from materialize.zippy.crdb_capabilities import CockroachIsRunning
+from materialize.zippy.framework import Action, Capability
+from materialize.zippy.mz_capabilities import MzIsRunning
+
+
+class BackupAndRestore(Action):
+    @classmethod
+    def requires(cls) -> set[type[Capability]]:
+        return {MzIsRunning, CockroachIsRunning}
+
+    def run(self, c: Composition) -> None:
+        # Required because of #22762
+        c.kill("storaged")
+
+        c.backup_crdb()
+        c.restore_mz()
+
+        c.up("storaged")

--- a/misc/python/materialize/zippy/framework.py
+++ b/misc/python/materialize/zippy/framework.py
@@ -10,9 +10,12 @@
 import random
 from collections.abc import Sequence
 from datetime import datetime, timedelta
-from typing import TypeVar, Union
+from typing import TYPE_CHECKING, TypeVar, Union
 
 from materialize.mzcompose.composition import Composition
+
+if TYPE_CHECKING:
+    from materialize.zippy.scenarios import Scenario
 
 
 class Capability:
@@ -152,19 +155,11 @@ class ActionFactory:
         return set()
 
 
-class Scenario:
-    def bootstrap(self) -> list[ActionOrFactory]:
-        return []
-
-    def config(self) -> dict[ActionOrFactory, float]:
-        assert False
-
-
 class Test:
     """A Zippy test, consisting of a sequence of actions."""
 
     def __init__(
-        self, scenario: Scenario, actions: int, max_execution_time: timedelta
+        self, scenario: "Scenario", actions: int, max_execution_time: timedelta
     ) -> None:
         """Generate a new Zippy test.
 
@@ -174,18 +169,22 @@ class Test:
         """
         self._scenario = scenario
         self._actions: list[Action] = []
+        self._final_actions: list[Action] = []
         self._capabilities = Capabilities()
-        self._config = self._scenario.config()
-        self._max_execution_time = max_execution_time
+        self._config: dict[ActionOrFactory, float] = self._scenario.config()
+        self._max_execution_time: timedelta = max_execution_time
 
         for action_or_factory in self._scenario.bootstrap():
-            self.append_actions(action_or_factory)
+            self._actions.extend(self.generate_actions(action_or_factory))
 
         while len(self._actions) < actions:
             action_or_factory = self._pick_action_or_factory()
-            self.append_actions(action_or_factory)
+            self._actions.extend(self.generate_actions(action_or_factory))
 
-    def append_actions(self, action_def: ActionOrFactory) -> None:
+        for action_or_factory in self._scenario.finalization():
+            self._final_actions.extend(self.generate_actions(action_or_factory))
+
+    def generate_actions(self, action_def: ActionOrFactory) -> list[Action]:
         if isinstance(action_def, ActionFactory):
             actions = action_def.new(capabilities=self._capabilities)
         elif issubclass(action_def, Action):
@@ -194,12 +193,13 @@ class Test:
             assert False
 
         for action in actions:
-            self._actions.append(action)
             print("test:", action)
             self._capabilities._extend(action.provides())
             print(" - ", self._capabilities, action.provides())
             self._capabilities._remove(action.withholds())
             print(" - ", self._capabilities, action.withholds())
+
+        return actions
 
     def run(self, c: Composition) -> None:
         """Run the Zippy test."""
@@ -212,6 +212,10 @@ class Test:
                     f"--- Desired execution time of {self._max_execution_time} has been reached."
                 )
                 break
+
+        for action in self._final_actions:
+            print(action)
+            action.run(c)
 
     def _pick_action_or_factory(self) -> ActionOrFactory:
         """Select the next Action to run in the Test"""

--- a/misc/python/materialize/zippy/table_actions.py
+++ b/misc/python/materialize/zippy/table_actions.py
@@ -91,8 +91,14 @@ class ValidateTable(Action):
     def requires(cls) -> set[type[Capability]]:
         return {BalancerdIsRunning, MzIsRunning, TableExists}
 
-    def __init__(self, capabilities: Capabilities) -> None:
-        self.table = random.choice(capabilities.get(TableExists))
+    def __init__(
+        self, capabilities: Capabilities, table: TableExists | None = None
+    ) -> None:
+        if table is not None:
+            self.table = table
+        else:
+            self.table = random.choice(capabilities.get(TableExists))
+
         self.select_limit = random.choices([True, False], weights=[0.2, 0.8], k=1)[0]
         super().__init__(capabilities)
 

--- a/misc/python/materialize/zippy/view_actions.py
+++ b/misc/python/materialize/zippy/view_actions.py
@@ -129,8 +129,14 @@ class ValidateView(Action):
     def requires(cls) -> set[type[Capability]]:
         return {BalancerdIsRunning, MzIsRunning, StoragedRunning, ViewExists}
 
-    def __init__(self, capabilities: Capabilities) -> None:
-        self.view = random.choice(capabilities.get(ViewExists))
+    def __init__(
+        self, capabilities: Capabilities, view: ViewExists | None = None
+    ) -> None:
+        if view is None:
+            self.view = random.choice(capabilities.get(ViewExists))
+        else:
+            self.view = view
+
         # Trigger the PeekPersist optimization
         self.select_limit = random.choice(["", "LIMIT 1"])
         super().__init__(capabilities)

--- a/test/backup-restore/mzcompose.py
+++ b/test/backup-restore/mzcompose.py
@@ -9,10 +9,10 @@
 from textwrap import dedent
 
 from materialize.mzcompose.composition import Composition
-from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.minio import Mc, Minio
+from materialize.mzcompose.services.persistcli import Persistcli
 from materialize.mzcompose.services.testdrive import Testdrive
 
 SERVICES = [
@@ -21,13 +21,7 @@ SERVICES = [
     Mc(),
     Materialized(external_minio=True, external_cockroach=True, sanity_restart=False),
     Testdrive(no_reset=True),
-    Service(
-        name="persistcli",
-        config={
-            # TODO: depends!
-            "mzbuild": "jobs"
-        },
-    ),
+    Persistcli(),
 ]
 
 
@@ -35,35 +29,7 @@ def workflow_default(c: Composition) -> None:
     # TODO: extract common substrings
 
     # Enable versioning for the Persist bucket
-    c.up("minio")
-    c.up("mc", persistent=True)
-    c.exec(
-        "mc",
-        "mc",
-        "alias",
-        "set",
-        "persist",
-        "http://minio:9000/",
-        "minioadmin",
-        "minioadmin",
-    )
-    c.exec("mc", "mc", "version", "enable", "persist/persist")
-    blob_uri = "s3://minioadmin:minioadmin@persist/persist?endpoint=http://minio:9000/&region=minio"
-
-    # Set up a backupable connection for CRDB
-    c.up("cockroach")
-    c.exec("mc", "mc", "mb", "persist/crdb-backup")
-    c.exec(
-        "cockroach",
-        "cockroach",
-        "sql",
-        "--insecure",
-        "-e",
-        "CREATE EXTERNAL CONNECTION backup_bucket as "
-        "'s3://persist/crdb-backup?AWS_ENDPOINT=http://minio:9000/&AWS_REGION=minio&"
-        "AWS_ACCESS_KEY_ID=minioadmin&AWS_SECRET_ACCESS_KEY=minioadmin';"
-        "SHOW CREATE ALL EXTERNAL CONNECTIONS;",
-    )
+    c.enable_minio_versioning()
 
     # Start Materialize, and set up some basic state in it
     c.up("materialized")
@@ -80,23 +46,7 @@ def workflow_default(c: Composition) -> None:
         )
     )
 
-    # Run a manual CRDB backup
-    c.exec(
-        "cockroach",
-        "cockroach",
-        "sql",
-        "--insecure",
-        "-e",
-        "BACKUP INTO 'external://backup_bucket';",
-    )
-    c.exec(
-        "cockroach",
-        "cockroach",
-        "sql",
-        "--insecure",
-        "-e",
-        "SHOW BACKUPS IN 'external://backup_bucket';",
-    )
+    c.backup_crdb()
 
     # Make further updates to Materialize's state
     for i in range(0, 100):
@@ -113,21 +63,8 @@ def workflow_default(c: Composition) -> None:
             )
         )
 
-    # Stop the running cluster and execute a restore
-    c.kill(
-        "materialized"
-    )  # Very important that MZ is not running during the restore process!
-    c.exec(
-        "cockroach", "cockroach", "sql", "--insecure", "-e", "DROP DATABASE defaultdb;"
-    )
-    c.exec(
-        "cockroach",
-        "cockroach",
-        "sql",
-        "--insecure",
-        "-e",
-        "RESTORE DATABASE defaultdb FROM LATEST IN 'external://backup_bucket';",
-    )
+    # Restore CRDB from backup, run persistcli restore-blob and restart Mz
+    c.restore_mz()
 
     # Confirm that the database is readable / has shard data
     c.exec(
@@ -139,19 +76,6 @@ def workflow_default(c: Composition) -> None:
         "SELECT shard, min(sequence_number), max(sequence_number) "
         "FROM consensus.consensus GROUP BY 1 ORDER BY 2 DESC, 3 DESC, 1 ASC LIMIT 32;",
     )
-
-    # Bring the persist state back into sync
-    c.run(
-        "persistcli",
-        "admin",
-        "--commit",
-        "restore-blob",
-        f"--blob-uri={blob_uri}",
-        "--consensus-uri=postgres://root@cockroach:26257?options=--search_path=consensus",
-    )
-
-    # Restart Materialize
-    c.up("materialized")
 
     # Check that the cluster is up and that it answers queries as of the old state
     c.testdrive(

--- a/test/zippy/mzcompose.py
+++ b/test/zippy/mzcompose.py
@@ -20,7 +20,8 @@ from materialize.mzcompose.services.debezium import Debezium
 from materialize.mzcompose.services.grafana import Grafana
 from materialize.mzcompose.services.kafka import Kafka
 from materialize.mzcompose.services.materialized import Materialized
-from materialize.mzcompose.services.minio import Minio
+from materialize.mzcompose.services.minio import Mc, Minio
+from materialize.mzcompose.services.persistcli import Persistcli
 from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.prometheus import Prometheus
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
@@ -41,6 +42,7 @@ SERVICES = [
     Postgres(),
     Cockroach(),
     Minio(setup_materialize=True),
+    Mc(),
     Balancerd(),
     # Those two are overriden below
     Materialized(),
@@ -49,6 +51,7 @@ SERVICES = [
     Grafana(),
     Prometheus(),
     SshBastionHost(),
+    Persistcli(),
 ]
 
 
@@ -134,6 +137,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     scenario_class = globals()[args.scenario]
 
     c.up("zookeeper", "kafka", "schema-registry", "ssh-bastion-host")
+    c.enable_minio_versioning()
 
     if args.observability:
         c.up("prometheus", "grafana")


### PR DESCRIPTION
```
commit 4dea7b42fb2b901bdece57f10a5686ff4f184663 (HEAD -> zippy-backup-restore, origin/zippy-backup-restore)
Author: Philip Stoev <pstoev@materialize.com>
Date:   Mon Nov 20 11:52:50 2023 +0100

    zippy: Add Backup+Restore
    
    - Implement a unified BackupAndRestore action
    - Implement a ValidateAll action factory that validates all tables and views
    - add Backup+Restore with low probability to the UserTables scenario
    - add a large-scale Backup+Restore test to the Release Qualification
    - make sure all scenario perform BackupAndRestore + ValidateAll at termination

commit 6dbb5898c0a35d23a7141eaabbdcc0689d6965f7
Author: Philip Stoev <pstoev@materialize.com>
Date:   Mon Nov 20 11:50:26 2023 +0100

    mzcompose: Centralize all backup+restore related actions
    
    Remove code duplication when it comes to taking CRDB backups,
    running persistcli and restoring Mz from backup.

```

### Motivation
Integration with Zippy is required so that large-scale backups and restores are performed in the CI.