### PR TITLE
parallel-workload: Use stash in kill and backuprestore scenarios

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -621,6 +621,21 @@ class PostgresSource(DBObject):
         self.executor.create()
 
 
+class Index:
+    _name: str
+    lock: threading.Lock
+
+    def __init__(self, name: str):
+        self._name = name
+        self.lock = threading.Lock()
+
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
+        return identifier(self.name())
+
+
 class Role:
     role_id: int
     lock: threading.Lock
@@ -733,7 +748,7 @@ class Database:
     role_id: int
     clusters: list[Cluster]
     cluster_id: int
-    indexes: set[str]
+    indexes: set[Index]
     webhook_sources: list[WebhookSource]
     webhook_source_id: int
     kafka_sources: list[KafkaSource]


### PR DESCRIPTION
I expected mypy to notice this, oops

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
