### PR TITLE
sql: Add suggestions to error for invalid storage or compute cluster

### DIFF
--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -796,4 +796,63 @@ DROP CLUSTER REPLICA t1.r1;
 statement ok
 DROP CLUSTER t1
 
+statement ok
+CREATE CLUSTER storage_a SIZE = '1';
+
+statement ok
+CREATE CLUSTER storage_b SIZE = '1';
+
+statement ok
+CREATE SOURCE storage_a_loadgen IN CLUSTER storage_a FROM LOAD GENERATOR COUNTER;
+
+statement ok
+CREATE SOURCE storage_b_loadgen IN CLUSTER storage_b FROM LOAD GENERATOR COUNTER;
+
+statement ok
+CREATE CLUSTER compute_a SIZE = '1';
+
+statement ok
+CREATE CLUSTER compute_b SIZE = '1';
+
+statement ok
+CREATE TABLE compute_t1 (x int);
+
+statement ok
+INSERT INTO compute_t1 VALUES (100), (200), (300);
+
+statement ok
+CREATE MATERIALIZED VIEW compute_a_mv1 IN CLUSTER compute_a AS ( SELECT AVG(x) FROM compute_t1 );
+
+statement ok
+CREATE MATERIALIZED VIEW compute_b_mv1 IN CLUSTER compute_b AS ( SELECT MIN(x) FROM compute_t1 );
+
+statement ok
+SET cluster TO storage_a;
+
+simple
+SELECT * FROM compute_t1;
+----
+db error: ERROR: cannot execute queries on cluster containing sources or sinks
+HINT: Clusters that do not contain sources or sinks: "default","compute_a","compute_b".
+
+statement ok
+SET cluster to default;
+
+simple
+CREATE MATERIALIZED VIEW storage_a_mv_1 IN CLUSTER storage_a AS ( SELECT MAX(x) FROM compute_t1 );
+----
+db error: ERROR: cannot create this kind of item in a cluster that contains sources or sinks
+
+statement ok
+DROP CLUSTER storage_a CASCADE;
+
+statement ok
+DROP CLUSTER storage_b CASCADE;
+
+statement ok
+DROP CLUSTER compute_a CASCADE;
+
+statement ok
+DROP CLUSTER compute_b CASCADE;
+
 reset-server


### PR DESCRIPTION
This PR updates the error that gets returned to a user when they try to run some compute operation (e.g. a peek or install a mat view) on a storage cluster, or when they try to install a storage resource on a compute cluster. If possible, the error now suggests other clusters that could be used.

For example, now if a user tries to run a peek on a cluster containing a source or sink, this is the error they'd receive:

```
> SELECT * FROM compute_t1;

ERROR: cannot execute queries on cluster containing sources or sinks
HINT: Clusters that do not contain sources or sinks: "default","compute_a","compute_b".
```

### Motivation

A few users have hit this recently ([example 1](https://materializeinc.slack.com/archives/C05J136GN6M/p1700090109690239?thread_ts=1700087156.096399&cid=C05J136GN6M), [example 2](https://materializeinc.slack.com/archives/C0371KDER40/p1699976103555779?thread_ts=1699628905.719879&cid=C0371KDER40)) and it seemed like the error could use some improvement.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates a user visible SQL error to provide suggestions of how they could fix the behavior.
