### PR TITLE
[persist] Batch-fetching tweaks

### DIFF
--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -357,7 +357,6 @@ pub(crate) enum SerdeLeasedBatchPartMetadata {
 ///
 /// `LeasedBatchPart` may only be dropped if it:
 /// - Does not have a leased `SeqNo (i.e. `self.leased_seqno.is_none()`)
-/// - Is consumed through `self.get_droppable_part()`
 ///
 /// In any other circumstance, dropping `LeasedBatchPart` panics.
 #[derive(Debug)]

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -76,23 +76,17 @@ where
     /// returned value.
     pub async fn fetch_leased_part(
         &self,
-        part: LeasedBatchPart<T>,
-    ) -> (
-        LeasedBatchPart<T>,
-        Result<FetchedPart<K, V, T, D>, InvalidUsage<T>>,
-    ) {
+        part: &LeasedBatchPart<T>,
+    ) -> Result<FetchedPart<K, V, T, D>, InvalidUsage<T>> {
         if &part.shard_id != &self.shard_id {
             let batch_shard = part.shard_id.clone();
-            return (
-                part,
-                Err(InvalidUsage::BatchNotFromThisShard {
-                    batch_shard,
-                    handle_shard: self.shard_id.clone(),
-                }),
-            );
+            return Err(InvalidUsage::BatchNotFromThisShard {
+                batch_shard,
+                handle_shard: self.shard_id.clone(),
+            });
         }
 
-        let (part, fetched_part) = fetch_leased_part(
+        let fetched_part = fetch_leased_part(
             part,
             self.blob.as_ref(),
             Arc::clone(&self.metrics),
@@ -102,7 +96,7 @@ where
             self.schemas.clone(),
         )
         .await;
-        (part, Ok(fetched_part))
+        Ok(fetched_part)
     }
 }
 
@@ -181,14 +175,14 @@ impl<T: Timestamp + Lattice> FetchBatchFilter<T> {
 /// Note to check the `LeasedBatchPart` documentation for how to handle the
 /// returned value.
 pub(crate) async fn fetch_leased_part<K, V, T, D>(
-    part: LeasedBatchPart<T>,
+    part: &LeasedBatchPart<T>,
     blob: &(dyn Blob + Send + Sync),
     metrics: Arc<Metrics>,
     read_metrics: &ReadMetrics,
     shard_metrics: &ShardMetrics,
     reader_id: Option<&LeasedReaderId>,
     schemas: Schemas<K, V>,
-) -> (LeasedBatchPart<T>, FetchedPart<K, V, T, D>)
+) -> FetchedPart<K, V, T, D>
 where
     K: Debug + Codec,
     V: Debug + Codec,
@@ -238,7 +232,7 @@ where
         _phantom: PhantomData,
     };
 
-    (part, fetched_part)
+    fetched_part
 }
 
 pub(crate) async fn fetch_batch_part<T>(

--- a/src/persist-client/src/fetch.rs
+++ b/src/persist-client/src/fetch.rs
@@ -32,8 +32,8 @@ use crate::error::InvalidUsage;
 use crate::internal::encoding::{LazyPartStats, Schemas};
 use crate::internal::machine::retry_external;
 use crate::internal::metrics::{Metrics, ReadMetrics, ShardMetrics};
-use crate::internal::paths::PartialBatchKey;
-use crate::read::{LeasedReaderId, ReadHandle};
+use crate::internal::paths::{BlobKey, PartialBatchKey};
+use crate::read::LeasedReaderId;
 use crate::stats::PartStats;
 use crate::ShardId;
 
@@ -65,19 +65,6 @@ where
     T: Timestamp + Lattice + Codec64,
     D: Semigroup + Codec64 + Send + Sync,
 {
-    pub(crate) async fn new(handle: ReadHandle<K, V, T, D>) -> Self {
-        let b = BatchFetcher {
-            blob: Arc::clone(&handle.blob),
-            metrics: Arc::clone(&handle.metrics),
-            shard_metrics: Arc::clone(&handle.machine.applier.shard_metrics),
-            shard_id: handle.machine.shard_id(),
-            schemas: handle.schemas.clone(),
-            _phantom: PhantomData,
-        };
-        handle.expire().await;
-        b
-    }
-
     /// Takes a [`SerdeLeasedBatchPart`] into a [`LeasedBatchPart`].
     pub fn leased_part_from_exchangeable(&self, x: SerdeLeasedBatchPart) -> LeasedBatchPart<T> {
         LeasedBatchPart::from(x, Arc::clone(&self.metrics))
@@ -408,7 +395,7 @@ where
     /// operator to safely expire leases.
     ///
     /// The part's `reader_id` is intentionally inaccessible, and should
-    /// be obtained from the issuing [`ReadHandle`], or one of its derived
+    /// be obtained from the issuing [`crate::ReadHandle`], or one of its derived
     /// structures, e.g. [`crate::read::Subscribe`].
     ///
     /// # Panics

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -40,6 +40,7 @@ use crate::internal::encoding::Schemas;
 use crate::internal::gc::GarbageCollector;
 use crate::internal::machine::{retry_external, Machine};
 use crate::internal::metrics::ShardMetrics;
+use crate::internal::paths::BlobKey;
 use crate::internal::state::{HollowBatch, HollowBatchPart};
 use crate::internal::trace::{ApplyMergeResult, FueledMergeRes};
 use crate::iter::Consolidator;

--- a/src/persist-client/src/internal/compact.rs
+++ b/src/persist-client/src/internal/compact.rs
@@ -1001,7 +1001,7 @@ impl Timings {
 #[derive(Debug)]
 enum CompactionPart<'a, T> {
     Queued(&'a HollowBatchPart),
-    Prefetched(usize, JoinHandle<Result<EncodedPart<T>, anyhow::Error>>),
+    Prefetched(usize, JoinHandle<Result<EncodedPart<T>, BlobKey>>),
 }
 
 impl<'a, T: Timestamp + Lattice + Codec64> CompactionPart<'a, T> {
@@ -1019,8 +1019,8 @@ impl<'a, T: Timestamp + Lattice + Codec64> CompactionPart<'a, T> {
         metrics: &Metrics,
         shard_metrics: &ShardMetrics,
         part_desc: &Description<T>,
-    ) -> Result<EncodedPart<T>, anyhow::Error> {
-        match self {
+    ) -> anyhow::Result<EncodedPart<T>> {
+        let result = match self {
             CompactionPart::Prefetched(_, task) => {
                 if task.is_finished() {
                     metrics.compaction.parts_prefetched.inc();
@@ -1042,7 +1042,8 @@ impl<'a, T: Timestamp + Lattice + Codec64> CompactionPart<'a, T> {
                 )
                 .await
             }
-        }
+        };
+        result.map_err(|blob_key| anyhow!("failed to fetch part for shard: {blob_key}"))
     }
 }
 

--- a/src/persist-client/src/iter.rs
+++ b/src/persist-client/src/iter.rs
@@ -9,7 +9,7 @@
 
 //! Code for iterating through one or more parts, including streaming consolidation.
 
-use anyhow::{anyhow, bail};
+use anyhow::anyhow;
 use std::cmp::{Ordering, Reverse};
 use std::collections::binary_heap::PeekMut;
 use std::collections::{BinaryHeap, VecDeque};
@@ -429,10 +429,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         self.metrics.consolidation.parts_fetched.inc();
                         let maybe_unconsolidated = data.maybe_unconsolidated();
                         *part = ConsolidationPart::from_encoded(
-                            data.take()
-                                .fetch()
-                                .await
-                                .ok_or_else(anyhow!("unexpectedly missing part"))?,
+                            data.take().fetch().await?,
                             &self.filter,
                             maybe_unconsolidated,
                         );
@@ -449,9 +446,7 @@ impl<T: Timestamp + Codec64 + Lattice, D: Codec64 + Semigroup> Consolidator<T, D
                         }
                         self.metrics.consolidation.parts_fetched.inc();
                         *part = ConsolidationPart::from_encoded(
-                            handle
-                                .await?
-                                .ok_or_else(anyhow!("unexpectedly missing part"))?,
+                            handle.await??,
                             &self.filter,
                             *maybe_unconsolidated,
                         );

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -461,10 +461,6 @@ impl PersistClient {
     }
 
     /// Creates and returns a [BatchFetcher] for the given shard id.
-    ///
-    /// The `_schema` parameter is currently unused, but should be an object
-    /// that represents the schema of the data in the shard. This will be required
-    /// in the future.
     #[instrument(level = "debug", skip_all, fields(shard = %shard_id))]
     pub async fn create_batch_fetcher<K, V, T, D>(
         &self,

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1179,7 +1179,7 @@ mod tests {
                 )
                 .await;
             for batch in snap {
-                let (batch, res) = fetcher1.fetch_leased_part(batch).await;
+                let res = fetcher1.fetch_leased_part(&batch).await;
                 read0.process_returned_leased_part(batch);
                 assert_eq!(
                     res.unwrap_err(),

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -1170,10 +1170,14 @@ mod tests {
             let shard_id1 = "s11111111-1111-1111-1111-111111111111"
                 .parse::<ShardId>()
                 .expect("invalid shard id");
-            let (_, read1) = client
-                .expect_open::<String, String, u64, i64>(shard_id1)
+            let fetcher1 = client
+                .create_batch_fetcher::<String, String, u64, i64>(
+                    shard_id1,
+                    Default::default(),
+                    Default::default(),
+                    Diagnostics::for_tests(),
+                )
                 .await;
-            let fetcher1 = read1.clone("").await.batch_fetcher().await;
             for batch in snap {
                 let (batch, res) = fetcher1.fetch_leased_part(batch).await;
                 read0.process_returned_leased_part(batch);

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -54,18 +54,9 @@ use crate::{Diagnostics, PersistClient, ShardId};
 /// The `map_filter_project` argument, if supplied, may be partially applied,
 /// and any un-applied part of the argument will be left behind in the argument.
 ///
-/// Users of this function have the ability to apply flow control to the output
-/// to limit the in-flight data (measured in bytes) it can emit. The flow control
-/// input is a timely stream that communicates the frontier at which the data
-/// emitted from by this source have been dropped.
-///
-/// **Note:** Because this function is reading batches from `persist`, it is working
-/// at batch granularity. In practice, the source will be overshooting the target
-/// flow control upper by an amount that is related to the size of batches.
-///
-/// If no flow control is desired an empty stream whose frontier immediately advances
-/// to the empty antichain can be used. An easy easy of creating such stream is by
-/// using [`timely::dataflow::operators::generic::operator::empty`].
+/// The `desc_transformer` interposes an operator in the stream before the
+/// chosen data is fetched. This is currently used to provide flow control... see
+/// usages for details.
 ///
 /// [advanced by]: differential_dataflow::lattice::Lattice::advance_by
 pub fn shard_source<'g, K, V, T, D, F, DT, G, C>(

--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -573,10 +573,11 @@ where
                 // `LeasedBatchPart`es cannot be dropped at this point w/o
                 // panicking, so swap them to an owned version.
                 for (_idx, part) in data.drain(..) {
-                    let (leased_part, fetched) = fetcher
-                        .fetch_leased_part(fetcher.leased_part_from_exchangeable(part))
-                        .await;
-                    let fetched = fetched.expect("shard_id should match across all workers");
+                    let leased_part = fetcher.leased_part_from_exchangeable(part);
+                    let fetched = fetcher
+                        .fetch_leased_part(&leased_part)
+                        .await
+                        .expect("shard_id should match across all workers");
                     {
                         // Do very fine-grained output activation/session
                         // creation to ensure that we don't hold activated

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -35,8 +35,8 @@ use uuid::Uuid;
 
 use crate::cfg::{PersistFeatureFlag, RetryParameters};
 use crate::fetch::{
-    fetch_leased_part, BatchFetcher, FetchBatchFilter, FetchedPart, LeasedBatchPart,
-    SerdeLeasedBatchPart, SerdeLeasedBatchPartMetadata,
+    fetch_leased_part, FetchBatchFilter, FetchedPart, LeasedBatchPart, SerdeLeasedBatchPart,
+    SerdeLeasedBatchPartMetadata,
 };
 use crate::internal::encoding::Schemas;
 use crate::internal::machine::Machine;
@@ -695,13 +695,6 @@ where
         Ok(Listen::new(self, as_of).await)
     }
 
-    /// Returns a [`BatchFetcher`], which does not hold since or seqno
-    /// capabilities.
-    #[instrument(level = "debug", skip_all, fields(shard = %self.machine.shard_id()))]
-    pub async fn batch_fetcher(self) -> BatchFetcher<K, V, T, D> {
-        BatchFetcher::new(self).await
-    }
-
     /// Returns all of the contents of the shard TVC at `as_of` broken up into
     /// [`LeasedBatchPart`]es. These parts can be "turned in" via
     /// `crate::fetch::fetch_batch_part` to receive the data they contain.
@@ -1278,7 +1271,7 @@ mod tests {
     use crate::internal::metrics::Metrics;
     use crate::rpc::NoopPubSubSender;
     use crate::tests::{all_ok, new_test_client};
-    use crate::{PersistClient, PersistConfig, ShardId};
+    use crate::{Diagnostics, PersistClient, PersistConfig, ShardId};
 
     use super::*;
 
@@ -1409,9 +1402,11 @@ mod tests {
             data.push(((i.to_string(), i.to_string()), i, 1))
         }
 
-        let (mut write, read) = new_test_client()
-            .await
-            .expect_open::<String, String, u64, i64>(crate::ShardId::new())
+        let shard_id = ShardId::new();
+
+        let client = new_test_client().await;
+        let (mut write, read) = client
+            .expect_open::<String, String, u64, i64>(shard_id)
             .await;
 
         // Seed with some values
@@ -1430,8 +1425,14 @@ mod tests {
         offset += width;
 
         // Create machinery for subscribe + fetch
-
-        let fetcher = read.clone("").await.batch_fetcher().await;
+        let fetcher = client
+            .create_batch_fetcher::<String, String, u64, i64>(
+                shard_id,
+                Default::default(),
+                Default::default(),
+                Diagnostics::for_tests(),
+            )
+            .await;
 
         let mut subscribe = read
             .subscribe(timely::progress::Antichain::from_elem(1))

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -424,8 +424,8 @@ where
     /// This is broken out into its own function to provide a trivial means for
     /// [`Subscribe`], which contains a [`Listen`], to fetch batches.
     async fn fetch_batch_part(&mut self, part: LeasedBatchPart<T>) -> FetchedPart<K, V, T, D> {
-        let (part, fetched_part) = fetch_leased_part(
-            part,
+        let fetched_part = fetch_leased_part(
+            &part,
             self.handle.blob.as_ref(),
             Arc::clone(&self.handle.metrics),
             &self.handle.metrics.read.listen,
@@ -1027,8 +1027,8 @@ where
         let mut last_consolidate_len = 0;
         let mut is_consolidated = true;
         for part in snap {
-            let (part, fetched_part) = fetch_leased_part(
-                part,
+            let fetched_part = fetch_leased_part(
+                &part,
                 self.blob.as_ref(),
                 Arc::clone(&self.metrics),
                 &self.metrics.read.snapshot,
@@ -1158,8 +1158,8 @@ where
         let mut lease_returner = self.lease_returner.clone();
         let stream = async_stream::stream! {
             for part in snap {
-                let (part, mut fetched_part) = fetch_leased_part(
-                    part,
+                let mut fetched_part = fetch_leased_part(
+                    &part,
                     blob.as_ref(),
                     Arc::clone(&metrics),
                     &snapshot_metrics,
@@ -1497,7 +1497,7 @@ mod tests {
             let last_seqno = this_seqno.replace(part_seqno);
             assert!(last_seqno.is_none() || this_seqno >= last_seqno);
 
-            let (part, _) = fetcher.fetch_leased_part(part).await;
+            let _ = fetcher.fetch_leased_part(&part).await;
 
             // Emulating drop
             subscribe.return_leased_part(part);


### PR DESCRIPTION
### Motivation

Various refactorings to our batch-fetching path.

These were done in support of a skunkwork that I didn't get over the finish line. (Trying to simplify, and improve the error attribution for, lease management in the persist source.) I still like the refactorings, though.

### Tips for reviewer

My usual refactoring policy applies: comparatively low value (at least without the motivating skunkwork!) so if you prefer things the way they are I'm likely / happy to drop the offending commit.

Happy to expand on the motives for any change, though!

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
