### PR TITLE
*: require rust 1.74

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -113,9 +113,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-# 1.72.0 has a compile time performance regression:
-# https://github.com/rust-lang/rust/issues/115283, so don't use it.
-rust-version = "1.71.0"
+rust-version = "1.74.0"
 
 [profile.dev]
 # TODO(gusywnn|benesch): incremental is still not reliable as of rust 1.72

--- a/bin/ci-builder
+++ b/bin/ci-builder
@@ -16,7 +16,7 @@
 
 set -euo pipefail
 
-NIGHTLY_RUST_DATE=2023-06-27
+NIGHTLY_RUST_DATE=2023-11-19
 
 cd "$(dirname "$0")/.."
 

--- a/bin/lint-versions
+++ b/bin/lint-versions
@@ -11,5 +11,5 @@
 #
 # lint-versions - Check rust version
 
-grep "rust-version = " Cargo.toml | grep -q "1\.71\.0" || \
+grep "rust-version = " Cargo.toml | grep -q "1\.74\.0" || \
 (echo "Please validate new Rust versions for compilation time performance regressions or ask Team Testing to do so. Afterwards change the tested version in bin/lint-versions" && exit 1)

--- a/ci/builder/Dockerfile
+++ b/ci/builder/Dockerfile
@@ -186,15 +186,14 @@ RUN mkdir rust \
     && tar -xzf rust.tar.gz -C /usr/local/lib/rustlib/ --strip-components=4 \
     && rm -rf rust.asc rust.tar.gz rust \
     && cargo install --root /usr/local --version "=0.8.0" --locked cargo-vet \
-    && cargo install --root /usr/local --version "=0.5.2" --locked cargo-about \
-    && cargo install --root /usr/local --version "=1.40.5" --locked cargo-deb \
+    && cargo install --root /usr/local --version "=0.5.7" --locked cargo-about \
+    && cargo install --root /usr/local --version "=2.0.2" --locked cargo-deb \
     && cargo install --root /usr/local --version "=0.12.2" --locked cargo-deny \
     && cargo install --root /usr/local --version "=0.1.0" --locked cargo-deplint \
-    && cargo install --root /usr/local --version ="0.9.18" --locked cargo-hakari \
-    && cargo install --root /usr/local --version "=0.9.44" --locked cargo-nextest \
-    && cargo install --root /usr/local --version "=0.5.18" --locked cargo-llvm-cov \
-    && `: Until https://github.com/est31/cargo-udeps/pull/147 is released in cargo-udeps` \
-    && cargo install --root /usr/local --git https://github.com/est31/cargo-udeps --rev=b84d478ef3efd7264dba8c15c31a50c6399dc5bb --locked cargo-udeps --features=vendored-openssl \
+    && cargo install --root /usr/local --version ="0.9.28" --locked cargo-hakari \
+    && cargo install --root /usr/local --version "=0.9.63" --locked cargo-nextest \
+    && cargo install --root /usr/local --version "=0.5.37" --locked cargo-llvm-cov \
+    && cargo install --root /usr/local --version "=0.1.43" --features=vendored-openssl cargo-udeps \
     && cargo install --root /usr/local --version "=0.2.15" --no-default-features --features=s3,openssl/vendored sccache \
     && cargo install --root /usr/local --version "=0.3.6" cargo-binutils \
     && cargo install --root /usr/local --version "=0.12.1" wasm-pack

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -57,6 +57,7 @@ def main() -> None:
             "--no-strip",
             "--deb-version",
             str(VERSION),
+            '--deb-revision=""',
             "-p",
             "mz",
             "-o",

--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -11,6 +11,7 @@
 # associated open GitHub issues in Materialize repository.
 
 import argparse
+import mmap
 import os
 import re
 import sys
@@ -25,8 +26,9 @@ CI_APPLY_TO = re.compile("ci-apply-to: (.*)")
 
 # Unexpected failures, report them
 ERROR_RE = re.compile(
-    r"""
-    ( panicked\ at
+    rb"""
+    ^ .*
+    ( panicked\ at.*:\n
     | segfault\ at
     | trap\ invalid\ opcode
     | general\ protection
@@ -55,13 +57,14 @@ ERROR_RE = re.compile(
     | unrecognized\ configuration\ parameter
     | Coordinator\ is\ stuck
     )
+    .* $
     """,
-    re.VERBOSE,
+    re.VERBOSE | re.MULTILINE,
 )
 
 # Expected failures, don't report them
 IGNORE_RE = re.compile(
-    r"""
+    rb"""
     # Expected in restart test
     ( restart-materialized-1\ \ \|\ thread\ 'coordinator'\ panicked\ at\ 'can't\ persist\ timestamp
     # Expected in cluster test
@@ -82,7 +85,7 @@ IGNORE_RE = re.compile(
     | larger\ sizes\ prevent\ running\ out\ of\ memory
     )
     """,
-    re.VERBOSE,
+    re.VERBOSE | re.MULTILINE,
 )
 
 
@@ -94,10 +97,9 @@ class KnownIssue:
 
 
 class ErrorLog:
-    def __init__(self, line: str, file: str, line_nr: int):
-        self.line = line
+    def __init__(self, match: bytes, file: str):
+        self.match = match
         self.file = file
-        self.line_nr = line_nr
 
 
 def main() -> int:
@@ -181,7 +183,7 @@ def annotate_logged_errors(log_files: list[str]) -> int:
             linked_file = error.file
 
         for issue in known_issues:
-            match = issue.regex.search(error.line)
+            match = issue.regex.search(error.match)
             if match and issue.info["state"] == "open":
                 if issue.apply_to and issue.apply_to not in (
                     step_key.lower(),
@@ -191,13 +193,13 @@ def annotate_logged_errors(log_files: list[str]) -> int:
 
                 if issue.info["number"] not in already_reported_issue_numbers:
                     known_errors.append(
-                        f"[{issue.info['title']} (#{issue.info['number']})]({issue.info['html_url']}) in {linked_file}:{error.line_nr}:  \n``{error.line}``"
+                        f"[{issue.info['title']} (#{issue.info['number']})]({issue.info['html_url']}) in {linked_file}:  \n``{error.match}``"
                     )
                     already_reported_issue_numbers.add(issue.info["number"])
                 break
         else:
             for issue in known_issues:
-                match = issue.regex.search(error.line)
+                match = issue.regex.search(error.match)
                 if match and issue.info["state"] == "closed":
                     if issue.apply_to and issue.apply_to not in (
                         step_key.lower(),
@@ -207,13 +209,13 @@ def annotate_logged_errors(log_files: list[str]) -> int:
 
                     if issue.info["number"] not in already_reported_issue_numbers:
                         unknown_errors.append(
-                            f"Potential regression [{issue.info['title']} (#{issue.info['number']}, closed)]({issue.info['html_url']}) in {linked_file}:{error.line_nr}:  \n``{error.line}``"
+                            f"Potential regression [{issue.info['title']} (#{issue.info['number']}, closed)]({issue.info['html_url']}) in {linked_file}:  \n``{error.match.decode('utf-8')}``"
                         )
                         already_reported_issue_numbers.add(issue.info["number"])
                     break
             else:
                 unknown_errors.append(
-                    f"Unknown error in {linked_file}:{error.line_nr}:  \n``{error.line}``"
+                    f"Unknown error in {linked_file}:  \n``{error.match.decode('utf-8')}``"
                 )
 
     annotate_errors(
@@ -235,18 +237,24 @@ def annotate_logged_errors(log_files: list[str]) -> int:
 def get_error_logs(log_files: list[str]) -> list[ErrorLog]:
     error_logs = []
     for log_file in log_files:
-        with open(log_file) as f:
-            for line_nr, line in enumerate(f):
-                if ERROR_RE.search(line) and not IGNORE_RE.search(line):
-                    # environmentd segfaults during normal shutdown in coverage builds, see #20016
-                    # Ignoring this in regular ways would still be quite spammy.
-                    if (
-                        "environmentd" in line
-                        and "segfault at" in line
-                        and ui.env_is_truthy("CI_COVERAGE_ENABLED")
-                    ):
-                        continue
-                    error_logs.append(ErrorLog(line, log_file, line_nr + 1))
+        with open(log_file, "r+") as f:
+            try:
+                data = mmap.mmap(f.fileno(), 0)
+            except ValueError:
+                # empty file, ignore
+                continue
+            for match in ERROR_RE.finditer(data):
+                if IGNORE_RE.search(match.group(0)):
+                    continue
+                # environmentd segfaults during normal shutdown in coverage builds, see #20016
+                # Ignoring this in regular ways would still be quite spammy.
+                if (
+                    b"environmentd" in match.group(0)
+                    and b"segfault at" in match.group(0)
+                    and ui.env_is_truthy("CI_COVERAGE_ENABLED")
+                ):
+                    continue
+                error_logs.append(ErrorLog(match.group(0), log_file))
     # TODO: Only report multiple errors once?
     return error_logs
 
@@ -290,7 +298,7 @@ def get_known_issues_from_github() -> tuple[list[KnownIssue], list[str]]:
         matches_apply_to = CI_APPLY_TO.findall(issue["body"])
         for match in matches:
             try:
-                regex_pattern = re.compile(match.strip())
+                regex_pattern = re.compile(match.strip().encode("utf-8"))
             except:
                 unknown_errors.append(
                     "[{issue.info['title']} (#{issue.info['number']})]({issue.info['html_url']}): Invalid regex in ci-regexp: {match.strip()}, ignoring"

--- a/src/expr/src/scalar/like_pattern.rs
+++ b/src/expr/src/scalar/like_pattern.rs
@@ -105,7 +105,7 @@ use matcher::MatcherImpl;
 // This lint interacts poorly with `derivative` here; we are confident it generates
 // compatible `PartialOrd` and `Ord` impls. Unfortunately it also requires we introduce
 // this module to allow it.
-#[allow(clippy::incorrect_partial_ord_impl_on_ord_type)]
+#[allow(clippy::non_canonical_partial_ord_impl)]
 mod matcher {
     use super::*;
 

--- a/src/persist-txn/src/txns.rs
+++ b/src/persist-txn/src/txns.rs
@@ -693,7 +693,7 @@ mod tests {
     /// bug that looks like an incorrect usage).
     #[mz_ore::test(tokio::test)]
     #[cfg_attr(miri, ignore)] // too slow
-    #[should_panic(expected = "assertion failed")]
+    #[should_panic(expected = "left: [(\"foo\", 2, 1)]\n right: [(\"foo\", 2, 2)]")]
     async fn incorrect_usage_register_write_same_time() {
         let client = PersistClient::new_for_tests().await;
         let mut txns = TxnsHandle::expect_open(client.clone()).await;


### PR DESCRIPTION
This is in service of workspace-level lint configs 👀 (this pr does not add those yet)

the original regression sticking us to 1.71 should be gone: https://github.com/rust-lang/rust/issues/115283

no new clippy lints to deal with!

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
