### PR TITLE
benchmark: LDBC BI updates (inserts and deletes)

### DIFF
--- a/test/ldbc-bi/.gitignore
+++ b/test/ldbc-bi/.gitignore
@@ -2,3 +2,5 @@ copy.sql
 factors-sf1
 bi-sf1-composite-merged-fk
 e*.sql
+batch_*.sql
+

--- a/test/ldbc-bi/ddl.sql
+++ b/test/ldbc-bi/ddl.sql
@@ -200,3 +200,48 @@ CREATE TABLE Person_knows_Person (
 CREATE INDEX Person_knows_Person_Person1id ON Person_knows_Person (Person1id);
 CREATE INDEX Person_knows_Person_Person2id ON person_knows_person (Person2id);
 CREATE INDEX Person_knows_Person_Person1id_Person2id ON Person_knows_Person (Person1id, Person2id);
+
+-- tables for deletion candidates
+
+DROP TABLE IF EXISTS Person_Delete_candidates;
+DROP TABLE IF EXISTS Forum_Delete_candidates;
+DROP TABLE IF EXISTS Comment_Delete_candidates;
+DROP TABLE IF EXISTS Post_Delete_candidates;
+DROP TABLE IF EXISTS Person_likes_Comment_Delete_candidates;
+DROP TABLE IF EXISTS Person_likes_Post_Delete_candidates;
+DROP TABLE IF EXISTS Forum_hasMember_Person_Delete_candidates;
+DROP TABLE IF EXISTS Person_knows_Person_Delete_candidates;
+
+CREATE TABLE Person_Delete_candidates                (deletionDate timestamp with time zone not null, id bigint not null);
+CREATE TABLE Forum_Delete_candidates                 (deletionDate timestamp with time zone not null, id bigint not null);
+CREATE TABLE Comment_Delete_candidates               (deletionDate timestamp with time zone not null, id bigint not null);
+CREATE TABLE Post_Delete_candidates                  (deletionDate timestamp with time zone not null, id bigint not null);
+CREATE TABLE Person_likes_Comment_Delete_candidates  (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null);
+CREATE TABLE Person_likes_Post_Delete_candidates     (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null);
+CREATE TABLE Forum_hasMember_Person_Delete_candidates(deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null);
+CREATE TABLE Person_knows_Person_Delete_candidates   (deletionDate timestamp with time zone not null, src bigint not null, trg bigint not null);
+
+CREATE INDEX Person_Delete_candidates_id ON Person_Delete_candidates (id);
+CREATE INDEX Forum_Delete_candidates_id ON Forum_Delete_candidates (id);
+CREATE INDEX Comment_Delete_candidates_id ON Comment_Delete_candidates (id);
+CREATE INDEX Post_Delete_candidates_id ON Post_Delete_candidates (id);
+CREATE INDEX Person_likes_Comment_Delete_candidates_src_trg ON Person_likes_Comment_Delete_candidates (src, trg);
+CREATE INDEX Person_likes_Post_Delete_candidates_src_trg ON Person_likes_Post_Delete_candidates (src, trg);
+CREATE INDEX Forum_hasMember_Person_Delete_candidates_src_trg ON Forum_hasMember_Person_Delete_candidates (src, trg);
+CREATE INDEX Person_knows_Person_Delete_candidates_src_trg ON Person_knows_Person_Delete_candidates (src, trg);
+
+CREATE VIEW Comment_Delete_candidates_with_subthreads (id bigint not null) AS
+  WITH MUTUALLY RECURSIVE
+    subthread (id bigint) AS (
+      SELECT id FROM Comment_Delete_candidates
+      UNION
+      SELECT subthread.MessageId AS id
+        FROM subthread
+        JOIN Message child
+          ON child.ParentMessageId = subthread.id
+    )
+  SELECT id
+  FROM subthread
+;
+
+CREATE INDEX Comment_Delete_candidates_with_subthreads_id ON Comment_Delete_candidates_with_subthreads_id (id);

--- a/test/ldbc-bi/deletes.sql
+++ b/test/ldbc-bi/deletes.sql
@@ -1,0 +1,256 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# deletes.sql — processes *_Delete_candidates tables into deletions
+
+----------------------------------------------------------------------------------------------------
+-- DEL1: Remove Person, its personal Forums, and its Message (sub)threads --------------------------
+----------------------------------------------------------------------------------------------------
+DELETE FROM Person
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person.id
+;
+
+DELETE FROM Person_likes_Message
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_likes_Message.PersonId
+;
+
+DELETE FROM Person_workAt_Company
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_workAt_Company.PersonId
+;
+
+DELETE FROM Person_studyAt_University
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_studyAt_University.PersonId
+;
+
+-- treat KNOWS edges as undirected
+DELETE FROM Person_knows_Person
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_knows_Person.Person1Id
+;
+DELETE FROM Person_knows_Person
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_knows_Person.Person2Id
+;
+
+DELETE FROM Person_hasInterest_Tag
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Person_hasInterest_Tag.PersonId
+;
+
+DELETE FROM Forum_hasMember_Person
+USING Person_Delete_candidates
+WHERE Person_Delete_candidates.id = Forum_hasMember_Person.PersonId
+;
+
+UPDATE Forum
+SET ModeratorPersonId = NULL
+WHERE Forum.title LIKE 'Group %'
+  AND ModeratorPersonId IN (SELECT id FROM Person_Delete_candidates)
+;
+
+-- offload cascading Forum deletes to DEL4
+-- MMG: this could instead be some kind of view
+INSERT INTO Forum_Delete_candidates
+SELECT Person_Delete_candidates.deletionDate AS deletionDate, Forum.id AS id
+FROM Person_Delete_candidates
+JOIN Forum
+  ON Forum.ModeratorPersonId = Person_Delete_candidates.id
+WHERE Forum.title LIKE 'Album %'
+   OR Forum.title LIKE 'Wall %'
+;
+
+-- offload cascading Post deletes to DEL6
+INSERT INTO Post_Delete_candidates
+SELECT Person_Delete_candidates.deletionDate AS deletionDate, Post_View.id AS id
+FROM Person_Delete_candidates
+JOIN Post_View
+  ON Post_View.CreatorPersonId = Person_Delete_candidates.id
+;
+
+-- offload cascading Comment deletes to DEL7
+INSERT INTO Comment_Delete_candidates
+SELECT Person_Delete_candidates.deletionDate AS deletionDate, Comment_View.id AS id
+FROM Person_Delete_candidates
+JOIN Comment_View
+  ON Comment_View.CreatorPersonId = Person_Delete_candidates.id
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL2: Remove Post like --------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+DELETE FROM Person_likes_Message
+USING Person_likes_Post_Delete_candidates
+WHERE Person_likes_Post_Delete_candidates.src = Person_likes_Message.PersonId
+  AND Person_likes_Post_Delete_candidates.trg = Person_likes_Message.MessageId
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL3: Remove Comment like -----------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+DELETE FROM Person_likes_Message
+USING Person_likes_Comment_Delete_candidates
+WHERE Person_likes_Comment_Delete_candidates.src = Person_likes_Message.PersonId
+  AND Person_likes_Comment_Delete_candidates.trg = Person_likes_Message.MessageId
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL4: Remove Forum and its content --------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+--INSERT INTO Forum_Delete_candidates_unique
+--  SELECT min(deletionDate), id
+--  FROM Forum_Delete_candidates
+--  GROUP BY id
+--;
+
+DELETE FROM Forum
+USING Forum_Delete_candidates_unique
+WHERE Forum.id = Forum_Delete_candidates.id -- was _unique
+;
+
+DELETE FROM Forum_hasMember_Person
+USING Forum_Delete_candidates -- was _unique
+WHERE Forum_Delete_candidates.id = Forum_hasMember_Person.ForumId
+;
+
+-- offload cascading Post deletes to DEL6
+INSERT INTO Post_Delete_candidates
+SELECT Forum_Delete_candidates.deletionDate AS deletionDate, Post_View.id AS id
+FROM Post_View
+JOIN Forum_Delete_candidates -- was _unique
+  ON Forum_Delete_candidates.id = Post_View.ContainerForumId
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL5: Remove Forum membership -------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+DELETE FROM Forum_hasMember_Person
+USING Forum_hasMember_Person_Delete_candidates
+WHERE Forum_hasMember_Person_Delete_candidates.src = Forum_hasMember_Person.ForumId
+  AND Forum_hasMember_Person_Delete_candidates.trg = Forum_hasMember_Person.PersonId
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL6: Remove Post thread ------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+--INSERT INTO Post_Delete_candidates_unique
+--  SELECT DISTINCT id
+--  FROM Post_Delete_candidates;
+
+-- in MZ, Message is a view!
+
+--DELETE FROM Message
+--USING Post_Delete_candidates_unique -- starting from the delete candidate post
+--WHERE Post_Delete_candidates_unique.id = Message.MessageId
+--;
+
+DELETE FROM Person_likes_Message
+USING Post_Delete_candidates -- was _unique
+WHERE Post_Delete_candidates.id = Person_likes_Message.MessageId
+;
+
+DELETE FROM Post_hasTag_Tag
+USING Post_Delete_candidates -- was _unique
+WHERE Post_Delete_candidates.id = Post_hasTag_Tag.PostId
+;
+
+-- offload cascading Comment deletes to DEL7
+INSERT INTO Comment_Delete_candidates
+SELECT Post_Delete_candidates.deletionDate AS deletionDate, Comment_View.id AS id
+FROM Comment_View
+JOIN Post_Delete_candidates
+  ON Post_Delete_candidates.id = Comment_View.ParentMessageId
+;
+
+----------------------------------------------------------------------------------------------------
+-- DEL7: Remove Comment subthread ------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+--INSERT INTO Comment_Delete_candidates_unique
+--  SELECT DISTINCT id
+--  FROM Comment_Delete_candidates;
+
+-- recursion has been offloaded to the Comment_Delete_candidates_with_subthreads view in ddl.sql
+
+DELETE FROM Comment
+USING Comment_Delete_candidates_with_subthreads sub
+WHERE sub.id = Comment.CommentId
+;
+
+--DELETE FROM Message
+--USING (
+--  WITH RECURSIVE MessagesToDelete AS (
+--      SELECT id
+--      FROM Comment_Delete_candidates_unique -- starting from the delete candidate comments
+--      UNION
+--      SELECT ChildComment.MessageId AS id
+--      FROM MessagesToDelete
+--      JOIN Message ChildComment
+--        ON ChildComment.ParentMessageId = MessagesToDelete.id
+--  )
+--  SELECT id
+--  FROM MessagesToDelete
+--  ) sub
+--WHERE sub.id = Message.MessageId
+--;
+
+DELETE FROM Person_likes_Message
+USING Comment_Delete_candidates_with_subthreads sub
+WHERE sub.id = Person_likes_Message.MessageId;
+
+--DELETE FROM Person_likes_Message
+--USING (
+--  WITH RECURSIVE MessagesToDelete AS (
+--      SELECT id
+--      FROM Comment_Delete_candidates_unique -- starting from the delete candidate comments
+--      UNION ALL
+--      SELECT ChildComment.MessageId AS id
+--      FROM MessagesToDelete
+--      JOIN Message ChildComment
+--        ON ChildComment.ParentMessageId = MessagesToDelete.id
+--  )
+--  SELECT id
+--  FROM MessagesToDelete
+--  ) sub
+--WHERE sub.id = Person_likes_Message.MessageId
+--;
+
+DELETE FROM Comment_hasTag_Tag
+USING Comment_Delete_candidates_with_subthreads sub
+WHERE sub.id = Comment_hasTag_Tag.CommentId;
+
+--DELETE FROM Comment_hasTag_Tag
+--USING (
+--  WITH RECURSIVE MessagesToDelete AS (
+--      SELECT id
+--      FROM Comment_Delete_candidates_unique -- starting from the delete candidate comments
+--      UNION ALL
+--      SELECT ChildComment.MessageId AS id
+--      FROM MessagesToDelete
+--      JOIN Message ChildComment
+--        ON ChildComment.ParentMessageId = MessagesToDelete.id
+--  )
+--  SELECT id
+--  FROM MessagesToDelete
+--  ) sub
+--WHERE sub.id = Comment_hasTag_Tag.CommentId
+--;
+
+----------------------------------------------------------------------------------------------------
+-- DEL8: Remove friendship -------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+DELETE FROM Person_knows_Person
+USING Person_knows_Person_Delete_candidates
+WHERE
+least(Person_knows_Person.Person1Id, Person_knows_Person.Person2Id) = least(Person_knows_Person_Delete_candidates.src, Person_knows_Person_Delete_candidates.trg)
+AND
+greatest(Person_knows_Person.Person1Id, Person_knows_Person.Person2Id) = greatest(Person_knows_Person_Delete_candidates.src, Person_knows_Person_Delete_candidates.trg)
+;

--- a/test/ldbc-bi/generate-all-updates.sh
+++ b/test/ldbc-bi/generate-all-updates.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+for batch in 2012-11-29 2012-11-30 2012-12-0{1,2,3,4,5,6,7,8,9} 2012-12-{1,2}{0,1,2,3,4,5,6,7,8,9} 2012-12-3{0,1}
+do
+    ./generate-batch-update.sh "$batch" >batch_"$batch".sql
+done

--- a/test/ldbc-bi/generate-batch-update.sh
+++ b/test/ldbc-bi/generate-batch-update.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+#
+# generate-batch-update — generates batch updates (inserts/deletes) from LDBC BI csv files
+
+set -eu -o pipefail
+
+: "${csvs=bi-sf1-composite-merged-fk/graphs/csv/bi/composite-merged-fk}"
+
+START=2012-11-29
+END=2012-12-31 # was 2013-01-01 exclusive
+
+[[ "$#" -eq 1 ]] || {
+    printf "Usage: %s [BATCH IN RANGE %s TO %s INCLUSIVE]\n" "$(basename "$0")" "$START" "$END" >&2
+    exit 1
+}
+
+case "$1" in
+    (2012-11-29|2012-11-30|2012-12-0[1-9]|2012-12-[12][0-9]|2012-12-3[01]);;
+    (*) printf "%s: %s is not a valid date between %s and %s (inclusive)\n" "$(basename "$0")" "$1" "$START" "$END" >&2
+    exit 1
+esac
+
+batch_id="batch_id=$1"
+#exec 1>"$batch_id.sql"
+
+# inserts
+printf -- "-- INSERTS\n\n"
+
+for entity in Comment Comment_hasTag_Tag Forum Forum_hasMember_Person Forum_hasTag_Tag Person Person_hasInterest_Tag Person_knows_Person Person_studyAt_University Person_workAt_Company Person_likes_Comment Person_likes_Post Post Post_hasTag_Tag
+do
+    for csv in "$csvs/inserts/dynamic/$entity/$batch_id/part-"*.csv
+    do
+        printf "\\copy %s FROM '%s' WITH (DELIMITER '|', HEADER, NULL '', FORMAT CSV);\n" "$entity" "$csv"
+
+	if [ "$entity" = "Person_knows_Person" ]
+	then
+            printf -- "-- make it symmetric\n"
+	    printf "\\copy %s (creationDate, Person2id, Person1id) FROM '%s' WITH (DELIMITER '|', HEADER, NULL '', FORMAT CSV);\n" "$entity" "$csv"
+	fi
+    done
+done
+
+# Umbra has some limitations that means they can't use a direct
+# `DELETE USING` if a deletion candidate shows up more than once. We
+# have no such limitation, which should make things easier.
+#
+# We'll still need to manually delete threads with deleted roots, though.
+
+# deletes
+printf -- "\n-- DELETES\n\n"
+
+for entity in Comment Post Forum Person Forum_hasMember_Person Person_knows_Person Person_likes_Comment Person_likes_Post
+do
+    printf "DELETE FROM %s_Delete_candidates;\n" "$entity"
+
+    for csv in  "$csvs/deletes/dynamic/$entity/$batch_id/part-"*.csv
+    do
+
+        printf "\\copy %s_Delete_candidates FROM '%s' WITH (DELIMITER '|', HEADER, NULL '', FORMAT CSV);\n" "$entity" "$csv"
+
+        # we don't symmetrize Person_knows_Person deletions---we'll do it in the deletes.sql
+    done
+done
+
+printf -- "\n-- APPLY DELETIONS\n"
+
+grep -ve '^#' deletes.sql

--- a/test/ldbc-bi/generate-copy.sh
+++ b/test/ldbc-bi/generate-copy.sh
@@ -9,7 +9,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 #
-# generate-copy — generates \copy commands from LDBC BI csv files
+# generate-copy — generates initial inserts from LDBC BI csv files
 
 set -eu -o pipefail
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

The LDBC BI benchmark is meant to run iteratively as the database updates, i.e., you run the queries, then run a bunch of `INSERT`s and `DELETE`s, and then run the queries again. This PR ports over the core batch update logic.

### Motivation

  * This PR adds a known-desirable feature.
    https://github.com/MaterializeInc/materialize/issues/17591