### PR TITLE
mzcompose: Fix running multiple commands at once

### DIFF
--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -162,12 +162,6 @@ class Composition:
         if munge_services:
             self.dependencies = self._munge_services(self.compose["services"].items())
 
-        # Emit the munged configuration to a temporary file so that we can later
-        # pass it to Docker Compose.
-        self.file = TemporaryFile(mode="w")
-        os.set_inheritable(self.file.fileno(), True)
-        self._write_compose()
-
     def _munge_services(
         self, services: list[tuple[str, dict]]
     ) -> mzbuild.DependencySet:
@@ -234,12 +228,6 @@ class Composition:
 
         return deps
 
-    def _write_compose(self) -> None:
-        self.file.seek(0)
-        self.file.truncate()
-        yaml.dump(self.compose, self.file)
-        self.file.flush()
-
     def invoke(
         self,
         *args: str,
@@ -264,8 +252,6 @@ class Composition:
         if not self.silent and not silent:
             print(f"--- docker compose {' '.join(args)}", file=sys.stderr)
 
-        self.file.seek(0)
-
         stdout = None
         if capture:
             stdout = subprocess.PIPE if capture == True else capture
@@ -276,14 +262,22 @@ class Composition:
             ("--project-name", self.project_name) if self.project_name else ()
         )
 
+        # Emit the munged configuration to a temporary file so that we can later
+        # pass it to Docker Compose.
+        file = TemporaryFile(mode="w")
+        os.set_inheritable(file.fileno(), True)
+        yaml.dump(self.compose, file)
+        file.flush()
+
         ret = None
         for retry in range(1, max_tries + 1):
+            file.seek(0)
             try:
                 ret = subprocess.run(
                     [
                         "docker",
                         "compose",
-                        f"-f/dev/fd/{self.file.fileno()}",
+                        f"-f/dev/fd/{file.fileno()}",
                         "--project-directory",
                         self.path,
                         *project_name_args,
@@ -398,8 +392,6 @@ class Composition:
         # config for an `mzbuild` config.
         deps.acquire()
 
-        self._write_compose()
-
         # Ensure image freshness
         self.pull_if_variable([service.name for service in services])
 
@@ -428,7 +420,6 @@ class Composition:
 
             # Restore the old composition.
             self.compose = old_compose
-            self._write_compose()
 
     @contextmanager
     def test_case(self, name: str) -> Iterator[None]:
@@ -687,7 +678,6 @@ class Composition:
             for service in self.compose["services"].values():
                 service["entrypoint"] = ["sleep", "infinity"]
                 service["command"] = []
-            self._write_compose()
 
         self.invoke(
             "up",
@@ -699,7 +689,6 @@ class Composition:
 
         if persistent:
             self.compose = old_compose  # type: ignore
-            self._write_compose()
 
     def validate_sources_sinks_clusters(self) -> str | None:
         """Validate that all sources, sinks & clusters are in a good state"""


### PR DESCRIPTION
in multiple threads. On Linux this happened to work, but on macOS for example `bin/mzcompose --find sqlsmith down && bin/mzcompose --find sqlsmith run default` would fail with cut off empty /dev/fd/3 files.

My understanding of the issue is that the old behaviour was always prone to such issues, it was just never noticed because only one thread was running compositions at a time.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
