### PR TITLE
testdrive: Fortify kafka-exactly-once-sink.td

### DIFF
--- a/test/testdrive/kafka-exactly-once-sink.td
+++ b/test/testdrive/kafka-exactly-once-sink.td
@@ -295,6 +295,8 @@ $ kafka-ingest format=avro topic=progress-test-input schema=${cdcv2-schema}
 {"com.materialize.cdc.progress":{"lower":[0],"upper":[2],"counts":[{"time":1,"count":2}]}}
 {"array":[{"data":{"a":2,"b":2},"time":3,"diff":1}]}
 
+$ kafka-verify-topic sink=materialize.public.compaction_test_sink await-value-schema=true
+
 $ kafka-verify-data headers=materialize-timestamp format=avro sink=materialize.public.compaction_test_sink sort-messages=true
 1	{"before": null, "after": {"row": {"a": 1, "b": 1}}}
 1	{"before": null, "after": {"row": {"a": 2, "b": 2}}}
@@ -317,6 +319,8 @@ $ kafka-ingest format=avro topic=rt-binding-progress-test-input key-format=avro 
   INTO KAFKA CONNECTION kafka_conn (TOPIC 'rt-binding-progress-test-output-${testdrive.seed}')
   FORMAT AVRO
   USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn ENVELOPE DEBEZIUM
+
+$ kafka-verify-topic sink=materialize.public.rt_binding_progress_test_sink await-value-schema=true
 
 $ kafka-verify-data format=avro sink=materialize.public.rt_binding_progress_test_sink
 {"before": null, "after": {"row": {"a": 1, "b": 1}}}


### PR DESCRIPTION
After a recent change, topics and schema registry entries are created asynchronously after the CREATE SINK statement has returned.

Therefore $ kafka-verify-topic needs to be used after CREATE SINK in order to make sure the sink's byproducts all exist before the test can move forward.


### Motivation

Nightly Redpanda was failing.