### PR TITLE
storage: guard against `build_fallible` footgun

### DIFF
--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -318,8 +318,8 @@ async fn ensure_replication_slot(client: &Client, slot: &str) -> Result<(), Tran
     }
 }
 
-/// Fetches the minimum LSN at which this slot can safely resume.
-async fn fetch_slot_resume_lsn(client: &Client, slot: &str) -> Result<MzOffset, TransientError> {
+/// Fetches the minimum LSN for which all updates that happened beyond it exist in the slot.
+async fn fetch_slot_resume_upper(client: &Client, slot: &str) -> Result<MzOffset, TransientError> {
     loop {
         let query = format!(
             "SELECT confirmed_flush_lsn FROM pg_replication_slots WHERE slot_name = '{slot}'"

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -86,6 +86,7 @@ use postgres_protocol::message::backend::{
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::{Scope, Stream};
+use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
@@ -198,6 +199,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 return Ok(());
             }
 
+            // This is an ugly hack that we need to do until because the `build_fallible`
+            // constructor (which we use here) is unsafe in the presence of retained input
+            // capabiltities (which we also use for the rewind requests). The mutable antichain is
+            // initialized with one copy of the minimum capability which represents the initial
+            // capability of this operator.
+            let mut fake_capability = MzOffset::minimum();
+            let mut fake_progress = MutableAntichain::new_bottom(MzOffset::minimum());
+
             // Calculate the minimum frontier that is required from the slot which is the
             // combination of the resume upper of each subsource and the requirements of each
             // rewind request.
@@ -213,11 +222,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             );
             let mut rewinds = BTreeMap::new();
             while let Some(event) = rewind_input.next_mut().await {
-                if let AsyncEvent::Data(cap, data) = event {
-                    let cap = cap.retain_for_output(0);
+                if let AsyncEvent::Data(_cap, data) = event {
+                    // We can't retain this capability due to build_fallible so simulate holding it
+                    // by accounting for it in the progress mutable antichain
+                    let created = data.len().try_into().unwrap();
+                    fake_progress.update_iter([(MzOffset::minimum(), created)]);
                     for req in data.drain(..) {
                         resume_upper.insert(req.snapshot_lsn + 1);
-                        rewinds.insert(req.oid, (cap.clone(), req));
+                        rewinds.insert(req.oid, req);
                     }
                 }
             }
@@ -251,7 +263,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             while let Some(event) = stream.as_mut().next().await {
                 use LogicalReplicationMessage::*;
                 use ReplicationMessage::*;
-                let mut new_upper = *data_cap_set[0].time();
+                let mut new_upper = fake_capability;
                 match event {
                     Ok(XLogData(data)) => match data.data() {
                         Begin(begin) => {
@@ -274,10 +286,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                     continue;
                                 }
                                 let data = (oid, event);
-                                if let Some((rewind_cap, req)) = rewinds.get(&oid) {
+                                if let Some(req) = rewinds.get(&oid) {
                                     if commit_lsn <= req.snapshot_lsn {
                                         let update = (data.clone(), MzOffset::from(0), -diff);
-                                        data_output.give(rewind_cap, update).await;
+                                        data_output.give(&data_cap_set[0], update).await;
                                     }
                                 }
                                 assert!(new_upper <= commit_lsn, "new_upper={} tx_lsn={}", new_upper, commit_lsn);
@@ -286,8 +298,10 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                             new_upper = commit_lsn + 1;
                             if container.len() > max_capacity {
                                 data_output.give_container(&data_cap_set[0], &mut container).await;
-                                upper_cap_set.downgrade([&new_upper]);
-                                data_cap_set.downgrade([&new_upper]);
+                                fake_progress.update_iter([(fake_capability, -1), (new_upper, 1)]);
+                                fake_capability = new_upper;
+                                upper_cap_set.downgrade(&*fake_progress.frontier());
+                                data_cap_set.downgrade(&*fake_progress.frontier());
                             }
                         },
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -303,9 +317,20 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 let will_yield = stream.as_mut().peek().now_or_never().is_none();
                 if will_yield {
                     data_output.give_container(&data_cap_set[0], &mut container).await;
-                    upper_cap_set.downgrade([&new_upper]);
-                    data_cap_set.downgrade([&new_upper]);
-                    rewinds.retain(|_, (_, req)| data_cap_set[0].time() <= &req.snapshot_lsn);
+                    // Count how many rewind request are dropped, and simulate the corresponding
+                    // capability drops
+                    let old_len = rewinds.len();
+                    rewinds.retain(|_, req| new_upper <= req.snapshot_lsn);
+                    let dropped = i64::try_from(old_len - rewinds.len()).unwrap();
+
+                    fake_progress.update_iter([
+                        (MzOffset::minimum(), -dropped),
+                        (fake_capability, -1),
+                        (new_upper, 1)
+                    ]);
+                    fake_capability = new_upper;
+                    upper_cap_set.downgrade(&*fake_progress.frontier());
+                    data_cap_set.downgrade(&*fake_progress.frontier());
                 }
             }
             // We never expect the replication stream to gracefully end

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -291,8 +291,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                                 // capability at minimum, because that is the timestamp rewinds are
                                 // produced at.
                                 if rewinds.is_empty() {
-                                    upper_cap_set.downgrade(&[new_upper]);
-                                    data_cap_set.downgrade(&[new_upper]);
+                                    upper_cap_set.downgrade([new_upper]);
+                                    data_cap_set.downgrade([new_upper]);
                                 }
                             }
                         },
@@ -315,8 +315,8 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                     // capability at minimum, because that is the timestamp rewinds are
                     // produced at.
                     if rewinds.is_empty() {
-                        upper_cap_set.downgrade(&[new_upper]);
-                        data_cap_set.downgrade(&[new_upper]);
+                        upper_cap_set.downgrade([new_upper]);
+                        data_cap_set.downgrade([new_upper]);
                     }
                 }
             }

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -86,7 +86,6 @@ use postgres_protocol::message::backend::{
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::{Scope, Stream};
-use timely::progress::frontier::MutableAntichain;
 use timely::progress::{Antichain, Timestamp};
 use tokio_postgres::replication::LogicalReplicationStream;
 use tokio_postgres::types::PgLsn;
@@ -199,14 +198,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 return Ok(());
             }
 
-            // This is an ugly hack that we need to do until because the `build_fallible`
-            // constructor (which we use here) is unsafe in the presence of retained input
-            // capabiltities (which we also use for the rewind requests). The mutable antichain is
-            // initialized with one copy of the minimum capability which represents the initial
-            // capability of this operator.
-            let mut fake_capability = MzOffset::minimum();
-            let mut fake_progress = MutableAntichain::new_bottom(MzOffset::minimum());
-
             // Calculate the minimum frontier that is required from the slot which is the
             // combination of the resume upper of each subsource and the requirements of each
             // rewind request.
@@ -223,10 +214,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let mut rewinds = BTreeMap::new();
             while let Some(event) = rewind_input.next_mut().await {
                 if let AsyncEvent::Data(_cap, data) = event {
-                    // We can't retain this capability due to build_fallible so simulate holding it
-                    // by accounting for it in the progress mutable antichain
-                    let created = data.len().try_into().unwrap();
-                    fake_progress.update_iter([(MzOffset::minimum(), created)]);
                     for req in data.drain(..) {
                         resume_upper.insert(req.snapshot_lsn + 1);
                         rewinds.insert(req.oid, req);
@@ -260,10 +247,11 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
             let mut container = Vec::new();
             let max_capacity = timely::container::buffer::default_capacity::<((u32, Result<Vec<Option<Bytes>>, DefiniteError>), MzOffset, Diff)>();
 
+            let mut cur_upper = MzOffset::minimum();
             while let Some(event) = stream.as_mut().next().await {
                 use LogicalReplicationMessage::*;
                 use ReplicationMessage::*;
-                let mut new_upper = fake_capability;
+                let mut new_upper = cur_upper;
                 match event {
                     Ok(XLogData(data)) => match data.data() {
                         Begin(begin) => {
@@ -298,10 +286,14 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                             new_upper = commit_lsn + 1;
                             if container.len() > max_capacity {
                                 data_output.give_container(&data_cap_set[0], &mut container).await;
-                                fake_progress.update_iter([(fake_capability, -1), (new_upper, 1)]);
-                                fake_capability = new_upper;
-                                upper_cap_set.downgrade(&*fake_progress.frontier());
-                                data_cap_set.downgrade(&*fake_progress.frontier());
+                                cur_upper = new_upper;
+                                // As long as there are pending rewinds we want to keep the
+                                // capability at minimum, because that is the timestamp rewinds are
+                                // produced at.
+                                if rewinds.is_empty() {
+                                    upper_cap_set.downgrade(&[new_upper]);
+                                    data_cap_set.downgrade(&[new_upper]);
+                                }
                             }
                         },
                         _ => return Err(TransientError::BareTransactionEvent),
@@ -317,20 +309,15 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 let will_yield = stream.as_mut().peek().now_or_never().is_none();
                 if will_yield {
                     data_output.give_container(&data_cap_set[0], &mut container).await;
-                    // Count how many rewind request are dropped, and simulate the corresponding
-                    // capability drops
-                    let old_len = rewinds.len();
+                    cur_upper = new_upper;
                     rewinds.retain(|_, req| new_upper <= req.snapshot_lsn);
-                    let dropped = i64::try_from(old_len - rewinds.len()).unwrap();
-
-                    fake_progress.update_iter([
-                        (MzOffset::minimum(), -dropped),
-                        (fake_capability, -1),
-                        (new_upper, 1)
-                    ]);
-                    fake_capability = new_upper;
-                    upper_cap_set.downgrade(&*fake_progress.frontier());
-                    data_cap_set.downgrade(&*fake_progress.frontier());
+                    // As long as there are pending rewinds we want to keep the
+                    // capability at minimum, because that is the timestamp rewinds are
+                    // produced at.
+                    if rewinds.is_empty() {
+                        upper_cap_set.downgrade(&[new_upper]);
+                        data_cap_set.downgrade(&[new_upper]);
+                    }
                 }
             }
             // We never expect the replication stream to gracefully end


### PR DESCRIPTION
### Motivation

Because the capabilities that we retained were stored in a btree map which was part of the future state, when we encountered an error and returned from the future those were dropped and created bogus frontiers that propagated down the dataflow. This can cause incorrect data to be persisted. Until `build_fallible` is fixed we must implement this ugly workaround.

Fixes #23287

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
