### PR TITLE
Enable arrangement_exert_proportionality in CI

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -77,6 +77,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # "persist_fast_path_limit": "1000",
     "enable_alter_swap": "true",
     "timestamp_oracle": "postgres",
+    "default_idle_arrangement_merge_effort": "0",
+    "default_arrangement_exert_proportionality": "16",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [


### PR DESCRIPTION
This PR enables the new proportionality-based arrangement merge strategy in CI.

### Motivation

  * This PR adds CI coverage for a new feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A