### PR TITLE
Update differential dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1743,7 +1743,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#d9896ce1f322fb89c3e6955441fb2d2c2e07bc1d"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#b55e5b6256ad94bb9047890704a1eaf912a0c2d1"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1800,7 +1800,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#d9896ce1f322fb89c3e6955441fb2d2c2e07bc1d"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#b55e5b6256ad94bb9047890704a1eaf912a0c2d1"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -12,6 +12,11 @@ criteria = "safe-to-deploy"
 version = "0.26.0"
 
 [[audits.differential-dataflow]]
+who = "Moritz Hoffmann <mh@materialize.com>"
+criteria = "safe-to-deploy"
+version = "0.12.0@git:b55e5b6256ad94bb9047890704a1eaf912a0c2d1"
+
+[[audits.differential-dataflow]]
 who = "Nikhil Benesch <nikhil.benesch@gmail.com>"
 criteria = "safe-to-deploy"
 delta = "0.12.0 -> 0.12.0@git:d9896ce1f322fb89c3e6955441fb2d2c2e07bc1d"

--- a/src/compute/src/extensions/arrange.rs
+++ b/src/compute/src/extensions/arrange.rs
@@ -393,13 +393,13 @@ where
             };
 
             trace.map_batches(|batch| {
-                batch.layer.offs.estimate_size(&mut heap_callback);
-                batch.layer.vals.offs.estimate_size(&mut heap_callback);
-                batch.layer.vals.vals.vals.estimate_size(&mut heap_callback);
+                batch.storage.keys_offs.estimate_size(&mut heap_callback);
+                batch.storage.vals_offs.estimate_size(&mut heap_callback);
 
                 let mut region_callback = |siz, cap| heap_callback(siz, cap, usize::from(cap > 0));
-                batch.layer.keys.heap_size(&mut region_callback);
-                batch.layer.vals.keys.heap_size(&mut region_callback);
+                batch.storage.keys.heap_size(&mut region_callback);
+                batch.storage.vals.heap_size(&mut region_callback);
+                batch.storage.updates.heap_size(&mut region_callback);
             });
 
             (heap_size, heap_capacity, heap_allocations)

--- a/src/compute/src/typedefs.rs
+++ b/src/compute/src/typedefs.rs
@@ -12,7 +12,8 @@
 #![allow(missing_docs)]
 
 use differential_dataflow::operators::arrange::TraceAgent;
-use differential_dataflow::trace::implementations::ord::{ColKeySpine, ColValSpine};
+use differential_dataflow::trace::implementations::ord::ColKeySpine;
+use differential_dataflow::trace::implementations::ord_neu::ColValSpine;
 
 use mz_ore::num::Overflowing;
 use mz_repr::{Diff, Row, Timestamp};

--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -264,9 +264,8 @@ $ set-regex match=\d{13} replacement=<TIMESTAMP>
 
 > CREATE DEFAULT INDEX ii_arr ON vv_arr
 
-# Under arrangement specialization of only empty values, a single-column relation
-# should demand 48 bytes per tuple instead of 96.
-> SELECT records >= 300, size >= 300*48, capacity >= 300*48 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
+# It's hard to come up with precise bounds because we might de-duplicate some data in arrangements.
+> SELECT records >= 300, size >= 10000, capacity >= 10000 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_arr' OR name LIKE '%mv_arr'
 true true true
 true true true
 
@@ -295,7 +294,8 @@ true true true
 
 > INSERT INTO t4 SELECT generate_series(1, 1000)
 
-> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 48*1000 AND size < 2*48*1000, capacity > 48*1000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
+# Determining exact sizes is difficult because of deduplication in arrangements, so we just use safe values.
+> SELECT records >= 1000 AND records <= 1001, batches > 0, size > 30000 AND size < 2*30000, capacity > 30000, allocations > 0 FROM mz_internal.mz_dataflow_arrangement_sizes WHERE name LIKE '%ii_t4'
 true true true true true
 
 > DROP INDEX ii_t4
@@ -364,8 +364,8 @@ true true true true
 
 > SELECT
     records > 2 * 1000 AND records < 1.1 * 2 * 1000,
-    size > (172 + 72) * 1000 AND size < 1.1 * (180 + 72) * 1000,
-    capacity > (172 + 72) * 1000 AND capacity < 1.1 * (180 + 72) * 1000,
+    size > 0.7 * (172 + 72) * 1000 AND size < 1.1 * (180 + 72) * 1000,
+    capacity > 0.7 * (172 + 72) * 1000 AND capacity < 1.1 * (180 + 72) * 1000,
     allocations > 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%c2%';
@@ -399,11 +399,11 @@ true true true true
 
 > SELECT
     records > (4 * 2 + 2 * 3) * 1000 AND records < 1.1 * (4 * 2 + 2 * 3) * 1000,
-    size > (3 * 72 * 2 + 62 * 3 + 106 * 2 + 68 * 3) * 1000
+    size > 0.7 * (3 * 72 * 2 + 62 * 3 + 106 * 2 + 68 * 3) * 1000
       AND size < 1.1 * (3 * 80 * 2 + 70 * 3 + 114 * 2 + 76 * 3) * 1000,
-    capacity > (3 * 72 * 2 + 62 * 3 + 106 * 2 + 68 * 3) * 1000
+    capacity > 0.7 * (3 * 72 * 2 + 62 * 3 + 106 * 2 + 68 * 3) * 1000
       AND capacity < 1.1 * (3 * 80 * 2 + 70 * 3 + 114 * 2 + 76 * 3) * 1000,
-    allocations > (4 * 2 + 2 * 3) * 1000
+    allocations > 0
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%rec%';
 true true true true
@@ -437,8 +437,8 @@ true true true true
 
 > SELECT
     records >= 2 * 1000 AND records < 1.1 * 2 * 1000,
-    size >= (124 + 72) * 1000 AND size < 1.1 * (124 + 72) * 1000,
-    capacity >= (124 + 72) * 1000 AND capacity < 1.1 * (124 + 72) * 1000,
+    size >= 0.7 * (124 + 72) * 1000 AND size < 1.1 * (124 + 72) * 1000,
+    capacity >= 0.7 * (124 + 72) * 1000 AND capacity < 1.1 * (124 + 72) * 1000,
     allocations > 1000
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_minmax%';
@@ -446,9 +446,9 @@ true true true true
 
 > SELECT
     records >= 2 * 1000 AND records < 1.1 * 2 * 1000,
-    size >= (104 + 72) * 1000 AND size < 1.1 * (104 + 72) * 1000,
-    capacity >= (104 + 72) * 1000 AND capacity < 1.1 * (104 + 72) * 1000,
-    allocations > 1000
+    size >= 0.7 * (104 + 72) * 1000 AND size < 2 * (104 + 72) * 1000,
+    capacity >= 0.7 * (104 + 72) * 1000 AND capacity < 2 * (104 + 72) * 1000,
+    allocations > 100
   FROM mz_internal.mz_dataflow_arrangement_sizes
   WHERE name LIKE '%m_top1%';
 true true true true


### PR DESCRIPTION
### Motivation

Switch Materialize over to Differential's `ord_neu` implementation. This allows us to region-allocate the `(T, R)` pair, which comes with deduplication as part of Differential, and better memory accounting because we can just ask the region about how much space is in use.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
