### PR TITLE
slt: Fix pretty.slt for auto indexes

### DIFF
--- a/test/sqllogictest/pretty.slt
+++ b/test/sqllogictest/pretty.slt
@@ -26,14 +26,14 @@ SELECT pretty_sql('select 1,2,3', 100)
 ----
 SELECT 1, 2, 3;
 
-query error db error: ERROR: invalid width
+query error invalid width
 SELECT pretty_sql('select 1,2,3', -1)
 
-query error db error: ERROR: expected exactly one statement
+query error expected exactly one statement
 SELECT pretty_sql('select 1; select 2')
 
-query error db error: ERROR: expected exactly one statement
+query error expected exactly one statement
 SELECT pretty_sql('')
 
-query error db error: ERROR: expected exactly one statement
+query error expected exactly one statement
 SELECT pretty_sql(';')


### PR DESCRIPTION
Failure seen in https://buildkite.com/materialize/sql-logic-tests/builds/5743#018bf2a6-a95d-443c-a433-0b72a1ff84fd
@vmarcos I'm not sure I understand why this fails though. The query already returns an error, and so does creating the view.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
