### PR TITLE
slt: Support different replica sizes and change the default to 2

### DIFF
--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -29,6 +29,19 @@ steps:
           composition: sqllogictest
           run: sqllogictest
 
+  - id: sqllogictest-1-replica
+    label: ":bulb: SQL logic tests 1 replica %n"
+    timeout_in_minutes: 180
+    parallelism: 10
+    artifact_paths: junit_*.xml
+    agents:
+      queue: linux-x86_64
+    plugins:
+      - ./ci/plugins/mzcompose:
+          composition: sqllogictest
+          run: sqllogictest
+          args: [--replicas=1]
+
   - wait: ~
     continue_on_failure: true
 

--- a/ci/slt/slt.sh
+++ b/ci/slt/slt.sh
@@ -34,7 +34,7 @@ tests=(
     test/sqllogictest/transform/*.slt \
     test/sqllogictest/special/* \
 )
-tests_without_views=(
+tests_without_views_and_replica=(
     # errors:
     test/sqllogictest/list.slt # https://github.com/MaterializeInc/materialize/issues/20534
 
@@ -50,9 +50,15 @@ tests_without_views=(
     test/sqllogictest/object_ownership.slt # different indexes auto-created
     test/sqllogictest/interval.slt # https://github.com/MaterializeInc/materialize/issues/20110
     test/sqllogictest/operator.slt # https://github.com/MaterializeInc/materialize/issues/20110
+
+    # specific replica size tested:
+    test/sqllogictest/managed_cluster.slt
+    test/sqllogictest/web-console.slt
+    test/sqllogictest/show_clusters.slt
 )
-# Exclude tests_without_views from tests
-for f in "${tests_without_views[@]}"; do
+
+# Exclude tests_without_views_and_replica from tests
+for f in "${tests_without_views_and_replica[@]}"; do
     tests=("${tests[@]/$f}")
 done
 # Remove empty entries from tests, since
@@ -66,7 +72,7 @@ done
 tests=("${temp[@]}")
 
 sqllogictest -v --auto-index-selects "$@" "${tests[@]}" | tee -a target/slt.log
-sqllogictest -v "$@" "${tests_without_views[@]}" | tee -a target/slt.log
+sqllogictest -v "$@" --replicas=2 "${tests_without_views_and_replica[@]}" | tee -a target/slt.log
 
 # Due to performance issues (see below), we pick two selected SLTs from
 # the SQLite corpus that we can reasonably run with --auto-index-selects

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -147,6 +147,9 @@ struct Args {
     /// Wrapper program to start child processes
     #[clap(long, env = "ORCHESTRATOR_PROCESS_WRAPPER")]
     orchestrator_process_wrapper: Option<String>,
+    /// Number of replicas, defaults to 2
+    #[clap(long, default_value = "2")]
+    replicas: usize,
     /// An list of NAME=VALUE pairs used to override static defaults
     /// for system parameters.
     #[clap(
@@ -216,6 +219,7 @@ async fn main() -> ExitCode {
                 return ExitCode::FAILURE;
             }
         },
+        replicas: args.replicas,
     };
 
     if let (Some(shard), Some(shard_count)) = (args.shard, args.shard_count) {

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -102,7 +102,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 11  create  cluster  {"id":"u1","name":"default"}  NULL
 12  grant  cluster  {"grantee_id":"p","grantor_id":"s1","object_id":"Cu1","privileges":"U"}  NULL
 13  grant  cluster  {"grantee_id":"u1","grantor_id":"s1","object_id":"Cu1","privileges":"UC"}  NULL
-14  create  cluster-replica  {"billed_as":null,"cluster_id":"u1","cluster_name":"default","disk":false,"internal":false,"logical_size":"1","replica_id":"u1","replica_name":"r1"}  NULL
+14  create  cluster-replica  {"billed_as":null,"cluster_id":"u1","cluster_name":"default","disk":false,"internal":false,"logical_size":"2","replica_id":"u1","replica_name":"r1"}  NULL
 15  grant  system  {"grantee_id":"s1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 16  grant  system  {"grantee_id":"u1","grantor_id":"s1","object_id":"SYSTEM","privileges":"RBN"}  NULL
 17  create  database  {"id":"u2","name":"test"}  materialize
@@ -181,7 +181,7 @@ false
 query TTTTBBBT
 SELECT replica_id, cluster_name, replica_name, size, created_at IS NOT NULL, dropped_at IS NOT NULL, created_at < dropped_at, credits_per_hour FROM mz_internal.mz_cluster_replica_history ORDER BY created_at
 ----
-u1  default  r1  1  true  false  NULL  1
+u1  default  r1  2  true  false  NULL  1
 u2  foo  r  1  true  true  true  1
 u3  materialize_public_s  linked  1  true  true  true  1
 u4  materialize_public_s  linked  2  true  true  true  1

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -436,10 +436,10 @@ CREATE CLUSTER REPLICA default.size_1 SIZE '1';
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default r1 1
-default size_1 1
-mz_introspection r1 1
-mz_system r1 1
+default  r1  2
+default  size_1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 statement ok
 CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
@@ -447,12 +447,12 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_2 (SIZE '2'))
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default r1 1
-default size_1 1
-foo size_1 1
-foo size_2 2
-mz_introspection r1 1
-mz_system r1 1
+default  r1  2
+default  size_1  1
+foo  size_1  1
+foo  size_2  2
+mz_introspection  r1  2
+mz_system  r1  2
 
 statement ok
 DROP CLUSTER REPLICA IF EXISTS default.bar
@@ -475,9 +475,9 @@ DROP CLUSTER REPLICA foo.size_1, foo.size_2
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default r1 1
-mz_introspection r1 1
-mz_system r1 1
+default  r1  2
+mz_introspection  r1  2
+mz_system  r1  2
 
 statement ok
 CREATE CLUSTER REPLICA default.foo_bar SIZE '1'
@@ -630,9 +630,9 @@ CREATE CLUSTER foo REPLICAS (size_1 (SIZE '1'), size_32 (SIZE '32'), size_2_2 (S
 query TTTTTTT
 SELECT r.name, r.size, s.processes, s.cpu_nano_cores, s.memory_bytes, s.workers, s.credits_per_hour FROM mz_cluster_replicas r JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size ORDER BY r.name
 ----
-r1  1  1  18446744073709000000  18446744073709551615  1  1
-r1  1  1  18446744073709000000  18446744073709551615  1  1
-r1  1  1  18446744073709000000  18446744073709551615  1  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
 size_1  1  1  18446744073709000000  18446744073709551615  1  1
 size_1_8g  1-8G  1  18446744073709000000  8589934592  1  1
 size_2_2  2-2  2  18446744073709000000  18446744073709551615  2  2
@@ -694,7 +694,7 @@ db error: ERROR: cannot modify managed cluster t1
 query TTTTT
 SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
 ----
-u1  r1  u1  1  s1
+u1  r1  u1  2  s1
 u2  r1  u2  1  u1
 u4  free  u2  2  u1
 u3  billed  u2  2  u1
@@ -766,7 +766,7 @@ DROP CLUSTER REPLICA t1.r2
 query TTTTT
 SELECT id, name, cluster_id, size, owner_id FROM mz_cluster_replicas WHERE cluster_id LIKE 'u%'
 ----
-u1  r1  u1  1  s1
+u1  r1  u1  2  s1
 u7  r1  u4  1  u1
 u8  free  u4  2  u1
 

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -55,7 +55,7 @@ SELECT id, name, managed, replication_factor, size FROM mz_clusters
 ----
 s1  mz_system  false  NULL  NULL
 s2  mz_introspection  false  NULL  NULL
-u1  default  true  1  1
+u1  default  true  1  2
 
 
 query T rowsort
@@ -124,9 +124,9 @@ CREATE CLUSTER baz REPLICAS (), INTROSPECTION INTERVAL 1
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
-mz_introspection  r1  1
-mz_system  r1  1
+default  r1  2
+mz_introspection  r1  2
+mz_system  r1  2
 
 statement error db error: ERROR: unknown cluster replica size abc
 CREATE CLUSTER foo SIZE 'abc', REPLICATION FACTOR 3
@@ -137,12 +137,12 @@ CREATE CLUSTER foo SIZE '1', REPLICATION FACTOR 3
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
 foo  r2  1
 foo  r3  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -155,12 +155,12 @@ ALTER CLUSTER foo SET (MANAGED = false)
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
 foo  r2  1
 foo  r3  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -182,12 +182,12 @@ ALTER CLUSTER foo SET (MANAGED, SIZE '1')
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
 foo  r2  1
 foo  r3  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -216,10 +216,10 @@ ALTER CLUSTER foo SET (REPLICATION FACTOR 1)
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -235,11 +235,11 @@ CREATE SOURCE loadgen IN CLUSTER foo FROM LOAD GENERATOR COUNTER
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
 foo  r2  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -252,10 +252,10 @@ ALTER CLUSTER foo RESET (REPLICATION FACTOR)
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -268,10 +268,10 @@ ALTER CLUSTER foo SET (SIZE '2')
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  2
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -284,10 +284,10 @@ ALTER CLUSTER foo SET (SIZE '1', REPLICATION FACTOR 1)
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
+default  r1  2
 foo  r1  1
-mz_introspection  r1  1
-mz_system  r1  1
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTT rowsort
 SELECT id, name, managed, replication_factor, size FROM mz_clusters WHERE name LIKE 'foo'
@@ -319,16 +319,16 @@ DROP CLUSTER REPLICA foo.r1
 query TTT
 SELECT cluster, replica, size FROM (SHOW CLUSTER REPLICAS) ORDER BY 1, 2, 3
 ----
-default  r1  1
-mz_introspection  r1  1
-mz_system  r1  1
+default  r1  2
+mz_introspection  r1  2
+mz_system  r1  2
 
 query TTTTTTT
 SELECT r.name, r.size, s.processes, s.cpu_nano_cores, s.memory_bytes, s.workers, s.credits_per_hour FROM mz_cluster_replicas r JOIN mz_internal.mz_cluster_replica_sizes s ON r.size = s.size ORDER BY r.name
 ----
-r1  1  1  18446744073709000000  18446744073709551615  1  1
-r1  1  1  18446744073709000000  18446744073709551615  1  1
-r1  1  1  18446744073709000000  18446744073709551615  1  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
+r1  2  1  18446744073709000000  18446744073709551615  2  1
 
 statement ok
 DROP CLUSTER foo CASCADE

--- a/test/sqllogictest/show_clusters.slt
+++ b/test/sqllogictest/show_clusters.slt
@@ -31,10 +31,10 @@ SELECT name, replicas FROM (SHOW CLUSTERS)
 bar
 r1 (1), r2 (1)
 default
-r1 (1)
+r1 (2)
 foo
 NULL
 mz_introspection
-r1 (1)
+r1 (2)
 mz_system
-r1 (1)
+r1 (2)

--- a/test/sqllogictest/web-console.slt
+++ b/test/sqllogictest/web-console.slt
@@ -25,7 +25,7 @@ JOIN mz_internal.mz_cluster_replica_utilization u ON u.replica_id = r.id
 WHERE r.cluster_id = 'u1'
 ORDER BY r.id;
 ----
-u1 r1 u1 1 0
+u1  r1  u1  2  0
 
 # useSinkErrors(...)
 query ITI
@@ -110,9 +110,9 @@ FROM mz_clusters c
 LEFT OUTER JOIN mz_cluster_replicas r ON c.id = r.cluster_id
 ORDER BY r.id
 ----
-s1 mz_system s1 r1 1
-s2 mz_introspection s2 r1 1
-u1 default u1 r1 1
+s1  mz_system  s1  r1  2
+s2  mz_introspection  s2  r1  2
+u1  default  u1  r1  2
 
 
 # ---- useClusterUtilization.ts


### PR DESCRIPTION
Fixes #16961

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
