### PR TITLE
Record the heap capacity of the shared row in compute

### DIFF
--- a/src/compute/src/metrics.rs
+++ b/src/compute/src/metrics.rs
@@ -8,8 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use mz_compute_client::metrics::{CommandMetrics, HistoryMetrics};
+use mz_ore::cast::CastFrom;
 use mz_ore::metric;
 use mz_ore::metrics::{raw, MetricsRegistry, UIntGauge};
+use mz_repr::SharedRow;
 use prometheus::core::{AtomicF64, GenericCounter};
 use prometheus::Histogram;
 
@@ -49,6 +51,9 @@ pub struct ComputeMetrics {
     pub(crate) timely_step_duration_seconds: Histogram,
 
     pub(crate) delayed_time_seconds_total: raw::CounterVec,
+
+    /// Heap capacity of the shared row
+    pub(crate) shared_row_heap_capacity_bytes: raw::UIntGaugeVec,
 }
 
 impl ComputeMetrics {
@@ -96,6 +101,11 @@ impl ComputeMetrics {
                 const_labels: {"cluster" => "compute"},
                 var_labels: ["worker_id"],
             )),
+            shared_row_heap_capacity_bytes: registry.register(metric!(
+                name: "mz_dataflow_shared_row_heap_capacity_bytes",
+                help: "The heap capacity of the shared row.",
+                var_labels: ["worker_id"],
+            ))
         }
     }
 
@@ -169,6 +179,16 @@ impl ComputeMetrics {
                 .with_label_values(&[&worker])
                 .inc();
         }
+    }
+
+    /// Record the heap capacity of the shared row.
+    pub fn record_shared_row_metrics(&self, worker_id: usize) {
+        let worker = worker_id.to_string();
+
+        let binding = SharedRow::get();
+        self.shared_row_heap_capacity_bytes
+            .with_label_values(&[&worker])
+            .set(u64::cast_from(binding.borrow().heap_capacity()));
     }
 }
 

--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -419,6 +419,9 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
                 compute_state.process_peeks();
                 compute_state.process_subscribes();
             }
+
+            self.metrics
+                .record_shared_row_metrics(self.timely_worker.index());
         }
     }
 


### PR DESCRIPTION
This change adds support to logging the heap capacity of the shared row in compute (but not other uses of the shared row.) The heap capacity should be low, but depends on the largest row we ever processed. This metric gives us the necessary insights to introducing a policy about sizing-down the row.

Fixes #23150.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
