### PR TITLE
storage: better separate encoding from publishing in Kafka sinks

### DIFF
--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -46,8 +46,8 @@ use mz_sql_parser::ident;
 use mz_storage_types::connections::inline::{ConnectionAccess, ReferencedConnection};
 use mz_storage_types::connections::Connection;
 use mz_storage_types::sinks::{
-    KafkaConsistencyConfig, KafkaSinkAvroFormatState, KafkaSinkConnection,
-    KafkaSinkConnectionRetention, KafkaSinkFormat, SinkEnvelope, StorageSinkConnection,
+    KafkaConsistencyConfig, KafkaSinkConnection, KafkaSinkConnectionRetention, KafkaSinkFormat,
+    SinkEnvelope, StorageSinkConnection,
 };
 use mz_storage_types::sources::encoding::{
     included_column_desc, AvroEncoding, ColumnSpec, CsvEncoding, DataEncoding, DataEncodingInner,
@@ -2631,11 +2631,11 @@ fn kafka_sink_builder(
                 .key_writer_schema()
                 .map(|key_schema| key_schema.to_string());
 
-            KafkaSinkFormat::Avro(KafkaSinkAvroFormatState::UnpublishedMaybe {
+            KafkaSinkFormat::Avro {
                 key_schema,
                 value_schema,
                 csr_connection,
-            })
+            }
         }
         Some(Format::Json) => KafkaSinkFormat::Json,
         Some(format) => bail_unsupported!(format!("sink format {:?}", format)),

--- a/src/sql/src/plan/statement/dml.rs
+++ b/src/sql/src/plan/statement/dml.rs
@@ -26,9 +26,7 @@ use mz_sql_parser::ast::{
     IfExistsBehavior, OrderByExpr, SubscribeOutput, UnresolvedItemName,
 };
 use mz_sql_parser::ident;
-use mz_storage_types::sinks::{
-    KafkaSinkAvroFormatState, KafkaSinkConnection, KafkaSinkFormat, StorageSinkConnection,
-};
+use mz_storage_types::sinks::{KafkaSinkConnection, KafkaSinkFormat, StorageSinkConnection};
 
 use crate::ast::display::AstDisplay;
 use crate::ast::{
@@ -447,11 +445,11 @@ pub fn plan_explain_schema(
         Plan::CreateSink(CreateSinkPlan { sink, .. }) => match sink.connection {
             StorageSinkConnection::Kafka(KafkaSinkConnection {
                 format:
-                    KafkaSinkFormat::Avro(KafkaSinkAvroFormatState::UnpublishedMaybe {
+                    KafkaSinkFormat::Avro {
                         key_schema,
                         value_schema,
                         ..
-                    }),
+                    },
                 ..
             }) => {
                 let schema = match schema_for {

--- a/src/storage-types/src/sinks.proto
+++ b/src/storage-types/src/sinks.proto
@@ -51,27 +51,17 @@ message ProtoSinkAsOf {
 }
 
 message ProtoKafkaSinkFormat {
-    message ProtoKafkaSinkAvroFormatState {
-        message ProtoUnpublishedMaybe {
-            optional string key_schema = 1;
-            string value_schema = 2;
-            mz_storage_types.connections.ProtoCsrConnection csr_connection = 3;
-        }
-        message ProtoPublished {
-            optional int32 key_schema_id = 1;
-            int32 value_schema_id = 2;
-        }
-        oneof kind {
-            ProtoUnpublishedMaybe unpublished_maybe = 1;
-            ProtoPublished published = 2;
-        }
+    message ProtoKafkaSinkAvroFormat {
+        optional string key_schema = 1;
+        string value_schema = 2;
+        mz_storage_types.connections.ProtoCsrConnection csr_connection = 3;
     }
 
-    reserved 1;
+    reserved 1, 3;
 
     oneof kind {
         google.protobuf.Empty json = 2;
-        ProtoKafkaSinkAvroFormatState avro = 3;
+        ProtoKafkaSinkAvroFormat avro = 4;
     }
 }
 

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -109,8 +109,6 @@ class KafkaTransactionLogGreaterThan1:
                   INTO KAFKA CONNECTION kafka_conn (TOPIC 'testdrive-kafka-sink-${testdrive.seed}')
                   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_conn
                   ENVELOPE DEBEZIUM
-
-                $ kafka-verify-topic sink=materialize.public.kafka_sink
                 """
             ),
         )


### PR DESCRIPTION
@sploiselle this will conflict with what you've got up in #23357, but the removal of `KafkaSinkAvroFormatState` is nice enough that I thought I'd put this up. This could plausibly merge first. The rebase doesn't look terrible because this commit is almost byte for byte identical to these three commits of yours...

* https://github.com/MaterializeInc/materialize/pull/23357/commits/c0c4cf4fe08c0f8d4f12ee3571f9e92c8c75c302
* https://github.com/MaterializeInc/materialize/pull/23357/commits/8be976e0e564536af2e940e7da67f564e981d33d
* https://github.com/MaterializeInc/materialize/pull/23357/commits/f15769a85199e824d0258e2897f4d6469bff4621

... which is pretty fun to see.

----

Previously the two operators involved in Kafka sinks (`encode_stream` and `produce_to_kafka`) had overlapping responsibilities. The former created the progress and data topics and published schemas to the schema registry, while the latter read the progress topic and wrote to the data topic. The two operators were scheduled concurrently, meaning that the former operator would be creating the topics as the latter operator was attempting to read from/write to them.

This commit moves all responsibility for managing the Kafka topics to the `produce_to_kafka` operator, leaving `encode_stream` with only the responsibility of publishing the schemas to the schema registry. The new separation of responsibilities makes the code much easier to follow.

Two nice side effects:

  * The ugly `KafkaSinkAvroFormatState` enum disappears.
  * The progress topic is only read a single time.

There is much more potential for refactoring, but I didn't want to fight too hard with @sploiselle's work in #23357.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code. Fixes #23359

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
