### PR TITLE
ci: Do not run the test for incident-72

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -944,15 +944,6 @@ steps:
           composition: cluster
           run: test-incident-70
 
-  - id: incident-72-remediation
-    label: "Remediation of incident 72"
-    agents:
-      queue: linux-x86_64
-    artifact_paths: junit_*.xml
-    plugins:
-      - ./ci/plugins/mzcompose:
-          composition: incident-72
-
   - id: balancerd
     label: "Tests for balancerd"
     agents:

--- a/test/incident-72/mzcompose.py
+++ b/test/incident-72/mzcompose.py
@@ -38,6 +38,9 @@ REJECT_LEGACY_MZ = Materialized(
 
 
 def workflow_default(c: Composition) -> None:
+    """This test can no longer run as it requires the use of v0.68.0
+    Upgrades from v0.68.0 to HEAD are no longer supported.
+    """
     c.up("zookeeper", "kafka", "schema-registry")
 
     with c.override(PRE_INCIDENT_MZ):


### PR DESCRIPTION
The test requires upgrading from a pre-incident version of Mz to the current HEAD, and this is no longer supported.

### Motivation

Nightly was failing because the incident-72 workflow was using a very old version of Mz. After recent code cleanups, apparently such old versions can no longer be upgraded to main and the test fails.

I believe the test has served its purpose to guard the upgrades immediately following the incident. The product has moved on and it is OK to no longer run it in CI.