### PR TITLE
balancerd: Fix the mzcompose workflow

### DIFF
--- a/test/balancerd/mzcompose.py
+++ b/test/balancerd/mzcompose.py
@@ -252,6 +252,8 @@ def workflow_mz_not_running(c: Composition) -> None:
                 "No route to host",
                 "Connection timed out",
                 "failure in name resolution",
+                "failed to lookup address information",
+                "Name or service not known",
             ]
         )
     except:


### PR DESCRIPTION
Additional error messages are possible when Mz is down.


### Motivation

Nightly CI was failing. The test was looking for a specific error message in case Mz is down and balancerd is up, but apparently more wordings are possible depends on how docker and/or the TCP stack feels like.