### PR TITLE
storage: fix kafka transational fencing logic

### DIFF
--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -82,9 +82,7 @@ class KafkaTransactionLogGreaterThan1:
         ):
             c.up("zookeeper", "badkafka", "schema-registry", "materialized")
             self.populate(c)
-            self.assert_error(
-                c, "retriable transaction error", "running a single Kafka broker"
-            )
+            self.assert_error(c, "transaction error", "running a single Kafka broker")
             c.down(sanity_restart_mz=False)
 
     def populate(self, c: Composition) -> None:


### PR DESCRIPTION
### Motivation

Until now we were putting the `worker_id` in our Kafka `transactional.id`. For each dataflow instantiation we pick a single worker that will be responsible for talking with Kafka. The worker picked is the one whose `worker_id` satisfies `(sink_id.hashed() % total_workers) == worker_id`.

The problem is that the chosen worker can change if the cluster gets resized or if the hashing implementation changes between two releases. This means a zombie cluster will not necessarily be fenced out by the new one, leading us to produce duplicate values, violating our exactly once guarantees.

This PR fixes the problem by transitioning our `transactional.id` to always pretend to be worker 0 and includes a defensive fencing of the old style `transactional.id` to minimize the probability of zombies not being fenced.

We will eventually transition to an even better `transactional.id` scheme[1] but that requires a more involved migration.

[1] https://github.com/MaterializeInc/materialize/issues/23198

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
