### PR TITLE
slt: Use scratch directory for lgalloc

### DIFF
--- a/src/clusterd/src/bin/clusterd.rs
+++ b/src/clusterd/src/bin/clusterd.rs
@@ -193,13 +193,17 @@ struct Args {
     announce_memory_limit: Option<usize>,
 }
 
-#[tokio::main]
-async fn main() {
+fn main() {
     let args = cli::parse_args(CliConfig {
         env_prefix: Some("CLUSTERD_"),
         enable_version_flag: true,
     });
-    if let Err(err) = run(args).await {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(1024 * 1024 * 1024)
+        .enable_all()
+        .build().expect("tokio runtime");
+
+    if let Err(err) = runtime.block_on(run(args)) {
         eprintln!("clusterd: fatal: {}", err.display_with_causes());
         process::exit(1);
     }

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -653,6 +653,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 let id = ATOMIC_ID.fetch_add(1, Ordering::SeqCst);
                 format!("tokio:work-{}", id)
             })
+            .thread_stack_size(1024 * 1024 * 1024)
             .enable_all()
             .build()?,
     );

--- a/src/sqllogictest/src/bin/sqllogictest.rs
+++ b/src/sqllogictest/src/bin/sqllogictest.rs
@@ -168,8 +168,16 @@ struct Args {
     pub log_filter: CloneableEnvFilter,
 }
 
-#[tokio::main]
-async fn main() -> ExitCode {
+fn main() -> ExitCode {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .thread_stack_size(1024 * 1024 * 1024)
+        .enable_all()
+        .build().expect("tokio runtime");
+
+    runtime.block_on(run())
+}
+
+async fn run() -> ExitCode {
     mz_ore::panic::set_abort_on_panic();
 
     let args: Args = cli::parse_args(CliConfig {

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -30,7 +30,7 @@ use std::error::Error;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::SocketAddr;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 use std::{env, fmt, ops, str, thread};
@@ -904,6 +904,7 @@ impl<'a> Runner<'a> {
 impl<'a> RunnerInner<'a> {
     pub async fn start(config: &RunConfig<'a>) -> Result<RunnerInner<'a>, anyhow::Error> {
         let temp_dir = tempfile::tempdir()?;
+        let scratch_dir = tempfile::tempdir()?;
         let environment_id = EnvironmentId::for_tests();
         let (consensus_uri, adapter_stash_url, storage_stash_url, timestamp_oracle_url) = {
             let postgres_url = &config.postgres_url;
@@ -957,7 +958,7 @@ impl<'a> RunnerInner<'a> {
                     .map_or(Ok(vec![]), |s| shell_words::split(s))?,
                 propagate_crashes: true,
                 tcp_proxy: None,
-                scratch_directory: PathBuf::from("scratch"),
+                scratch_directory: scratch_dir.path().to_path_buf(),
             })
             .await?,
         );

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -30,7 +30,7 @@ use std::error::Error;
 use std::fs::{File, OpenOptions};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::net::SocketAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 use std::{env, fmt, ops, str, thread};
@@ -904,7 +904,6 @@ impl<'a> Runner<'a> {
 impl<'a> RunnerInner<'a> {
     pub async fn start(config: &RunConfig<'a>) -> Result<RunnerInner<'a>, anyhow::Error> {
         let temp_dir = tempfile::tempdir()?;
-        let scratch_dir = tempfile::tempdir()?;
         let environment_id = EnvironmentId::for_tests();
         let (consensus_uri, adapter_stash_url, storage_stash_url, timestamp_oracle_url) = {
             let postgres_url = &config.postgres_url;
@@ -958,7 +957,7 @@ impl<'a> RunnerInner<'a> {
                     .map_or(Ok(vec![]), |s| shell_words::split(s))?,
                 propagate_crashes: true,
                 tcp_proxy: None,
-                scratch_directory: scratch_dir.path().to_path_buf(),
+                scratch_directory: PathBuf::from("scratch"),
             })
             .await?,
         );


### PR DESCRIPTION
Currently SLT is seeing many warnings:
```
WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
