### PR TITLE
ci: Give cloudtest-upgrade a larger instance

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -584,7 +584,7 @@ steps:
         label: "Platform checks upgrade in Cloudtest/K8s"
         timeout_in_minutes: 60
         agents:
-          queue: linux-x86_64
+          queue: builder-linux-x86_64
         artifact_paths: junit_*.xml
         plugins:
           - ./ci/plugins/scratch-aws-access: ~


### PR DESCRIPTION
Upgrading Mz, cloudtest or not, requires a restart, which is known to cause OOMs in Platform Checks.

Give the cloudtest-upgrade Buildkite step a larger CI instance, thus bringing it in alignment with the other Platform Checks CI steps that perform restarts.

### Motivation

Nightly CI was failing with "agent lost", indicating an OOM.