### PR TITLE
adapter: enforce max_sources limit with ALTER SOURCE

### DIFF
--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1102,10 +1102,36 @@ impl Coordinator {
                         }
                     }
                 },
+                Op::UpdateItem {
+                    name: _,
+                    id,
+                    to_item,
+                } => match to_item {
+                    CatalogItem::Source(source) => {
+                        let current_source = self
+                            .catalog()
+                            .get_entry(id)
+                            .source()
+                            .expect("source update is for source item");
+
+                        new_sources += source.user_controllable_persist_shard_count()
+                            - current_source.user_controllable_persist_shard_count();
+                    }
+                    CatalogItem::Connection(_)
+                    | CatalogItem::Table(_)
+                    | CatalogItem::Sink(_)
+                    | CatalogItem::MaterializedView(_)
+                    | CatalogItem::Secret(_)
+                    | CatalogItem::Log(_)
+                    | CatalogItem::View(_)
+                    | CatalogItem::Index(_)
+                    | CatalogItem::Type(_)
+                    | CatalogItem::Func(_) => {}
+                },
                 Op::AlterRole { .. }
                 | Op::AlterSink { .. }
-                | Op::AlterSource { .. }
                 | Op::AlterSetCluster { .. }
+                | Op::AlterSource { .. }
                 | Op::UpdatePrivilege { .. }
                 | Op::UpdateDefaultPrivilege { .. }
                 | Op::GrantRole { .. }
@@ -1121,7 +1147,6 @@ impl Coordinator {
                 | Op::UpdateSystemConfiguration { .. }
                 | Op::ResetSystemConfiguration { .. }
                 | Op::ResetAllSystemConfiguration { .. }
-                | Op::UpdateItem { .. }
                 | Op::UpdateRotatedKeys { .. }
                 | Op::Comment { .. } => {}
             }

--- a/test/cluster/resources/resource-limits.td
+++ b/test/cluster/resources/resource-limits.td
@@ -367,6 +367,20 @@ contains:creating source would violate max_sources limit (desired: 5, limit: 3, 
 > SELECT * FROM t4
 4
 
+$ postgres-execute connection=postgres://postgres:postgres@postgres
+ALTER PUBLICATION mz_source2 ADD TABLE t1, t2, t3;
+
+! ALTER SOURCE mz_source2 ADD SUBSOURCE t1, t2, t3;
+contains:creating source would violate max_sources limit (desired: 4, limit: 3, current: 1)
+
+# Can add them in smaller quantities
+> ALTER SOURCE mz_source2 ADD SUBSOURCE t1, t2;
+
+> ALTER SOURCE mz_source2 DROP SUBSOURCE t1;
+
+! ALTER SOURCE mz_source2 ADD SUBSOURCE t1, t3;
+contains:creating source would violate max_sources limit (desired: 4, limit: 3, current: 2)
+
 > DROP SOURCE mz_source2
 
 > SHOW max_aws_privatelink_connections


### PR DESCRIPTION
We failed to adjust the `new_sources` count when executing `ALTER SOURCE...ADD SUBSOURCE`.

### Motivation

This PR fixes a recognized bug. Discovered on [Slack](https://materializeinc.slack.com/archives/C066G215L95/p1700657721733029)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Appropriately count new PostgreSQL subsources being added through `ALTER SOURCE...ADD SUBSOURCE`.
