### PR TITLE
infra: Update proptest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6915,7 +6915,7 @@ dependencies = [
 [[package]]
 name = "proptest"
 version = "1.0.0"
-source = "git+https://github.com/MaterializeInc/proptest.git#fc9660f0f45ad49949d42341f964597a44e5fce0"
+source = "git+https://github.com/MaterializeInc/proptest.git#4d8c406c32260484747c828050016de599b9f3a4"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",
@@ -6931,7 +6931,7 @@ dependencies = [
 [[package]]
 name = "proptest-derive"
 version = "0.3.0"
-source = "git+https://github.com/MaterializeInc/proptest.git#fc9660f0f45ad49949d42341f964597a44e5fce0"
+source = "git+https://github.com/MaterializeInc/proptest.git#4d8c406c32260484747c828050016de599b9f3a4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1383,11 +1383,11 @@ version = "0.13.3"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest]]
-version = "1.0.0@git:fc9660f0f45ad49949d42341f964597a44e5fce0"
+version = "1.0.0@git:4d8c406c32260484747c828050016de599b9f3a4"
 criteria = "safe-to-deploy"
 
 [[exemptions.proptest-derive]]
-version = "0.3.0@git:fc9660f0f45ad49949d42341f964597a44e5fce0"
+version = "0.3.0@git:4d8c406c32260484747c828050016de599b9f3a4"
 criteria = "safe-to-deploy"
 
 [[exemptions.prost]]


### PR DESCRIPTION
### Motivation
Updates version of proptest

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
