### PR TITLE
storage/sink: use read_uncommitted isolation when determining progress

### DIFF
--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -34,7 +34,7 @@ use mz_ssh_util::tunnel::SshTunnelStatus;
 use mz_storage_client::client::SinkStatisticsUpdate;
 use mz_storage_client::sink::progress_key::ProgressKey;
 use mz_storage_client::sink::ProgressRecord;
-use mz_storage_types::connections::ConnectionContext;
+use mz_storage_types::connections::{ConnectionContext, KafkaConnection};
 use mz_storage_types::errors::{ContextCreationError, ContextCreationErrorExt, DataflowError};
 use mz_storage_types::sinks::{
     KafkaConsistencyConfig, KafkaSinkConnection, KafkaSinkFormat, MetadataFilled, SinkAsOf,
@@ -214,6 +214,15 @@ impl ProducerContext for SinkProducerContext {
     }
 }
 
+struct KafkaTxProducerConfig<'a> {
+    name: String,
+    connection: &'a KafkaConnection,
+    connection_context: &'a ConnectionContext,
+    producer_context: SinkProducerContext,
+    sink_id: GlobalId,
+    worker_id: String,
+}
+
 #[derive(Clone)]
 struct KafkaTxProducer {
     name: String,
@@ -222,6 +231,88 @@ struct KafkaTxProducer {
 }
 
 impl KafkaTxProducer {
+    async fn new<'a>(
+        KafkaTxProducerConfig {
+            name,
+            connection,
+            connection_context,
+            producer_context,
+            sink_id,
+            worker_id,
+        }: KafkaTxProducerConfig<'a>,
+    ) -> Result<KafkaTxProducer, ContextCreationError> {
+        // Create a producer with the old transactional id to fence out writers from older
+        // versions, if any. This section should be removed after it has been running in
+        // production for a week or two.
+        let fence_producer: ThreadedProducer<_> = connection
+            .create_with_context(
+                connection_context,
+                MzClientContext::default(),
+                &btreemap! {
+                    "transactional.id" => format!("mz-producer-{sink_id}-{worker_id}"),
+                },
+            )
+            .await?;
+        let fence_producer = Arc::new(fence_producer);
+
+        task::spawn_blocking(|| format!("init_transactions:{name}"), {
+            let fence_producer = Arc::clone(&fence_producer);
+            move || fence_producer.init_transactions(Duration::from_secs(5))
+        })
+        .unwrap_or_else(|_| Err(KafkaError::Canceled))
+        .await
+        .check_ssh_status(fence_producer.context())?;
+
+        let producer = connection
+            .create_with_context(
+                connection_context,
+                producer_context,
+                &btreemap! {
+                    // Ensure that messages are sinked in order and without
+                    // duplicates. Note that this only applies to a single
+                    // instance of a producer - in the case of restarts, all
+                    // bets are off and full exactly once support is required.
+                    "enable.idempotence" => "true".into(),
+                    // Increase limits for the Kafka producer's internal
+                    // buffering of messages Currently we don't have a great
+                    // backpressure mechanism to tell indexes or views to slow
+                    // down, so the only thing we can do with a message that we
+                    // can't immediately send is to put it in a buffer and
+                    // there's no point having buffers within the dataflow layer
+                    // and Kafka If the sink starts falling behind and the
+                    // buffers start consuming too much memory the best thing to
+                    // do is to drop the sink Sets the buffer size to be 16 GB
+                    // (note that this setting is in KB)
+                    "queue.buffering.max.kbytes" => format!("{}", 16 << 20),
+                    // Set the max messages buffered by the producer at any time
+                    // to 10MM which is the maximum allowed value.
+                    "queue.buffering.max.messages" => format!("{}", 10_000_000),
+                    // Make the Kafka producer wait at least 10 ms before
+                    // sending out MessageSets TODO(rkhaitan): experiment with
+                    // different settings for this value to see if it makes a
+                    // big difference.
+                    "queue.buffering.max.ms" => format!("{}", 10),
+                    "transactional.id" => format!("mz-producer-{sink_id}-{worker_id}"),
+                    // Time out transactions after 10 seconds
+                    "transaction.timeout.ms" => format!("{}", 10_000),
+                },
+            )
+            .await?;
+
+        let producer = KafkaTxProducer {
+            name,
+            inner: Arc::new(producer),
+            timeout: Duration::from_secs(5),
+        };
+
+        producer
+            .retry_on_txn_error(|p| p.init_transactions())
+            .await
+            .check_ssh_status(producer.inner.client().context())?;
+
+        Ok(producer)
+    }
+
     fn init_transactions(&self) -> impl Future<Output = KafkaResult<()>> {
         let self_producer = Arc::clone(&self.inner);
         let self_timeout = self.timeout;
@@ -371,7 +462,7 @@ impl KafkaSinkState {
     // Until `try` blocks, we need this for using `fail_point!` correctly.
     async fn new(
         sink_id: GlobalId,
-        connection: &KafkaSinkConnection,
+        connection: KafkaSinkConnection,
         sink_name: String,
         worker_id: usize,
         write_frontier: Rc<RefCell<Antichain<Timestamp>>>,
@@ -379,7 +470,7 @@ impl KafkaSinkState {
         connection_context: &ConnectionContext,
         gate_ts: Rc<Cell<Option<Timestamp>>>,
         healthchecker: HealthOutputHandle,
-    ) -> Self {
+    ) -> (Self, Option<Timestamp>) {
         let metrics = Arc::new(metrics.get_sink_metrics(&connection.topic, sink_id, worker_id));
         let worker_id = worker_id.to_string();
 
@@ -399,92 +490,52 @@ impl KafkaSinkState {
                     ContextCreationError::Other(anyhow::anyhow!("synthetic error"))
                 ));
 
-                // Create a producer with the old transactional id to fence out writers from older
-                // versions, if any. This section should be removed after it has been running in
-                // production for a week or two.
-                let fence_producer: ThreadedProducer<_> = connection
-                    .connection
-                    .create_with_context(
-                        connection_context,
-                        MzClientContext::default(),
-                        &btreemap! {
-                            "transactional.id" => format!("mz-producer-{sink_id}-{worker_id}"),
-                        },
-                    )
-                    .await?;
-                let fence_producer = Arc::new(fence_producer);
-
-                task::spawn_blocking(|| format!("init_transactions:{sink_name}"), {
-                    let fence_producer = Arc::clone(&fence_producer);
-                    move || fence_producer.init_transactions(Duration::from_secs(5))
+                KafkaTxProducer::new(KafkaTxProducerConfig {
+                    name: sink_name.clone(),
+                    connection: &connection.connection,
+                    connection_context,
+                    producer_context,
+                    sink_id,
+                    worker_id,
                 })
-                .unwrap_or_else(|_| Err(KafkaError::Canceled))
                 .await
-                .check_ssh_status(fence_producer.context())?;
-
-                connection
-                    .connection
-                    .create_with_context(
-                        connection_context,
-                        producer_context,
-                        &btreemap! {
-                            // Ensure that messages are sinked in order and without
-                            // duplicates. Note that this only applies to a single
-                            // instance of a producer - in the case of restarts, all
-                            // bets are off and full exactly once support is required.
-                            "enable.idempotence" => "true".into(),
-                            // Increase limits for the Kafka producer's internal
-                            // buffering of messages Currently we don't have a great
-                            // backpressure mechanism to tell indexes or views to slow
-                            // down, so the only thing we can do with a message that we
-                            // can't immediately send is to put it in a buffer and
-                            // there's no point having buffers within the dataflow layer
-                            // and Kafka If the sink starts falling behind and the
-                            // buffers start consuming too much memory the best thing to
-                            // do is to drop the sink Sets the buffer size to be 16 GB
-                            // (note that this setting is in KB)
-                            "queue.buffering.max.kbytes" => format!("{}", 16 << 20),
-                            // Set the max messages buffered by the producer at any time
-                            // to 10MM which is the maximum allowed value.
-                            "queue.buffering.max.messages" => format!("{}", 10_000_000),
-                            // Make the Kafka producer wait at least 10 ms before
-                            // sending out MessageSets TODO(rkhaitan): experiment with
-                            // different settings for this value to see if it makes a
-                            // big difference.
-                            "queue.buffering.max.ms" => format!("{}", 10),
-                            "transactional.id" => format!("mz-producer-{sink_id}-0"),
-                        },
-                    )
-                    .await
             })()
             .await,
             None,
         )
         .await;
 
-        let producer = KafkaTxProducer {
-            name: sink_name.clone(),
-            inner: Arc::new(producer),
-            timeout: Duration::from_secs(5),
-        };
+        // Note that where this lies in the rendering cycle means that we might
+        // create the collateral topics each time the sink is rendered, e.g. if
+        // the broker's admin deleted the progress and data topics. For more
+        // details, see `mz_storage_client::sink::build_kafka`.
+        let latest_ts = halt_on_err(
+            &healthchecker,
+            mz_storage_client::sink::build_kafka(sink_id, &connection, connection_context).await,
+            None,
+        )
+        .await;
 
-        KafkaSinkState {
-            name: sink_name,
-            topic: connection.topic.clone(),
-            metrics,
-            producer,
-            pending_rows: BTreeMap::new(),
-            ready_rows: VecDeque::new(),
-            retry_manager,
-            progress_topic: match &connection.consistency_config {
-                KafkaConsistencyConfig::Progress { topic } => topic.clone(),
+        (
+            KafkaSinkState {
+                name: sink_name,
+                topic: connection.topic,
+                metrics,
+                producer,
+                pending_rows: BTreeMap::new(),
+                ready_rows: VecDeque::new(),
+                retry_manager,
+                progress_topic: match connection.consistency_config {
+                    KafkaConsistencyConfig::Progress { topic } => topic,
+                },
+                progress_key: ProgressKey::new(sink_id),
+                healthchecker,
+                gate_ts,
+                latest_progress_ts: Timestamp::minimum(),
+                write_frontier,
             },
-            progress_key: ProgressKey::new(sink_id),
-            healthchecker,
-            gate_ts,
-            latest_progress_ts: Timestamp::minimum(),
-            write_frontier,
-        }
+            latest_ts,
+        )
     }
 
     async fn send<'a, K, P>(&self, mut record: BaseRecord<'a, K, P>)
@@ -895,9 +946,9 @@ where
             return;
         }
 
-        let mut s = KafkaSinkState::new(
+        let (mut s, latest_ts) = KafkaSinkState::new(
             id,
-            &connection,
+            connection,
             name,
             worker_id,
             write_frontier,
@@ -908,20 +959,6 @@ where
                 health_cap,
                 handle: Mutex::new(health_output),
             },
-        )
-        .await;
-
-        s.halt_on_err(
-            s.producer
-                .retry_on_txn_error(|p| p.init_transactions())
-                .await,
-        )
-        .await;
-
-        let latest_ts = halt_on_err(
-            &s.healthchecker,
-            mz_storage_client::sink::build_kafka(id, &connection, &connection_context).await,
-            None,
         )
         .await;
 


### PR DESCRIPTION
Implements https://github.com/MaterializeInc/materialize/pull/23286 as discussed.

Regarding https://github.com/MaterializeInc/materialize/pull/23357#discussion_r1402483308 ––this approach requires moving a lot of code into the same module. This is easy to do but introduces an undesirable number of merge conflicts with #23224. What I've done here instead is just structure the code so it behaves in the way we want and left comments about the invariants we expect.

### Motivation

This PR fixes a recognized bug. https://github.com/MaterializeInc/materialize/issues/18628

### Tips for reviewer

~Ignore the first two commits. Those are https://github.com/MaterializeInc/materialize/pull/23438.~

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fix [an issue](https://github.com/MaterializeInc/materialize/issues/18628) that could cause spurious panics when restarting sinks.
