### PR TITLE
cargo: Fix unused dev dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4430,7 +4430,6 @@ dependencies = [
 name = "mz-lsp-server"
 version = "0.2.1"
 dependencies = [
- "assert_cmd",
  "httparse",
  "mz-build-info",
  "mz-ore",
@@ -5287,7 +5286,6 @@ dependencies = [
  "mz-cloud-resources",
  "mz-controller-types",
  "mz-expr",
- "mz-expr-test-util",
  "mz-interchange",
  "mz-kafka-util",
  "mz-lowertest",
@@ -5460,7 +5458,6 @@ dependencies = [
  "differential-dataflow",
  "fail",
  "futures",
- "insta",
  "itertools",
  "mz-ore",
  "mz-proto",
@@ -5769,7 +5766,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.107",
- "tokio",
  "workspace-hack",
 ]
 

--- a/src/lsp-server/Cargo.toml
+++ b/src/lsp-server/Cargo.toml
@@ -23,7 +23,6 @@ mz-sql-pretty = { path = "../sql-pretty" }
 workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
-assert_cmd = "2.0.5"
 httparse = "1.8.0"
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/ore/Cargo.toml
+++ b/src/ore/Cargo.toml
@@ -136,3 +136,4 @@ required-features = ["async"]
 
 [package.metadata.cargo-udeps.ignore]
 normal = ["workspace-hack"]
+development = ["tokio-test"]

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -74,7 +74,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 datadriven = "0.6.0"
-mz-expr-test-util = { path = "../expr-test-util" }
 mz-lowertest = { path = "../lowertest" }
 
 [package.metadata.cargo-udeps.ignore]

--- a/src/stash/Cargo.toml
+++ b/src/stash/Cargo.toml
@@ -35,7 +35,6 @@ workspace-hack = { version = "0.0.0", path = "../workspace-hack" }
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["async_tokio"] }
-insta = "1.32"
 itertools = "0.10.5"
 once_cell = "1.16.0"
 

--- a/src/test-macro/Cargo.toml
+++ b/src/test-macro/Cargo.toml
@@ -13,9 +13,6 @@ quote = {version = "1.0"}
 syn = {version = "1.0", features = ["extra-traits", "full"]}
 workspace-hack = { version = "0.0.0", path = "../workspace-hack", optional = true }
 
-[dev-dependencies]
-tokio = {version = "1.32.0", default-features = false, features = ["rt-multi-thread", "macros"]}
-
 [features]
 default = ["workspace-hack"]
 


### PR DESCRIPTION
Following Rust 1.74 upgrade

Seen in https://buildkite.com/materialize/nightlies/builds/5332#018bf998-0f7c-4d8a-aa89-38582a511b63
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
