### PR TITLE
platform checks: Fix merge skew in check selection

### DIFF
--- a/misc/python/materialize/checks/scenarios.py
+++ b/misc/python/materialize/checks/scenarios.py
@@ -48,7 +48,7 @@ class Scenario:
         self.rng = None if seed is None else Random(seed)
         self._base_version = MzVersion.parse_cargo()
 
-        check_classes = []
+        filtered_check_classes = []
 
         for check_class in self.checks():
             if (
@@ -56,13 +56,13 @@ class Scenario:
                 and not check_class.externally_idempotent
             ):
                 continue
-            check_classes.append(check_class)
+            filtered_check_classes.append(check_class)
 
         # Use base_version() here instead of _base_version so that overwriting
         # upgrade scenarios can specify another base version.
         self.check_objects = [
             check_class(self.base_version(), self.rng)
-            for check_class in self.checks()
+            for check_class in filtered_check_classes
             # TODO: improve
             if not check_class.__name__.endswith("Base")
         ]


### PR DESCRIPTION
We first filter the checks based on whether they can run in a non-idempotent scenario.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Nightly CI was failing as non-idempotent checks were being run in an idempotence-requiring backup+restore scenario.