### PR TITLE
ci: Increase timeout for platform check

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -428,7 +428,7 @@ steps:
         label: "Checks + restart of environmentd & storage clusterd"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -441,7 +441,7 @@ steps:
         label: "Checks + DROP/CREATE replica"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -454,7 +454,7 @@ steps:
         label: "Checks without restart or upgrade"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -467,7 +467,7 @@ steps:
         label: "Checks + restart clusterd compute"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -480,7 +480,7 @@ steps:
         label: "Checks + kill storage clusterd"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -493,7 +493,7 @@ steps:
         label: "Checks + restart source Postgres"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
-        timeout_in_minutes: 30
+        timeout_in_minutes: 45
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64


### PR DESCRIPTION
It was already close to timing out before (26 min), now doesn't finish in 30 min most of the times.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
