### PR TITLE
ci: introduce typed mz versions, reduce usages of semver versions

### DIFF
--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -193,6 +193,8 @@ if __name__ == "__main__":
     if args.do_release and "NPM_TOKEN" not in os.environ:
         raise ValueError("'NPM_TOKEN' must be set")
     workspace = cargo.Workspace(MZ_ROOT)
-    crate_version = workspace.crates["mz-environmentd"].version
+    crate_version = VersionInfo.parse(
+        workspace.crates["mz-environmentd"].version_string
+    )
     version = generate_version(crate_version, build_id)
     build_all(workspace, version, do_release=args.do_release)

--- a/ci/deploy/npm.py
+++ b/ci/deploy/npm.py
@@ -31,7 +31,7 @@ PUBLISH_CRATES = ["mz-sql-lexer-wasm"]
 
 
 @dataclass(frozen=True)
-class Version:
+class NpmPackageVersion:
     rust: VersionInfo
     node: str
     is_development: bool
@@ -39,7 +39,7 @@ class Version:
 
 def generate_version(
     crate_version: VersionInfo, build_identifier: int | None
-) -> Version:
+) -> NpmPackageVersion:
     node_version = str(crate_version)
     is_development = False
     if crate_version.prerelease == "dev":
@@ -55,10 +55,12 @@ def generate_version(
         assert (
             buildkite_tag == f"v{node_version}"
         ), f"Buildkite tag ({buildkite_tag}) does not match environmentd version ({crate_version})"
-    return Version(rust=crate_version, node=node_version, is_development=is_development)
+    return NpmPackageVersion(
+        rust=crate_version, node=node_version, is_development=is_development
+    )
 
 
-def build_package(version: Version, crate_path: Path) -> Path:
+def build_package(version: NpmPackageVersion, crate_path: Path) -> Path:
     spawn.runv(["bin/wasm-build", str(crate_path)])
     package_path = crate_path / "pkg"
     shutil.copyfile(str(MZ_ROOT / "LICENSE"), str(package_path / "LICENSE"))
@@ -76,7 +78,7 @@ def build_package(version: Version, crate_path: Path) -> Path:
     return package_path
 
 
-def release_package(version: Version, package_path: Path) -> None:
+def release_package(version: NpmPackageVersion, package_path: Path) -> None:
     with open(package_path / "package.json") as package_file:
         package = json.load(package_file)
     name = package["name"]
@@ -105,7 +107,7 @@ def release_package(version: Version, package_path: Path) -> None:
 
 
 def build_all(
-    workspace: cargo.Workspace, version: Version, *, do_release: bool = True
+    workspace: cargo.Workspace, version: NpmPackageVersion, *, do_release: bool = True
 ) -> None:
     for crate_name in PUBLISH_CRATES:
         crate_path = workspace.all_crates[crate_name].path
@@ -136,7 +138,7 @@ def get_latest_version(name: str) -> VersionInfo | None:
     return VersionInfo.parse(version)
 
 
-def version_exists_in_npm(name: str, version: Version) -> bool:
+def version_exists_in_npm(name: str, version: NpmPackageVersion) -> bool:
     res = _query_npm_version(name, version.node)
     if res.status_code == 404:
         # This is a new package

--- a/ci/deploy_mz/deploy_util.py
+++ b/ci/deploy_mz/deploy_util.py
@@ -17,12 +17,12 @@ import boto3
 import humanize
 
 from materialize import git
-from materialize.mz_version import MzAptVersion
+from materialize.mz_version import MzCliVersion
 
 APT_BUCKET = "materialize-apt"
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-VERSION = MzAptVersion.parse_mz(TAG)
+VERSION = MzCliVersion.parse_mz(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:
@@ -94,7 +94,7 @@ def deploy_tarball(platform: str, mz: Path) -> None:
 def is_latest_version() -> bool:
     latest_version = max(
         t
-        for t in git.get_version_tags(version_type=MzAptVersion)
+        for t in git.get_version_tags(version_type=MzCliVersion)
         if t.prerelease is None
     )
     return VERSION == latest_version

--- a/ci/deploy_mz/deploy_util.py
+++ b/ci/deploy_mz/deploy_util.py
@@ -22,7 +22,7 @@ from materialize.mz_version import MzCliVersion
 APT_BUCKET = "materialize-apt"
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-MZ_CLI_VERSION = MzCliVersion.parse_mz(TAG)
+MZ_CLI_VERSION = MzCliVersion.parse(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:

--- a/ci/deploy_mz/deploy_util.py
+++ b/ci/deploy_mz/deploy_util.py
@@ -22,7 +22,7 @@ from materialize.mz_version import MzCliVersion
 APT_BUCKET = "materialize-apt"
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-VERSION = MzCliVersion.parse_mz(TAG)
+MZ_CLI_VERSION = MzCliVersion.parse_mz(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:
@@ -86,9 +86,9 @@ def deploy_tarball(platform: str, mz: Path) -> None:
     size = humanize.naturalsize(os.lstat(tar_path).st_size)
     print(f"Tarball size: {size}")
 
-    upload_tarball(tar_path, platform, f"v{VERSION.str_without_prefix()}")
+    upload_tarball(tar_path, platform, f"v{MZ_CLI_VERSION.str_without_prefix()}")
     if is_latest_version():
-        upload_latest_redirect(platform, f"v{VERSION.str_without_prefix()}")
+        upload_latest_redirect(platform, f"v{MZ_CLI_VERSION.str_without_prefix()}")
 
 
 def is_latest_version() -> bool:
@@ -97,4 +97,4 @@ def is_latest_version() -> bool:
         for t in git.get_version_tags(version_type=MzCliVersion)
         if t.prerelease is None
     )
-    return VERSION == latest_version
+    return MZ_CLI_VERSION == latest_version

--- a/ci/deploy_mz/deploy_util.py
+++ b/ci/deploy_mz/deploy_util.py
@@ -86,9 +86,9 @@ def deploy_tarball(platform: str, mz: Path) -> None:
     size = humanize.naturalsize(os.lstat(tar_path).st_size)
     print(f"Tarball size: {size}")
 
-    upload_tarball(tar_path, platform, f"v{VERSION}")
+    upload_tarball(tar_path, platform, f"v{VERSION.str_without_prefix()}")
     if is_latest_version():
-        upload_latest_redirect(platform, f"v{VERSION}")
+        upload_latest_redirect(platform, f"v{VERSION.str_without_prefix()}")
 
 
 def is_latest_version() -> bool:

--- a/ci/deploy_mz/docker.py
+++ b/ci/deploy_mz/docker.py
@@ -13,7 +13,7 @@ from materialize import mzbuild
 from materialize.xcompile import Arch
 
 from . import deploy_util
-from .deploy_util import VERSION
+from .deploy_util import MZ_CLI_VERSION
 
 
 def main() -> None:
@@ -25,7 +25,7 @@ def main() -> None:
     print("--- Tagging Docker images")
     deps = [[repo.resolve_dependencies([repo.images["mz"]])["mz"]] for repo in repos]
 
-    mzbuild.publish_multiarch_images(f"v{VERSION.str_without_prefix()}", deps)
+    mzbuild.publish_multiarch_images(f"v{MZ_CLI_VERSION.str_without_prefix()}", deps)
     if deploy_util.is_latest_version():
         mzbuild.publish_multiarch_images("latest", deps)
 

--- a/ci/deploy_mz/docker.py
+++ b/ci/deploy_mz/docker.py
@@ -25,7 +25,7 @@ def main() -> None:
     print("--- Tagging Docker images")
     deps = [[repo.resolve_dependencies([repo.images["mz"]])["mz"]] for repo in repos]
 
-    mzbuild.publish_multiarch_images(f"v{VERSION}", deps)
+    mzbuild.publish_multiarch_images(f"v{VERSION.str_without_prefix()}", deps)
     if deploy_util.is_latest_version():
         mzbuild.publish_multiarch_images("latest", deps)
 

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -54,7 +54,7 @@ def main() -> None:
     deploy_util.deploy_tarball(target, mz)
 
     print("--- Publishing Debian package")
-    filename = f"mz_{VERSION}_{repo.rd.arch.go_str()}.deb"
+    filename = f"mz_{VERSION.str_without_prefix()}_{repo.rd.arch.go_str()}.deb"
     print(f"Publishing {filename}")
     spawn.runv(
         [
@@ -62,7 +62,7 @@ def main() -> None:
             "--no-build",
             "--no-strip",
             "--deb-version",
-            str(VERSION),
+            VERSION.str_without_prefix(),
             '--deb-revision=""',
             "-p",
             "mz",

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -11,6 +11,7 @@ import os
 from pathlib import Path
 
 from materialize import mzbuild, spawn
+from materialize.mz_version import MzAptVersion
 
 from . import deploy_util
 from .deploy_util import APT_BUCKET, VERSION
@@ -21,7 +22,12 @@ def main() -> None:
     target = f"{repo.rd.arch}-unknown-linux-gnu"
 
     print("--- Checking version")
-    assert repo.rd.cargo_workspace.crates["mz"].version == VERSION
+    assert (
+        MzAptVersion.parse_mz_without_prefix(
+            repo.rd.cargo_workspace.crates["mz"].version_string
+        )
+        == VERSION
+    )
 
     print("--- Building mz")
     deps = repo.resolve_dependencies([repo.images["mz"]])

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -14,7 +14,7 @@ from materialize import mzbuild, spawn
 from materialize.mz_version import MzCliVersion
 
 from . import deploy_util
-from .deploy_util import APT_BUCKET, VERSION
+from .deploy_util import APT_BUCKET, MZ_CLI_VERSION
 
 
 def main() -> None:
@@ -26,7 +26,7 @@ def main() -> None:
         MzCliVersion.parse_mz_without_prefix(
             repo.rd.cargo_workspace.crates["mz"].version_string
         )
-        == VERSION
+        == MZ_CLI_VERSION
     )
 
     print("--- Building mz")
@@ -54,7 +54,7 @@ def main() -> None:
     deploy_util.deploy_tarball(target, mz)
 
     print("--- Publishing Debian package")
-    filename = f"mz_{VERSION.str_without_prefix()}_{repo.rd.arch.go_str()}.deb"
+    filename = f"mz_{MZ_CLI_VERSION.str_without_prefix()}_{repo.rd.arch.go_str()}.deb"
     print(f"Publishing {filename}")
     spawn.runv(
         [
@@ -62,7 +62,7 @@ def main() -> None:
             "--no-build",
             "--no-strip",
             "--deb-version",
-            VERSION.str_without_prefix(),
+            MZ_CLI_VERSION.str_without_prefix(),
             '--deb-revision=""',
             "-p",
             "mz",

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -11,7 +11,7 @@ import os
 from pathlib import Path
 
 from materialize import mzbuild, spawn
-from materialize.mz_version import MzAptVersion
+from materialize.mz_version import MzCliVersion
 
 from . import deploy_util
 from .deploy_util import APT_BUCKET, VERSION
@@ -23,7 +23,7 @@ def main() -> None:
 
     print("--- Checking version")
     assert (
-        MzAptVersion.parse_mz_without_prefix(
+        MzCliVersion.parse_mz_without_prefix(
             repo.rd.cargo_workspace.crates["mz"].version_string
         )
         == VERSION

--- a/ci/deploy_mz/linux.py
+++ b/ci/deploy_mz/linux.py
@@ -23,7 +23,7 @@ def main() -> None:
 
     print("--- Checking version")
     assert (
-        MzCliVersion.parse_mz_without_prefix(
+        MzCliVersion.parse_without_prefix(
             repo.rd.cargo_workspace.crates["mz"].version_string
         )
         == MZ_CLI_VERSION

--- a/ci/deploy_mz/version.py
+++ b/ci/deploy_mz/version.py
@@ -15,7 +15,7 @@ from .deploy_util import BINARIES_BUCKET, VERSION
 def main() -> None:
     print("--- Uploading version file")
     boto3.client("s3").put_object(
-        Body=f"{VERSION}",
+        Body=f"{VERSION.str_without_prefix()}",
         Bucket=BINARIES_BUCKET,
         Key="mz-latest.version",
         ContentType="text/plain",

--- a/ci/deploy_mz/version.py
+++ b/ci/deploy_mz/version.py
@@ -9,13 +9,13 @@
 
 import boto3
 
-from .deploy_util import BINARIES_BUCKET, VERSION
+from .deploy_util import BINARIES_BUCKET, MZ_CLI_VERSION
 
 
 def main() -> None:
     print("--- Uploading version file")
     boto3.client("s3").put_object(
-        Body=f"{VERSION.str_without_prefix()}",
+        Body=f"{MZ_CLI_VERSION.str_without_prefix()}",
         Bucket=BINARIES_BUCKET,
         Key="mz-latest.version",
         ContentType="text/plain",

--- a/ci/deploy_mz_lsp_server/README.md
+++ b/ci/deploy_mz_lsp_server/README.md
@@ -5,7 +5,7 @@ You can try the process by running the following commands:
 
 ```bash
 # Set a tag version.
-export BUILDKITE_TAG=x.y.z
+export BUILDKITE_TAG=mz-lsp-server-vx.y.z
 
 # macOS
 bin/pyactivate -m ci.deploy_mz_lsp_server.macos

--- a/ci/deploy_mz_lsp_server/deploy_util.py
+++ b/ci/deploy_mz_lsp_server/deploy_util.py
@@ -21,7 +21,7 @@ from materialize.mz_version import MzLspServerVersion
 
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-VERSION = MzLspServerVersion.parse_mz(TAG)
+MZ_LSP_SERVER_VERSION = MzLspServerVersion.parse_mz(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:
@@ -93,9 +93,11 @@ def deploy_tarball(platform: str, lsp: Path) -> None:
     size = humanize.naturalsize(os.lstat(tar_path).st_size)
     print(f"Tarball size: {size}")
 
-    upload_tarball(tar_path, platform, f"v{VERSION.str_without_prefix()}")
+    upload_tarball(tar_path, platform, f"v{MZ_LSP_SERVER_VERSION.str_without_prefix()}")
     if is_latest_version():
-        upload_latest_redirect(platform, f"v{VERSION.str_without_prefix()}")
+        upload_latest_redirect(
+            platform, f"v{MZ_LSP_SERVER_VERSION.str_without_prefix()}"
+        )
 
 
 def is_latest_version() -> bool:
@@ -104,4 +106,4 @@ def is_latest_version() -> bool:
         for t in git.get_version_tags(version_type=MzLspServerVersion)
         if t.prerelease is None
     )
-    return VERSION == latest_version
+    return MZ_LSP_SERVER_VERSION == latest_version

--- a/ci/deploy_mz_lsp_server/deploy_util.py
+++ b/ci/deploy_mz_lsp_server/deploy_util.py
@@ -21,7 +21,7 @@ from materialize.mz_version import MzLspServerVersion
 
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-MZ_LSP_SERVER_VERSION = MzLspServerVersion.parse_mz(TAG)
+MZ_LSP_SERVER_VERSION = MzLspServerVersion.parse(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:

--- a/ci/deploy_mz_lsp_server/deploy_util.py
+++ b/ci/deploy_mz_lsp_server/deploy_util.py
@@ -93,9 +93,9 @@ def deploy_tarball(platform: str, lsp: Path) -> None:
     size = humanize.naturalsize(os.lstat(tar_path).st_size)
     print(f"Tarball size: {size}")
 
-    upload_tarball(tar_path, platform, f"v{VERSION}")
+    upload_tarball(tar_path, platform, f"v{VERSION.str_without_prefix()}")
     if is_latest_version():
-        upload_latest_redirect(platform, f"v{VERSION}")
+        upload_latest_redirect(platform, f"v{VERSION.str_without_prefix()}")
 
 
 def is_latest_version() -> bool:

--- a/ci/deploy_mz_lsp_server/deploy_util.py
+++ b/ci/deploy_mz_lsp_server/deploy_util.py
@@ -13,19 +13,15 @@ import tempfile
 import time
 from pathlib import Path
 
-try:
-    from semver.version import Version
-except ImportError:
-    from semver import VersionInfo as Version  # type: ignore
-
 import boto3
 import humanize
 
 from materialize import git
+from materialize.mz_version import MzLspServerVersion
 
 BINARIES_BUCKET = "materialize-binaries"
 TAG = os.environ["BUILDKITE_TAG"]
-VERSION = Version.parse(TAG.removeprefix("mz-lsp-server-v"))
+VERSION = MzLspServerVersion.parse_mz(TAG)
 
 
 def _tardir(name: str) -> tarfile.TarInfo:
@@ -103,9 +99,9 @@ def deploy_tarball(platform: str, lsp: Path) -> None:
 
 
 def is_latest_version() -> bool:
-    latest_version = next(
+    latest_version = max(
         t
-        for t in git.get_version_tags(prefix="mz-lsp-server-v")
+        for t in git.get_version_tags(version_type=MzLspServerVersion)
         if t.prerelease is None
     )
     return VERSION == latest_version

--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -15,7 +15,7 @@ from materialize import mzbuild, spawn
 from materialize.mz_version import MzLspServerVersion
 
 from . import deploy_util
-from .deploy_util import VERSION
+from .deploy_util import MZ_LSP_SERVER_VERSION
 
 
 def main() -> None:
@@ -27,7 +27,7 @@ def main() -> None:
         MzLspServerVersion.parse_mz_without_prefix(
             repo.rd.cargo_workspace.crates["mz-lsp-server"].version_string
         )
-        == VERSION
+        == MZ_LSP_SERVER_VERSION
     )
 
     print("--- Building mz-lsp-server")

--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from ci.deploy.deploy_util import rust_version
 from materialize import mzbuild, spawn
+from materialize.mz_version import MzLspServerVersion
 
 from . import deploy_util
 from .deploy_util import VERSION
@@ -22,7 +23,12 @@ def main() -> None:
     target = f"{repo.rd.arch}-unknown-linux-gnu"
 
     print("--- Checking version")
-    assert repo.rd.cargo_workspace.crates["mz-lsp-server"].version == VERSION
+    assert (
+        MzLspServerVersion.parse_mz_without_prefix(
+            repo.rd.cargo_workspace.crates["mz-lsp-server"].version_string
+        )
+        == VERSION
+    )
 
     print("--- Building mz-lsp-server")
     # The bin/ci-builder uses target-xcompile as the volume and

--- a/ci/deploy_mz_lsp_server/linux.py
+++ b/ci/deploy_mz_lsp_server/linux.py
@@ -24,7 +24,7 @@ def main() -> None:
 
     print("--- Checking version")
     assert (
-        MzLspServerVersion.parse_mz_without_prefix(
+        MzLspServerVersion.parse_without_prefix(
             repo.rd.cargo_workspace.crates["mz-lsp-server"].version_string
         )
         == MZ_LSP_SERVER_VERSION

--- a/ci/deploy_mz_lsp_server/version.py
+++ b/ci/deploy_mz_lsp_server/version.py
@@ -15,7 +15,7 @@ from .deploy_util import BINARIES_BUCKET, VERSION
 def main() -> None:
     print("--- Uploading version file")
     boto3.client("s3").put_object(
-        Body=f"{VERSION}",
+        Body=f"{VERSION.str_without_prefix()}",
         Bucket=BINARIES_BUCKET,
         Key="mz-lsp-server-latest.version",
         ContentType="text/plain",

--- a/ci/deploy_mz_lsp_server/version.py
+++ b/ci/deploy_mz_lsp_server/version.py
@@ -9,13 +9,13 @@
 
 import boto3
 
-from .deploy_util import BINARIES_BUCKET, VERSION
+from .deploy_util import BINARIES_BUCKET, MZ_LSP_SERVER_VERSION
 
 
 def main() -> None:
     print("--- Uploading version file")
     boto3.client("s3").put_object(
-        Body=f"{VERSION.str_without_prefix()}",
+        Body=f"{MZ_LSP_SERVER_VERSION.str_without_prefix()}",
         Bucket=BINARIES_BUCKET,
         Key="mz-lsp-server-latest.version",
         ContentType="text/plain",

--- a/misc/python/materialize/cargo.py
+++ b/misc/python/materialize/cargo.py
@@ -17,10 +17,6 @@ necessary to support this repository are implemented.
 
 from pathlib import Path
 
-try:
-    from semver.version import Version
-except ImportError:
-    from semver import VersionInfo as Version  # type: ignore
 import toml
 
 from materialize import git
@@ -56,7 +52,7 @@ class Crate:
         with open(path / "Cargo.toml") as f:
             config = toml.load(f)
         self.name = config["package"]["name"]
-        self.version = Version.parse(config["package"]["version"])
+        self.version_string = config["package"]["version"]
         self.features = config.get("features", {})
         self.path = path
         self.path_build_dependencies: set[str] = set()

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -50,7 +50,7 @@ class AlterConnectionSshChangeBase(Check):
         self.index = index
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.78.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.78.0-dev")
 
     def initialize(self) -> Testdrive:
         i = self.index

--- a/misc/python/materialize/checks/all_checks/array_type.py
+++ b/misc/python/materialize/checks/all_checks/array_type.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class ArrayType(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/cluster_unification.py
+++ b/misc/python/materialize/checks/all_checks/cluster_unification.py
@@ -15,7 +15,7 @@ from materialize.mz_version import MzVersion
 
 class UnifiedCluster(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.71.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.71.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/comment.py
+++ b/misc/python/materialize/checks/all_checks/comment.py
@@ -18,7 +18,7 @@ class Comment(Check):
     """Test comments on types and tables, as well as the comment export as avro sink schema docs"""
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.74.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.74.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/default_privileges.py
+++ b/misc/python/materialize/checks/all_checks/default_privileges.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class DefaultPrivileges(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/identifiers.py
+++ b/misc/python/materialize/checks/all_checks/identifiers.py
@@ -46,7 +46,7 @@ def cluster() -> str:
 class Identifiers(Check):
     def _can_run(self, e: Executor) -> bool:
         # CREATE ROLE not compatible with older releases
-        return self.base_version >= MzVersion.parse("0.47.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.47.0-dev")
 
     IDENT_KEYS = [
         "db",

--- a/misc/python/materialize/checks/all_checks/json_source.py
+++ b/misc/python/materialize/checks/all_checks/json_source.py
@@ -18,7 +18,7 @@ class JsonSource(Check):
     """Test CREATE SOURCE ... FORMAT JSON"""
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.60.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.60.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/kafka_protocols.py
+++ b/misc/python/materialize/checks/all_checks/kafka_protocols.py
@@ -17,7 +17,7 @@ from materialize.mz_version import MzVersion
 @externally_idempotent(False)
 class KafkaProtocols(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.78.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.78.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/managed_cluster.py
+++ b/misc/python/materialize/checks/all_checks/managed_cluster.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class CreateManagedCluster(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def manipulate(self) -> list[Testdrive]:
         return [
@@ -68,7 +68,7 @@ class CreateManagedCluster(Check):
 
 class DropManagedCluster(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def manipulate(self) -> list[Testdrive]:
         return [

--- a/misc/python/materialize/checks/all_checks/materialized_views.py
+++ b/misc/python/materialize/checks/all_checks/materialized_views.py
@@ -72,7 +72,7 @@ class MaterializedViews(Check):
 class MaterializedViewsAssertNotNull(Check):
     def _can_run(self, e: Executor) -> bool:
         # ASSERT NOT NULL known broken in earlier releases
-        return self.base_version >= MzVersion.parse("0.74.0")
+        return self.base_version >= MzVersion.parse_mz("v0.74.0")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/owners.py
+++ b/misc/python/materialize/checks/all_checks/owners.py
@@ -116,7 +116,7 @@ class Owners(Check):
 
     def _can_run(self, e: Executor) -> bool:
         # Object owner changes weren't persisted in some cases earlier than 0.63.0.
-        return self.base_version >= MzVersion.parse("0.63.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.63.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -205,7 +205,7 @@ class Owners(Check):
                     + self._drop_objects("materialize", 7, success=False)
                     + self._drop_objects("materialize", 8, success=False)
                 )
-                if self.base_version >= MzVersion.parse("0.51.0-dev")
+                if self.base_version >= MzVersion.parse_mz("v0.51.0-dev")
                 else ""
             )
             + self._create_objects("owner_role_01", 9)

--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -209,7 +209,7 @@ class PgCdcBase:
                       - materialize.public.postgres_source_tablea{self.suffix}_primary_idx (*** full scan ***)
                     """
                 )
-                if self.base_version >= MzVersion.parse("0.50.0-dev")
+                if self.base_version >= MzVersion.parse_mz("v0.50.0-dev")
                 else ""
             )
         )

--- a/misc/python/materialize/checks/all_checks/privileges.py
+++ b/misc/python/materialize/checks/all_checks/privileges.py
@@ -123,7 +123,7 @@ class Privileges(Check):
 
     def _can_run(self, e: Executor) -> bool:
         # Privilege changes weren't persisted in some cases earlier than 0.63.0.
-        return self.base_version >= MzVersion.parse("0.63.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.63.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/rename_cluster.py
+++ b/misc/python/materialize/checks/all_checks/rename_cluster.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class RenameCluster(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def manipulate(self) -> list[Testdrive]:
         return [

--- a/misc/python/materialize/checks/all_checks/rename_replica.py
+++ b/misc/python/materialize/checks/all_checks/rename_replica.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class RenameReplica(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.58.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.58.0-dev")
 
     def manipulate(self) -> list[Testdrive]:
         return [

--- a/misc/python/materialize/checks/all_checks/rename_schema.py
+++ b/misc/python/materialize/checks/all_checks/rename_schema.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class RenameSchema(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.75.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.75.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/replica.py
+++ b/misc/python/materialize/checks/all_checks/replica.py
@@ -79,7 +79,7 @@ class CreateReplica(Check):
                   AND details->>'replica_id' NOT LIKE 'u%';
                 true
                 """
-                if self.base_version < MzVersion.parse("0.66.0-dev")
+                if self.base_version < MzVersion.parse_mz("v0.66.0-dev")
                 else TESTDRIVE_NOP
             )
         )
@@ -139,7 +139,7 @@ class DropReplica(Check):
 
 class ReplicaAnnotations(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.71.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.71.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/roles.py
+++ b/misc/python/materialize/checks/all_checks/roles.py
@@ -16,10 +16,10 @@ from materialize.mz_version import MzVersion
 
 class CreateRole(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.45.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.45.0-dev")
 
     def _if_can_grant_revoke(self, text: str) -> str:
-        if self.base_version >= MzVersion.parse("0.47.0-dev"):
+        if self.base_version >= MzVersion.parse_mz("v0.47.0-dev"):
             return text
         return ""
 

--- a/misc/python/materialize/checks/all_checks/sink.py
+++ b/misc/python/materialize/checks/all_checks/sink.py
@@ -305,7 +305,7 @@ class SinkNullDefaults(Check):
     """Check on an Avro sink with NULL DEFAULTS"""
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.71.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.71.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(
@@ -554,7 +554,7 @@ class SinkComments(Check):
     """Check on an Avro sink with comments"""
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.73.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.73.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/swap_cluster.py
+++ b/misc/python/materialize/checks/all_checks/swap_cluster.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class SwapCluster(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.75.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.75.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/swap_schema.py
+++ b/misc/python/materialize/checks/all_checks/swap_schema.py
@@ -16,7 +16,7 @@ from materialize.mz_version import MzVersion
 
 class SwapSchema(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.75.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.75.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/temporal_types.py
+++ b/misc/python/materialize/checks/all_checks/temporal_types.py
@@ -86,7 +86,7 @@ class TemporalTypes(Check):
 
 class TemporalPrecisionTypes(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.70.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.70.0-dev")
 
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/webhook.py
+++ b/misc/python/materialize/checks/all_checks/webhook.py
@@ -21,10 +21,10 @@ def schemas() -> str:
 
 class Webhook(Check):
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse("0.62.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.62.0-dev")
 
     def enable(self) -> str:
-        if self.base_version < MzVersion.parse("0.76.0-dev"):
+        if self.base_version < MzVersion.parse_mz("v0.76.0-dev"):
             return dedent(
                 """
                 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}

--- a/misc/python/materialize/checks/checks.py
+++ b/misc/python/materialize/checks/checks.py
@@ -31,7 +31,7 @@ class Check:
 
     def _kafka_broker(self) -> str:
         result = "BROKER '${testdrive.kafka-addr}'"
-        if self.current_version >= MzVersion.parse("0.78.0-dev"):
+        if self.current_version >= MzVersion.parse_mz("v0.78.0-dev"):
             result += ", SECURITY PROTOCOL PLAINTEXT"
         return result
 

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -39,7 +39,7 @@ class StartMz(MzcomposeAction):
         self.system_parameter_defaults = system_parameter_defaults
         self.catalog_store = (
             "shadow"
-            if scenario.base_version() >= MzVersion.parse("0.78.0-dev")
+            if scenario.base_version() >= MzVersion.parse_mz("v0.78.0-dev")
             else "stash"
         )
 
@@ -138,22 +138,26 @@ class ConfigureMz(MzcomposeAction):
 
         # Since we already test with RBAC enabled, we have to give materialize
         # user the relevant attributes so the existing tests keep working.
-        if MzVersion(0, 45, 0) <= e.current_mz_version < MzVersion.parse("0.59.0-dev"):
+        if (
+            MzVersion.parse_mz("v0.45.0")
+            <= e.current_mz_version
+            < MzVersion.parse_mz("v0.59.0-dev")
+        ):
             system_settings.add(
                 "ALTER ROLE materialize CREATEROLE CREATEDB CREATECLUSTER;"
             )
-        elif e.current_mz_version >= MzVersion.parse("0.59.0"):
+        elif e.current_mz_version >= MzVersion.parse_mz("v0.59.0"):
             system_settings.add("GRANT ALL PRIVILEGES ON SYSTEM TO materialize;")
 
-        if e.current_mz_version >= MzVersion(0, 47, 0):
+        if e.current_mz_version >= MzVersion.parse_mz("v0.47.0"):
             system_settings.add("ALTER SYSTEM SET enable_rbac_checks TO true;")
 
-        if e.current_mz_version >= MzVersion.parse(
-            "0.51.0-dev"
-        ) and e.current_mz_version < MzVersion.parse("0.76.0-dev"):
+        if e.current_mz_version >= MzVersion.parse_mz(
+            "v0.51.0-dev"
+        ) and e.current_mz_version < MzVersion.parse_mz("v0.76.0-dev"):
             system_settings.add("ALTER SYSTEM SET enable_ld_rbac_checks TO true;")
 
-        if e.current_mz_version >= MzVersion.parse("0.52.0-dev"):
+        if e.current_mz_version >= MzVersion.parse_mz("v0.52.0-dev"):
             # Since we already test with RBAC enabled, we have to give materialize
             # user the relevant privileges so the existing tests keep working.
             system_settings.add("GRANT CREATE ON DATABASE materialize TO materialize;")
@@ -163,16 +167,16 @@ class ConfigureMz(MzcomposeAction):
             system_settings.add("GRANT CREATE ON CLUSTER default TO materialize;")
 
         if (
-            MzVersion.parse("0.58.0-dev")
+            MzVersion.parse_mz("v0.58.0-dev")
             <= e.current_mz_version
-            <= MzVersion.parse("0.63.99")
+            <= MzVersion.parse_mz("v0.63.99")
         ):
             system_settings.add("ALTER SYSTEM SET enable_managed_clusters = on;")
 
         # Before #22790, enable_specialized_arrangements=on would cause a panic on upgrade
         # This flag must be disabled by default in StartMz() and then conditionally enabled
         # here for the versions where it is expected to work.
-        if e.current_mz_version >= MzVersion.parse("0.75.0"):
+        if e.current_mz_version >= MzVersion.parse_mz("v0.75.0"):
             system_settings.add(
                 "ALTER SYSTEM SET enable_specialized_arrangements = on;"
             )
@@ -187,7 +191,7 @@ class ConfigureMz(MzcomposeAction):
 
         kafka_broker = "BROKER '${testdrive.kafka-addr}'"
         print(e.current_mz_version)
-        if e.current_mz_version >= MzVersion.parse("0.78.0-dev"):
+        if e.current_mz_version >= MzVersion.parse_mz("v0.78.0-dev"):
             kafka_broker += ", SECURITY PROTOCOL PLAINTEXT"
         input += dedent(
             f"""

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -311,7 +311,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         except ValueError:
             return default
 
-        cmp_version = MzVersion.parse_mz_without_prefix(version)
+        cmp_version = MzVersion.parse_without_prefix(version)
         return bool(operator(tag_version, cmp_version))
 
     def _meets_minimum_version(self, version: str) -> bool:

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -33,15 +33,10 @@ from kubernetes.client import (
 )
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
-from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
-
-try:
-    from semver.version import Version
-except ImportError:
-    from semver import VersionInfo as Version  # type: ignore
-
 from materialize.cloudtest.k8s.api.k8s_service import K8sService
 from materialize.cloudtest.k8s.api.k8s_stateful_set import K8sStatefulSet
+from materialize.mz_version import MzVersion
+from materialize.mzcompose import DEFAULT_SYSTEM_PARAMETERS
 
 
 class EnvironmentdService(K8sService):
@@ -312,11 +307,11 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         if self.tag is None:
             return default
         try:
-            tag_version = Version.parse(self.tag.removeprefix("v"))
+            tag_version = MzVersion.parse_mz(self.tag)
         except ValueError:
             return default
 
-        cmp_version = Version.parse(version)
+        cmp_version = MzVersion.parse_mz_without_prefix(version)
         return bool(operator(tag_version, cmp_version))
 
     def _meets_minimum_version(self, version: str) -> bool:

--- a/misc/python/materialize/deb.py
+++ b/misc/python/materialize/deb.py
@@ -14,7 +14,7 @@ from materialize import cargo, git
 
 def unstable_version(workspace: cargo.Workspace) -> str:
     """Computes the version to use for the materialized-unstable package."""
-    mz_version = workspace.crates["materialized"].version
+    mz_version_string = workspace.crates["materialized"].version_string
     commit_count = git.rev_count("HEAD")
     commit_hash = git.rev_parse("HEAD")
-    return f"{mz_version}-{commit_count}-{commit_hash}"
+    return f"{mz_version_string}-{commit_count}-{commit_hash}"

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -108,7 +108,7 @@ def get_version_tags(
         if not t.startswith(version_type.get_prefix()):
             continue
         try:
-            tags.append(version_type.parse_mz(t))
+            tags.append(version_type.parse(t))
         except ValueError as e:
             print(f"WARN: {e}", file=sys.stderr)
 

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -271,7 +271,7 @@ def get_common_ancestor_commit(remote: str, branch: str, fetch_branch: bool) -> 
 
 def is_on_release_version() -> bool:
     git_tags = get_tags_of_current_commit()
-    return any(MzVersion.is_mz_version_string(git_tag) for git_tag in git_tags)
+    return any(MzVersion.is_valid_version_string(git_tag) for git_tag in git_tags)
 
 
 def is_on_main_branch() -> bool:
@@ -289,10 +289,8 @@ def get_tagged_release_version(version_type: type[VERSION_TYPE]) -> VERSION_TYPE
     versions: list[VERSION_TYPE] = []
 
     for git_tag in git_tags:
-        version = version_type.try_parse_mz(git_tag)
-
-        if version is not None:
-            versions.append(version)
+        if version_type.is_valid_version_string(git_tag):
+            versions.append(version_type.parse(git_tag))
 
     if len(versions) == 0:
         return None
@@ -328,7 +326,7 @@ def get_previous_version(
 
     if version.prerelease is not None and len(version.prerelease) > 0:
         # simply drop the prerelease, do not try to find a decremented version
-        found_version = MzVersion.create_mz(version.major, version.minor, version.patch)
+        found_version = MzVersion.create(version.major, version.minor, version.patch)
 
         if found_version not in excluded_versions:
             return found_version

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -31,7 +31,7 @@ class TypedVersionBase(Version):
         raise NotImplementedError(f"Not implemented in {cls}")
 
     @classmethod
-    def create_mz(
+    def create(
         cls: type[T], major: int, minor: int, patch: int, prerelease: str | None = None
     ) -> T:
         prerelease_suffix = f"-{prerelease}" if prerelease is not None else ""
@@ -40,7 +40,7 @@ class TypedVersionBase(Version):
         )
 
     @classmethod
-    def parse_mz_without_prefix(
+    def parse_without_prefix(
         cls: type[T], version_without_prefix: str, drop_dev_suffix: bool = False
     ) -> T:
         version = f"{cls.get_prefix()}{version_without_prefix}"
@@ -67,7 +67,7 @@ class TypedVersionBase(Version):
         return cls.parse(version)
 
     @classmethod
-    def try_parse_mz(
+    def try_parse(
         cls: type[T], version: str, drop_dev_suffix: bool = False
     ) -> T | None:
         """Parses a version string but returns empty if that fails"""
@@ -77,8 +77,8 @@ class TypedVersionBase(Version):
             return None
 
     @classmethod
-    def is_mz_version_string(cls, version: str) -> bool:
-        return cls.try_parse_mz(version) is not None
+    def is_valid_version_string(cls, version: str) -> bool:
+        return cls.try_parse(version) is not None
 
     def str_without_prefix(self) -> str:
         return super().__str__()

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -7,35 +7,54 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-"""Various utilities"""
+"""Version types"""
 
 from __future__ import annotations
 
 import json
 import subprocess
+from typing import TypeVar
 
 try:
     from semver.version import Version
 except ImportError:
     from semver import VersionInfo as Version  # type: ignore
 
+T = TypeVar("T", bound="TypedVersionBase")
 
-class MzVersion(Version):
-    """Version of Materialize, can be parsed from version string, SQL, cargo"""
+
+class TypedVersionBase(Version):
+    """Typed version, can be parsed from version string"""
+
+    @classmethod
+    def get_prefix(cls) -> str:
+        raise NotImplementedError(f"Not implemented in {cls}")
 
     @classmethod
     def create_mz(
-        cls, major: int, minor: int, patch: int, prerelease: str | None = None
-    ) -> MzVersion:
+        cls: type[T], major: int, minor: int, patch: int, prerelease: str | None = None
+    ) -> T:
         prerelease_suffix = f"-{prerelease}" if prerelease is not None else ""
-        return cls.parse_mz(f"v{major}.{minor}.{patch}{prerelease_suffix}")
+        return cls.parse_mz(
+            f"{cls.get_prefix()}{major}.{minor}.{patch}{prerelease_suffix}"
+        )
 
     @classmethod
-    def parse_mz(cls, version: str, drop_dev_suffix: bool = False) -> MzVersion:
-        """Parses a Mz version string, for example:  v0.45.0-dev (f01773cb1)"""
-        if not version[0] == "v":
-            raise ValueError(f"Invalid mz version string: {version}")
-        version = version[1:]
+    def parse_mz_without_prefix(
+        cls: type[T], version_without_prefix: str, drop_dev_suffix: bool = False
+    ) -> T:
+        version = f"{cls.get_prefix()}{version_without_prefix}"
+        return cls.parse_mz(version, drop_dev_suffix=drop_dev_suffix)
+
+    @classmethod
+    def parse_mz(cls: type[T], version: str, drop_dev_suffix: bool = False) -> T:
+        """Parses a version string with prefix, for example: v0.45.0-dev (f01773cb1)"""
+        expected_prefix = cls.get_prefix()
+        if not version.startswith(expected_prefix):
+            raise ValueError(
+                f"Invalid version string '{version}', expected prefix '{expected_prefix}'"
+            )
+        version = version.removeprefix(expected_prefix)
         if " " in version:
             version, git_hash = version.split(" ")
             if not git_hash[0] == "(" or not git_hash[-1] == ")":
@@ -49,9 +68,9 @@ class MzVersion(Version):
 
     @classmethod
     def try_parse_mz(
-        cls, version: str, drop_dev_suffix: bool = False
-    ) -> MzVersion | None:
-        """Parses a Mz version string but returns empty if that fails"""
+        cls: type[T], version: str, drop_dev_suffix: bool = False
+    ) -> T | None:
+        """Parses a version string but returns empty if that fails"""
         try:
             return cls.parse_mz(version, drop_dev_suffix=drop_dev_suffix)
         except ValueError:
@@ -60,6 +79,20 @@ class MzVersion(Version):
     @classmethod
     def is_mz_version_string(cls, version: str) -> bool:
         return cls.try_parse_mz(version) is not None
+
+    def str_without_prefix(self) -> str:
+        return super().__str__()
+
+    def __str__(self) -> str:
+        return f"{self.get_prefix()}{self.str_without_prefix()}"
+
+
+class MzVersion(TypedVersionBase):
+    """Version of Materialize, can be parsed from version string, SQL, cargo"""
+
+    @classmethod
+    def get_prefix(cls) -> str:
+        return "v"
 
     @classmethod
     def parse_cargo(cls) -> MzVersion:
@@ -75,12 +108,18 @@ class MzVersion(Version):
         else:
             raise ValueError("No mz-environmentd version found in cargo metadata")
 
+
+class MzAptVersion(TypedVersionBase):
+    """Version of Materialize APT"""
+
     @classmethod
-    def from_semver(cls, version: Version) -> MzVersion:
-        return cls.parse(str(version))
+    def get_prefix(cls) -> str:
+        return "mz-v"
 
-    def to_semver(self) -> Version:
-        return Version.parse(str(self).lstrip("v"))
 
-    def __str__(self) -> str:
-        return "v" + super().__str__()
+class MzLspServerVersion(TypedVersionBase):
+    """Version of Materialize LSP Server"""
+
+    @classmethod
+    def get_prefix(cls) -> str:
+        return "mz-lsp-server-v"

--- a/misc/python/materialize/mz_version.py
+++ b/misc/python/materialize/mz_version.py
@@ -109,7 +109,7 @@ class MzVersion(TypedVersionBase):
             raise ValueError("No mz-environmentd version found in cargo metadata")
 
 
-class MzAptVersion(TypedVersionBase):
+class MzCliVersion(TypedVersionBase):
     """Version of Materialize APT"""
 
     @classmethod

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -124,7 +124,7 @@ class Materialized(Service):
             and "latest" not in image
             and "devel" not in image
             and "unstable" not in image
-            and MzVersion.parse_mz(image.split(":")[1]) < MzVersion.parse("0.41.0")
+            and MzVersion.parse_mz(image.split(":")[1]) < MzVersion.parse_mz("v0.41.0")
             else "1"
             if default_size == 1
             else f"{default_size}-1"

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -84,7 +84,7 @@ class VersionsFromGit(VersionList):
 
     def __init__(self) -> None:
         self.versions = list(
-            {MzVersion.from_semver(t) for t in git.get_version_tags(fetch=True)}
+            set(git.get_version_tags(version_type=MzVersion, fetch=True))
             - INVALID_VERSIONS
         )
         self.versions.sort()

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -75,7 +75,7 @@ class VersionsFromGit(VersionList):
     >>> len(VersionsFromGit().minor_versions()) > 0
     True
 
-    >>> len(VersionsFromGit().patch_versions(minor_version=MzVersion.parse("0.52.0")))
+    >>> len(VersionsFromGit().patch_versions(minor_version=MzVersion.parse_mz("v0.52.0")))
     4
 
     >>> min(VersionsFromGit().all_versions())
@@ -102,7 +102,7 @@ class VersionsFromDocs(VersionList):
     >>> len(VersionsFromDocs().minor_versions()) > 0
     True
 
-    >>> len(VersionsFromDocs().patch_versions(minor_version=MzVersion.parse("0.52.0")))
+    >>> len(VersionsFromDocs().patch_versions(minor_version=MzVersion.parse_mz("v0.52.0")))
     4
 
     >>> min(VersionsFromDocs().all_versions())

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -111,8 +111,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     parser.add_argument(
         "--min-version",
         metavar="VERSION",
-        type=MzVersion.parse,
-        default=MzVersion.parse("0.39.0"),
+        type=MzVersion.parse_without_prefix,
+        default=MzVersion.parse_without_prefix("0.39.0"),
         help="Minimum Mz version to involve.",
     )
 


### PR DESCRIPTION
### What?
This PR reduces direct usages of the semver `Version` / `VersionInfo` class as well as imports of these classes. It introduces further dedicated types for the used version types (`MzAptVersion` and `MzLspServerVersion` next to the already existing type `MzVersion`).

### Why?
* prevent problems that arise(d) when mixing `Version` and `MzVersion` (for example, checking if a version `v` of type `MzVersion` is part of a `set[Version]` will fail at runtime because the `Version`'s equality check requires both instances to be of exactly the same type)
* get rid of most conditional semver imports, which are necessary because some code is used in the cloud repo that needs to use another semver version

### Risks
I might not have caught all places where a version is implicitly converted to a string. Conversions of the new types to string include the version prefix by default (the prefix was previously stripped immediately away when creating an instance of `Version`).

### Breaking changes
`MzVersion.parse()` now behaves like `MzVersion.parse_mz()`. To parse a version string without a prefix, use `MzVersion.parse_without_prefix()`.

### [Commits](https://github.com/MaterializeInc/materialize/pull/23397/commits)
* ci: rename to NpmPackageVersion
* ci: refactor MzVersion, introduce further types
* ci: adapt usages
* ci: fix string usages of versions
* ci: rename to MzCliVersion
* ci: rename VERSION constants
* ci: MzVersion: change used method
* ci: MzVersion: rename methods (1/2)
* ci: MzVersion: rename methods (2/2): parse_mz => parse (breaking change!), keep parse_mz for MzVersion


### Nightly
https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Aci%2Frework-version-usages

