### PR TITLE
lsp: cmd for accepting runtime options update

### DIFF
--- a/src/lsp-server/src/backend.rs
+++ b/src/lsp-server/src/backend.rs
@@ -22,6 +22,7 @@ use mz_sql_parser::ast::{statement_kind_label_value, Raw, Statement};
 use mz_sql_parser::parser::parse_statements;
 use regex::Regex;
 use ropey::Rope;
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{json, Value};
 use tokio::sync::Mutex;
@@ -199,50 +200,34 @@ impl LanguageServer for Backend {
     async fn execute_command(&self, command_params: ExecuteCommandParams) -> Result<Option<Value>> {
         match command_params.command.as_str() {
             "parse" => {
-                let json_args = command_params.arguments.get(0);
+                let args: String = get_first_param(command_params)?;
+                let statements = parse_statements(&args)
+                    .map_err(|_| build_error("Error parsing the statements."))?;
 
-                if let Some(json_args) = json_args {
-                    let args = serde_json::from_value::<String>(json_args.clone())
-                        .map_err(|_| build_error("Error deserializing parse args as String."))?;
-                    let statements = parse_statements(&args)
-                        .map_err(|_| build_error("Error parsing the statements."))?;
+                // Transform raw statements to splitted statements
+                // and infere the kind.
+                // E.g. if it is a select or a create_table statement.
+                let parse_statements: Vec<ExecuteCommandParseStatement> = statements
+                    .iter()
+                    .map(|x| ExecuteCommandParseStatement {
+                        kind: statement_kind_label_value(x.ast.clone().into()).to_string(),
+                        sql: x.sql.to_string(),
+                    })
+                    .collect();
 
-                    // Transform raw statements to splitted statements
-                    // and infere the kind.
-                    // E.g. if it is a select or a create_table statement.
-                    let parse_statements: Vec<ExecuteCommandParseStatement> = statements
-                        .iter()
-                        .map(|x| ExecuteCommandParseStatement {
-                            kind: statement_kind_label_value(x.ast.clone().into()).to_string(),
-                            sql: x.sql.to_string(),
-                        })
-                        .collect();
-
-                    return Ok(Some(json!(ExecuteCommandParseResponse {
-                        statements: parse_statements
-                    })));
-                } else {
-                    return Err(build_error("Missing command args."));
-                }
+                return Ok(Some(json!(ExecuteCommandParseResponse {
+                    statements: parse_statements
+                })));
             }
             "optionsUpdate" => {
-                let json_args = command_params.arguments.get(0);
+                let args: InitializeOptions = get_first_param(command_params)?;
 
-                if let Some(json_args) = json_args {
-                    let args = serde_json::from_value::<InitializeOptions>(json_args.clone())
-                        .map_err(|_| {
-                            build_error("Error deserializing parse args as InitializeOptions.")
-                        })?;
-
-                    if let Some(formatting_width) = args.formatting_width {
-                        let mut formatting_width_guard = self.formatting_width.lock().await;
-                        *formatting_width_guard = formatting_width;
-                    }
-
-                    return Ok(None);
-                } else {
-                    return Err(build_error("Missing command args."));
+                if let Some(formatting_width) = args.formatting_width {
+                    let mut formatting_width_guard = self.formatting_width.lock().await;
+                    *formatting_width_guard = formatting_width;
                 }
+
+                return Ok(None);
             }
             _ => {
                 return Err(build_error("Unknown command."));
@@ -453,5 +438,30 @@ fn build_error(message: &'static str) -> tower_lsp::jsonrpc::Error {
         code: ErrorCode::InternalError,
         message: std::borrow::Cow::Borrowed(message),
         data: None,
+    }
+}
+
+/// Parses and returns the first argument from the provided [ExecuteCommandParams]
+/// using the generic type `T`.
+///
+/// Command parameters are expected to be inside an array, but typically,
+/// only a single parameter is present within the array. This function serves as a utility
+/// to avoid code repetition when retrieving that single parameter.
+///
+/// # Note
+///
+/// Ensure that the type `T` implements the `DeserializeOwned` trait for successful deserialization.
+fn get_first_param<T>(cmd: ExecuteCommandParams) -> Result<T>
+where
+    T: DeserializeOwned,
+{
+    let json_args = cmd.arguments.get(0);
+
+    if let Some(json_args) = json_args {
+        let args = serde_json::from_value::<T>(json_args.clone())
+            .map_err(|_| build_error("Error deserializing parse args as String."))?;
+        Ok(args)
+    } else {
+        Err(build_error("Missing command args."))
     }
 }

--- a/src/lsp-server/src/backend.rs
+++ b/src/lsp-server/src/backend.rs
@@ -225,6 +225,25 @@ impl LanguageServer for Backend {
                     return Err(build_error("Missing command args."));
                 }
             }
+            "optionsUpdate" => {
+                let json_args = command_params.arguments.get(0);
+
+                if let Some(json_args) = json_args {
+                    let args = serde_json::from_value::<InitializeOptions>(json_args.clone())
+                        .map_err(|_| {
+                            build_error("Error deserializing parse args as InitializeOptions.")
+                        })?;
+
+                    if let Some(formatting_width) = args.formatting_width {
+                        let mut formatting_width_guard = self.formatting_width.lock().await;
+                        *formatting_width_guard = formatting_width;
+                    }
+
+                    return Ok(None);
+                } else {
+                    return Err(build_error("Missing command args."));
+                }
+            }
             _ => {
                 return Err(build_error("Unknown command."));
             }

--- a/src/lsp-server/tests/test.rs
+++ b/src/lsp-server/tests/test.rs
@@ -297,6 +297,34 @@ mod tests {
             expected_response,
         )
         .await;
+
+        // Test options update
+        let request = r#"{
+            "jsonrpc":"2.0",
+            "id": 2,
+            "method":"workspace/executeCommand",
+            "params": {
+                "command": "optionsUpdate",
+                "arguments": [{ "formattingWidth": 10 }]
+            }
+        }"#;
+        let expected_response = vec![LspMessage::<(), ()> {
+            jsonrpc: "2.0".to_string(),
+            id: Some(2),
+            result: None,
+            method: None,
+            params: None,
+            error: None,
+        }];
+
+        write_and_assert(
+            req_client,
+            resp_client,
+            &mut [0; 1024],
+            request,
+            expected_response,
+        )
+        .await;
     }
 
     /// Asserts that the server can parse a single SQL statement `SELECT 100;`.


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR adds a new command to the LSP, `optionsUpdate`, making it possible to change runtime options (for now only `formatting_width`). This avoids the need to restart the server and deal with the [associated issues](https://github.com/MaterializeInc/vscode-extension/issues/153).

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
