### PR TITLE
ci: Decode unknown error matches too

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -195,7 +195,7 @@ def annotate_logged_errors(log_files: list[str]) -> int:
 
                 if issue.info["number"] not in already_reported_issue_numbers:
                     known_errors.append(
-                        f"[{issue.info['title']} (#{issue.info['number']})]({issue.info['html_url']}) in {linked_file}:  \n``{error.match}``"
+                        f"[{issue.info['title']} (#{issue.info['number']})]({issue.info['html_url']}) in {linked_file}:  \n``{error.match.decode('utf-8')}``"
                     )
                     already_reported_issue_numbers.add(issue.info["number"])
                 break


### PR DESCRIPTION
Forgotten since it switched to bytes, currently gets printed as:
```
b'platform-checks-materialized-1 | environmentd: 2023-11-23T11:34:30.521278Z ERROR mz_adapter::coord: Coordinator is stuck on cluster_event, did not respond after 60s'
```
With this change:
```
platform-checks-materialized-1 | environmentd: 2023-11-23T11:34:30.521278Z ERROR mz_adapter::coord: Coordinator is stuck on cluster_event, did not respond after 60s
```

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
