### PR TITLE
ci: Disable fast-path peeks again

### DIFF
--- a/misc/python/materialize/checks/all_checks/peek_persist.py
+++ b/misc/python/materialize/checks/all_checks/peek_persist.py
@@ -52,9 +52,10 @@ class PeekPersist(Check):
             3
             3
 
-            ? EXPLAIN SELECT * FROM peek_persist LIMIT 100
-            Explained Query (fast path):
-              Finish limit=100 output=[#0]
-                PeekPersist materialize.public.peek_persist
+            # TODO(bkirwi): revisit this when persist peeks have stabilized
+            # ? EXPLAIN SELECT * FROM peek_persist LIMIT 100
+            # Explained Query (fast path):
+            #   Finish limit=100 output=[#0]
+            #     PeekPersist materialize.public.peek_persist
             """
         )

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -73,7 +73,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_sink_doc_on_option": "true",
     "enable_assert_not_null": "true",
     "enable_specialized_arrangements": "true",
-    "persist_fast_path_limit": "1000",
+    # TODO(def-,bkirwi): Reenable before this is used in production, #22042
+    # "persist_fast_path_limit": "1000",
     "enable_alter_swap": "true",
     "timestamp_oracle": "postgres",
 }


### PR DESCRIPTION
See discussion in https://github.com/MaterializeInc/materialize/pull/23353

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
