### PR TITLE
build: Use unpacked split debuginfo and incremental build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ rust-version = "1.74.0"
 # TODO(gusywnn|benesch): incremental is still not reliable as of rust 1.72
 # in our workspace.
 incremental = false
+split-debuginfo = "unpacked"
 
 [profile.dev.package]
 # Compile the backtrace crate and its dependencies with all optimizations, even
@@ -135,6 +136,7 @@ rustc-demangle = { opt-level = 3 }
 [profile.release]
 # Compile time seems similar to "lto = false", runtime ~10% faster
 lto = "thin"
+split-debuginfo = "unpacked"
 
 # Emit full debug info, allowing us to easily analyze core dumps from
 # staging (and, in an emergency, also prod).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -116,9 +116,6 @@ edition = "2021"
 rust-version = "1.74.0"
 
 [profile.dev]
-# TODO(gusywnn|benesch): incremental is still not reliable as of rust 1.72
-# in our workspace.
-incremental = false
 split-debuginfo = "unpacked"
 
 [profile.dev.package]
@@ -136,7 +133,6 @@ rustc-demangle = { opt-level = 3 }
 [profile.release]
 # Compile time seems similar to "lto = false", runtime ~10% faster
 lto = "thin"
-split-debuginfo = "unpacked"
 
 # Emit full debug info, allowing us to easily analyze core dumps from
 # staging (and, in an emergency, also prod).


### PR DESCRIPTION
See https://doc.rust-lang.org/rustc/codegen-options/index.html#split-debuginfo

This should lead to:
- slightly faster scratch build locally (4:12 -> 4:03)
- faster release build in CI (~23 min -> ~17 min)
- much faster incremental builds (`cargo build && echo "//" >> src/environmentd/src/bin/environmentd/main.rs && time cargo build`: 20 s -> 2.3 s)
- smaller executable (2.7 GB -> 1.6 GB environmentd)
- reduced disk usage (39 GB -> 32 GB target dir, but incremental makes it bloat again)
- reduced memory usage during compilation (18.3 GB -> 17.4 GB from scratch, 1.8 GB -> 1.1 GB max incremental)

See for example https://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/ from a former colleague of mine, we had good experiences with split dwarf.

Does this matter for our release process or will the debuginfo still be uploaded correctly? Have to check with Brennan.

Also enable incremental build again, the previous problem seems to have been cargo clippy, see https://materializeinc.slack.com/archives/CMH6PG4CW/p1694572440379559 . Now that we enforce Rust 1.74 the issue seems to be fixed.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
