### PR TITLE
scalability framework: replace two workloads

### DIFF
--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -36,6 +36,11 @@ class SelectCount(Operation):
         return "SELECT COUNT(*) FROM t1;"
 
 
+class SelectCountInMv(Operation):
+    def sql_statement(self) -> str:
+        return "SELECT count FROM mv1;"
+
+
 class SelectUnionAll(Operation):
     def sql_statement(self) -> str:
         return "SELECT * FROM t1 UNION ALL SELECT * FROM t1;"

--- a/misc/python/materialize/scalability/schema.py
+++ b/misc/python/materialize/scalability/schema.py
@@ -51,11 +51,13 @@ class Schema:
                     [
                         f"CREATE TABLE t{t} (f1 INTEGER DEFAULT 1);",
                         f"INSERT INTO t{t} DEFAULT VALUES;",
+                        f"CREATE OR REPLACE MATERIALIZED VIEW mv{t} AS SELECT count(*) AS count FROM t{t};",
                     ]
                 )
 
                 if self.create_index:
                     init_sqls.append(f"CREATE INDEX i{t} ON t{t} (f1);")
+                    init_sqls.append(f"CREATE INDEX mv_i{t} ON mv{t} (count);")
 
         return init_sqls
 

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -56,9 +56,9 @@ class InsertAndSelectCountInMvWorkload(Workload):
         return [InsertDefaultValues(), SelectCountInMv()]
 
 
-class InsertAndSelectStarWorkload(Workload):
+class InsertAndSelectLimitWorkload(Workload):
     def operations(self) -> list["Operation"]:
-        return [InsertDefaultValues(), SelectStar()]
+        return [InsertDefaultValues(), SelectLimit()]
 
 
 class UpdateWorkload(Workload):

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -11,6 +11,7 @@ from materialize.scalability.operation import Operation
 from materialize.scalability.operations import (
     InsertDefaultValues,
     SelectCount,
+    SelectCountInMv,
     SelectLimit,
     SelectOne,
     SelectStar,
@@ -50,9 +51,9 @@ class SelectUnionAllWorkload(Workload):
         return [SelectUnionAll()]
 
 
-class InsertAndSelectCountWorkload(Workload):
+class InsertAndSelectCountInMvWorkload(Workload):
     def operations(self) -> list["Operation"]:
-        return [InsertDefaultValues(), SelectCount()]
+        return [InsertDefaultValues(), SelectCountInMv()]
 
 
 class InsertAndSelectStarWorkload(Workload):


### PR DESCRIPTION
Replace workloads that get more expensive after each execution:
* replace workload `InsertAndSelectCountWorkload` with `InsertAndSelectCountInMvWorkload`
* replace workload `InsertAndSelectStarWorkload` with `InsertAndSelectLimitWorkload`

See also the discussion in https://materializeinc.slack.com/archives/C057X0NG91B/p1700744346005769

Nightly: https://buildkite.com/materialize/nightlies/builds/5349