### PR TITLE
adapter: remove stale migrations

### DIFF
--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -13,11 +13,8 @@ use futures::future::BoxFuture;
 use mz_catalog::durable::Transaction;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_sql::ast::display::AstDisplay;
 use mz_sql::ast::Raw;
-use mz_sql::catalog::SessionCatalog;
-use mz_sql::session::user::MZ_SUPPORT_ROLE_ID;
 use mz_storage_types::connections::ConnectionContext;
 use semver::Version;
 use tracing::info;
@@ -27,13 +24,13 @@ use crate::catalog::{Catalog, CatalogState, ConnCatalog};
 
 async fn rewrite_items<F>(
     tx: &mut Transaction<'_>,
-    cat: Option<&ConnCatalog<'_>>,
+    cat: &ConnCatalog<'_>,
     mut f: F,
 ) -> Result<(), anyhow::Error>
 where
     F: for<'a> FnMut(
         &'a mut Transaction<'_>,
-        &'a Option<&ConnCatalog<'_>>,
+        &'a &ConnCatalog<'_>,
         &'a mut mz_sql::ast::Statement<Raw>,
     ) -> BoxFuture<'a, Result<(), anyhow::Error>>,
 {
@@ -54,11 +51,11 @@ where
 
 pub(crate) async fn migrate(
     state: &CatalogState,
-    txn: &mut Transaction<'_>,
-    now: NowFn,
+    tx: &mut Transaction<'_>,
+    _now: NowFn,
     _connection_context: &ConnectionContext,
 ) -> Result<(), anyhow::Error> {
-    let catalog_version = txn.get_catalog_content_version();
+    let catalog_version = tx.get_catalog_content_version();
     let catalog_version = match catalog_version {
         Some(v) => Version::parse(&v)?,
         None => Version::new(0, 0, 0),
@@ -66,31 +63,37 @@ pub(crate) async fn migrate(
 
     info!("migrating from catalog version {:?}", catalog_version);
 
-    let _now = now();
-    // First, do basic AST -> AST transformations.
-    // rewrite_items(&mut tx, None, |_tx, _cat, _stmt| Box::pin(async { Ok(()) })).await?;
+    // Load up a temporary catalog.
+    let state = Catalog::load_catalog_items(tx, state)?;
 
-    // Then, load up a temporary catalog with the rewritten items, and perform
-    // some transformations that require introspecting the catalog. These
-    // migrations are *weird*: they're rewriting the catalog while looking at
-    // it. You probably should be adding a basic AST migration above, unless
-    // you are really certain you want one of these crazy migrations.
-    let state = Catalog::load_catalog_items(txn, state)?;
+    // Perform per-item AST migrations.
     let conn_cat = state.for_system_session();
-    rewrite_items(txn, Some(&conn_cat), |_tx, cat, item| {
-        let catalog_version = catalog_version.clone();
+    rewrite_items(tx, &conn_cat, |_tx, _conn_cat, _item| {
+        let _catalog_version = catalog_version.clone();
         Box::pin(async move {
-            let _conn_cat = cat.expect("must provide access to conn catalog");
-            ast_rewrite_create_connection_options_0_77_0(item)?;
-            if catalog_version <= Version::new(0, 77, u64::MAX) {
-                ast_rewrite_create_connection_options_0_78_0(item)?;
-            }
+            // Add per-item AST migrations below.
+            //
+            // Each migration should be a function that takes `item` (the AST
+            // representing the creation SQL for the item) as input. Any
+            // mutations to `item` will be staged for commit to the catalog.
+            //
+            // Be careful if you reference `conn_cat`. Doing so is *weird*,
+            // as you'll be rewriting the catalog while looking at it. If
+            // possible, make your migration independent of `conn_cat`, and only
+            // consider a single item at a time.
+            //
+            // Migration functions may also take `tx` as input to stage
+            // arbitrary changes to the catalog.
+
             Ok(())
         })
     })
     .await?;
 
-    mz_support_read_progress_sources(txn, &conn_cat)?;
+    // Add whole-catalog migrations below.
+    //
+    // Each migration should be a function that takes `tx` and `conn_cat` as
+    // input and stages arbitrary transformations to the catalog on `tx`.
 
     info!(
         "migration from catalog version {:?} complete",
@@ -106,138 +109,8 @@ pub(crate) async fn migrate(
 // The convention is to name the migration function using snake case:
 // > <category>_<description>_<version>
 //
-// Note that:
-// - The sum of all migrations must be idempotent because all migrations run
-//   every time the catalog opens, unless migrations are explicitly disabled.
-//   This might mean changing code outside the migration itself, or only
-//   executing some migrations when encountering certain versions.
-// - Migrations must preserve backwards compatibility with all past releases of
-//   Materialize.
-//
-// Please include @benesch on any code reviews that add or edit migrations.
-
-// ****************************************************************************
-// AST migrations -- Basic AST -> AST transformations
-// ****************************************************************************
-
-/// Remove any durably recorded `WITH (VALIDATE = true|false)` from `CREATE
-/// CONNECTION` statements.
-///
-/// This `WITH` option only has an effect when creating the connection, and the
-/// fact that it was persisted in the item's definition is unclear, especially
-/// in light of `ALTER CONNECTION`, which also offers a `WITH (VALIDATE =
-/// true|false)` option, but cannot alter the `VALIDATE` clause on the `CREATE
-/// CONNECTION` statement.
-fn ast_rewrite_create_connection_options_0_77_0(
-    stmt: &mut mz_sql::ast::Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    use mz_sql::ast::visit_mut::VisitMut;
-    struct CreateConnectionRewriter;
-    impl<'ast> VisitMut<'ast, Raw> for CreateConnectionRewriter {
-        fn visit_create_connection_statement_mut(
-            &mut self,
-            node: &'ast mut mz_sql::ast::CreateConnectionStatement<Raw>,
-        ) {
-            node.with_options
-                .retain(|o| o.name != mz_sql::ast::CreateConnectionOptionName::Validate);
-        }
-    }
-
-    CreateConnectionRewriter.visit_statement_mut(stmt);
-    Ok(())
-}
-
-/// Add `SECURITY PROTOCOL` to all existing Kafka connections, based on the
-fn ast_rewrite_create_connection_options_0_78_0(
-    stmt: &mut mz_sql::ast::Statement<Raw>,
-) -> Result<(), anyhow::Error> {
-    use mz_sql::ast::visit_mut::VisitMut;
-    use mz_sql::ast::ConnectionOptionName::*;
-    use mz_sql::ast::{
-        ConnectionOption, CreateConnectionStatement, CreateConnectionType, Value, WithOptionValue,
-    };
-
-    struct CreateConnectionRewriter;
-    impl<'ast> VisitMut<'ast, Raw> for CreateConnectionRewriter {
-        fn visit_create_connection_statement_mut(
-            &mut self,
-            node: &'ast mut CreateConnectionStatement<Raw>,
-        ) {
-            if node.connection_type != CreateConnectionType::Kafka {
-                return;
-            }
-            let has_security_protocol = node
-                .values
-                .iter()
-                .any(|o| matches!(o.name, SecurityProtocol));
-            let is_ssl = node
-                .values
-                .iter()
-                .any(|o| matches!(o.name, SslCertificate | SslKey));
-            let is_sasl = node
-                .values
-                .iter()
-                .any(|o| matches!(o.name, SaslMechanisms | SaslUsername | SaslPassword));
-            if has_security_protocol {
-                panic!(
-                    "Kafka connection has security protocol pre-v0.78.0: {:#?}",
-                    node.values
-                );
-            }
-            let security_protocol = match (is_ssl, is_sasl) {
-                (false, false) => "PLAINTEXT",
-                (true, false) => "SSL",
-                (false, true) => "SASL_SSL", // Pre-v0.78, any SASL option always meant SASL_SSL.
-                (true, true) => panic!(
-                    "impossible Kafka connection with both SSL and SASL options: {:#?}",
-                    node.values
-                ),
-            };
-            node.values.push(ConnectionOption {
-                name: SecurityProtocol,
-                value: Some(WithOptionValue::Value(Value::String(
-                    security_protocol.into(),
-                ))),
-            });
-        }
-    }
-
-    CreateConnectionRewriter.visit_statement_mut(stmt);
-    Ok(())
-}
-
-// ****************************************************************************
-// Semantic migrations -- Weird migrations that require access to the catalog
-// ****************************************************************************
-
-/// Grant SELECT on all progress sources to the mz_support role.
-fn mz_support_read_progress_sources(
-    txn: &mut Transaction<'_>,
-    conn_catalog: &ConnCatalog,
-) -> Result<(), anyhow::Error> {
-    let mut updated_items = BTreeMap::new();
-    for mut item in txn.loaded_items() {
-        let catalog_item = conn_catalog.get_item(&item.id);
-        if catalog_item.is_progress_source() {
-            let privileges = catalog_item.privileges();
-            match privileges.get_acl_item(&MZ_SUPPORT_ROLE_ID, &catalog_item.owner_id()) {
-                Some(acl_item) if acl_item.acl_mode.contains(AclMode::SELECT) => {}
-                _ => {
-                    let mut new_privileges = privileges.clone();
-                    new_privileges.grant(MzAclItem {
-                        grantee: MZ_SUPPORT_ROLE_ID,
-                        grantor: catalog_item.owner_id(),
-                        acl_mode: AclMode::SELECT,
-                    });
-                    item.privileges = new_privileges.into_all_values().collect();
-                    updated_items.insert(item.id, item);
-                }
-            }
-        }
-    }
-    txn.update_items(updated_items)?;
-    Ok(())
-}
+// Please include the adapter team on any code reviews that add or edit
+// migrations.
 
 fn _add_to_audit_log(
     tx: &mut Transaction,


### PR DESCRIPTION
In #22945, I promised to fix the incomplete doc comment on the migration function I added (ast_rewrite_create_connection_options_0_78_0). I accidentally waited long enough to address that request that I can just remove the migration entirely, as v0.78 has now been cut with the migration and the migration only needs to run once.

While I was in here, I also removed the
ast_rewrite_create_connection_options_0_77_0 migration, which similarly only needed to run once.

I also took the opportunity to clean up the migration framework. The distinction between AST -> AST and semantic migrations has been lost, so ditch commentary about it. Also consistently use `tx` instead of `txn` to refer to the `Transaction` option.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
