### PR TITLE
platform-checks: Mark the ALTER CONNECTION Checks as not externally i…

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -13,7 +13,7 @@ from random import Random
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
@@ -206,16 +206,19 @@ class AlterConnectionSshChangeBase(Check):
         )
 
 
+@externally_idempotent(False)
 class AlterConnectionToSsh(AlterConnectionSshChangeBase):
     def __init__(self, base_version: MzVersion, rng: Random | None):
         super().__init__(SshChange.ADD_SSH, 1, base_version, rng)
 
 
+@externally_idempotent(False)
 class AlterConnectionToNonSsh(AlterConnectionSshChangeBase):
     def __init__(self, base_version: MzVersion, rng: Random | None):
         super().__init__(SshChange.DROP_SSH, 2, base_version, rng)
 
 
+@externally_idempotent(False)
 class AlterConnectionHost(AlterConnectionSshChangeBase):
     def __init__(self, base_version: MzVersion, rng: Random | None):
         super().__init__(SshChange.CHANGE_SSH_HOST, 3, base_version, rng)


### PR DESCRIPTION
…tempotent

Those Checks modify external state and are therefore incompatible with backup+restore scenarios that run the manipulate() phase twice.

### Motivation

Nightly CI was failing.