### PR TITLE
parallel-workload: Fix running with random scenario/complexity

### DIFF
--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -59,28 +59,16 @@ def run(
     ports: dict[str, int],
     seed: str,
     runtime: int,
-    complexity_str: str,
-    scenario_str: str,
+    complexity: Complexity,
+    scenario: Scenario,
     num_threads: int | None,
     naughty_identifiers: bool,
     fast_startup: bool,
     composition: Composition | None,
 ) -> None:
     num_threads = num_threads or os.cpu_count() or 10
-    random.seed(seed)
 
     rng = random.Random(random.randrange(SEED_RANGE))
-
-    complexity = (
-        Complexity(rng.choice([elem.value for elem in Complexity]))
-        if complexity_str == "random"
-        else Complexity(complexity_str)
-    )
-    scenario = (
-        Scenario(rng.choice([elem.value for elem in Scenario]))
-        if scenario_str == "random"
-        else Scenario(scenario_str)
-    )
 
     print(
         f"+++ Running with: --seed={seed} --threads={num_threads} --runtime={runtime} --complexity={complexity.value} --scenario={scenario.value} {'--naughty-identifiers ' if naughty_identifiers else ''} {'--fast-startup' if fast_startup else ''}(--host={host})"
@@ -435,13 +423,15 @@ def main() -> int:
             cur.execute(f"ALTER SYSTEM SET {key} = '{value}'")
     system_conn.close()
 
+    random.seed(args.seed)
+
     run(
         args.host,
         ports,
         args.seed,
         args.runtime,
-        args.complexity,
-        args.scenario,
+        Complexity(args.complexity),
+        Scenario(args.scenario),
         args.threads,
         args.naughty_identifiers,
         args.fast_startup,

--- a/misc/python/materialize/parallel_workload/settings.py
+++ b/misc/python/materialize/parallel_workload/settings.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import random
 from enum import Enum
 
 
@@ -15,6 +16,11 @@ class Complexity(Enum):
     DML = "dml"
     DDL = "ddl"
 
+    @classmethod
+    def _missing_(cls, value):
+        if value == "random":
+            return cls(random.choice([elem.value for elem in cls]))
+
 
 class Scenario(Enum):
     Regression = "regression"
@@ -22,3 +28,8 @@ class Scenario(Enum):
     Kill = "kill"
     Rename = "rename"
     BackupRestore = "backup-restore"
+
+    @classmethod
+    def _missing_(cls, value):
+        if value == "random":
+            return cls(random.choice([elem.value for elem in cls]))

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -8,6 +8,8 @@
 # by the Apache License, Version 2.0.
 
 
+import random
+
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.service import Service
 from materialize.mzcompose.services.cockroach import Cockroach
@@ -18,7 +20,7 @@ from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.parallel_workload.parallel_workload import parse_common_args, run
-from materialize.parallel_workload.settings import Scenario
+from materialize.parallel_workload.settings import Complexity, Scenario
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -60,7 +62,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "materialized",
     ]
 
-    if Scenario(args.scenario) in (Scenario.Kill, Scenario.BackupRestore):
+    random.seed(args.seed)
+    scenario = Scenario(args.scenario)
+    complexity = Complexity(args.complexity)
+
+    if args.scenario in (Scenario.Kill, Scenario.BackupRestore):
         catalog_store = "stash"
         sanity_restart = False
     else:
@@ -100,8 +106,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             ports,
             args.seed,
             args.runtime,
-            args.complexity,
-            args.scenario,
+            complexity,
+            scenario,
             args.threads,
             args.naughty_identifiers,
             args.fast_startup,


### PR DESCRIPTION
Broke because of stash/shadow distinction

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
