### PR TITLE
Add documentation for `INCLUDE HEADER` option for Kafka sources

### DIFF
--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -203,7 +203,7 @@ Note that:
 #### Headers
 
 Message headers can be exposed via the `INCLUDE HEADER key AS name` option.
-The `bytea` value of the header is automatically parsed into a UTF-8 string. To expose the raw bytes instead, the `BYTES` option can be used.
+The `bytea` value of the header is automatically parsed into an UTF-8 string. To expose the raw `bytea` instead, the `BYTES` option can be used.
 
 The following example demonstrates use of the `INCLUDE HEADER` option.
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -236,7 +236,7 @@ Note that:
 
 - The `DEBEZIUM` envelope is incompatible with this option.
 - Messages that do not contain all header keys as specified in the source DDL will cause an error that prevents further querying the source.
-- Headers values containing badly formed UTF-8 strings will cause an error in the source that prevents querying it, unless the `BYTES` option is specified.
+- Header values containing badly formed UTF-8 strings will cause an error in the source that prevents querying it, unless the `BYTES` option is specified.
 
 #### Partition, offset, timestamp
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -211,7 +211,7 @@ The following example demonstrates use of the `INCLUDE HEADER` option.
 CREATE SOURCE kafka_metadata
   FROM KAFKA CONNECTION kafka_connection (TOPIC 'data')
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION csr_connection
-  INCLUDE HEADER 'c_id' AS client_id, HEADER 'key' AS encryption_key BYTES, 
+  INCLUDE HEADER 'c_id' AS client_id, HEADER 'key' AS encryption_key BYTES,
   ENVELOPE NONE
   WITH (SIZE = '3xsmall');
 ```

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -235,8 +235,8 @@ FROM kafka_metadata;
 Note that:
 
 - The `DEBEZIUM` envelope is incompatible with this option.
-- Messages that do not contain all header keys as specified by the source will cause an error that prevents further querying the source.
-- Headers values containing ill-formed UTF-8 strings will cause an error in the source that prevents querying it unless the `BYTES` option is specified.
+- Messages that do not contain all header keys as specified in the source DDL will cause an error that prevents further querying the source.
+- Headers values containing badly formed UTF-8 strings will cause an error in the source that prevents querying it, unless the `BYTES` option is specified.
 
 #### Partition, offset, timestamp
 

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -205,7 +205,6 @@ Note that:
 Message headers can be exposed via the `INCLUDE HEADER key AS name` option.
 The `bytea` value of the header is automatically parsed into an UTF-8 string. To expose the raw `bytea` instead, the `BYTES` option can be used.
 
-The following example demonstrates use of the `INCLUDE HEADER` option.
 
 ```sql
 CREATE SOURCE kafka_metadata
@@ -216,7 +215,7 @@ CREATE SOURCE kafka_metadata
   WITH (SIZE = '3xsmall');
 ```
 
-The headers can then be queried as any other column of the message.
+Headers can be queried as any other column in the source:
 
 ```sql
 SELECT

--- a/doc/user/layouts/partials/create-source/connector/kafka/syntax.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/syntax.html
@@ -3,3 +3,5 @@
 **INCLUDE PARTITION** | Include a `partition` column containing the Kafka message partition. The column can be renamed with the optional **AS** *name* clause.
 **INCLUDE OFFSET** | Include an `offset` column containing the Kafka message offset. The column can be renamed with the optional **AS** *name* clause.
 **INCLUDE TIMESTAMP** | Include a `timestamp` column containing the Kafka message timestamp. The column can be renamed with the optional **AS** *name* clause. <br><br>Note that the timestamp of a Kafka message depends on how the topic and its producers are configured. See the [Confluent documentation](https://docs.confluent.io/3.0.0/streams/concepts.html?#time) for details.
+**INCLUDE HEADERS** | Include a `header` column containing the Kafka message headers as a list of records of type `(key text, value bytea)`. The column can be renamed with the optional **AS** *name* clause.
+**INCLUDE HEADER** _key_ **AS** _name_ | Include a _name_ column containing the Kafka message header _key_ parsed as a UTF-8 string. The header values can alsp be exposed as `bytea` with the optional **BYTES** flag.

--- a/doc/user/layouts/partials/create-source/connector/kafka/syntax.html
+++ b/doc/user/layouts/partials/create-source/connector/kafka/syntax.html
@@ -3,5 +3,5 @@
 **INCLUDE PARTITION** | Include a `partition` column containing the Kafka message partition. The column can be renamed with the optional **AS** *name* clause.
 **INCLUDE OFFSET** | Include an `offset` column containing the Kafka message offset. The column can be renamed with the optional **AS** *name* clause.
 **INCLUDE TIMESTAMP** | Include a `timestamp` column containing the Kafka message timestamp. The column can be renamed with the optional **AS** *name* clause. <br><br>Note that the timestamp of a Kafka message depends on how the topic and its producers are configured. See the [Confluent documentation](https://docs.confluent.io/3.0.0/streams/concepts.html?#time) for details.
-**INCLUDE HEADERS** | Include a `header` column containing the Kafka message headers as a list of records of type `(key text, value bytea)`. The column can be renamed with the optional **AS** *name* clause.
-**INCLUDE HEADER** _key_ **AS** _name_ | Include a _name_ column containing the Kafka message header _key_ parsed as a UTF-8 string. The header values can alsp be exposed as `bytea` with the optional **BYTES** flag.
+**INCLUDE HEADERS** | Include a `headers` column containing the Kafka message headers as a list of records of type `(key text, value bytea)`. The column can be renamed with the optional **AS** *name* clause.
+**INCLUDE HEADER** _key_ **AS** _name_ [**BYTES**] | Include a _name_ column containing the Kafka message header _key_ parsed as a UTF-8 string. To expose the header value as `bytea`, use the `BYTES` option.

--- a/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-source-kafka.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="597" height="1153">
+<svg xmlns="http://www.w3.org/2000/svg" width="673" height="1241">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="140" height="32" rx="10"/>
@@ -20,305 +20,347 @@
    <rect x="371" y="3" width="82" height="32"/>
    <rect x="369" y="1" width="82" height="32" class="nonterminal"/>
    <text class="nonterminal" x="379" y="21">src_name</text>
-   <rect x="47" y="145" width="26" height="32" rx="10"/>
-   <rect x="45"
+   <rect x="85" y="145" width="26" height="32" rx="10"/>
+   <rect x="83"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="55" y="163">(</text>
-   <rect x="113" y="145" width="82" height="32"/>
-   <rect x="111" y="143" width="82" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="121" y="163">col_name</text>
-   <rect x="113" y="101" width="24" height="32" rx="10"/>
-   <rect x="111"
+   <text class="terminal" x="93" y="163">(</text>
+   <rect x="151" y="145" width="82" height="32"/>
+   <rect x="149" y="143" width="82" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="159" y="163">col_name</text>
+   <rect x="151" y="101" width="24" height="32" rx="10"/>
+   <rect x="149"
          y="99"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="121" y="119">,</text>
-   <rect x="235" y="145" width="26" height="32" rx="10"/>
-   <rect x="233"
+   <text class="terminal" x="159" y="119">,</text>
+   <rect x="273" y="145" width="26" height="32" rx="10"/>
+   <rect x="271"
          y="143"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="243" y="163">)</text>
-   <rect x="321" y="177" width="104" height="32" rx="10"/>
-   <rect x="319"
+   <text class="terminal" x="281" y="163">)</text>
+   <rect x="359" y="177" width="104" height="32" rx="10"/>
+   <rect x="357"
          y="175"
          width="104"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="329" y="195">IN CLUSTER</text>
-   <rect x="445" y="177" width="108" height="32"/>
-   <rect x="443" y="175" width="108" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="453" y="195">cluster_name</text>
-   <rect x="57" y="243" width="60" height="32" rx="10"/>
-   <rect x="55"
+   <text class="terminal" x="367" y="195">IN CLUSTER</text>
+   <rect x="483" y="177" width="108" height="32"/>
+   <rect x="481" y="175" width="108" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="491" y="195">cluster_name</text>
+   <rect x="95" y="243" width="60" height="32" rx="10"/>
+   <rect x="93"
          y="241"
          width="60"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="65" y="261">FROM</text>
-   <rect x="137" y="243" width="68" height="32" rx="10"/>
-   <rect x="135"
+   <text class="terminal" x="103" y="261">FROM</text>
+   <rect x="175" y="243" width="68" height="32" rx="10"/>
+   <rect x="173"
          y="241"
          width="68"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="145" y="261">KAFKA</text>
-   <rect x="225" y="243" width="116" height="32" rx="10"/>
-   <rect x="223"
+   <text class="terminal" x="183" y="261">KAFKA</text>
+   <rect x="263" y="243" width="116" height="32" rx="10"/>
+   <rect x="261"
          y="241"
          width="116"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="233" y="261">CONNECTION</text>
-   <rect x="361" y="243" width="136" height="32"/>
-   <rect x="359" y="241" width="136" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="369" y="261">connection_name</text>
-   <rect x="517" y="243" width="26" height="32" rx="10"/>
-   <rect x="515"
+   <text class="terminal" x="271" y="261">CONNECTION</text>
+   <rect x="399" y="243" width="136" height="32"/>
+   <rect x="397" y="241" width="136" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="407" y="261">connection_name</text>
+   <rect x="555" y="243" width="26" height="32" rx="10"/>
+   <rect x="553"
          y="241"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="525" y="261">(</text>
-   <rect x="87" y="309" width="64" height="32" rx="10"/>
-   <rect x="85"
+   <text class="terminal" x="563" y="261">(</text>
+   <rect x="125" y="309" width="64" height="32" rx="10"/>
+   <rect x="123"
          y="307"
          width="64"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="95" y="327">TOPIC</text>
-   <rect x="171" y="309" width="52" height="32"/>
-   <rect x="169" y="307" width="52" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="179" y="327">topic</text>
-   <rect x="263" y="341" width="24" height="32" rx="10"/>
-   <rect x="261"
+   <text class="terminal" x="133" y="327">TOPIC</text>
+   <rect x="209" y="309" width="52" height="32"/>
+   <rect x="207" y="307" width="52" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="217" y="327">topic</text>
+   <rect x="301" y="341" width="24" height="32" rx="10"/>
+   <rect x="299"
          y="339"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="271" y="359">,</text>
-   <rect x="307" y="341" width="140" height="32"/>
-   <rect x="305" y="339" width="140" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="315" y="359">connection_option</text>
-   <rect x="487" y="309" width="26" height="32" rx="10"/>
-   <rect x="485"
+   <text class="terminal" x="309" y="359">,</text>
+   <rect x="345" y="341" width="140" height="32"/>
+   <rect x="343" y="339" width="140" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="353" y="359">connection_option</text>
+   <rect x="525" y="309" width="26" height="32" rx="10"/>
+   <rect x="523"
          y="307"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="495" y="327">)</text>
-   <rect x="45" y="407" width="114" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="533" y="327">)</text>
+   <rect x="83" y="407" width="114" height="32" rx="10"/>
+   <rect x="81"
          y="405"
          width="114"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="425">KEY FORMAT</text>
-   <rect x="179" y="407" width="102" height="32"/>
-   <rect x="177" y="405" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="187" y="425">format_spec</text>
-   <rect x="301" y="407" width="132" height="32" rx="10"/>
-   <rect x="299"
+   <text class="terminal" x="91" y="425">KEY FORMAT</text>
+   <rect x="217" y="407" width="102" height="32"/>
+   <rect x="215" y="405" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="225" y="425">format_spec</text>
+   <rect x="339" y="407" width="132" height="32" rx="10"/>
+   <rect x="337"
          y="405"
          width="132"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="309" y="425">VALUE FORMAT</text>
-   <rect x="45" y="451" width="80" height="32" rx="10"/>
-   <rect x="43"
+   <text class="terminal" x="347" y="425">VALUE FORMAT</text>
+   <rect x="83" y="451" width="80" height="32" rx="10"/>
+   <rect x="81"
          y="449"
          width="80"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="53" y="469">FORMAT</text>
-   <rect x="473" y="407" width="102" height="32"/>
-   <rect x="471" y="405" width="102" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="481" y="425">format_spec</text>
-   <rect x="48" y="533" width="82" height="32" rx="10"/>
-   <rect x="46"
-         y="531"
+   <text class="terminal" x="91" y="469">FORMAT</text>
+   <rect x="511" y="407" width="102" height="32"/>
+   <rect x="509" y="405" width="102" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="519" y="425">format_spec</text>
+   <rect x="45" y="561" width="82" height="32" rx="10"/>
+   <rect x="43"
+         y="559"
          width="82"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="56" y="551">INCLUDE</text>
-   <rect x="210" y="533" width="48" height="32" rx="10"/>
-   <rect x="208"
-         y="531"
+   <text class="terminal" x="53" y="579">INCLUDE</text>
+   <rect x="207" y="561" width="48" height="32" rx="10"/>
+   <rect x="205"
+         y="559"
          width="48"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="551">KEY</text>
-   <rect x="210" y="577" width="96" height="32" rx="10"/>
-   <rect x="208"
-         y="575"
+   <text class="terminal" x="215" y="579">KEY</text>
+   <rect x="207" y="605" width="96" height="32" rx="10"/>
+   <rect x="205"
+         y="603"
          width="96"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="595">PARTITION</text>
-   <rect x="210" y="621" width="74" height="32" rx="10"/>
-   <rect x="208"
-         y="619"
+   <text class="terminal" x="215" y="623">PARTITION</text>
+   <rect x="207" y="649" width="74" height="32" rx="10"/>
+   <rect x="205"
+         y="647"
          width="74"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="639">OFFSET</text>
-   <rect x="210" y="665" width="106" height="32" rx="10"/>
-   <rect x="208"
-         y="663"
+   <text class="terminal" x="215" y="667">OFFSET</text>
+   <rect x="207" y="693" width="106" height="32" rx="10"/>
+   <rect x="205"
+         y="691"
          width="106"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="683">TIMESTAMP</text>
-   <rect x="210" y="709" width="86" height="32" rx="10"/>
-   <rect x="208"
-         y="707"
+   <text class="terminal" x="215" y="711">TIMESTAMP</text>
+   <rect x="207" y="737" width="86" height="32" rx="10"/>
+   <rect x="205"
+         y="735"
          width="86"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="218" y="727">HEADERS</text>
-   <rect x="376" y="565" width="40" height="32" rx="10"/>
-   <rect x="374"
-         y="563"
+   <text class="terminal" x="215" y="755">HEADERS</text>
+   <rect x="373" y="593" width="40" height="32" rx="10"/>
+   <rect x="371"
+         y="591"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="384" y="583">AS</text>
-   <rect x="436" y="565" width="56" height="32"/>
-   <rect x="434" y="563" width="56" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="444" y="583">name</text>
-   <rect x="177" y="823" width="94" height="32" rx="10"/>
-   <rect x="175"
-         y="821"
-         width="94"
+   <text class="terminal" x="381" y="611">AS</text>
+   <rect x="433" y="593" width="56" height="32"/>
+   <rect x="431" y="591" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="441" y="611">name</text>
+   <rect x="187" y="781" width="78" height="32" rx="10"/>
+   <rect x="185"
+         y="779"
+         width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="185" y="841">ENVELOPE</text>
-   <rect x="311" y="823" width="60" height="32" rx="10"/>
-   <rect x="309"
-         y="821"
-         width="60"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="319" y="841">NONE</text>
-   <rect x="311" y="867" width="92" height="32" rx="10"/>
-   <rect x="309"
-         y="865"
-         width="92"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="319" y="885">DEBEZIUM</text>
-   <rect x="311" y="911" width="76" height="32" rx="10"/>
-   <rect x="309"
-         y="909"
-         width="76"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="319" y="929">UPSERT</text>
-   <rect x="66" y="993" width="76" height="32" rx="10"/>
-   <rect x="64"
-         y="991"
-         width="76"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="74" y="1011">EXPOSE</text>
-   <rect x="162" y="993" width="96" height="32" rx="10"/>
-   <rect x="160"
-         y="991"
-         width="96"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="170" y="1011">PROGRESS</text>
-   <rect x="278" y="993" width="40" height="32" rx="10"/>
-   <rect x="276"
-         y="991"
+   <text class="terminal" x="195" y="799">HEADER</text>
+   <rect x="285" y="781" width="44" height="32"/>
+   <rect x="283" y="779" width="44" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="293" y="799">key</text>
+   <rect x="349" y="781" width="40" height="32" rx="10"/>
+   <rect x="347"
+         y="779"
          width="40"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="286" y="1011">AS</text>
-   <rect x="338" y="993" width="196" height="32"/>
-   <rect x="336" y="991" width="196" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="346" y="1011">progress_subsource_name</text>
-   <rect x="185" y="1103" width="58" height="32" rx="10"/>
-   <rect x="183"
-         y="1101"
-         width="58"
+   <text class="terminal" x="357" y="799">AS</text>
+   <rect x="409" y="781" width="56" height="32"/>
+   <rect x="407" y="779" width="56" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="417" y="799">name</text>
+   <rect x="505" y="813" width="66" height="32" rx="10"/>
+   <rect x="503"
+         y="811"
+         width="66"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="193" y="1121">WITH</text>
-   <rect x="263" y="1103" width="26" height="32" rx="10"/>
-   <rect x="261"
-         y="1101"
-         width="26"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="271" y="1121">(</text>
-   <rect x="329" y="1103" width="48" height="32"/>
-   <rect x="327" y="1101" width="48" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="337" y="1121">field</text>
-   <rect x="397" y="1103" width="28" height="32" rx="10"/>
-   <rect x="395"
-         y="1101"
-         width="28"
-         height="32"
-         class="terminal"
-         rx="10"/>
-   <text class="terminal" x="405" y="1121">=</text>
-   <rect x="445" y="1103" width="38" height="32"/>
-   <rect x="443" y="1101" width="38" height="32" class="nonterminal"/>
-   <text class="nonterminal" x="453" y="1121">val</text>
-   <rect x="329" y="1059" width="24" height="32" rx="10"/>
-   <rect x="327"
-         y="1057"
+   <text class="terminal" x="513" y="831">BYTES</text>
+   <rect x="167" y="517" width="24" height="32" rx="10"/>
+   <rect x="165"
+         y="515"
          width="24"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="337" y="1077">,</text>
-   <rect x="523" y="1103" width="26" height="32" rx="10"/>
-   <rect x="521"
-         y="1101"
+   <text class="terminal" x="175" y="535">,</text>
+   <rect x="215" y="911" width="94" height="32" rx="10"/>
+   <rect x="213"
+         y="909"
+         width="94"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="223" y="929">ENVELOPE</text>
+   <rect x="349" y="911" width="60" height="32" rx="10"/>
+   <rect x="347"
+         y="909"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="357" y="929">NONE</text>
+   <rect x="349" y="955" width="92" height="32" rx="10"/>
+   <rect x="347"
+         y="953"
+         width="92"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="357" y="973">DEBEZIUM</text>
+   <rect x="349" y="999" width="76" height="32" rx="10"/>
+   <rect x="347"
+         y="997"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="357" y="1017">UPSERT</text>
+   <rect x="104" y="1081" width="76" height="32" rx="10"/>
+   <rect x="102"
+         y="1079"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="112" y="1099">EXPOSE</text>
+   <rect x="200" y="1081" width="96" height="32" rx="10"/>
+   <rect x="198"
+         y="1079"
+         width="96"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="208" y="1099">PROGRESS</text>
+   <rect x="316" y="1081" width="40" height="32" rx="10"/>
+   <rect x="314"
+         y="1079"
+         width="40"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="324" y="1099">AS</text>
+   <rect x="376" y="1081" width="196" height="32"/>
+   <rect x="374"
+         y="1079"
+         width="196"
+         height="32"
+         class="nonterminal"/>
+   <text class="nonterminal" x="384" y="1099">progress_subsource_name</text>
+   <rect x="261" y="1191" width="58" height="32" rx="10"/>
+   <rect x="259"
+         y="1189"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="269" y="1209">WITH</text>
+   <rect x="339" y="1191" width="26" height="32" rx="10"/>
+   <rect x="337"
+         y="1189"
          width="26"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="531" y="1121">)</text>
+   <text class="terminal" x="347" y="1209">(</text>
+   <rect x="405" y="1191" width="48" height="32"/>
+   <rect x="403" y="1189" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="413" y="1209">field</text>
+   <rect x="473" y="1191" width="28" height="32" rx="10"/>
+   <rect x="471"
+         y="1189"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="481" y="1209">=</text>
+   <rect x="521" y="1191" width="38" height="32"/>
+   <rect x="519" y="1189" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="529" y="1209">val</text>
+   <rect x="405" y="1147" width="24" height="32" rx="10"/>
+   <rect x="403"
+         y="1145"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="413" y="1165">,</text>
+   <rect x="599" y="1191" width="26" height="32" rx="10"/>
+   <rect x="597"
+         y="1189"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="607" y="1209">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-470 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m40 -34 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-532 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-591 126 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m-342 -32 l20 0 m-1 0 q-9 0 -9 -10 l0 -12 q0 -10 10 -10 m342 32 l20 0 m-20 0 q10 0 10 -10 l0 -12 q0 -10 -10 -10 m-342 0 h10 m0 0 h332 m-382 32 h20 m382 0 h20 m-422 0 q10 0 10 10 m402 0 q0 -10 10 -10 m-412 10 v190 m402 0 v-190 m-402 190 q0 10 10 10 m382 0 q10 0 10 -10 m-392 10 h10 m0 0 h372 m-524 -210 h20 m524 0 h20 m-564 0 q10 0 10 10 m544 0 q0 -10 10 -10 m-554 10 v206 m544 0 v-206 m-544 206 q0 10 10 10 m524 0 q10 0 10 -10 m-534 10 h10 m0 0 h514 m22 -226 l2 0 m2 0 l2 0 m2 0 l2 0 m-459 258 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-441 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-433 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
-   <polygon points="587 1117 595 1113 595 1121"/>
-   <polygon points="587 1117 579 1113 579 1121"/>
+         d="m17 17 h2 m0 0 h10 m140 0 h10 m20 0 h10 m0 0 h130 m-160 0 h20 m140 0 h20 m-180 0 q10 0 10 10 m160 0 q0 -10 10 -10 m-170 10 v12 m160 0 v-12 m-160 12 q0 10 10 10 m140 0 q10 0 10 -10 m-150 10 h10 m120 0 h10 m20 -32 h10 m82 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-432 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m26 0 h10 m20 0 h10 m82 0 h10 m-122 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m102 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-102 0 h10 m24 0 h10 m0 0 h58 m20 44 h10 m26 0 h10 m-254 0 h20 m234 0 h20 m-274 0 q10 0 10 10 m254 0 q0 -10 10 -10 m-264 10 v14 m254 0 v-14 m-254 14 q0 10 10 10 m234 0 q10 0 10 -10 m-244 10 h10 m0 0 h224 m40 -34 h10 m0 0 h242 m-272 0 h20 m252 0 h20 m-292 0 q10 0 10 10 m272 0 q0 -10 10 -10 m-282 10 v12 m272 0 v-12 m-272 12 q0 10 10 10 m252 0 q10 0 10 -10 m-262 10 h10 m104 0 h10 m0 0 h10 m108 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-560 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m60 0 h10 m0 0 h10 m68 0 h10 m0 0 h10 m116 0 h10 m0 0 h10 m136 0 h10 m0 0 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 66 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m64 0 h10 m0 0 h10 m52 0 h10 m20 0 h10 m0 0 h194 m-224 0 h20 m204 0 h20 m-244 0 q10 0 10 10 m224 0 q0 -10 10 -10 m-234 10 v12 m224 0 v-12 m-224 12 q0 10 10 10 m204 0 q10 0 10 -10 m-214 10 h10 m24 0 h10 m0 0 h10 m140 0 h10 m20 -32 h10 m26 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-532 98 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m114 0 h10 m0 0 h10 m102 0 h10 m0 0 h10 m132 0 h10 m-428 0 h20 m408 0 h20 m-448 0 q10 0 10 10 m428 0 q0 -10 10 -10 m-438 10 v24 m428 0 v-24 m-428 24 q0 10 10 10 m408 0 q10 0 10 -10 m-418 10 h10 m80 0 h10 m0 0 h308 m20 -44 h10 m102 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-632 154 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m82 0 h10 m60 0 h10 m48 0 h10 m0 0 h58 m-146 0 h20 m126 0 h20 m-166 0 q10 0 10 10 m146 0 q0 -10 10 -10 m-156 10 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m96 0 h10 m0 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m74 0 h10 m0 0 h32 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m106 0 h10 m-136 -10 v20 m146 0 v-20 m-146 20 v24 m146 0 v-24 m-146 24 q0 10 10 10 m126 0 q10 0 10 -10 m-136 10 h10 m86 0 h10 m0 0 h20 m40 -176 h10 m0 0 h126 m-156 0 h20 m136 0 h20 m-176 0 q10 0 10 10 m156 0 q0 -10 10 -10 m-166 10 v12 m156 0 v-12 m-156 12 q0 10 10 10 m136 0 q10 0 10 -10 m-146 10 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 -32 h82 m-444 0 h20 m424 0 h20 m-464 0 q10 0 10 10 m444 0 q0 -10 10 -10 m-454 10 v200 m444 0 v-200 m-444 200 q0 10 10 10 m424 0 q10 0 10 -10 m-434 10 h10 m78 0 h10 m0 0 h10 m44 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m56 0 h10 m20 0 h10 m0 0 h76 m-106 0 h20 m86 0 h20 m-126 0 q10 0 10 10 m106 0 q0 -10 10 -10 m-116 10 v12 m106 0 v-12 m-106 12 q0 10 10 10 m86 0 q10 0 10 -10 m-96 10 h10 m66 0 h10 m-444 -252 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m464 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-464 0 h10 m24 0 h10 m0 0 h420 m-606 44 h20 m606 0 h20 m-646 0 q10 0 10 10 m626 0 q0 -10 10 -10 m-636 10 v266 m626 0 v-266 m-626 266 q0 10 10 10 m606 0 q10 0 10 -10 m-616 10 h10 m0 0 h596 m22 -286 l2 0 m2 0 l2 0 m2 0 l2 0 m-500 318 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h256 m-286 0 h20 m266 0 h20 m-306 0 q10 0 10 10 m286 0 q0 -10 10 -10 m-296 10 v12 m286 0 v-12 m-286 12 q0 10 10 10 m266 0 q10 0 10 -10 m-276 10 h10 m94 0 h10 m20 0 h10 m60 0 h10 m0 0 h32 m-132 0 h20 m112 0 h20 m-152 0 q10 0 10 10 m132 0 q0 -10 10 -10 m-142 10 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m92 0 h10 m-122 -10 v20 m132 0 v-20 m-132 20 v24 m132 0 v-24 m-132 24 q0 10 10 10 m112 0 q10 0 10 -10 m-122 10 h10 m76 0 h10 m0 0 h16 m42 -120 l2 0 m2 0 l2 0 m2 0 l2 0 m-441 170 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h478 m-508 0 h20 m488 0 h20 m-528 0 q10 0 10 10 m508 0 q0 -10 10 -10 m-518 10 v12 m508 0 v-12 m-508 12 q0 10 10 10 m488 0 q10 0 10 -10 m-498 10 h10 m76 0 h10 m0 0 h10 m96 0 h10 m0 0 h10 m40 0 h10 m0 0 h10 m196 0 h10 m22 -32 l2 0 m2 0 l2 0 m2 0 l2 0 m-395 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m58 0 h10 m0 0 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m38 0 h10 m-194 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m174 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-174 0 h10 m24 0 h10 m0 0 h130 m20 44 h10 m26 0 h10 m-404 0 h20 m384 0 h20 m-424 0 q10 0 10 10 m404 0 q0 -10 10 -10 m-414 10 v14 m404 0 v-14 m-404 14 q0 10 10 10 m384 0 q10 0 10 -10 m-394 10 h10 m0 0 h374 m23 -34 h-3"/>
+   <polygon points="663 1205 671 1201 671 1209"/>
+   <polygon points="663 1205 655 1201 655 1209"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -141,7 +141,8 @@ create_source_kafka ::=
   '(' 'TOPIC' topic ( ( ',' connection_option )? ) ')'
   ('KEY FORMAT' format_spec 'VALUE FORMAT' format_spec | 'FORMAT' format_spec)
   ('INCLUDE'
-    ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? )*
+         ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? | 'HEADER' key 'AS' name ('BYTES')? )
+    (',' ( ('KEY' | 'PARTITION' | 'OFFSET' | 'TIMESTAMP' | 'HEADERS' ) ('AS' name)? | 'HEADER' key 'AS' name ('BYTES')? ) )*
   )?
   ('ENVELOPE' ('NONE' | 'DEBEZIUM' | 'UPSERT'))?
   ('EXPOSE' 'PROGRESS' 'AS' progress_subsource_name)?


### PR DESCRIPTION
Add missing docs for https://github.com/MaterializeInc/materialize/pull/22806.

I've deliberately removed the examples for the `INCLUDE HEADERS` option to prevent people from accidentally using it and be surprised by the [resulting memory footprint](https://github.com/MaterializeInc/materialize/issues/20958).

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->