### PR TITLE
ci: Check buildkite pipelines for timeout_in_minutes

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -20,6 +20,7 @@ steps:
   - wait: ~
 
   - command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.trim_pipeline nightly
+    timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
       queue: linux
@@ -27,6 +28,7 @@ steps:
   - wait: ~
 
   - id: closed-issues-detect
+    timeout_in_minutes: 10
     label: Detect references to already closed issues
     command: bin/ci-builder run stable bin/ci-closed-issues-detect
     agents:
@@ -81,6 +83,7 @@ steps:
 
   - id: kafka-matrix
     label: Kafka smoke test against previous Kafka versions
+    timeout_in_minutes: 60
     agents:
       queue: linux-x86_64
     artifact_paths: junit_*.xml
@@ -90,6 +93,7 @@ steps:
 
   - id: kafka-multi-broker
     label: Kafka multi-broker test
+    timeout_in_minutes: 10
     agents:
       queue: linux-x86_64
     artifact_paths: junit_*.xml
@@ -937,6 +941,7 @@ steps:
 
   - id: incident-70
     label: "Test for incident 70"
+    timeout_in_minutes: 15
     skip: "Affected by #15209"
     agents:
       queue: linux-x86_64-large
@@ -961,6 +966,7 @@ steps:
 
   - id: analyze
     label: Analyze tests
+    timeout_in_minutes: 15
     plugins:
       - junit-annotate#v2.0.2:
           artifacts: "*junit_*.xml"

--- a/ci/release-qualification/pipeline.template.yml
+++ b/ci/release-qualification/pipeline.template.yml
@@ -24,6 +24,7 @@ steps:
   - wait: ~
 
   - command: bin/ci-builder run stable bin/pyactivate -m materialize.ci_util.trim_pipeline release-qualification
+    timeout_in_minutes: 10
     if: build.source == "ui"
     agents:
       queue: linux
@@ -148,6 +149,7 @@ steps:
 
   - id: analyze
     label: Analyze tests
+    timeout_in_minutes: 15
     plugins:
       - junit-annotate#v2.0.2:
           artifacts: "*junit_*.xml"

--- a/ci/slt/pipeline.template.yml
+++ b/ci/slt/pipeline.template.yml
@@ -47,6 +47,7 @@ steps:
 
   - id: analyze
     label: Analyze tests
+    timeout_in_minutes: 15
     plugins:
       - junit-annotate#v2.0.2:
           artifacts: "*junit_*.xml"

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -811,6 +811,7 @@ steps:
 
   - id: coverage-pr-analyze
     label: Analyze code coverage for PR
+    timeout_in_minutes: 20
     command: bin/ci-builder run stable ci/test/coverage_report.sh
     inputs: ["*"]
     priority: 1
@@ -823,6 +824,7 @@ steps:
 
   - id: analyze
     label: Analyze tests
+    timeout_in_minutes: 15
     inputs: ["*"]
     plugins:
       - junit-annotate#v2.0.2:


### PR DESCRIPTION
Inspired by https://github.com/MaterializeInc/materialize/pull/23417

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
