### PR TITLE
doc/developer: update `sqllogictest.md` useful tips

### DIFF
--- a/doc/developer/sqllogictest.md
+++ b/doc/developer/sqllogictest.md
@@ -78,15 +78,29 @@ CREATE TABLE bar (
 * If you use Visual Studio Code, @benesch has made a syntax highlighter for
   sqllogictest, which you can find
   [here](https://marketplace.visualstudio.com/items?itemName=benesch.sqllogictest).
-* If you run `cargo run --bin sqllogictest -- <path_to_test_file>
-  --rewrite-results`, sqllogictest will automatically replace the expected
-  results with the actual results. The main time you use this argument is if you
-  have made an improvement to the query planner and need to update the expected
-  plan for every `EXPLAIN PLAN` query.
-* If you want to debug a sqllogictest run via debugger, use `rust-lldb --
-  target/debug/sqllogictest <path_to_test_file_to_run>`. Do not use `rust-gdb`
-  to debug sqllogictest on MacOS because gdb will print a bunch of error
-  messages and then freeze.
+* If you run
+  ```bash
+  bin/sqllogictest -- --rewrite-results <path_to_test_file>
+  ```
+  sqllogictest will automatically replace the expected results with the actual
+  results. The main time you use this argument is if you have made an improvement to
+  the query planner and need to update the expected plan for every `EXPLAIN` query.
+* If you want to debug a sqllogictest run via debugger, use one of the following
+
+  ```bash
+  bin/sqllogictest --wrapper 'rust-lldb --' -- <paths_to_test_files_to_run>
+  (lldb) run
+  (lldb) bt
+
+  bin/sqllogictest --wrapper 'rust-gdb --args' -- <paths_to_test_files_to_run>
+  (gdb) run
+  (gdb) bt
+  ```
+  See [GDB to LLDB command map](https://lldb.llvm.org/use/map.html) for more
+  details. *Note*:
+
+  Do not use `rust-gdb` to debug sqllogictest on MacOS because `gdb` will print
+  a bunch of error messages and then freeze.
 
 ## Materialize-specific behavior in sqllogictest
 


### PR DESCRIPTION
Update the "Useful tips" section with up-to-date instructions how to run a debugger.

### Motivation

   * This PR refactors existing code.

Fixes developer docs.

### Tips for reviewer

For some reason the `rust-lldb` doesn't work for me on Linux. I get the following error:

```bash
bin/sqllogictest --wrapper 'rust-gdb --args' -- test/sqllogictest/transform/literal_constraints.slt

error: module importing failed: Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/alexander/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/etc/lldb_lookup.py", line 1, in <module>
    import lldb
ModuleNotFoundError: No module named 'lldb'
```

However when I just run 

```bash
rust-gdb
```

it seems that this is not an issue. It will be good if somebody else can check this. Update: I think this doesn't work for me because `bin/sqllogictest` forks a new process before running the command, which doesn't play well with my `pyenv` Python installation.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
