### PR TITLE
doc/user: make Kafka sink DOC ON docs more rigorous

### DIFF
--- a/doc/user/layouts/partials/sql-grammar/create-sink-doc-on-option.svg
+++ b/doc/user/layouts/partials/sql-grammar/create-sink-doc-on-option.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="529" height="211">
+   <polygon points="9 17 1 13 1 21"/>
+   <polygon points="17 17 9 13 9 21"/>
+   <rect x="51" y="35" width="48" height="32" rx="10"/>
+   <rect x="49"
+         y="33"
+         width="48"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="53">KEY</text>
+   <rect x="51" y="79" width="68" height="32" rx="10"/>
+   <rect x="49"
+         y="77"
+         width="68"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="59" y="97">VALUE</text>
+   <rect x="159" y="3" width="76" height="32" rx="10"/>
+   <rect x="157"
+         y="1"
+         width="76"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="167" y="21">DOC ON</text>
+   <rect x="275" y="3" width="56" height="32" rx="10"/>
+   <rect x="273"
+         y="1"
+         width="56"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="283" y="21">TYPE</text>
+   <rect x="351" y="3" width="92" height="32"/>
+   <rect x="349" y="1" width="92" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="359" y="21">type_name</text>
+   <rect x="275" y="47" width="82" height="32" rx="10"/>
+   <rect x="273"
+         y="45"
+         width="82"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="283" y="65">COLUMN</text>
+   <rect x="377" y="47" width="110" height="32"/>
+   <rect x="375" y="45" width="110" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="385" y="65">column_name</text>
+   <rect x="375" y="177" width="28" height="32" rx="10"/>
+   <rect x="373"
+         y="175"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="383" y="195">=</text>
+   <rect x="443" y="145" width="58" height="32"/>
+   <rect x="441" y="143" width="58" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="451" y="163">string</text>
+   <path class="line"
+         d="m17 17 h2 m20 0 h10 m0 0 h78 m-108 0 h20 m88 0 h20 m-128 0 q10 0 10 10 m108 0 q0 -10 10 -10 m-118 10 v12 m108 0 v-12 m-108 12 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m48 0 h10 m0 0 h20 m-98 -10 v20 m108 0 v-20 m-108 20 v24 m108 0 v-24 m-108 24 q0 10 10 10 m88 0 q10 0 10 -10 m-98 10 h10 m68 0 h10 m20 -76 h10 m76 0 h10 m20 0 h10 m56 0 h10 m0 0 h10 m92 0 h10 m0 0 h44 m-252 0 h20 m232 0 h20 m-272 0 q10 0 10 10 m252 0 q0 -10 10 -10 m-262 10 v24 m252 0 v-24 m-252 24 q0 10 10 10 m232 0 q10 0 10 -10 m-242 10 h10 m82 0 h10 m0 0 h10 m110 0 h10 m22 -44 l2 0 m2 0 l2 0 m2 0 l2 0 m-196 142 l2 0 m2 0 l2 0 m2 0 l2 0 m22 0 h10 m0 0 h38 m-68 0 h20 m48 0 h20 m-88 0 q10 0 10 10 m68 0 q0 -10 10 -10 m-78 10 v12 m68 0 v-12 m-68 12 q0 10 10 10 m48 0 q10 0 10 -10 m-58 10 h10 m28 0 h10 m20 -32 h10 m58 0 h10 m3 0 h-3"/>
+   <polygon points="519 159 527 155 527 163"/>
+   <polygon points="519 159 511 155 511 163"/>
+</svg>

--- a/doc/user/layouts/shortcodes/replica-options.html
+++ b/doc/user/layouts/shortcodes/replica-options.html
@@ -1,7 +1,7 @@
 Field                               | Value      | Description
 ------------------------------------|------------|-------------------------------------
 `SIZE`                              | `text`     | The size of the replica. For valid sizes, see [Size](/sql/create-cluster-replica#size).
-`AVAILABILITY ZONE`                 | `text`     | The availability zone of the underlying clodu provider in which to provision the replica. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1`, `eu-west-1`, or `us-west-2`, e.g. `use1-az1`. Note that you must use the zone's ID, not its name.
+`AVAILABILITY ZONE`                 | `text`     | The availability zone of the underlying cloud provider in which to provision the replica. You must specify an [AWS availability zone ID](https://docs.aws.amazon.com/ram/latest/userguide/working-with-az-ids.html) in either `us-east-1`, `eu-west-1`, or `us-west-2`, e.g. `use1-az1`. Note that you must use the zone's ID, not its name.
 `INTROSPECTION INTERVAL`            | `interval` | The interval at which to collect introspection data. See [Troubleshooting](/ops/troubleshooting) for details about introspection data. The special value `0` entirely disables the gathering of introspection data.<br>Default: `1s`
 `INTROSPECTION DEBUGGING`           | `bool`     | Whether to introspect the gathering of the introspection data.<br>Default: `FALSE`
 `IDLE ARRANGEMENT MERGE EFFORT`     | `integer`  | ***Unstable.** This option may be changed or removed at any time.*<br>The amount of effort the replica should exert on compacting arrangements during idle periods.

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -133,6 +133,8 @@ sink_definition ::=
     ('FORMAT' sink_format_spec)?
     ('ENVELOPE' ('DEBEZIUM'|'UPSERT'))
     ('WITH' with_options)?
+create_sink_doc_on_option ::=
+    ('KEY' | 'VALUE')? 'DOC ON' ('TYPE' type_name | 'COLUMN' column_name) '='? string
 create_source_kafka ::=
   'CREATE SOURCE' ('IF NOT EXISTS')? src_name
   ('(' (col_name) ( ( ',' col_name ) )* ')')?


### PR DESCRIPTION
Expand upon the documentation added in https://github.com/MaterializeInc/materialize/pull/22483 for the `DOC ON` option
for Kafka sinks to include:

  * A diagram and explanation for the syntax itself.
  * Details about the precedence of the various sources of
    documentation.

Also, move the example of using the `DOC ON` option to the dedicated
"Examples" section, to avoid cluttering the main explanation.

### Motivation

* This PR refactors and improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
