### PR TITLE
doc/user: add parens around CREATE CLUSTER [REPLICA] options

### DIFF
--- a/doc/user/content/ingest-data/rudderstack.md
+++ b/doc/user/content/ingest-data/rudderstack.md
@@ -28,7 +28,7 @@ create a [cluster](/sql/create-cluster) guide,
 or create a managed cluster using the following SQL statement:
 
 ```sql
-CREATE CLUSTER rudderstack_cluster SIZE = '3xsmall';
+CREATE CLUSTER rudderstack_cluster (SIZE = '3xsmall');
 ```
 
 ## Step 2. Create a Shared Secret

--- a/doc/user/content/ingest-data/segment.md
+++ b/doc/user/content/ingest-data/segment.md
@@ -28,7 +28,7 @@ create a [cluster guide](/sql/create-cluster),
 or create a managed cluster for all your webhooks using the following SQL statement:
 
 ```sql
-CREATE CLUSTER webhooks_cluster SIZE = '3xsmall';
+CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
 ```
 
 ## Step 2. Create a Shared Secret

--- a/doc/user/content/ingest-data/snowcatcloud.md
+++ b/doc/user/content/ingest-data/snowcatcloud.md
@@ -27,7 +27,7 @@ To create a Materialize cluster, follow the steps outlined in Materialize create
 or create a managed cluster using the following SQL statement:
 
 ```sql
-CREATE CLUSTER snowcatcloud_cluster SIZE = '3xsmall';
+CREATE CLUSTER snowcatcloud_cluster (SIZE = '3xsmall');
 ```
 
 ## Step 2. Create a Shared Secret

--- a/doc/user/content/ingest-data/stripe.md
+++ b/doc/user/content/ingest-data/stripe.md
@@ -29,7 +29,7 @@ create a [cluster guide](/sql/create-cluster),
 or create a managed cluster for all your webhooks using the following SQL statement:
 
 ```sql
-CREATE CLUSTER webhooks_cluster SIZE = '3xsmall';
+CREATE CLUSTER webhooks_cluster (SIZE = '3xsmall');
 ```
 
 ## Step 2. Set up a webhook source

--- a/doc/user/content/manage/access-control/rbac-tutorial.md
+++ b/doc/user/content/manage/access-control/rbac-tutorial.md
@@ -93,7 +93,7 @@ privileges the role needs.
    other environments:
 
    ```sql
-   CREATE CLUSTER dev_cluster REPLICAS (devr1 (SIZE = '3xsmall'));
+   CREATE CLUSTER dev_cluster (SIZE = '3xsmall');
    ```
 
 1. Change into the example cluster:

--- a/doc/user/content/quickstarts/streaming-analytics.md
+++ b/doc/user/content/quickstarts/streaming-analytics.md
@@ -33,7 +33,7 @@ Materialize provides public Kafka topics and a Confluent Schema Registry for its
 1. In your `psql` terminal, create a new [cluster](https://materialize.com/docs/sql/create-cluster/) and [schema](https://materialize.com/docs/sql/create-schema/):
 
     ```sql
-    CREATE CLUSTER demo REPLICAS (r1 (SIZE = 'xsmall'))
+    CREATE CLUSTER demo (SIZE = 'xsmall');
     CREATE SCHEMA shop;
     ```
 

--- a/doc/user/content/sql/create-cluster-replica.md
+++ b/doc/user/content/sql/create-cluster-replica.md
@@ -106,7 +106,7 @@ machines had computed.
 ## Example
 
 ```sql
-CREATE CLUSTER REPLICA c1.r1 SIZE = 'medium';
+CREATE CLUSTER REPLICA c1.r1 (SIZE = 'medium');
 ```
 
 ## Privileges

--- a/doc/user/content/sql/create-cluster.md
+++ b/doc/user/content/sql/create-cluster.md
@@ -201,7 +201,7 @@ As an example, consider the following sequence of events:
 
 Time                | Event
 --------------------|---------------------------------------------------------
-2023-08-29 3:45:00  | `CREATE CLUSTER c SIZE 'medium', REPLICATION FACTOR 2`
+2023-08-29 3:45:00  | `CREATE CLUSTER c (SIZE 'medium', REPLICATION FACTOR 2`)
 2023-08-29 3:45:45  | `ALTER CLUSTER c SET (REPLICATION FACTOR 1)`
 2023-08-29 3:47:15  | `DROP CLUSTER c`
 
@@ -239,7 +239,7 @@ We plan to remove these restrictions in future versions of Materialize.
 Create a cluster with two `medium` replicas:
 
 ```sql
-CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
+CREATE CLUSTER c1 (SIZE = 'medium', REPLICATION FACTOR = 2);
 ```
 
 ### Introspection disabled
@@ -247,7 +247,7 @@ CREATE CLUSTER c1 SIZE = 'medium', REPLICATION FACTOR = 2;
 Create a cluster with a single replica and introspection disabled:
 
 ```sql
-CREATE CLUSTER c SIZE = 'xsmall', INTROSPECTION INTERVAL = 0;
+CREATE CLUSTER c (SIZE = 'xsmall', INTROSPECTION INTERVAL = 0);
 ```
 
 Disabling introspection can yield a small performance improvement, but you lose
@@ -259,7 +259,7 @@ that cluster replica.
 Create a cluster with no replicas:
 
 ```sql
-CREATE CLUSTER c1 SIZE 'xsmall', REPLICATION FACTOR = 0;
+CREATE CLUSTER c1 (SIZE 'xsmall', REPLICATION FACTOR = 0);
 ```
 
 You can later add replicas to this cluster with [`ALTER CLUSTER`].

--- a/doc/user/content/sql/create-source/kafka.md
+++ b/doc/user/content/sql/create-source/kafka.md
@@ -152,9 +152,10 @@ See the [reference documentation](/sql/create-cluster/#disk) for more details.
 To create a new cluster with spill to disk enabled, use the [`DISK` option](/sql/create-cluster/#disk):
 
 ```sql
-CREATE CLUSTER cluster_with_disk,
+CREATE CLUSTER cluster_with_disk (
   SIZE = '<size>',
-  DISK = true;
+  DISK = true
+);
 ```
 
 Alternatively, you can attach disk storage to an existing cluster using the [`ALTER CLUSTER`](/sql/alter-cluster/) command:

--- a/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
+++ b/doc/user/layouts/shortcodes/postgres-direct/create-an-ingestion-cluster.html
@@ -5,7 +5,7 @@ In this case, you'll create 1 new cluster containing 1 `medium` replica for inge
 1. In the `psql` shell connected to Materialize, use the [`CREATE CLUSTER`](/sql/create-cluster/) command to create the new cluster:
 
     ```sql
-    CREATE CLUSTER ingest_postgres SIZE = 'medium';
+    CREATE CLUSTER ingest_postgres (SIZE = 'medium');
     ```
 
     We recommend starting with a `medium` [size](/sql/create-cluster/#size) replica or larger. This will help Materialize more quickly process the initial snapshot of the tables in your publication. Once the snapshot is finished, you'll right-size the cluster.


### PR DESCRIPTION
Adapts documentation for the new blessed form of the `CREATE CLUSTER [REPLICA]` syntax introduced in #23433.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR improvements documentation.

### Tips for reviewer

Do not merge until https://github.com/MaterializeInc/materialize/pull/23433 merges.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
