### PR TITLE
storage-client: fix liveness issue in `determine_latest_progress_record`

### DIFF
--- a/doc/user/content/sql/create-sink/kafka.md
+++ b/doc/user/content/sql/create-sink/kafka.md
@@ -389,6 +389,7 @@ Operation type  | Resource type    | Resource name
 Read, Write     | Topic            | Consult `mz_kafka_connections.sink_progress_topic` for the sink's connection
 Write           | Topic            | The specified `TOPIC` option
 Write           | Transactional ID | `mz-producer-{SINK ID}-*`
+Read            | Group            | `materialize-bootstrap-sink-{SINK ID}`
 
 When using [automatic topic creation](#automatic-topic-creation), Materialize
 additionally requires access to the following operations:

--- a/src/storage/src/sink/kafka.rs
+++ b/src/storage/src/sink/kafka.rs
@@ -33,6 +33,7 @@ use mz_ore::task;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
 use mz_ssh_util::tunnel::SshTunnelStatus;
 use mz_storage_client::client::SinkStatisticsUpdate;
+use mz_storage_client::sink::progress_key::ProgressKey;
 use mz_storage_client::sink::ProgressRecord;
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::{ContextCreationError, DataflowError};
@@ -383,7 +384,7 @@ struct KafkaSinkState {
     retry_manager: Arc<Mutex<KafkaSinkSendRetryManager>>,
 
     progress_topic: String,
-    progress_key: String,
+    progress_key: ProgressKey,
 
     healthchecker: HealthOutputHandle,
     gate_ts: Rc<Cell<Option<Timestamp>>>,
@@ -495,7 +496,7 @@ impl KafkaSinkState {
             progress_topic: match &connection.consistency_config {
                 KafkaConsistencyConfig::Progress { topic } => topic.clone(),
             },
-            progress_key: mz_storage_client::sink::ProgressKey::new(sink_id),
+            progress_key: ProgressKey::new(sink_id),
             healthchecker,
             gate_ts,
             latest_progress_ts: Timestamp::minimum(),

--- a/test/kafka-auth/mzcompose.py
+++ b/test/kafka-auth/mzcompose.py
@@ -187,8 +187,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
 
     # Restrict the `materialize_no_describe_configs` user from running the
-    # `DescribeConfigs` cluster operation, but allow it to idempotently write
-    # to all topics.
+    # `DescribeConfigs` cluster operation, but allow it to idempotently read and
+    # write to all topics.
     c.exec(
         "kafka",
         "kafka-acls",
@@ -218,6 +218,16 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--allow-principal=User:materialize_no_describe_configs",
         "--operation=ALL",
         "--topic=*",
+    )
+    c.exec(
+        "kafka",
+        "kafka-acls",
+        "--bootstrap-server",
+        "localhost:9092",
+        "--add",
+        "--allow-principal=User:materialize_no_describe_configs",
+        "--operation=ALL",
+        "--group=*",
     )
 
     # Now that the Kafka topic has been bootstrapped, it's safe to bring up all


### PR DESCRIPTION
Before this commit, Kafka sinks would occasionally get wedged on boot
inside of the `determine_latest_progress_record` function. The issue was
particularly prevalent when there were multiple other live sinks writing
to the progress topic.

The issue was introduced in by a refactoring in PR https://github.com/MaterializeInc/materialize/pull/23300. Funnily
enough, @bkirwi even called out a liveness issue during code review, but
this one slipped through. This liveness issue is very similar, if not
identical, to one that @bkirwi fixed several months ago in https://github.com/MaterializeInc/materialize/pull/19879.

The cause was that the message fetching loop in
`determine_latest_progress_record` would `continue` upon discovering a
progress message with a key for a different sink, without checking if
the consumer had reached the the high water mark and breaking out of the
loop if so. The only way to hit the high water mark check was if the
*last* progress record in the topic was for the sink under
consideration. In the case of a live, high traffic progress topic, this
is unlikely; in the case of a new sink, it's altogether impossible.

The upshot is we were always relying on Kafka returning `PartitionEOF`
(or timing out) to break out of the loop. But as @bkirwi described in
his writeup for https://github.com/MaterializeInc/materialize/pull/19879, `PartitionEOF` messages are not guaranteed to be
delivered, and tend to get dropped on high-traffic topics.

This commit adjusts `determine_latest_progress_record` to restore the
old and correct behavior of checking whether the high water mark has
been reached after every message read from the progress topic.

It also substantially refactors the method to improve clarity:

  * Many documentation comments are added; in particular @bkirwi's
    argument for the safety of the overall approach from https://github.com/MaterializeInc/materialize/pull/19879.
  * Comparing the consumer's position to the high water mark is moved to
    the loop condition, and reading a message from the topic is moved to
    the body. This better captures the intent of the loop--we need to
    keep reading messages until we reach the high water mark--and means
    we don't need to check the consumer's position after we exit the
    loop.
  * `get_next_message` is folded into `get_latest_ts`, so that failure
    to read a message can be propagated as the error that it is.
  * The loop tracks positions, rather than offsets. This avoids
    `Option`s (the initial position is 0).
  * Polling for progress records uses a more sensible timeout that's
    based on the transaction idle timeout rather than the default
    metadata fetch timeout.
  * The retry loop around `get_latest_ts` is removed, as the comment on
    the retry policy was wrong (all errors were retried, not just
    transient errors), and we can instead just fail and rely on the
    outermost `SuspendAndResume` loop to restart the sink.

### Motivation

  * This PR fixes a recognized bug: #23359.

### Tips for reviewer

Go commit by commit. The first commit is relatively immaterial for the bugfix but I figured I'd clean it up while I was looking at it.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
