### PR TITLE
testdrive: automatically determine environment ID

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/testdrive.py
+++ b/misc/python/materialize/cloudtest/k8s/testdrive.py
@@ -14,7 +14,6 @@ from kubernetes.client import V1Container, V1EnvVar, V1ObjectMeta, V1Pod, V1PodS
 
 from materialize.cloudtest import DEFAULT_K8S_NAMESPACE
 from materialize.cloudtest.k8s.api.k8s_pod import K8sPod
-from materialize.mzcompose import DEFAULT_MZ_ENVIRONMENT_ID
 
 
 class TestdriveBase:
@@ -57,7 +56,6 @@ class TestdriveBase:
             f"--schema-registry-url={self.schema_registry_url}",
             f"--default-timeout={default_timeout}",
             f"--log-filter={log_filter}",
-            f"--environment-id={DEFAULT_MZ_ENVIRONMENT_ID}",
             "--var=replicas=1",
             "--var=default-storage-size=1",
             "--var=default-replica-size=1",

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -10,10 +10,7 @@
 import os
 import random
 
-from materialize.mzcompose import (
-    DEFAULT_MZ_ENVIRONMENT_ID,
-    DEFAULT_MZ_VOLUMES,
-)
+from materialize.mzcompose import DEFAULT_MZ_VOLUMES
 from materialize.mzcompose.service import (
     Service,
     ServiceDependency,
@@ -41,7 +38,6 @@ class Testdrive(Service):
         entrypoint: list[str] | None = None,
         entrypoint_extra: list[str] = [],
         environment: list[str] | None = None,
-        environment_id: str | None = None,
         volumes_extra: list[str] = [],
         volume_workdir: str = ".:/workdir",
         propagate_uid_gid: bool = True,
@@ -147,10 +143,6 @@ class Testdrive(Service):
             entrypoint.append(
                 "--persist-consensus-url=postgres://root@materialized:26257?options=--search_path=consensus"
             )
-
-        if not environment_id:
-            environment_id = DEFAULT_MZ_ENVIRONMENT_ID
-        entrypoint.append(f"--environment-id={environment_id}")
 
         entrypoint.extend(entrypoint_extra)
 

--- a/src/testdrive/src/bin/testdrive.rs
+++ b/src/testdrive/src/bin/testdrive.rs
@@ -90,7 +90,6 @@ use itertools::Itertools;
 use mz_build_info::{build_info, BuildInfo};
 use mz_ore::cli::{self, CliConfig};
 use mz_ore::path::PathExt;
-use mz_sql::catalog::EnvironmentId;
 use mz_testdrive::{CatalogConfig, Config};
 use rand::rngs::StdRng;
 use rand::seq::SliceRandom;
@@ -316,9 +315,6 @@ struct Args {
         env = "AWS_SECRET_ACCESS_KEY"
     )]
     aws_secret_access_key: String,
-
-    #[clap(long)]
-    environment_id: String,
 }
 
 #[derive(ArgEnum, Debug, Clone)]
@@ -464,8 +460,6 @@ async fn main() {
         materialize_params: args.materialize_param,
         materialize_catalog_config,
         build_info: &BUILD_INFO,
-        environment_id: <EnvironmentId as std::str::FromStr>::from_str(&args.environment_id)
-            .unwrap(),
 
         // === Persist options. ===
         persist_consensus_url: args.persist_consensus_url,


### PR DESCRIPTION
Rather than requiring the testdrive invoker to pass in the environment ID, query the connected Materialize instance for its environment ID. This makes it easier to run testdrive locally outside of mzcompose, because you don't need to hunt down the environment ID in the mzdata directory.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
