### PR TITLE
adapter,sql: add a welcome notice

### DIFF
--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -7,6 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
 use std::future::Future;
 use std::pin::Pin;
@@ -56,9 +57,6 @@ pub enum Command {
     Startup {
         cancel_tx: Arc<watch::Sender<Canceled>>,
         tx: oneshot::Sender<Result<StartupResponse, AdapterError>>,
-        /// keys of settings that were set on statup, and thus should not be
-        /// overridden by defaults.
-        set_setting_keys: Vec<String>,
         user: User,
         conn_id: ConnectionId,
         secret_key: u32,
@@ -185,10 +183,10 @@ pub struct StartupResponse {
     /// A future that completes when all necessary Builtin Table writes have completed.
     #[derivative(Debug = "ignore")]
     pub write_notify: BoxFuture<'static, ()>,
-    /// Vec of (name, VarInput::Flat) tuples of session variables that should be set.
-    pub session_vars: Vec<(String, OwnedVarInput)>,
+    /// Vec of (name, VarInput::Flat) tuples of session default variables that should be set.
+    pub session_defaults: Vec<(String, Box<dyn Any + Send + Sync>)>,
     /// Vec of (name, VarInput::Flat) tuples of Role default variables that should be set.
-    pub role_vars: Vec<(String, OwnedVarInput)>,
+    pub role_defaults: Vec<(String, OwnedVarInput)>,
     pub catalog: Arc<Catalog>,
 }
 

--- a/src/adapter/src/config/backend.rs
+++ b/src/adapter/src/config/backend.rs
@@ -27,7 +27,7 @@ impl SystemParameterBackend {
     pub async fn new(client: Client) -> Result<Self, AdapterError> {
         let conn_id = client.new_conn_id()?;
         let session = client.new_session(conn_id, SYSTEM_USER.clone());
-        let session_client = client.startup(session, vec![]).await?;
+        let session_client = client.startup(session).await?;
         Ok(Self { session_client })
     }
 

--- a/src/adapter/src/notice.rs
+++ b/src/adapter/src/notice.rs
@@ -125,6 +125,7 @@ pub enum AdapterNotice {
     PerReplicaLogRead {
         log_names: Vec<String>,
     },
+    Welcome(String),
 }
 
 impl AdapterNotice {
@@ -184,6 +185,7 @@ impl AdapterNotice {
             AdapterNotice::WebhookSourceCreated { .. } => Severity::Notice,
             AdapterNotice::DroppedInUseIndex { .. } => Severity::Notice,
             AdapterNotice::PerReplicaLogRead { .. } => Severity::Notice,
+            AdapterNotice::Welcome(_) => Severity::Notice,
         }
     }
 
@@ -272,6 +274,7 @@ impl AdapterNotice {
             AdapterNotice::DroppedInUseIndex { .. } => SqlState::WARNING,
             AdapterNotice::WebhookSourceCreated { .. } => SqlState::WARNING,
             AdapterNotice::PerReplicaLogRead { .. } => SqlState::WARNING,
+            AdapterNotice::Welcome(_) => SqlState::SUCCESSFUL_COMPLETION,
         }
     }
 }
@@ -422,6 +425,7 @@ impl fmt::Display for AdapterNotice {
             AdapterNotice::PerReplicaLogRead { log_names } => {
                 write!(f, "Queried introspection relations: {}. Unlike other objects in Materialize, results from querying these objects depend on the current values of the `cluster` and `cluster_replica` session variables.", log_names.join(", "))
             }
+            AdapterNotice::Welcome(message) => message.fmt(f),
         }
     }
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2184,10 +2184,13 @@ fn test_internal_ws_auth() {
     };
 
     let (mut ws, _resp) = tungstenite::connect(make_req()).unwrap();
-    let options = BTreeMap::from([(
-        "application_name".to_string(),
-        "billion_dollar_idea".to_string(),
-    )]);
+    let options = BTreeMap::from([
+        (
+            "application_name".to_string(),
+            "billion_dollar_idea".to_string(),
+        ),
+        ("welcome_message".to_string(), "off".to_string()),
+    ]);
     // We should receive error if sending the standard bearer auth, since that is unexpected
     // for the Internal HTTP API
     assert_eq!(

--- a/src/pgtest/src/lib.rs
+++ b/src/pgtest/src/lib.rs
@@ -197,6 +197,7 @@ impl PgConn {
 
         conn.stream.set_read_timeout(Some(timeout))?;
         options.insert(0, ("user", user));
+        options.insert(0, ("welcome_message", "off"));
         conn.send(|buf| frontend::startup_message(options, buf).unwrap())?;
         match conn.recv()?.1 {
             Message::AuthenticationOk => {}

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -236,7 +236,6 @@ where
         (session, is_expired)
     };
 
-    let mut setting_keys = vec![];
     for (name, value) in params {
         let settings = match name.as_str() {
             "options" => match parse_options(&value) {
@@ -265,8 +264,6 @@ where
                     name: key,
                     reason: err.to_string(),
                 });
-            } else {
-                setting_keys.push(key);
             }
         }
     }
@@ -303,7 +300,7 @@ where
     conn.flush().await?;
 
     // Register session with adapter.
-    let mut adapter_client = match adapter_client.startup(session, setting_keys).await {
+    let mut adapter_client = match adapter_client.startup(session).await {
         Ok(adapter_client) => adapter_client,
         Err(e) => return conn.send(e.into_response(Severity::Fatal)).await,
     };

--- a/src/sql/src/catalog.rs
+++ b/src/sql/src/catalog.rs
@@ -933,6 +933,14 @@ impl EnvironmentId {
         &self.cloud_provider_region
     }
 
+    /// Returns the name of the region associted with this environment ID.
+    ///
+    /// A region is a combination of [`EnvironmentId::cloud_provider`] and
+    /// [`EnvironmentId::cloud_provider_region`].
+    pub fn region(&self) -> String {
+        format!("{}/{}", self.cloud_provider, self.cloud_provider_region)
+    }
+
     /// Returns the organization ID associated with this environment ID.
     pub fn organization_id(&self) -> Uuid {
         self.organization_id

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -554,6 +554,13 @@ pub const MAX_IDENTIFIER_LENGTH: ServerVar<usize> = ServerVar {
     internal: false,
 };
 
+pub const WELCOME_MESSAGE: ServerVar<bool> = ServerVar {
+    name: UncasedStr::new("welcome_message"),
+    value: &true,
+    description: "Whether to send a notice with a welcome message after a successful connection (Materialize).",
+    internal: false,
+};
+
 /// The logical compaction window for builtin tables and sources that have the
 /// `retained_metrics_relation` flag set.
 ///
@@ -2175,6 +2182,7 @@ impl SessionVars {
             )
             .with_var(&EMIT_INTROSPECTION_QUERY_NOTICE)
             .with_var(&UNSAFE_NEW_TRANSACTION_WALL_TIME)
+            .with_var(&WELCOME_MESSAGE)
     }
 
     fn with_var<V>(mut self, var: &'static ServerVar<V>) -> Self
@@ -2339,6 +2347,16 @@ impl SessionVars {
             })
             .transpose()?
             .ok_or_else(|| VarError::UnknownParameter(name.to_string()))
+    }
+
+    /// Sets the default value for the parameter named `name` to the value
+    /// represented by `value`.
+    pub fn set_default(&mut self, name: &str, input: &'static dyn Any) {
+        let name = UncasedStr::new(name);
+        let var = self.vars.get_mut(name).unwrap_or_else(|| {
+            panic!("SessionVars::set_default called with unknown variable {name}")
+        });
+        var.set_default(input);
     }
 
     /// Sets the "role default" parameter named `name` to the value represented by `value`.
@@ -2600,6 +2618,11 @@ impl SessionVars {
 
     pub fn unsafe_new_transaction_wall_time(&self) -> Option<CheckedTimestamp<DateTime<Utc>>> {
         *self.expect_value(&UNSAFE_NEW_TRANSACTION_WALL_TIME)
+    }
+
+    /// Returns the value of the `welcome_message` configuration parameter.
+    pub fn welcome_message(&self) -> bool {
+        *self.expect_value(&WELCOME_MESSAGE)
     }
 }
 
@@ -3962,7 +3985,7 @@ where
     V: Value + ToOwned + Debug + PartialEq + 'static,
 {
     /// Default value.
-    default_value: &'static V,
+    default_value: Option<&'static V>,
     /// Value persisted with the current role.
     role_value: Option<V::Owned>,
     /// Value `LOCAL` to a transaction, will be unset at the completion of the transaction.
@@ -4039,7 +4062,7 @@ where
 {
     fn new(parent: &'static ServerVar<V>) -> SessionVar<V> {
         SessionVar {
-            default_value: parent.value,
+            default_value: None,
             role_value: None,
             local_value: None,
             staged_value: None,
@@ -4083,6 +4106,7 @@ where
             .or_else(|| self.staged_value.as_ref().map(|v| v.borrow()))
             .or_else(|| self.session_value.as_ref().map(|v| v.borrow()))
             .or_else(|| self.role_value.as_ref().map(|v| v.borrow()))
+            .or(self.default_value)
             .unwrap_or(self.parent.value)
     }
 }
@@ -4128,6 +4152,9 @@ pub trait SessionVarMut: Var + Send + Sync {
     /// Parse the input and update the stored value to match.
     fn set(&mut self, input: VarInput, local: bool) -> Result<(), VarError>;
 
+    /// Sets the default value for the variable.
+    fn set_default(&mut self, value: &'static dyn Any);
+
     /// Parse the input and update the default Role value.
     ///
     /// Note: these only get set on Session start. Updating the default value for a role will not
@@ -4170,6 +4197,18 @@ where
         Ok(())
     }
 
+    /// Sets the default value.
+    fn set_default(&mut self, input: &'static dyn Any) {
+        let v = input.downcast_ref().unwrap_or_else(|| {
+            panic!(
+                "SessionVar::set_default called with invalid value {:?} for {}",
+                input,
+                self.name()
+            )
+        });
+        self.default_value = Some(v);
+    }
+
     /// Parse the input and set the default Role value.
     fn set_role_default(&mut self, input: VarInput) -> Result<(), VarError> {
         let v = V::parse(self, input)?;
@@ -4183,8 +4222,10 @@ where
         let value = self
             .role_value
             .as_ref()
-            .map(|val| val.borrow().to_owned())
-            .unwrap_or_else(|| self.default_value.to_owned());
+            .map(|v| v.borrow())
+            .or_else(|| self.default_value.map(|v| v.borrow()))
+            .unwrap_or(self.parent.value)
+            .to_owned();
         if local {
             self.local_value = Some(value);
         } else {

--- a/test/testdrive/session.td
+++ b/test/testdrive/session.td
@@ -71,6 +71,7 @@ statement_timeout                   "10 s"                  "Sets the maximum al
 TimeZone                            UTC                     "Sets the time zone for displaying and interpreting time stamps (PostgreSQL)."
 transaction_isolation               "strict serializable"   "Sets the current transaction's isolation level (PostgreSQL)."
 unsafe_new_transaction_wall_time    ""                      "Sets the wall time for all new explicit or implicit transactions to control the value of `now()`. If not set, uses the system's clock."
+welcome_message                     on                      "Whether to send a notice with a welcome message after a successful connection (Materialize)."
 enable_consolidate_after_union_negate on                    "consolidation after Unions that have a Negated input (Materialize)."
 enable_sink_doc_on_option           on                     "Whether DOC ON option for sinks is allowed (Materialize)."
 


### PR DESCRIPTION
Emit a human-readable notice upon successful connection that lists out the important connection parameters (the Materialize version, organization ID, region, username, cluster, database, schema/search path) along with some getting started links.

We expect this to be useful for both new folks, by pointing them at where to get help, and advanced folks who are regularly connecting to multiple use cases in Materialize, to help them keep their connection parameters straight.

Fix #22350.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Here's how the welcome notice added here currently renders in psql:

```
$ psql -h localhost -p 6875 -U materialize materialize
psql (14.10 (Homebrew), server 9.5.0)
Type "help" for help.

materialize=> select 1;
NOTICE:  connected to Materialize v0.79.0-dev
  Org ID: dec23a71-8f55-4821-9630-101b9ac3a97d
  Region: local/az1
  User: materialize
  Cluster: default
  Database: materialize
  Schema: public

Issue a SQL query to get started. Need help?
  View documentation: https://materialize.com/s/docs
  Join our Slack community: https://materialize.com/s/chat

 ?column? 
----------
        1
(1 row)

materialize=> 
```

This is a bit silly, and is due to the way we eagerly send the initial `ReadyForQuery` message for our SLA. I'm ~going to~ put up a separate PR that changes that behavior, which has the nice side effect of moving the welcome message to a more sensible place: #23441.

### Tips for reviewer

The second commit is cleanup that I figured I'd tackle while I was in the area. It's unrelated to the welcome notice feature, but touches some of the same session parameter startup code.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
