### PR TITLE
pgwire: stop eagerly sending `ReadyForQuery`

### DIFF
--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -290,15 +290,12 @@ async fn test_conn_startup() {
     // A welcome notice should be sent.
     {
         let (notice_tx, mut notice_rx) = mpsc::unbounded_channel();
-        let client = server
+        let _client = server
             .connect()
             .options("") // Override the test harness's default of `--welcome_message=off`.
             .notice_callback(move |notice| notice_tx.send(notice).unwrap())
             .await
             .unwrap();
-        // Issuing a query is required to see the notice due to delayed startup.
-        // TODO: remove this when we remove delayed startup.
-        client.query_one("SELECT 1", &[]).await.unwrap();
         match notice_rx.recv().await {
             Some(n) => {
                 assert_eq!(*n.code(), SqlState::SUCCESSFUL_COMPLETION);

--- a/src/pgwire/src/protocol.rs
+++ b/src/pgwire/src/protocol.rs
@@ -279,39 +279,30 @@ where
         }
     };
 
-    let mut buf = vec![BackendMessage::AuthenticationOk];
-    for var in session.vars().notify_set() {
-        buf.push(BackendMessage::ParameterStatus(var.name(), var.value()));
-    }
-    buf.push(BackendMessage::BackendKeyData {
-        conn_id: session.conn_id().unhandled(),
-        secret_key: session.secret_key(),
-    });
-    // Immediately respond with connection success without waiting on the
-    // coordinator. This allows us to better meet SLA goals (like able to
-    // connect) at the expense of some specific problems:
-    // - Startup notices (like unknown database) won't be sent until the first
-    //   query.
-    // - An unknown username won't error until the first query. This won't be
-    //   noticed by users, though, since with frontegg enabled unknown users are
-    //   always created.
-    buf.push(BackendMessage::ReadyForQuery(session.transaction().into()));
-    conn.send_all(buf).await?;
-    conn.flush().await?;
-
     // Register session with adapter.
     let mut adapter_client = match adapter_client.startup(session).await {
         Ok(adapter_client) => adapter_client,
         Err(e) => return conn.send(e.into_response(Severity::Fatal)).await,
     };
 
-    let mut buf = Vec::new();
-    // NoticeResponse messages can be sent at any time
-    // (https://www.postgresql.org/docs/current/protocol-flow.html#PROTOCOL-ASYNC),
-    // so it is within spec to send them after the initial ReadyForQuery.
-    for notice in adapter_client.session().drain_notices() {
-        buf.push(notice.into_response().into());
+    let mut buf = vec![BackendMessage::AuthenticationOk];
+    for var in adapter_client.session().vars().notify_set() {
+        buf.push(BackendMessage::ParameterStatus(var.name(), var.value()));
     }
+    buf.push(BackendMessage::BackendKeyData {
+        conn_id: adapter_client.session().conn_id().unhandled(),
+        secret_key: adapter_client.session().secret_key(),
+    });
+    buf.extend(
+        adapter_client
+            .session()
+            .drain_notices()
+            .into_iter()
+            .map(|notice| BackendMessage::ErrorResponse(notice.into_response())),
+    );
+    buf.push(BackendMessage::ReadyForQuery(
+        adapter_client.session().transaction().into(),
+    ));
     conn.send_all(buf).await?;
     conn.flush().await?;
 


### PR DESCRIPTION
In #16949, we adjusted connection startup to send the initial `ReadyForQuery` message *before* the coordinator had actually handled the registration of the session. We did this to better meet our SLA guarantees around connection startup.

There are several downsides to this behavior, however:

  1. Startup notices aren't sent until the first query. This is particularly bad for the proposed welcome notice proposed in #23440.
  2. Unknown username errors aren't generated until after the first query is submitted.
  3. Query latency for the first query is often much worse than it would be otherwise, as processing of the first query is blocked on session registration, which requires a system table write. This is particularly bad for fast index lookup queries that wouldn't otherwise need to hit `persist`.

This commit removes the behavior, restoring the old behavior of waiting for session registration before sending the initial `ReadyForQuery` message

The primary motiviation is eliminating downside (3), which we weren't aware of when we implemented the eager `ReadyForQuery` behavior. Our users expect consistently low response times to queries, and sacrificing query response time in order to improve our ability to hit our uptime SLA does not seem to be the right tradeoff--especially since we are comfortably meeting our uptime SLA, even when using a strict definition of "uptime" that means "SHOW VIEWS succeeds" rather than "connection requests succeed.".

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation


   * This PR refactors existing behavior.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
