### PR TITLE
storage-client: enable compaction of progress topics

### DIFF
--- a/misc/python/materialize/cloudtest/k8s/redpanda.py
+++ b/misc/python/materialize/cloudtest/k8s/redpanda.py
@@ -34,7 +34,7 @@ class RedpandaDeployment(K8sDeployment):
         super().__init__(namespace)
         container = V1Container(
             name="redpanda",
-            image="vectorized/redpanda:v21.11.13",
+            image="vectorized/redpanda:v23.1.9",
             command=[
                 "/usr/bin/rpk",
                 "redpanda",

--- a/test/cloudtest/test_secrets.py
+++ b/test/cloudtest/test_secrets.py
@@ -33,7 +33,7 @@ def test_secrets(mz: MaterializeApplication) -> None:
                 SASL USERNAME = SECRET username,
                 SASL PASSWORD = SECRET password
               );
-            contains:Meta data fetch error: BrokerTransportFailure (Local: Broker transport failure)
+            contains:Broker does not support SSL connections
             """
         )
     )

--- a/test/kafka-matrix/mzcompose.py
+++ b/test/kafka-matrix/mzcompose.py
@@ -16,7 +16,7 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 
-REDPANDA_VERSIONS = ["v23.2.15", "v23.1.20", "v22.3.25", "v22.2.13", "v22.1.11"]
+REDPANDA_VERSIONS = ["v23.2.15", "v23.1.20", "v22.3.25"]
 
 CONFLUENT_PLATFORM_VERSIONS = [
     "6.2.12",


### PR DESCRIPTION
When Materialize creates a progress topic, enable key-based compaction on the topic so that progress records do not pile up forever. Also add some documentation that points users in the right direction if they choose to manage the creation of topics themselves.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

Noticed somewhere in the flurry of recent sink work that we were failing to do this.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Automatically enable compaction when creating the progress topic for a Kafka sink. **Warning:** Versions of Redpanda before v22.3 do not support using compaction for Materialize's progress topics. You will need to manually create the connection's progress topic with compaction disabled to use sinks with these versions of Redpanda.
