### PR TITLE
tests: version handling: streamline to single version provider

### DIFF
--- a/ci/deploy/docker.py
+++ b/ci/deploy/docker.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 from materialize import git, mzbuild
 from materialize.mz_version import MzVersion
+from materialize.version_list import get_all_mz_versions
 from materialize.xcompile import Arch
 
 
@@ -40,11 +41,7 @@ def main() -> None:
 
         # Also tag the images as `latest` if this is the latest version.
         version = MzVersion.parse_mz(buildkite_tag)
-        latest_version = max(
-            t
-            for t in git.get_version_tags(version_type=MzVersion)
-            if t.prerelease is None
-        )
+        latest_version = max(t for t in get_all_mz_versions() if t.prerelease is None)
         if version == latest_version:
             mzbuild.publish_multiarch_images("latest", deps)
     else:

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -17,11 +17,10 @@ from materialize.checks.mzcompose_actions import (
     UseClusterdCompute,
 )
 from materialize.checks.scenarios import Scenario
+from materialize.docker import get_published_minor_mz_versions
 from materialize.mz_version import MzVersion
-from materialize.version_list import VersionsFromDocs
 
-version_list = VersionsFromDocs()
-minor_versions = version_list.minor_versions()
+minor_versions = get_published_minor_mz_versions(limit=4)
 previous_version, last_version = minor_versions[-2:]
 
 
@@ -119,7 +118,7 @@ class UpgradeEntireMzFourVersions(Scenario):
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {minor_versions[-2]} -> {minor_versions[-1]}"
+            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {previous_version} -> {last_version}"
         )
         return [
             StartMz(self, tag=minor_versions[-4]),
@@ -128,10 +127,10 @@ class UpgradeEntireMzFourVersions(Scenario):
             StartMz(self, tag=minor_versions[-3]),
             Manipulate(self, phase=1),
             KillMz(),
-            StartMz(self, tag=minor_versions[-2]),
+            StartMz(self, tag=previous_version),
             Manipulate(self, phase=2),
             KillMz(),
-            StartMz(self, tag=minor_versions[-1]),
+            StartMz(self, tag=last_version),
             KillMz(),
             StartMz(self, tag=None),
             Validate(self),

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -21,7 +21,7 @@ from materialize.mz_version import MzVersion
 from materialize.version_list import get_published_minor_mz_versions
 
 minor_versions = get_published_minor_mz_versions(limit=4)
-previous_version, last_version = minor_versions[-2:]
+last_version, previous_version = minor_versions[:2]
 
 
 class UpgradeEntireMz(Scenario):
@@ -114,17 +114,17 @@ class UpgradeEntireMzFourVersions(Scenario):
     """Test upgrade X-4 -> X-3 -> X-2 -> X-1 -> X"""
 
     def base_version(self) -> MzVersion:
-        return minor_versions[-4]
+        return minor_versions[3]
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrading going through {minor_versions[-4]} -> {minor_versions[-3]} -> {previous_version} -> {last_version}"
+            f"Upgrading going through {minor_versions[3]} -> {minor_versions[2]} -> {previous_version} -> {last_version}"
         )
         return [
-            StartMz(self, tag=minor_versions[-4]),
+            StartMz(self, tag=minor_versions[3]),
             Initialize(self),
             KillMz(),
-            StartMz(self, tag=minor_versions[-3]),
+            StartMz(self, tag=minor_versions[2]),
             Manipulate(self, phase=1),
             KillMz(),
             StartMz(self, tag=previous_version),

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -20,15 +20,38 @@ from materialize.checks.scenarios import Scenario
 from materialize.mz_version import MzVersion
 from materialize.version_list import get_published_minor_mz_versions
 
-minor_versions = get_published_minor_mz_versions(limit=4)
-last_version, previous_version = minor_versions[:2]
+# late initialization
+_minor_versions: list[MzVersion] | None = None
+_last_version: MzVersion | None = None
+_previous_version: MzVersion | None = None
+
+
+def get_minor_versions() -> list[MzVersion]:
+    global _minor_versions
+    if _minor_versions is None:
+        _minor_versions = get_published_minor_mz_versions(limit=4)
+    return _minor_versions
+
+
+def get_last_version() -> MzVersion:
+    global _last_version
+    if _last_version is None:
+        _last_version = get_minor_versions()[0]
+    return _last_version
+
+
+def get_previous_version() -> MzVersion:
+    global _previous_version
+    if _previous_version is None:
+        _previous_version = get_minor_versions()[1]
+    return _previous_version
 
 
 class UpgradeEntireMz(Scenario):
     """Upgrade the entire Mz instance from the last released version."""
 
     def base_version(self) -> MzVersion:
-        return last_version
+        return get_last_version()
 
     def actions(self) -> list[Action]:
         print(f"Upgrading from tag {self.base_version()}")
@@ -51,7 +74,7 @@ class UpgradeEntireMzPreviousVersion(UpgradeEntireMz):
     """Upgrade the entire Mz instance from the previous released version."""
 
     def base_version(self) -> MzVersion:
-        return previous_version
+        return get_previous_version()
 
 
 class UpgradeEntireMzTwoVersions(Scenario):
@@ -59,11 +82,11 @@ class UpgradeEntireMzTwoVersions(Scenario):
     released version and passing through the last released version."""
 
     def base_version(self) -> MzVersion:
-        return previous_version
+        return get_previous_version()
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrading starting from tag {self.base_version()} going through {last_version}"
+            f"Upgrading starting from tag {self.base_version()} going through {get_last_version()}"
         )
         return [
             # Start with previous_version
@@ -71,7 +94,7 @@ class UpgradeEntireMzTwoVersions(Scenario):
             Initialize(self),
             # Upgrade to last_version
             KillMz(),
-            StartMz(self, tag=last_version),
+            StartMz(self, tag=get_last_version()),
             Manipulate(self, phase=1),
             # Upgrade to current source
             KillMz(),
@@ -89,13 +112,13 @@ class UpgradeEntireMzSkipVersion(Scenario):
     """Upgrade the entire Mz instance from the previous version directly to the current HEAD"""
 
     def base_version(self) -> MzVersion:
-        return previous_version
+        return get_previous_version()
 
     def actions(self) -> list[Action]:
         print(f"Upgrading starting from tag {self.base_version()} directly to HEAD")
         return [
             # Start with previous_version
-            StartMz(self, tag=previous_version),
+            StartMz(self, tag=get_previous_version()),
             Initialize(self),
             Manipulate(self, phase=1),
             # Upgrade directly to current source
@@ -113,24 +136,26 @@ class UpgradeEntireMzSkipVersion(Scenario):
 class UpgradeEntireMzFourVersions(Scenario):
     """Test upgrade X-4 -> X-3 -> X-2 -> X-1 -> X"""
 
+    minor_versions = get_minor_versions()
+
     def base_version(self) -> MzVersion:
-        return minor_versions[3]
+        return self.minor_versions[3]
 
     def actions(self) -> list[Action]:
         print(
-            f"Upgrading going through {minor_versions[3]} -> {minor_versions[2]} -> {previous_version} -> {last_version}"
+            f"Upgrading going through {self.minor_versions[3]} -> {self.minor_versions[2]} -> {get_previous_version()} -> {get_last_version()}"
         )
         return [
-            StartMz(self, tag=minor_versions[3]),
+            StartMz(self, tag=self.minor_versions[3]),
             Initialize(self),
             KillMz(),
-            StartMz(self, tag=minor_versions[2]),
+            StartMz(self, tag=self.minor_versions[2]),
             Manipulate(self, phase=1),
             KillMz(),
-            StartMz(self, tag=previous_version),
+            StartMz(self, tag=get_previous_version()),
             Manipulate(self, phase=2),
             KillMz(),
-            StartMz(self, tag=last_version),
+            StartMz(self, tag=get_last_version()),
             KillMz(),
             StartMz(self, tag=None),
             Validate(self),
@@ -153,7 +178,7 @@ class UpgradeClusterdComputeLast(Scenario):
     """Upgrade compute's clusterd separately after upgrading environmentd"""
 
     def base_version(self) -> MzVersion:
-        return last_version
+        return get_last_version()
 
     def actions(self) -> list[Action]:
         return [
@@ -185,7 +210,7 @@ class UpgradeClusterdComputeFirst(Scenario):
     """Upgrade compute's clusterd separately before environmentd"""
 
     def base_version(self) -> MzVersion:
-        return last_version
+        return get_last_version()
 
     def actions(self) -> list[Action]:
         return [

--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -17,8 +17,8 @@ from materialize.checks.mzcompose_actions import (
     UseClusterdCompute,
 )
 from materialize.checks.scenarios import Scenario
-from materialize.docker import get_published_minor_mz_versions
 from materialize.mz_version import MzVersion
+from materialize.version_list import get_published_minor_mz_versions
 
 minor_versions = get_published_minor_mz_versions(limit=4)
 previous_version, last_version = minor_versions[-2:]

--- a/misc/python/materialize/cloudtest/k8s/environmentd.py
+++ b/misc/python/materialize/cloudtest/k8s/environmentd.py
@@ -229,7 +229,7 @@ class EnvironmentdStatefulSet(K8sStatefulSet):
         if self._meets_minimum_version("0.63.0-dev"):
             args += ["--secrets-controller=kubernetes"]
 
-        if self._meets_minimum_version("0.78.0-dev"):
+        if self._meets_minimum_version("0.79.0-dev"):
             args += [
                 f"--timestamp-oracle-url=postgres://root@cockroach.{self.cockroach_namespace}:26257?options=--search_path=tsoracle"
             ]

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -136,7 +136,7 @@ def get_latest_published_version() -> MzVersion:
             version_type=MzVersion, excluded_versions=excluded_versions
         )
 
-        if _image_of_release_version_exists(latest_published_version):
+        if image_of_release_version_exists(latest_published_version):
             return latest_published_version
         else:
             print(
@@ -153,7 +153,7 @@ def get_previous_published_version(release_version: MzVersion) -> MzVersion:
             release_version, excluded_versions=excluded_versions
         )
 
-        if _image_of_release_version_exists(previous_published_version):
+        if image_of_release_version_exists(previous_published_version):
             return previous_published_version
         else:
             print(f"Skipping version {previous_published_version} (image not found)")
@@ -183,7 +183,7 @@ def _get_override_commit_instead_of_version(
     return None
 
 
-def _image_of_release_version_exists(version: MzVersion) -> bool:
+def image_of_release_version_exists(version: MzVersion) -> bool:
     return _mz_image_tag_exists(_version_to_image_tag(version))
 
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -12,6 +12,7 @@ import subprocess
 
 from materialize import buildkite, git
 from materialize.mz_version import MzVersion
+from materialize.version_list import get_previous_mz_version
 
 """
 Git revisions that are based on commits listed as keys require at least the version specified in the value.
@@ -149,7 +150,7 @@ def get_previous_published_version(release_version: MzVersion) -> MzVersion:
     excluded_versions = set()
 
     while True:
-        previous_published_version = git.get_previous_version(
+        previous_published_version = get_previous_mz_version(
             release_version, excluded_versions=excluded_versions
         )
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -205,6 +205,7 @@ def _mz_image_tag_exists(image_tag: str) -> bool:
         subprocess.check_output(command, stderr=subprocess.STDOUT, text=True)
         return True
     except subprocess.CalledProcessError as e:
+        print(f"Failed to pull image: {image}")
         return "not found: manifest unknown: manifest unknown" not in e.output
 
 

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -10,203 +10,18 @@
 """Docker utilities."""
 import subprocess
 
-from materialize import buildkite, git
 from materialize.mz_version import MzVersion
-from materialize.version_list import get_all_minor_mz_versions, get_previous_mz_version
-
-"""
-Git revisions that are based on commits listed as keys require at least the version specified in the value.
-Note that specified versions do not necessarily need to be already published.
-Commits must be ordered descending by their date.
-"""
-MIN_ANCESTOR_MZ_VERSION_PER_COMMIT: dict[str, MzVersion] = {
-    # insert newer commits at the top
-    # PR#23421 (coord: smorgasbord of improvements for the crdb-backed timestamp oracle) introduces regressions against 0.78.13
-    "5179ebd39aea4867622357a832aaddcde951b411": MzVersion.parse_mz("v0.79.0")
-}
-
-
-def resolve_ancestor_image_tag() -> str:
-    image_tag, context = _resolve_ancestor_image_tag()
-    print(f"Using {image_tag} as image tag for ancestor (context: {context})")
-    return image_tag
-
-
-def _resolve_ancestor_image_tag() -> tuple[str, str]:
-    if buildkite.is_in_buildkite():
-        return _resolve_ancestor_image_tag_when_in_buildkite()
-    else:
-        return _resolve_ancestor_image_tag_when_running_locally()
-
-
-def _resolve_ancestor_image_tag_when_in_buildkite() -> tuple[str, str]:
-    if buildkite.is_in_pull_request():
-        # return the merge base
-        common_ancestor_commit = buildkite.get_merge_base()
-        if _image_of_commit_exists(common_ancestor_commit):
-            return (
-                _commit_to_image_tag(common_ancestor_commit),
-                "merge base of pull request",
-            )
-        else:
-            return (
-                _version_to_image_tag(get_latest_published_version()),
-                "latest release because image of merge base of pull request not available",
-            )
-    elif git.is_on_release_version():
-        # return the previous release
-        tagged_release_version = git.get_tagged_release_version(version_type=MzVersion)
-        assert tagged_release_version is not None
-        previous_release_version = get_previous_published_version(
-            tagged_release_version
-        )
-        return (
-            _version_to_image_tag(previous_release_version),
-            f"previous release because on release branch {tagged_release_version}",
-        )
-    else:
-        latest_published_version = get_latest_published_version()
-        override_commit = _get_override_commit_instead_of_version(
-            latest_published_version
-        )
-
-        if override_commit is not None:
-            # use the commit instead of the latest release
-            return (
-                _commit_to_image_tag(override_commit),
-                f"commit override instead of latest release ({latest_published_version})",
-            )
-
-        # return the latest release
-        return (
-            _version_to_image_tag(latest_published_version),
-            "latest release because not in a pull request and not on a release branch",
-        )
-
-
-def _resolve_ancestor_image_tag_when_running_locally() -> tuple[str, str]:
-    if git.is_on_release_version():
-        # return the previous release
-        tagged_release_version = git.get_tagged_release_version(version_type=MzVersion)
-        assert tagged_release_version is not None
-        previous_release_version = get_previous_published_version(
-            tagged_release_version
-        )
-        return (
-            _version_to_image_tag(previous_release_version),
-            f"previous release because on local release branch {tagged_release_version}",
-        )
-    elif git.is_on_main_branch():
-        # return the latest release
-        latest_published_version = get_latest_published_version()
-        override_commit = _get_override_commit_instead_of_version(
-            latest_published_version
-        )
-
-        if override_commit is not None:
-            # use the commit instead of the latest release
-            return (
-                _commit_to_image_tag(override_commit),
-                f"commit override instead of latest release ({latest_published_version})",
-            )
-
-        return (
-            _version_to_image_tag(latest_published_version),
-            "latest release because on local main branch",
-        )
-    else:
-        # return the merge base
-        common_ancestor_commit = buildkite.get_merge_base()
-        if _image_of_commit_exists(common_ancestor_commit):
-            return (
-                _commit_to_image_tag(common_ancestor_commit),
-                "merge base of local non-main branch",
-            )
-        else:
-            return (
-                _version_to_image_tag(get_latest_published_version()),
-                "latest release because image of merge base of local non-main branch not available",
-            )
-
-
-def get_latest_published_version() -> MzVersion:
-    excluded_versions = set()
-
-    while True:
-        latest_published_version = git.get_latest_version(
-            version_type=MzVersion, excluded_versions=excluded_versions
-        )
-
-        if image_of_release_version_exists(latest_published_version):
-            return latest_published_version
-        else:
-            print(
-                f"Skipping version {latest_published_version} (image not found), trying earlier version"
-            )
-            excluded_versions.add(latest_published_version)
-
-
-def get_previous_published_version(release_version: MzVersion) -> MzVersion:
-    excluded_versions = set()
-
-    while True:
-        previous_published_version = get_previous_mz_version(
-            release_version, excluded_versions=excluded_versions
-        )
-
-        if image_of_release_version_exists(previous_published_version):
-            return previous_published_version
-        else:
-            print(f"Skipping version {previous_published_version} (image not found)")
-            excluded_versions.add(previous_published_version)
-
-
-def get_published_minor_mz_versions(limit: int | None = None) -> list[MzVersion]:
-    minor_mz_versions = get_all_minor_mz_versions()
-    versions = []
-
-    for v in minor_mz_versions:
-        if image_of_release_version_exists(v):
-            versions.append(v)
-
-        if limit is not None and len(versions) == limit:
-            break
-
-    return versions
-
-
-def _get_override_commit_instead_of_version(
-    latest_published_version: MzVersion,
-) -> str | None:
-    """
-    If a commit specifies a mz version as prerequisite (to avoid regressions) that is newer than the
-    provided latest version (i.e., prerequisite not satisfied by the latest version), then return
-    that commit's hash if the commit contained in the current state.
-    Otherwise, return none.
-    """
-    for (
-        commit_hash,
-        min_required_mz_version,
-    ) in MIN_ANCESTOR_MZ_VERSION_PER_COMMIT.items():
-        if latest_published_version >= min_required_mz_version:
-            continue
-
-        if git.contains_commit(commit_hash):
-            # commit would require at least min_required_mz_version
-            return commit_hash
-
-    return None
 
 
 def image_of_release_version_exists(version: MzVersion) -> bool:
-    return _mz_image_tag_exists(_version_to_image_tag(version))
+    return mz_image_tag_exists(version_to_image_tag(version))
 
 
-def _image_of_commit_exists(commit_hash: str) -> bool:
-    return _mz_image_tag_exists(_commit_to_image_tag(commit_hash))
+def image_of_commit_exists(commit_hash: str) -> bool:
+    return mz_image_tag_exists(commit_to_image_tag(commit_hash))
 
 
-def _mz_image_tag_exists(image_tag: str) -> bool:
+def mz_image_tag_exists(image_tag: str) -> bool:
     image = f"materialize/materialized:{image_tag}"
     command = [
         "docker",
@@ -224,9 +39,9 @@ def _mz_image_tag_exists(image_tag: str) -> bool:
         return "not found: manifest unknown: manifest unknown" not in e.output
 
 
-def _commit_to_image_tag(commit_hash: str) -> str:
+def commit_to_image_tag(commit_hash: str) -> str:
     return f"devel-{commit_hash}"
 
 
-def _version_to_image_tag(version: MzVersion) -> str:
+def version_to_image_tag(version: MzVersion) -> str:
     return str(version)

--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -12,7 +12,7 @@ import subprocess
 
 from materialize import buildkite, git
 from materialize.mz_version import MzVersion
-from materialize.version_list import get_previous_mz_version
+from materialize.version_list import get_all_minor_mz_versions, get_previous_mz_version
 
 """
 Git revisions that are based on commits listed as keys require at least the version specified in the value.
@@ -159,6 +159,20 @@ def get_previous_published_version(release_version: MzVersion) -> MzVersion:
         else:
             print(f"Skipping version {previous_published_version} (image not found)")
             excluded_versions.add(previous_published_version)
+
+
+def get_published_minor_mz_versions(limit: int | None = None) -> list[MzVersion]:
+    minor_mz_versions = get_all_minor_mz_versions()
+    versions = []
+
+    for v in minor_mz_versions:
+        if image_of_release_version_exists(v):
+            versions.append(v)
+
+        if limit is not None and len(versions) == limit:
+            break
+
+    return versions
 
 
 def _get_override_commit_instead_of_version(

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -18,7 +18,6 @@ from typing import TypeVar
 from materialize import spawn
 from materialize.mz_version import MzVersion, TypedVersionBase
 from materialize.util import YesNoOnce
-from materialize.version_list import INVALID_VERSIONS
 
 VERSION_TYPE = TypeVar("VERSION_TYPE", bound=TypedVersionBase)
 
@@ -322,34 +321,6 @@ def get_commit_message(commit_sha: str) -> str | None:
 def get_branch_name() -> str:
     command = ["git", "branch", "--show-current"]
     return spawn.capture(command).strip()
-
-
-def get_previous_version(
-    version: VERSION_TYPE, excluded_versions: set[VERSION_TYPE] | None = None
-) -> VERSION_TYPE:
-    if excluded_versions is None:
-        excluded_versions = set()
-
-    if version.prerelease is not None and len(version.prerelease) > 0:
-        # simply drop the prerelease, do not try to find a decremented version
-        found_version = MzVersion.create(version.major, version.minor, version.patch)
-
-        if found_version not in excluded_versions:
-            return found_version
-        else:
-            # start searching with this version
-            version = found_version
-
-    all_versions: list[VERSION_TYPE] = get_version_tags(version_type=type(version))
-    all_suitable_previous_versions = [
-        v
-        for v in all_versions
-        if v < version
-        and (v.prerelease is None or len(v.prerelease) == 0)
-        and (not isinstance(version, MzVersion) or v not in INVALID_VERSIONS)
-        and v not in excluded_versions
-    ]
-    return max(all_suitable_previous_versions)
 
 
 # Work tree mutation

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -89,7 +89,7 @@ def expand_globs(root: Path, *specs: Path | str) -> set[str]:
 
 
 def get_version_tags(
-    *, version_type: type[VERSION_TYPE], fetch: bool = True
+    *, version_type: type[VERSION_TYPE], newest_first: bool = True, fetch: bool = True
 ) -> list[VERSION_TYPE]:
     """List all the version-like tags in the repo
 
@@ -111,7 +111,7 @@ def get_version_tags(
         except ValueError as e:
             print(f"WARN: {e}", file=sys.stderr)
 
-    return sorted(tags, reverse=True)
+    return sorted(tags, reverse=newest_first)
 
 
 def get_latest_version(

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -237,7 +237,7 @@ def get_published_minor_mz_versions(
             break
 
     assert len(minor_versions) > 0
-    return sorted(minor_versions.values())
+    return sorted(minor_versions.values(), reverse=True)
 
 
 def get_all_mz_versions() -> list[MzVersion]:

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -213,17 +213,7 @@ def get_previous_published_version(release_version: MzVersion) -> MzVersion:
 
 
 def get_published_minor_mz_versions(limit: int | None = None) -> list[MzVersion]:
-    minor_mz_versions = get_all_minor_mz_versions()
-    versions = []
-
-    for v in minor_mz_versions:
-        if image_of_release_version_exists(v):
-            versions.append(v)
-
-        if limit is not None and len(versions) == limit:
-            break
-
-    return versions
+    return limit_to_published_versions(get_all_minor_mz_versions(), limit)
 
 
 def get_all_mz_versions() -> list[MzVersion]:
@@ -232,6 +222,25 @@ def get_all_mz_versions() -> list[MzVersion]:
         for version in get_version_tags(version_type=MzVersion)
         if version not in INVALID_VERSIONS
     ]
+
+
+def get_all_published_mz_versions(limit: int | None = None) -> list[MzVersion]:
+    return limit_to_published_versions(get_all_mz_versions(), limit)
+
+
+def limit_to_published_versions(
+    all_versions: list[MzVersion], limit: int | None = None
+) -> list[MzVersion]:
+    versions = []
+
+    for v in all_versions:
+        if image_of_release_version_exists(v):
+            versions.append(v)
+
+        if limit is not None and len(versions) == limit:
+            break
+
+    return versions
 
 
 def get_all_minor_mz_versions() -> list[MzVersion]:

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -215,12 +215,14 @@ def get_previous_published_version(release_version: MzVersion) -> MzVersion:
 
 
 def get_published_minor_mz_versions(
-    limit: int | None = None, include_filter: Callable[[MzVersion], bool] | None = None
+    newest_first: bool = True,
+    limit: int | None = None,
+    include_filter: Callable[[MzVersion], bool] | None = None,
 ) -> list[MzVersion]:
-    """Get the latest patch version for every minor version in descending order."""
+    """Get the latest patch version for every minor version."""
 
     # sorted in descending order
-    all_versions = get_all_mz_versions()
+    all_versions = get_all_mz_versions(newest_first=True)
     minor_versions: dict[str, MzVersion] = {}
 
     # Note that this method must not apply limit_to_published_versions to a created list
@@ -246,21 +248,29 @@ def get_published_minor_mz_versions(
             break
 
     assert len(minor_versions) > 0
-    return sorted(minor_versions.values(), reverse=True)
+    return sorted(minor_versions.values(), reverse=newest_first)
 
 
-def get_all_mz_versions() -> list[MzVersion]:
-    """Get all mz versions based on git tags in descending order. Versions known to be invalid are excluded."""
+def get_all_mz_versions(
+    newest_first: bool = True,
+) -> list[MzVersion]:
+    """Get all mz versions based on git tags. Versions known to be invalid are excluded."""
     return [
         version
-        for version in get_version_tags(version_type=MzVersion)
+        for version in get_version_tags(
+            version_type=MzVersion, newest_first=newest_first
+        )
         if version not in INVALID_VERSIONS
     ]
 
 
-def get_all_published_mz_versions(limit: int | None = None) -> list[MzVersion]:
-    """Get all mz versions based on git tags in descending order. This method ensures that images of the versions exist."""
-    return limit_to_published_versions(get_all_mz_versions(), limit)
+def get_all_published_mz_versions(
+    newest_first: bool = True, limit: int | None = None
+) -> list[MzVersion]:
+    """Get all mz versions based on git tags. This method ensures that images of the versions exist."""
+    return limit_to_published_versions(
+        get_all_mz_versions(newest_first=newest_first), limit
+    )
 
 
 def limit_to_published_versions(

--- a/misc/python/materialize/version_list.py
+++ b/misc/python/materialize/version_list.py
@@ -36,6 +36,30 @@ INVALID_VERSIONS = {
 }
 
 
+def get_all_mz_versions() -> list[MzVersion]:
+    return [
+        version
+        for version in get_version_tags(version_type=MzVersion)
+        if version not in INVALID_VERSIONS
+    ]
+
+
+def get_all_minor_mz_versions() -> list[MzVersion]:
+    """Return the latest patch version for every minor version."""
+
+    # sorted in descending order
+    all_versions = get_all_mz_versions()
+    minor_versions: dict[str, MzVersion] = {}
+
+    for version in all_versions:
+        minor_version = f"{version.major}.{version.minor}"
+        if minor_version not in minor_versions.keys():
+            minor_versions[minor_version] = version
+
+    assert len(minor_versions) > 0
+    return sorted(minor_versions.values())
+
+
 def get_previous_mz_version(
     version: MzVersion, excluded_versions: set[MzVersion] | None = None
 ) -> MzVersion:

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -21,9 +21,9 @@ from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.wait import wait
-from materialize.docker import get_latest_published_version
 from materialize.mz_version import MzVersion
 from materialize.util import all_subclasses
+from materialize.version_list import get_latest_published_version
 
 LOGGER = logging.getLogger(__name__)
 

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -14,6 +14,7 @@ import pytest
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Validate
 from materialize.checks.all_checks import *  # noqa: F401 F403
+from materialize.checks.all_checks.kafka_protocols import KafkaProtocols
 from materialize.checks.all_checks.ssh import SshKafka, SshPg
 from materialize.checks.checks import Check
 from materialize.checks.cloudtest_actions import ReplaceEnvironmentdStatefulSet
@@ -66,7 +67,8 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
     )
 
     executor = CloudtestExecutor(application=mz, version=last_released_version)
-    # No SSH bastion host in cloudtest (yet)
-    checks = list(all_subclasses(Check) - {SshPg, SshKafka})
+    # SshPg, SshKafka: No SSH bastion host
+    # KafkaProtocols: No shared secrets directory
+    checks = list(all_subclasses(Check) - {SshPg, SshKafka, KafkaProtocols})
     scenario = CloudtestUpgrade(checks=checks, executor=executor)
     scenario.run()

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -27,14 +27,12 @@ from materialize.version_list import get_latest_published_version
 
 LOGGER = logging.getLogger(__name__)
 
-LAST_RELEASED_VERSION = get_latest_published_version()
-
 
 class CloudtestUpgrade(Scenario):
     """A Platform Checks scenario that performs an upgrade in cloudtest/K8s"""
 
     def base_version(self) -> MzVersion:
-        return LAST_RELEASED_VERSION
+        return get_latest_published_version()
 
     def actions(self) -> list[Action]:
         return [
@@ -49,12 +47,14 @@ class CloudtestUpgrade(Scenario):
 @pytest.mark.long
 def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> None:
     """Test upgrade from the last released verison to the current source by running all the Platform Checks"""
+    last_released_version = get_latest_published_version()
+
     LOGGER.info(
-        f"Testing upgrade from base version {LAST_RELEASED_VERSION} to current version"
+        f"Testing upgrade from base version {last_released_version} to current version"
     )
 
     mz = MaterializeApplication(
-        tag=str(LAST_RELEASED_VERSION),
+        tag=str(last_released_version),
         aws_region=aws_region,
         log_filter=log_filter,
         release_mode=(not dev),
@@ -65,7 +65,7 @@ def test_upgrade(aws_region: str | None, log_filter: str | None, dev: bool) -> N
         label="cluster.environmentd.materialize.cloud/cluster-id=u1",
     )
 
-    executor = CloudtestExecutor(application=mz, version=LAST_RELEASED_VERSION)
+    executor = CloudtestExecutor(application=mz, version=last_released_version)
     # No SSH bastion host in cloudtest (yet)
     checks = list(all_subclasses(Check) - {SshPg, SshKafka})
     scenario = CloudtestUpgrade(checks=checks, executor=executor)

--- a/test/cloudtest/test_upgrade.py
+++ b/test/cloudtest/test_upgrade.py
@@ -21,13 +21,13 @@ from materialize.checks.executors import CloudtestExecutor
 from materialize.checks.scenarios import Scenario
 from materialize.cloudtest.app.materialize_application import MaterializeApplication
 from materialize.cloudtest.util.wait import wait
+from materialize.docker import get_latest_published_version
 from materialize.mz_version import MzVersion
 from materialize.util import all_subclasses
-from materialize.version_list import VersionsFromDocs
 
 LOGGER = logging.getLogger(__name__)
 
-LAST_RELEASED_VERSION = VersionsFromDocs().minor_versions()[-1]
+LAST_RELEASED_VERSION = get_latest_published_version()
 
 
 class CloudtestUpgrade(Scenario):

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -15,6 +15,7 @@ import uuid
 from textwrap import dedent
 
 from materialize import docker
+from materialize.docker import get_latest_published_version
 
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
@@ -56,7 +57,6 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
 from materialize.util import all_subclasses
-from materialize.version_list import VersionsFromDocs
 
 #
 # Global feature benchmark thresholds and termination conditions
@@ -270,7 +270,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         "--other-tag",
         metavar="TAG",
         type=str,
-        default=os.getenv("OTHER_TAG", str(VersionsFromDocs().all_versions()[-1])),
+        default=os.getenv("OTHER_TAG", str(get_latest_published_version())),
         help="'Other' Materialize container tag to benchmark. If not provided, the last released Mz version will be used.",
     )
 

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -14,8 +14,10 @@ import time
 import uuid
 from textwrap import dedent
 
-from materialize import docker
-from materialize.docker import get_latest_published_version
+from materialize.version_list import (
+    get_latest_published_version,
+    resolve_ancestor_image_tag,
+)
 
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
@@ -132,7 +134,7 @@ def run_one_scenario(
         )
 
         if tag == "common-ancestor":
-            tag = docker.resolve_ancestor_image_tag()
+            tag = resolve_ancestor_image_tag()
 
         entrypoint_host = "balancerd" if balancerd else "materialized"
 

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -23,10 +23,12 @@ from materialize.mzcompose.services.schema_registry import SchemaRegistry
 from materialize.mzcompose.services.test_certs import TestCerts
 from materialize.mzcompose.services.testdrive import Testdrive
 from materialize.mzcompose.services.zookeeper import Zookeeper
-from materialize.version_list import VersionsFromDocs
+from materialize.version_list import (
+    get_all_published_mz_versions,
+    get_published_minor_mz_versions,
+)
 
-version_list = VersionsFromDocs()
-all_versions = version_list.all_versions()
+all_versions = get_all_published_mz_versions()
 
 mz_options: dict[MzVersion, str] = {}
 
@@ -69,11 +71,11 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     )
     args = parser.parse_args()
 
-    tested_versions = version_list.minor_versions()[-2:]
+    tested_versions = get_published_minor_mz_versions(limit=2)
 
-    for version in tested_versions:
-        priors = [v for v in all_versions if v <= version]
-        test_upgrade_from_version(c, f"{version}", priors, filter=args.filter)
+    for tested_version in tested_versions:
+        priors = [v for v in all_versions if v <= tested_version]
+        test_upgrade_from_version(c, f"{tested_version}", priors, filter=args.filter)
 
     test_upgrade_from_version(c, "current_source", priors=[], filter=args.filter)
 

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -28,8 +28,6 @@ from materialize.version_list import (
     get_published_minor_mz_versions,
 )
 
-all_versions = get_all_published_mz_versions()
-
 mz_options: dict[MzVersion, str] = {}
 
 SERVICES = [
@@ -72,6 +70,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     tested_versions = get_published_minor_mz_versions(limit=2)
+    all_versions = get_all_published_mz_versions()
 
     for tested_version in tested_versions:
         priors = [v for v in all_versions if v <= tested_version]

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -70,10 +70,10 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     args = parser.parse_args()
 
     tested_versions = get_published_minor_mz_versions(limit=2)
-    all_versions = get_all_published_mz_versions()
+    all_versions_ascending = get_all_published_mz_versions(newest_first=False)
 
     for tested_version in tested_versions:
-        priors = [v for v in all_versions if v <= tested_version]
+        priors = [v for v in all_versions_ascending if v <= tested_version]
         test_upgrade_from_version(c, f"{tested_version}", priors, filter=args.filter)
 
     test_upgrade_from_version(c, "current_source", priors=[], filter=args.filter)

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -15,7 +15,7 @@ import pandas as pd
 from jupyter_core.command import main as jupyter_core_command_main
 from matplotlib import pyplot as plt
 
-from materialize import buildkite, docker, git
+from materialize import buildkite, git
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.materialized import Materialized
 from materialize.mzcompose.services.postgres import Postgres
@@ -45,6 +45,7 @@ from materialize.scalability.workload import Workload, WorkloadSelfTest
 from materialize.scalability.workloads import *  # noqa: F401 F403
 from materialize.scalability.workloads_test import *  # noqa: F401 F403
 from materialize.util import YesNoOnce, all_subclasses
+from materialize.version_list import resolve_ancestor_image_tag
 
 SERVICES = [
     Materialized(
@@ -251,7 +252,7 @@ def get_baseline_and_other_endpoints(
             )
         else:
             if target == "common-ancestor":
-                target = docker.resolve_ancestor_image_tag()
+                target = resolve_ancestor_image_tag()
             endpoint = MaterializeContainer(
                 composition=c,
                 specified_target=original_target,

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -148,6 +148,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     versions = get_published_minor_mz_versions(
         include_filter=lambda v: v >= args.min_version
     )
+    # sort versions in ascending order
+    versions.sort(reverse=False)
     print(
         "--- Testing upgrade scenarios involving the following versions: "
         + " ".join([str(v) for v in versions])

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -145,19 +145,18 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     executor = MzcomposeExecutor(composition=c)
 
-    versions = get_published_minor_mz_versions(
-        include_filter=lambda v: v >= args.min_version
+    versions_in_ascending_order = get_published_minor_mz_versions(
+        newest_first=False, include_filter=lambda v: v >= args.min_version
     )
-    # sort versions in ascending order
-    versions.sort(reverse=False)
+
     print(
         "--- Testing upgrade scenarios involving the following versions: "
-        + " ".join([str(v) for v in versions])
+        + " ".join([str(v) for v in versions_in_ascending_order])
     )
 
     for id, upgrade_scenario in enumerate(
         get_upgrade_scenarios(
-            versions=versions,
+            versions=versions_in_ascending_order,
             num_scenarios=args.num_scenarios,
         )
     ):

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -16,6 +16,9 @@ from collections.abc import Generator
 import networkx as nx
 
 from materialize.util import all_subclasses
+from materialize.version_list import (
+    get_published_minor_mz_versions,
+)
 
 # mzcompose may start this script from the root of the Mz repository,
 # so we need to explicitly add this directory to the Python module search path
@@ -49,7 +52,6 @@ from materialize.mzcompose.services.postgres import Postgres
 from materialize.mzcompose.services.redpanda import Redpanda
 from materialize.mzcompose.services.ssh_bastion_host import SshBastionHost
 from materialize.mzcompose.services.testdrive import Testdrive as TestdriveService
-from materialize.version_list import VersionsFromDocs
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -143,8 +145,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     executor = MzcomposeExecutor(composition=c)
 
-    versions = list(
-        [v for v in VersionsFromDocs().minor_versions() if v >= args.min_version]
+    versions = get_published_minor_mz_versions(
+        include_filter=lambda v: v >= args.min_version
     )
     print(
         "--- Testing upgrade scenarios involving the following versions: "

--- a/test/version-consistency/mzcompose.py
+++ b/test/version-consistency/mzcompose.py
@@ -8,7 +8,6 @@
 # by the Apache License, Version 2.0.
 from random import Random
 
-from materialize import docker
 from materialize.mzcompose.composition import Composition, WorkflowArgumentParser
 from materialize.mzcompose.services.cockroach import Cockroach
 from materialize.mzcompose.services.materialized import Materialized
@@ -17,6 +16,7 @@ from materialize.version_consistency.version_consistency_test import (
     EVALUATION_STRATEGY_NAMES,
     VersionConsistencyTest,
 )
+from materialize.version_list import resolve_ancestor_image_tag
 
 SERVICES = [
     Cockroach(setup_materialize=True),
@@ -53,7 +53,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     name_mz_this, name_mz_other = "mz_this", "mz_other"
     port_mz_internal, port_mz_this, port_mz_other = 6875, 6875, 16875
-    tag_mz_other = docker.resolve_ancestor_image_tag()
+    tag_mz_other = resolve_ancestor_image_tag()
 
     print(f"Using {tag_mz_other} as tag for other mz version")
 


### PR DESCRIPTION
This PR streamlines the provider for used versions and predecessor versions. In particular, it removes / replaces `VersionsFromGit` and `VersionsFromDocs`. It is a follow-up to https://github.com/MaterializeInc/materialize/pull/23145.

### Status
Ready for review now. Result of nightly is good.

### Important notes
* The order of versions provided by some utility methods changed to newest-first, e.g., `get_published_minor_mz_versions()` returns the latest version as first element.
* There is a check / filter that makes sure that the docker image of recent versions exist. This is done by pulling the image. As performance optimization, this is not done for versions older than a certain specified version.

### Commits
Commit-wise review might be easier due to some moved code.

### Nightly builds
https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Aci%2Fversion-resolution