### PR TITLE
catalog: Add metrics to persist catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "once_cell",
  "paste",
  "postgres-openssl",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "prost",

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -530,10 +530,9 @@ impl Catalog {
         environment_id: EnvironmentId,
     ) -> Result<Catalog, anyhow::Error> {
         let openable_storage = Box::new(
-            mz_catalog::durable::persist_backed_catalog_state(
+            mz_catalog::durable::test_persist_backed_catalog_state(
                 persist_client,
                 environment_id.organization_id(),
-                &MetricsRegistry::new(),
             )
             .await,
         );

--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -533,6 +533,7 @@ impl Catalog {
             mz_catalog::durable::persist_backed_catalog_state(
                 persist_client,
                 environment_id.organization_id(),
+                &MetricsRegistry::new(),
             )
             .await,
         );

--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -242,7 +242,10 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             };
             let persist_client = persist_clients.open(persist_location).await?;
             let organization_id = args.organization_id.expect("required for persist");
-            Box::new(persist_backed_catalog_state(persist_client, organization_id).await)
+            Box::new(
+                persist_backed_catalog_state(persist_client, organization_id, &metrics_registry)
+                    .await,
+            )
         }
     };
 

--- a/src/catalog/Cargo.toml
+++ b/src/catalog/Cargo.toml
@@ -37,6 +37,7 @@ mz-stash-types = { path = "../stash-types" }
 mz-storage-client = { path = "../storage-client" }
 mz-storage-types = { path = "../storage-types" }
 paste = "1.0.11"
+prometheus = { version = "0.13.3", default-features = false }
 proptest = { version = "1.0.0", default-features = false, features = ["std"] }
 proptest-derive = { version = "0.3.0", features = ["boxed_union"] }
 prost = { version = "0.11.9" }

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -277,6 +277,15 @@ pub async fn persist_backed_catalog_state(
     PersistHandle::new(persist_client, organization_id, registry).await
 }
 
+/// Creates an openable durable catalog state implemented using persist that is meant to be used in
+/// tests.
+pub async fn test_persist_backed_catalog_state(
+    persist_client: PersistClient,
+    organization_id: Uuid,
+) -> PersistHandle {
+    persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new()).await
+}
+
 /// Creates an openable durable catalog state implemented using both the stash and persist, that
 /// compares the results. The stash results is used as the source of truth when there's a
 /// discrepancy.
@@ -286,10 +295,9 @@ pub async fn shadow_catalog_state(
     organization_id: Uuid,
 ) -> impl OpenableDurableCatalogState {
     let stash = Box::new(stash_backed_catalog_state(stash_config));
-    let persist = Box::new(
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await,
-    );
+    // Shadow catalog is only used for tests, so it's OK to get a test persist catalog state.
+    let persist =
+        Box::new(test_persist_backed_catalog_state(persist_client, organization_id).await);
     OpenableShadowCatalogState { stash, persist }
 }
 

--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -41,6 +41,7 @@ use crate::durable::transaction::TransactionBatch;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::collections::CollectionExt;
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::EpochMillis;
 use mz_persist_client::PersistClient;
 use mz_repr::GlobalId;
@@ -271,8 +272,9 @@ pub fn test_stash_backed_catalog_state(
 pub async fn persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,
+    registry: &MetricsRegistry,
 ) -> PersistHandle {
-    PersistHandle::new(persist_client, organization_id).await
+    PersistHandle::new(persist_client, organization_id, registry).await
 }
 
 /// Creates an openable durable catalog state implemented using both the stash and persist, that
@@ -284,7 +286,10 @@ pub async fn shadow_catalog_state(
     organization_id: Uuid,
 ) -> impl OpenableDurableCatalogState {
     let stash = Box::new(stash_backed_catalog_state(stash_config));
-    let persist = Box::new(persist_backed_catalog_state(persist_client, organization_id).await);
+    let persist = Box::new(
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await,
+    );
     OpenableShadowCatalogState { stash, persist }
 }
 

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -575,6 +575,7 @@ impl PersistCatalogState {
     }
 
     /// Listen and apply all updates up to `target_upper`.
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sync(&mut self, target_upper: Timestamp) -> Result<(), CatalogError> {
         self.metrics.syncs.inc();
         let counter = self.metrics.sync_latency_duration_seconds.clone();
@@ -584,8 +585,7 @@ impl PersistCatalogState {
             .await
     }
 
-    /// Listen and apply all updates up to `target_upper`.
-    #[tracing::instrument(level = "debug", skip_all)]
+    #[tracing::instrument(level = "debug", skip(self))]
     async fn sync_inner(&mut self, target_upper: Timestamp) -> Result<(), CatalogError> {
         let mut updates = Vec::new();
 
@@ -1088,7 +1088,7 @@ async fn compare_and_append(
 /// state up to, and including, `as_of`.
 ///
 /// The output is consolidated and sorted by timestamp in ascending order.
-#[tracing::instrument(level = "debug", skip(read_handle))]
+#[tracing::instrument(level = "debug", skip(read_handle, metrics))]
 async fn snapshot(
     read_handle: &mut ReadHandle<StateUpdateKind, (), Timestamp, Diff>,
     as_of: Timestamp,
@@ -1102,6 +1102,7 @@ async fn snapshot(
         .await
 }
 
+#[tracing::instrument(level = "debug", skip(read_handle))]
 async fn snapshot_inner(
     read_handle: &mut ReadHandle<StateUpdateKind, (), Timestamp, Diff>,
     as_of: Timestamp,

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -12,15 +12,18 @@
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
 use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::{Histogram, IntCounterVec};
+use prometheus::{Counter, Histogram, IntCounterVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
     pub transactions: IntCounter,
     pub transaction_commit_errors: IntCounterVec,
-    pub transaction_commit_latency_duration_seconds: Histogram,
-    pub snapshot_latency_duration_seconds: Histogram,
-    pub sync_latency_duration_seconds: Histogram,
+    pub transaction_commit_latency_duration_seconds: Counter,
+    pub transactions_committed: IntCounter,
+    pub snapshot_latency_duration_seconds: Counter,
+    pub snapshots_taken: IntCounter,
+    pub sync_latency_duration_seconds: Counter,
+    pub syncs: IntCounter,
 }
 
 impl Metrics {
@@ -39,17 +42,26 @@ impl Metrics {
             transaction_commit_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_transaction_latency",
                 help: "Latency for durable catalog transactions.",
-                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+            transactions_committed: registry.register(metric!(
+                name: "catalog_transactions_committed",
+                help: "Count of transactions committed.",
             )),
             snapshot_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_snapshot_latency",
                 help: "Latency for fetching a snapshot of the durable catalog.",
-                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+            snapshots_taken: registry.register(metric!(
+                name: "catalog_snapshots_taken",
+                help: "Count of snapshots taken.",
             )),
             sync_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_sync_latency",
                 help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents.",
-                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+            syncs: registry.register(metric!(
+                name: "catalog_syncs",
+                help: "Count of catalog syncs.",
             )),
         }
     }

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -1,0 +1,49 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Prometheus monitoring metrics.
+
+use mz_ore::metric;
+use mz_ore::metrics::{IntCounter, MetricsRegistry};
+use mz_ore::stats::histogram_seconds_buckets;
+use prometheus::{Histogram, IntCounterVec};
+
+#[derive(Debug, Clone)]
+pub struct Metrics {
+    pub transactions: IntCounter,
+    pub transaction_commit_errors: IntCounterVec,
+    pub transaction_commit_latency_duration_seconds: Histogram,
+    pub snapshot_latency_duration_seconds: Histogram,
+    pub sync_latency_duration_seconds: Histogram,
+}
+
+impl Metrics {
+    /// Returns a new [Metrics] instance connected to the given registry.
+    pub fn new(registry: &MetricsRegistry) -> Self {
+        Self {
+            transactions: registry.register(metric!(name: "catalog_transactions", help: "Total number of started transactions.")),
+            transaction_commit_errors: registry.register(metric!(name: "catalog_transaction_errors", help: "Total number of transaction errors.", var_labels: ["cause"],)),
+            transaction_commit_latency_duration_seconds: registry.register(metric!(
+                name: "catalog_transaction_latency",
+                help: "Latency for durable catalog transactions",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+            snapshot_latency_duration_seconds: registry.register(metric!(
+                name: "catalog_snapshot_latency",
+                help: "Latency for fetching a snapshot of the durable catalog",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+            sync_latency_duration_seconds: registry.register(metric!(
+                name: "catalog_sync_latency",
+                help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents",
+                buckets: histogram_seconds_buckets(0.000_128, 32.0),
+            )),
+        }
+    }
+}

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -55,7 +55,7 @@ impl Metrics {
                 help: "Count of snapshots taken.",
             )),
             sync_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_sync_latency",
+                name: "catalog_sync_latency_seconds",
                 help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents.",
             )),
             syncs: registry.register(metric!(

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -39,7 +39,7 @@ impl Metrics {
                 var_labels: ["cause"],
             )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_transaction_latency",
+                name: "catalog_transaction_latency_seconds",
                 help: "Latency for durable catalog transactions.",
             )),
             transactions_committed: registry.register(metric!(

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -11,8 +11,7 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
-use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::{Counter, Histogram, IntCounterVec};
+use prometheus::{Counter, IntCounterVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -40,7 +40,7 @@ impl Metrics {
             )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_transaction_latency_seconds",
-                help: "Latency for durable catalog transactions.",
+                help: "Total latency for durable catalog transactions.",
             )),
             transactions_committed: registry.register(metric!(
                 name: "catalog_transactions_committed",
@@ -48,7 +48,7 @@ impl Metrics {
             )),
             snapshot_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_snapshot_latency_seconds",
-                help: "Latency for fetching a snapshot of the durable catalog.",
+                help: "Total latency for fetching a snapshot of the durable catalog.",
             )),
             snapshots_taken: registry.register(metric!(
                 name: "catalog_snapshots_taken",
@@ -56,7 +56,7 @@ impl Metrics {
             )),
             sync_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_sync_latency_seconds",
-                help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents.",
+                help: "Total latency for syncing the in-memory state of the durable catalog with the persisted contents.",
             )),
             syncs: registry.register(metric!(
                 name: "catalog_syncs",

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -30,12 +30,12 @@ impl Metrics {
     pub fn new(registry: &MetricsRegistry) -> Self {
         Self {
             transactions: registry.register(metric!(
-                name: "catalog_transactions", 
+                name: "catalog_transactions",
                 help: "Total number of started transactions.",
             )),
             transaction_commit_errors: registry.register(metric!(
-                name: "catalog_transaction_errors", 
-                help: "Total number of transaction errors.", 
+                name: "catalog_transaction_errors",
+                help: "Total number of transaction errors.",
                 var_labels: ["cause"],
             )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -47,7 +47,7 @@ impl Metrics {
                 help: "Count of transactions committed.",
             )),
             snapshot_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_snapshot_latency",
+                name: "catalog_snapshot_latency_seconds",
                 help: "Latency for fetching a snapshot of the durable catalog.",
             )),
             snapshots_taken: registry.register(metric!(

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -27,21 +27,28 @@ impl Metrics {
     /// Returns a new [Metrics] instance connected to the given registry.
     pub fn new(registry: &MetricsRegistry) -> Self {
         Self {
-            transactions: registry.register(metric!(name: "catalog_transactions", help: "Total number of started transactions.")),
-            transaction_commit_errors: registry.register(metric!(name: "catalog_transaction_errors", help: "Total number of transaction errors.", var_labels: ["cause"],)),
+            transactions: registry.register(metric!(
+                name: "catalog_transactions", 
+                help: "Total number of started transactions.",
+            )),
+            transaction_commit_errors: registry.register(metric!(
+                name: "catalog_transaction_errors", 
+                help: "Total number of transaction errors.", 
+                var_labels: ["cause"],
+            )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_transaction_latency",
-                help: "Latency for durable catalog transactions",
+                help: "Latency for durable catalog transactions.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             snapshot_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_snapshot_latency",
-                help: "Latency for fetching a snapshot of the durable catalog",
+                help: "Latency for fetching a snapshot of the durable catalog.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
             sync_latency_duration_seconds: registry.register(metric!(
                 name: "catalog_sync_latency",
-                help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents",
+                help: "Latency for syncing the in-memory state of the durable catalog with the persisted contents.",
                 buckets: histogram_seconds_buckets(0.000_128, 32.0),
             )),
         }

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -82,6 +82,7 @@ use mz_catalog::durable::{
     CatalogError, DurableCatalogError, OpenableDurableCatalogState,
 };
 use mz_ore::collections::CollectionExt;
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NOW_ZERO;
 use mz_persist_client::PersistClient;
 use mz_stash::DebugStashFactory;
@@ -109,12 +110,24 @@ async fn test_stash_debug() {
 async fn test_persist_debug() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state2 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state3 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
 
     test_debug(
         "persist",

--- a/src/catalog/tests/debug.rs
+++ b/src/catalog/tests/debug.rs
@@ -78,11 +78,10 @@
 use mz_catalog::durable::debug::SettingCollection;
 use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::{
-    persist_backed_catalog_state, test_bootstrap_args, test_stash_backed_catalog_state,
+    test_bootstrap_args, test_persist_backed_catalog_state, test_stash_backed_catalog_state,
     CatalogError, DurableCatalogError, OpenableDurableCatalogState,
 };
 use mz_ore::collections::CollectionExt;
-use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::NOW_ZERO;
 use mz_persist_client::PersistClient;
 use mz_stash::DebugStashFactory;
@@ -110,24 +109,12 @@ async fn test_stash_debug() {
 async fn test_persist_debug() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state2 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state3 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state2 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state3 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
 
     test_debug(
         "persist",

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -81,6 +81,7 @@ use mz_catalog::durable::{
     test_bootstrap_args, test_stash_backed_catalog_state, CatalogError, Epoch,
     OpenableDurableCatalogState, StashConfig,
 };
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
 use mz_persist_client::PersistClient;
 use mz_proto::RustType;
@@ -114,10 +115,15 @@ async fn test_debug_stash_is_initialized() {
 async fn test_persist_is_initialized() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client, organization_id).await;
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_is_initialized(persist_openable_state1, persist_openable_state2).await;
 }
 
@@ -172,10 +178,15 @@ async fn test_debug_stash_get_deployment_generation() {
 async fn test_persist_get_deployment_generation() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client, organization_id).await;
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_get_deployment_generation(persist_openable_state1, persist_openable_state2).await;
 }
 
@@ -249,14 +260,27 @@ async fn test_debug_stash_open_savepoint() {
 async fn test_persist_open_savepoint() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state2 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state3 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     let persist_openable_state4 =
-        persist_backed_catalog_state(persist_client, organization_id).await;
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_open_savepoint(
         persist_openable_state1,
         persist_openable_state2,
@@ -370,12 +394,21 @@ async fn test_debug_stash_open_read_only() {
 async fn test_persist_open_read_only() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state2 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client, organization_id).await;
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_open_read_only(
         persist_openable_state1,
         persist_openable_state2,
@@ -511,12 +544,21 @@ async fn test_debug_stash_open() {
 async fn test_persist_open() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let persist_openable_state2 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client, organization_id).await;
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_open(
         persist_openable_state1,
         persist_openable_state2,

--- a/src/catalog/tests/open.rs
+++ b/src/catalog/tests/open.rs
@@ -77,11 +77,10 @@
 
 use mz_catalog::durable::objects::serialization::proto;
 use mz_catalog::durable::{
-    persist_backed_catalog_state, shadow_catalog_state, stash_backed_catalog_state,
-    test_bootstrap_args, test_stash_backed_catalog_state, CatalogError, Epoch,
+    shadow_catalog_state, stash_backed_catalog_state, test_bootstrap_args,
+    test_persist_backed_catalog_state, test_stash_backed_catalog_state, CatalogError, Epoch,
     OpenableDurableCatalogState, StashConfig,
 };
-use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{NOW_ZERO, SYSTEM_TIME};
 use mz_persist_client::PersistClient;
 use mz_proto::RustType;
@@ -115,15 +114,10 @@ async fn test_debug_stash_is_initialized() {
 async fn test_persist_is_initialized() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+        test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_is_initialized(persist_openable_state1, persist_openable_state2).await;
 }
 
@@ -178,15 +172,10 @@ async fn test_debug_stash_get_deployment_generation() {
 async fn test_persist_get_deployment_generation() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state2 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+        test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_get_deployment_generation(persist_openable_state1, persist_openable_state2).await;
 }
 
@@ -260,27 +249,14 @@ async fn test_debug_stash_open_savepoint() {
 async fn test_persist_open_savepoint() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state2 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state3 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state2 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state3 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state4 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+        test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_open_savepoint(
         persist_openable_state1,
         persist_openable_state2,
@@ -394,21 +370,12 @@ async fn test_debug_stash_open_read_only() {
 async fn test_persist_open_read_only() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state2 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state2 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+        test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_open_read_only(
         persist_openable_state1,
         persist_openable_state2,
@@ -544,21 +511,12 @@ async fn test_debug_stash_open() {
 async fn test_persist_open() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let persist_openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let persist_openable_state2 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let persist_openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let persist_openable_state2 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     let persist_openable_state3 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+        test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_open(
         persist_openable_state1,
         persist_openable_state2,

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -82,12 +82,11 @@ use mz_audit_log::{
 };
 use mz_catalog::durable::objects::{DurableType, IdAlloc};
 use mz_catalog::durable::{
-    persist_backed_catalog_state, test_bootstrap_args, test_stash_backed_catalog_state,
+    test_bootstrap_args, test_persist_backed_catalog_state, test_stash_backed_catalog_state,
     CatalogError, DurableCatalogError, Item, OpenableDurableCatalogState, TimelineTimestamp,
     USER_ITEM_ALLOC_KEY,
 };
 use mz_ore::collections::CollectionExt;
-use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::PersistClient;
 use mz_proto::RustType;
@@ -114,15 +113,9 @@ async fn test_stash_confirm_leadership() {
 async fn test_persist_confirm_leadership() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state1 = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
-    let openable_state2 =
-        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
-            .await;
+    let openable_state1 =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state2 = test_persist_backed_catalog_state(persist_client, organization_id).await;
     test_confirm_leadership(openable_state1, openable_state2).await;
 }
 
@@ -175,12 +168,8 @@ async fn test_stash_get_and_prune_storage_usage() {
 async fn test_persist_get_and_prune_storage_usage() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     test_get_and_prune_storage_usage(openable_state).await;
 }
 
@@ -241,12 +230,8 @@ async fn test_stash_timestamps() {
 async fn test_persist_timestamps() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     test_timestamps(openable_state).await;
 }
 
@@ -295,12 +280,8 @@ async fn test_stash_allocate_id() {
 async fn test_persist_allocate_id() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     test_allocate_id(openable_state).await;
 }
 
@@ -346,12 +327,8 @@ async fn test_stash_audit_logs() {
 async fn test_persist_audit_logs() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     test_audit_logs(openable_state).await;
 }
 
@@ -418,12 +395,8 @@ async fn test_stash_items() {
 async fn test_persist_items() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state = persist_backed_catalog_state(
-        persist_client.clone(),
-        organization_id,
-        &MetricsRegistry::new(),
-    )
-    .await;
+    let openable_state =
+        test_persist_backed_catalog_state(persist_client.clone(), organization_id).await;
     test_items(openable_state).await;
 }
 

--- a/src/catalog/tests/read-write.rs
+++ b/src/catalog/tests/read-write.rs
@@ -87,6 +87,7 @@ use mz_catalog::durable::{
     USER_ITEM_ALLOC_KEY,
 };
 use mz_ore::collections::CollectionExt;
+use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::SYSTEM_TIME;
 use mz_persist_client::PersistClient;
 use mz_proto::RustType;
@@ -113,9 +114,15 @@ async fn test_stash_confirm_leadership() {
 async fn test_persist_confirm_leadership() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state1 =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
-    let openable_state2 = persist_backed_catalog_state(persist_client, organization_id).await;
+    let openable_state1 = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
+    let openable_state2 =
+        persist_backed_catalog_state(persist_client, organization_id, &MetricsRegistry::new())
+            .await;
     test_confirm_leadership(openable_state1, openable_state2).await;
 }
 
@@ -168,8 +175,12 @@ async fn test_stash_get_and_prune_storage_usage() {
 async fn test_persist_get_and_prune_storage_usage() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     test_get_and_prune_storage_usage(openable_state).await;
 }
 
@@ -230,8 +241,12 @@ async fn test_stash_timestamps() {
 async fn test_persist_timestamps() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     test_timestamps(openable_state).await;
 }
 
@@ -280,8 +295,12 @@ async fn test_stash_allocate_id() {
 async fn test_persist_allocate_id() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     test_allocate_id(openable_state).await;
 }
 
@@ -327,8 +346,12 @@ async fn test_stash_audit_logs() {
 async fn test_persist_audit_logs() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     test_audit_logs(openable_state).await;
 }
 
@@ -395,8 +418,12 @@ async fn test_stash_items() {
 async fn test_persist_items() {
     let persist_client = PersistClient::new_for_tests().await;
     let organization_id = Uuid::new_v4();
-    let openable_state =
-        persist_backed_catalog_state(persist_client.clone(), organization_id).await;
+    let openable_state = persist_backed_catalog_state(
+        persist_client.clone(),
+        organization_id,
+        &MetricsRegistry::new(),
+    )
+    .await;
     test_items(openable_state).await;
 }
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -944,7 +944,10 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             CatalogKind::Stash => CatalogConfig::Stash {
                 url: args.adapter_stash_url.expect("required for stash catalog"),
             },
-            CatalogKind::Persist => CatalogConfig::Persist { persist_clients },
+            CatalogKind::Persist => CatalogConfig::Persist {
+                persist_clients,
+                metrics_registry: metrics_registry.clone(),
+            },
             CatalogKind::Shadow => CatalogConfig::Shadow {
                 url: args.adapter_stash_url.expect("required for shadow catalog"),
                 persist_clients,

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -261,6 +261,8 @@ pub enum CatalogConfig {
     Persist {
         /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
         persist_clients: Arc<PersistClientCache>,
+        /// Metrics registry.
+        metrics_registry: MetricsRegistry,
     },
     /// The catalog contents are stored in both persist and the stash and their contents are
     /// compared. This is mostly used for testing purposes.
@@ -724,7 +726,10 @@ async fn catalog_opener(
                 },
             ))
         }
-        CatalogConfig::Persist { persist_clients } => {
+        CatalogConfig::Persist {
+            persist_clients,
+            metrics_registry,
+        } => {
             info!("Using persist backed catalog");
             let persist_client = persist_clients
                 .open(controller_config.persist_location.clone())
@@ -734,6 +739,7 @@ async fn catalog_opener(
                 mz_catalog::durable::persist_backed_catalog_state(
                     persist_client,
                     environment_id.organization_id(),
+                    metrics_registry,
                 )
                 .await,
             )


### PR DESCRIPTION
Resolves #23465

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
