### PR TITLE
parallel-workload: Fix passing cluster to sources

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -482,7 +482,12 @@ class KafkaSource(DBObject):
             KafkaColumn(field.name, field.data_type, False, self) for field in fields
         ]
         self.executor = KafkaExecutor(
-            self.source_id, ports, fields, schema.db.name(), schema.name()
+            self.source_id,
+            ports,
+            fields,
+            schema.db.name(),
+            schema.name(),
+            cluster.name(),
         )
         workload = rng.choice(list(WORKLOADS))(None)
         for transaction_def in workload.cycle:
@@ -606,7 +611,12 @@ class PostgresSource(DBObject):
             PostgresColumn(field.name, field.data_type, False, self) for field in fields
         ]
         self.executor = PgExecutor(
-            self.source_id, ports, fields, schema.db.name(), schema.name()
+            self.source_id,
+            ports,
+            fields,
+            schema.db.name(),
+            schema.name(),
+            cluster.name(),
         )
         self.generator = rng.choice(list(WORKLOADS))(None).generate(fields)
         self.lock = threading.Lock()

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -66,7 +66,7 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     scenario = Scenario(args.scenario)
     complexity = Complexity(args.complexity)
 
-    if args.scenario in (Scenario.Kill, Scenario.BackupRestore):
+    if scenario in (Scenario.Kill, Scenario.BackupRestore):
         catalog_store = "stash"
         sanity_restart = False
     else:


### PR DESCRIPTION
Thanks to Jan for noticing: https://materializeinc.slack.com/archives/C01LKF361MZ/p1701085063090739

I somehow forgot this when implementing the sources and our Python linters are not smart enough to have noticed the unused cluster member variable.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
