### PR TITLE
platform-checks: Also save services.log before calling c.rm

### DIFF
--- a/ci/plugins/mzcompose/hooks/post-command
+++ b/ci/plugins/mzcompose/hooks/post-command
@@ -91,11 +91,11 @@ find cores -name 'core.*' | while read -r core; do
     exe=$(echo "$core" | sed -e "s/core\.\(.*\)\.[0-9]*/\1/" -e "s/.*\!//")
     bin/ci-builder run stable gdb --batch -ex "bt full" -ex "thread apply all bt" -ex "quit" cores/"$exe" "$core" > "$core".txt || true
     if grep -q "Program terminated with signal SIGABRT, Aborted." "$core".txt; then
-      echo "SIGABRT found in \"$core.txt\", ignoring core file"
+        echo "SIGABRT found in \"$core.txt\", ignoring core file"
     else
-      zstd --rm "$core"
-      buildkite-agent artifact upload "$core".txt
-      buildkite-agent artifact upload "$core".zst
+        zstd --rm "$core"
+        buildkite-agent artifact upload "$core".txt
+        buildkite-agent artifact upload "$core".zst
     fi
 done
 # can be huge, clean up
@@ -107,3 +107,8 @@ artifacts=(run.log services.log journalctl-merge.log netstat-ant.log netstat-pan
 artifacts_str=$(IFS=";"; echo "${artifacts[*]}")
 buildkite-agent artifact upload "$artifacts_str"
 bin/ci-builder run stable bin/ci-logged-errors-detect "${artifacts[@]}"
+
+if [ ! -s services.log ] && [ "$BUILDKITE_STEP_KEY" != "persist-maelstrom" ]; then
+    echo "services.log is empty"
+    exit 1
+fi

--- a/misc/python/materialize/mzcompose/composition.py
+++ b/misc/python/materialize/mzcompose/composition.py
@@ -778,6 +778,12 @@ class Composition:
                 "Sanity Restart skipped because Mz not in services or `sanity_restart` label not set"
             )
 
+    def capture_logs(self) -> None:
+        # Capture logs into services.log since they will be lost otherwise
+        # after dowing a composition.
+        with open(MZ_ROOT / "services.log", "a") as f:
+            self.invoke("logs", "--no-color", capture=f)
+
     def down(
         self,
         destroy_volumes: bool = True,
@@ -796,12 +802,7 @@ class Composition:
         """
         if sanity_restart_mz:
             self.sanity_restart_mz()
-
-        # Capture logs into services.log since they will be lost otherwise
-        # after dowing a composition.
-        with open(MZ_ROOT / "services.log", "a") as f:
-            self.invoke("logs", "--no-color", capture=f)
-
+        self.capture_logs()
         self.invoke(
             "down",
             *(["--volumes"] if destroy_volumes else []),
@@ -863,6 +864,7 @@ class Composition:
                 service. Note that this does not destroy any named volumes
                 attached to the service.
         """
+        self.capture_logs()
         self.invoke(
             "rm",
             "--force",

--- a/test/cluster-isolation/mzcompose.py
+++ b/test/cluster-isolation/mzcompose.py
@@ -78,7 +78,7 @@ ALTER SYSTEM SET enable_unstable_dependencies = true;
 
 > CREATE TABLE panic_table (f1 TEXT);
 
-> INSERT INTO panic_table VALUES ('panic!');
+> INSERT INTO panic_table VALUES ('forced panic');
 
 ! INSERT INTO panic_table SELECT mz_internal.mz_panic(f1) FROM panic_table;
 contains: statement timeout


### PR DESCRIPTION
Currently services.log is empty in platform-checks in successful runs, as noticed by Nikhil in
https://materializeinc.slack.com/archives/C01CFKM1QRF/p1701104667677569?thread_ts=1701087470.941589&cid=C01CFKM1QRF

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
