### PR TITLE
storage: reduce an error in disk metric fetching to a warning with justification

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -713,7 +713,13 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
                                         None
                                     }
                                 } else {
-                                    tracing::error!(
+                                    // `fetch_service_metrics` gets the `disk_limit` from the
+                                    // `service_infos`, which can be _more_ up-to-date than the
+                                    // actual replica when it is altered, so we warn instead of
+                                    // error. This is the same as the warning above about not
+                                    // finding the containers above, which could occur when the
+                                    // `scale` is being altered.
+                                    tracing::warn!(
                                         "disk capacity {} is larger than the disk limit {} ?",
                                         disk_capacity,
                                         disk_limit.0


### PR DESCRIPTION
See the comment for details

Closes https://github.com/MaterializeInc/materialize/issues/22436 

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
