### PR TITLE
persist-txn: read txns shard once per txns_progress construction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4749,6 +4749,7 @@ dependencies = [
  "mz-timely-util",
  "prost",
  "rand",
+ "serde",
  "timely",
  "tokio",
  "tracing",

--- a/src/persist-txn/Cargo.toml
+++ b/src/persist-txn/Cargo.toml
@@ -14,6 +14,7 @@ mz-persist-types = { path = "../persist-types" }
 mz-persist-client = { path = "../persist-client" }
 mz-timely-util = { path = "../timely-util" }
 prost = { version = "0.11.3", features = ["no-recursion-limit"] }
+serde = { version = "1.0.152", features = ["derive", "rc"] }
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
 tracing = "0.1.37"

--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -279,6 +279,7 @@ use mz_persist_client::{ShardId, ShardIdSchema};
 use mz_persist_types::codec_impls::VecU8Schema;
 use mz_persist_types::{Codec, Codec64, Opaque, StepForward};
 use prost::Message;
+use serde::{Deserialize, Serialize};
 use timely::order::TotalOrder;
 use timely::progress::{Antichain, Timestamp};
 use tracing::{debug, error, instrument};
@@ -290,7 +291,7 @@ pub mod txn_write;
 pub mod txns;
 
 /// The in-mem representation of an update in the txns shard.
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TxnsEntry {
     /// A data shard register operation.
     Register(ShardId),

--- a/src/persist-txn/src/txn_read.rs
+++ b/src/persist-txn/src/txn_read.rs
@@ -263,13 +263,13 @@ impl<T: Timestamp + Lattice + Codec64> TxnsRead<T> {
     }
 
     /// See [crate::txn_cache::TxnsCacheState::data_listen_next].
-    pub(crate) async fn data_listen_next(&self, data_id: ShardId, ts: T) -> DataListenNext<T> {
+    pub async fn data_listen_next(&self, data_id: ShardId, ts: T) -> DataListenNext<T> {
         self.send(|tx| TxnsReadCmd::DataListenNext { data_id, ts, tx })
             .await
     }
 
     /// See [TxnsCache::update_ge].
-    pub(crate) async fn update_ge(&self, ts: T) {
+    pub async fn update_ge(&self, ts: T) {
         let ts = WaitTs::GreaterEqual(ts);
         self.send(|tx| TxnsReadCmd::Wait { ts, tx }).await
     }


### PR DESCRIPTION
Previously this was a single-stage operator where each worker read the txns shard. This was wasteful and, critically, required `O(workers)` linearized persist read lease registrations.

Instead, it's now a two-stage operator where the first reads the txns_shard, filters it for data_id, and then broadcasts the contents to all workers of the second stage. This means we only need one read lease registration per operator construction, regardless of the number of workers.

I had been thinking at one point last week that we should just have one thing reading the txns shard per-process, which is where the TxnsRead worker came from. That's probably still a good idea, to get this down to one txns shard reader per-process instead of one per operator, but that requires quite solving quite a few more tricky issues (compaction, quiescence, pushing down mixed data_id filters, etc), and this two-stage operator is an "aha!" moment I had for getting things unblocked faster. Plus, this two-stage operator seems desirable even if we later do that (see next paragraph).

An alterative protocol for the timely edge between the two stages would be something like "read up to frontier A and then advance progress to frontier B". That would enable us to use the TxnsRead for the first operator, but it's quite a bit more subtle and I'd like to keep pressing specifically on getting CI passing, so I'm punting it for now.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
