### PR TITLE
coord: Run some DDL tasks concurrently

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -389,12 +389,14 @@ where
     /// Sets the given key value pairs, if not already set. If a new key appears
     /// multiple times in `entries`, its value will be from the first occurrence
     /// in `entries`.
+    ///
+    /// Returns the new state of the collection.
     #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn insert_without_overwrite<I>(
         &self,
         stash: &mut Stash,
         entries: I,
-    ) -> Result<(), StashError>
+    ) -> Result<BTreeMap<K, V>, StashError>
     where
         I: IntoIterator<Item = (K, V)>,
         // TODO: Figure out if it's possible to remove the 'static bounds.
@@ -431,7 +433,7 @@ where
                         }
                     }
                     tx.append(vec![batch]).await?;
-                    Ok(())
+                    Ok(prev)
                 })
             })
             .await

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -536,6 +536,7 @@ impl Stash {
     }
 
     /// Sets `client` to a new connection to the Postgres server.
+    #[tracing::instrument(name = "stash::connect", level = "debug", skip_all)]
     async fn connect(&mut self) -> Result<(), StashError> {
         let (mut client, connection) = self.config.lock().await.connect(self.tls.clone()).await?;
         mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {

--- a/src/storage-controller/src/command_wals.rs
+++ b/src/storage-controller/src/command_wals.rs
@@ -60,7 +60,7 @@ where
                 entries.into_iter().map(|key| (key.into_proto(), ())),
             )
             .await
-            .expect("must be able to write to stash")
+            .expect("must be able to write to stash");
     }
 
     /// Removes the shard from the finalization register.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -524,17 +524,13 @@ where
 
         // Perform all stash writes in a single transaction, to minimize transaction overhead and
         // the time spent waiting for stash.
-        METADATA_COLLECTION
+        let durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> = METADATA_COLLECTION
             .insert_without_overwrite(
                 &mut self.stash,
                 entries
                     .into_iter()
                     .map(|(key, val)| (key.into_proto(), val.into_proto())),
             )
-            .await?;
-
-        let durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> = METADATA_COLLECTION
-            .peek_one(&mut self.stash)
             .await?
             .into_iter()
             .map(RustType::from_proto)


### PR DESCRIPTION
**_work in progress_** - putting up a PR so I can test in staging

This PR refactors some code in the create table workflow to run some async tasks concurrently, which should improve the end-to-end time for DDL.

### Motivation

Improves https://github.com/MaterializeInc/materialize/issues/23547

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
