### PR TITLE
webhook: Move timestamp evaluation to when we receive the request

### DIFF
--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -408,7 +408,7 @@ class WebhookSource(DBObject):
                 "map_length(HEADERS) = map_length(HEADERS)",
             ]
             if "timestamp" in self.explicit_include_headers:
-                exprs.append("(headers->'timestamp'::text)::timestamp <= now()")
+                exprs.append("(headers->'timestamp'::text)::timestamp + INTERVAL '10s' >= now()")
             self.check_expr = " AND ".join(
                 rng.sample(exprs, k=rng.randint(1, len(exprs)))
             )

--- a/misc/python/materialize/parallel_workload/database.py
+++ b/misc/python/materialize/parallel_workload/database.py
@@ -408,7 +408,9 @@ class WebhookSource(DBObject):
                 "map_length(HEADERS) = map_length(HEADERS)",
             ]
             if "timestamp" in self.explicit_include_headers:
-                exprs.append("(headers->'timestamp'::text)::timestamp + INTERVAL '10s' >= now()")
+                exprs.append(
+                    "(headers->'timestamp'::text)::timestamp + INTERVAL '10s' >= now()"
+                )
             self.check_expr = " AND ".join(
                 rng.sample(exprs, k=rng.randint(1, len(exprs)))
             )

--- a/src/adapter/src/client.rs
+++ b/src/adapter/src/client.rs
@@ -307,12 +307,18 @@ Issue a SQL query to get started. Need help?
         &self.metrics
     }
 
+    /// The current time according to the [`Client`].
+    pub fn now(&self) -> DateTime<Utc> {
+        to_datetime((self.now)())
+    }
+
     pub async fn append_webhook(
         &self,
         database: String,
         schema: String,
         name: String,
         conn_id: ConnectionId,
+        received_at: DateTime<Utc>,
     ) -> Result<AppendWebhookResponse, AdapterError> {
         let (tx, rx) = oneshot::channel();
 
@@ -322,6 +328,7 @@ Issue a SQL query to get started. Need help?
             schema,
             name,
             conn_id,
+            received_at,
             tx,
         });
 

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -13,6 +13,7 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use derivative::Derivative;
 use enum_kinds::EnumKind;
 use futures::future::BoxFuture;
@@ -97,6 +98,7 @@ pub enum Command {
         schema: String,
         name: String,
         conn_id: ConnectionId,
+        received_at: DateTime<Utc>,
         tx: oneshot::Sender<Result<AppendWebhookResponse, AdapterError>>,
     },
 

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -32,6 +32,8 @@ pub async fn handle_webhook(
     headers: http::HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    // Record the time we receive the request, for use if validation checks the current timestamp.
+    let received_at = client.now();
     let conn_id = client.new_conn_id().context("allocate connection id")?;
 
     // Collect headers into a map, while converting them into strings.
@@ -55,7 +57,7 @@ pub async fn handle_webhook(
         header_tys,
         validator,
     } = client
-        .append_webhook(database, schema, name, conn_id)
+        .append_webhook(database, schema, name, conn_id, received_at)
         .await?;
 
     // If this source requires validation, then validate!


### PR DESCRIPTION
This PR updates the logic for evaluating "now" when it's used in the validation statement of a webhook. Instead of getting "now" when validating a request, we get "now" when we receive the request. It's possible for 10s of seconds to pass between receiving a request and when it gets evaluated, if the Coordinator is blocked, this was occurring during a run of the parallel-workload test.

It also updates the `CHECK` statement used in the parallel-workload test to have a 10 second buffer, which is how we recommend users run webhooks in production.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23461

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
