### PR TITLE
webhook: Better error message when Source gets dropped

### DIFF
--- a/src/storage-controller/src/collection_mgmt.rs
+++ b/src/storage-controller/src/collection_mgmt.rs
@@ -202,12 +202,22 @@ where
                         'collect: while let Ok((_batch, sender)) = rx.try_recv() {
                             senders.push(sender);
 
-                            if senders.len() >= CHANNEL_CAPACITY {
+                            // Note: because we're shutting down the sending side of `rx` is no
+                            // longer accessible, and thus we should no longer receive new
+                            // requests. We add this check just as an extra guard.
+                            if senders.len() > CHANNEL_CAPACITY {
+                                // There's not a correctness issue if we receive new requests, just
+                                // unexpected behavior.
+                                tracing::error!("Write task channel should not be receiving new requests");
                                 break 'collect;
                             }
                         }
 
                         // Notify them that this collection is closed.
+                        //
+                        // Note: if a task is shutting down, that indicates the source has been
+                        // dropped, at which point the identifier is invalid. Returning this
+                        // error provides a better user experience.
                         notify_listeners(senders, || Err(StorageError::IdentifierInvalid(id)));
 
                         break 'run;


### PR DESCRIPTION
This PR updates the errors that gets returned when a queued webhook append fails because the source was concurrently dropped or Materialize is shutting down, e.g. during an upgrade. 

Previously we would return "500 internal storage failure" for both cases, but now if the Source was concurrently dropped we will return a 404, and if we're shutting down we return a 503.

### Motivation

Fixes https://github.com/MaterializeInc/materialize/issues/23028

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Updates the returned error for an edge case.
