### PR TITLE
Prevent karpenter from evicting database pods

### DIFF
--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -978,12 +978,13 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
         };
 
         let pod_annotations = btreemap! {
-            // Prevent the cluster-autoscaler from evicting these pods in attempts to scale down
+            // Prevent the cluster-autoscaler (or karpenter) from evicting these pods in attempts to scale down
             // and terminate nodes.
             // This will cost us more money, but should give us better uptime.
             // This does not prevent all evictions by Kubernetes, only the ones initiated by the
-            // cluster-autoscaler. Notably, eviction of pods for resource overuse is still enabled.
+            // cluster-autoscaler (or karpenter). Notably, eviction of pods for resource overuse is still enabled.
             "cluster-autoscaler.kubernetes.io/safe-to-evict".to_owned() => "false".to_string(),
+            "karpenter.sh/do-not-evict".to_owned() => "true".to_string(),
         };
 
         let mut node_selector: BTreeMap<String, String> = self

--- a/src/orchestrator-kubernetes/src/lib.rs
+++ b/src/orchestrator-kubernetes/src/lib.rs
@@ -985,6 +985,9 @@ impl NamespacedOrchestrator for NamespacedKubernetesOrchestrator {
             // cluster-autoscaler (or karpenter). Notably, eviction of pods for resource overuse is still enabled.
             "cluster-autoscaler.kubernetes.io/safe-to-evict".to_owned() => "false".to_string(),
             "karpenter.sh/do-not-evict".to_owned() => "true".to_string(),
+
+            // It's called do-not-disrupt in newer versions of karpenter, so adding for forward/backward compatibility
+            "karpenter.sh/do-not-disrupt".to_owned() => "true".to_string(),
         };
 
         let mut node_selector: BTreeMap<String, String> = self


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR adds a feature that has not yet been specified.

We use karpenter on AWS instead of cluster autoscaler. To prevent karpenter from evicting the database pods (when consolidation is enabled for example) we need to add the `karpenter.sh/do-not-evict` annotation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
