### PR TITLE
stash/storage: Return updated collection with insert_without_overwrite

### DIFF
--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -389,12 +389,14 @@ where
     /// Sets the given key value pairs, if not already set. If a new key appears
     /// multiple times in `entries`, its value will be from the first occurrence
     /// in `entries`.
+    ///
+    /// Returns the new state of the collection after this operation.
     #[tracing::instrument(level = "debug", skip_all, fields(collection = self.name))]
     pub async fn insert_without_overwrite<I>(
         &self,
         stash: &mut Stash,
         entries: I,
-    ) -> Result<(), StashError>
+    ) -> Result<BTreeMap<K, V>, StashError>
     where
         I: IntoIterator<Item = (K, V)>,
         // TODO: Figure out if it's possible to remove the 'static bounds.
@@ -431,7 +433,7 @@ where
                         }
                     }
                     tx.append(vec![batch]).await?;
-                    Ok(())
+                    Ok(prev)
                 })
             })
             .await

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -536,6 +536,7 @@ impl Stash {
     }
 
     /// Sets `client` to a new connection to the Postgres server.
+    #[tracing::instrument(name = "stash::connect", level = "debug", skip_all)]
     async fn connect(&mut self) -> Result<(), StashError> {
         let (mut client, connection) = self.config.lock().await.connect(self.tls.clone()).await?;
         mz_ore::task::spawn(|| "tokio-postgres stash connection", async move {

--- a/src/storage-controller/src/command_wals.rs
+++ b/src/storage-controller/src/command_wals.rs
@@ -60,7 +60,7 @@ where
                 entries.into_iter().map(|key| (key.into_proto(), ())),
             )
             .await
-            .expect("must be able to write to stash")
+            .expect("must be able to write to stash");
     }
 
     /// Removes the shard from the finalization register.

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -529,17 +529,13 @@ where
 
         // Perform all stash writes in a single transaction, to minimize transaction overhead and
         // the time spent waiting for stash.
-        METADATA_COLLECTION
+        let durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> = METADATA_COLLECTION
             .insert_without_overwrite(
                 &mut self.stash,
                 entries
                     .into_iter()
                     .map(|(key, val)| (key.into_proto(), val.into_proto())),
             )
-            .await?;
-
-        let durable_metadata: BTreeMap<GlobalId, DurableCollectionMetadata> = METADATA_COLLECTION
-            .peek_one(&mut self.stash)
             .await?
             .into_iter()
             .map(RustType::from_proto)


### PR DESCRIPTION
This PR updates the `insert_without_overwrite` Stash method to return the state of the collection after inserting the new values, and updates call sites to either discard or use the returned state.

### Motivation

DDL, especially in Staging, is known to be slow, [Slack](https://materializeinc.slack.com/archives/C02FWJ94HME/p1700080573818659).

I enabled OpenTelemetry tracing in Staging, and ran `CREATE TABLE t1 (x int, y text, z timestamp)` until it was particularly slow. And after a bit of attempts I got an execution that took 2.4 seconds!

<img width="2032" alt="Screenshot 2023-11-27 at 5 08 14 PM" src="https://github.com/MaterializeInc/materialize/assets/4438098/ccf9f245-a6d3-494d-b2f1-eaa538454a18">

The biggest offenders were two Stash transactions made by the storage-controller to `insert_without_overwrite` and `peek_one`. It turns out the `peek_one` is reading the `METADATA_COLLETION` immediately after we insert values to it. But the call to `insert_without_overwrite` already has those values! So we eliminate the second Stash transaction, by returning the values from `insert_without_overwrite` instead of reading them a second time.

Note: the next thing we can do is run the `insert_without_overwrite` concurrently with the `builtin_table_updates`, which should improve times further. The tricky part is figuring out the correct API.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
