### PR TITLE
testdrive: Only 1 partition for zstd

### DIFF
--- a/test/testdrive/kafka-compression.td
+++ b/test/testdrive/kafka-compression.td
@@ -51,7 +51,7 @@ world
 hello
 world
 
-$ kafka-create-topic topic=zstd compression=zstd
+$ kafka-create-topic topic=zstd compression=zstd partitions=1
 
 $ kafka-ingest format=bytes topic=zstd timestamp=1
 hello


### PR DESCRIPTION
I'm not sure why this is required for zstd (only?), this might be a Kafka bug. At least gets CI green again, we had this issue for a while, see #23482

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
