### PR TITLE
Disable alter-connection checks and kafka-auth

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -388,6 +388,7 @@ steps:
       - id: kafka-auth
         label: Kafka auth test
         depends_on: build-x86_64
+        skip: "TODO(def-) Reenable when #23469 is fixed"
         timeout_in_minutes: 30
         inputs: [test/kafka-auth/smoketest.td]
         artifact_paths: junit_*.xml

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -13,7 +13,7 @@ from random import Random
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check, externally_idempotent
+from materialize.checks.checks import Check, disabled, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
@@ -37,6 +37,7 @@ SHOW_CONNECTION_SSH_TUNNEL_OTHER = """materialize.public.ssh_tunnel_{i} "CREATE 
 WITH_SSH_SUFFIX = "USING SSH TUNNEL ssh_tunnel_{i}"
 
 
+@disabled("reenable when #23450 is fixed/understood")
 class AlterConnectionSshChangeBase(Check):
     def __init__(
         self,


### PR DESCRIPTION
Trying to get CI to be more useful, this fails a lot even in tests pipeline, thus annoying for developers. See https://github.com/MaterializeInc/materialize/issues/23450, but doesn't get solved by this of course.

Same for https://github.com/MaterializeInc/materialize/issues/23469

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
