### PR TITLE
catalog: Fixup persist catalog metrics

### DIFF
--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -11,14 +11,14 @@
 
 use mz_ore::metric;
 use mz_ore::metrics::{IntCounter, MetricsRegistry};
-use prometheus::{Counter, IntCounterVec};
+use prometheus::Counter;
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
     pub transactions: IntCounter,
-    pub transaction_commit_errors: IntCounterVec,
+    pub transaction_commit_errors: IntCounter,
     pub transaction_commit_latency_duration_seconds: Counter,
-    pub transactions_committed: IntCounter,
+    pub transaction_commits_initiated: IntCounter,
     pub snapshot_latency_duration_seconds: Counter,
     pub snapshots_taken: IntCounter,
     pub sync_latency_duration_seconds: Counter,
@@ -30,36 +30,36 @@ impl Metrics {
     pub fn new(registry: &MetricsRegistry) -> Self {
         Self {
             transactions: registry.register(metric!(
-                name: "catalog_transactions",
+                name: "mz_catalog_transactions",
                 help: "Total number of started transactions.",
             )),
             transaction_commit_errors: registry.register(metric!(
-                name: "catalog_transaction_errors",
+                name: "mz_catalog_transaction_errors",
                 help: "Total number of transaction errors.",
                 var_labels: ["cause"],
             )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_transaction_latency_seconds",
+                name: "mz_catalog_transaction_latency_seconds",
                 help: "Total latency for durable catalog transactions.",
             )),
-            transactions_committed: registry.register(metric!(
-                name: "catalog_transactions_committed",
-                help: "Count of transactions committed.",
+            transaction_commits_initiated: registry.register(metric!(
+                name: "mz_catalog_transaction_commits_initiated",
+                help: "Count of transaction commits that were initiated, this includes ones that ended in successes or failures.",
             )),
             snapshot_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_snapshot_latency_seconds",
+                name: "mz_catalog_snapshot_latency_seconds",
                 help: "Total latency for fetching a snapshot of the durable catalog.",
             )),
             snapshots_taken: registry.register(metric!(
-                name: "catalog_snapshots_taken",
+                name: "mz_catalog_snapshots_taken",
                 help: "Count of snapshots taken.",
             )),
             sync_latency_duration_seconds: registry.register(metric!(
-                name: "catalog_sync_latency_seconds",
+                name: "mz_catalog_sync_latency_seconds",
                 help: "Total latency for syncing the in-memory state of the durable catalog with the persisted contents.",
             )),
             syncs: registry.register(metric!(
-                name: "catalog_syncs",
+                name: "mz_catalog_syncs",
                 help: "Count of catalog syncs.",
             )),
         }

--- a/src/catalog/src/durable/impls/persist/metrics.rs
+++ b/src/catalog/src/durable/impls/persist/metrics.rs
@@ -36,7 +36,6 @@ impl Metrics {
             transaction_commit_errors: registry.register(metric!(
                 name: "mz_catalog_transaction_errors",
                 help: "Total number of transaction errors.",
-                var_labels: ["cause"],
             )),
             transaction_commit_latency_duration_seconds: registry.register(metric!(
                 name: "mz_catalog_transaction_latency_seconds",


### PR DESCRIPTION
Resolves https://github.com/MaterializeInc/materialize/issues/23465

### Motivation
This PR adds a known-desirable feature.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
