### PR TITLE
ci: Restart docker before starting mzcompose-based jobs

### DIFF
--- a/ci/plugins/mzcompose/hooks/command
+++ b/ci/plugins/mzcompose/hooks/command
@@ -31,6 +31,7 @@ date +"%Y-%m-%d %H:%M:%S" > step_start_timestamp
 # Docker Compose run, which can leave old containers or volumes around that will
 # interfere with this build.
 ci_collapsed_heading ":docker: Purging containers and volumes from previous builds"
+sudo systemctl restart docker
 mzcompose --mz-quiet kill
 mzcompose --mz-quiet rm --force -v
 mzcompose --mz-quiet down --volumes


### PR DESCRIPTION
There are many mysterious docker problems recently, one guess is that they might be caused by https://github.com/MaterializeInc/i2/pull/1388 updating the buildkite stack. One idea we had was to restart docker daemon before each buildkite job. Some examples: https://buildkite.com/materialize/tests/builds/69819#018c1689-af50-429a-a915-4f08aa975c4e https://buildkite.com/materialize/tests/builds/69815#018c168c-8881-4238-912e-aa06d8b3c838

Hopefully fixes https://github.com/MaterializeInc/materialize/issues/23481

Depends on https://github.com/MaterializeInc/i2/pull/1408

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
