### PR TITLE
Add new cargo vet certify option

### DIFF
--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -1,6 +1,14 @@
 
 # cargo-vet audits file
 
+[criteria.maintained-and-necessary]
+description = '''
+Certification of this crate means the reviewer has confirmed the crate is:
+- actively maintained
+- necessary and useful to Materialize
+- well-documented
+'''
+
 [[audits.array-concat]]
 who = "Matt Arthur <matthewleearthur@gmail.com>"
 criteria = "safe-to-deploy"


### PR DESCRIPTION
PR adds a third cargo-vet certify option that matches our internal criteria for certifying audits. 

### Motivation

The canned cargo vet certification language does not fit Materialize use of the cargo vet tool. 

### Checklist

User-facing behavior change: Additional cargo vet certify option 'maintained-and-necessary'. 