### PR TITLE
test: Replace Result with unwrap

### DIFF
--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -1775,8 +1775,7 @@ async fn test_timeline_read_holds() {
     let source_name = "source_hold";
     let (pg_client, cleanup_fn) =
         test_util::create_postgres_source_with_table(&mz_client, view_name, "(a INT)", source_name)
-            .await
-            .unwrap();
+            .await;
 
     // Create user table in Materialize.
     mz_client
@@ -1800,9 +1799,7 @@ async fn test_timeline_read_holds() {
             .unwrap();
     }
 
-    test_util::wait_for_view_population(&mz_client, view_name, source_rows)
-        .await
-        .unwrap();
+    test_util::wait_for_view_population(&mz_client, view_name, source_rows).await;
 
     // Make sure that the table and view are joinable immediately at some timestamp.
     let mz_join_client = server.connect().await.unwrap();
@@ -1818,7 +1815,7 @@ async fn test_timeline_read_holds() {
     .await
     .unwrap();
 
-    cleanup_fn(&mz_client, &pg_client).await.unwrap();
+    cleanup_fn(&mz_client, &pg_client).await;
 }
 
 #[mz_ore::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
@@ -1840,17 +1837,14 @@ async fn test_linearizability() {
     let source_name = "source_lin";
     let (pg_client, cleanup_fn) =
         test_util::create_postgres_source_with_table(&mz_client, view_name, "(a INT)", source_name)
-            .await
-            .unwrap();
+            .await;
     // Insert value into postgres table.
     let _ = pg_client
         .execute(&format!("INSERT INTO {view_name} VALUES (42);"), &[])
         .await
         .unwrap();
 
-    test_util::wait_for_view_population(&mz_client, view_name, 1)
-        .await
-        .unwrap();
+    test_util::wait_for_view_population(&mz_client, view_name, 1).await;
 
     // The user table's write frontier will be close to zero because we use a deterministic
     // now function in this test. It may be slightly higher than zero because bootstrapping
@@ -1904,7 +1898,7 @@ async fn test_linearizability() {
     // If we go back to serializable, then timestamps can revert again.
     assert!(join_ts < view_ts);
 
-    cleanup_fn(&mz_client, &pg_client).await.unwrap();
+    cleanup_fn(&mz_client, &pg_client).await;
 }
 
 #[mz_ore::test]


### PR DESCRIPTION
This commit updates some test helpers to unwrap `Result`s immediately, instead of bubbling them up with `?`. This makes it much easier to debug test failures, because we can get a stack trace from where the error first appears, instead of from where it is unwrapped.

Works towards resolving #23449

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
