### PR TITLE
persist: demo token dropping bug

### DIFF
--- a/src/persist-client/src/operators/shard_source.rs
+++ b/src/persist-client/src/operators/shard_source.rs
@@ -110,7 +110,8 @@ where
     //    operator returns the `LeasedBatchPart` to the original worker, so it
     //    can release the SeqNo lease.
 
-    let chosen_worker = usize::cast_from(name.hashed()) % scope.peers();
+    // Worker 0 is our "persist worker".
+    let chosen_worker = 0;
 
     // we can safely pass along a zero summary from this feedback edge,
     // as the input is disconnected from the operator's output

--- a/test/kafka-auth/test-schema-registry-ssl-basic.td
+++ b/test/kafka-auth/test-schema-registry-ssl-basic.td
@@ -112,8 +112,8 @@ a
   FORMAT AVRO USING CONFLUENT SCHEMA REGISTRY CONNECTION schema_registry
   ENVELOPE DEBEZIUM
 
-$ kafka-verify-data format=avro sink=materialize.public.snk_backup sort-messages=true
-{"before": null, "after": {"row":{"a": 1}}}
+# $ kafka-verify-data format=avro sink=materialize.public.snk_backup sort-messages=true
+# {"before": null, "after": {"row":{"a": 1}}}
 
 ### Break sink broker connection and produce data
 


### PR DESCRIPTION
@petrosagg and I examined a number of failures that occur in proximity to an `ALTER CONNECTION` statement executing that restarts a sink. @guswynn triaged a similar bug and, it turned out, came to the same conclusion independently.

The common thread of these failures is that the sink's write frontier advances to [], even though the item that it's sinking has not been dropped.

In reading the logs and the code, it appears as if the tokens created in `shard_source_descs` are not managed properly. It is possible for n-1 workers to drop their tokens, and the nth worker to still be running and see the effects of the other workers' token drops, i.e. it receives an `Event::Progress` whose data is the empty frontier.

This commit substantiates the above claim by ensuring:
- Different workers are responsible for producing values to Kafka and reading values from persist.
- The Kafka-writing worker ignores any commands to restart the sink. This ensures that any effects of the n-1 workers dropping their tokens are observed by a worker.

We consider the claim substantiated if the running worker receives an `Event::Progress` whose data is the empty frontier. This is easy to check in the logs, because we will output:

> advancing write frontier to empty

Deterministically, using the code in this commit, running the schema-registry-ssl-basic test in test/kafka-auth demonstrates that the write frontier is advanced to the empty antichain, as demonstrated by the presence of the above line in the logs.

e.g.

cd test/kafka-auth && ./mzcompose run default schema-registry-ssl-basic

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
