### PR TITLE
storage: ban start offsets with more partitions that topic

### DIFF
--- a/test/testdrive/kafka-avro-sources.td
+++ b/test/testdrive/kafka-avro-sources.td
@@ -255,21 +255,6 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 
 > SELECT * FROM non_dbz_data_varying_partition
 
-# Erroneously adds START OFFSET for non-existent partitions.
-> CREATE SOURCE non_dbz_data_varying_partition_2
-  FROM KAFKA CONNECTION kafka_conn (
-    TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}',
-    TOPIC METADATA REFRESH INTERVAL MS=10,
-    START OFFSET=[0,1]
-  )
-  FORMAT AVRO USING SCHEMA '${non-dbz-schema}'
-  ENVELOPE NONE
-
-> SELECT * FROM non_dbz_data_varying_partition_2
-a  b
-----
-5  6
-
 $ kafka-add-partitions topic=non-dbz-data-varying-partition total-partitions=2
 
 # Reading data that's ingested to a new partition takes longer than the default timeout.
@@ -287,15 +272,7 @@ a  b
 7  8
 9  10
 
-# Because the start offsets erronously included an offset for partition 1 (which didn't exist at the time),
-# the first record ingested into partition 1 will be ignored.
-> SELECT * FROM non_dbz_data_varying_partition_2
-a  b
------
-5  6
-9  10
-
-> CREATE SOURCE non_dbz_data_varying_partition_3
+> CREATE SOURCE non_dbz_data_varying_partition_2
   FROM KAFKA CONNECTION kafka_conn (
     TOPIC 'testdrive-non-dbz-data-varying-partition-${testdrive.seed}',
     TOPIC METADATA REFRESH INTERVAL MS=10,
@@ -311,7 +288,7 @@ $ kafka-ingest format=avro topic=non-dbz-data-varying-partition schema=${non-dbz
 
 # Because the start offset for any new partitions will be 0, the first record sent to the new
 # partition will be included.
-> SELECT * FROM non_dbz_data_varying_partition_3
+> SELECT * FROM non_dbz_data_varying_partition_2
 a  b
 -----
 9  10

--- a/test/testdrive/kafka-start-offset.td
+++ b/test/testdrive/kafka-start-offset.td
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM SET enable_create_source_denylist_with_options = true
+ALTER SYSTEM SET enable_kafka_config_denylist_options = true
+
+$ kafka-create-topic topic=t0 partitions=1
+
+> CREATE CONNECTION kafka_conn
+  TO KAFKA (BROKER '${testdrive.kafka-addr}', SECURITY PROTOCOL PLAINTEXT);
+
+! CREATE SOURCE too_many_offsets
+  FROM KAFKA CONNECTION kafka_conn (
+      TOPIC 'testdrive-t0-${testdrive.seed}',
+      START OFFSET (100, 100)
+    )
+  FORMAT TEXT
+  INCLUDE OFFSET
+exact:START OFFSET specified more partitions (2) than topic (testdrive-t0-${testdrive.seed}) contains (1)


### PR DESCRIPTION
Closes #23482

will document after it merges

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
