### PR TITLE
testdrive: Disable broken part of introspection-sources.td

### DIFF
--- a/test/testdrive/introspection-sources.td
+++ b/test/testdrive/introspection-sources.td
@@ -354,23 +354,24 @@ true true true true true
   GROUP BY 1
   HAVING COUNT(*) > 1;
 
-> SELECT
-    records > 2 * 1000 AND records < 1.1 * 2 * 1000,
-    size > (68 + 68) * 1000 AND size < 1.1 * (68 + 68) * 1000,
-    capacity > (68 + 68) * 1000 AND capacity < 1.1 * (68 + 68) * 1000,
-    allocations > 0
-  FROM mz_internal.mz_dataflow_arrangement_sizes
-  WHERE name LIKE '%c1%';
-true true true true
-
-> SELECT
-    records > 2 * 1000 AND records < 1.1 * 2 * 1000,
-    size > 0.7 * (172 + 72) * 1000 AND size < 1.1 * (180 + 72) * 1000,
-    capacity > 0.7 * (172 + 72) * 1000 AND capacity < 1.1 * (180 + 72) * 1000,
-    allocations > 1000
-  FROM mz_internal.mz_dataflow_arrangement_sizes
-  WHERE name LIKE '%c2%';
-true true true true
+# TODO(vmarcos): Reenable when #23509 is fixed
+# > SELECT
+#     records > 2 * 1000 AND records < 1.1 * 2 * 1000,
+#     size > (68 + 68) * 1000 AND size < 1.1 * (68 + 68) * 1000,
+#     capacity > (68 + 68) * 1000 AND capacity < 1.1 * (68 + 68) * 1000,
+#     allocations > 0
+#   FROM mz_internal.mz_dataflow_arrangement_sizes
+#   WHERE name LIKE '%c1%';
+# true true true true
+#
+# > SELECT
+#     records > 2 * 1000 AND records < 1.1 * 2 * 1000,
+#     size > 0.7 * (172 + 72) * 1000 AND size < 1.1 * (180 + 72) * 1000,
+#     capacity > 0.7 * (172 + 72) * 1000 AND capacity < 1.1 * (180 + 72) * 1000,
+#     allocations > 1000
+#   FROM mz_internal.mz_dataflow_arrangement_sizes
+#   WHERE name LIKE '%c2%';
+# true true true true
 
 # For coverage, we also include a recursive materialized view to account for dynamic timestamps.
 # Here, the timestamps take not 8 bytes, but (8 + (24 + [0|1 * 8])) = [32|40] bytes. There are also


### PR DESCRIPTION
Workaround for #23509 to get tests pipeline green again, can fix it up later

This test was introduced in https://github.com/MaterializeInc/materialize/pull/23205
@vmarcos Can you check if this makes sense?

I'll bisect where this failure came from in the meantime. Edit: As suggested by @antiguru I won't bisect.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
