### PR TITLE
mzcompose: Safer docker compose file

### DIFF
--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -74,7 +74,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
 
     for i, name in enumerate(c.workflows):
         # incident-70 requires more memory, runs in separate CI step
-        if name in ("default", "test-incident-70"):
+        # concurrent-connections is too flaky
+        if name in ("default", "test-incident-70", "test-concurrent-connections"):
             continue
         if shard is None or shard_count is None or i % int(shard_count) == shard:
             with c.test_case(name):
@@ -2570,7 +2571,7 @@ def workflow_test_concurrent_connections(c: Composition) -> None:
 
     def worker(c: Composition, i: int) -> None:
         start_time = time.time()
-        c.sql("SELECT 1")
+        c.sql("SELECT 1", print_statement=False)
         end_time = time.time()
         runtimes[i] = end_time - start_time
 


### PR DESCRIPTION
Follow-up to #23330

I hope this fixes #23481, but I don't understand why my old approach is wrong.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
