### PR TITLE
sql-pretty: pretty for copy and subscribe

### DIFF
--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -84,7 +84,8 @@ use pretty::RcDoc;
 use thiserror::Error;
 
 use crate::doc::{
-    doc_create_materialized_view, doc_create_view, doc_display, doc_insert, doc_select_statement,
+    doc_copy, doc_create_materialized_view, doc_create_view, doc_display, doc_insert,
+    doc_select_statement, doc_subscribe,
 };
 
 const TAB: isize = 4;
@@ -95,6 +96,8 @@ fn to_doc<T: AstInfo>(v: &Statement<T>) -> RcDoc {
         Statement::Insert(v) => doc_insert(v),
         Statement::CreateView(v) => doc_create_view(v),
         Statement::CreateMaterializedView(v) => doc_create_materialized_view(v),
+        Statement::Copy(v) => doc_copy(v),
+        Statement::Subscribe(v) => doc_subscribe(v),
         _ => doc_display(v, "statement"),
     }
 }

--- a/src/sql-pretty/src/util.rs
+++ b/src/sql-pretty/src/util.rs
@@ -13,10 +13,15 @@ use pretty::{Doc, RcDoc};
 
 use crate::TAB;
 
+pub(crate) fn intersperse_line_nest<'a, I>(v: I) -> RcDoc<'a>
+where
+    I: IntoIterator<Item = RcDoc<'a, ()>>,
+{
+    RcDoc::intersperse(v, Doc::line()).nest(TAB).group()
+}
+
 pub(crate) fn nest<'a>(title: RcDoc<'a>, v: RcDoc<'a>) -> RcDoc<'a> {
-    RcDoc::intersperse([title, v], Doc::line())
-        .nest(TAB)
-        .group()
+    intersperse_line_nest([title, v])
 }
 
 pub(crate) fn nest_title<S>(title: S, v: RcDoc) -> RcDoc


### PR DESCRIPTION
Add COPY and SUBSCRIBE support to pretty.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a