### PR TITLE
 ci: provide mechanism to override ancestor release

### DIFF
--- a/misc/python/materialize/docker.py
+++ b/misc/python/materialize/docker.py
@@ -20,6 +20,8 @@ Commits must be ordered descending by their date.
 """
 MIN_ANCESTOR_MZ_VERSION_PER_COMMIT: dict[str, MzVersion] = {
     # insert newer commits at the top
+    # PR#23421 (coord: smorgasbord of improvements for the crdb-backed timestamp oracle) introduces regressions against 0.78.13
+    "5179ebd39aea4867622357a832aaddcde951b411": MzVersion.parse_mz("v0.79.0")
 }
 
 

--- a/misc/python/materialize/git.py
+++ b/misc/python/materialize/git.py
@@ -278,6 +278,12 @@ def is_on_main_branch() -> bool:
     return get_branch_name() == "main"
 
 
+def contains_commit(commit_sha: str, target: str = "HEAD") -> bool:
+    command = ["git", "merge-base", "--is-ancestor", commit_sha, target]
+    return_code = spawn.run_and_get_return_code(command)
+    return return_code == 0
+
+
 def get_tagged_release_version(version_type: type[VERSION_TYPE]) -> VERSION_TYPE | None:
     """
     This returns the release version if exactly this commit is tagged.

--- a/misc/python/materialize/spawn.py
+++ b/misc/python/materialize/spawn.py
@@ -125,3 +125,17 @@ def capture(
     return subprocess.check_output(
         args, cwd=cwd, env=env, input=input, stdin=stdin, stderr=stderr, text=True
     )
+
+
+def run_and_get_return_code(
+    args: Sequence[Path | str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
+    """Run a subprocess and return the return code."""
+    try:
+        capture(args, cwd=cwd, env=env, stderr=subprocess.DEVNULL)
+        return 0
+    except CalledProcessError as e:
+        return e.returncode


### PR DESCRIPTION
[PR#23421](https://github.com/MaterializeInc/materialize/pull/23421) introduced performance and scalability regressions. This will cause nightly builds against 0.78.13+ to fail. This PR introduces a mechanism to provide the merge commit of PR#23421 as ancestor / comparison base when this commit is included in the current state and as long as the next release 0.79.0 (which will contain the PR) is not reached.

This should address the current failures of the feature benchmark and scalability benchmark in [nightly#5406](https://buildkite.com/materialize/nightlies/builds/5406), [nightly#5411](https://buildkite.com/materialize/nightlies/builds/5411), and subsequent builds until the next major release.

This PR also contains refactorings. Either review commit-wise or focus on commit 034fe030f62e004b4fdc35eb37a4dca6d1dd3d93.