### PR TITLE
adapter: fix timestamp oracle tests

### DIFF
--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -291,8 +291,12 @@ where
 
             let txn = client.transaction().await?;
 
+            // Using `table_schema = CURRENT_SCHEMA` makes sure we only include
+            // tables that are queryable by us. Otherwise this check might
+            // return true but then the query below fails with a confusing
+            // "table does not exist" error.
             let q = r#"
-            SELECT EXISTS (SELECT * FROM information_schema.tables where table_name = 'timestamp_oracle');
+            SELECT EXISTS (SELECT * FROM information_schema.tables WHERE table_name = 'timestamp_oracle' AND table_schema = CURRENT_SCHEMA);
         "#;
             let statement = txn.prepare(q).await?;
             let exists_row = txn.query_one(&statement, &[]).await?;

--- a/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
+++ b/src/adapter/src/coord/timestamp_oracle/postgres_oracle.rs
@@ -629,8 +629,6 @@ mod tests {
             }
         };
 
-        cleanup(config.clone()).await?;
-
         timestamp_oracle::tests::timestamp_oracle_impl_test(|timeline, now_fn, initial_ts| {
             let oracle =
                 PostgresTimestampOracle::open(config.clone(), timeline, initial_ts, now_fn);
@@ -638,8 +636,6 @@ mod tests {
             oracle
         })
         .await?;
-
-        cleanup(config).await?;
 
         Ok(())
     }
@@ -658,8 +654,6 @@ mod tests {
             }
         };
 
-        cleanup(config.clone()).await?;
-
         timestamp_oracle::tests::shareable_timestamp_oracle_impl_test(
             |timeline, now_fn, initial_ts| {
                 let oracle =
@@ -674,20 +668,6 @@ mod tests {
             },
         )
         .await?;
-
-        cleanup(config).await?;
-
-        Ok(())
-    }
-
-    // Best-effort cleanup!
-    async fn cleanup(config: PostgresTimestampOracleConfig) -> Result<(), anyhow::Error> {
-        let postgres_client = PostgresClient::open(config.into())?;
-        let client = postgres_client.get_connection().await?;
-
-        client
-            .execute("DROP TABLE IF EXISTS timestamp_oracle", &[])
-            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
The tests for the postgres/crdb oracle and the batching oracle both use an external crdb (passed in via `COCKROACH_URL`). And both try and do best-effort cleanup where they remove the `timestamp_oracle` table. This means it can happen that one test removes the table from under another test that is still running. The tests don't clash otherwise because we pick UUIDs for the timeline names.

This commit fixes the issue by removing the best-effort cleanup.

Another solution would be to use individual table names but it's harder to pass a runtime table name to the oracle implementations. Though it's not at all impossible and we could do that if we want to invest more time. This proposal here is the quickest fix, and if we throw away the crdb instance after tests in CI it seems fine to do it like that for now.

Fixes #23521

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
