### PR TITLE
storage: ban custom shutdown tokens

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -100,6 +100,7 @@
 //! stream. This reduces the amount of recomputation that must be performed
 //! if/when the errors are retracted.
 
+use std::any::Any;
 use std::collections::{BTreeMap, BTreeSet};
 use std::rc::{Rc, Weak};
 use std::sync::Arc;
@@ -247,6 +248,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                     imported_sources.push((mz_expr::Id::Global(*source_id), (oks, errs)));
 
                     // Associate returned tokens with the source identifier.
+                    let token: Rc<dyn Any> = Rc::new(token);
                     tokens.insert(*source_id, token);
                 });
             }

--- a/src/storage/src/decode/mod.rs
+++ b/src/storage/src/decode/mod.rs
@@ -13,7 +13,6 @@
 //! The primary exports are [`render_decode_delimited`], and
 //! [`render_decode_cdcv2`]. See their docs for more details about their differences.
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::rc::Rc;
@@ -30,7 +29,9 @@ use mz_storage_types::errors::{CsrConnectError, DecodeError, DecodeErrorKind};
 use mz_storage_types::sources::encoding::{
     AvroEncoding, DataEncoding, DataEncodingInner, RegexEncoding,
 };
-use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::builder_async::{
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
 use regex::Regex;
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::Map;
@@ -60,7 +61,7 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
     connection_context: ConnectionContext,
     csr_connection: Option<CsrConnection>,
     confluent_wire_format: bool,
-) -> (Collection<G, Row, Diff>, Box<dyn Any + Send + Sync>) {
+) -> (Collection<G, Row, Diff>, PressOnDropButton) {
     let channel_rx = Rc::new(RefCell::new(VecDeque::new()));
     let activator_set: Rc<RefCell<Option<SyncActivator>>> = Rc::new(RefCell::new(None));
 
@@ -137,7 +138,16 @@ pub fn render_decode_cdcv2<G: Scope<Timestamp = Timestamp>>(
         *activator_set.borrow_mut() = Some(ac);
         YieldingIter::new_from(VdIterator(channel_rx), Duration::from_millis(10))
     });
-    (stream.as_collection(), token)
+
+    // The token returned by DD's operator is not compatible with the shutdown mechanism used in
+    // storage so we create a dummy operator to hold onto that token.
+    let builder = AsyncOperatorBuilder::new("CDCv2-Token".to_owned(), input.scope());
+    let button = builder.build(move |_caps| async move {
+        let _dd_token = token;
+        // Keep this operator around until shutdown
+        std::future::pending::<()>().await;
+    });
+    (stream.as_collection(), button.press_on_drop())
 }
 
 // These don't know how to find delimiters --
@@ -405,7 +415,6 @@ pub fn render_decode_delimited<G>(
 ) -> (
     Collection<G, DecodeResult, Diff>,
     Stream<G, HealthStatusMessage>,
-    Option<Box<dyn Any + Send + Sync>>,
 )
 where
     G: Scope,
@@ -530,5 +539,5 @@ where
         }
     });
 
-    (output.as_collection(), health, None)
+    (output.as_collection(), health)
 }

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -9,7 +9,6 @@
 
 //! Healthcheck common
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::collections::btree_map::Entry;
 use std::collections::{BTreeMap, BTreeSet};
@@ -24,7 +23,9 @@ use mz_ore::cast::CastFrom;
 use mz_ore::now::NowFn;
 use mz_repr::GlobalId;
 use mz_storage_client::client::StatusUpdate;
-use mz_timely_util::builder_async::{Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::builder_async::{
+    Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
 use timely::dataflow::channels::pact::Exchange;
 use timely::dataflow::operators::{Enter, Map};
 use timely::dataflow::scopes::Child;
@@ -325,7 +326,7 @@ pub(crate) fn health_operator<'g, G, P>(
     health_operator_impl: P,
     // Whether or not we should actually write namespaced errors in the `details` column.
     write_namespaced_map: bool,
-) -> Rc<dyn Any>
+) -> PressOnDropButton
 where
     G: Scope<Timestamp = ()>,
     P: HealthOperator + 'static,
@@ -501,7 +502,7 @@ where
         }
     });
 
-    Rc::new(button.press_on_drop())
+    button.press_on_drop()
 }
 
 use serde::{Deserialize, Serialize};

--- a/src/storage/src/render/persist_sink.rs
+++ b/src/storage/src/render/persist_sink.rs
@@ -87,7 +87,6 @@
 //!
 // TODO(guswynn): merge at least the `append_batches` operator`
 
-use std::any::Any;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -110,7 +109,9 @@ use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
 use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sources::SourceData;
-use mz_timely_util::builder_async::{Event, OperatorBuilder as AsyncOperatorBuilder};
+use mz_timely_util::builder_async::{
+    Event, OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton,
+};
 use serde::{Deserialize, Serialize};
 use timely::dataflow::channels::pact::{Exchange, Pipeline};
 use timely::dataflow::operators::{Broadcast, Capability, CapabilitySet, Inspect};
@@ -314,7 +315,11 @@ pub(crate) fn render<G>(
     storage_state: &StorageState,
     metrics: SourcePersistSinkMetrics,
     output_index: usize,
-) -> (Stream<G, ()>, Stream<G, Rc<anyhow::Error>>, Rc<dyn Any>)
+) -> (
+    Stream<G, ()>,
+    Stream<G, Rc<anyhow::Error>>,
+    Vec<PressOnDropButton>,
+)
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {
@@ -358,7 +363,7 @@ where
     (
         upper_stream,
         append_errors,
-        Rc::new((mint_token, write_token, append_token)),
+        vec![mint_token, write_token, append_token],
     )
 }
 
@@ -380,7 +385,7 @@ fn mint_batch_descriptions<G>(
 ) -> (
     Stream<G, (Antichain<mz_repr::Timestamp>, Antichain<mz_repr::Timestamp>)>,
     Stream<G, (Result<Row, DataflowError>, mz_repr::Timestamp, Diff)>,
-    Rc<dyn Any>,
+    PressOnDropButton,
 )
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -536,8 +541,11 @@ where
         }
     });
 
-    let token = Rc::new(shutdown_button.press_on_drop());
-    (output_stream, data_output_stream, token)
+    (
+        output_stream,
+        data_output_stream,
+        shutdown_button.press_on_drop(),
+    )
 }
 
 /// Writes `desired_collection` to persist, but only for updates
@@ -559,7 +567,7 @@ fn write_batches<G>(
     storage_state: &StorageState,
 ) -> (
     Stream<G, HollowBatchAndMetadata<SourceData, (), mz_repr::Timestamp, Diff>>,
-    Rc<dyn Any>,
+    PressOnDropButton,
 )
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
@@ -884,8 +892,7 @@ where
         output_stream.inspect(|d| trace!("batch: {:?}", d));
     }
 
-    let token = Rc::new(shutdown_button.press_on_drop());
-    (output_stream, token)
+    (output_stream, shutdown_button.press_on_drop())
 }
 
 /// Fuses written batches together and appends them to persist using one
@@ -908,7 +915,11 @@ fn append_batches<G>(
     storage_state: &StorageState,
     output_index: usize,
     metrics: SourcePersistSinkMetrics,
-) -> (Stream<G, ()>, Stream<G, Rc<anyhow::Error>>, Rc<dyn Any>)
+) -> (
+    Stream<G, ()>,
+    Stream<G, Rc<anyhow::Error>>,
+    PressOnDropButton,
+)
 where
     G: Scope<Timestamp = mz_repr::Timestamp>,
 {
@@ -1257,9 +1268,5 @@ where
         }
     }));
 
-    (
-        upper_stream,
-        errors,
-        Rc::new(shutdown_button.press_on_drop()),
-    )
+    (upper_stream, errors, shutdown_button.press_on_drop())
 }

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -9,7 +9,6 @@
 
 //! Logic related to the creation of dataflow sinks.
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -24,6 +23,7 @@ use mz_storage_types::errors::DataflowError;
 use mz_storage_types::sinks::{
     MetadataFilled, SinkEnvelope, StorageSinkConnection, StorageSinkDesc,
 };
+use mz_timely_util::builder_async::PressOnDropButton;
 use timely::dataflow::operators::Leave;
 use timely::dataflow::scopes::Child;
 use timely::dataflow::{Scope, Stream};
@@ -38,13 +38,13 @@ use crate::storage_state::StorageState;
 pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
     scope: &mut Child<'g, G, mz_repr::Timestamp>,
     storage_state: &mut StorageState,
-    tokens: &mut Vec<Rc<dyn std::any::Any>>,
     sink_id: GlobalId,
     sink: &StorageSinkDesc<MetadataFilled, mz_repr::Timestamp>,
-) -> Stream<G, HealthStatusMessage> {
+) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>) {
     let sink_render = get_sink_render_for(&sink.connection);
 
-    let (ok_collection, err_collection, source_token) = persist_source::persist_source(
+    let mut tokens = vec![];
+    let (ok_collection, err_collection, persist_tokens) = persist_source::persist_source(
         scope,
         sink.from,
         Arc::clone(&storage_state.persist_clients),
@@ -54,12 +54,12 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         None,
         None,
     );
-    tokens.push(source_token);
+    tokens.extend(persist_tokens);
 
     let ok_collection =
         apply_sink_envelope(sink_id, sink, &sink_render, ok_collection.as_collection());
 
-    let (health, sink_token) = sink_render.render_continuous_sink(
+    let (health, sink_tokens) = sink_render.render_continuous_sink(
         storage_state,
         sink,
         sink_id,
@@ -67,11 +67,9 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         err_collection.as_collection(),
     );
 
-    if let Some(sink_token) = sink_token {
-        tokens.push(sink_token);
-    }
+    tokens.extend(sink_tokens);
 
-    health.leave()
+    (health.leave(), tokens)
 }
 
 #[allow(clippy::borrowed_box)]
@@ -227,7 +225,7 @@ where
         sink_id: GlobalId,
         sinked_collection: Collection<G, (Option<Row>, Option<Row>), Diff>,
         err_collection: Collection<G, DataflowError, Diff>,
-    ) -> (Stream<G, HealthStatusMessage>, Option<Rc<dyn Any>>)
+    ) -> (Stream<G, HealthStatusMessage>, Vec<PressOnDropButton>)
     where
         G: Scope<Timestamp = Timestamp>;
 }

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -11,7 +11,6 @@
 //!
 //! See [`render_source`] for more details.
 
-use std::any::Any;
 use std::collections::BTreeMap;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -28,6 +27,7 @@ use mz_storage_types::errors::{
 use mz_storage_types::parameters::StorageMaxInflightBytesConfig;
 use mz_storage_types::sources::encoding::*;
 use mz_storage_types::sources::*;
+use mz_timely_util::builder_async::PressOnDropButton;
 use mz_timely_util::operator::CollectionExt;
 use mz_timely_util::order::refine_antichain;
 use serde::{Deserialize, Serialize};
@@ -85,10 +85,10 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
         Collection<Child<'g, G, mz_repr::Timestamp>, DataflowError, Diff>,
     )>,
     Stream<G, HealthStatusMessage>,
-    Rc<dyn Any>,
+    Vec<PressOnDropButton>,
 ) {
     // Tokens that we should return from the method.
-    let mut needed_tokens: Vec<Rc<dyn Any>> = Vec::new();
+    let mut needed_tokens = Vec::new();
 
     // Note that this `render_source` attaches a single _instance_ of a source
     // to the passed `Scope`, and this instance may be disabled if the
@@ -149,9 +149,9 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
 
     // Build the _raw_ ok and error sources using `create_raw_source` and the
     // correct `SourceReader` implementations
-    let (streams, mut health, capability) = match connection {
+    let (streams, mut health, source_tokens) = match connection {
         GenericSourceConnection::Kafka(connection) => {
-            let (streams, health, cap) = source::create_raw_source(
+            let (streams, health, source_tokens) = source::create_raw_source(
                 scope,
                 resume_stream,
                 base_source_config.clone(),
@@ -163,10 +163,10 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 .into_iter()
                 .map(|(ok, err)| (SourceType::Delimited(ok), err))
                 .collect();
-            (streams, health, cap)
+            (streams, health, source_tokens)
         }
         GenericSourceConnection::Postgres(connection) => {
-            let (streams, health, cap) = source::create_raw_source(
+            let (streams, health, source_tokens) = source::create_raw_source(
                 scope,
                 resume_stream,
                 base_source_config.clone(),
@@ -178,10 +178,10 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 .into_iter()
                 .map(|(ok, err)| (SourceType::Row(ok), err))
                 .collect();
-            (streams, health, cap)
+            (streams, health, source_tokens)
         }
         GenericSourceConnection::LoadGenerator(connection) => {
-            let (streams, health, cap) = source::create_raw_source(
+            let (streams, health, source_tokens) = source::create_raw_source(
                 scope,
                 resume_stream,
                 base_source_config.clone(),
@@ -193,10 +193,10 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 .into_iter()
                 .map(|(ok, err)| (SourceType::Row(ok), err))
                 .collect();
-            (streams, health, cap)
+            (streams, health, source_tokens)
         }
         GenericSourceConnection::TestScript(connection) => {
-            let (streams, health, cap) = source::create_raw_source(
+            let (streams, health, source_tokens) = source::create_raw_source(
                 scope,
                 resume_stream,
                 base_source_config.clone(),
@@ -208,13 +208,11 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
                 .into_iter()
                 .map(|(ok, err)| (SourceType::Delimited(ok), err))
                 .collect();
-            (streams, health, cap)
+            (streams, health, source_tokens)
         }
     };
 
-    let source_token = Rc::new(capability);
-
-    needed_tokens.push(source_token);
+    needed_tokens.extend(source_tokens);
 
     let mut outputs = vec![];
     for (ok_source, err_source) in streams {
@@ -240,7 +238,7 @@ pub fn render_source<'g, G: Scope<Timestamp = ()>>(
 
         health = health.concat(&health_stream.leave());
     }
-    (outputs, health, Rc::new(needed_tokens))
+    (outputs, health, needed_tokens)
 }
 
 /// Completes the rendering of a particular source stream by applying decoding and envelope
@@ -259,13 +257,13 @@ fn render_source_stream<G>(
 ) -> (
     Collection<G, Row, Diff>,
     Collection<G, DataflowError, Diff>,
-    Vec<Rc<dyn Any>>,
+    Vec<PressOnDropButton>,
     Stream<G, HealthStatusMessage>,
 )
 where
     G: Scope<Timestamp = Timestamp>,
 {
-    let mut needed_tokens: Vec<Rc<dyn Any>> = vec![];
+    let mut needed_tokens = vec![];
 
     let SourceDesc {
         encoding,
@@ -307,13 +305,13 @@ where
                 csr_connection,
                 confluent_wire_format,
             );
-            needed_tokens.push(Rc::new(token));
+            needed_tokens.push(token);
             (oks, None, empty(scope))
         } else {
             // Depending on the type of _raw_ source produced for the given source
             // connection, render the _decode_ part of the pipeline, that turns a raw data
             // stream into a `DecodeResult`.
-            let (decoded_stream, decode_health, extra_token) = match ok_source {
+            let (decoded_stream, decode_health) = match ok_source {
                 SourceType::Delimited(source) => render_decode_delimited(
                     &source,
                     key_encoding,
@@ -330,12 +328,8 @@ where
                         position_for_upsert: r.position_for_upsert,
                     }),
                     empty(scope),
-                    None,
                 ),
             };
-            if let Some(tok) = extra_token {
-                needed_tokens.push(Rc::new(tok));
-            }
 
             // render envelopes
             let (envelope_ok, envelope_err, envelope_health) = match &envelope {
@@ -363,7 +357,7 @@ where
                                 tx_source_ok_stream.as_collection(),
                                 tx_source_err_stream.as_collection(),
                             );
-                            needed_tokens.push(tx_token);
+                            needed_tokens.extend(tx_token);
                             error_collections.push(tx_source_err);
 
                             super::debezium::render_tx(dbz_envelope, &decoded_stream, tx_source_ok)

--- a/src/storage/src/render/upsert.rs
+++ b/src/storage/src/render/upsert.rs
@@ -7,12 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::cell::RefCell;
 use std::cmp::Reverse;
 use std::convert::AsRef;
 use std::hash::{Hash, Hasher};
-use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -29,6 +27,7 @@ use mz_storage_types::errors::{DataflowError, EnvelopeError, UpsertError};
 use mz_storage_types::sources::UpsertEnvelope;
 use mz_timely_util::builder_async::{
     AsyncOutputHandle, Event as AsyncEvent, OperatorBuilder as AsyncOperatorBuilder,
+    PressOnDropButton,
 };
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
@@ -187,7 +186,7 @@ pub(crate) fn upsert<G: Scope, O: timely::ExchangeData + Ord>(
     upsert_envelope: UpsertEnvelope,
     resume_upper: Antichain<G::Timestamp>,
     previous: Collection<G, Result<Row, DataflowError>, Diff>,
-    previous_token: Option<Rc<dyn Any>>,
+    previous_token: Option<Vec<PressOnDropButton>>,
     source_config: crate::source::RawSourceCreationConfig,
     instance_context: &StorageInstanceContext,
     dataflow_paramters: &crate::internal_control::DataflowParameters,
@@ -195,7 +194,7 @@ pub(crate) fn upsert<G: Scope, O: timely::ExchangeData + Ord>(
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
-    Rc<dyn Any>,
+    PressOnDropButton,
 )
 where
     G::Timestamp: TotalOrder,
@@ -362,7 +361,7 @@ fn upsert_inner<G: Scope, O: timely::ExchangeData + Ord, F, Fut, US>(
     mut key_indices: Vec<usize>,
     resume_upper: Antichain<G::Timestamp>,
     previous: Collection<G, Result<Row, DataflowError>, Diff>,
-    previous_token: Option<Rc<dyn Any>>,
+    previous_token: Option<Vec<PressOnDropButton>>,
     upsert_metrics: UpsertMetrics,
     source_config: crate::source::RawSourceCreationConfig,
     state: F,
@@ -370,7 +369,7 @@ fn upsert_inner<G: Scope, O: timely::ExchangeData + Ord, F, Fut, US>(
 ) -> (
     Collection<G, Result<Row, DataflowError>, Diff>,
     Stream<G, (OutputIndex, HealthStatusUpdate)>,
-    Rc<dyn Any>,
+    PressOnDropButton,
 )
 where
     G::Timestamp: TotalOrder,
@@ -720,7 +719,7 @@ where
             Err(err) => Err(DataflowError::from(EnvelopeError::Upsert(err))),
         }),
         health_stream,
-        Rc::new(shutdown_button.press_on_drop()),
+        shutdown_button.press_on_drop(),
     )
 }
 

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -7,9 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::convert::Infallible;
-use std::rc::Rc;
 use std::time::Duration;
 
 use differential_dataflow::{AsCollection, Collection};
@@ -19,7 +17,7 @@ use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sources::{
     Generator, LoadGenerator, LoadGeneratorSourceConnection, MzOffset, SourceTimestamp,
 };
-use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 use timely::dataflow::operators::to_stream::Event;
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
@@ -94,7 +92,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
         >,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
-        Rc<dyn Any>,
+        Vec<PressOnDropButton>,
     ) {
         let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
@@ -170,7 +168,7 @@ impl SourceRender for LoadGeneratorSourceConnection {
             stream.as_collection(),
             None,
             status,
-            Rc::new(button.press_on_drop()),
+            vec![button.press_on_drop()],
         )
     }
 }

--- a/src/storage/src/source/kafka.rs
+++ b/src/storage/src/source/kafka.rs
@@ -7,11 +7,9 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::collections::btree_map::Entry;
 use std::collections::BTreeMap;
 use std::convert::Infallible;
-use std::rc::Rc;
 use std::str::{self};
 use std::sync::{Arc, Mutex};
 use std::thread;
@@ -37,7 +35,7 @@ use mz_storage_types::sources::{
     KafkaMetadataKind, KafkaSourceConnection, MzOffset, SourceTimestamp,
 };
 use mz_timely_util::antichain::AntichainExt;
-use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 use mz_timely_util::order::Partitioned;
 use rdkafka::client::Client;
 use rdkafka::consumer::base_consumer::PartitionQueue;
@@ -156,7 +154,7 @@ impl SourceRender for KafkaSourceConnection {
         >,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
-        Rc<dyn Any>,
+        Vec<PressOnDropButton>,
     ) {
         let mut builder = AsyncOperatorBuilder::new(config.name.clone(), scope.clone());
 
@@ -710,7 +708,7 @@ impl SourceRender for KafkaSourceConnection {
             stream.as_collection(),
             Some(progress_stream),
             health_stream,
-            Rc::new(button.press_on_drop()),
+            vec![button.press_on_drop()],
         )
     }
 }

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -7,16 +7,14 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-use std::any::Any;
 use std::convert::Infallible;
-use std::rc::Rc;
 
 use differential_dataflow::{AsCollection, Collection};
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Diff, Row};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sources::{MzOffset, TestScriptSourceConnection};
-use mz_timely_util::builder_async::OperatorBuilder as AsyncOperatorBuilder;
+use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 use timely::dataflow::operators::ToStream;
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -68,7 +66,7 @@ impl SourceRender for TestScriptSourceConnection {
         >,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
-        Rc<dyn Any>,
+        Vec<PressOnDropButton>,
     ) {
         let mut builder = AsyncOperatorBuilder::new(config.name, scope.clone());
 
@@ -113,7 +111,7 @@ impl SourceRender for TestScriptSourceConnection {
             stream.as_collection(),
             None,
             status,
-            Rc::new(button.press_on_drop()),
+            vec![button.press_on_drop()],
         )
     }
 }

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -12,16 +12,15 @@
 // https://github.com/tokio-rs/prost/issues/237
 // #![allow(missing_docs)]
 
-use std::any::Any;
 use std::convert::Infallible;
 use std::fmt::Debug;
-use std::rc::Rc;
 
 use differential_dataflow::Collection;
 use mz_repr::{Diff, Row};
 use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::{DecodeError, SourceErrorDetails};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
+use mz_timely_util::builder_async::PressOnDropButton;
 use serde::{Deserialize, Serialize};
 use timely::dataflow::{Scope, Stream};
 use timely::progress::Antichain;
@@ -79,7 +78,7 @@ pub trait SourceRender {
         >,
         Option<Stream<G, Infallible>>,
         Stream<G, HealthStatusMessage>,
-        Rc<dyn Any>,
+        Vec<PressOnDropButton>,
     );
 }
 


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Dataflow shutdown has proven to be extremely tricky and the only safe to
use API currently is the `AsyncOperatorBuilder` together with its button
implementation. In light of the recent shutdown bugs this PR bans all
custom tokens from storage by requiring that all tokens are instances of
the `PressOnDropButton` type which is provided by the `mz_timely_util`
crate.

Truly custom shutdown workflows can still be built by manually
manipulating the button but at the time of writing all operators are
accomodated by the default behavior.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
