### PR TITLE
catalog: Expire catalog storage after use

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -138,7 +138,7 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     async fn trace(&mut self) -> Result<Trace, CatalogError>;
 
     /// Politely releases all external resources that can only be released in an async context.
-    async fn expire(self);
+    async fn expire(self: Box<Self>);
 }
 
 // TODO(jkosh44) No method should take &mut self, but due to stash implementations we need it.

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -534,7 +534,7 @@ impl OpenableDurableCatalogState for PersistHandle {
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    async fn expire(self) {
+    async fn expire(self: Box<Self>) {
         self.read_handle.expire().await;
         self.write_handle.expire().await;
     }

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -160,7 +160,7 @@ where
         panic!("ShadowCatalog is not used for catalog-debug tool");
     }
 
-    async fn expire(self) {
+    async fn expire(self: Box<Self>) {
         futures::future::join(self.stash.expire(), self.persist.expire()).await;
     }
 }

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -411,7 +411,7 @@ impl OpenableDurableCatalogState for OpenableConnection {
         })
     }
 
-    async fn expire(self) {
+    async fn expire(self: Box<Self>) {
         // Nothing to release in the stash.
     }
 }
@@ -1152,7 +1152,7 @@ impl OpenableDurableCatalogState for TestOpenableConnection<'_> {
         self.openable_connection.trace().await
     }
 
-    async fn expire(self) {
+    async fn expire(self: Box<Self>) {
         self.openable_connection.expire().await
     }
 }

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -410,6 +410,7 @@ impl Listeners {
 
             if !openable_adapter_storage.is_initialized().await? {
                 tracing::info!("Stash doesn't exist so there's no current deploy generation. We won't wait to be leader");
+                openable_adapter_storage.expire().await;
                 break 'leader_promotion;
             }
             // TODO: once all stashes have a deploy_generation, don't need to handle the Option
@@ -452,7 +453,9 @@ impl Listeners {
                 }
             } else if stash_generation == Some(deploy_generation) {
                 tracing::info!("Server requested generation {deploy_generation} which is equal to stash's generation");
+                openable_adapter_storage.expire().await;
             } else {
+                openable_adapter_storage.expire().await;
                 mz_ore::halt!("Server started with requested generation {deploy_generation} but stash was already at {stash_generation:?}. Deploy generations must increase monotonically");
             }
         }


### PR DESCRIPTION
This commit makes sure to expire durable catalog storage after using it so that resources are freed efficiently.

Works towards resolving #22392

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
