### PR TITLE
Fix statement logging for subscribes in HTTP queries (incl. websocket).

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -94,10 +94,10 @@ use mz_expr::{MirRelationExpr, OptimizedMirRelationExpr};
 use mz_orchestrator::ServiceProcessMetrics;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::now::{EpochMillis, NowFn};
-use mz_ore::stack;
 use mz_ore::task::spawn;
 use mz_ore::thread::JoinHandleExt;
 use mz_ore::tracing::{OpenTelemetryContext, TracingHandle};
+use mz_ore::{soft_panic_or_log, stack};
 use mz_persist_client::usage::{ShardsUsageReferenced, StorageUsageClient};
 use mz_repr::explain::ExplainFormat;
 use mz_repr::role_id::RoleId;
@@ -792,20 +792,10 @@ impl Drop for ExecuteContextExtra {
     fn drop(&mut self) {
         let Self { statement_uuid } = &*self;
         if let Some(statement_uuid) = statement_uuid {
-            // TODO [btv] -- We know this is happening in prod now,
-            // seemingly only related to SUBSCRIBEs from the console.
-            //
-            // This is `error` for now until I get around to debugging
-            // the root cause, as it's not a severe enough issue to be
-            // worth breaking staging.
-            //
-            // Once all known causes of this are resolved, bump this
-            // back to a soft_assert.
-            //
             // Note: the impact when this error hits
             // is that the statement will never be marked
             // as finished in the statement log.
-            tracing::error!("execute context for statement {statement_uuid:?} dropped without being properly retired.");
+            soft_panic_or_log!("execute context for statement {statement_uuid:?} dropped without being properly retired.");
         }
     }
 }

--- a/src/environmentd/src/http/sql.rs
+++ b/src/environmentd/src/http/sql.rs
@@ -558,6 +558,13 @@ trait ResultSender: Send {
 
 #[async_trait]
 impl ResultSender for SqlResponse {
+    // The first component of the return value is
+    // Err if sending to the client
+    // produced an error and the server should disconnect. It is Ok(Err) if the statement
+    // produced an error and should error the transaction, but remain connected. It is Ok(Ok(()))
+    // if the statement succeeded.
+    // The second component of the return value is `Some` if execution still
+    // needs to be retired for statement logging purposes.
     async fn add_result<C, F>(
         &mut self,
         _canceled: C,
@@ -608,6 +615,13 @@ impl ResultSender for SqlResponse {
 
 #[async_trait]
 impl ResultSender for WebSocket {
+    // The first component of the return value is
+    // Err if sending to the client
+    // produced an error and the server should disconnect. It is Ok(Err) if the statement
+    // produced an error and should error the transaction, but remain connected. It is Ok(Ok(()))
+    // if the statement succeeded.
+    // The second component of the return value is `Some` if execution still
+    // needs to be retired for statement logging purposes.
     async fn add_result<C, F>(
         &mut self,
         canceled: C,

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -1779,6 +1779,37 @@ fn test_ws_passes_options() {
 }
 
 #[mz_ore::test]
+// Test that statement logging
+// doesn't cause a crash with subscribes over web sockets,
+// which was previously happening (in staging) due to us
+// dropping the `ExecuteContext` on the floor in that case.
+fn test_ws_subscribe_no_crash() {
+    let server = test_util::TestHarness::default()
+        .with_system_parameter_default(
+            "statement_logging_max_sample_rate".to_string(),
+            "1.0".to_string(),
+        )
+        .with_system_parameter_default(
+            "statement_logging_default_sample_rate".to_string(),
+            "1.0".to_string(),
+        )
+        .start_blocking();
+
+    // Create our WebSocket.
+    let ws_url = server.ws_addr();
+    let (mut ws, _resp) = tungstenite::connect(ws_url).unwrap();
+    test_util::auth_with_ws(&mut ws, Default::default()).unwrap();
+
+    let query = "SUBSCRIBE (SELECT 1)";
+    let json = format!("{{\"query\":\"{query}\"}}");
+    let json: serde_json::Value = serde_json::from_str(&json).unwrap();
+    ws.send(Message::Text(json.to_string())).unwrap();
+
+    // Give the server time to crash, if it's going to.
+    std::thread::sleep(Duration::from_secs(1))
+}
+
+#[mz_ore::test]
 #[cfg_attr(miri, ignore)] // too slow
 fn test_ws_notifies_for_bad_options() {
     let server = test_util::TestHarness::default().start_blocking();


### PR DESCRIPTION
The protocol for statement logging of subscribes is as follows:

1. When the statement begins execution, an ID is generated (this is the payload of the `ExecuteContextExtra`). This struct has a `Drop` impl that logs an error (actually a soft_panic) if we forget to retire it.
2. This `ExecuteContextExtra` is handed back to the client (pgwire or http) as part of the `ExecuteResponse` for subscribes.
3. Once the subscribe ends (either by finishing normally, erroring, or being canceled) the client is supposed to send the `ExecuteContextExtra` back to the coordinator for the statement log entry to be finalized.

This works fine in pgwire, but step 3 never got implemented in the HTTP layer.

### Motivation

Fixes #21598 

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixed a bug causing `SUBSCRIBE` statements issued via the web console to never be marked as finished in `mz_activity_log`.
