### PR TITLE
test: enable debug logging for #18628's investigation

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -79,6 +79,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "timestamp_oracle": "postgres",
     "default_idle_arrangement_merge_effort": "0",
     "default_arrangement_exert_proportionality": "16",
+    # TODO: remove this once #18628 is resolved
+    "log_filter": "mz_storage::sink::kafka=debug,info",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/test/sqllogictest/mz-support-privileges.slt
+++ b/test/sqllogictest/mz-support-privileges.slt
@@ -10,6 +10,13 @@
 # Tests that assert the privileges that are assumed to be always granted to
 # the mz_support user.
 
+# This can be removed once #18628 is resolved and we no longer need debug logging
+# in Kafka sinks
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM RESET log_filter
+----
+COMPLETE 0
+
 statement ok
 CREATE TABLE t (a INT)
 

--- a/test/tracing/mzcompose.py
+++ b/test/tracing/mzcompose.py
@@ -37,7 +37,7 @@ def workflow_with_otel(c: Composition) -> None:
 
     # Start with fastpath
     info = requests.get(f"http://localhost:{port}/api/tracing").json()
-    assert info["current_level_filter"] == "info"
+    assert info["current_level_filter"] == "debug"
 
     # update the stderr config
     c.sql(


### PR DESCRIPTION
To aid in #18628 's investigation, we want to increase the logging of `mz_storage::sink::kafka` to `DEBUG` in CI. This seems like the most sane approach to me, but maybe there's something better?

### Motivation

This PR adds a known-desirable feature.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
