### PR TITLE
catalog: Prevent duplicate catalog metrics reg

### DIFF
--- a/src/catalog-debug/src/main.rs
+++ b/src/catalog-debug/src/main.rs
@@ -242,10 +242,8 @@ async fn run(args: Args) -> Result<(), anyhow::Error> {
             };
             let persist_client = persist_clients.open(persist_location).await?;
             let organization_id = args.organization_id.expect("required for persist");
-            Box::new(
-                persist_backed_catalog_state(persist_client, organization_id, &metrics_registry)
-                    .await,
-            )
+            let metrics = Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry));
+            Box::new(persist_backed_catalog_state(persist_client, organization_id, metrics).await)
         }
     };
 

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -7,7 +7,7 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod metrics;
+pub(crate) mod metrics;
 pub(crate) mod state_update;
 
 use std::collections::BTreeMap;
@@ -23,7 +23,7 @@ use futures::StreamExt;
 use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_ore::collections::CollectionExt;
-use mz_ore::metrics::{MetricsFutureExt, MetricsRegistry};
+use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::retry::{Retry, RetryResult};
 use mz_ore::{soft_assert, soft_assert_eq, soft_assert_ne};
@@ -103,7 +103,7 @@ impl PersistHandle {
     pub(crate) async fn new(
         persist_client: PersistClient,
         organization_id: Uuid,
-        registry: &MetricsRegistry,
+        metrics: Arc<Metrics>,
     ) -> PersistHandle {
         const SEED: usize = 1;
         let shard_id = Self::shard_id(organization_id, SEED);
@@ -117,7 +117,6 @@ impl PersistHandle {
             )
             .await
             .expect("invalid usage");
-        let metrics = Arc::new(Metrics::new(registry));
         PersistHandle {
             write_handle,
             read_handle,

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -946,7 +946,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
             },
             CatalogKind::Persist => CatalogConfig::Persist {
                 persist_clients,
-                metrics_registry: metrics_registry.clone(),
+                metrics: Arc::new(mz_catalog::durable::Metrics::new(&metrics_registry)),
             },
             CatalogKind::Shadow => CatalogConfig::Shadow {
                 url: args.adapter_stash_url.expect("required for shadow catalog"),

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -261,8 +261,8 @@ pub enum CatalogConfig {
     Persist {
         /// A process-global cache of (blob_uri, consensus_uri) -> PersistClient.
         persist_clients: Arc<PersistClientCache>,
-        /// Metrics registry.
-        metrics_registry: MetricsRegistry,
+        /// Persist catalog metrics.
+        metrics: Arc<mz_catalog::durable::Metrics>,
     },
     /// The catalog contents are stored in both persist and the stash and their contents are
     /// compared. This is mostly used for testing purposes.
@@ -728,7 +728,7 @@ async fn catalog_opener(
         }
         CatalogConfig::Persist {
             persist_clients,
-            metrics_registry,
+            metrics,
         } => {
             info!("Using persist backed catalog");
             let persist_client = persist_clients
@@ -739,7 +739,7 @@ async fn catalog_opener(
                 mz_catalog::durable::persist_backed_catalog_state(
                     persist_client,
                     environment_id.organization_id(),
-                    metrics_registry,
+                    Arc::clone(metrics),
                 )
                 .await,
             )


### PR DESCRIPTION
This commit prevents catalog metrics from being registered multiple times and panicking.

Resolves #23465

### Motivation
This PR fixes a previously unreported bug.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes. 
