### PR TITLE
persist-txn: fix bug resulting in phantom latest_write

### DIFF
--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -294,16 +294,20 @@ pub mod txns;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum TxnsEntry {
     /// A data shard register operation.
-    Register(ShardId),
+    ///
+    /// The `[u8; 8]` is a Codec64 encoded timestamp.
+    Register(ShardId, [u8; 8]),
     /// A batch written to a data shard in a txn.
-    Append(ShardId, Vec<u8>),
+    ///
+    /// The `[u8; 8]` is a Codec64 encoded timestamp.
+    Append(ShardId, [u8; 8], Vec<u8>),
 }
 
 impl TxnsEntry {
     fn data_id(&self) -> &ShardId {
         match self {
-            TxnsEntry::Register(data_id) => data_id,
-            TxnsEntry::Append(data_id, _) => data_id,
+            TxnsEntry::Register(data_id, _) => data_id,
+            TxnsEntry::Append(data_id, _, _) => data_id,
         }
     }
 }
@@ -351,15 +355,22 @@ impl TxnsCodec for TxnsCodecDefault {
     }
     fn encode(e: TxnsEntry) -> (Self::Key, Self::Val) {
         match e {
-            TxnsEntry::Register(data_id) => (data_id, Vec::new()),
-            TxnsEntry::Append(data_id, batch) => (data_id, batch),
+            TxnsEntry::Register(data_id, ts) => (data_id, ts.to_vec()),
+            TxnsEntry::Append(data_id, ts, batch) => {
+                // Put the ts at the end to let decode truncate it off.
+                (data_id, batch.into_iter().chain(ts).collect())
+            }
         }
     }
-    fn decode(key: Self::Key, val: Self::Val) -> TxnsEntry {
+    fn decode(key: Self::Key, mut val: Self::Val) -> TxnsEntry {
+        let mut ts = [0u8; 8];
+        let ts_idx = val.len().checked_sub(8).expect("ts encoded at end of val");
+        ts.copy_from_slice(&val[ts_idx..]);
+        val.truncate(ts_idx);
         if val.is_empty() {
-            TxnsEntry::Register(key)
+            TxnsEntry::Register(key, ts)
         } else {
-            TxnsEntry::Append(key, val)
+            TxnsEntry::Append(key, ts, val)
         }
     }
     fn should_fetch_part(data_id: &ShardId, stats: &PartStats) -> Option<bool> {

--- a/src/persist-txn/src/txn_write.rs
+++ b/src/persist-txn/src/txn_write.rs
@@ -142,7 +142,11 @@ where
                         batch_raw.hashed(),
                         updates.len()
                     );
-                    let update = C::encode(TxnsEntry::Append(*data_id, batch_raw));
+                    let update = C::encode(TxnsEntry::Append(
+                        *data_id,
+                        T::encode(&commit_ts),
+                        batch_raw,
+                    ));
                     (data_write, batch, update)
                 })
             }
@@ -162,8 +166,8 @@ where
             let filtered_retractions = handle
                 .read_cache()
                 .filter_retractions(&txns_upper, self.tidy.retractions.iter())
-                .map(|(batch_raw, data_id)| {
-                    C::encode(TxnsEntry::Append(*data_id, batch_raw.clone()))
+                .map(|(batch_raw, (ts, data_id))| {
+                    C::encode(TxnsEntry::Append(*data_id, *ts, batch_raw.clone()))
                 })
                 .collect::<Vec<_>>();
             txns_updates.extend(


### PR DESCRIPTION
This fixes the regression test I previously added for a bug where:

- We commit a txn at some `t0`
- We later apply it and tidy/retract it at `t3`
- We start reading the txns shard as_of `t1` to serve a snapshot at `t2`
- `t0` < `t1` < `t2` < `t3`

The txns shard snapshot sees the write at `t0` advanced to `t1` and so the DataSnapshot gets a `latest_write` of `Some(t1)`, but this is incorrect (it should be `None` because we wouldn't compact to `t1` unless we had applied everything before it). The apply will advance the physical upper to `t0` but the `unblock_reads` call will wait forever for it to get to `t1`.

The fix: encode the original `commit_ts` in the persist `K, V` where it won't get advanced by compaction. I don't love this, it seems redundant and clunky, but I've let this sit for a couple weeks and haven't come up with anything else.

This commit also does the same for the `register_ts`, which is not necessary to fix the bug, but only doing one would be subtle. Also, reasoning about the compaction timestamps has been reasonably confusing while working on persist-txn, so this is all probably better in the long run, anyway.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR fixes a recognized bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
