### PR TITLE
sqllogictest: emit buildkite friendly section headers

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1833,7 +1833,7 @@ pub async fn run_string(
     // Transactions are currently relatively slow. Since sqllogictest runs in a single connection
     // there should be no difference in having longer running transactions.
     let mut in_transaction = false;
-    writeln!(runner.config.stdout, "==> {}", source);
+    writeln!(runner.config.stdout, "--- {}", source);
 
     for record in parser.parse_records()? {
         // In maximal-verbosity mode, print the query before attempting to run
@@ -1910,7 +1910,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
     let mut buf = RewriteBuffer::new(&input);
 
     let mut parser = crate::parser::Parser::new(filename.to_str().unwrap_or(""), &input);
-    writeln!(runner.config.stdout, "==> {}", filename.display());
+    writeln!(runner.config.stdout, "--- {}", filename.display());
     let mut in_transaction = false;
 
     fn append_values_output(


### PR DESCRIPTION
This switches the "==>" header for each file to be "---", which gets us a section for each file in the buildkite logs.

<img width="870" alt="image" src="https://github.com/MaterializeInc/materialize/assets/52528/3955ae0a-515b-41ef-917d-2b99fb182d29">

### Motivation

  * This PR adds a feature that has not yet been specified.

### Tips for reviewer

How much do we care about the old section header? If we do, this could be a cli flag that CI sets.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
