### PR TITLE
coord: Parallelize builtin table writes with side effects

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -194,13 +194,6 @@ pub enum Message<T = mz_repr::Timestamp> {
         Vec<CompletedClientTransmitter>,
         /// Optional lock if the group commit contained writes to user tables.
         Option<OwnedMutexGuard<()>>,
-        /// Operations waiting on this group commit to finish.
-        ///
-        /// Note: this differs from the [`CompletedClientTransmitter`]s above because those are
-        /// used to send a response to a request, which indicates the Coordinator has finished all
-        /// of it's work, but these represent auxiliary work that still needs to be done, e.g.
-        /// waiting for a write to Persist to complete.
-        Vec<oneshot::Sender<()>>,
         /// Permit which limits how many group commits we run at once.
         Option<GroupCommitPermit>,
     ),
@@ -1460,37 +1453,57 @@ impl Coordinator {
         }
 
         debug!("coordinator init: sending builtin table updates");
-        self.send_builtin_table_updates_blocking(builtin_table_updates)
+        let builtin_updates_fut = self
+            .builtin_table_update()
+            .execute(builtin_table_updates)
             .await;
+
+        // Destructure Self so we can do some concurrent work.
+        let Self {
+            controller,
+            secrets_controller,
+            catalog,
+            ..
+        } = self;
 
         // Signal to the storage controller that it is now free to reconcile its
         // state with what it has learned from the adapter.
-        self.controller.storage.reconcile_state().await;
+        let storage_reconcile_fut = controller.storage.reconcile_state();
 
         // Cleanup orphaned secrets. Errors during list() or delete() do not
         // need to prevent bootstrap from succeeding; we will retry next
         // startup.
-        match self.secrets_controller.list().await {
-            Ok(controller_secrets) => {
-                // Fetch all IDs from the catalog to future-proof against other
-                // things using secrets. Today, SECRET and CONNECTION objects use
-                // secrets_controller.ensure, but more things could in the future
-                // that would be easy to miss adding here.
-                let catalog_ids: BTreeSet<GlobalId> =
-                    self.catalog().entries().map(|entry| entry.id()).collect();
-                let controller_secrets: BTreeSet<GlobalId> =
-                    controller_secrets.into_iter().collect();
-                let orphaned = controller_secrets.difference(&catalog_ids);
-                for id in orphaned {
-                    info!("coordinator init: deleting orphaned secret {id}");
-                    fail_point!("orphan_secrets");
-                    if let Err(e) = self.secrets_controller.delete(*id).await {
-                        warn!("Dropping orphaned secret has encountered an error: {}", e);
+        let secrets_cleanup_fut = async move {
+            match secrets_controller.list().await {
+                Ok(controller_secrets) => {
+                    // Fetch all IDs from the catalog to future-proof against other
+                    // things using secrets. Today, SECRET and CONNECTION objects use
+                    // secrets_controller.ensure, but more things could in the future
+                    // that would be easy to miss adding here.
+                    let catalog_ids: BTreeSet<GlobalId> =
+                        catalog.entries().map(|entry| entry.id()).collect();
+                    let controller_secrets: BTreeSet<GlobalId> =
+                        controller_secrets.into_iter().collect();
+                    let orphaned = controller_secrets.difference(&catalog_ids);
+                    for id in orphaned {
+                        info!("coordinator init: deleting orphaned secret {id}");
+                        fail_point!("orphan_secrets");
+                        if let Err(e) = secrets_controller.delete(*id).await {
+                            warn!("Dropping orphaned secret has encountered an error: {}", e);
+                        }
                     }
                 }
+                Err(e) => warn!("Failed to list secrets during orphan cleanup: {:?}", e),
             }
-            Err(e) => warn!("Failed to list secrets during orphan cleanup: {:?}", e),
-        }
+        };
+
+        // Run all of our final steps concurrently.
+        futures::future::join_all([
+            storage_reconcile_fut,
+            builtin_updates_fut,
+            Box::pin(secrets_cleanup_fut),
+        ])
+        .await;
 
         info!("coordinator init: bootstrap complete");
         Ok(())
@@ -2028,8 +2041,8 @@ impl Coordinator {
                 // cancellation safe and add a comment explaining why. You can refer here for more
                 // info: https://docs.rs/tokio/latest/tokio/macro.select.html#cancellation-safety
                 let msg = select! {
-                    // Order matters here. We want to process internal commands
-                    // before processing external commands.
+                    // Order matters here. Some correctness properties rely on us processing
+                    // internal commands before processing external commands.
                     biased;
 
                     // `recv()` on `UnboundedReceiver` is cancel-safe:

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -14,8 +14,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use derivative::Derivative;
-use futures::future::BoxFuture;
-use futures::FutureExt;
+use futures::future::{BoxFuture, FutureExt};
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::task;
 use mz_ore::vec::VecExt;
@@ -53,11 +52,8 @@ pub(crate) struct DeferredPlan {
 /// Describes what action triggered an update to a builtin table.
 #[derive(Debug)]
 pub(crate) enum BuiltinTableUpdateSource {
-    /// Update was triggered by some DDL.
-    DDL,
-    /// Update was triggered by something we don't want to block on but should notify the caller
-    /// when it's complete.
-    AsyncSystem(oneshot::Sender<()>),
+    /// Internal update, notify the caller when it's complete.
+    Internal(oneshot::Sender<()>),
     /// Update was triggered by some background process, such as periodic heartbeats from COMPUTE.
     Background,
 }
@@ -92,28 +88,13 @@ impl PendingWriteTxn {
         }
     }
 
-    /// Returns true if this transaction should cause group commit to block and not be executed
-    /// asynchronously.
-    fn should_block(&self) -> bool {
+    fn is_internal_system(&self) -> bool {
         match self {
-            PendingWriteTxn::User { .. } => false,
-            PendingWriteTxn::System { source, .. } => match source {
-                BuiltinTableUpdateSource::DDL => true,
-                BuiltinTableUpdateSource::AsyncSystem(_) | BuiltinTableUpdateSource::Background => {
-                    false
-                }
-            },
-        }
-    }
-
-    /// Returns true if this transaction has an external request waiting on its completion.
-    fn is_async_system(&self) -> bool {
-        match self {
-            PendingWriteTxn::User { .. } => false,
-            PendingWriteTxn::System { source, .. } => match source {
-                BuiltinTableUpdateSource::AsyncSystem(_) => true,
-                BuiltinTableUpdateSource::Background | BuiltinTableUpdateSource::DDL => false,
-            },
+            PendingWriteTxn::System {
+                source: BuiltinTableUpdateSource::Internal(_),
+                ..
+            } => true,
+            _ => false,
         }
     }
 }
@@ -186,12 +167,12 @@ impl Coordinator {
         // those tests to advance the walltime while creating a connection is too much.
         //
         // TODO(parkmycar): Get rid of the check below when refactoring group commits.
-        let contains_async_system_write = self
+        let contains_internal_system_write = self
             .pending_writes
             .iter()
-            .any(|write| write.is_async_system());
+            .any(|write| write.is_internal_system());
 
-        if timestamp > now && !contains_async_system_write {
+        if timestamp > now && !contains_internal_system_write {
             // Cap retry time to 1s. In cases where the system clock has retreated by
             // some large amount of time, this prevents against then waiting for that
             // large amount of time in case the system clock then advances back to near
@@ -312,8 +293,8 @@ impl Coordinator {
 
         let mut appends: BTreeMap<GlobalId, Vec<(Row, Diff)>> = BTreeMap::new();
         let mut responses = Vec::with_capacity(self.pending_writes.len());
-        let should_block = pending_writes.iter().any(|write| write.should_block());
         let mut notifies = Vec::new();
+
         for pending_write_txn in pending_writes {
             match pending_write_txn {
                 PendingWriteTxn::User {
@@ -351,7 +332,7 @@ impl Coordinator {
                             .push((update.row, update.diff));
                     }
                     // Once the write completes we notify any waiters.
-                    if let BuiltinTableUpdateSource::AsyncSystem(tx) = source {
+                    if let BuiltinTableUpdateSource::Internal(tx) = source {
                         notifies.push(tx);
                     }
                 }
@@ -377,11 +358,10 @@ impl Coordinator {
             .collect();
 
         // Instrument our table writes since they can block the coordinator.
-        let label = should_block.then_some("true").unwrap_or("false");
         let histogram = self
             .metrics
             .append_table_duration_seconds
-            .with_label_values(&[label]);
+            .with_label_values(&["false"]);
         let append_fut = self
             .controller
             .storage
@@ -390,39 +370,34 @@ impl Coordinator {
             .wall_time()
             .observe(histogram);
 
-        if should_block {
-            // We may panic here if the storage controller has shut down, because we cannot
-            // correctly return control, nor can we simply hang here.
-            // TODO: Clean shutdown.
+        // Spawn a task to do the table writes.
+        let internal_cmd_tx = self.internal_cmd_tx.clone();
+        task::spawn(|| "group_commit_apply", async move {
+            // Wait for the writes to complete.
             append_fut
                 .await
-                .expect("One-shot dropped while waiting synchronously")
+                .expect("One-shot dropped while waiting")
                 .unwrap_or_terminate("cannot fail to apply appends");
-            self.group_commit_apply(timestamp, responses, write_lock_guard, notifies, permit)
-                .await;
-        } else {
-            let internal_cmd_tx = self.internal_cmd_tx.clone();
-            task::spawn(
-                || "group_commit_apply",
-                async move {
-                    if let Ok(response) = append_fut.await {
-                        response.unwrap_or_terminate("cannot fail to apply appends");
-                        if let Err(e) = internal_cmd_tx.send(Message::GroupCommitApply(
-                            timestamp,
-                            responses,
-                            write_lock_guard,
-                            notifies,
-                            permit,
-                        )) {
-                            warn!("Server closed with non-responded writes, {e}");
-                        }
-                    } else {
-                        warn!("Writer terminated with writes in indefinite state");
-                    }
-                }
-                .instrument(Span::current()),
-            );
-        }
+
+            // Note: while technically we should have `GroupCommitApply` update the notifies, we
+            // know that internal commands get processed before any user commands, so the writes
+            // are still guaranteed to be observable before any user commands.
+            for notify in notifies {
+                // We don't care if the listeners have gone away.
+                let _ = notify.send(());
+            }
+
+            // Trigger a GroupCommitApply, which will run before any user commands since we're
+            // sending it on the internal command sender.
+            if let Err(e) = internal_cmd_tx.send(Message::GroupCommitApply(
+                timestamp,
+                responses,
+                write_lock_guard,
+                permit,
+            )) {
+                warn!("Server closed with non-responded writes, {e}");
+            }
+        });
     }
 
     /// Applies the results of a completed group commit. The read timestamp of the timeline
@@ -441,16 +416,12 @@ impl Coordinator {
         timestamp: Timestamp,
         responses: Vec<CompletedClientTransmitter>,
         _write_lock_guard: Option<OwnedMutexGuard<()>>,
-        notifies: Vec<oneshot::Sender<()>>,
         _permit: Option<GroupCommitPermit>,
     ) {
         self.apply_local_write(timestamp).await;
         for response in responses {
             let (ctx, result) = response.finalize();
             ctx.retire(result);
-        }
-        for tx in notifies {
-            let _ = tx.send(());
         }
 
         // Advancing timelines will update all timeline read holds, and update the read timestamps
@@ -471,59 +442,9 @@ impl Coordinator {
         self.trigger_group_commit();
     }
 
-    /// Submit a write to a system table be executed during the next group commit. This method does
-    /// not trigger a group commit.
-    ///
-    /// This is useful for non-critical writes like metric updates because it allows us to piggy
-    /// back off the next group commit instead of triggering a potentially expensive group commit.
-    ///
-    /// DO NOT call this for DDL which needs the system tables updated immediately.
-    #[tracing::instrument(level = "debug", skip_all, fields(updates = updates.len()))]
-    pub(crate) fn buffer_builtin_table_updates(&mut self, updates: Vec<BuiltinTableUpdate>) {
-        self.pending_writes.push(PendingWriteTxn::System {
-            updates,
-            source: BuiltinTableUpdateSource::Background,
-        });
-    }
-
-    /// Submit a write to a system table. This method will block the Coordinator until the write
-    /// has been applied.
-    #[tracing::instrument(level = "debug", skip_all, fields(updates = updates.len()))]
-    pub(crate) async fn send_builtin_table_updates_blocking(
-        &mut self,
-        updates: Vec<BuiltinTableUpdate>,
-    ) {
-        // Most DDL queries cause writes to system tables. Unlike writes to user tables, system
-        // table writes do not wait for a group commit, they explicitly trigger one. There is a
-        // possibility that if a user is executing DDL at a rate faster than 1 query per
-        // millisecond, then the global timeline will unboundedly advance past the system clock.
-        // This can cause future queries to block, but will not affect correctness. Since this
-        // rate of DDL is unlikely, we allow DDL to explicitly trigger group commit.
-        self.pending_writes.push(PendingWriteTxn::System {
-            updates,
-            source: BuiltinTableUpdateSource::DDL,
-        });
-        self.group_commit_initiate(None, None).await;
-        // Avoid excessive group commits by resetting the periodic table advancement timer. The
-        // group commit triggered by above will already advance all tables.
-        self.advance_timelines_interval.reset();
-    }
-
-    /// Submits a write to be executed during the next group commit and triggers a group commit.
-    ///
-    /// Returns a Future that resolves when the write has completed, does not block the
-    /// Coordinator.
-    pub(crate) fn send_builtin_table_updates_defer<'a>(
-        &'a mut self,
-        updates: Vec<BuiltinTableUpdate>,
-    ) -> BoxFuture<'static, ()> {
-        let (tx, rx) = oneshot::channel();
-        self.pending_writes.push(PendingWriteTxn::System {
-            updates,
-            source: BuiltinTableUpdateSource::AsyncSystem(tx),
-        });
-        self.trigger_group_commit();
-        Box::pin(rx.map(|_| ()))
+    /// Append some [`BuiltinTableUpdate`]s, with various degrees of waiting and blocking.
+    pub(crate) fn builtin_table_update<'a>(&'a mut self) -> BuiltinTableAppend<'a> {
+        BuiltinTableAppend { coord: self }
     }
 
     /// Defers executing `deferred` until the write lock becomes available; waiting
@@ -558,6 +479,84 @@ impl Coordinator {
         Arc::clone(&self.write_lock).try_lock_owned().map(|p| {
             session.grant_write_lock(p);
         })
+    }
+}
+
+/// Helper struct to run a builtin table append.
+pub struct BuiltinTableAppend<'a> {
+    coord: &'a mut Coordinator,
+}
+
+/// [`Future`] that notifies when a builtin table write has completed.
+///
+/// Note: builtin table writes need to talk to persist, which can take 100s of milliseconds. This
+/// type allows you to execute a builtin table write, e.g. via [`BuiltinTableAppend::execute`], and
+/// wait for it to complete, while other long running tasks are concurrently executing.
+pub type BuiltinTableAppendNotify = BoxFuture<'static, ()>;
+
+impl<'a> BuiltinTableAppend<'a> {
+    /// Submit a write to a system table be executed during the next group commit. This method
+    /// __does not__ trigger a group commit.
+    ///
+    /// This is useful for non-critical writes like metric updates because it allows us to piggy
+    /// back off the next group commit instead of triggering a potentially expensive group commit.
+    ///
+    /// Note: __do not__ call this for DDL which needs the system tables updated immediately.
+    pub fn background(self, updates: Vec<BuiltinTableUpdate>) {
+        self.coord.pending_writes.push(PendingWriteTxn::System {
+            updates,
+            source: BuiltinTableUpdateSource::Background,
+        });
+    }
+
+    /// Submits a write to be executed during the next group commit __and__ triggers a group commit.
+    ///
+    /// Returns a [`Future`] that resolves when the write has completed, does not block the
+    /// Coordinator.
+    pub fn defer(self, updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
+        let (tx, rx) = oneshot::channel();
+        self.coord.pending_writes.push(PendingWriteTxn::System {
+            updates,
+            source: BuiltinTableUpdateSource::Internal(tx),
+        });
+        self.coord.trigger_group_commit();
+
+        Box::pin(rx.map(|_| ()))
+    }
+
+    /// Submit a write to a system table.
+    ///
+    /// This method will block the Coordinator on doing some initial work, and then returns a
+    /// [`Future`] that will complete once the write has been applied.
+    pub async fn execute(self, updates: Vec<BuiltinTableUpdate>) -> BuiltinTableAppendNotify {
+        let (tx, rx) = oneshot::channel();
+
+        // Most DDL queries cause writes to system tables. Unlike writes to user tables, system
+        // table writes do not wait for a group commit, they explicitly trigger one. There is a
+        // possibility that if a user is executing DDL at a rate faster than 1 query per
+        // millisecond, then the global timeline will unboundedly advance past the system clock.
+        // This can cause future queries to block, but will not affect correctness. Since this
+        // rate of DDL is unlikely, we allow DDL to explicitly trigger group commit.
+        self.coord.pending_writes.push(PendingWriteTxn::System {
+            updates,
+            source: BuiltinTableUpdateSource::Internal(tx),
+        });
+        self.coord.group_commit_initiate(None, None).await;
+
+        // Avoid excessive group commits by resetting the periodic table advancement timer. The
+        // group commit triggered by above will already advance all tables.
+        self.coord.advance_timelines_interval.reset();
+
+        Box::pin(rx.map(|_| ()))
+    }
+
+    /// Submit a write to a system table, blocking until complete.
+    ///
+    /// Note: if possible you should use the `execute(...)` method, which returns a [`Future`] that
+    /// can be `await`-ed concurrently with other tasks.
+    pub async fn blocking(self, updates: Vec<BuiltinTableUpdate>) {
+        let notify = self.execute(updates).await;
+        notify.await;
     }
 }
 

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -48,7 +48,7 @@ use mz_storage_types::sources::GenericSourceConnection;
 use serde_json::json;
 use tracing::{event, warn, Level};
 
-use crate::catalog::{CatalogItem, CatalogState, DataSourceDesc, Op, Sink, TransactionResult};
+use crate::catalog::{CatalogState, Op, TransactionResult};
 use crate::coord::appends::BuiltinTableAppendNotify;
 use crate::coord::read_policy::SINCE_GRANULARITY;
 use crate::coord::timeline::{TimelineContext, TimelineState};

--- a/src/adapter/src/coord/message_handler.rs
+++ b/src/adapter/src/coord/message_handler.rs
@@ -77,21 +77,9 @@ impl Coordinator {
                     tracing::Span::current().add_link(span.context().span().span_context().clone());
                     self.try_group_commit(permit).instrument(span).await
                 }
-                Message::GroupCommitApply(
-                    timestamp,
-                    responses,
-                    write_lock_guard,
-                    notifies,
-                    permit,
-                ) => {
-                    self.group_commit_apply(
-                        timestamp,
-                        responses,
-                        write_lock_guard,
-                        notifies,
-                        permit,
-                    )
-                    .await;
+                Message::GroupCommitApply(timestamp, responses, write_lock_guard, permit) => {
+                    self.group_commit_apply(timestamp, responses, write_lock_guard, permit)
+                        .await;
                 }
                 Message::AdvanceTimelines => {
                     self.advance_timelines().await;
@@ -327,7 +315,7 @@ impl Coordinator {
                     } else {
                         insertions
                     };
-                    self.buffer_builtin_table_updates(updates);
+                    self.builtin_table_update().background(updates);
                 }
             }
         }

--- a/src/adapter/src/metrics.rs
+++ b/src/adapter/src/metrics.rs
@@ -125,7 +125,6 @@ impl Metrics {
             append_table_duration_seconds: registry.register(metric!(
                 name: "mz_append_table_duration_seconds",
                 help: "Latency for appending to any (user or system) table.",
-                var_labels: ["is_blocking"],
                 buckets: histogram_seconds_buckets(0.128, 32.0),
             )),
             webhook_validation_reduce_failures: registry.register(metric!(


### PR DESCRIPTION
This PR improves the latency of creation DDL, e.g. `CREATE TABLE`, by waiting for builtin table updates to complete concurrently with any side effects, e.g. creating a storage collection.

Part of this change which might be particularly controversial, is refactoring the handling of group commits, and removing the notion of blocking. Now it's up to the caller as to whether or not they want to block on a group commit finishing, by `.await`-ing a returned `Future`. This change makes it possible to wait on builtin table updates concurrently with other tasks. Specifically we no longer call `self.group_commit_apply(...)` directly in `group_commit_initiate(...)` instead we queue a `GroupCommitApply` task on the internal command sender. I believe this is okay to do because all internal commands are handled before user commands, so we'll still process the group commit apply before users could observe any intermediate state, e.g. a table being created but not showing up in `mz_tables`. Briefly I was concerned about the "late" GroupCommitApply message moving the write timestamp backwards, but this invariant is enforced in the implementations of the timestamp oracle.


### Open Telemetry Trace

<img width="2032" alt="Screenshot 2023-11-29 at 5 53 34 PM" src="https://github.com/MaterializeInc/materialize/assets/4438098/7fad9915-4a1b-4d4d-b947-b7c3c11f79af">

The above is the result of running `CREATE TABLE t1 (x int, y text, z timestamp)` on staging with this built deployed. You can see that "group_commit_initiate" (builtin table updates) and "insert_without_overwrite" (a side effect), get run in parallel.

### Motivation

Improves https://github.com/MaterializeInc/materialize/issues/23547

### Tips for reviewer

Hiding white space is helpful since a number of things either got indented or de-dented a level.

This PR is split into two commits which can be reviewed independently:

1. Refactoring builtin table updates
2. Refactoring sequencing so the relevant DDLs run their side effects concurrently with the builtin table updates. 

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Internal performance improvement
