### PR TITLE
Setting aws connection flag default to false

### DIFF
--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -2075,7 +2075,7 @@ feature_flags!(
     {
         name: enable_aws_connection,
         desc: "CREATE CONNECTION ... TO AWS",
-        default: &true, // will set to false once we verify that nobody's using this
+        default: &false,
         internal: true,
         enable_for_item_parsing: false,
     },

--- a/test/sqllogictest/default_privileges.slt
+++ b/test/sqllogictest/default_privileges.slt
@@ -3372,6 +3372,16 @@ DROP CONNECTION c
 statement ok
 CREATE SECRET s3_api_secret_key as 'secret_key';
 
+# aws connections is now disabled by default
+statement error db error: ERROR: CREATE CONNECTION ... TO AWS is not supported
+CREATE CONNECTION materialize.public.a TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET s3_api_secret_key) WITH (VALIDATE = false);
+
+# Enable aws connections
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_aws_connection TO true;
+----
+COMPLETE 0
+
 statement ok
 CREATE CONNECTION materialize.public.a TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET s3_api_secret_key) WITH (VALIDATE = false);
 
@@ -3387,14 +3397,11 @@ a  materialize=U/materialize
 statement ok
 DROP CONNECTION a
 
-# Disable aws connections, it should be on by default
+# Disable aws connections
 simple conn=mz_system,user=mz_system
 ALTER SYSTEM SET enable_aws_connection TO false;
 ----
 COMPLETE 0
-
-statement error db error: ERROR: CREATE CONNECTION ... TO AWS is not supported
-CREATE CONNECTION materialize.public.a TO AWS (ACCESS KEY ID = 'access_key', SECRET ACCESS KEY = SECRET s3_api_secret_key) WITH (VALIDATE = false);
 
 statement ok
 DROP SECRET s3_api_secret_key;


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->
Follow up after https://github.com/MaterializeInc/materialize/pull/23227. 
It was validated that nobody's using this feature https://github.com/MaterializeInc/cloud/issues/8145#issuecomment-1823386185. 
In launchdarkly it has already been disabled https://app.launchdarkly.com/default/production/features/enable_aws_connection/targeting. 
Changing in code to disable it as well.

### Motivation
We want to put aws connection behind a feature flag.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
