### PR TITLE
storage: create subsources in the source schema

### DIFF
--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -645,8 +645,7 @@ async fn purify_create_source(
                             Ident::new(&table.namespace)?,
                             Ident::new(&table.name)?,
                         ]);
-                        let subsource_name = Ident::new(&table.name)?;
-                        let subsource_name = UnresolvedItemName::unqualified(subsource_name);
+                        let subsource_name = subsource_name_gen(source_name, &table.name)?;
                         validated_requested_subsources.push((upstream_name, subsource_name, table));
                     }
                 }

--- a/test/pg-cdc/subsource-names.td
+++ b/test/pg-cdc/subsource-names.td
@@ -74,3 +74,14 @@ contains: unknown
 # table2 gets created in mentioned bar because it does have a prefix
 > SELECT * FROM bar.table2;
 5
+
+> CREATE SCHEMA baz;
+> CREATE SOURCE baz.mz_source
+  FROM POSTGRES CONNECTION pg (PUBLICATION 'mz_source')
+  FOR SCHEMAS (public);
+
+> SELECT * FROM baz.t1;
+1
+
+> SELECT * FROM baz.t2;
+5


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
Fixes https://github.com/MaterializeInc/materialize/issues/23557

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - This PR is changing user behaviour. When using `FOR SCHEMAS` the subsources will now be created in the source's schema if provided. Previously they were incorrectly getting created in the current schema in use, which could be different than the source's schema. This is a backwards incompatible change but will not affect any existing sources.
