### PR TITLE
zippy: Make sure Mz is running during the finalization phase.

### DIFF
--- a/misc/python/materialize/zippy/scenarios.py
+++ b/misc/python/materialize/zippy/scenarios.py
@@ -69,7 +69,14 @@ class Scenario:
         assert False
 
     def finalization(self) -> list[ActionOrFactory]:
-        return [ValidateAll(), BackupAndRestore, ValidateAll()]
+        return [
+            MzStart,
+            BalancerdStart,
+            StoragedStart,
+            ValidateAll(),
+            BackupAndRestore,
+            ValidateAll(),
+        ]
 
 
 class KafkaSources(Scenario):


### PR DESCRIPTION
Make sure the required Mz components are running during the finalization phase.


### Motivation

Nightly CI was failing because Mz was in a partially-killed state at the end of the main body of the Zippy workload, so final validation could not run correctly.