### PR TITLE
adapter: convert index bootstrap assert to soft-assert

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1872,9 +1872,17 @@ impl Coordinator {
             dependent_matviews,
         );
 
-        let mut as_of = min_as_of.clone();
-        as_of.join_assign(&max_compaction_frontier);
-        as_of.meet_assign(&max_as_of);
+        // Ensure that we never select an `as_of` that's less than `min_as_of`,
+        // even if that means selecting an `as_of` that's greater than `max_as_of`.
+        // The former makes environmentd crash, the latter "only" leads to correctness bugs.
+        let as_of = if PartialOrder::less_equal(&min_as_of, &max_as_of) {
+            let mut as_of = min_as_of.clone();
+            as_of.join_assign(&max_compaction_frontier);
+            as_of.meet_assign(&max_as_of);
+            as_of
+        } else {
+            min_as_of.clone()
+        };
 
         tracing::info!(
             export_ids = %dataflow.display_export_ids(),


### PR DESCRIPTION
We saw this assert firing in production and preventing envd from coming up. This might be a bug in the as-of bootstrap logic or somewhere else, but until we know we should not panic here, to allow envd to boot.

### Motivation

  * This PR fixes a recognized bug.

Part of #23563.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A