### PR TITLE
pub-sub-disruption: Replace pause/unpause with SIGSTOP/CONT

### DIFF
--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -58,10 +58,11 @@ disruptions = [
         breakage=lambda c: c.kill("toxiproxy"),
         fixage=lambda c: toxiproxy_start(c),
     ),
+    # docker compose pause has become unreliable recently
     Disruption(
-        name="pause-pubsub",
-        breakage=lambda c: c.pause("toxiproxy"),
-        fixage=lambda c: c.unpause("toxiproxy"),
+        name="sigstop-pubsub",
+        breakage=lambda c: c.kill("toxiproxy", signal="SIGSTOP"),
+        fixage=lambda c: c.kill("toxiproxy", signal="SIGCONT"),
     ),
 ]
 


### PR DESCRIPTION
Same as https://github.com/MaterializeInc/materialize/pull/23559

Seen in https://buildkite.com/materialize/nightlies/builds/5426#018c2037-7a29-41ae-a002-521e1d7fa6d0

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
