### PR TITLE
parallel-workload: More concise output of statistics

### DIFF
--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -1615,7 +1615,7 @@ write_action_list = ActionList(
         (HttpPostAction, 50),
         (CommitRollbackAction, 10),
         (ReconnectAction, 1),
-        (SourceInsertAction, 100),
+        (SourceInsertAction, 50),
     ],
     autocommit=False,
 )

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -751,7 +751,7 @@ class CreateViewAction(Action):
         if self.rng.choice([True, False]) or base_object2 == base_object:
             base_object2 = None
         schema = self.rng.choice(exe.db.schemas)
-        with schema.db.lock:
+        with schema.lock:
             if schema not in exe.db.schemas:
                 return False
             view = View(

--- a/misc/python/materialize/parallel_workload/action.py
+++ b/misc/python/materialize/parallel_workload/action.py
@@ -728,10 +728,14 @@ class TransactionIsolationAction(Action):
 
 class CommitRollbackAction(Action):
     def run(self, exe: Executor) -> bool:
+        if not exe.action_run_since_last_commit_rollback:
+            return False
+
         if self.rng.random() < 0.7:
             exe.commit()
         else:
             exe.rollback()
+        exe.action_run_since_last_commit_rollback = False
         return True
 
 
@@ -1609,7 +1613,7 @@ write_action_list = ActionList(
         (InsertAction, 50),
         # (SetClusterAction, 1),  # SET cluster cannot be called in an active transaction
         (HttpPostAction, 50),
-        (CommitRollbackAction, 100),
+        (CommitRollbackAction, 10),
         (ReconnectAction, 1),
         (SourceInsertAction, 100),
     ],

--- a/misc/python/materialize/parallel_workload/executor.py
+++ b/misc/python/materialize/parallel_workload/executor.py
@@ -38,6 +38,7 @@ class Executor:
     reconnect_next: bool
     rollback_next: bool
     last_log: str
+    action_run_since_last_commit_rollback: bool
 
     def __init__(self, rng: random.Random, cur: pg8000.Cursor, db: "Database"):
         self.rng = rng
@@ -48,6 +49,7 @@ class Executor:
         self.reconnect_next = True
         self.rollback_next = True
         self.last_log = ""
+        self.action_run_since_last_commit_rollback = False
 
     def set_isolation(self, level: str) -> None:
         self.execute(f"SET TRANSACTION_ISOLATION TO '{level}'")
@@ -93,3 +95,4 @@ class Executor:
             self.cur.execute(query)
         except Exception as e:
             raise QueryError(str(e), query)
+        self.action_run_since_last_commit_rollback = True

--- a/misc/python/materialize/parallel_workload/parallel_workload.py
+++ b/misc/python/materialize/parallel_workload/parallel_workload.py
@@ -146,7 +146,7 @@ def run(
     for i in range(num_threads):
         weights: list[float]
         if complexity == Complexity.DDL:
-            weights = [60, 30, 30, 30, 10]
+            weights = [60, 30, 30, 30, 100]
         elif complexity == Complexity.DML:
             weights = [60, 30, 30, 30, 0]
         elif complexity == Complexity.Read:
@@ -180,7 +180,7 @@ def run(
         )
         thread_name = f"worker_{i}"
         print(
-            f"{thread_name}: {', '.join(action_class.__name__ for action_class in action_list.action_classes)}"
+            f"{thread_name}: {', '.join(action_class.__name__.removesuffix('Action') for action_class in action_list.action_classes)}"
         )
         workers.append(worker)
 

--- a/misc/python/materialize/parallel_workload/worker.py
+++ b/misc/python/materialize/parallel_workload/worker.py
@@ -16,13 +16,14 @@ import pg8000
 
 from materialize.data_ingest.query_error import QueryError
 from materialize.mzcompose.composition import Composition
-from materialize.parallel_workload.action import Action, ReconnectAction
+from materialize.parallel_workload.action import Action, ActionList, ReconnectAction
 from materialize.parallel_workload.database import Database
 from materialize.parallel_workload.executor import Executor
 
 
 class Worker:
     rng: random.Random
+    action_list: ActionList | None
     actions: list[Action]
     weights: list[float]
     end_time: float
@@ -42,8 +43,10 @@ class Worker:
         autocommit: bool,
         system: bool,
         composition: Composition | None,
+        action_list: ActionList | None = None,
     ):
         self.rng = rng
+        self.action_list = action_list
         self.actions = actions
         self.weights = weights
         self.end_time = end_time


### PR DESCRIPTION
Before:
```
--- Action statistics:
  SelectAction: 112, SQLsmithAction: 10, CommitRollbackAction: 39, ReconnectAction: 0
  FetchAction: 6, ReconnectAction: 0
  InsertAction: 26, HttpPostAction: 49, CommitRollbackAction: 39, ReconnectAction: 0, SourceInsertAction: 112
  DeleteAction: 0, UpdateAction: 1, CommentAction: 9, SetClusterAction: 2, ReconnectAction: 0
  CreateIndexAction: 2, DropIndexAction: 0, CreateTableAction: 2, DropTableAction: 0, CreateViewAction: 8, DropViewAction: 4, CreateRoleAction: 2, DropRoleAction: 1, CreateClusterAction: 2, DropClusterAction: 1, SwapClusterAction: 0, CreateClusterReplicaAction: 0, DropClusterReplicaAction: 0, SetClusterAction: 2, CreateWebhookSourceAction: 0, DropWebhookSourceAction: 0, CreateKafkaSinkAction: 2, DropKafkaSinkAction: 1, CreateKafkaSourceAction: 0, DropKafkaSourceAction: 1, CreatePostgresSourceAction: 3, DropPostgresSourceAction: 0, GrantPrivilegesAction: 3, RevokePrivilegesAction: 0, ReconnectAction: 0, CreateDatabaseAction: 2, DropDatabaseAction: 0, CreateSchemaAction: 0, DropSchemaAction: 0, RenameSchemaAction: 0, RenameTableAction: 0, RenameViewAction: 0, RenameSinkAction: 0, SwapSchemaAction: 0
```
After:
```
--- Action statistics:
  Select: 4235, SQLsmith: 0, CommitRollback: 400, Reconnect: 4
  Fetch: 6, Reconnect: 0
  Insert: 33, HttpPost: 160, CommitRollback: 1081, Reconnect: 1, SourceInsert: 439
  Delete: 11, Update: 9, Comment: 0, SetCluster: 1, Reconnect: 1
  CreateIndex: 0, DropIndex: 0, CreateTable: 1, DropTable: 0, CreateView: 26, DropView: 2, CreateRole: 4, DropRole: 1, CreateCluster: 0, DropCluster: 0, SwapCluster: 0, CreateClusterReplica: 0, DropClusterReplica: 0, SetCluster: 0, CreateWebhookSource: 0, DropWebhookSource: 0, CreateKafkaSink: 10, DropKafkaSink: 0, CreateKafkaSource: 2, DropKafkaSource: 0, CreatePostgresSource: 2, DropPostgresSource: 0, GrantPrivileges: 2, RevokePrivileges: 0, Reconnect: 0, CreateDatabase: 0, DropDatabase: 0, CreateSchema: 1, DropSchema: 0, RenameSchema: 0, RenameTable: 0, RenameView: 0, RenameSink: 0, SwapSchema: 0
```
### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
