### PR TITLE
ci: parallelize platform checks

### DIFF
--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -426,10 +426,11 @@ steps:
     key: platform-checks
     steps:
       - id: checks-restart-environmentd-clusterd-storage
-        label: "Checks + restart of environmentd & storage clusterd"
+        label: "Checks + restart of environmentd & storage clusterd (%n)"
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
+        parallelism: 2
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64

--- a/ci/test/pipeline.template.yml
+++ b/ci/test/pipeline.template.yml
@@ -444,6 +444,7 @@ steps:
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
+        parallelism: 2
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -457,6 +458,7 @@ steps:
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
+        parallelism: 2
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -470,6 +472,7 @@ steps:
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
+        parallelism: 2
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64
@@ -483,6 +486,7 @@ steps:
         depends_on: build-x86_64
         inputs: [misc/python/materialize/checks]
         timeout_in_minutes: 45
+        parallelism: 2
         artifact_paths: junit_*.xml
         agents:
           queue: builder-linux-x86_64

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -6,7 +6,7 @@
 # As of the Change Date specified in that file, in accordance with
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
-
+import os
 from enum import Enum
 
 from materialize.checks.all_checks import *  # noqa: F401 F403
@@ -188,6 +188,13 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         checks = [all_checks[check] for check in args.check]
     else:
         checks = list(all_subclasses(Check))
+
+    parallel_job_index = int(os.environ.get("BUILDKITE_PARALLEL_JOB", 0))
+    parallel_job_count = int(os.environ.get("BUILDKITE_PARALLEL_JOB_COUNT", 1))
+
+    if parallel_job_count > 1:
+        checks.sort(key=lambda c: c.__name__)
+        checks = checks[parallel_job_index::parallel_job_count]
 
     executor = MzcomposeExecutor(composition=c)
     for scenario_class in scenarios:

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -195,6 +195,9 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     if parallel_job_count > 1:
         checks.sort(key=lambda c: c.__name__)
         checks = checks[parallel_job_index::parallel_job_count]
+        print(
+            f"Selected checks in job with index {parallel_job_index}: {[c.__name__ for c in checks]}"
+        )
 
     executor = MzcomposeExecutor(composition=c)
     for scenario_class in scenarios:


### PR DESCRIPTION
https://materializeinc.slack.com/archives/C057X0NG91B/p1701355220162159

I did not parallelize `checks-restart-source-postgres`, which is already faster because it only runs a subset of the checks.