### PR TITLE
tests: Add DDL to scalability benchmark

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -75,7 +75,7 @@ steps:
                - common-ancestor
     - id: scalability-benchmark
       label: "Scalability benchmark against merge base or 'latest'"
-      timeout_in_minutes: 180
+      timeout_in_minutes: 600
       agents:
         queue: linux-x86_64-large
       artifact_paths: junit_*.xml

--- a/misc/python/materialize/checks/mzcompose_actions.py
+++ b/misc/python/materialize/checks/mzcompose_actions.py
@@ -40,11 +40,6 @@ class StartMz(MzcomposeAction):
         self.tag = tag
         self.environment_extra = environment_extra
         self.system_parameter_defaults = system_parameter_defaults
-        self.catalog_store = (
-            "shadow"
-            if scenario.base_version() >= MzVersion.parse_mz("v0.81.0-dev")
-            else "stash"
-        )
 
     def execute(self, e: Executor) -> None:
         c = e.mzcompose_composition()
@@ -68,7 +63,6 @@ class StartMz(MzcomposeAction):
             system_parameter_defaults=self.system_parameter_defaults,
             additional_system_parameter_defaults=additional_system_parameter_defaults,
             sanity_restart=False,
-            catalog_store=self.catalog_store,
         )
 
         with c.override(mz):

--- a/misc/python/materialize/mzcompose/services/materialized.py
+++ b/misc/python/materialize/mzcompose/services/materialized.py
@@ -52,7 +52,6 @@ class Materialized(Service):
         additional_system_parameter_defaults: dict[str, str] | None = None,
         soft_assertions: bool = True,
         sanity_restart: bool = True,
-        catalog_store: str | None = "shadow",
     ) -> None:
         depends_graph: dict[str, ServiceDependency] = {
             s: {"condition": "service_started"} for s in depends_on
@@ -70,7 +69,6 @@ class Materialized(Service):
             "MZ_ORCHESTRATOR_PROCESS_PROMETHEUS_SERVICE_DISCOVERY_DIRECTORY=/mzdata/prometheus",
             "MZ_BOOTSTRAP_ROLE=materialize",
             "MZ_INTERNAL_PERSIST_PUBSUB_LISTEN_ADDR=0.0.0.0:6879",
-            f"MZ_CATALOG_STORE={catalog_store}",
             # Please think twice before forwarding additional environment
             # variables from the host, as it's easy to write tests that are
             # then accidentally dependent on the state of the host machine.

--- a/misc/python/materialize/mzcompose/services/testdrive.py
+++ b/misc/python/materialize/mzcompose/services/testdrive.py
@@ -34,7 +34,6 @@ class Testdrive(Service):
         seed: int | None = None,
         consistent_seed: bool = False,
         postgres_stash: str | None = None,
-        validate_catalog_store: str | None = None,
         entrypoint: list[str] | None = None,
         entrypoint_extra: list[str] = [],
         environment: list[str] | None = None,
@@ -92,9 +91,6 @@ class Testdrive(Service):
             entrypoint.append(
                 f"--postgres-stash=postgres://root@{postgres_stash}:26257?options=--search_path=adapter"
             )
-
-        if validate_catalog_store:
-            entrypoint.append(f"--validate-catalog-store={validate_catalog_store}")
 
         if no_reset:
             entrypoint.append("--no-reset")

--- a/misc/python/materialize/scalability/operations.py
+++ b/misc/python/materialize/scalability/operations.py
@@ -7,6 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
+import uuid
 
 from materialize.scalability.operation import Operation
 
@@ -49,3 +50,42 @@ class SelectUnionAll(Operation):
 class Update(Operation):
     def sql_statement(self) -> str:
         return "UPDATE t1 SET f1 = f1 + 1;"
+
+
+class CreateDropTable(Operation):
+    def sql_statement(self) -> str:
+        seed = str(uuid.uuid4())
+        return (
+            "BEGIN;"
+            f'CREATE TABLE "ddl_t{seed}" (a INT);'
+            "COMMIT;"
+            "BEGIN;"
+            f'DROP TABLE "ddl_t{seed}";'
+            "COMMIT;"
+        )
+
+
+class CreateDropView(Operation):
+    def sql_statement(self) -> str:
+        seed = str(uuid.uuid4())
+        return (
+            "BEGIN;"
+            f'CREATE VIEW "ddl_v{seed}" AS SELECT 42;'
+            "COMMIT;"
+            "BEGIN;"
+            f'DROP VIEW "ddl_v{seed}";'
+            "COMMIT;"
+        )
+
+
+class CreateDropMaterializedView(Operation):
+    def sql_statement(self) -> str:
+        seed = str(uuid.uuid4())
+        return (
+            "BEGIN;"
+            f'CREATE MATERIALIZED VIEW "ddl_mv{seed}" AS SELECT 42;'
+            "COMMIT;"
+            "BEGIN;"
+            f'DROP MATERIALIZED VIEW "ddl_mv{seed}";'
+            "COMMIT;"
+        )

--- a/misc/python/materialize/scalability/workloads.py
+++ b/misc/python/materialize/scalability/workloads.py
@@ -9,6 +9,9 @@
 
 from materialize.scalability.operation import Operation
 from materialize.scalability.operations import (
+    CreateDropMaterializedView,
+    CreateDropTable,
+    CreateDropView,
     InsertDefaultValues,
     SelectCount,
     SelectCountInMv,
@@ -64,3 +67,12 @@ class InsertAndSelectLimitWorkload(Workload):
 class UpdateWorkload(Workload):
     def operations(self) -> list["Operation"]:
         return [Update()]
+
+
+class DDLWorkload(Workload):
+    def operations(self) -> list["Operation"]:
+        return [
+            CreateDropTable(),
+            CreateDropView(),
+            CreateDropMaterializedView(),
+        ]

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -443,7 +443,7 @@ pub struct Args {
     )]
     adapter_stash_url: Option<String>,
     /// The backing durable store of the catalog.
-    #[clap(long, arg_enum, env = "CATALOG_STORE", default_value("stash"))]
+    #[clap(long, arg_enum, env = "CATALOG_STORE", default_value("persist"))]
     catalog_store: CatalogKind,
     /// The PostgreSQL URL for the Postgres-backed timestamp oracle.
     #[clap(long, env = "TIMESTAMP_ORACLE_URL", value_name = "POSTGRES_URL")]

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -50,8 +50,6 @@ SERVICES = [
         # We use mz_panic() in some test scenarios, so environmentd must stay up.
         propagate_crashes=False,
         external_cockroach=True,
-        # Kills make the shadow catalog not work properly
-        catalog_store="stash",
     ),
     Redpanda(),
     Toxiproxy(),

--- a/test/feature-benchmark/mzcompose.py
+++ b/test/feature-benchmark/mzcompose.py
@@ -213,7 +213,6 @@ def create_mz_service(
         external_cockroach=True,
         external_minio=True,
         sanity_restart=False,
-        catalog_store="stash",
     )
 
 

--- a/test/incident-72/mzcompose.py
+++ b/test/incident-72/mzcompose.py
@@ -20,20 +20,18 @@ SERVICES = [
     Zookeeper(),
     Kafka(),
     SchemaRegistry(),
-    Materialized(external_minio=True, catalog_store="stash"),
+    Materialized(external_minio=True),
     Testdrive(no_reset=True, external_minio=True, consistent_seed=True),
 ]
 
 PRE_INCIDENT_MZ = Materialized(
     image="materialize/materialized:v0.68.0",
     external_minio=True,
-    catalog_store="stash",
 )
 
 REJECT_LEGACY_MZ = Materialized(
     external_minio=True,
     environment_extra=["FAILPOINTS=reject_legacy_upsert_errors=panic"],
-    catalog_store="stash",
 )
 
 

--- a/test/legacy-upgrade/mzcompose.py
+++ b/test/legacy-upgrade/mzcompose.py
@@ -42,7 +42,6 @@ SERVICES = [
         options=list(mz_options.values()),
         volumes_extra=["secrets:/share/secrets"],
         external_cockroach=True,
-        catalog_store="stash",
     ),
     # N.B.: we need to use `validate_catalog_store=None` because testdrive uses
     # HEAD to load the catalog from disk but does *not* run migrations. There
@@ -56,7 +55,6 @@ SERVICES = [
     # because that would involve maintaining backwards compatibility for all
     # testdrive commands.
     Testdrive(
-        validate_catalog_store=None,
         volumes_extra=["secrets:/share/secrets"],
     ),
 ]
@@ -141,7 +139,6 @@ def test_upgrade_from_version(
             ],
             volumes_extra=["secrets:/share/secrets"],
             external_cockroach=True,
-            catalog_store="stash",
         )
         with c.override(mz_from):
             c.up("materialized")
@@ -172,7 +169,6 @@ def test_upgrade_from_version(
     with c.override(
         Testdrive(
             postgres_stash="cockroach",
-            validate_catalog_store="stash",
             volumes_extra=["secrets:/share/secrets"],
         )
     ):

--- a/test/parallel-workload/mzcompose.py
+++ b/test/parallel-workload/mzcompose.py
@@ -67,10 +67,8 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
     complexity = Complexity(args.complexity)
 
     if scenario in (Scenario.Kill, Scenario.BackupRestore):
-        catalog_store = "stash"
         sanity_restart = False
     else:
-        catalog_store = "shadow"
         sanity_restart = True
 
     with c.override(
@@ -79,7 +77,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
             restart="on-failure",
             external_minio=True,
             ports=["6975:6875", "6976:6876", "6977:6877"],
-            catalog_store=catalog_store,
             sanity_restart=sanity_restart,
         )
     ):

--- a/test/platform-checks/mzcompose.py
+++ b/test/platform-checks/mzcompose.py
@@ -88,7 +88,6 @@ SERVICES = [
         external_minio=True,
         sanity_restart=False,
         volumes_extra=["secrets:/share/secrets"],
-        catalog_store="stash",
     ),
     TestdriveService(
         default_timeout="300s",

--- a/test/scalability/mzcompose.py
+++ b/test/scalability/mzcompose.py
@@ -59,7 +59,6 @@ SERVICES = [
     Materialized(
         image="materialize/materialized:latest",
         sanity_restart=False,
-        catalog_store="stash",
     ),
     Postgres(),
 ]

--- a/test/testdrive/mzcompose.py
+++ b/test/testdrive/mzcompose.py
@@ -84,7 +84,6 @@ def workflow_default(c: Composition, parser: WorkflowArgumentParser) -> None:
         kafka_default_partitions=args.kafka_default_partitions,
         aws_region=args.aws_region,
         postgres_stash="materialized",
-        validate_catalog_store="shadow",
         default_timeout=args.default_timeout,
         volumes_extra=["mzdata:/mzdata"],
     )

--- a/test/upgrade-matrix/mzcompose.py
+++ b/test/upgrade-matrix/mzcompose.py
@@ -60,7 +60,7 @@ SERVICES = [
     Debezium(redpanda=True),
     Minio(setup_materialize=True),
     Materialized(
-        external_minio=True, catalog_store="stash"
+        external_minio=True
     ),  # Overriden inside Platform Checks
     TestdriveService(
         default_timeout="300s",

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -97,7 +97,6 @@ def workflow_testdrive(c: Composition, parser: WorkflowArgumentParser) -> None:
         forward_buildkite_shard=True,
         kafka_default_partitions=args.kafka_default_partitions,
         postgres_stash="materialized",
-        validate_catalog_store="shadow",
         volumes_extra=["mzdata:/mzdata"],
     )
 


### PR DESCRIPTION
This commit adds a DDL workload to the scalability benchmark.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
