### PR TITLE
postgres-util: configure pg tcp connections over privatelink correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6721,7 +6721,7 @@ checksum = "15eb2c6e362923af47e13c23ca5afb859e83d54452c55b0b9ac763b8f7c1ac16"
 [[package]]
 name = "postgres"
 version = "0.19.5"
-source = "git+https://github.com/MaterializeInc/rust-postgres#7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+source = "git+https://github.com/MaterializeInc/rust-postgres#b759caa33610403aa74b1cfdd37f45eb3100c9af"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -6734,7 +6734,7 @@ dependencies = [
 [[package]]
 name = "postgres-openssl"
 version = "0.5.0"
-source = "git+https://github.com/MaterializeInc/rust-postgres#7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+source = "git+https://github.com/MaterializeInc/rust-postgres#b759caa33610403aa74b1cfdd37f45eb3100c9af"
 dependencies = [
  "openssl",
  "tokio",
@@ -6745,7 +6745,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.5"
-source = "git+https://github.com/MaterializeInc/rust-postgres#7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+source = "git+https://github.com/MaterializeInc/rust-postgres#b759caa33610403aa74b1cfdd37f45eb3100c9af"
 dependencies = [
  "base64 0.21.5",
  "byteorder",
@@ -6762,7 +6762,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.5"
-source = "git+https://github.com/MaterializeInc/rust-postgres#7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+source = "git+https://github.com/MaterializeInc/rust-postgres#b759caa33610403aa74b1cfdd37f45eb3100c9af"
 dependencies = [
  "bytes",
  "chrono",
@@ -8709,7 +8709,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.8"
-source = "git+https://github.com/MaterializeInc/rust-postgres#7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+source = "git+https://github.com/MaterializeInc/rust-postgres#b759caa33610403aa74b1cfdd37f45eb3100c9af"
 dependencies = [
  "async-trait",
  "byteorder",

--- a/misc/cargo-vet/config.toml
+++ b/misc/cargo-vet/config.toml
@@ -1310,19 +1310,19 @@ version = "0.3.15"
 criteria = "safe-to-deploy"
 
 [[exemptions.postgres]]
-version = "0.19.5@git:7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+version = "0.19.5@git:b759caa33610403aa74b1cfdd37f45eb3100c9af"
 criteria = "safe-to-deploy"
 
 [[exemptions.postgres-openssl]]
-version = "0.5.0@git:7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+version = "0.5.0@git:b759caa33610403aa74b1cfdd37f45eb3100c9af"
 criteria = "safe-to-deploy"
 
 [[exemptions.postgres-protocol]]
-version = "0.6.5@git:7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+version = "0.6.5@git:b759caa33610403aa74b1cfdd37f45eb3100c9af"
 criteria = "safe-to-deploy"
 
 [[exemptions.postgres-types]]
-version = "0.2.5@git:7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+version = "0.2.5@git:b759caa33610403aa74b1cfdd37f45eb3100c9af"
 criteria = "safe-to-deploy"
 
 [[exemptions.postgres_array]]
@@ -1858,7 +1858,7 @@ version = "0.2.12"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-postgres]]
-version = "0.7.8@git:7bdd17b5acf4d7dbc53b08a9038793ab7e49da6c"
+version = "0.7.8@git:b759caa33610403aa74b1cfdd37f45eb3100c9af"
 criteria = "safe-to-deploy"
 
 [[exemptions.tokio-tungstenite]]


### PR DESCRIPTION
Touches https://github.com/MaterializeInc/materialize/issues/18683

@benesch any pointers on how to test this?

### Motivation

  * This PR fixes a recognized bug.


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
