### PR TITLE
mzbuild: break out some *-base Dockerfiles with apt-get and such

### DIFF
--- a/misc/images/balancerd/Dockerfile
+++ b/misc/images/balancerd/Dockerfile
@@ -7,14 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
-
-RUN apt-get update \
-    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-        ca-certificates \
-        tini \
-    && groupadd --system --gid=999 materialize \
-    && useradd --system --gid=999 --uid=999 --create-home materialize
+MZFROM prod-base
 
 COPY mz-balancerd /usr/local/bin/balancerd
 

--- a/misc/images/jobs/Dockerfile
+++ b/misc/images/jobs/Dockerfile
@@ -7,9 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
-
-RUN apt-get update && apt-get -qy install ca-certificates
+MZFROM prod-base
 
 COPY persistcli /usr/local/bin/persistcli
 COPY mz-stash-debug /usr/local/bin/mz-stash-debug

--- a/misc/images/materialized-base/Dockerfile
+++ b/misc/images/materialized-base/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This is a separate mzimage so that we don't have to re-install the apt things
+# every time we get a CI builder with a cold cache.
+
+FROM cockroachdb/cockroach:v23.1.11 AS crdb
+
+MZFROM ubuntu-base
+
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        curl \
+        postgresql-client-14 \
+        tini \
+        ssh \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize \
+    && mkdir /mzdata \
+    && mkdir /cockroach-data \
+    && mkdir /scratch \
+    && chown materialize /mzdata /cockroach-data /scratch
+
+COPY --from=crdb /cockroach/cockroach /usr/local/bin/cockroach

--- a/misc/images/materialized-base/mzbuild.yml
+++ b/misc/images/materialized-base/mzbuild.yml
@@ -7,10 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM prod-base
-
-COPY environmentd /usr/local/bin/
-
-USER materialize
-
-ENTRYPOINT ["tini", "--", "environmentd", "--sql-listen-addr=0.0.0.0:6875", "--http-listen-addr=0.0.0.0:6876"]
+name: materialized-base

--- a/misc/images/materialized/Dockerfile
+++ b/misc/images/materialized/Dockerfile
@@ -7,25 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-FROM cockroachdb/cockroach:v23.1.11 AS crdb
-
-MZFROM ubuntu-base
-
-RUN apt-get update \
-    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
-        ca-certificates \
-        curl \
-        postgresql-client-14 \
-        tini \
-        ssh \
-    && groupadd --system --gid=999 materialize \
-    && useradd --system --gid=999 --uid=999 --create-home materialize \
-    && mkdir /mzdata \
-    && mkdir /cockroach-data \
-    && mkdir /scratch \
-    && chown materialize /mzdata /cockroach-data /scratch
-
-COPY --from=crdb /cockroach/cockroach /usr/local/bin/cockroach
+MZFROM materialized-base
 
 COPY clusterd environmentd entrypoint.sh /usr/local/bin/
 

--- a/misc/images/prod-base/Dockerfile
+++ b/misc/images/prod-base/Dockerfile
@@ -1,0 +1,26 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+# This is a separate mzimage so that we don't have to re-install the apt things
+# every time we get a CI builder with a cold cache.
+
+MZFROM ubuntu-base
+
+RUN apt-get update \
+    && TZ=UTC DEBIAN_FRONTEND=noninteractive apt-get -qy install \
+        ca-certificates \
+        curl \
+        tini \
+        ssh \
+    && groupadd --system --gid=999 materialize \
+    && useradd --system --gid=999 --uid=999 --create-home materialize \
+    && mkdir /scratch \
+    && chown materialize /scratch \
+    && mkdir /mzdata \
+    && chown materialize /mzdata

--- a/misc/images/prod-base/README.md
+++ b/misc/images/prod-base/README.md
@@ -1,0 +1,3 @@
+# prod-base
+
+A common docker image for all our production binaries.

--- a/misc/images/prod-base/mzbuild.yml
+++ b/misc/images/prod-base/mzbuild.yml
@@ -7,10 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM prod-base
-
-COPY environmentd /usr/local/bin/
-
-USER materialize
-
-ENTRYPOINT ["tini", "--", "environmentd", "--sql-listen-addr=0.0.0.0:6875", "--http-listen-addr=0.0.0.0:6876"]
+name: prod-base

--- a/misc/python/materialize/mzbuild.py
+++ b/misc/python/materialize/mzbuild.py
@@ -723,6 +723,7 @@ class ResolvedImage:
         Requires that the caller has already acquired all dependencies and
         prepared all `PreImage` actions via `PreImage.prepare_batch`.
         """
+        ui.header(f"Building {self.spec()}")
         spawn.runv(["git", "clean", "-ffdX", self.image.path])
 
         for pre_image in self.image.pre_images:
@@ -944,6 +945,7 @@ class DependencySet:
                 images_to_push.append(dep.spec())
 
         # Push all Docker images in parallel to minimize build time.
+        ui.header("Pushing images")
         pushes: list[subprocess.Popen] = []
         for image in images_to_push:
             # Piping through `cat` disables terminal control codes, and so the

--- a/src/clusterd/ci/Dockerfile
+++ b/src/clusterd/ci/Dockerfile
@@ -7,14 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
-
-RUN apt-get update \
-    && apt-get -qy install ca-certificates curl ssh tini \
-    && groupadd --system --gid=999 materialize \
-    && useradd --system --gid=999 --uid=999 --create-home materialize \
-    && mkdir /scratch \
-    && chown materialize /scratch
+MZFROM prod-base
 
 COPY clusterd entrypoint.sh /usr/local/bin/
 

--- a/src/testdrive/ci-base/Dockerfile
+++ b/src/testdrive/ci-base/Dockerfile
@@ -7,10 +7,17 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM prod-base
+# This is a separate mzimage so that we don't have to re-install the apt things
+# every time we get a CI builder with a cold cache.
 
-COPY environmentd /usr/local/bin/
+MZFROM ubuntu-base
 
-USER materialize
-
-ENTRYPOINT ["tini", "--", "environmentd", "--sql-listen-addr=0.0.0.0:6875", "--http-listen-addr=0.0.0.0:6876"]
+RUN apt-get update && apt-get -qy install --no-install-recommends \
+    ca-certificates \
+    curl \
+    dnsutils \
+    iputils-ping \
+    postgresql-client \
+    ssh \
+    wait-for-it \
+    wget

--- a/src/testdrive/ci-base/mzbuild.yml
+++ b/src/testdrive/ci-base/mzbuild.yml
@@ -7,10 +7,4 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM prod-base
-
-COPY environmentd /usr/local/bin/
-
-USER materialize
-
-ENTRYPOINT ["tini", "--", "environmentd", "--sql-listen-addr=0.0.0.0:6875", "--http-listen-addr=0.0.0.0:6876"]
+name: testdrive-base

--- a/src/testdrive/ci/Dockerfile
+++ b/src/testdrive/ci/Dockerfile
@@ -7,17 +7,7 @@
 # the Business Source License, use of this software will be governed
 # by the Apache License, Version 2.0.
 
-MZFROM ubuntu-base
-
-RUN apt-get update && apt-get -qy install --no-install-recommends \
-    ca-certificates \
-    curl \
-    dnsutils \
-    iputils-ping \
-    postgresql-client \
-    ssh \
-    wait-for-it \
-    wget
+MZFROM testdrive-base
 
 COPY testdrive /usr/local/bin/
 


### PR DESCRIPTION
This allows us to avoid re-installing the apt things every time we get a CI builder with a cold cache, saving CI time and resources. The time is still dominated by copying huge binaries into the images, but this was easy and should save a few minutes.

We already do this for the persistcli image. Copy the pattern for some other commonly invalidated images.

### Motivation

   * This PR refactors existing code.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
