### PR TITLE
stash: Parallelize PrepareStatements, batch some variable setting, add metrics

### DIFF
--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use differential_dataflow::lattice::Lattice;
-use futures::StreamExt;
+use futures::{FutureExt, StreamExt};
 use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_ore::collections::CollectionExt;
@@ -476,6 +476,7 @@ impl OpenableDurableCatalogState for PersistHandle {
         deploy_generation: Option<u64>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Savepoint, boot_ts, bootstrap_args, deploy_generation)
+            .boxed()
             .await
     }
 
@@ -486,6 +487,7 @@ impl OpenableDurableCatalogState for PersistHandle {
         bootstrap_args: &BootstrapArgs,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Readonly, boot_ts, bootstrap_args, None)
+            .boxed()
             .await
     }
 
@@ -497,6 +499,7 @@ impl OpenableDurableCatalogState for PersistHandle {
         deploy_generation: Option<u64>,
     ) -> Result<Box<dyn DurableCatalogState>, CatalogError> {
         self.open_inner(Mode::Writable, boot_ts, bootstrap_args, deploy_generation)
+            .boxed()
             .await
     }
 

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -91,6 +91,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::{anyhow, bail, Context};
+use futures::FutureExt;
 use mz_adapter::catalog::ClusterReplicaSizeMap;
 use mz_adapter::config::{system_parameter_sync, SystemParameterSyncConfig};
 use mz_adapter::webhook::WebhookConcurrencyLimiter;
@@ -402,6 +403,7 @@ impl Listeners {
                 &config.controller,
                 &config.environment_id,
             )
+            .boxed()
             .await?;
 
             if !openable_adapter_storage.is_initialized().await? {
@@ -461,6 +463,7 @@ impl Listeners {
             &config.controller,
             &config.environment_id,
         )
+        .boxed()
         .await?;
         // Get the value from Launch Darkly as of the last time this environment
         // was running. (Ideally it would be the current value, but that's
@@ -519,6 +522,7 @@ impl Listeners {
             envd_epoch,
             enable_persist_txn_tables,
         )
+        .boxed()
         .await;
 
         // Initialize the system parameter frontend if `launchdarkly_sdk_key` is set.


### PR DESCRIPTION
When investigating slow DDL we found that occasionally we need to reconnect to the Stash, which can take 100s of ms. This PR aims to speed that up by doing two things:

1. Prepare all of our statements in parallel
2. Group a couple commands into a single batch

It also adds Prometheus metrics so we can track connections to the Stash.

Note: after initially putting up this PR there were some test failures for overflowing the stack, because of this I `.boxed()` a few of the large futures I found via the `large_futures` lint. IMO we should take a more holistic approach to this, but for now the couple of `.boxed()` calls I added seem to do the trick.

### Motivation

Improves https://github.com/MaterializeInc/materialize/issues/23547

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
