### PR TITLE
catalog: Add commit transaction metrics to stash

### DIFF
--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use postgres_openssl::MakeTlsConnector;
 
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
+use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::result::ResultExt;
 use mz_ore::retry::Retry;
@@ -751,177 +752,193 @@ impl DurableCatalogState for Connection {
             Ok(())
         }
 
-        // The with_transaction fn below requires a Fn that can be cloned,
-        // meaning anything it closes over must be Clone. TransactionBatch
-        // implements Clone, thus, the Arcs here aren't strictly necessary.
-        // However, using an Arc means that we never clone the TransactionBatch
-        // (which would happen at least one time when the txn starts), and
-        // instead only clone the Arc.
-        let txn_batch = Arc::new(txn_batch);
-        let is_initialized = is_stash_initialized(&mut self.stash).await?;
+        async fn commit_transaction_inner(
+            catalog: &mut Connection,
+            txn_batch: TransactionBatch,
+        ) -> Result<(), CatalogError> {
+            // The with_transaction fn below requires a Fn that can be cloned,
+            // meaning anything it closes over must be Clone. TransactionBatch
+            // implements Clone, thus, the Arcs here aren't strictly necessary.
+            // However, using an Arc means that we never clone the TransactionBatch
+            // (which would happen at least one time when the txn starts), and
+            // instead only clone the Arc.
+            let txn_batch = Arc::new(txn_batch);
+            let is_initialized = is_stash_initialized(&mut catalog.stash).await?;
 
-        // Before doing anything else, set the connection timeout if it changed.
-        if let Some(connection_timeout) = txn_batch.connection_timeout {
-            self.stash.set_connect_timeout(connection_timeout).await;
-        }
+            // Before doing anything else, set the connection timeout if it changed.
+            if let Some(connection_timeout) = txn_batch.connection_timeout {
+                catalog.stash.set_connect_timeout(connection_timeout).await;
+            }
 
-        self.stash
-            .with_transaction(move |tx| {
-                Box::pin(async move {
-                    let mut batches = Vec::new();
+            catalog
+                .stash
+                .with_transaction(move |tx| {
+                    Box::pin(async move {
+                        let mut batches = Vec::new();
 
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &DATABASES_COLLECTION,
-                        &txn_batch.databases,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &SCHEMAS_COLLECTION,
-                        &txn_batch.schemas,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &ITEM_COLLECTION,
-                        &txn_batch.items,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &COMMENTS_COLLECTION,
-                        &txn_batch.comments,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &ROLES_COLLECTION,
-                        &txn_batch.roles,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &CLUSTER_COLLECTION,
-                        &txn_batch.clusters,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &CLUSTER_REPLICA_COLLECTION,
-                        &txn_batch.cluster_replicas,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &CLUSTER_INTROSPECTION_SOURCE_INDEX_COLLECTION,
-                        &txn_batch.introspection_sources,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &ID_ALLOCATOR_COLLECTION,
-                        &txn_batch.id_allocator,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &CONFIG_COLLECTION,
-                        &txn_batch.configs,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &SETTING_COLLECTION,
-                        &txn_batch.settings,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &TIMESTAMP_COLLECTION,
-                        &txn_batch.timestamps,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &SYSTEM_GID_MAPPING_COLLECTION,
-                        &txn_batch.system_gid_mapping,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &SYSTEM_CONFIGURATION_COLLECTION,
-                        &txn_batch.system_configurations,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &DEFAULT_PRIVILEGES_COLLECTION,
-                        &txn_batch.default_privileges,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &SYSTEM_PRIVILEGES_COLLECTION,
-                        &txn_batch.system_privileges,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &AUDIT_LOG_COLLECTION,
-                        &txn_batch.audit_log_updates,
-                        is_initialized,
-                    )
-                    .await?;
-                    add_batch(
-                        &tx,
-                        &mut batches,
-                        &STORAGE_USAGE_COLLECTION,
-                        &txn_batch.storage_usage_updates,
-                        is_initialized,
-                    )
-                    .await?;
-                    tx.append(batches).await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &DATABASES_COLLECTION,
+                            &txn_batch.databases,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &SCHEMAS_COLLECTION,
+                            &txn_batch.schemas,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &ITEM_COLLECTION,
+                            &txn_batch.items,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &COMMENTS_COLLECTION,
+                            &txn_batch.comments,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &ROLES_COLLECTION,
+                            &txn_batch.roles,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &CLUSTER_COLLECTION,
+                            &txn_batch.clusters,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &CLUSTER_REPLICA_COLLECTION,
+                            &txn_batch.cluster_replicas,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &CLUSTER_INTROSPECTION_SOURCE_INDEX_COLLECTION,
+                            &txn_batch.introspection_sources,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &ID_ALLOCATOR_COLLECTION,
+                            &txn_batch.id_allocator,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &CONFIG_COLLECTION,
+                            &txn_batch.configs,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &SETTING_COLLECTION,
+                            &txn_batch.settings,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &TIMESTAMP_COLLECTION,
+                            &txn_batch.timestamps,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &SYSTEM_GID_MAPPING_COLLECTION,
+                            &txn_batch.system_gid_mapping,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &SYSTEM_CONFIGURATION_COLLECTION,
+                            &txn_batch.system_configurations,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &DEFAULT_PRIVILEGES_COLLECTION,
+                            &txn_batch.default_privileges,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &SYSTEM_PRIVILEGES_COLLECTION,
+                            &txn_batch.system_privileges,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &AUDIT_LOG_COLLECTION,
+                            &txn_batch.audit_log_updates,
+                            is_initialized,
+                        )
+                        .await?;
+                        add_batch(
+                            &tx,
+                            &mut batches,
+                            &STORAGE_USAGE_COLLECTION,
+                            &txn_batch.storage_usage_updates,
+                            is_initialized,
+                        )
+                        .await?;
+                        tx.append(batches).await?;
 
-                    Ok(())
+                        Ok(())
+                    })
                 })
-            })
-            .await?;
+                .await?;
 
-        Ok(())
+            Ok(())
+        }
+        self.stash.metrics.catalog_transaction_commits.inc();
+        let counter = self
+            .stash
+            .metrics
+            .catalog_transaction_commit_latency_seconds
+            .clone();
+        commit_transaction_inner(self, txn_batch)
+            .wall_time()
+            .inc_by(counter)
+            .await
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/src/stash-types/src/metrics.rs
+++ b/src/stash-types/src/metrics.rs
@@ -12,11 +12,13 @@
 use mz_ore::metric;
 use mz_ore::metrics::MetricsRegistry;
 use mz_ore::stats::histogram_seconds_buckets;
-use prometheus::{HistogramVec, IntCounter, IntCounterVec};
+use prometheus::{Counter, HistogramVec, IntCounter, IntCounterVec};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
     pub transactions: IntCounter,
+    pub catalog_transaction_commits: IntCounter,
+    pub catalog_transaction_commit_latency_seconds: Counter,
     pub transaction_errors: IntCounterVec,
     pub query_latency_duration_seconds: HistogramVec,
 }
@@ -27,6 +29,14 @@ impl Metrics {
             transactions: registry.register(metric!(
                 name: "mz_stash_transactions",
                 help: "Total number of started transactions.",
+            )),
+            catalog_transaction_commits: registry.register(metric!(
+                name: "mz_stash_catalog_transaction_commits",
+                help: "Total number of catalog transaction commits.",
+            )),
+            catalog_transaction_commit_latency_seconds: registry.register(metric!(
+                name: "mz_stash_transaction_latency_seconds",
+                help: "Total latency for catalog transaction commits.",
             )),
             transaction_errors: registry.register(metric!(
                 name: "mz_stash_transaction_errors",

--- a/src/stash/src/postgres.rs
+++ b/src/stash/src/postgres.rs
@@ -447,7 +447,7 @@ pub struct Stash {
     nonce: [u8; 16],
     pub(crate) sinces_tx: mpsc::UnboundedSender<ConsolidateRequest>,
     pub(crate) collections: BTreeMap<String, Id>,
-    metrics: Arc<Metrics>,
+    pub metrics: Arc<Metrics>,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This commit adds latency metrics to the stash catalog for how long `commit_transaction()` takes.

Works towards resolving #22392

### Motivation
This PR adds a known-desirable feature.

### Tips for reviewer
The diff is much smaller if viewed with whitespace hidden.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
