### PR TITLE
storage: configure pg connections the same as storage during purification

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1079,7 +1079,7 @@ impl Coordinator {
         let merge_effort = system_config.default_idle_arrangement_merge_effort();
         let exert_prop = system_config.default_arrangement_exert_proportionality();
         self.controller.compute.update_configuration(compute_config);
-        self.controller.storage.update_configuration(storage_config);
+        self.controller.storage.update_parameters(storage_config);
         self.controller
             .update_orchestrator_scheduling_config(scheduling_config);
         self.controller

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -241,7 +241,10 @@ impl Coordinator {
                                             .into_inline_connection(self.catalog().state());
                                         let config = conn
                                             .connection
-                                            .config(self.secrets_reader())
+                                            .config(
+                                                self.secrets_reader(),
+                                                self.controller.storage.config(),
+                                            )
                                             .await
                                             .map_err(|e| {
                                                 AdapterError::Storage(StorageError::Generic(
@@ -836,7 +839,7 @@ impl Coordinator {
 
     fn update_storage_config(&mut self) {
         let config_params = flags::storage_config(self.catalog().system_config());
-        self.controller.storage.update_configuration(config_params);
+        self.controller.storage.update_parameters(config_params);
     }
 
     fn update_metrics_retention(&mut self) {

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -578,12 +578,15 @@ impl Coordinator {
                     ctx.retire(result);
                 }
                 Plan::ValidateConnection(plan) => {
-                    let connection_context = self.connection_context().clone();
                     let connection = plan
                         .connection
                         .into_inline_connection(self.catalog().state());
+                    let current_storage_configuration = self.controller.storage.config().clone();
                     mz_ore::task::spawn(|| "coord::validate_connection", async move {
-                        let res = match connection.validate(plan.id, &connection_context).await {
+                        let res = match connection
+                            .validate(plan.id, &current_storage_configuration)
+                            .await
+                        {
                             Ok(()) => Ok(ExecuteResponse::ValidatedConnection),
                             Err(err) => Err(err.into()),
                         };

--- a/src/controller/src/clusters.rs
+++ b/src/controller/src/clusters.rs
@@ -585,8 +585,8 @@ where
             ClusterRole::System => "system",
             ClusterRole::User => "user",
         };
-        let environment_id = self.connection_context.environment_id.clone();
-        let aws_external_id_prefix = self.connection_context.aws_external_id_prefix.clone();
+        let environment_id = self.connection_context().environment_id.clone();
+        let aws_external_id_prefix = self.connection_context().aws_external_id_prefix.clone();
         let persist_pubsub_url = self.persist_pubsub_url.clone();
         let persist_txn_tables = self.persist_txn_tables;
         let secrets_args = self.secrets_args.to_flags();

--- a/src/postgres-util/src/tunnel.rs
+++ b/src/postgres-util/src/tunnel.rs
@@ -90,8 +90,12 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn new(inner: tokio_postgres::Config, tunnel: TunnelConfig) -> Result<Self, PostgresError> {
-        let config = Self { inner, tunnel }.tcp_timeouts(TcpTimeoutConfig::default());
+    pub fn new(
+        inner: tokio_postgres::Config,
+        tunnel: TunnelConfig,
+        tcp_timeouts: TcpTimeoutConfig,
+    ) -> Result<Self, PostgresError> {
+        let config = Self { inner, tunnel }.tcp_timeouts(tcp_timeouts);
 
         // Early validate that the configuration contains only a single TCP
         // server.
@@ -100,7 +104,7 @@ impl Config {
         Ok(config)
     }
 
-    pub fn tcp_timeouts(mut self, tcp_timeouts: TcpTimeoutConfig) -> Config {
+    fn tcp_timeouts(mut self, tcp_timeouts: TcpTimeoutConfig) -> Config {
         if let Some(connect_timeout) = tcp_timeouts.connect_timeout {
             self.inner.connect_timeout(connect_timeout);
         }

--- a/src/storage-client/src/controller.rs
+++ b/src/storage-client/src/controller.rs
@@ -33,6 +33,7 @@ use mz_persist_client::read::{Cursor, ReadHandle};
 use mz_persist_client::stats::SnapshotStats;
 use mz_persist_types::Codec64;
 use mz_repr::{Diff, GlobalId, RelationDesc, Row, TimestampManipulation};
+use mz_storage_types::configuration::StorageConfiguration;
 use mz_storage_types::controller::{CollectionMetadata, StorageError};
 use mz_storage_types::instances::StorageInstanceId;
 use mz_storage_types::parameters::StorageParameters;
@@ -209,8 +210,11 @@ pub trait StorageController: Debug {
     /// This method can be invoked immediately, at the potential expense of performance.
     fn initialization_complete(&mut self);
 
-    /// Update storage configuration.
-    fn update_configuration(&mut self, config_params: StorageParameters);
+    /// Update storage configuration with new parameters.
+    fn update_parameters(&mut self, config_params: StorageParameters);
+
+    /// Get the current configuration, including parameters updated with `update_parameters`.
+    fn config(&self) -> &StorageConfiguration;
 
     /// Acquire an immutable reference to the collection state, should it exist.
     fn collection(&self, id: GlobalId) -> Result<&CollectionState<Self::Timestamp>, StorageError>;

--- a/src/storage-types/src/configuration.rs
+++ b/src/storage-types/src/configuration.rs
@@ -1,0 +1,50 @@
+// Copyright Materialize, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+//! Configuration parameter types.
+
+use crate::{connections::ConnectionContext, parameters::StorageParameters};
+
+include!(concat!(env!("OUT_DIR"), "/mz_storage_types.parameters.rs"));
+
+/// A struct representing the _entirety_ of configuration required for interacting with storage APIs.
+///
+/// Portions of this struct are mutable, but it remains _clone-able_ so it can be moved between
+/// tasks.
+///
+/// Usable within clusterd and environmentd.
+#[derive(Debug, Clone)]
+pub struct StorageConfiguration {
+    /// Mutable, LD-controlled parameters related to upstream storage connections,
+    /// persist, and rendering of dataflows.
+    ///
+    /// This type can be serialized and copied from environmentd to clusterd, and can
+    /// be merged into a `StorageConfiguration` with `StorageConfiguration::update`.
+    pub parameters: StorageParameters,
+
+    /// Immutable, CLI-configured parameters.
+    ///
+    /// TODO(guswynn): `ConnectionContext` also contains some shared global state that should
+    /// eventually be moved up to this struct.
+    pub connection_context: ConnectionContext,
+}
+
+impl StorageConfiguration {
+    /// Instantiate a new `StorageConfiguration` with default parameters and
+    pub fn new(connection_context: ConnectionContext) -> StorageConfiguration {
+        StorageConfiguration {
+            parameters: Default::default(),
+            connection_context,
+        }
+    }
+
+    pub fn update(&mut self, parameters: StorageParameters) {
+        self.parameters.update(parameters)
+    }
+}

--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -1052,7 +1052,7 @@ impl PostgresConnection<InlinedConnection> {
     pub async fn config(
         &self,
         secrets_reader: &dyn mz_secrets::SecretsReader,
-        _storage_configuration: &StorageConfiguration,
+        storage_configuration: &StorageConfiguration,
     ) -> Result<mz_postgres_util::Config, anyhow::Error> {
         let mut config = tokio_postgres::Config::new();
         config
@@ -1100,7 +1100,14 @@ impl PostgresConnection<InlinedConnection> {
             }
         };
 
-        Ok(mz_postgres_util::Config::new(config, tunnel)?)
+        Ok(mz_postgres_util::Config::new(
+            config,
+            tunnel,
+            storage_configuration
+                .parameters
+                .pg_source_tcp_timeouts
+                .clone(),
+        )?)
     }
 
     async fn validate(

--- a/src/storage-types/src/connections/aws.rs
+++ b/src/storage-types/src/connections/aws.rs
@@ -17,7 +17,7 @@ use mz_secrets::SecretsReader;
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 
-use crate::connections::{ConnectionContext, StringOrSecret};
+use crate::{configuration::StorageConfiguration, connections::StringOrSecret};
 
 include!(concat!(
     env!("OUT_DIR"),
@@ -185,7 +185,7 @@ impl AwsConfig {
     pub(crate) async fn validate(
         &self,
         _id: GlobalId,
-        _connection_context: &ConnectionContext,
+        _storage_configuration: &StorageConfiguration,
     ) -> Result<(), anyhow::Error> {
         Err(anyhow!("Validating SSH connections is not supported yet"))
     }

--- a/src/storage-types/src/lib.rs
+++ b/src/storage-types/src/lib.rs
@@ -78,6 +78,7 @@
 //! Shared types for the `mz-storage*` crates
 
 pub mod collections;
+pub mod configuration;
 pub mod connections;
 pub mod controller;
 pub mod errors;

--- a/src/storage-types/src/parameters.rs
+++ b/src/storage-types/src/parameters.rs
@@ -146,6 +146,9 @@ impl RustType<ProtoUpsertAutoSpillConfig> for UpsertAutoSpillConfig {
 
 impl StorageParameters {
     /// Update the parameter values with the set ones from `other`.
+    ///
+    /// NOTE that this does not necessarily update all global state related
+    /// to these parameters, like persist parameters.
     pub fn update(
         &mut self,
         StorageParameters {

--- a/src/storage/src/render/mod.rs
+++ b/src/storage/src/render/mod.rs
@@ -332,7 +332,10 @@ pub fn build_ingestion_dataflow<A: Allocate>(
                     command_tx: Rc::clone(&storage_state.internal_cmd_tx),
                     updates: Rc::clone(&storage_state.object_status_updates),
                 },
-                storage_state.dataflow_parameters.record_namespaced_errors,
+                storage_state
+                    .storage_configuration
+                    .parameters
+                    .record_namespaced_errors,
             );
             tokens.push(health_token);
 
@@ -390,7 +393,10 @@ pub fn build_export_dataflow<A: Allocate>(
                     command_tx: Rc::clone(&storage_state.internal_cmd_tx),
                     updates: Rc::clone(&storage_state.object_status_updates),
                 },
-                storage_state.dataflow_parameters.record_namespaced_errors,
+                storage_state
+                    .storage_configuration
+                    .parameters
+                    .record_namespaced_errors,
             );
             tokens.push(health_token);
 

--- a/src/storage/src/source/generator.rs
+++ b/src/storage/src/source/generator.rs
@@ -13,7 +13,6 @@ use std::time::Duration;
 use differential_dataflow::{AsCollection, Collection};
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Diff, Row};
-use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sources::{
     Generator, LoadGenerator, LoadGeneratorSourceConnection, MzOffset, SourceTimestamp,
 };
@@ -78,7 +77,6 @@ impl SourceRender for LoadGeneratorSourceConnection {
         self,
         scope: &mut G,
         config: RawSourceCreationConfig,
-        _connection_context: ConnectionContext,
         _resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (

--- a/src/storage/src/source/mod.rs
+++ b/src/storage/src/source/mod.rs
@@ -38,6 +38,4 @@ pub mod testscript;
 pub mod types;
 
 pub use kafka::KafkaSourceReader;
-pub use source_reader_pipeline::{
-    create_raw_source, RawSourceCreationConfig, SourceCreationParams, SourceStatistics,
-};
+pub use source_reader_pipeline::{create_raw_source, RawSourceCreationConfig, SourceStatistics};

--- a/src/storage/src/source/postgres.rs
+++ b/src/storage/src/source/postgres.rs
@@ -90,7 +90,6 @@ use mz_postgres_util::desc::PostgresTableDesc;
 use mz_postgres_util::{simple_query_opt, PostgresError};
 use mz_repr::{Datum, Diff, Row};
 use mz_sql_parser::ast::{display::AstDisplay, Ident};
-use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::SourceErrorDetails;
 use mz_storage_types::sources::{MzOffset, PostgresSourceConnection, SourceTimestamp};
 use mz_timely_util::builder_async::PressOnDropButton;
@@ -122,7 +121,6 @@ impl SourceRender for PostgresSourceConnection {
         self,
         scope: &mut G,
         config: RawSourceCreationConfig,
-        context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (
@@ -168,7 +166,6 @@ impl SourceRender for PostgresSourceConnection {
             scope.clone(),
             config.clone(),
             self.clone(),
-            context.clone(),
             subsource_resume_uppers.clone(),
             table_info.clone(),
         );
@@ -177,7 +174,6 @@ impl SourceRender for PostgresSourceConnection {
             scope.clone(),
             config,
             self,
-            context,
             subsource_resume_uppers,
             table_info,
             &rewinds,

--- a/src/storage/src/source/testscript.rs
+++ b/src/storage/src/source/testscript.rs
@@ -12,7 +12,6 @@ use std::convert::Infallible;
 use differential_dataflow::{AsCollection, Collection};
 use mz_ore::collections::CollectionExt;
 use mz_repr::{Diff, Row};
-use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::sources::{MzOffset, TestScriptSourceConnection};
 use mz_timely_util::builder_async::{OperatorBuilder as AsyncOperatorBuilder, PressOnDropButton};
 use timely::dataflow::operators::ToStream;
@@ -52,7 +51,6 @@ impl SourceRender for TestScriptSourceConnection {
         self,
         scope: &mut G,
         config: RawSourceCreationConfig,
-        _connection_context: ConnectionContext,
         _resume_uppers: impl futures::Stream<Item = Antichain<MzOffset>> + 'static,
         _start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (

--- a/src/storage/src/source/types.rs
+++ b/src/storage/src/source/types.rs
@@ -17,7 +17,6 @@ use std::fmt::Debug;
 
 use differential_dataflow::Collection;
 use mz_repr::{Diff, Row};
-use mz_storage_types::connections::ConnectionContext;
 use mz_storage_types::errors::{DecodeError, SourceErrorDetails};
 use mz_storage_types::sources::{MzOffset, SourceTimestamp};
 use mz_timely_util::builder_async::PressOnDropButton;
@@ -64,7 +63,6 @@ pub trait SourceRender {
         self,
         scope: &mut G,
         config: RawSourceCreationConfig,
-        connection_context: ConnectionContext,
         resume_uppers: impl futures::Stream<Item = Antichain<Self::Time>> + 'static,
         start_signal: impl std::future::Future<Output = ()> + 'static,
     ) -> (


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/18683

I noticed that we configure pg clients without the default but not the LD parameters in the adapter. This pr adjusts this, requiring the tcp timeouts config when creating a `tokio_postgres::Config`. I consolidated `ConnectionContext` and `StorageParameters` into `StorageConfiguration` to simplify this (and future work)


A few nice things that came out of this:
- Stop duplicating a bunch of work in `DataflowParameters`, just store a `StorageParameters` on storage state
- When I come back and make ssh connect timeouts configurable, this will allow me to drop those changes in nicely

### Motivation

   * This PR refactors existing code.


### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
