### PR TITLE
platform-checks: Disable KafkaChecks for backup+restore

### DIFF
--- a/misc/python/materialize/checks/all_checks/error.py
+++ b/misc/python/materialize/checks/all_checks/error.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 
 class ParseError(Check):
@@ -136,6 +136,7 @@ def schemas() -> str:
     )
 
 
+@externally_idempotent(False)
 class DecodeError(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/json_source.py
+++ b/misc/python/materialize/checks/all_checks/json_source.py
@@ -9,11 +9,12 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
 
 
+@externally_idempotent(False)
 class JsonSource(Check):
     """Test CREATE SOURCE ... FORMAT JSON"""
 

--- a/misc/python/materialize/checks/all_checks/kafka_formats.py
+++ b/misc/python/materialize/checks/all_checks/kafka_formats.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 
 PROTOBUF = dedent(
     """
@@ -31,6 +31,7 @@ PROTOBUF = dedent(
 )
 
 
+@externally_idempotent(False)
 class KafkaFormats(Check):
     def initialize(self) -> Testdrive:
         return Testdrive(

--- a/misc/python/materialize/checks/all_checks/upsert_wide.py
+++ b/misc/python/materialize/checks/all_checks/upsert_wide.py
@@ -9,7 +9,7 @@
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 
 PAD_100K = "X" * (100 * 1024)
@@ -17,6 +17,7 @@ PAD_500K = "Y" * (500 * 1024)
 PAD_1M = "Z" * (1000 * 1024)
 
 
+@externally_idempotent(False)
 class UpsertWideValue(Check):
     """Perform upsert over records with a very long/wide value."""
 
@@ -83,6 +84,7 @@ class UpsertWideValue(Check):
         )
 
 
+@externally_idempotent(False)
 class UpsertWideKey(Check):
     """Perform upsert over records with a very long/wide key."""
 


### PR DESCRIPTION
As described in https://github.com/MaterializeInc/materialize/issues/18628#issuecomment-1834656109

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
