### PR TITLE
platform-checks: Only run git fetch when required

### DIFF
--- a/misc/python/materialize/checks/scenarios_upgrade.py
+++ b/misc/python/materialize/checks/scenarios_upgrade.py
@@ -9,6 +9,8 @@
 
 
 from materialize.checks.actions import Action, Initialize, Manipulate, Sleep, Validate
+from materialize.checks.checks import Check
+from materialize.checks.executors import Executor
 from materialize.checks.mzcompose_actions import (
     KillClusterdCompute,
     KillMz,
@@ -136,7 +138,11 @@ class UpgradeEntireMzSkipVersion(Scenario):
 class UpgradeEntireMzFourVersions(Scenario):
     """Test upgrade X-4 -> X-3 -> X-2 -> X-1 -> X"""
 
-    minor_versions = get_minor_versions()
+    def __init__(
+        self, checks: list[type[Check]], executor: Executor, seed: str | None = None
+    ):
+        super().__init__(checks, executor, seed)
+        self.minor_versions = get_minor_versions()
 
     def base_version(self) -> MzVersion:
         return self.minor_versions[3]


### PR DESCRIPTION
Otherwise even "bin/mzcompose --find platform-checks down" takes > 1 minute for me. The classes are created even if you don't use them, just by importing, and thus the `git fetch` was run on all the forks of all Mz colleagues.

Follow-up to https://github.com/MaterializeInc/materialize/pull/23455


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
