### PR TITLE
storage: enable socket keepalives in kafka connections

### DIFF
--- a/src/storage-types/src/connections.rs
+++ b/src/storage-types/src/connections.rs
@@ -427,6 +427,11 @@ impl KafkaConnection {
             );
         }
 
+        // We don't override any socket timeouts (like `socket.timeout.ms`) as we allow rdkafka
+        // to choose a reasonably default for us, but we do enable keepalives, as
+        // they have no downsides <https://github.com/confluentinc/librdkafka/issues/283>.
+        options.insert("socket.keepalive.enable".into(), "true".into());
+
         let mut config = mz_kafka_util::client::create_new_client_config(
             connection_context.librdkafka_log_level,
         );


### PR DESCRIPTION
Part of https://github.com/MaterializeInc/materialize/issues/18683

We are deciding to leave the socket timeout choice to rdkafka, but we are turning on keepalives.

### Motivation

  * This PR adds a known-desirable feature.


- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
