### PR TITLE
adapter: clean up `bootstrap_index_as_of`

### DIFF
--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1860,27 +1860,27 @@ impl Coordinator {
             max_as_of.meet_assign(&since.join(upper));
         }
 
-        mz_ore::soft_assert!(
-            PartialOrder::less_equal(&min_as_of, &max_as_of),
-            "error bootrapping index `as_of`: \
-             min_as_of {:?} greater than max_as_of {:?} \
-             (import_ids={}, export_ids={}, dependent_matviews={:?})",
-            min_as_of.elements(),
-            max_as_of.elements(),
-            dataflow.display_import_ids(),
-            dataflow.display_export_ids(),
-            dependent_matviews,
-        );
-
-        // Ensure that we never select an `as_of` that's less than `min_as_of`,
-        // even if that means selecting an `as_of` that's greater than `max_as_of`.
-        // The former makes environmentd crash, the latter "only" leads to correctness bugs.
         let as_of = if PartialOrder::less_equal(&min_as_of, &max_as_of) {
-            let mut as_of = min_as_of.clone();
-            as_of.join_assign(&max_compaction_frontier);
-            as_of.meet_assign(&max_as_of);
-            as_of
+            min_as_of.join(&max_compaction_frontier).meet(&max_as_of)
         } else {
+            // This should not happen. If we get here that means we _will_ skip times in some of
+            // the dependent materialized views, which is a correctness bug. However, skipping
+            // times in materialized views is probably preferable to panicking and thus making the
+            // entire environment unavailable. So we chose to handle this case gracefully and only
+            // log an error, unless soft-asserts are enabled, and continue with the `min_as_of` to
+            // make the dependent materialized views skip as few times as possible.
+
+            mz_ore::soft_panic_or_log!(
+                "error bootstrapping index `as_of`: \
+                 `min_as_of` {:?} greater than `max_as_of` {:?} \
+                 (import_ids={}, export_ids={}, dependent_matviews={:?})",
+                min_as_of.elements(),
+                max_as_of.elements(),
+                dataflow.display_import_ids(),
+                dataflow.display_export_ids(),
+                dependent_matviews,
+            );
+
             min_as_of.clone()
         };
 


### PR DESCRIPTION
Follow-up on #23564 with some minor cleanup, more clarifying comments, and making sure that we log an error when soft assertions are disabled.

### Motivation

  * This PR fixes a previously unreported bug.

Part of #23563

### Tips for reviewer

See this [Slack thread](https://materializeinc.slack.com/archives/C067ZUCKNF4/p1701343961978359) and channel for context.

The statement that keeping the environment alive is more important than allowing correctness bugs might be contentious. It is definitely the right thing to do as long as we have production environments that hit this error, but we might want to reconsider after these have been fixed.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/A