### PR TITLE
persist-source: make producing the snapshot optional

### DIFF
--- a/src/compute/src/render/mod.rs
+++ b/src/compute/src/render/mod.rs
@@ -114,6 +114,7 @@ use itertools::izip;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::plan::Plan;
 use mz_expr::{EvalError, Id};
+use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Diff, GlobalId};
 use mz_storage_operators::persist_source;
 use mz_storage_types::controller::CollectionMetadata;
@@ -215,6 +216,7 @@ pub fn build_compute_dataflow<A: Allocate>(
                         Arc::clone(&compute_state.persist_clients),
                         source.storage_metadata.clone(),
                         dataflow.as_of.clone(),
+                        SnapshotMode::Include,
                         dataflow.until.clone(),
                         mfp.as_mut(),
                         compute_state.dataflow_max_inflight_bytes,

--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -21,6 +21,7 @@ use mz_ore::cast::CastFrom;
 use mz_ore::collections::HashMap;
 use mz_persist_client::batch::{Batch, BatchBuilder, ProtoBatch};
 use mz_persist_client::cache::PersistClientCache;
+use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_persist_client::Diagnostics;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_repr::{Diff, GlobalId, Row, Timestamp};
@@ -95,6 +96,7 @@ where
         Arc::clone(&compute_state.persist_clients),
         target.clone(),
         source_as_of,
+        SnapshotMode::Include,
         Antichain::new(), // we want all updates
         None,             // no MFP
         None,             // no flow control

--- a/src/persist-client/src/read.rs
+++ b/src/persist-client/src/read.rs
@@ -199,11 +199,6 @@ where
     pub fn return_leased_part(&mut self, leased_part: LeasedBatchPart<T>) {
         self.listen.handle.process_returned_leased_part(leased_part)
     }
-
-    /// Returns a [`SubscriptionLeaseReturner`] tied to this [`Subscribe`].
-    pub(crate) fn lease_returner(&self) -> &SubscriptionLeaseReturner {
-        self.listen.handle.lease_returner()
-    }
 }
 
 impl<K, V, T, D> Drop for Subscribe<K, V, T, D>

--- a/src/persist-txn/src/operator.rs
+++ b/src/persist-txn/src/operator.rs
@@ -20,7 +20,7 @@ use differential_dataflow::difference::Semigroup;
 use differential_dataflow::lattice::Lattice;
 use differential_dataflow::Hashable;
 use mz_ore::cast::CastFrom;
-use mz_persist_client::operators::shard_source::shard_source;
+use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
 use mz_persist_client::read::ListenEvent;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
 use mz_persist_types::codec_impls::{StringSchema, UnitSchema};
@@ -515,6 +515,7 @@ impl DataSubscribe {
                     move || std::future::ready(client.clone()),
                     data_id,
                     Some(Antichain::from_elem(as_of)),
+                    SnapshotMode::Include,
                     Antichain::new(),
                     false.then_some(|_, _: &_, _| unreachable!()),
                     Arc::new(StringSchema),

--- a/src/storage-operators/src/persist_source.rs
+++ b/src/storage-operators/src/persist_source.rs
@@ -25,7 +25,7 @@ use mz_persist_client::cache::PersistClientCache;
 use mz_persist_client::cfg::{PersistConfig, RetryParameters};
 use mz_persist_client::fetch::FetchedPart;
 use mz_persist_client::fetch::SerdeLeasedBatchPart;
-use mz_persist_client::operators::shard_source::shard_source;
+use mz_persist_client::operators::shard_source::{shard_source, SnapshotMode};
 use mz_persist_txn::operator::txns_progress;
 use mz_persist_types::codec_impls::UnitSchema;
 use mz_persist_types::Codec64;
@@ -133,6 +133,7 @@ pub fn persist_source<G>(
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
     as_of: Option<Antichain<Timestamp>>,
+    snapshot_mode: SnapshotMode,
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
     max_inflight_bytes: Option<usize>,
@@ -188,6 +189,7 @@ where
             Arc::clone(&persist_clients),
             metadata.clone(),
             as_of.clone(),
+            snapshot_mode,
             until,
             map_filter_project,
             flow_control,
@@ -261,6 +263,7 @@ pub fn persist_source_core<'g, G>(
     persist_clients: Arc<PersistClientCache>,
     metadata: CollectionMetadata,
     as_of: Option<Antichain<Timestamp>>,
+    snapshot_mode: SnapshotMode,
     until: Antichain<Timestamp>,
     map_filter_project: Option<&mut MfpPlan>,
     flow_control: Option<FlowControl<RefinedScope<'g, G>>>,
@@ -318,6 +321,7 @@ where
         },
         metadata.data_shard,
         as_of,
+        snapshot_mode,
         until.clone(),
         desc_transformer,
         Arc::new(metadata.relation_desc),

--- a/src/storage/src/render/sinks.rs
+++ b/src/storage/src/render/sinks.rs
@@ -17,6 +17,7 @@ use differential_dataflow::operators::arrange::Arrange;
 use differential_dataflow::trace::implementations::ord::ColValSpine;
 use differential_dataflow::{AsCollection, Collection, Hashable};
 use mz_interchange::envelopes::{combine_at_timestamp, dbz_format};
+use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Datum, Diff, GlobalId, Row, Timestamp};
 use mz_storage_operators::persist_source;
 use mz_storage_types::errors::DataflowError;
@@ -50,6 +51,7 @@ pub(crate) fn render_sink<'g, G: Scope<Timestamp = ()>>(
         Arc::clone(&storage_state.persist_clients),
         sink.from_storage_metadata.clone(),
         Some(sink.as_of.frontier.clone()),
+        SnapshotMode::Include,
         timely::progress::Antichain::new(),
         None,
         None,

--- a/src/storage/src/render/sources.rs
+++ b/src/storage/src/render/sources.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 
 use differential_dataflow::{collection, AsCollection, Collection, Hashable};
 use mz_ore::cast::CastLossy;
+use mz_persist_client::operators::shard_source::SnapshotMode;
 use mz_repr::{Datum, Diff, GlobalId, Row, RowPacker, Timestamp};
 use mz_storage_operators::persist_source;
 use mz_storage_operators::persist_source::Subtime;
@@ -349,6 +350,7 @@ where
                                     persist_clients,
                                     tx_storage_metadata,
                                     Some(as_of),
+                                    SnapshotMode::Include,
                                     Antichain::new(),
                                     None,
                                     None,
@@ -445,6 +447,7 @@ where
                                         persist_clients,
                                         description.ingestion_metadata,
                                         Some(as_of),
+                                        SnapshotMode::Include,
                                         Antichain::new(),
                                         None,
                                         flow_control,


### PR DESCRIPTION
### Motivation

This PR adds the option to `persist_source` to produce only the updates that happen at `t: as_of < t`.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->



<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

Most of the diff is indentation changes so view it with whitespace hidden

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
