### PR TITLE
balancer: test that connection dedup occurs

### DIFF
--- a/src/environmentd/tests/auth.rs
+++ b/src/environmentd/tests/auth.rs
@@ -1736,7 +1736,7 @@ async fn test_auth_deduplication() {
         roles,
         SYSTEM_TIME.clone(),
         i64::try_from(EXPIRES_IN_SECS).unwrap(),
-        Some(2),
+        Some(Duration::from_secs(2)),
     )
     .unwrap();
 

--- a/src/frontegg-auth/src/auth.rs
+++ b/src/frontegg-auth/src/auth.rs
@@ -433,7 +433,7 @@ fn continuously_refresh(
                 Err(err) => {
                     tracing::warn!(?id, ?err, "Token expired!");
                     drop(refresh_tx);
-                    return;
+                    break;
                 }
                 Ok(claims) => claims,
             };
@@ -502,7 +502,7 @@ fn continuously_refresh(
 
                     // Dropping the channel will close it.
                     drop(refresh_tx);
-                    return;
+                    break;
                 }
             };
 


### PR DESCRIPTION
We want to prevent quota limiting by frontegg. Envd and balancerd both do connection deduplication, but balancerd didn't have a test for it.

### Motivation

  * This PR adds a known-desirable feature.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a