### PR TITLE
tests: fix and make alter-connection tests more robust

### DIFF
--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -13,7 +13,7 @@ from random import Random
 from textwrap import dedent
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check, disabled, externally_idempotent
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.checks.common import KAFKA_SCHEMA_WITH_SINGLE_STRING_FIELD
 from materialize.checks.executors import Executor
 from materialize.mz_version import MzVersion
@@ -34,7 +34,6 @@ SHOW_CONNECTION_SSH_TUNNEL = """materialize.public.ssh_tunnel_{i} "CREATE CONNEC
 WITH_SSH_SUFFIX = "USING SSH TUNNEL ssh_tunnel_{i}"
 
 
-@disabled("reenable with 23613")
 class AlterConnectionSshChangeBase(Check):
     def __init__(
         self,

--- a/misc/python/materialize/checks/all_checks/alter_connection.py
+++ b/misc/python/materialize/checks/all_checks/alter_connection.py
@@ -47,7 +47,7 @@ class AlterConnectionSshChangeBase(Check):
         self.index = index
 
     def _can_run(self, e: Executor) -> bool:
-        return self.base_version >= MzVersion.parse_mz("v0.78.0-dev")
+        return self.base_version >= MzVersion.parse_mz("v0.79.0-dev")
 
     def initialize(self) -> Testdrive:
         i = self.index


### PR DESCRIPTION
This should fix https://github.com/MaterializeInc/materialize/issues/23613 and replace https://github.com/MaterializeInc/materialize/pull/23614. The order of the connection parameters was not stable.

Nightly: https://buildkite.com/materialize/nightlies/builds?branch=nrainer-materialize%3Atests%2Fmake-alter-connection-tests-robust