### PR TITLE
logging: downgrade noisy trace

### DIFF
--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -46,7 +46,7 @@ use timely::order::PartialOrder;
 use timely::progress::frontier::Antichain;
 use timely::worker::Worker as TimelyWorker;
 use tokio::sync::oneshot;
-use tracing::{error, info, span, warn, Level};
+use tracing::{debug, error, info, span, warn, Level};
 use uuid::Uuid;
 
 use crate::arrangement::manager::{SpecializedTraceHandle, TraceBundle, TraceManager};
@@ -267,7 +267,7 @@ impl<'a, A: Allocate + 'static> ActiveComputeState<'a, A> {
                             }),
                     );
                 } else {
-                    warn!("Not enabling lgalloc, scratch directory not specified");
+                    debug!("Not enabling lgalloc, scratch directory not specified");
                 }
             }
             Some(false) => {


### PR DESCRIPTION
This trace gets printed quite often when running sqllogictests, which makes the test output quite noisy. Downgrading it to `debug!` prevents it from being printed. Example,

```
--- test/sqllogictest/autogenerated/mz_internal.slt
    PASS: success=73 total=73
2023-12-01T18:17:46.811707Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:46.811721Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:46.811756Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:46.811762Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:46.811791Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:46.811851Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145069Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145130Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145137Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145166Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145211Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:48.145305Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
--- test/sqllogictest/transform/relax_must_consolidate.slt
    PASS: success=39 total=39
2023-12-01T18:17:59.706602Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:59.706649Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:59.706699Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:59.706733Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:59.706753Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:17:59.706857Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941515Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941528Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941557Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941579Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941606Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:18:01.941636Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
--- test/sqllogictest/cockroach/aggregate.slt
    Warning detected for: 
    SELECT count(*), count(k), count(kv.v) FROM kv
    PASS: warning=1 success=221 total=222
2023-12-01T18:19:26.067383Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:26.067466Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:26.067477Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:26.067505Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:26.067531Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:26.067581Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.155110Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.155188Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.155189Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.155285Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.155297Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:28.156112Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
--- test/sqllogictest/cockroach/distinct_on.slt
    PASS: success=46 total=46
2023-12-01T18:19:49.656516Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:49.656571Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:49.656570Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:49.656575Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:49.656646Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:49.656688Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697796Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697804Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697832Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697872Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697896Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
2023-12-01T18:19:51.697948Z  WARN mz_compute::compute_state: Not enabling lgalloc, scratch directory not specified
```

### Motivation

Reduce noise in test output

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - N/a
