### PR TITLE
catalog: Remove re-export from adapter::catalog

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+// TODO(jkosh44) Move to mz_catalog crate.
+
 //! Persistent metadata storage for the coordinator.
 
 use std::borrow::Cow;
@@ -31,12 +33,11 @@ use mz_catalog::builtin::{
 use mz_catalog::durable::{
     test_bootstrap_args, DurableCatalogState, OpenableDurableCatalogState, StashConfig, Transaction,
 };
-pub use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
-pub use mz_catalog::memory::objects::{
+use mz_catalog::memory::error::{AmbiguousRename, Error, ErrorKind};
+use mz_catalog::memory::objects::{
     CatalogEntry, CatalogItem, Cluster, ClusterConfig, ClusterReplica, ClusterReplicaProcessStatus,
-    ClusterVariant, ClusterVariantManaged, CommentsMap, Connection, DataSourceDesc, Database,
-    DefaultPrivileges, Func, Index, Log, MaterializedView, Role, Schema, Secret, Sink, Source,
-    Table, Type, View,
+    ClusterVariant, Connection, DataSourceDesc, Database, Func, Index, MaterializedView, Role,
+    Schema, Sink, Source, Type, View,
 };
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_compute_types::dataflows::DataflowDescription;
@@ -88,6 +89,7 @@ use mz_storage_types::connections::inline::{ConnectionResolver, InlinedConnectio
 use mz_storage_types::sources::Timeline;
 use mz_transform::dataflow::DataflowMetainfo;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 pub use crate::catalog::builtin_table_updates::BuiltinTableUpdate;
 pub use crate::catalog::config::{AwsPrincipalContext, ClusterReplicaSizeMap, Config, StateConfig};
 pub use crate::catalog::open::BuiltinMigrationMetadata;

--- a/src/adapter/src/catalog/builtin_table_updates.rs
+++ b/src/adapter/src/catalog/builtin_table_updates.rs
@@ -52,6 +52,7 @@ use mz_storage_types::sources::{
     GenericSourceConnection, KafkaSourceConnection, PostgresSourceConnection,
 };
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{
     AwsPrincipalContext, CatalogItem, CatalogState, ClusterVariant, Connection, DataSourceDesc,
     Database, DefaultPrivilegeObject, Func, Index, MaterializedView, Sink, Type, View,

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -26,6 +26,7 @@ use mz_sql::catalog::EnvironmentId;
 use mz_sql::session::vars::ConnectionCounter;
 use serde::{Deserialize, Serialize};
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::config::SystemParameterSyncConfig;
 
 /// Configures a catalog.

--- a/src/adapter/src/catalog/consistency.rs
+++ b/src/adapter/src/catalog/consistency.rs
@@ -24,6 +24,7 @@ use mz_sql_parser::ast::{self, Statement};
 use mz_sql_parser::parser::ParserStatementError;
 use serde::Serialize;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use super::CatalogState;
 
 #[derive(Debug, Default, Clone, Serialize, PartialEq)]

--- a/src/adapter/src/catalog/inner.rs
+++ b/src/adapter/src/catalog/inner.rs
@@ -20,6 +20,7 @@ use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{Ident, RawClusterName, Statement};
 use mz_storage_types::sources::IngestionDescription;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{
     catalog_type_to_audit_object_type, BuiltinTableUpdate, Catalog, CatalogEntry, CatalogItem,
     CatalogState, DataSourceDesc, Index, MaterializedView, Sink, Source,

--- a/src/adapter/src/catalog/migrate.rs
+++ b/src/adapter/src/catalog/migrate.rs
@@ -22,6 +22,7 @@ use mz_storage_types::connections::ConnectionContext;
 use semver::Version;
 use tracing::info;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{Catalog, CatalogState, ConnCatalog};
 
 async fn rewrite_items<F>(

--- a/src/adapter/src/catalog/open.rs
+++ b/src/adapter/src/catalog/open.rs
@@ -65,6 +65,7 @@ use mz_sql_parser::ast::Expr;
 use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_types::sources::Timeline;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::config::StateConfig;
 use crate::catalog::{
     is_reserved_name, migrate, BuiltinTableUpdate, Catalog, CatalogPlans, CatalogState, Config,

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -72,6 +72,7 @@ use mz_storage_types::connections::inline::{
 };
 use mz_transform::Optimizer;
 
+// DO NOT add any more imports from `crate` outside of `crate::catalog`.
 use crate::catalog::{AwsPrincipalContext, BuiltinTableUpdate, ClusterReplicaSizeMap, ConnCatalog};
 use crate::coord::ConnMeta;
 use crate::optimize::{self, Optimize};

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -83,7 +83,7 @@ use itertools::Itertools;
 use mz_adapter_types::compaction::DEFAULT_LOGICAL_COMPACTION_WINDOW_TS;
 use mz_adapter_types::connection::ConnectionId;
 use mz_build_info::BuildInfo;
-use mz_catalog::memory::objects::CatalogEntry;
+use mz_catalog::memory::objects::{CatalogEntry, CatalogItem, Connection, DataSourceDesc, Source};
 use mz_cloud_resources::{CloudResourceController, VpcEndpointConfig};
 use mz_compute_types::dataflows::DataflowDescription;
 use mz_compute_types::plan::Plan;
@@ -127,8 +127,8 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 use uuid::Uuid;
 
 use crate::catalog::{
-    self, AwsPrincipalContext, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog, CatalogItem,
-    ClusterReplicaSizeMap, Connection, DataSourceDesc, Source,
+    self, AwsPrincipalContext, BuiltinMigrationMetadata, BuiltinTableUpdate, Catalog,
+    ClusterReplicaSizeMap,
 };
 use crate::client::{Client, Handle};
 use crate::command::{Canceled, Command, ExecuteResponse};
@@ -1134,7 +1134,7 @@ impl Coordinator {
         // express the entries' dependency graph.
         let mut entries_awaiting_dependencies: BTreeMap<
             GlobalId,
-            Vec<(catalog::CatalogEntry, Vec<GlobalId>)>,
+            Vec<(CatalogEntry, Vec<GlobalId>)>,
         > = BTreeMap::new();
 
         let mut loaded_items = BTreeSet::new();
@@ -1148,8 +1148,7 @@ impl Coordinator {
         //
         // This can likely be removed in the next version of Materialize
         // (v0.46).
-        let mut entries_awaiting_dependent: BTreeMap<GlobalId, Vec<catalog::CatalogEntry>> =
-            BTreeMap::new();
+        let mut entries_awaiting_dependent: BTreeMap<GlobalId, Vec<CatalogEntry>> = BTreeMap::new();
         let mut awaited_dependent_seen = BTreeSet::new();
 
         let mut unsorted_entries: VecDeque<_> = self

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -18,6 +18,7 @@ use chrono::{DateTime, Utc};
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
+use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, Source};
 use mz_compute_client::protocol::response::PeekResponse;
 use mz_ore::task;
 use mz_ore::tracing::OpenTelemetryContext;
@@ -41,7 +42,6 @@ use tokio::sync::{mpsc, oneshot, watch};
 use tracing::Instrument;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 
-use crate::catalog::{CatalogItem, DataSourceDesc, Source};
 use crate::command::{
     Canceled, CatalogSnapshot, Command, ExecuteResponse, GetVariablesResponse, StartupResponse,
 };

--- a/src/adapter/src/coord/dataflows.rs
+++ b/src/adapter/src/coord/dataflows.rs
@@ -19,6 +19,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use chrono::{DateTime, Utc};
 use maplit::{btreemap, btreeset};
 use mz_adapter_types::compaction::DEFAULT_LOGICAL_COMPACTION_WINDOW_TS;
+use mz_catalog::memory::objects::{CatalogItem, DataSourceDesc, MaterializedView, Source, View};
 use mz_compute_client::controller::error::InstanceMissing;
 use mz_compute_types::dataflows::{BuildDesc, DataflowDesc, DataflowDescription, IndexDesc};
 use mz_compute_types::plan::Plan;
@@ -40,7 +41,7 @@ use mz_sql::rbac;
 use mz_transform::dataflow::DataflowMetainfo;
 use tracing::warn;
 
-use crate::catalog::{CatalogItem, CatalogState, DataSourceDesc, MaterializedView, Source, View};
+use crate::catalog::CatalogState;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::Coordinator;
 use crate::session::{Session, SERVER_MAJOR_VERSION, SERVER_MINOR_VERSION};

--- a/src/adapter/src/coord/indexes.rs
+++ b/src/adapter/src/coord/indexes.rs
@@ -9,12 +9,12 @@
 
 use std::collections::BTreeSet;
 
+use mz_catalog::memory::objects::{CatalogItem, Index, Log};
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{CollectionPlan, MirScalarExpr};
 use mz_repr::GlobalId;
 use mz_transform::IndexOracle;
 
-use crate::catalog::{CatalogItem, Index, Log};
 use crate::coord::dataflows::DataflowBuilder;
 use crate::coord::{CollectionIdBundle, Coordinator};
 

--- a/src/adapter/src/coord/sequencer/cluster.rs
+++ b/src/adapter/src/coord/sequencer/cluster.rs
@@ -13,6 +13,7 @@ use mz_adapter_types::compaction::DEFAULT_LOGICAL_COMPACTION_WINDOW_TS;
 use std::collections::BTreeSet;
 use std::time::Duration;
 
+use mz_catalog::memory::objects::{ClusterConfig, ClusterVariant, ClusterVariantManaged};
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{
     CreateReplicaConfig, ManagedReplicaAvailabilityZones, ManagedReplicaLocation, ReplicaConfig,
@@ -31,7 +32,7 @@ use mz_sql::plan::{
 };
 use mz_sql::session::vars::{SystemVars, Var, MAX_REPLICAS_PER_CLUSTER};
 
-use crate::catalog::{ClusterConfig, ClusterVariant, ClusterVariantManaged, Op};
+use crate::catalog::Op;
 use crate::coord::Coordinator;
 use crate::session::Session;
 use crate::{catalog, AdapterError, ExecuteResponse};
@@ -535,7 +536,7 @@ impl Coordinator {
             options,
         }: AlterClusterPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        use catalog::ClusterVariant::*;
+        use mz_catalog::memory::objects::ClusterVariant::*;
 
         let config = self.catalog.get_cluster(cluster_id).config.clone();
         let mut new_config = config.clone();

--- a/src/adapter/src/coord/sequencer/linked_cluster.rs
+++ b/src/adapter/src/coord/sequencer/linked_cluster.rs
@@ -9,9 +9,10 @@
 
 //! Coordinator functionality to sequence linked-cluster-related plans
 
-use mz_catalog::LINKED_CLUSTER_REPLICA_NAME;
 use std::time::Duration;
 
+use mz_catalog::memory::objects::{ClusterConfig, ClusterVariant};
+use mz_catalog::LINKED_CLUSTER_REPLICA_NAME;
 use mz_compute_client::controller::ComputeReplicaConfig;
 use mz_controller::clusters::{ReplicaAllocation, ReplicaConfig, ReplicaLogging};
 use mz_controller_types::{ClusterId, DEFAULT_REPLICA_LOGGING_INTERVAL_MICROS};
@@ -21,7 +22,7 @@ use mz_sql::catalog::CatalogCluster;
 use mz_sql::names::QualifiedItemName;
 use mz_sql::plan::SourceSinkClusterConfig;
 
-use crate::catalog::{self, ClusterConfig, ClusterVariant};
+use crate::catalog::{self};
 use crate::coord::Coordinator;
 use crate::error::AdapterError;
 use crate::session::Session;

--- a/src/adapter/src/coord/timeline.rs
+++ b/src/adapter/src/coord/timeline.rs
@@ -16,6 +16,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use itertools::Itertools;
 use mz_adapter_types::connection::ConnectionId;
+use mz_catalog::memory::objects::CatalogItem;
 use mz_compute_types::ComputeInstanceId;
 use mz_expr::{CollectionPlan, OptimizedMirRelationExpr};
 use mz_ore::collections::CollectionExt;
@@ -28,7 +29,6 @@ use mz_storage_types::sources::Timeline;
 use timely::progress::Timestamp as TimelyTimestamp;
 use tracing::{debug, error, info};
 
-use crate::catalog::CatalogItem;
 use crate::coord::id_bundle::CollectionIdBundle;
 use crate::coord::read_policy::ReadHolds;
 use crate::coord::timestamp_oracle::batching_oracle::BatchingTimestampOracle;

--- a/src/adapter/src/error.rs
+++ b/src/adapter/src/error.rs
@@ -32,8 +32,6 @@ use smallvec::SmallVec;
 use tokio::sync::oneshot;
 use tokio_postgres::error::SqlState;
 
-use crate::catalog;
-
 /// Errors that can occur in the coordinator.
 #[derive(Debug)]
 pub enum AdapterError {
@@ -47,7 +45,7 @@ pub enum AdapterError {
     // resolved because it prevents us from adding columns to system tables.
     AmbiguousSystemColumnReference,
     /// An error occurred in a catalog operation.
-    Catalog(catalog::Error),
+    Catalog(mz_catalog::memory::error::Error),
     /// The cached plan or descriptor changed.
     ChangedPlan,
     /// The cursor already exists.
@@ -733,15 +731,15 @@ impl From<TryFromDecimalError> for AdapterError {
     }
 }
 
-impl From<catalog::Error> for AdapterError {
-    fn from(e: catalog::Error) -> AdapterError {
+impl From<mz_catalog::memory::error::Error> for AdapterError {
+    fn from(e: mz_catalog::memory::error::Error) -> AdapterError {
         AdapterError::Catalog(e)
     }
 }
 
 impl From<mz_catalog::durable::CatalogError> for AdapterError {
     fn from(e: mz_catalog::durable::CatalogError) -> Self {
-        catalog::Error::from(e).into()
+        mz_catalog::memory::error::Error::from(e).into()
     }
 }
 
@@ -762,7 +760,7 @@ impl From<ExplainError> for AdapterError {
 
 impl From<mz_sql::catalog::CatalogError> for AdapterError {
     fn from(e: mz_sql::catalog::CatalogError) -> AdapterError {
-        AdapterError::Catalog(catalog::Error::from(e))
+        AdapterError::Catalog(mz_catalog::memory::error::Error::from(e))
     }
 }
 

--- a/src/adapter/src/optimize/materialized_view.rs
+++ b/src/adapter/src/optimize/materialized_view.rs
@@ -178,7 +178,7 @@ impl LocalMirPlan {
 }
 
 /// This is needed only because the pipeline in the bootstrap code starts from an
-/// [`OptimizedMirRelationExpr`] attached to a [`crate::catalog::CatalogItem`].
+/// [`OptimizedMirRelationExpr`] attached to a [`mz_catalog::memory::objects::CatalogItem`].
 impl Optimize<OptimizedMirRelationExpr> for Optimizer {
     type To = GlobalMirPlan;
 

--- a/src/adapter/src/util.rs
+++ b/src/adapter/src/util.rs
@@ -291,10 +291,10 @@ impl ShouldHalt for AdapterError {
     }
 }
 
-impl ShouldHalt for crate::catalog::Error {
+impl ShouldHalt for mz_catalog::memory::error::Error {
     fn should_halt(&self) -> bool {
         match &self.kind {
-            crate::catalog::ErrorKind::Durable(e) => e.should_halt(),
+            mz_catalog::memory::error::ErrorKind::Durable(e) => e.should_halt(),
             _ => false,
         }
     }

--- a/src/adapter/tests/sql.rs
+++ b/src/adapter/tests/sql.rs
@@ -89,8 +89,9 @@
 use std::collections::BTreeSet;
 use std::sync::Arc;
 
-use mz_adapter::catalog::{Catalog, CatalogItem, Op, Table};
+use mz_adapter::catalog::{Catalog, Op};
 use mz_adapter::session::{Session, DEFAULT_DATABASE_NAME};
+use mz_catalog::memory::objects::{CatalogItem, Table};
 use mz_catalog::SYSTEM_CONN_ID;
 use mz_ore::now::NOW_ZERO;
 use mz_repr::RelationDesc;


### PR DESCRIPTION
Previously, the mz_adapter::catalog module was re-exporting modules from the mz_catalog crate. This commit removes those re-exports.

Works towards resolving #22593

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
