### PR TITLE
adapter: Changes to get aws_external_connection_role from args

### DIFF
--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -225,6 +225,10 @@ impl Default for ClusterReplicaSizeMap {
 pub struct AwsPrincipalContext {
     pub aws_account_id: String,
     pub aws_external_id_prefix: AwsExternalIdPrefix,
+    /// TODO(mouli): This is optional temporarily. Once the changes
+    /// (Github issue: https://github.com/MaterializeInc/cloud/issues/8191) are in
+    /// place to always pass this value, will make this required.
+    pub aws_external_connection_role: Option<String>,
 }
 
 impl AwsPrincipalContext {

--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -226,8 +226,8 @@ pub struct AwsPrincipalContext {
     pub aws_account_id: String,
     pub aws_external_id_prefix: AwsExternalIdPrefix,
     /// TODO(mouli): This is optional temporarily. Once the changes
-    /// (Github issue: https://github.com/MaterializeInc/cloud/issues/8191) are in
-    /// place to always pass this value, will make this required.
+    /// (Github issue: <https://github.com/MaterializeInc/cloud/issues/8191>)
+    /// are in place to always pass this value, will make this required.
     pub aws_external_connection_role: Option<String>,
 }
 

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -537,6 +537,7 @@ pub struct Config {
     pub egress_ips: Vec<Ipv4Addr>,
     pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
     pub aws_account_id: Option<String>,
+    pub aws_external_connection_role: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
     pub webhook_concurrency_limit: WebhookConcurrencyLimiter,
@@ -2235,6 +2236,7 @@ pub fn serve(
         segment_client,
         egress_ips,
         aws_account_id,
+        aws_external_connection_role,
         aws_privatelink_availability_zones,
         system_parameter_sync_config,
         active_connection_count,
@@ -2263,11 +2265,15 @@ pub fn serve(
                 .connection_context()
                 .aws_external_id_prefix
                 .clone(),
+            aws_external_connection_role,
         ) {
-            (Some(aws_account_id), Some(aws_external_id_prefix)) => Some(AwsPrincipalContext {
-                aws_account_id,
-                aws_external_id_prefix,
-            }),
+            (Some(aws_account_id), Some(aws_external_id_prefix), aws_external_connection_role) => {
+                Some(AwsPrincipalContext {
+                    aws_account_id,
+                    aws_external_id_prefix,
+                    aws_external_connection_role,
+                })
+            }
             _ => None,
         };
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -557,6 +557,10 @@ pub struct Args {
     #[clap(long, env = "AWS_ACCOUNT_ID")]
     aws_account_id: Option<String>,
 
+    /// The Materialize role arn to assume when connecting to external user's AWS account.
+    #[clap(long, env = "AWS_EXTERNAL_CONNECTION_ROLE")]
+    aws_external_connection_role: Option<String>,
+
     /// The list of supported AWS PrivateLink availability zone ids.
     /// Must be zone IDs, of format e.g. "use-az1".
     #[clap(
@@ -992,6 +996,7 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 segment_api_key: args.segment_api_key,
                 egress_ips: args.announce_egress_ip,
                 aws_account_id: args.aws_account_id,
+                aws_external_connection_role: args.aws_external_connection_role,
                 aws_privatelink_availability_zones: args.aws_privatelink_availability_zones,
                 launchdarkly_sdk_key: args.launchdarkly_sdk_key,
                 launchdarkly_key_map: args

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -194,6 +194,8 @@ pub struct Config {
     pub egress_ips: Vec<Ipv4Addr>,
     /// 12-digit AWS account id, which will be used to generate an AWS Principal.
     pub aws_account_id: Option<String>,
+    /// The Materialize AWS role arn which will be used to connect to customer's AWS account.
+    pub aws_external_connection_role: Option<String>,
     /// Supported AWS PrivateLink availability zone ids.
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     /// An SDK key for LaunchDarkly. Enables system parameter synchronization
@@ -558,6 +560,7 @@ impl Listeners {
             egress_ips: config.egress_ips,
             system_parameter_sync_config: system_parameter_sync_config.clone(),
             aws_account_id: config.aws_account_id,
+            aws_external_connection_role: config.aws_external_connection_role,
             aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             active_connection_count: Arc::clone(&active_connection_count),
             webhook_concurrency_limit: webhook_concurrency_limit.clone(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -524,6 +524,7 @@ impl Listeners {
                 segment_api_key: None,
                 egress_ips: vec![],
                 aws_account_id: None,
+                aws_external_connection_role: None,
                 aws_privatelink_availability_zones: None,
                 launchdarkly_sdk_key: None,
                 launchdarkly_key_map: Default::default(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1043,6 +1043,7 @@ impl<'a> RunnerInner<'a> {
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,
+            aws_external_connection_role: None,
             aws_privatelink_availability_zones: None,
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

Adding an argument to accept a Materialize Role ARN in environmentd and setting it in AwsPrincipalContext to be used later for AWS connections https://github.com/MaterializeInc/materialize/pull/23282

### Motivation
Split this PR from https://github.com/MaterializeInc/materialize/pull/23282, so that this can be merged by 0.79 in case the other one takes longer (and unblock cloud so that they can start passing the materialize role arn).

Corresponding cloud issue: https://github.com/MaterializeInc/cloud/issues/8191
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->

cc @jubrad 