### PR TITLE
sql: ensure functions + CTE names don't intermingle in resolution

### DIFF
--- a/src/sql/src/names.rs
+++ b/src/sql/src/names.rs
@@ -1291,20 +1291,23 @@ impl<'a> NameResolver<'a> {
                     }
                 };
 
-                // Check if unqualified name refers to a CTE.
-                if raw_name.database.is_none() && raw_name.schema.is_none() {
-                    let norm_name = normalize::ident(Ident::new_unchecked(&raw_name.item));
-                    if let Some(id) = self.ctes.get(&norm_name) {
-                        return ResolvedItemName::Cte {
-                            id: *id,
-                            name: norm_name,
-                        };
-                    }
-                }
-
                 let r = if consider_function {
                     self.catalog.resolve_function(&raw_name)
                 } else {
+                    // Check if unqualified name refers to a CTE.
+                    //
+                    // Note that this is done in non-function contexts as CTEs
+                    // are treated as relations.
+                    if raw_name.database.is_none() && raw_name.schema.is_none() {
+                        let norm_name = normalize::ident(Ident::new_unchecked(&raw_name.item));
+                        if let Some(id) = self.ctes.get(&norm_name) {
+                            return ResolvedItemName::Cte {
+                                id: *id,
+                                name: norm_name,
+                            };
+                        }
+                    }
+
                     self.catalog.resolve_item(&raw_name)
                 };
 

--- a/test/sqllogictest/cte.slt
+++ b/test/sqllogictest/cte.slt
@@ -242,3 +242,10 @@ WITH outermost(x) AS (
          UNION SELECT * FROM innermost)
 )
 SELECT * FROM outermost ORDER BY 1;
+
+# test #23629
+query I colnames
+WITH count AS (VALUES (9)) SELECT count(*) FROM count;
+----
+count
+1


### PR DESCRIPTION
### Motivation

This PR fixes a recognized bug. Fixes #23629

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
