### PR TITLE
repr: make WMR type coercion more like SQL

### DIFF
--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -237,7 +237,7 @@ impl RelationType {
             if col1.nullable && !col2.nullable {
                 return false;
             }
-            if col1.scalar_type != col2.scalar_type {
+            if !col1.scalar_type.base_eq(&col2.scalar_type) {
                 return false;
             }
         }

--- a/test/sqllogictest/with_mutually_recursive.slt
+++ b/test/sqllogictest/with_mutually_recursive.slt
@@ -607,3 +607,14 @@ statement error db error: ERROR: Invalid WITH MUTUALLY RECURSIVE recursion limit
 WITH MUTUALLY RECURSIVE (RECURSION LIMIT 0)
   cnt (i int) AS (SELECT 1 AS i UNION SELECT i+1 FROM cnt)
 SELECT * FROM cnt;
+
+# Test WMR coercion
+statement ok
+CREATE TABLE y (a BIGINT);
+
+query I
+WITH MUTUALLY RECURSIVE
+    bar(x NUMERIC) as (SELECT sum(a) FROM y)
+SELECT * FROM bar
+----
+NULL


### PR DESCRIPTION
The code on `main` prevented you from using `numeric` values with different scales interchangeably, though SQL supports the operation.

@frankmcsherry Would you mind coming up with a minimal test case? I tried for a few minutes but couldn't get the angle of attack just right.

### Motivation

This PR fixes a recognized bug. [Slack](https://materializeinc.slack.com/archives/C02FWJ94HME/p1701516686370889)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Improve type coercion in `WITH MUTUALLY RECURSIVE` queries. For example, you can now use `NUMERIC` values of arbitrary scales.
