### PR TITLE
doc/user: add caveats to constant_time_eq docs

### DIFF
--- a/doc/user/data/sql_funcs.yml
+++ b/doc/user/data/sql_funcs.yml
@@ -293,10 +293,10 @@
     description: Return the `n`th byte from `b`, where the left-most byte in `b` is at the 0th position.
 
   - signature: 'constant_time_eq(a: bytea, b: bytea) -> bool'
-    description: Performs a constant-time comparison between byte arrays `a` and `b`. Returns `true` if the arrays are identical, otherwise returns `false`. This method is designed to mitigate timing attacks by ensuring the comparison takes the same amount of time regardless of the content of the arrays.
+    description: Returns `true` if the arrays are identical, otherwise returns `false`. The implementation mitigates timing attacks by making a best-effort attempt to execute in constant time if the arrays have the same length, regardless of their contents.
 
   - signature: 'constant_time_eq(a: text, b: text) -> bool'
-    description: Performs a constant-time comparison between strings `a` and `b` by first converting them to byte sequences. Returns `true` if the strings are identical, otherwise returns `false`. This method is designed to mitigate timing attacks by ensuring the comparison takes the same amount of time regardless of the content of the strings.
+    description: Returns `true` if the strings are identical, otherwise returns `false`. The implementation mitigates timing attacks by making a best-effort attempt to execute in constant time if the strings have the same length, regardless of their contents.
 
   - signature: 'left(s: str, n: int) -> str'
     description: The first `n` characters of `s`. If `n` is negative, all but the last `|n|` characters of `s`.


### PR DESCRIPTION
Note that the functions do not execute in constant time if the inputs do not have the same length. Also note that the implementation is best effort and not guaranteed to be eliminate all timing attacks.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR improves documentation.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
