### PR TITLE
sql-parser: further improve error for trailing comma in SELECT list

### DIFF
--- a/src/sql-parser/tests/testdata/error
+++ b/src/sql-parser/tests/testdata/error
@@ -21,9 +21,9 @@
 parse-statement
 SELECT 1, 2, FROM a
 ----
-error: expected expression, but found reserved keyword: FROM
+error: invalid trailing comma in SELECT list
 SELECT 1, 2, FROM a
-             ^
+           ^
 
 parse-statement
 UPDATE t WHERE 1


### PR DESCRIPTION
Trailing commas in SELECT lists, e.g.:

    SELECT
       1,
       2,
    FROM ...

are common enough that it's worth a little bit of extra code to make the error message as explicit as possible that it's a trailing comma problem. This commit changes the error message from "expected expression, but found reserved keyword: FROM" to "invalid trailing comma in SELECT list".

Follow up to MaterializeInc/database-issues#7100/#23627.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

  * This PR fixes a recognized bug.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
