### PR TITLE
*: use more logging soft assertions

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -2028,7 +2028,11 @@ impl Catalog {
                     let comment_id = state.get_comment_id(id.clone());
                     let deleted = tx.drop_comments(comment_id)?;
                     let dropped = state.comments.drop_comments(comment_id);
-                    mz_ore::soft_assert_eq!(deleted, dropped, "transaction and state out of sync");
+                    mz_ore::soft_assert_eq_or_log!(
+                        deleted,
+                        dropped,
+                        "transaction and state out of sync"
+                    );
 
                     let updates = dropped.into_iter().map(|(id, col_pos, comment)| {
                         state.pack_comment_update(id, col_pos, &comment, -1)

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -43,7 +43,7 @@ use mz_expr::MirScalarExpr;
 use mz_ore::cast::CastFrom;
 use mz_ore::collections::CollectionExt;
 use mz_ore::now::{to_datetime, EpochMillis, NOW_ZERO};
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_no_log;
 use mz_repr::adt::mz_acl_item::PrivilegeMap;
 use mz_repr::namespaces::{
     INFORMATION_SCHEMA, MZ_CATALOG_SCHEMA, MZ_INTERNAL_SCHEMA, MZ_TEMP_SCHEMA, MZ_UNSAFE_SCHEMA,
@@ -703,7 +703,7 @@ impl CatalogState {
             if !membership.contains(cur_id) {
                 membership.insert(cur_id.clone());
                 let role = self.get_role(cur_id);
-                soft_assert!(
+                soft_assert_no_log!(
                     !role.membership().keys().contains(id),
                     "circular membership exists in the catalog"
                 );

--- a/src/adapter/src/command.rs
+++ b/src/adapter/src/command.rs
@@ -19,7 +19,7 @@ use enum_kinds::EnumKind;
 use futures::future::BoxFuture;
 use mz_adapter_types::connection::{ConnectionId, ConnectionIdType};
 use mz_ore::collections::CollectionExt;
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_no_log;
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_pgcopy::CopyFormatParams;
 use mz_repr::role_id::RoleId;
@@ -423,7 +423,7 @@ impl TryFrom<&Statement<Raw>> for ExecuteResponse {
             _ => return Err(()),
         };
         // Ensure that if the planner ever adds possible plans we complain here.
-        soft_assert!(
+        soft_assert_no_log!(
             resp_kinds.len() == 1
                 && resp_kinds.first().expect("must exist") == &ExecuteResponseKind::from(&resp),
             "ExecuteResponses out of sync with planner"

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1199,7 +1199,7 @@ impl Coordinator {
 
                     if let Some(waiting_on_this_dependent) = entries_awaiting_dependent.remove(&id)
                     {
-                        mz_ore::soft_assert! {{
+                        mz_ore::soft_assert_no_log! {{
                             let subsources =  entry.subsources();
                             let w: Vec<_> = waiting_on_this_dependent.iter().map(|e| e.id()).collect();
                             w.iter().all(|w| subsources.contains(w))

--- a/src/adapter/src/coord/command_handler.rs
+++ b/src/adapter/src/coord/command_handler.rs
@@ -865,7 +865,12 @@ impl Coordinator {
                     // Assert we have one column for the body, and how ever many are required for
                     // the headers.
                     let num_columns = headers.num_columns() + 1;
-                    mz_ore::soft_assert!(desc.arity() <= num_columns);
+                    mz_ore::soft_assert_or_log!(
+                        desc.arity() <= num_columns,
+                        "expected at most {} columns, but got {}",
+                        num_columns,
+                        desc.arity()
+                    );
 
                     let body = desc
                         .get_by_name(&"body".into())

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -637,7 +637,7 @@ impl Coordinator {
 
         // Note: It's important that we keep the function call inside macro, this way we only run
         // the consistency checks if sort assertions are enabled.
-        mz_ore::soft_assert_eq!(
+        mz_ore::soft_assert_eq_no_log!(
             self.check_consistency(),
             Ok(()),
             "coordinator inconsistency detected"

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -28,7 +28,7 @@ use mz_expr::{
 use mz_ore::collections::{CollectionExt, HashSet};
 use mz_ore::tracing::OpenTelemetryContext;
 use mz_ore::vec::VecExt;
-use mz_ore::{soft_assert, task};
+use mz_ore::{soft_assert_or_log, task};
 use mz_repr::adt::jsonb::Jsonb;
 use mz_repr::adt::mz_acl_item::{MzAclItem, PrivilegeMap};
 use mz_repr::explain::json::json_string;
@@ -5076,7 +5076,7 @@ impl Coordinator {
                 }
             }
             plan::AlterSourceAction::DropSubsourceExports { to_drop } => {
-                mz_ore::soft_assert!(!to_drop.is_empty());
+                mz_ore::soft_assert_or_log!(!to_drop.is_empty(), "`to_drop` is empty");
 
                 const ALTER_SOURCE: &str = "ALTER SOURCE...DROP TABLES";
 
@@ -5158,8 +5158,8 @@ impl Coordinator {
                                         WithOptionValue::UnresolvedItemName(
                                             column_qualified_reference,
                                         ) => {
-                                            mz_ore::soft_assert!(
-                                                column_qualified_reference.0.len() == 4
+                                            mz_ore::soft_assert_eq_or_log!(
+                                                column_qualified_reference.0.len(), 4
                                             );
                                             if column_qualified_reference.0.len() == 4 {
                                                 let mut table = column_qualified_reference.clone();
@@ -5273,7 +5273,7 @@ impl Coordinator {
                     "dropping subsources does not drop DBs or clusters"
                 );
 
-                soft_assert!(
+                soft_assert_or_log!(
                     dropped_in_use_indexes.is_empty(),
                     "Dropping subsources might drop indexes, but then all objects dependent on the index should also be dropped."
                 );

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -5318,7 +5318,7 @@ impl Coordinator {
                     .ok_or(purification_err())?
                 {
                     ReferencedSubsources::SubsetTables(c) => {
-                        mz_ore::soft_assert!(
+                        mz_ore::soft_assert_no_log!(
                             {
                                 let current_references: BTreeSet<_> = c
                                     .iter()
@@ -5379,21 +5379,21 @@ impl Coordinator {
                         curr.extend(new);
                         curr.sort();
 
-                        mz_ore::soft_assert!(
+                        mz_ore::soft_assert_no_log!(
                             curr.iter()
                                 .all(|v| matches!(v, WithOptionValue::UnresolvedItemName(_))),
                             "all elements of text columns must be UnresolvedItemName, but got {:?}",
                             curr
                         );
 
-                        mz_ore::soft_assert!(
+                        mz_ore::soft_assert_no_log!(
                             curr.iter().duplicates().next().is_none(),
                             "TEXT COLUMN references must be unique among both sets, but got {:?}",
                             curr
                         );
                     }
                     (None, Some(new)) => {
-                        mz_ore::soft_assert!(
+                        mz_ore::soft_assert_no_log!(
                             match &new.value {
                                 Some(WithOptionValue::Sequence(v)) => v
                                     .iter()

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -26,7 +26,9 @@ use mz_ore::collections::CollectionExt;
 use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::retry::{Retry, RetryResult};
-use mz_ore::{soft_assert, soft_assert_eq_or_log, soft_assert_ne_or_log, soft_assert_or_log};
+use mz_ore::{
+    soft_assert_eq_or_log, soft_assert_ne_or_log, soft_assert_no_log, soft_assert_or_log,
+};
 use mz_persist_client::read::{ListenEvent, ReadHandle, Subscribe};
 use mz_persist_client::write::WriteHandle;
 use mz_persist_client::{Diagnostics, PersistClient, ShardId};
@@ -238,7 +240,7 @@ impl UnopenedPersistCatalogState {
             }
             txn
         } else {
-            soft_assert!(
+            soft_assert_no_log!(
                 catalog.snapshot.is_empty(),
                 "snapshot should not contain anything for an uninitialized catalog: {:?}",
                 catalog.snapshot
@@ -1235,7 +1237,7 @@ async fn snapshot_binary_inner(
         .snapshot_and_fetch(Antichain::from_elem(as_of))
         .await
         .expect("we have advanced the restart_as_of by the since");
-    soft_assert!(
+    soft_assert_no_log!(
         snapshot.iter().all(|(_, _, diff)| *diff == 1),
         "snapshot_and_fetch guarantees a consolidated result: {snapshot:?}"
     );

--- a/src/catalog/src/durable/impls/stash.rs
+++ b/src/catalog/src/durable/impls/stash.rs
@@ -24,7 +24,7 @@ use mz_ore::metrics::MetricsFutureExt;
 use mz_ore::now::EpochMillis;
 use mz_ore::result::ResultExt;
 use mz_ore::retry::Retry;
-use mz_ore::soft_assert_eq;
+use mz_ore::soft_assert_eq_no_log;
 use mz_proto::{ProtoType, RustType, TryFromProtoError};
 use mz_repr::Timestamp;
 use mz_sql::catalog::CatalogError as SqlCatalogError;
@@ -877,7 +877,7 @@ impl DurableCatalogState for Connection {
                 return Ok(());
             }
             let collection = typed.from_tx(tx).await?;
-            soft_assert_eq!(
+            soft_assert_eq_no_log!(
                 is_initialized,
                 collection.is_initialized(tx).await?,
                 "stash initialization status should match collection '{}' initialization status",

--- a/src/catalog/src/durable/transaction.rs
+++ b/src/catalog/src/durable/transaction.rs
@@ -12,7 +12,7 @@ use itertools::Itertools;
 use mz_audit_log::{VersionedEvent, VersionedStorageUsage};
 use mz_controller_types::{ClusterId, ReplicaId};
 use mz_ore::collections::CollectionExt;
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_or_log;
 use mz_proto::{ProtoType, RustType};
 use mz_repr::adt::mz_acl_item::{AclMode, MzAclItem};
 use mz_repr::role_id::RoleId;
@@ -214,7 +214,7 @@ impl<'a> Transaction<'a> {
         owner_id: RoleId,
         privileges: Vec<MzAclItem>,
     ) -> Result<SchemaId, CatalogError> {
-        soft_assert!(id.is_system(), "ID {id:?} is not system variant");
+        soft_assert_or_log!(id.is_system(), "ID {id:?} is not system variant");
         self.insert_schema(id, None, schema_name.to_string(), owner_id, privileges)?;
         Ok(id)
     }

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -189,7 +189,7 @@ pub(crate) mod stash {
 }
 
 pub(crate) mod persist {
-    use mz_ore::{soft_assert_eq, soft_assert_ne};
+    use mz_ore::{soft_assert_eq_or_log, soft_assert_ne_or_log};
     use timely::progress::Timestamp as TimelyTimestamp;
 
     use crate::durable::impls::persist::state_update::{
@@ -264,7 +264,7 @@ pub(crate) mod persist {
         persist_handle: &mut UnopenedPersistCatalogState,
         mut upper: Timestamp,
     ) -> Result<Timestamp, CatalogError> {
-        soft_assert_ne!(
+        soft_assert_ne_or_log!(
             upper,
             Timestamp::minimum(),
             "cannot upgrade uninitialized catalog"
@@ -354,7 +354,7 @@ pub(crate) mod persist {
         let snapshot: Vec<_> = snapshot
             .into_iter()
             .map(|update| {
-                soft_assert_eq!(1, update.diff, "snapshot is consolidated");
+                soft_assert_eq_or_log!(1, update.diff, "snapshot is consolidated");
                 V1::try_from(update.clone().kind).expect("invalid catalog data persisted")
             })
             .collect();

--- a/src/compute/src/render/sinks.rs
+++ b/src/compute/src/render/sinks.rs
@@ -16,7 +16,7 @@ use std::rc::Rc;
 use differential_dataflow::Collection;
 use mz_compute_types::sinks::{ComputeSinkConnection, ComputeSinkDesc};
 use mz_expr::{permutation_for_arrangement, EvalError, MapFilterProject};
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_or_log;
 use mz_ore::vec::PartialOrdVecExt;
 use mz_repr::{Diff, GlobalId, Row};
 use mz_storage_types::controller::CollectionMetadata;
@@ -45,7 +45,11 @@ where
         sink_id: GlobalId,
         sink: &ComputeSinkDesc<CollectionMetadata>,
     ) {
-        soft_assert!(sink.non_null_assertions.is_strictly_sorted());
+        soft_assert_or_log!(
+            sink.non_null_assertions.is_strictly_sorted(),
+            "non-null assertions not sorted"
+        );
+
         // put together tokens that belong to the export
         let mut needed_tokens = Vec::new();
         for dep_id in dependency_ids {

--- a/src/expr/src/explain/text.rs
+++ b/src/expr/src/explain/text.rs
@@ -12,7 +12,7 @@
 use std::collections::BTreeMap;
 use std::fmt;
 
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_eq_or_log;
 use mz_ore::str::{closure_to_display, separated, Indent, IndentLike, StrExt};
 use mz_repr::explain::text::{fmt_text_constant_rows, DisplayText};
 use mz_repr::explain::{
@@ -638,7 +638,7 @@ impl MirRelationExpr {
                                 (start_idx, start_key, start_characteristics),
                                 tail,
                             ) => {
-                                soft_assert!(inputs.len() == tail.len() + 1);
+                                soft_assert_eq_or_log!(inputs.len(), tail.len() + 1);
 
                                 writeln!(f, "{}implementation", ctx.indent)?;
                                 ctx.indented(|ctx| {
@@ -656,7 +656,7 @@ impl MirRelationExpr {
                                 })?;
                             }
                             JoinImplementation::DeltaQuery(half_join_chains) => {
-                                soft_assert!(inputs.len() == half_join_chains.len());
+                                soft_assert_eq_or_log!(inputs.len(), half_join_chains.len());
 
                                 writeln!(f, "{}implementation", ctx.indent)?;
                                 ctx.indented(|ctx| {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -360,7 +360,7 @@ pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types
 
     if completed.iter().any(|p| {
         (p.is_literal_false() || p.is_literal_null()) &&
-        // This extra check is only needed if we determine that the soft_assert!
+        // This extra check is only needed if we determine that the soft-assert
         // at the top of this function would ever fail for a good reason.
         p.typ(column_types).scalar_type == ScalarType::Bool
     }) {

--- a/src/expr/src/relation/canonicalize.rs
+++ b/src/expr/src/relation/canonicalize.rs
@@ -13,7 +13,7 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_or_log;
 use mz_repr::{ColumnType, Datum, ScalarType};
 
 use crate::visit::Visit;
@@ -205,7 +205,7 @@ where
 /// Additionally, it also removes IS NOT NULL predicates if there is another
 /// null rejecting predicate for the same sub-expression.
 pub fn canonicalize_predicates(predicates: &mut Vec<MirScalarExpr>, column_types: &[ColumnType]) {
-    soft_assert!(
+    soft_assert_or_log!(
         predicates
             .iter()
             .all(|p| p.typ(column_types).scalar_type == ScalarType::Bool),

--- a/src/expr/src/relation/func.rs
+++ b/src/expr/src/relation/func.rs
@@ -20,7 +20,7 @@ use itertools::Itertools;
 use mz_lowertest::MzReflect;
 use mz_ore::cast::CastFrom;
 
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_or_log;
 use mz_ore::str::separated;
 use mz_proto::{IntoRustIfSome, ProtoType, RustType, TryFromProtoError};
 use mz_repr::adt::array::ArrayDimension;
@@ -819,10 +819,11 @@ where
     // - Groups frame mode is currently not supported;
     // - Range frame mode is currently supported only for the default frame, which includes the
     //   current row.
-    soft_assert!(
+    soft_assert_or_log!(
         !((matches!(window_frame.units, WindowFrameUnits::Groups)
             || matches!(window_frame.units, WindowFrameUnits::Range))
-            && !window_frame.includes_current_row())
+            && !window_frame.includes_current_row()),
+        "window frame without current row"
     );
 
     if (matches!(

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -6620,7 +6620,7 @@ where
 }
 
 fn array_index<'a>(datums: &[Datum<'a>], offset: i64) -> Datum<'a> {
-    mz_ore::soft_assert!(offset == 0 || offset == 1, "offset must be either 0 or 1");
+    mz_ore::soft_assert_no_log!(offset == 0 || offset == 1, "offset must be either 0 or 1");
 
     let array = datums[0].unwrap_array();
     let dims = array.dims();

--- a/src/expr/src/scalar/func.rs
+++ b/src/expr/src/scalar/func.rs
@@ -33,7 +33,7 @@ use mz_ore::fmt::FormatBuffer;
 use mz_ore::lex::LexBuf;
 use mz_ore::option::OptionExt;
 use mz_ore::result::ResultExt;
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_eq_or_log;
 use mz_pgrepr::Type;
 use mz_pgtz::timezone::{Timezone, TimezoneSpec};
 use mz_proto::chrono::any_naive_datetime;
@@ -2781,9 +2781,9 @@ impl BinaryFunc {
             | RangeAdjacent => ScalarType::Bool.nullable(in_nullable),
 
             RangeUnion | RangeIntersection | RangeDifference => {
-                soft_assert!(
-                    input1_type.scalar_type.without_modifiers()
-                        == input2_type.scalar_type.without_modifiers()
+                soft_assert_eq_or_log!(
+                    input1_type.scalar_type.without_modifiers(),
+                    input2_type.scalar_type.without_modifiers()
                 );
                 input1_type.scalar_type.without_modifiers().nullable(true)
             }

--- a/src/expr/src/scalar/func/impls/timestamp.rs
+++ b/src/expr/src/scalar/func/impls/timestamp.rs
@@ -136,8 +136,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampPrecision {
         a: CheckedTimestamp<NaiveDateTime>,
     ) -> Result<CheckedTimestamp<NaiveDateTime>, EvalError> {
         // This should never have been called if precisions are same.
-        // Adding a soft_assert to flag if there are such instances.
-        mz_ore::soft_assert!(self.to != self.from);
+        // Adding a soft-assert to flag if there are such instances.
+        mz_ore::soft_assert_no_log!(self.to != self.from);
 
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)
@@ -236,8 +236,8 @@ impl<'a> EagerUnaryFunc<'a> for AdjustTimestampTzPrecision {
         a: CheckedTimestamp<DateTime<Utc>>,
     ) -> Result<CheckedTimestamp<DateTime<Utc>>, EvalError> {
         // This should never have been called if precisions are same.
-        // Adding a soft_assert to flag if there are such instances.
-        mz_ore::soft_assert!(self.to != self.from);
+        // Adding a soft-assert to flag if there are such instances.
+        mz_ore::soft_assert_no_log!(self.to != self.from);
 
         let updated = a.round_to_precision(self.to)?;
         Ok(updated)

--- a/src/ore/src/assert.rs
+++ b/src/ore/src/assert.rs
@@ -32,13 +32,18 @@
 //!
 //! Ore provides the following macros to make soft assertions:
 //!
-//!   * [`soft_assert`](crate::soft_assert)
-//!   * [`soft_assert_eq`](crate::soft_assert_eq)
-//!   * [`soft_assert_ne`](crate::soft_assert_ne)
 //!   * [`soft_assert_or_log`](crate::soft_assert_or_log)
 //!   * [`soft_assert_eq_or_log`](crate::soft_assert_eq_or_log)
 //!   * [`soft_assert_ne_or_log`](crate::soft_assert_ne_or_log)
 //!   * [`soft_panic_or_log`](crate::soft_panic_or_log)
+//!   * [`soft_assert_no_log`](crate::soft_assert_no_log)
+//!   * [`soft_assert_eq_no_log`](crate::soft_assert_eq_no_log)
+//!   * [`soft_assert_ne_no_log`](crate::soft_assert_ne_no_log)
+//!
+//! The `_or_log` variants should be used by default, as they allow us to find
+//! failed condition checks in production. The `_no_log` variants are silent
+//! in production and should only be used when performance considerations
+//! prohibit the use of the logging variants.
 //!
 //! Due to limitations in Rust, these macros are exported at the crate root.
 
@@ -73,7 +78,7 @@ pub static SOFT_ASSERTIONS: AtomicBool = AtomicBool::new(true);
 /// Soft assertions have a small runtime cost even when disabled. See
 /// [`ore::assert`](crate::assert#Soft-assertions) for details.
 #[macro_export]
-macro_rules! soft_assert {
+macro_rules! soft_assert_no_log {
     ($cond:expr $(, $($arg:tt)+)?) => {{
         if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
             assert!($cond$(, $($arg)+)?);
@@ -86,7 +91,7 @@ macro_rules! soft_assert {
 /// Soft assertions have a small runtime cost even when disabled. See
 /// [`ore::assert`](crate::assert#Soft-assertions) for details.
 #[macro_export]
-macro_rules! soft_assert_eq {
+macro_rules! soft_assert_eq_no_log {
     ($cond:expr, $($arg:tt)+) => {{
         if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
             assert_eq!($cond, $($arg)+);
@@ -99,7 +104,7 @@ macro_rules! soft_assert_eq {
 /// Soft assertions have a small runtime cost even when disabled. See
 /// [`ore::assert`](crate::assert#Soft-assertions) for details.
 #[macro_export]
-macro_rules! soft_assert_ne {
+macro_rules! soft_assert_ne_no_log {
     ($cond:expr, $($arg:tt)+) => {{
         if $crate::assert::SOFT_ASSERTIONS.load(::std::sync::atomic::Ordering::Relaxed) {
             assert_ne!($cond, $($arg)+);

--- a/src/repr/src/row.rs
+++ b/src/repr/src/row.rs
@@ -19,7 +19,7 @@ use std::str;
 use chrono::{DateTime, Datelike, NaiveDate, NaiveDateTime, NaiveTime, Timelike, Utc};
 use compact_bytes::CompactBytes;
 use mz_ore::cast::{CastFrom, ReinterpretCast};
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_no_log;
 use mz_ore::vec::Vector;
 use mz_persist_types::Codec64;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
@@ -1350,14 +1350,14 @@ where
                 let (prefix, lsu_bytes, suffix) = unsafe { lsu.align_to::<u8>() };
                 // The `u8` aligned version of the `lsu` should have twice as many
                 // elements as we expect for the `u16` version.
-                soft_assert!(
+                soft_assert_no_log!(
                     lsu_bytes.len() == Numeric::digits_to_lsu_elements_len(digits) * 2,
                     "u8 version of numeric LSU contained the wrong number of elements; expected {}, but got {}",
                     Numeric::digits_to_lsu_elements_len(digits) * 2,
                     lsu_bytes.len()
                 );
                 // There should be no unaligned elements in the prefix or suffix.
-                soft_assert!(prefix.is_empty() && suffix.is_empty());
+                soft_assert_no_log!(prefix.is_empty() && suffix.is_empty());
                 data.extend_from_slice(lsu_bytes);
             } else {
                 for u in lsu {

--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -20,7 +20,7 @@
 
 use std::{fmt, mem};
 
-use mz_ore::soft_assert_eq;
+use mz_ore::soft_assert_eq_or_log;
 use mz_sql_lexer::keywords::*;
 
 use crate::ast::display::{self, AstDisplay, AstFormatter};
@@ -903,7 +903,7 @@ impl<T: AstInfo> FunctionArgs<T> {
             FunctionArgs::Star => unreachable!(),
             FunctionArgs::Args { args, .. } => args,
         };
-        soft_assert_eq!(args.len(), kws.len());
+        soft_assert_eq_or_log!(args.len(), kws.len());
         let mut delim = "";
         for (arg, kw) in args.iter().zip(kws) {
             if let Some(kw) = kw {

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -177,7 +177,7 @@ impl Ident {
 
     /// Append the provided `suffix`, truncating `self` as necessary to satisfy our invariants.
     ///
-    /// Note: We `soft_assert!` that the provided `suffix` is not too long, if it is, we'll
+    /// Note: We soft-assert that the provided `suffix` is not too long, if it is, we'll
     /// truncate it.
     ///
     /// # Examples
@@ -230,7 +230,7 @@ impl Ident {
         const MAX_SUFFIX_LENGTH: usize = Ident::MAX_LENGTH - 8;
 
         let mut suffix: String = suffix.into();
-        mz_ore::soft_assert!(suffix.len() <= MAX_SUFFIX_LENGTH, "suffix too long");
+        mz_ore::soft_assert_or_log!(suffix.len() <= MAX_SUFFIX_LENGTH, "suffix too long");
 
         // Truncate the suffix as necessary.
         if suffix.len() > MAX_SUFFIX_LENGTH {

--- a/src/sql-parser/src/ast/defs/name.rs
+++ b/src/sql-parser/src/ast/defs/name.rs
@@ -107,7 +107,7 @@ impl Ident {
     /// [`ident!`]: [`mz_sql_parser::ident`]
     pub fn new_unchecked<S: Into<String>>(value: S) -> Self {
         let s = value.into();
-        mz_ore::soft_assert!(s.len() <= Self::MAX_LENGTH);
+        mz_ore::soft_assert_no_log!(s.len() <= Self::MAX_LENGTH);
 
         Ident(s)
     }

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -398,7 +398,7 @@ pub fn plan(
     };
 
     if let Ok(plan) = &plan {
-        mz_ore::soft_assert!(
+        mz_ore::soft_assert_no_log!(
             permitted_plans.contains(&PlanKind::from(plan)),
             "plan {:?}, permitted plans {:?}",
             plan,

--- a/src/stash/src/lib.rs
+++ b/src/stash/src/lib.rs
@@ -83,7 +83,7 @@ use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 use std::sync::Arc;
 
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_no_log;
 use mz_proto::{RustType, TryFromProtoError};
 use mz_stash_types::{InternalStashError, StashError};
 use serde::{Deserialize, Serialize};
@@ -647,7 +647,7 @@ where
         K: RustType<KP>,
         V: RustType<VP>,
     {
-        soft_assert!(self.verify().is_ok());
+        soft_assert_no_log!(self.verify().is_ok());
         // Pending describes the desired final state for some keys. K,V pairs should be
         // retracted if they already exist and were deleted or are being updated.
         self.pending
@@ -752,7 +752,7 @@ where
             return Err(violation.into());
         }
         self.pending.insert(k, Some(v));
-        soft_assert!(self.verify().is_ok());
+        soft_assert_no_log!(self.verify().is_ok());
         Ok(())
     }
 
@@ -890,7 +890,7 @@ where
                 p.insert(k.clone(), None);
             }
         });
-        soft_assert!(self.verify().is_ok());
+        soft_assert_no_log!(self.verify().is_ok());
         deleted
     }
 
@@ -899,6 +899,6 @@ where
         self.for_values_mut(|p, k, _v| {
             p.insert(k.clone(), None);
         });
-        soft_assert!(self.verify().is_ok());
+        soft_assert_no_log!(self.verify().is_ok());
     }
 }

--- a/src/storage-controller/src/lib.rs
+++ b/src/storage-controller/src/lib.rs
@@ -2867,7 +2867,7 @@ where
         I: Iterator<Item = GlobalId>,
     {
         assert!(self.txns_init_run);
-        mz_ore::soft_assert!(diff == -1 || diff == 1, "use 1 for insert or -1 for delete");
+        mz_ore::soft_assert_or_log!(diff == -1 || diff == 1, "use 1 for insert or -1 for delete");
 
         let id = match self
             .introspection_ids

--- a/src/storage/src/healthcheck.rs
+++ b/src/storage/src/healthcheck.rs
@@ -481,7 +481,7 @@ where
                 // directly to the places where `should_halt = true` originates.
                 // We should definitely do that, but this is okay for a PoC.
                 if let Some((id, halt_with)) = halt_with_outer {
-                    mz_ore::soft_assert!(
+                    mz_ore::soft_assert_or_log!(
                         id == halting_id,
                         "sub{object_type}s should not produce \
                         halting errors, however {:?} halted while primary \

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -285,7 +285,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 &format!("SET statement_timeout = {}", config.params.pg_source_snapshot_statement_timeout.as_millis())
             ).await?;
 
-            mz_ore::soft_assert!{{
+            mz_ore::soft_assert_no_log!{{
                 let row = simple_query_opt(&client, "SHOW statement_timeout;")
                     .await?
                     .unwrap();

--- a/src/storage/src/source/postgres/snapshot.rs
+++ b/src/storage/src/source/postgres/snapshot.rs
@@ -219,7 +219,7 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
     let reader_snapshot_table_info: BTreeMap<_, _> = table_info
         .iter()
         .filter(|(oid, (output_index, _, _))| {
-            mz_ore::soft_assert!(
+            mz_ore::soft_assert_or_log!(
                 *output_index != 0,
                 "primary collection should not be represented in table info"
             );

--- a/src/transform/src/dataflow.rs
+++ b/src/transform/src/dataflow.rs
@@ -24,7 +24,7 @@ use mz_expr::{
     MirRelationExpr, MirScalarExpr, RECURSION_LIMIT,
 };
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
-use mz_ore::{soft_assert, soft_assert_eq, soft_panic_or_log};
+use mz_ore::{soft_assert_eq_or_log, soft_assert_or_log, soft_panic_or_log};
 use mz_repr::explain::IndexUsageType;
 use mz_repr::GlobalId;
 
@@ -701,7 +701,7 @@ id: {}, key: {:?}",
         if let Some(index_reqs) = index_reqs_by_id.get(&index_desc.on_id) {
             for (req_idx_id, req_key, req_usage_type) in index_reqs {
                 if req_idx_id == index_id {
-                    soft_assert_eq!(*req_key, index_desc.key);
+                    soft_assert_eq_or_log!(*req_key, index_desc.key);
                     new_usage_types.push(req_usage_type.clone());
                 }
             }
@@ -757,7 +757,7 @@ id: {}, key: {:?}",
                     access_strategy: AccessStrategy::Index(accesses),
                 } => {
                     for (idx_id, _) in accesses {
-                        soft_assert!(
+                        soft_assert_or_log!(
                             dataflow.index_imports.contains_key(idx_id),
                             "Dangling Get index annotation"
                         );

--- a/src/transform/src/join_implementation.rs
+++ b/src/transform/src/join_implementation.rs
@@ -603,7 +603,7 @@ mod delta_queries {
 
 mod differential {
     use mz_expr::{JoinImplementation, JoinInputMapper, MirRelationExpr, MirScalarExpr};
-    use mz_ore::soft_assert;
+    use mz_ore::soft_assert_eq_or_log;
 
     use crate::join_implementation::{FilterCharacteristics, JoinInputCharacteristics};
     use crate::TransformError;
@@ -684,7 +684,7 @@ mod differential {
             } else {
                 // if max_min_characteristics is None, then there must only be
                 // one input and thus only one order in orders
-                soft_assert!(orders.len() == 1);
+                soft_assert_eq_or_log!(orders.len(), 1);
                 orders
                     .remove(0)
                     .into_iter()

--- a/src/transform/src/lib.rs
+++ b/src/transform/src/lib.rs
@@ -133,7 +133,7 @@ pub mod union_cancel;
 
 use crate::dataflow::DataflowMetainfo;
 pub use dataflow::optimize_dataflow;
-use mz_ore::soft_assert;
+use mz_ore::soft_assert_or_log;
 
 /// Compute the conjunction of a variadic number of expressions.
 #[macro_export]
@@ -679,7 +679,10 @@ impl Optimizer {
         // TODO: we should actually wire up notices that come from here. This is not urgent, because
         // currently notices can only come from the physical MIR optimizer (specifically,
         // `LiteralConstraints`), and callers of this method are running the logical MIR optimizer.
-        soft_assert!(dataflow_metainfo.optimizer_notices.is_empty());
+        soft_assert_or_log!(
+            dataflow_metainfo.optimizer_notices.is_empty(),
+            "logical MIR optimization unexpectedly produced notices"
+        );
 
         match transform_result {
             Ok(_) => {

--- a/src/transform/src/predicate_pushdown.rs
+++ b/src/transform/src/predicate_pushdown.rs
@@ -89,7 +89,7 @@ use mz_expr::{
     func, AggregateFunc, Id, JoinInputMapper, LocalId, MirRelationExpr, MirScalarExpr,
     VariadicFunc, RECURSION_LIMIT,
 };
-use mz_ore::soft_assert_eq;
+use mz_ore::soft_assert_eq_no_log;
 use mz_ore::stack::{CheckedRecursion, RecursionGuard, RecursionLimitError};
 use mz_repr::{ColumnType, Datum, ScalarType};
 
@@ -1039,7 +1039,7 @@ impl PredicatePushdown {
                 }
             })?;
 
-            soft_assert_eq!(new_size, new_expr.size()?);
+            soft_assert_eq_no_log!(new_size, new_expr.size()?);
             if new_size <= size_limit {
                 Ok(Some(new_expr)) // We managed to stay within the limit.
             } else {


### PR DESCRIPTION
This PR improves our usage of soft assertions in two ways:

* It replaces some of the existing non-logging soft assertions with their logging variants.
* It adds a `_no_log` suffix to the non-logging soft-assert macros, to make it clear that these will not fall back to error logging if `SOFT_ASSERTIONS` are disabled.

### Motivation

* This PR improves our logging in production.

When adding soft assertions, we should default to using the logging variants, as the non-logging variants will swallow bugs encountered in production. The code base today has many instances of usages of the non-logging variants where the logging variants should be used instead. The reason for this is most likely that the non-logging variants are named in a way that makes people default to them and that doesn't make it obvious that they don't fall back to error logging.

### Tips for reviewer

You can look at the commits separately.

I have tried to be conservative with which soft-asserts to convert to the `_or_log` variants. There are probably some instances that should be made logging that I didn't convert, and there may be some that I did convert that I shouldn't have. Please check the diff of commit 2 for the latter and the diff of commit 3 for the former and lmk!

Also, I'm happy to find another suffix than `_no_log` for the non-logging variants. It's unambiguous and reasonably short, but it's also maybe a tad too easy to confuse with `_or_log`, so perhaps we can come up with something better.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
