### PR TITLE
sqllogictest: rewrite whitespace as '␠' in strings

### DIFF
--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -40,6 +40,7 @@ use bytes::BytesMut;
 use chrono::{DateTime, NaiveDateTime, NaiveTime, Utc};
 use fallible_iterator::FallibleIterator;
 use futures::sink::SinkExt;
+use itertools::Itertools;
 use md5::{Digest, Md5};
 use mz_controller::ControllerConfig;
 use mz_environmentd::CatalogConfig;
@@ -1932,7 +1933,7 @@ pub async fn rewrite_file(runner: &mut Runner<'_>, filename: &Path) -> Result<()
                     if i != 0 {
                         buf.append("\n");
                     }
-                    buf.append(&row.join("  "));
+                    buf.append(&row.iter().map(|col| col.replace(' ', "␠")).join("  "));
                 }
                 // In standard mode, output each value on its own line,
                 // and ignore row boundaries.


### PR DESCRIPTION
Change the `rewrite_file` command to insert '␠' which is the complement of what happens in `parse_query` when `mode cockroach` is selected.


### Motivation

  * This PR fixes a previously unreported bug.

At the moment

```sh
RUST_BACKTRACE=1 bin/sqllogictest -- -v --rewrite-results $FILE
```

will break tests in `$FILE` that contain `query *T*` output strings with spaces in the `T` column.

See [this conversation for example](https://github.com/MaterializeInc/materialize/pull/23360#discussion_r1413669620).

### Tips for reviewer

I just searched for `␠` in all `src/sqllogictest/*.rs` files and changed the `rewrite_file` code to match what happens in `parse_query`. Alternatively I can also change the definition of:

```rust
pub(crate) fn split_cols(line: &str, expected_columns: usize) -> Vec<&str> {
    if expected_columns == 1 {
        vec![line.trim()]
    } else {
        line.split_whitespace().collect()
    }
}
```
which at the moment is only called when `Mode::Cockroach = self.mode` to split not on a single, but on a double whitespace.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
