### PR TITLE
Add `persist_sink` `correction` metrics

### DIFF
--- a/src/compute/src/server.rs
+++ b/src/compute/src/server.rs
@@ -391,6 +391,10 @@ impl<'w, A: Allocate + 'static> Worker<'w, A> {
             self.metrics
                 .timely_step_duration_seconds
                 .observe(start.elapsed().as_secs_f64());
+            self.persist_clients
+                .metrics()
+                .sink
+                .update_sink_correction_peak_metrics();
 
             // Report frontier information back the coordinator.
             if let Some(mut compute_state) = self.activate_compute(&mut response_tx) {

--- a/src/persist-client/src/lib.rs
+++ b/src/persist-client/src/lib.rs
@@ -135,7 +135,9 @@ pub mod fetch;
 pub mod internals_bench;
 pub mod metrics {
     //! Utilities related to metrics.
-    pub use crate::internal::metrics::{encode_ts_metric, Metrics};
+    pub use crate::internal::metrics::{
+        encode_ts_metric, Metrics, SinkMetrics, SinkWorkerMetrics, UpdateDelta,
+    };
 }
 pub mod operators {
     //! [timely] operators for reading and writing persist Shards.

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2340,6 +2340,43 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     delayed_time = metrics.get_value("mz_dataflow_delayed_time_seconds_total")
     assert delayed_time < 1, f"unexpected delayed time: {delayed_time}"
 
+    mv_correction_insertions = metrics.get_value(
+        "mz_persist_sink_correction_insertions_total"
+    )
+    assert (
+        mv_correction_insertions > 0
+    ), f"unexpected persist sink correction insertions: {mv_correction_insertions}"
+    mv_correction_cap_increases = metrics.get_value(
+        "mz_persist_sink_correction_capacity_increases_total"
+    )
+    assert (
+        mv_correction_cap_increases > 0
+    ), f"unexpected persist sink correction capacity increases: {mv_correction_cap_increases}"
+    mv_correction_max_len_per_worker = metrics.get_value(
+        "mz_persist_sink_correction_max_per_sink_worker_len_updates"
+    )
+    assert (
+        mv_correction_max_len_per_worker > 0
+    ), f"unexpected persist max correction len per worker: {mv_correction_max_len_per_worker}"
+    mv_correction_max_cap_per_worker = metrics.get_value(
+        "mz_persist_sink_correction_max_per_sink_worker_capacity_updates"
+    )
+    assert (
+        mv_correction_max_cap_per_worker > 0
+    ), f"unexpected persist sink max correction capacity per worker: {mv_correction_max_cap_per_worker}"
+    mv_correction_peak_len = metrics.get_value(
+        "mz_persist_sink_correction_peak_len_updates"
+    )
+    assert (
+        mv_correction_peak_len > 0
+    ), f"unexpected persist peak correction len: {mv_correction_peak_len}"
+    mv_correction_peak_cap = metrics.get_value(
+        "mz_persist_sink_correction_peak_capacity_updates"
+    )
+    assert (
+        mv_correction_peak_cap > 0
+    ), f"unexpected persist sink peak correction capacity: {mv_correction_peak_cap}"
+
 
 def workflow_test_compute_controller_metrics(c: Composition) -> None:
     """Test metrics exposed by the compute controller."""


### PR DESCRIPTION
This PR adds metrics to track the length and capacity of the `correction` buffer in `persist_sink`. These first four metrics capture, respectively:

1. The cumulative insertions made to this buffer across instances of `persist_sink` and workers;
2. The cumulative deletions made to this buffer across instances of ` persist_sink` and workers;
3. The cumulative capacity increases made to this buffer across instances of `persist_sink` and workers;
4. The cumulative capacity decreases made to this buffer across instances of `persist_sink` and workers.

Since the metrics are monotonic and only ever added to, we can estimate, modulo concurrent updates from workers, the total joint memory required created by the correction buffers of all active `persist_sink` instances. Based on this estimate, we can keep track of peak length and capacity metrics across workers. Note that updating the estimate requires quiescence of updates to the monotonic metrics across workers, and is thus performed every `step_or_park` cycle.
    
In addition to the aggregate peak length and capacity metrics introduced above, this PR also tracks of maximum values seen for any _individual_ `correction` buffer to allow for drill downs and debugging. We note that the capacity metric is the most important to characterize memory usage, but the length metric provides additional information about the demand dynamics experienced by the buffer that lead to the capacity changes.

Advances #22881.

Also advances https://github.com/MaterializeInc/materialize/issues/23332 and  https://github.com/MaterializeInc/materialize/issues/19866. This is by improving our internal accounting of the portion of a memory spike during hydration that can be attributed to `persist_sink`.

### Motivation

  * This PR adds a known-desirable feature. Advances https://github.com/MaterializeInc/materialize/issues/23340

### Tips for reviewer

Note that we absolutely know that in some scenarios there will be a memory spike caused by `persist_sink` that is proportional to the number of updates for materialized view contents in `persist`. What we do not know and would like to find out with these metrics is how relevant this spike is in practice across different environments. If relevance is demonstrated, this would give us evidence for prioritizing work on an `lgalloc`-based solution for the `correction` buffer.

Note about overhead: In its current state, the monotonic metrics are shared across workers, and we need to perform (potentially contended) atomic operations to read/write to them. I felt this was not a significant problem in `persist_sink`, since we are already in an asynchronous context that will result downstream in expensive I/O operations. If you disagree, I'd be happy to change the monotonic metrics to be per-worker (making the atomics uncontended), and make the logic to aggregate these metrics every `step_or_park` more complex. There is some annoyance regarding types for the latter, as the APIs from Prometheus will insist on converting everything to `f64` when you need to iterate over values for multiple labels.

A simple evaluation of the peak metrics is provided in an [internal doc](https://www.notion.so/materialize/Simple-Evaluation-of-persist_sink-Memory-Spikes-c75568f1acf54b5695df3166b932ccf7?pvs=4#01267cef2387416b93a4309ee79beb05). We look there at two settings where we know that there should be a big memory spike, modeling consolidated and unconsolidated update extremes. TL;DR: The per-replica peak capacity metric derived from the monotonic counters is reliable and models the peak memory usage well in the evaluation.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
