### PR TITLE
[DNM] sql: user compaction for indexes

### DIFF
--- a/src/adapter/src/catalog.rs
+++ b/src/adapter/src/catalog.rs
@@ -3075,23 +3075,23 @@ impl Catalog {
                         1,
                     ));
                 }
-                Op::UpdateItem { id, name, to_item } => {
+                Op::UpdateItem { id, to_item } => {
                     builtin_table_updates.extend(state.pack_item_update(id, -1));
                     Self::update_item(
                         state,
                         builtin_table_updates,
                         id,
-                        name.clone(),
+                        state.get_entry(&id).name.clone(),
                         to_item.clone(),
                     )?;
                     let entry = state.get_entry(&id);
                     tx.update_item(id, entry.clone().into())?;
 
                     if Self::should_audit_log_item(&to_item) {
-                        let name = Self::full_name_detail(
-                            &state
-                                .resolve_full_name(&name, session.map(|session| session.conn_id())),
-                        );
+                        let name = Self::full_name_detail(&state.resolve_full_name(
+                            entry.name(),
+                            session.map(|session| session.conn_id()),
+                        ));
 
                         state.add_to_audit_log(
                             oracle_write_ts,
@@ -3817,7 +3817,6 @@ pub enum Op {
     },
     UpdateItem {
         id: GlobalId,
-        name: QualifiedItemName,
         to_item: CatalogItem,
     },
     UpdateStorageUsage {

--- a/src/adapter/src/catalog/state.rs
+++ b/src/adapter/src/catalog/state.rs
@@ -789,7 +789,7 @@ impl CatalogState {
     ) -> Result<CatalogItem, AdapterError> {
         // TODO - The `None` needs to be changed if we ever allow custom
         // logical compaction windows in user-defined objects.
-        self.parse_item(id, create_sql, Some(&PlanContext::zero()), false, None)
+        self.parse_item(id, create_sql, Some(&PlanContext::zero()), false)
     }
 
     /// Parses the given SQL string into a `CatalogItem`.
@@ -800,7 +800,6 @@ impl CatalogState {
         create_sql: String,
         pcx: Option<&PlanContext>,
         is_retained_metrics_object: bool,
-        custom_logical_compaction_window: Option<Duration>,
     ) -> Result<CatalogItem, AdapterError> {
         let mut session_catalog = self.for_system_session();
         // Enable catalog features that might be required during planning in
@@ -826,7 +825,6 @@ impl CatalogState {
                 defaults: table.defaults,
                 conn_id: None,
                 resolved_ids,
-                custom_logical_compaction_window,
                 is_retained_metrics_object,
             }),
             Plan::CreateSource(CreateSourcePlan {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1258,10 +1258,8 @@ impl Coordinator {
                 .item()
                 .initial_logical_compaction_window()
                 .map(|duration| {
-                    let ts = Timestamp::from(
-                        u64::try_from(duration.as_millis())
-                            .expect("Timestamp millis must fit in u64"),
-                    );
+                    let ts =
+                        Timestamp::try_from(duration).expect("Timestamp millis must fit in u64");
                     ts
                 });
             match entry.item() {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -1247,6 +1247,7 @@ impl Coordinator {
 
         debug!("coordinator init: installing existing objects in catalog");
         let mut privatelink_connections = BTreeMap::new();
+        let system_config = self.catalog().system_config();
 
         for entry in &entries {
             debug!(
@@ -1256,7 +1257,7 @@ impl Coordinator {
             );
             let policy = entry
                 .item()
-                .initial_logical_compaction_window()
+                .initial_logical_compaction_window(system_config)
                 .map(|duration| {
                     let ts =
                         Timestamp::try_from(duration).expect("Timestamp millis must fit in u64");

--- a/src/adapter/src/coord/ddl.rs
+++ b/src/adapter/src/coord/ddl.rs
@@ -1102,11 +1102,7 @@ impl Coordinator {
                         }
                     }
                 },
-                Op::UpdateItem {
-                    name: _,
-                    id,
-                    to_item,
-                } => match to_item {
+                Op::UpdateItem { id, to_item } => match to_item {
                     CatalogItem::Source(source) => {
                         let current_source = self
                             .catalog()

--- a/src/adapter/src/coord/sequencer.rs
+++ b/src/adapter/src/coord/sequencer.rs
@@ -399,11 +399,15 @@ impl Coordinator {
                     ctx.retire(result);
                 }
                 Plan::AlterIndexSetOptions(plan) => {
-                    let result = self.sequence_alter_index_set_options(plan);
+                    let result = self
+                        .sequence_alter_index_set_options(ctx.session(), plan)
+                        .await;
                     ctx.retire(result);
                 }
                 Plan::AlterIndexResetOptions(plan) => {
-                    let result = self.sequence_alter_index_reset_options(plan);
+                    let result = self
+                        .sequence_alter_index_reset_options(ctx.session(), plan)
+                        .await;
                     ctx.retire(result);
                 }
                 Plan::AlterRole(plan) => {

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -1171,7 +1171,7 @@ impl Coordinator {
 
                 self.ship_dataflow(df_desc, cluster_id).await;
 
-                self.set_index_options(id, options).expect("index enabled");
+                self.set_index_options(id, options);
                 Ok(ExecuteResponse::CreatedIndex)
             }
             Err(AdapterError::Catalog(mz_catalog::memory::error::Error {
@@ -4480,7 +4480,7 @@ impl Coordinator {
         &mut self,
         plan: plan::AlterIndexSetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        self.set_index_options(plan.id, plan.options)?;
+        self.set_index_options(plan.id, plan.options);
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
@@ -4492,23 +4492,17 @@ impl Coordinator {
         for o in plan.options {
             options.push(match o {
                 IndexOptionName::LogicalCompactionWindow => {
-                    IndexOption::LogicalCompactionWindow(Some(Duration::from_millis(
-                        DEFAULT_LOGICAL_COMPACTION_WINDOW_TS.into(),
-                    )))
+                    IndexOption::LogicalCompactionWindow(Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS))
                 }
             });
         }
 
-        self.set_index_options(plan.id, options)?;
+        self.set_index_options(plan.id, options);
 
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
-    pub(super) fn set_index_options(
-        &mut self,
-        id: GlobalId,
-        options: Vec<IndexOption>,
-    ) -> Result<(), AdapterError> {
+    pub(super) fn set_index_options(&mut self, id: GlobalId, options: Vec<IndexOption>) {
         for o in options {
             match o {
                 IndexOption::LogicalCompactionWindow(window) => {
@@ -4520,16 +4514,13 @@ impl Coordinator {
                         .expect("setting options on index")
                         .cluster_id;
                     let policy = match window {
-                        Some(time) => {
-                            ReadPolicy::lag_writes_by(time.try_into()?, SINCE_GRANULARITY)
-                        }
+                        Some(time) => ReadPolicy::lag_writes_by(time, SINCE_GRANULARITY),
                         None => ReadPolicy::ValidFrom(Antichain::from_elem(Timestamp::minimum())),
                     };
                     self.update_compute_base_read_policy(cluster, id, policy);
                 }
             }
         }
-        Ok(())
     }
 
     pub(super) async fn sequence_alter_role(

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -4840,7 +4840,6 @@ impl Coordinator {
 
         let ops = vec![catalog::Op::UpdateItem {
             id,
-            name: self.catalog.get_entry(&id).name().clone(),
             to_item: CatalogItem::Connection(connection.clone()),
         }];
 
@@ -5183,9 +5182,6 @@ impl Coordinator {
                 // Redefine source.
                 ops.push(catalog::Op::UpdateItem {
                     id,
-                    // Look this up again so we don't have to hold an immutable reference to the
-                    // entry for so long.
-                    name: self.catalog.get_entry(&id).name().clone(),
                     to_item: CatalogItem::Source(source),
                 });
 
@@ -5382,9 +5378,6 @@ impl Coordinator {
                 // Redefine source.
                 ops.push(catalog::Op::UpdateItem {
                     id,
-                    // Look this up again so we don't have to hold an immutable reference to the
-                    // entry for so long.
-                    name: self.catalog.get_entry(&id).name().clone(),
                     to_item: CatalogItem::Source(source),
                 });
 

--- a/src/adapter/src/coord/sequencer/inner.rs
+++ b/src/adapter/src/coord/sequencer/inner.rs
@@ -68,7 +68,7 @@ use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::ast::{
     AlterSourceAddSubsourceOptionName, ConnectionOption, ConnectionOptionName,
     CreateSourceConnection, CreateSourceSubsource, DeferredItemName, PgConfigOption,
-    PgConfigOptionName, ReferencedSubsources, Statement, TransactionMode, WithOptionValue,
+    PgConfigOptionName, Raw, ReferencedSubsources, Statement, TransactionMode, WithOptionValue,
 };
 use mz_ssh_util::keys::SshKeyPairSet;
 use mz_storage_client::controller::{
@@ -4476,36 +4476,101 @@ impl Coordinator {
         }
     }
 
-    pub(super) fn sequence_alter_index_set_options(
+    pub(super) async fn sequence_alter_index_set_options(
         &mut self,
+        session: &Session,
         plan: plan::AlterIndexSetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        self.set_index_options(plan.id, plan.options);
-        Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
+        self.apply_index_options(session, plan.id, |index, with_options| {
+            for o in &plan.options {
+                match o {
+                    IndexOption::LogicalCompactionWindow {
+                        window: _,
+                        ast,
+                        duration,
+                    } => {
+                        index.custom_logical_compaction_window = duration.clone();
+                        with_options
+                            .retain(|opt| opt.name != IndexOptionName::LogicalCompactionWindow);
+                        with_options.push(mz_sql_parser::ast::IndexOption {
+                            name: IndexOptionName::LogicalCompactionWindow,
+                            value: ast.as_ref().map(|ast| WithOptionValue::Value(ast.clone())),
+                        });
+                    }
+                }
+            }
+            plan.options
+        })
+        .await
     }
 
-    pub(super) fn sequence_alter_index_reset_options(
+    pub(super) async fn sequence_alter_index_reset_options(
         &mut self,
+        session: &Session,
         plan: plan::AlterIndexResetOptionsPlan,
     ) -> Result<ExecuteResponse, AdapterError> {
-        let mut options = Vec::with_capacity(plan.options.len());
-        for o in plan.options {
-            options.push(match o {
-                IndexOptionName::LogicalCompactionWindow => {
-                    IndexOption::LogicalCompactionWindow(Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS))
-                }
-            });
-        }
+        self.apply_index_options(session, plan.id, |index, with_options| {
+            let mut options = Vec::with_capacity(plan.options.len());
+            for o in &plan.options {
+                options.push(match o {
+                    IndexOptionName::LogicalCompactionWindow => {
+                        index.custom_logical_compaction_window = None;
+                        with_options
+                            .retain(|opt| opt.name != IndexOptionName::LogicalCompactionWindow);
+                        IndexOption::LogicalCompactionWindow {
+                            ast: None,
+                            duration: None,
+                            window: Some(DEFAULT_LOGICAL_COMPACTION_WINDOW_TS),
+                        }
+                    }
+                });
+            }
+            options
+        })
+        .await
+    }
 
-        self.set_index_options(plan.id, options);
-
+    /// For the given index id, provide a fn to mutate it and its SQL for updating.
+    async fn apply_index_options<F>(
+        &mut self,
+        session: &Session,
+        id: GlobalId,
+        f: F,
+    ) -> Result<ExecuteResponse, AdapterError>
+    where
+        F: FnOnce(
+            &mut mz_catalog::memory::objects::Index,
+            &mut Vec<mz_sql_parser::ast::IndexOption<Raw>>,
+        ) -> Vec<IndexOption>,
+    {
+        let mut index = self
+            .catalog()
+            .get_entry(&id)
+            .index()
+            .expect("setting options on index")
+            .clone();
+        let create_stmt = mz_sql::parse::parse(&index.create_sql)
+            .unwrap_or_else(|_| panic!("create_sql cannot be invalid: {}", index.create_sql))
+            .into_element()
+            .ast;
+        let Statement::CreateIndex(mut create_stmt) = create_stmt else {
+            panic!("expected CreateIndex statement");
+        };
+        let options = f(&mut index, &mut create_stmt.with_options);
+        index.create_sql = create_stmt.to_ast_string_stable();
+        let op = catalog::Op::UpdateItem {
+            id,
+            to_item: CatalogItem::Index(index),
+        };
+        self.catalog_transact(Some(session), vec![op]).await?;
+        self.set_index_options(id, options);
         Ok(ExecuteResponse::AlteredObject(ObjectType::Index))
     }
 
     pub(super) fn set_index_options(&mut self, id: GlobalId, options: Vec<IndexOption>) {
         for o in options {
             match o {
-                IndexOption::LogicalCompactionWindow(window) => {
+                IndexOption::LogicalCompactionWindow { window, .. } => {
                     // The index is on a specific cluster.
                     let cluster = self
                         .catalog()

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -1547,7 +1547,7 @@ pub enum ExecuteTimeout {
 pub enum IndexOption {
     /// Configures the logical compaction window for an index. `None` disables
     /// logical compaction entirely.
-    LogicalCompactionWindow(Option<Duration>),
+    LogicalCompactionWindow(Option<mz_repr::Timestamp>),
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan.rs
+++ b/src/sql/src/plan.rs
@@ -42,8 +42,8 @@ use mz_repr::explain::{ExplainConfig, ExplainFormat};
 use mz_repr::role_id::RoleId;
 use mz_repr::{ColumnName, Diff, GlobalId, RelationDesc, Row, ScalarType};
 use mz_sql_parser::ast::{
-    AlterSourceAddSubsourceOption, ConnectionOptionName, CreateSourceSubsource, QualifiedReplica,
-    TransactionIsolationLevel, TransactionMode, WithOptionValue,
+    self, AlterSourceAddSubsourceOption, ConnectionOptionName, CreateSourceSubsource,
+    QualifiedReplica, TransactionIsolationLevel, TransactionMode, WithOptionValue,
 };
 use mz_storage_types::connections::inline::ReferencedConnection;
 use mz_storage_types::sinks::{SinkEnvelope, StorageSinkConnection};
@@ -1545,9 +1545,13 @@ pub enum ExecuteTimeout {
 
 #[derive(Clone, Debug)]
 pub enum IndexOption {
-    /// Configures the logical compaction window for an index. `None` disables
-    /// logical compaction entirely.
-    LogicalCompactionWindow(Option<mz_repr::Timestamp>),
+    /// Configures the logical compaction window for an index. `None` disables logical compaction
+    /// entirely. Passes the original WITH option and duration for persisting to the catalog.
+    LogicalCompactionWindow {
+        window: Option<mz_repr::Timestamp>,
+        duration: Option<Duration>,
+        ast: Option<ast::Value>,
+    },
 }
 
 #[derive(Clone, Debug)]

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -4113,7 +4113,10 @@ fn plan_index_options(
     if let Some(OptionalInterval(lcw)) = logical_compaction_window {
         scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
         out.push(crate::plan::IndexOption::LogicalCompactionWindow(
-            lcw.map(|interval| interval.duration()).transpose()?,
+            lcw.map(|interval| interval.duration())
+                .transpose()?
+                .map(|duration| duration.try_into())
+                .transpose()?,
         ))
     }
 

--- a/src/sql/src/plan/statement/ddl.rs
+++ b/src/sql/src/plan/statement/ddl.rs
@@ -99,7 +99,7 @@ use crate::plan::scope::Scope;
 use crate::plan::statement::ddl::connection::{INALTERABLE_OPTIONS, MUTUALLY_EXCLUSIVE_SETS};
 use crate::plan::statement::{scl, StatementContext, StatementDesc};
 use crate::plan::typeconv::{plan_cast, CastContext};
-use crate::plan::with_options::{OptionalInterval, TryFromValue};
+use crate::plan::with_options::{OptionalInterval, RetainedValue, TryFromValue};
 use crate::plan::{
     plan_utils, query, transform_ast, AlterClusterPlan, AlterClusterRenamePlan,
     AlterClusterReplicaRenamePlan, AlterClusterSwapPlan, AlterConnectionPlan,
@@ -4092,32 +4092,34 @@ pub fn plan_drop_owned(
     }))
 }
 
-generate_extracted_config!(IndexOption, (LogicalCompactionWindow, OptionalInterval));
+generate_extracted_config!(
+    IndexOption,
+    (LogicalCompactionWindow, RetainedValue<OptionalInterval>)
+);
 
 fn plan_index_options(
     scx: &StatementContext,
     with_opts: Vec<IndexOption<Aug>>,
 ) -> Result<Vec<crate::plan::IndexOption>, PlanError> {
-    if !with_opts.is_empty() {
-        // Index options are not durable.
-        scx.require_feature_flag(&vars::ENABLE_INDEX_OPTIONS)?;
-    }
-
     let IndexOptionExtracted {
         logical_compaction_window,
-        ..
+        seen: _,
     }: IndexOptionExtracted = with_opts.try_into()?;
 
     let mut out = Vec::with_capacity(1);
 
-    if let Some(OptionalInterval(lcw)) = logical_compaction_window {
+    if let Some(lcw) = logical_compaction_window {
         scx.require_feature_flag(&vars::ENABLE_LOGICAL_COMPACTION_WINDOW)?;
-        out.push(crate::plan::IndexOption::LogicalCompactionWindow(
-            lcw.map(|interval| interval.duration())
-                .transpose()?
-                .map(|duration| duration.try_into())
-                .transpose()?,
-        ))
+        let duration = lcw
+            .value
+            .0
+            .map(|interval| interval.duration())
+            .transpose()?;
+        out.push(crate::plan::IndexOption::LogicalCompactionWindow {
+            window: duration.map(|duration| duration.try_into()).transpose()?,
+            ast: Some(lcw.ast),
+            duration,
+        })
     }
 
     Ok(out)

--- a/src/sql/src/plan/with_options.rs
+++ b/src/sql/src/plan/with_options.rs
@@ -215,6 +215,34 @@ impl ImpliedValue for OptionalInterval {
     }
 }
 
+/// Retains the original SQL ast Value when planning WITH options.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Hash, Deserialize)]
+pub struct RetainedValue<T> {
+    pub ast: Value,
+    pub value: T,
+}
+
+impl<T> TryFromValue<Value> for RetainedValue<T>
+where
+    T: TryFromValue<Value>,
+{
+    fn try_from_value(v: Value) -> Result<Self, PlanError> {
+        Ok(Self {
+            ast: v.clone(),
+            value: T::try_from_value(v)?,
+        })
+    }
+    fn name() -> String {
+        "retained value".to_string()
+    }
+}
+
+impl<T> ImpliedValue for RetainedValue<T> {
+    fn implied_value() -> Result<Self, PlanError> {
+        sql_bail!("unsupported implied value")
+    }
+}
+
 impl TryFromValue<Value> for String {
     fn try_from_value(v: Value) -> Result<Self, PlanError> {
         match v {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1779,13 +1779,6 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_index_options,
-        desc: "INDEX OPTIONS",
-        default: false,
-        internal: true,
-        enable_for_item_parsing: true,
-    },
-    {
         name: enable_kafka_config_denylist_options,
         desc: "Kafka sources with non-allowlisted options",
         default: false,

--- a/test/sqllogictest/logical-compaction-window.slt
+++ b/test/sqllogictest/logical-compaction-window.slt
@@ -1,0 +1,45 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+mode cockroach
+
+simple conn=mz_system,user=mz_system
+ALTER SYSTEM SET enable_logical_compaction_window TO true;
+----
+COMPLETE 0
+
+statement ok
+CREATE TABLE t (i INT)
+
+statement ok
+CREATE INDEX t_ind ON t (i)
+
+query T multiline
+SELECT create_sql FROM (SHOW CREATE INDEX t_ind)
+----
+CREATE INDEX "t_ind" IN CLUSTER "default" ON "materialize"."public"."t" ("i")
+EOF
+
+statement ok
+ALTER INDEX t_ind SET (LOGICAL COMPACTION WINDOW = '1m');
+
+query T multiline
+SELECT create_sql FROM (SHOW CREATE INDEX t_ind)
+----
+CREATE INDEX "t_ind" IN CLUSTER "default" ON "materialize"."public"."t" ("i") WITH (LOGICAL COMPACTION WINDOW = '1m')
+EOF
+
+statement ok
+ALTER INDEX t_ind RESET (LOGICAL COMPACTION WINDOW)
+
+query T multiline
+SELECT create_sql FROM (SHOW CREATE INDEX t_ind)
+----
+CREATE INDEX "t_ind" IN CLUSTER "default" ON "materialize"."public"."t" ("i")
+EOF


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
