### PR TITLE
sql: pretty print in `SHOW CREATE`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5307,6 +5307,7 @@ dependencies = [
  "mz-secrets",
  "mz-sql-lexer",
  "mz-sql-parser",
+ "mz-sql-pretty",
  "mz-ssh-util",
  "mz-storage-types",
  "mz-tracing",

--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -88,6 +88,8 @@ use crate::doc::{
     doc_select_statement, doc_subscribe,
 };
 
+pub const DEFAULT_WIDTH: usize = 100;
+
 const TAB: isize = 4;
 
 fn to_doc<T: AstInfo>(v: &Statement<T>) -> RcDoc {

--- a/src/sql/Cargo.toml
+++ b/src/sql/Cargo.toml
@@ -42,6 +42,7 @@ mz-repr = { path = "../repr", features = ["tracing_"] }
 mz-rocksdb-types = { path = "../rocksdb-types" }
 mz-secrets = { path = "../secrets" }
 mz-sql-parser = { path = "../sql-parser" }
+mz-sql-pretty = { path = "../sql-pretty" }
 mz-sql-lexer = { path = "../sql-lexer" }
 mz-ssh-util = { path = "../ssh-util" }
 mz-storage-types = { path = "../storage-types" }

--- a/src/sql/src/func.rs
+++ b/src/sql/src/func.rs
@@ -3668,7 +3668,7 @@ pub static MZ_CATALOG_BUILTINS: Lazy<BTreeMap<&'static str, Func>> = Lazy::new(|
         "pretty_sql" => Scalar {
             params!(String, Int32) => BinaryFunc::PrettySql => String, oid::FUNC_PRETTY_SQL;
             params!(String) => Operation::unary(|_ecx, s| {
-                let width = HirScalarExpr::literal(Datum::Int32(100), ScalarType::Int32);
+                let width = HirScalarExpr::literal(Datum::Int32(mz_sql_pretty::DEFAULT_WIDTH.try_into().expect("must fit")), ScalarType::Int32);
                 Ok(s.call_binary(width, BinaryFunc::PrettySql))
             }) => String, oid::FUNC_PRETTY_SQL_NOWIDTH;
         },


### PR DESCRIPTION
Pretty print `SHOW CREATE` statements.

### Motivation

  * This PR adds a feature that has not yet been specified.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Change `SHOW CREATE` to pretty print objects. The previous output is still available through the various `create_sql` fields of `mz_catalog.mz_views` and related tables.