### PR TITLE
persist-txn: enable in CI with "eager uppers"

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -62,7 +62,7 @@ steps:
     steps:
     - id: feature-benchmark
       label: "Feature benchmark against merge base or 'latest'"
-      timeout_in_minutes: 360
+      timeout_in_minutes: 720
       agents:
         queue: linux-x86_64-large
       artifact_paths: junit_*.xml
@@ -75,7 +75,7 @@ steps:
                - common-ancestor
     - id: scalability-benchmark
       label: "Scalability benchmark against merge base or 'latest'"
-      timeout_in_minutes: 120
+      timeout_in_minutes: 180
       agents:
         queue: linux-x86_64-large
       artifact_paths: junit_*.xml
@@ -226,7 +226,7 @@ steps:
       plugins:
         - ./ci/plugins/mzcompose:
             composition: limits
-      timeout_in_minutes: 50
+      timeout_in_minutes: 90
 
     - id: limits-instance-size
       label: "Instance size limits"

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -80,6 +80,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "timestamp_oracle": "postgres",
     "default_idle_arrangement_merge_effort": "0",
     "default_arrangement_exert_proportionality": "16",
+    "persist_txn_tables": "eager",
 }
 
 DEFAULT_CRDB_ENVIRONMENT = [

--- a/src/adapter/src/coord/appends.rs
+++ b/src/adapter/src/coord/appends.rs
@@ -278,18 +278,11 @@ impl Coordinator {
         //
         // TODO: Remove this after both (either?) of the above features are on
         // for good and no possibility of running the old code.
-        //
-        // TODO(txn): To bundle all the perf differences up in one PR, I'm
-        // leaving this disabled for now. Re-enable it in the same PR that turns
-        // persist-txn on for CI, so we can get a full picture of the perf
-        // impact.
-        if false {
-            let () = self
-                .catalog
-                .confirm_leadership()
-                .await
-                .unwrap_or_terminate("unable to confirm leadership");
-        }
+        let () = self
+            .catalog
+            .confirm_leadership()
+            .await
+            .unwrap_or_terminate("unable to confirm leadership");
 
         let mut appends: BTreeMap<GlobalId, Vec<(Row, Diff)>> = BTreeMap::new();
         let mut responses = Vec::with_capacity(self.pending_writes.len());

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -111,6 +111,7 @@ use mz_server_core::TlsCertConfig;
 use mz_sql::catalog::EnvironmentId;
 use mz_stash_types::metrics::Metrics as StashMetrics;
 use mz_storage_types::connections::ConnectionContext;
+use mz_storage_types::controller::PersistTxnTablesImpl;
 use mz_tracing::CloneableEnvFilter;
 use once_cell::sync::Lazy;
 use openssl::asn1::Asn1Time;
@@ -532,8 +533,8 @@ impl Listeners {
                 deploy_generation: config.deploy_generation,
                 http_host_name: Some(host_name),
                 internal_console_redirect_url: config.internal_console_redirect_url,
-                // TODO(txn): Get this flipped on before turning anything on in prod.
-                persist_txn_tables_cli: None,
+                // TODO(txn-lazy): Get "lazy" flipped on before turning "lazy" on in prod.
+                persist_txn_tables_cli: Some(PersistTxnTablesImpl::Eager),
             })
             .await?;
 

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -76,6 +76,7 @@ use mz_sql_parser::ast::{
 use mz_sql_parser::parser;
 use mz_stash_types::metrics::Metrics as StashMetrics;
 use mz_storage_types::connections::ConnectionContext;
+use mz_storage_types::controller::PersistTxnTablesImpl;
 use once_cell::sync::Lazy;
 use postgres_protocol::types;
 use regex::Regex;
@@ -1052,8 +1053,8 @@ impl<'a> RunnerInner<'a> {
             deploy_generation: None,
             http_host_name: Some(host_name),
             internal_console_redirect_url: None,
-            // TODO(txn): Get this flipped on before turning anything on in prod.
-            persist_txn_tables_cli: None,
+            // TODO(txn-lazy): Get "lazy" flipped on before turning "lazy" on in prod.
+            persist_txn_tables_cli: Some(PersistTxnTablesImpl::Eager),
         };
         // We need to run the server on its own Tokio runtime, which in turn
         // requires its own thread, so that we can wait for any tasks spawned


### PR DESCRIPTION
The new persist-txn code has three settings:
- off: The previous implementation of tables. Each is a persist shard
  with an upper that is advanced at least once per second by group
  commit.
- eager: The persist-txn "WAL" (the txns shard) is used as the source of
  truth for what is committed to tables. This is denormalized into every
  table (data shard) whenever the txns shard upper advances, meaning
  every data shard's upper advances whenever the txns shard does. This
  means that all persist reads on tables can be served through the
  previous codepaths.
- lazy: The persist-txn "WAL" (the txns shard) is used as the source of
  truth for what is committed to tables. This is denormalized into the
  tables (data shards) _only when they change_. This means the CRDB
  traffic is no longer a function of the total number of tables, instead
  it's a function of how many tables are actually changed in a txn.
  However, this means that all reads of tables (data shards) need to go
  through persist-txn so that it can account for the lazy upper
  behavior.

This PR sets CI to "eager" as a necessary precondition for rolling
"eager" out to prod. We'd like to get all the way to "lazy" but eager is
enough to unblock the Pv2 Use Case Isolation work. Breaking the rollout
to prod into two steps also de-risks it because "off" -> "eager" only
changes write paths and then "eager" -> "lazy" only changes read paths.
We'll later switch CI to "lazy" before rolling that out to prod.

The selected behavior of this feature is set on envd startup and not
again. To select a new behavior, envd needs to be restarted (which in
turn intentionally restarts clusterd). In order of decreasing
priority/override:

- The value of the --enable-persist-txn-tables cli flag, if any. This is
  possibly vestigial given the new default_system_parameters sniffing in
  this commit, but I'd like to keep it around for now in case it helps
  us write tests.
- The "default_system_parameters" flag/env, which is how we hook it up
  to the usual CI override list in `__init__.py`.
- The most recent value, if any, set for the `enable_persist_txn_tables`
  system var before restart, which is how we hook it up to Launch
  Darkly for the staging/prod rollout.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR adds a known-desirable feature.

### Tips for reviewer

It is known that this will be a severe regression to INSERT/UPDATE performance on SQL tables. Throughput should be roughly unaffected, but we go from one s3 + one crdb write (in serial) to two of each (all in serial) so latency might ~double. This is quite unfortunate; however, this removes a blocker for Use Case Isolation, which is critical for customers.

@MaterializeInc/testing  I'd like to merge this once CI and nightlies are passing (modulo the expected performance change, which both the Feature Benchmark and the Scalability Benchmark catch) because I'd like to get persist-txn used in our end-to-end tests ASAP. However, things are _finally_ at a point that y'all could start writing new tests.

For step 1 ("eager"):
- The read paths are unchanged.
- All writes to tables go through the _txns shard_ (it's completely correct to just think of the txns shard as a Write Ahead Log). This is new code, but it's heavily unit tested and I think our existing sqllogictests, etc should have pretty good coverage. Do please feel free to write new tests for this if you can think of them though!
  - On the other hand, the migration of an individual environment from "off" -> "eager" (or "lazy") is somewhat stressful. The correctness of persist-txn depends on no-one writing directly to the underlying shards, but this is exactly what used to happen. To flip the setting, an environment has to be restarted and if the old one sticks around as a zombie, bad things can happen: in particular, lost writes. We've come up with a [protocol for fencing out the old environment from doing the bad things](https://github.com/MaterializeInc/materialize/pull/23329), but I think our test coverage here could probably be improved. In particular, it'd be good to write a test that does something like 1) continually starting up a new envd, which fences out the old one while alternating "off" and "eager" 2) attempting INSERTs to _both_ envds until one of them stops accepting connections 3) keeping track of which INSERTs are acknowledged as successful and 4) making sure that all acknowledged writes continue to appear in reads. Also a heads up that this process is even harder when Aljsocha's `timestamp_oracle=postgres` is used. I tried typing something like this myself, but I was not up to the task :).
  - Note that if someone tries writing this test, I've (incidentally) [left you a bug to find](https://github.com/MaterializeInc/materialize/blob/05017592afbfbc0a2381d6e86b2ebfc9f0b65dfa/src/adapter/src/coord/appends.rs#L282-L292)!

For step 2 ("lazy"):
- Note that existing CI is not quite passing yet, much less Nightlies. So maybe too early to spend much time here yet.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
