### PR TITLE
ci-logged-errors: service names can contain varying number of spaces

### DIFF
--- a/misc/python/materialize/cli/ci_logged_errors_detect.py
+++ b/misc/python/materialize/cli/ci_logged_errors_detect.py
@@ -63,8 +63,8 @@ ERROR_RE = re.compile(
 # Panics are multiline and our log lines of multiple services are interleaved,
 # making them complex to handle in regular expressions, thus handle them
 # separately.
-PANIC_START_RE = re.compile(rb"^(?P<service>.*) \| thread '.*' panicked at ")
-SERVICES_LOG_LINE_RE = re.compile(rb"^(?P<service>.*) \| (?P<msg>.*)$")
+PANIC_START_RE = re.compile(rb"^(?P<service>[^ ]*) *\| thread '.*' panicked at ")
+SERVICES_LOG_LINE_RE = re.compile(rb"^(?P<service>[^ ]*) *\| (?P<msg>.*)$")
 
 # Expected failures, don't report them
 IGNORE_RE = re.compile(


### PR DESCRIPTION
Seen in https://buildkite.com/materialize/tests/builds/70354#018c3606-93ab-4363-bb13-68956241edf3
```
cluster-isolation-clusterd_1_2-1  | thread 'timely:work-0' panicked at src/expr/src/scalar/func/impls/string.rs:1025:9:
cluster-isolation-clusterd_1_2-1     | forced panic
```
Didn't know this can happen before.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
