### PR TITLE
adapter: Rename dangerous function flag

### DIFF
--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -53,7 +53,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_columnation_lgalloc": "true",
     "enable_rbac_checks": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
-    "enable_dangerous_functions": "true",
+    "enable_unsafe_functions": "true",
     "enable_disk_cluster_replicas": "true",
     "statement_logging_max_sample_rate": "1.0",
     "statement_logging_default_sample_rate": "1.0",

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -54,6 +54,8 @@ DEFAULT_SYSTEM_PARAMETERS = {
     "enable_rbac_checks": "true",
     "enable_try_parse_monotonic_iso8601_timestamp": "true",
     "enable_unsafe_functions": "true",
+    # Old name of `enable_unsafe_functions`.
+    "enable_dangerous_functions": "true",
     "enable_disk_cluster_replicas": "true",
     "statement_logging_max_sample_rate": "1.0",
     "statement_logging_default_sample_rate": "1.0",

--- a/src/environmentd/tests/pgwire.rs
+++ b/src/environmentd/tests/pgwire.rs
@@ -575,7 +575,7 @@ fn test_pgtest_mz() {
         &[
             "enable_raise_statement",
             "enable_unmanaged_cluster_replicas",
-            "enable_dangerous_functions",
+            "enable_unsafe_functions",
         ],
     );
 }

--- a/src/environmentd/tests/server.rs
+++ b/src/environmentd/tests/server.rs
@@ -2731,7 +2731,7 @@ fn test_cancel_read_then_write() {
     let server = test_util::TestHarness::default()
         .unsafe_mode()
         .start_blocking();
-    server.enable_feature_flags(&["enable_dangerous_functions"]);
+    server.enable_feature_flags(&["enable_unsafe_functions"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     client
@@ -3016,7 +3016,7 @@ fn webhook_concurrency_limit() {
     let server = test_util::TestHarness::default().start_blocking();
 
     // Note: we need enable_unstable_dependencies to use mz_sleep.
-    server.enable_feature_flags(&["enable_unstable_dependencies", "enable_dangerous_functions"]);
+    server.enable_feature_flags(&["enable_unstable_dependencies", "enable_unsafe_functions"]);
 
     // Reduce the webhook concurrency limit;
     let mut mz_client = server

--- a/src/environmentd/tests/sql.rs
+++ b/src/environmentd/tests/sql.rs
@@ -329,7 +329,7 @@ async fn test_drop_connection_race() {
 #[mz_ore::test]
 fn test_time() {
     let server = test_util::TestHarness::default().start_blocking();
-    server.enable_feature_flags(&["enable_dangerous_functions"]);
+    server.enable_feature_flags(&["enable_unsafe_functions"]);
     let mut client = server.connect(postgres::NoTls).unwrap();
 
     // Confirm that `now()` and `current_timestamp()` both return a
@@ -1535,7 +1535,7 @@ async fn test_github_12546() {
         .start()
         .await;
     server
-        .enable_feature_flags(&["enable_dangerous_functions"])
+        .enable_feature_flags(&["enable_unsafe_functions"])
         .await;
 
     let (client, conn_task) = server.connect().with_handle().await.unwrap();
@@ -2197,7 +2197,7 @@ fn test_introspection_user_permissions() {
 #[mz_ore::test]
 fn test_idle_in_transaction_session_timeout() {
     let server = test_util::TestHarness::default().start_blocking();
-    server.enable_feature_flags(&["enable_dangerous_functions"]);
+    server.enable_feature_flags(&["enable_unsafe_functions"]);
 
     let mut client = server.connect(postgres::NoTls).unwrap();
     client

--- a/src/sql/src/plan/statement.rs
+++ b/src/sql/src/plan/statement.rs
@@ -288,7 +288,7 @@ pub fn plan(
                     == SchemaSpecifier::Id(*catalog.get_mz_internal_schema_id())
         })
     {
-        scx.require_feature_flag(&vars::ENABLE_DANGEROUS_FUNCTIONS)?;
+        scx.require_feature_flag(&vars::ENABLE_UNSAFE_FUNCTIONS)?;
     }
 
     let plan = match stmt {

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1947,7 +1947,7 @@ feature_flags!(
         enable_for_item_parsing: true,
     },
     {
-        name: enable_dangerous_functions,
+        name: enable_unsafe_functions,
         desc: "executing potentially dangerous functions",
         default: false,
         internal: true,

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1136,7 +1136,7 @@ impl<'a> RunnerInner<'a> {
 
         // Dangerous functions are useful for tests so we enable it for all tests.
         self.system_client
-            .execute("ALTER SYSTEM SET enable_dangerous_functions = on", &[])
+            .execute("ALTER SYSTEM SET enable_unsafe_functions = on", &[])
             .await?;
         Ok(())
     }

--- a/src/testdrive/src/action.rs
+++ b/src/testdrive/src/action.rs
@@ -406,7 +406,7 @@ impl State {
 
         // Dangerous functions are useful for tests so we enable it for all tests.
         inner_client
-            .batch_execute("ALTER SYSTEM SET enable_dangerous_functions = on")
+            .batch_execute("ALTER SYSTEM SET enable_unsafe_functions = on")
             .await
             .context("enabling dangerous functions")?;
 

--- a/test/sqllogictest/explain/broken_statements.slt
+++ b/test/sqllogictest/explain/broken_statements.slt
@@ -22,7 +22,7 @@
 # Enable feature flags required for this test
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_dangerous_functions = true
+ALTER SYSTEM SET enable_unsafe_functions = true
 ----
 COMPLETE 0
 

--- a/test/sqllogictest/funcs.slt
+++ b/test/sqllogictest/funcs.slt
@@ -1624,10 +1624,10 @@ SELECT pg_stat_get_numscans('pg_views'::regclass::oid)
 ----
 -1
 
-# mz_internal functions can't be executed with the enable_dangerous_functions flag turned off
+# mz_internal functions can't be executed with the enable_unsafe_functions flag turned off
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_dangerous_functions = false
+ALTER SYSTEM SET enable_unsafe_functions = false
 ----
 COMPLETE 0
 
@@ -1659,7 +1659,7 @@ statement error executing potentially dangerous functions is not supported
 SELECT mz_internal.mz_resolve_object_name('t');
 
 simple conn=mz_system,user=mz_system
-ALTER SYSTEM SET enable_dangerous_functions = true
+ALTER SYSTEM SET enable_unsafe_functions = true
 ----
 COMPLETE 0
 


### PR DESCRIPTION
This commit renames the feature flag `enable_dangerous_functions` to `enable_unsafe_functions`, because it matches our other terminology better.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
