### PR TITLE
environmentd: drop "external" from "aws connection role" parameter

### DIFF
--- a/src/adapter/src/catalog/config.rs
+++ b/src/adapter/src/catalog/config.rs
@@ -225,10 +225,6 @@ impl Default for ClusterReplicaSizeMap {
 pub struct AwsPrincipalContext {
     pub aws_account_id: String,
     pub aws_external_id_prefix: AwsExternalIdPrefix,
-    /// TODO(mouli): This is optional temporarily. Once the changes
-    /// (Github issue: <https://github.com/MaterializeInc/cloud/issues/8191>)
-    /// are in place to always pass this value, will make this required.
-    pub aws_external_connection_role: Option<String>,
 }
 
 impl AwsPrincipalContext {

--- a/src/adapter/src/coord.rs
+++ b/src/adapter/src/coord.rs
@@ -537,7 +537,6 @@ pub struct Config {
     pub egress_ips: Vec<Ipv4Addr>,
     pub system_parameter_sync_config: Option<SystemParameterSyncConfig>,
     pub aws_account_id: Option<String>,
-    pub aws_external_connection_role: Option<String>,
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     pub active_connection_count: Arc<Mutex<ConnectionCounter>>,
     pub webhook_concurrency_limit: WebhookConcurrencyLimiter,
@@ -2236,7 +2235,6 @@ pub fn serve(
         segment_client,
         egress_ips,
         aws_account_id,
-        aws_external_connection_role,
         aws_privatelink_availability_zones,
         system_parameter_sync_config,
         active_connection_count,
@@ -2265,15 +2263,11 @@ pub fn serve(
                 .connection_context()
                 .aws_external_id_prefix
                 .clone(),
-            aws_external_connection_role,
         ) {
-            (Some(aws_account_id), Some(aws_external_id_prefix), aws_external_connection_role) => {
-                Some(AwsPrincipalContext {
-                    aws_account_id,
-                    aws_external_id_prefix,
-                    aws_external_connection_role,
-                })
-            }
+            (Some(aws_account_id), Some(aws_external_id_prefix)) => Some(AwsPrincipalContext {
+                aws_account_id,
+                aws_external_id_prefix,
+            }),
             _ => None,
         };
 

--- a/src/environmentd/src/bin/environmentd/main.rs
+++ b/src/environmentd/src/bin/environmentd/main.rs
@@ -455,11 +455,6 @@ pub struct Args {
         value_name = "<CLOUD>-<REGION>-<ORG-ID>-<ORDINAL>"
     )]
     environment_id: EnvironmentId,
-    /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
-    ///
-    /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
-    #[clap(long, env = "AWS_EXTERNAL_ID_PREFIX", value_name = "ID", parse(from_str = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable))]
-    aws_external_id_prefix: Option<AwsExternalIdPrefix>,
     /// Availability zones in which storage and compute resources may be
     /// deployed.
     #[clap(long, env = "AVAILABILITY_ZONE", use_value_delimiter = true)]
@@ -554,14 +549,20 @@ pub struct Args {
     )]
     config_sync_loop_interval: Option<Duration>,
 
-    /// The 12-digit AWS account id, which is used to generate an AWS Principal.
+    // === AWS options. ===
+    /// The AWS account ID, which will be used to generate ARNs for
+    /// Materialize-controlled AWS resources.
     #[clap(long, env = "AWS_ACCOUNT_ID")]
     aws_account_id: Option<String>,
-
-    /// The Materialize role arn to assume when connecting to external user's AWS account.
-    #[clap(long, env = "AWS_EXTERNAL_CONNECTION_ROLE")]
-    aws_external_connection_role: Option<String>,
-
+    /// The ARN for a Materialize-controlled role to assume before assuming
+    /// a customer's requested role for an AWS connection.
+    #[clap(long, env = "AWS_CONNECTION_ROLE_ARN")]
+    aws_connection_role_arn: Option<String>,
+    /// Prefix for an external ID to be supplied to all AWS AssumeRole operations.
+    ///
+    /// Details: <https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html>
+    #[clap(long, env = "AWS_EXTERNAL_ID_PREFIX", value_name = "ID", parse(from_str = AwsExternalIdPrefix::new_from_cli_argument_or_environment_variable))]
+    aws_external_id_prefix: Option<AwsExternalIdPrefix>,
     /// The list of supported AWS PrivateLink availability zone ids.
     /// Must be zone IDs, of format e.g. "use-az1".
     #[clap(
@@ -571,7 +572,6 @@ pub struct Args {
         use_delimiter = true
     )]
     aws_privatelink_availability_zones: Option<Vec<String>>,
-
     /// The list of tags to be set on AWS Secrets Manager secrets created by the
     /// AwsSecretsController.
     #[clap(
@@ -997,7 +997,6 @@ fn run(mut args: Args) -> Result<(), anyhow::Error> {
                 segment_api_key: args.segment_api_key,
                 egress_ips: args.announce_egress_ip,
                 aws_account_id: args.aws_account_id,
-                aws_external_connection_role: args.aws_external_connection_role,
                 aws_privatelink_availability_zones: args.aws_privatelink_availability_zones,
                 launchdarkly_sdk_key: args.launchdarkly_sdk_key,
                 launchdarkly_key_map: args

--- a/src/environmentd/src/lib.rs
+++ b/src/environmentd/src/lib.rs
@@ -193,10 +193,9 @@ pub struct Config {
     pub segment_api_key: Option<String>,
     /// IP Addresses which will be used for egress.
     pub egress_ips: Vec<Ipv4Addr>,
-    /// 12-digit AWS account id, which will be used to generate an AWS Principal.
+    /// The AWS account ID, which will be used to generate ARNs for
+    /// Materialize-controlled AWS resources.
     pub aws_account_id: Option<String>,
-    /// The Materialize AWS role arn which will be used to connect to customer's AWS account.
-    pub aws_external_connection_role: Option<String>,
     /// Supported AWS PrivateLink availability zone ids.
     pub aws_privatelink_availability_zones: Option<Vec<String>>,
     /// An SDK key for LaunchDarkly. Enables system parameter synchronization
@@ -562,7 +561,6 @@ impl Listeners {
             egress_ips: config.egress_ips,
             system_parameter_sync_config: system_parameter_sync_config.clone(),
             aws_account_id: config.aws_account_id,
-            aws_external_connection_role: config.aws_external_connection_role,
             aws_privatelink_availability_zones: config.aws_privatelink_availability_zones,
             active_connection_count: Arc::clone(&active_connection_count),
             webhook_concurrency_limit: webhook_concurrency_limit.clone(),

--- a/src/environmentd/src/test_util.rs
+++ b/src/environmentd/src/test_util.rs
@@ -524,7 +524,6 @@ impl Listeners {
                 segment_api_key: None,
                 egress_ips: vec![],
                 aws_account_id: None,
-                aws_external_connection_role: None,
                 aws_privatelink_availability_zones: None,
                 launchdarkly_sdk_key: None,
                 launchdarkly_key_map: Default::default(),

--- a/src/sqllogictest/src/runner.rs
+++ b/src/sqllogictest/src/runner.rs
@@ -1044,7 +1044,6 @@ impl<'a> RunnerInner<'a> {
             segment_api_key: None,
             egress_ips: vec![],
             aws_account_id: None,
-            aws_external_connection_role: None,
             aws_privatelink_availability_zones: None,
             launchdarkly_sdk_key: None,
             launchdarkly_key_map: Default::default(),


### PR DESCRIPTION
Noticed while reviewing #23282.

----

I'd like to standardize on calling these "AWS connections" everywhere possible, without bringing "external" into the picture. "External" came from "external ID", but that's a standalone term of art, and I think it's clearer to call the role here just the "AWS connection role".  (If anything, the "external connection role" seems like the customer supplied role, not our internal intermediary role.)

Also unplumb the argument from the coordinator, since as mentioned in the review for #23282 I think we'll want to instead plumb this argument through the ConnectionContext.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

   * This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - n/a
