### PR TITLE
tests: re-enable PgCdcNoWait

### DIFF
--- a/misc/python/materialize/checks/all_checks/pg_cdc.py
+++ b/misc/python/materialize/checks/all_checks/pg_cdc.py
@@ -12,7 +12,7 @@ from textwrap import dedent
 from typing import Any
 
 from materialize.checks.actions import Testdrive
-from materialize.checks.checks import Check, disabled, externally_idempotent
+from materialize.checks.checks import Check, externally_idempotent
 from materialize.mz_version import MzVersion
 
 
@@ -221,7 +221,6 @@ class PgCdc(PgCdcBase, Check):
         super().__init__(wait=True, base_version=base_version, rng=rng)
 
 
-@disabled("requires #18940 to be fixed")
 @externally_idempotent(False)
 class PgCdcNoWait(PgCdcBase, Check):
     def __init__(self, base_version: MzVersion, rng: Random | None) -> None:


### PR DESCRIPTION
> Issue is referenced in comment but already closed: [#18940](https://github.com/MaterializeInc/materialize/issues/18940)
misc/python/materialize/checks/all_checks/pg_cdc.py:224: @disabled("requires #18940 to be fixed")

Nightly: https://buildkite.com/materialize/nightlies/builds/5494