### PR TITLE
Check for invalid characters in webhooks

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -346,6 +346,9 @@ After the source is created, you can connect with EventBridge. Follow
 using the shared secret specified in the `CHECK` statement (`x-mz-api-key`) as
 the **API key name** for request validation.
 
+## Invalid characters
+Incorporating certain characters into the database name, schema name or webhook name will lead to odd failure modes. For this reason, names incorporating '.', '..' or CRLF (character return  / line feed) are not allowed and will return an error.
+
 ## Related pages
 
 - [`CREATE SECRET`](/sql/create-secret)

--- a/src/environmentd/src/http/webhook.rs
+++ b/src/environmentd/src/http/webhook.rs
@@ -26,12 +26,25 @@ use bytes::Bytes;
 use http::StatusCode;
 use thiserror::Error;
 
+// Validate webhook does not contain invalid characters
+fn is_name_valid(name: &&str) -> bool {
+    let name = *name;
+    !(name == "." || name == ".." || name.contains('\r') || name.contains('\n'))
+}
+
 pub async fn handle_webhook(
     State(client): State<mz_adapter::Client>,
     Path((database, schema, name)): Path<(String, String, String)>,
     headers: http::HeaderMap,
     body: Bytes,
 ) -> impl IntoResponse {
+    // Validate names
+    if [database.as_str(), schema.as_str(), name.as_str()]
+        .iter()
+        .all(is_name_valid)
+    {
+        return Err(WebhookError::InvalidName);
+    }
     // Record the time we receive the request, for use if validation checks the current timestamp.
     let received_at = client.now();
     let conn_id = client.new_conn_id().context("allocate connection id")?;
@@ -195,6 +208,8 @@ pub enum WebhookError {
     InternalAdapterError(AdapterError),
     #[error("internal failure! {0:?}")]
     Internal(#[from] anyhow::Error),
+    #[error("invalid characters . or .. in webhook source fields")]
+    InvalidName,
 }
 
 impl From<StorageError> for WebhookError {
@@ -245,6 +260,9 @@ impl IntoResponse for WebhookError {
         match self {
             e @ WebhookError::NotFound(_) | e @ WebhookError::SecretMissing => {
                 (StatusCode::NOT_FOUND, e.to_string()).into_response()
+            }
+            e @ WebhookError::InvalidName => {
+                (StatusCode::BAD_REQUEST, e.to_string()).into_response()
             }
             e @ WebhookError::Unsupported(_)
             | e @ WebhookError::InvalidBody { .. }

--- a/src/sql/src/plan/error.rs
+++ b/src/sql/src/plan/error.rs
@@ -208,6 +208,7 @@ pub enum PlanError {
     VarError(VarError),
     UnsolvablePolymorphicFunctionInput,
     ShowCommandInView,
+    InvalidWebhookField,
     WebhookValidationDoesNotUseColumns,
     WebhookValidationNonDeterministic,
     InternalFunctionCall,
@@ -568,6 +569,7 @@ impl fmt::Display for PlanError {
                 "could not determine polymorphic type because input has type unknown"
             ),
             Self::ShowCommandInView => f.write_str("SHOW commands are not allowed in views"),
+            Self::InvalidWebhookField => f.write_str("webhook fields may not contain . or .."),
             Self::WebhookValidationDoesNotUseColumns => f.write_str(
                 "expression provided in CHECK does not reference any columns"
             ),

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -333,3 +333,12 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 
 # Cleanup.
 > DROP CLUSTER webhook_cluster CASCADE;
+
+# Test cases for invalid characters in webhook names
+! CREATE SOURCE "webhook_invalid_1" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT NAME ".";
+
+! CREATE SOURCE "webhook_invalid_2" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT NAME "..";
+
+! CREATE SOURCE "webhook_invalid_3" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT NAME "test..";
+
+! CREATE SOURCE "webhook_invalid_4" IN CLUSTER webhook_cluster FROM WEBHOOK BODY FORMAT TEXT NAME ".test";


### PR DESCRIPTION
Adds check to see if names of webhooks, databases, or schemas contain invalid characters and return an error if so.

### Motivation

  * This PR fixes [23247](https://github.com/MaterializeInc/materialize/issues/23247), flagged by Latacora during review of webhook implementation. 

### Tips for reviewer

Check added to both the handle_webhook function in webhook.rs and the webhook creation plan in ddl.rs. 

### Checklist

- [X] This PR includes the following user-facing behavior changes: invalid characters ".", "..", and CRLFs will now error. 