### PR TITLE
sql: Make is_similar check for UnknownColumn name error smarter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5072,6 +5072,7 @@ dependencies = [
  "serde_json",
  "smallvec",
  "static_assertions",
+ "strsim",
  "thiserror",
  "timely",
  "tokio-postgres",

--- a/src/repr/Cargo.toml
+++ b/src/repr/Cargo.toml
@@ -48,6 +48,7 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.89", features = ["arbitrary_precision"] }
 smallvec = { version = "1.10.0", features = ["serde", "union"] }
 static_assertions = "1.1"
+strsim = "0.10"
 timely = { version = "0.12.0", default-features = false, features = ["bincode"] }
 tokio-postgres = { version = "0.7.8" }
 tracing-core = "0.1.30"

--- a/src/repr/src/relation.rs
+++ b/src/repr/src/relation.rs
@@ -297,7 +297,12 @@ impl ColumnName {
 
     /// Returns if this [`ColumnName`] is similar to the provided one.
     pub fn is_similar(&self, other: &ColumnName) -> bool {
-        self.0.to_lowercase() == other.as_str().to_lowercase()
+        const SIMILARITY_THRESHOLD: f64 = 0.6;
+
+        let a_lowercase = self.0.to_lowercase();
+        let b_lowercase = other.as_str().to_lowercase();
+
+        strsim::normalized_levenshtein(&a_lowercase, &b_lowercase) >= SIMILARITY_THRESHOLD
     }
 }
 

--- a/test/sqllogictest/cockroach/case_sensitive_names.slt
+++ b/test/sqllogictest/cockroach/case_sensitive_names.slt
@@ -197,7 +197,7 @@ DROP TABLE "B"
 # Case sensitivity of column names.
 
 statement ok
-CREATE TABLE foo(X INT, "Y" INT)
+CREATE TABLE foo(X INT, "Y" INT, "created_AT" timestamp)
 
 query III colnames
 SELECT x, X, "Y" FROM foo
@@ -209,6 +209,12 @@ SELECT "X" FROM foo
 
 statement error column "y" does not exist\nHINT: The similarly named column "Y" does exist.
 SELECT Y FROM foo
+
+simple
+SELECT creaetd_at FROM foo
+----
+db error: ERROR: column "creaetd_at" does not exist
+HINT: The similarly named column "created_AT" does exist. Make sure to surround case sensitive names in double quotes.
 
 # The following should not be ambiguous.
 query II colnames


### PR DESCRIPTION
This PR changes the `is_similar(...)` function to not only make a case insensitive check, but to also use the `strsim` crate to check for cases where you have a typo, e.g. `creaed_at` instead of `created_at`.

### Motivation

Was chatting with Frank whose been writing a lot of large SQL statements lately, and this seems like an easy win.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Detecting similar column names is smarter.
