### PR TITLE
sql-pretty: add tests for exprs; fix and change some

### DIFF
--- a/src/sql-parser/src/ast/defs/expr.rs
+++ b/src/sql-parser/src/ast/defs/expr.rs
@@ -886,7 +886,7 @@ impl<T: AstInfo> FunctionArgs<T> {
     }
 
     /// Returns the number of arguments. Star (`*`) is None.
-    fn len(&self) -> Option<usize> {
+    pub fn len(&self) -> Option<usize> {
         match self {
             FunctionArgs::Star => None,
             FunctionArgs::Args { args, .. } => Some(args.len()),

--- a/src/sql-pretty/src/lib.rs
+++ b/src/sql-pretty/src/lib.rs
@@ -88,6 +88,8 @@ use crate::doc::{
     doc_select_statement, doc_subscribe,
 };
 
+pub use crate::doc::doc_expr;
+
 const TAB: isize = 4;
 
 fn to_doc<T: AstInfo>(v: &Statement<T>) -> RcDoc {

--- a/src/sql-pretty/tests/parser.rs
+++ b/src/sql-pretty/tests/parser.rs
@@ -78,8 +78,8 @@
 use datadriven::walk;
 use mz_sql_parser::ast::display::AstDisplay;
 use mz_sql_parser::datadriven_testcase;
-use mz_sql_parser::parser::parse_statements;
-use mz_sql_pretty::to_pretty;
+use mz_sql_parser::parser::{parse_expr, parse_statements};
+use mz_sql_pretty::{doc_expr, to_pretty};
 
 // Use the parser's datadriven tests to get a comprehensive set of SQL statements. Assert they all
 // generate identical ASTs when pretty printed. Output the same output as the parser so datadriven
@@ -89,15 +89,40 @@ use mz_sql_pretty::to_pretty;
 fn test_parser() {
     walk("../sql-parser/tests/testdata", |f| {
         f.run(|tc| -> String {
-            if tc.directive == "parse-statement" {
-                verify_pretty_print(&tc.input);
+            match tc.directive.as_str() {
+                "parse-statement" => {
+                    verify_pretty_statement(&tc.input);
+                }
+                "parse-scalar" => {
+                    verify_pretty_expr(&tc.input);
+                }
+                _ => {}
             }
             datadriven_testcase(tc)
         })
     });
 }
 
-fn verify_pretty_print(stmt: &str) {
+fn verify_pretty_expr(expr: &str) {
+    let Ok(original) = parse_expr(expr) else {
+        return;
+    };
+    for n in &[1, 40, 1000000] {
+        let n = *n;
+        let pretty1 = format!("{}", doc_expr(&original).pretty(n));
+        let prettied = parse_expr(&pretty1)
+            .unwrap_or_else(|_| panic!("could not parse: {pretty1}, original: {expr}"));
+        let pretty2 = format!("{}", doc_expr(&prettied).pretty(n));
+        assert_eq!(pretty1, pretty2);
+        assert_eq!(
+            original.to_ast_string_stable(),
+            prettied.to_ast_string_stable(),
+            "\noriginal: {expr}",
+        );
+    }
+}
+
+fn verify_pretty_statement(stmt: &str) {
     let original = match parse_statements(stmt) {
         Ok(stmt) => match stmt.into_iter().next() {
             Some(stmt) => stmt,
@@ -120,9 +145,7 @@ fn verify_pretty_print(stmt: &str) {
             prettied.ast.to_ast_string_stable(),
             "\noriginal: {stmt}",
         );
-        // Everything should always squash to a single line.
-        if n > (stmt.len() * 2) {
-            assert_eq!(pretty1.lines().count(), 1, "{}: {}", n, pretty1);
-        }
+        // It'd be nice to assert that this squashes to a single line at high Ns, but literals and
+        // idents can contain newlines so that's not always possible.
     }
 }


### PR DESCRIPTION
Exprs were assumed to be tested via statements, but that was wrong. Explicitly test exprs too and fix a number of bugs found. Change CAST to print with ::.

Fixes https://github.com/mjibson/mzfmt/issues/3

### Motivation

  * This PR fixes a previously unreported bug.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Fixes some errors when printing expressions in the `pretty_sql` function.