### PR TITLE
catalog: Refactor get_enable_persist_txn_tables

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -130,15 +130,6 @@ pub trait OpenableDurableCatalogState: Debug + Send {
     /// Get the deployment generation of this instance.
     async fn get_deployment_generation(&mut self) -> Result<Option<u64>, CatalogError>;
 
-    /// Get the `enabled_persist_txn_tables` config value of this instance.
-    ///
-    /// This mirrors the `enabled_persist_txn_tables` "system var" so that we
-    /// can toggle the flag with Launch Darkly, but use it in boot before Launch
-    /// Darkly is available.
-    async fn get_enable_persist_txn_tables(
-        &mut self,
-    ) -> Result<Option<EnablePersistTxnTables>, CatalogError>;
-
     /// Generate an unconsolidated [`Trace`] of catalog contents.
     async fn trace(&mut self) -> Result<Trace, CatalogError>;
 
@@ -185,6 +176,15 @@ pub trait ReadOnlyDurableCatalogState: Debug + Send {
     async fn get_next_user_replica_id(&mut self) -> Result<u64, CatalogError> {
         self.get_next_id(USER_REPLICA_ID_ALLOC_KEY).await
     }
+
+    /// Get the `enabled_persist_txn_tables` config value of this instance.
+    ///
+    /// This mirrors the `enabled_persist_txn_tables` "system var" so that we
+    /// can toggle the flag with Launch Darkly, but use it in boot before Launch
+    /// Darkly is available.
+    async fn get_enable_persist_txn_tables(
+        &mut self,
+    ) -> Result<Option<EnablePersistTxnTables>, CatalogError>;
 
     /// Get a snapshot of the catalog.
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError>;

--- a/src/catalog/src/durable/impls/shadow.rs
+++ b/src/catalog/src/durable/impls/shadow.rs
@@ -153,12 +153,6 @@ where
         compare_and_return_async!(self, get_deployment_generation)
     }
 
-    async fn get_enable_persist_txn_tables(
-        &mut self,
-    ) -> Result<Option<EnablePersistTxnTables>, CatalogError> {
-        compare_and_return_async!(self, get_enable_persist_txn_tables)
-    }
-
     async fn trace(&mut self) -> Result<Trace, CatalogError> {
         panic!("ShadowCatalog is not used for catalog-debug tool");
     }
@@ -340,6 +334,12 @@ impl ReadOnlyDurableCatalogState for ShadowCatalogState {
         } else {
             compare_and_return_async!(self, get_next_id, id_type)
         }
+    }
+
+    async fn get_enable_persist_txn_tables(
+        &mut self,
+    ) -> Result<Option<EnablePersistTxnTables>, CatalogError> {
+        compare_and_return_async!(self, get_enable_persist_txn_tables)
     }
 
     async fn snapshot(&mut self) -> Result<Snapshot, CatalogError> {


### PR DESCRIPTION
This commit moves get_enable_persist_txn_tables from the OpenableDurableCatalogState trait to the ReadOnlyDurableCatalogState trait. This value isn't actually needed until after the catalog is opened, so moving it simplifies the pre-open state of the catalog.


### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
