### PR TITLE
postgres consistency: remove ignore on timezone function

### DIFF
--- a/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
+++ b/misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py
@@ -109,9 +109,6 @@ class PgPreExecutionInconsistencyIgnoreFilter(
         ):
             return YesIgnore("inconsistent ordering, not an error")
 
-        if db_function.function_name_in_lower_case == "timezone":
-            return YesIgnore("#21999: timezone")
-
         if db_function.function_name_in_lower_case == "jsonb_pretty":
             return YesIgnore("Accepted")
 


### PR DESCRIPTION
> Issue is referenced in comment but already closed: [#21999](https://github.com/MaterializeInc/materialize/issues/21999)
misc/python/materialize/postgres_consistency/ignore_filter/pg_inconsistency_ignore_filter.py:111: return YesIgnore("#21999: timezone")