### PR TITLE
[DNM, EXPERIMENTAL] Tweak to consolidation of `persist_sink` `correction`

### DIFF
--- a/src/compute/src/sink/persist_sink.rs
+++ b/src/compute/src/sink/persist_sink.rs
@@ -607,6 +607,7 @@ where
             .open(persist_location)
             .await
             .expect("could not open persist client");
+        let mut sink_worker_metrics = persist_client.metrics().sink.for_worker(worker_index);
 
         let mut write = persist_client
             .open_writer::<SourceData, (), Timestamp, Diff>(
@@ -774,6 +775,10 @@ where
                 );
 
                 if !ready_batches.is_empty() {
+                    // Prior to potentially reducing the size of the `correction`
+                    // buffer, report its length.
+                    sink_worker_metrics.report_correction_len(correction.len());
+
                     // Consolidate updates only when they are required by an
                     // attempt to write out new updates. Otherwise, we might
                     // spend a lot of time "consolidating" the same updates

--- a/test/cluster/mzcompose.py
+++ b/test/cluster/mzcompose.py
@@ -2340,6 +2340,11 @@ def workflow_test_replica_metrics(c: Composition) -> None:
     delayed_time = metrics.get_value("mz_dataflow_delayed_time_seconds_total")
     assert delayed_time < 1, f"unexpected delayed time: {delayed_time}"
 
+    mv_correction = metrics.get_value("mz_persist_sink_correction_max_len")
+    assert (
+        mv_correction > 0
+    ), f"unexpected persist sink maximum correction length: {mv_correction}"
+
 
 def workflow_test_compute_controller_metrics(c: Composition) -> None:
     """Test metrics exposed by the compute controller."""


### PR DESCRIPTION
This PR adds a metric, `mz_persist_sink_correction_max_len`, that captures the maximum number of updates seen in the `correction` buffer per worker across all instances of `persist_sink`. The metric should correlate with the memory spike produced by instances of `persist_sink` during hydration, but not model it perfectly. This is because concurrent (as opposed to sequential) hydration can create conditions where the peaks introduced by multiple instances of `persist_sink` reinforce each other. Under sequential hydration, this metric would give us an upper bound on the length of the buffer that we would expect to see.

This PR also introduces a small change to the consolidation policy of the `correction` buffer in the `write_batches` operator of `persist_sink`. The previous consolidation moments are extended to also include doublings of the correction buffer. This should not be of much effectiveness when inputs are consolidated, except for timing issues with batch readiness, but can provide benefits when inputs are not. At the same time, the overhead introduced is expected to be manageable in the scenarios where the buffer grows, especially for hydration.

Advances #22881.

### Motivation

  * This PR adds a known-desirable feature. Provides some results supporting https://github.com/MaterializeInc/materialize/pull/23646. Only experimental, not to be merged!

### Tips for reviewer

A simple evaluation of this metric is captured in an [internal doc](https://www.notion.so/materialize/Simple-Evaluation-of-persist_sink-Memory-Spikes-c75568f1acf54b5695df3166b932ccf7). What we see there is that in single materialized-view settings, the metric correlates well with peak memory usage, reached during hydration. However, after the tweak, the metric is somewhat unreliable, as it shows less records but similar or even higher peak memory usage.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [x] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [x] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
