### PR TITLE
ci: Enable disk replicas by default

### DIFF
--- a/misc/kind/cluster.yaml
+++ b/misc/kind/cluster.yaml
@@ -155,35 +155,35 @@ nodes:
 
   - role: worker
     labels:
-      materialize.cloud/disk: false
+      materialize.cloud/disk: true
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
   - role: worker
     labels:
-      materialize.cloud/disk: false
+      materialize.cloud/disk: true
       materialize.cloud/availability-zone: "2"
       topology.kubernetes.io/zone: "2"
   - role: worker
     labels:
-      materialize.cloud/disk: false
+      materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
 
-  # disk
+  # no-disk
   - role: worker
     labels:
-      materialize.cloud/disk: true
+      materialize.cloud/disk: false
       materialize.cloud/availability-zone: "1"
       topology.kubernetes.io/zone: "1"
 
   # others
   - role: worker
     labels:
-      materialize.cloud/disk: false
+      materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"
   - role: worker
     labels:
-      materialize.cloud/disk: false
+      materialize.cloud/disk: true
       materialize.cloud/availability-zone: "3"
       topology.kubernetes.io/zone: "3"

--- a/misc/python/materialize/mzcompose/__init__.py
+++ b/misc/python/materialize/mzcompose/__init__.py
@@ -53,6 +53,7 @@ DEFAULT_SYSTEM_PARAMETERS = {
     # Old name of `enable_unsafe_functions`.
     "enable_dangerous_functions": "true",
     "enable_disk_cluster_replicas": "true",
+    "disk_cluster_replicas_default": "true",
     "statement_logging_max_sample_rate": "0.01",
     "statement_logging_default_sample_rate": "0.01",
     # Following values are set based on Load Test environment to

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-sink.td
@@ -25,4 +25,4 @@ materialize_public_upgrade_kafka_sink  linked
     details->>'cluster_name' = 'materialize_public_upgrade_kafka_sink'
   ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_upgrade_kafka_sink\"}"
-create  cluster-replica  "{\"cluster_name\":\"materialize_public_upgrade_kafka_sink\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"
+create  cluster-replica  "{\"cluster_name\":\"materialize_public_upgrade_kafka_sink\",\"disk\":true,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"

--- a/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
+++ b/test/legacy-upgrade/check-from-v0.27.0-kafka-source.td
@@ -54,4 +54,4 @@ materialize_public_kafka_source  linked
     details->>'cluster_name' = 'materialize_public_kafka_source'
   ) AND user IS NOT NULL
 create  cluster          "{\"name\":\"materialize_public_kafka_source\"}"  ${expected-user}
-create  cluster-replica  "{\"cluster_name\":\"materialize_public_kafka_source\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"  ${expected-user}
+create  cluster-replica  "{\"cluster_name\":\"materialize_public_kafka_source\",\"disk\":true,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}"  ${expected-user}

--- a/test/sqllogictest/audit_log.slt
+++ b/test/sqllogictest/audit_log.slt
@@ -116,7 +116,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 25  create  role  {"id":"u2","name":"foo"}  materialize
 26  drop  role  {"id":"u2","name":"foo"}  materialize
 27  create  cluster  {"id":"u2","name":"foo"}  materialize
-28  create  cluster-replica  {"billed_as":null,"cluster_id":"u2","cluster_name":"foo","disk":false,"internal":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
+28  create  cluster-replica  {"billed_as":null,"cluster_id":"u2","cluster_name":"foo","disk":true,"internal":false,"logical_size":"1","replica_id":"u2","replica_name":"r"}  materialize
 29  create  materialized-view  {"database":"materialize","id":"u1","item":"v2","schema":"public"}  materialize
 30  create  view  {"database":"materialize","id":"u2","item":"unmat","schema":"public"}  materialize
 31  create  table  {"database":"materialize","id":"u3","item":"t","schema":"public"}  materialize
@@ -129,10 +129,10 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 38  drop  view  {"database":"materialize","id":"u2","item":"renamed","schema":"public"}  materialize
 39  create  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public","size":null,"type":"progress"}  materialize
 40  create  cluster  {"id":"u3","name":"materialize_public_s"}  materialize
-41  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"internal":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
+41  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":true,"internal":false,"logical_size":"1","replica_id":"u3","replica_name":"linked"}  materialize
 42  create  source  {"database":"materialize","id":"u8","item":"s","schema":"public","size":"1","type":"load-generator"}  materialize
 43  drop  cluster-replica  {"cluster_id":"u3","cluster_name":"materialize_public_s","replica_id":"u3","replica_name":"linked"}  materialize
-44  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":false,"internal":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
+44  create  cluster-replica  {"billed_as":null,"cluster_id":"u3","cluster_name":"materialize_public_s","disk":true,"internal":false,"logical_size":"2","replica_id":"u4","replica_name":"linked"}  materialize
 45  alter  source  {"database":"materialize","id":"u8","item":"s","new_size":"2","old_size":"1","schema":"public"}  materialize
 46  drop  source  {"database":"materialize","id":"u7","item":"s_progress","schema":"public"}  materialize
 47  drop  source  {"database":"materialize","id":"u8","item":"s","schema":"public"}  materialize
@@ -145,7 +145,7 @@ SELECT id, event_type, object_type, details, user FROM mz_audit_events ORDER BY 
 54  create  source  {"database":"materialize","id":"u13","item":"users","schema":"public","size":null,"type":"subsource"}  materialize
 55  create  source  {"database":"materialize","id":"u14","item":"multiplex_progress","schema":"public","size":null,"type":"progress"}  materialize
 56  create  cluster  {"id":"u4","name":"materialize_public_multiplex"}  materialize
-57  create  cluster-replica  {"billed_as":null,"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":false,"internal":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
+57  create  cluster-replica  {"billed_as":null,"cluster_id":"u4","cluster_name":"materialize_public_multiplex","disk":true,"internal":false,"logical_size":"1","replica_id":"u5","replica_name":"linked"}  materialize
 58  create  source  {"database":"materialize","id":"u15","item":"multiplex","schema":"public","size":"1","type":"load-generator"}  materialize
 59  alter  cluster-replica  {"cluster_id":"u2","new_name":"s","old_name":"r","replica_id":"u2"}  materialize
 60  alter  cluster  {"id":"u2","new_name":"bar","old_name":"foo"}  materialize

--- a/test/sqllogictest/cluster.slt
+++ b/test/sqllogictest/cluster.slt
@@ -692,7 +692,7 @@ db error: ERROR: cannot modify managed cluster t1
 query TTTT
 SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
 ----
-create  cluster-replica  {"billed_as":"free","cluster_id":"u2","cluster_name":"t1","disk":false,"internal":true,"logical_size":"2","replica_id":"u4","replica_name":"free"}  mz_system
+create  cluster-replica  {"billed_as":"free","cluster_id":"u2","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"u4","replica_name":"free"}  mz_system
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER REPLICA t1.r123 SIZE '2', BILLED AS 'free'
@@ -753,7 +753,7 @@ COMPLETE 0
 query TTTT
 SELECT event_type, object_type, details, user FROM mz_audit_events ORDER BY occurred_at DESC LIMIT 1;
 ----
-create  cluster-replica  {"billed_as":"free","cluster_id":"u4","cluster_name":"t1","disk":false,"internal":true,"logical_size":"2","replica_id":"u8","replica_name":"free"}  mz_system
+create  cluster-replica  {"billed_as":"free","cluster_id":"u4","cluster_name":"t1","disk":true,"internal":true,"logical_size":"2","replica_id":"u8","replica_name":"free"}  mz_system
 
 simple conn=mz_system,user=mz_system
 CREATE CLUSTER REPLICA t1.internal_r2 SIZE '2', INTERNAL

--- a/test/sqllogictest/managed_cluster.slt
+++ b/test/sqllogictest/managed_cluster.slt
@@ -411,8 +411,8 @@ COMPLETE 0
 statement ok
 CREATE CLUSTER foo REPLICAS (r1 (SIZE '1'), r2 (SIZE '1', DISK))
 
-statement error db error: ERROR: Cannot convert unmanaged cluster to managed, non-unique replica DISK options
-ALTER CLUSTER foo SET (MANAGED, SIZE '1')
+statement error db error: ERROR: Cluster replicas with DISK true do not match expected DISK false
+ALTER CLUSTER foo SET (MANAGED, DISK=False, SIZE '1')
 
 statement ok
 DROP CLUSTER foo
@@ -420,8 +420,8 @@ DROP CLUSTER foo
 statement ok
 CREATE CLUSTER foo REPLICAS (r1 (SIZE '1'))
 
-statement error db error: ERROR: Cluster replicas with DISK false do not match expected DISK true
-ALTER CLUSTER foo SET (MANAGED, SIZE '1', DISK)
+statement error db error: ERROR: Cluster replicas with DISK true do not match expected DISK false
+ALTER CLUSTER foo SET (MANAGED, SIZE '1', DISK=False)
 
 statement ok
 DROP CLUSTER foo

--- a/test/testdrive/audit-log.td
+++ b/test/testdrive/audit-log.td
@@ -23,7 +23,7 @@ $ kafka-create-topic topic=test
 
 > SELECT event_type, object_type, details - 'replica_id' - 'billed_as' - 'internal', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
 create  cluster "{\"id\":\"<GID>\",\"name\":\"materialize_public_kafka_src\"}"  materialize
-create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_kafka_src\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
+create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_kafka_src\",\"disk\":true,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
 create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"kafka_src\",\"schema\":\"public\",\"size\":\"${arg.default-storage-size}\",\"type\":\"kafka\"}"  materialize
 
 > CREATE SOURCE counter_src
@@ -31,7 +31,7 @@ create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"kafka
 
 > SELECT event_type, object_type, details - 'replica_id' - 'billed_as' - 'internal', user FROM mz_audit_events ORDER BY id DESC LIMIT 3
 create  cluster "{\"id\":\"<GID>\",\"name\":\"materialize_public_counter_src\"}"  materialize
-create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_counter_src\",\"disk\":false,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
+create  cluster-replica "{\"cluster_id\":\"<GID>\",\"cluster_name\":\"materialize_public_counter_src\",\"disk\":true,\"logical_size\":\"${arg.default-storage-size}\",\"replica_name\":\"linked\"}" materialize
 create  source  "{\"database\":\"materialize\",\"id\":\"<GID>\",\"item\":\"counter_src\",\"schema\":\"public\",\"size\":\"${arg.default-storage-size}\",\"type\":\"load-generator\"}"  materialize
 
 > DROP SOURCE counter_src

--- a/test/testdrive/disk-feature-flag.td
+++ b/test/testdrive/disk-feature-flag.td
@@ -59,6 +59,9 @@ r2 1 true
 
 > DROP CLUSTER c;
 
+$ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
+ALTER SYSTEM RESET disk_cluster_replicas_default
+
 # Can disable whether disk-backed replicas are allowed
 $ postgres-execute connection=postgres://mz_system:materialize@${testdrive.materialize-internal-sql-addr}
 ALTER SYSTEM SET enable_disk_cluster_replicas = false

--- a/test/upsert/mzcompose.py
+++ b/test/upsert/mzcompose.py
@@ -431,7 +431,7 @@ def workflow_autospill(c: Composition) -> None:
                 "--orchestrator-process-scratch-directory=/mzdata/source_data",
             ],
             additional_system_parameter_defaults={
-                "upsert_source_disk_default": "true",
+                "disk_cluster_replicas_default": "false",
                 "upsert_rocksdb_auto_spill_to_disk": "true",
                 "upsert_rocksdb_auto_spill_threshold_bytes": "200",
                 "storage_dataflow_delay_sources_past_rehydration": "true",


### PR DESCRIPTION
disk_cluster_replicas_default needs to be enabled in addition to enable_disk_cluster_replicas

Relates to: #19245

### Motivation

disk replicas were not being tested in Nightly