### PR TITLE
Update to Differential with GATs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1723,7 +1723,7 @@ checksum = "0e25ea47919b1560c4e3b7fe0aaab9becf5b84a10325ddf7db0f0ba5e1026499"
 [[package]]
 name = "differential-dataflow"
 version = "0.12.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#9623aaad1020b799e43c6e59d93624d6c8449699"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
 dependencies = [
  "abomonation",
  "abomonation_derive",
@@ -1780,7 +1780,7 @@ checksum = "923dea538cea0aa3025e8685b20d6ee21ef99c4f77e954a30febbaac5ec73a97"
 [[package]]
 name = "dogsdogsdogs"
 version = "0.1.0"
-source = "git+https://github.com/MaterializeInc/differential-dataflow.git#9623aaad1020b799e43c6e59d93624d6c8449699"
+source = "git+https://github.com/MaterializeInc/differential-dataflow.git#1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
 dependencies = [
  "abomonation",
  "abomonation_derive",

--- a/misc/cargo-vet/audits.toml
+++ b/misc/cargo-vet/audits.toml
@@ -23,7 +23,7 @@ version = "0.26.0"
 [[audits.differential-dataflow]]
 who = "Moritz Hoffmann <mh@materialize.com>"
 criteria = "safe-to-deploy"
-version = "0.12.0@git:9623aaad1020b799e43c6e59d93624d6c8449699"
+version = "0.12.0@git:1bb6dc6d54a5e1f56f2e489cd8471b766d8caed5"
 
 [[audits.futures-timer]]
 who = "Roshan Jobanputra <roshan@materialize.com>"

--- a/src/compute/src/compute_state.rs
+++ b/src/compute/src/compute_state.rs
@@ -971,9 +971,16 @@ impl IndexPeek {
         max_result_size: u32,
     ) -> Result<Vec<(Row, NonZeroUsize)>, String>
     where
-        Tr: TraceReader<Key = K, Val = V, Time = Timestamp, Diff = Diff>,
-        Tr::Key: Columnation + Data + FromRowByTypes + IntoRowByTypes,
-        Tr::Val: Columnation + Data + IntoRowByTypes,
+        Tr: for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V,
+            ValOwned = V,
+            Time = Timestamp,
+            Diff = Diff,
+        >,
+        Tr::KeyOwned: Columnation + Data + FromRowByTypes + IntoRowByTypes,
+        Tr::ValOwned: Columnation + Data + IntoRowByTypes,
     {
         let max_result_size = usize::cast_from(max_result_size);
         let count_byte_size = std::mem::size_of::<NonZeroUsize>();

--- a/src/compute/src/extensions/reduce.rs
+++ b/src/compute/src/extensions/reduce.rs
@@ -32,12 +32,15 @@ where
     /// Applies `reduce` to arranged data, and returns an arrangement of output data.
     fn mz_reduce_abelian<L, T2>(&self, name: &str, logic: L) -> Arranged<G, TraceAgent<T2>>
     where
-        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
-        T2::Val: Data,
+        T2: Trace
+            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + 'static,
+        T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder: Builder<Output = T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::Diff)>,
-        L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::Diff)>) + 'static,
+        T2::Builder:
+            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        L: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {
         // Allow access to `reduce_abelian` since we're within Mz's wrapper.
@@ -54,7 +57,14 @@ where
     K: Data,
     V: Data,
     R: Semigroup,
-    T1: TraceReader<Key = K, Val = V, Time = G::Timestamp, Diff = R> + Clone + 'static,
+    T1: for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V,
+            Time = G::Timestamp,
+            Diff = R,
+        > + Clone
+        + 'static,
 {
 }
 
@@ -77,18 +87,24 @@ where
         logic2: L2,
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
     where
-        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
-        T1::Val: Data,
+        T1: Trace
+            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + 'static,
+        T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
-        T1::Builder: Builder<Output = T1::Batch, Item = ((T1::Key, T1::Val), T1::Time, T1::Diff)>,
-        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::Diff)>) + 'static,
-        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
-        T2::Val: Data,
+        T1::Builder:
+            Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::ValOwned, T1::Diff)>) + 'static,
+        T2: Trace
+            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + 'static,
+        T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder: Builder<Output = T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::Diff)>,
-        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::Diff)>) + 'static,
+        T2::Builder:
+            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
         Arranged<G, TraceAgent<T2>>: ArrangementSize;
 }
@@ -96,7 +112,14 @@ where
 impl<G: Scope, K: Data, V: Data, Tr, R: Semigroup> ReduceExt<G, K, V, R> for Arranged<G, Tr>
 where
     G::Timestamp: Lattice + Ord,
-    Tr: TraceReader<Key = K, Val = V, Time = G::Timestamp, Diff = R> + Clone + 'static,
+    Tr: for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V,
+            Time = G::Timestamp,
+            Diff = R,
+        > + Clone
+        + 'static,
 {
     fn reduce_pair<L1, T1, L2, T2>(
         &self,
@@ -106,18 +129,24 @@ where
         logic2: L2,
     ) -> (Arranged<G, TraceAgent<T1>>, Arranged<G, TraceAgent<T2>>)
     where
-        T1: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
-        T1::Val: Data,
+        T1: Trace
+            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + 'static,
+        T1::ValOwned: Data,
         T1::Diff: Abelian,
         T1::Batch: Batch,
-        T1::Builder: Builder<Output = T1::Batch, Item = ((T1::Key, T1::Val), T1::Time, T1::Diff)>,
-        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::Val, T1::Diff)>) + 'static,
-        T2: Trace + TraceReader<Key = K, Time = G::Timestamp> + 'static,
-        T2::Val: Data,
+        T1::Builder:
+            Builder<Output = T1::Batch, Item = ((T1::KeyOwned, T1::ValOwned), T1::Time, T1::Diff)>,
+        L1: FnMut(&K, &[(&V, R)], &mut Vec<(T1::ValOwned, T1::Diff)>) + 'static,
+        T2: Trace
+            + for<'a> TraceReader<Key<'a> = &'a K, KeyOwned = K, Time = G::Timestamp>
+            + 'static,
+        T2::ValOwned: Data,
         T2::Diff: Abelian,
         T2::Batch: Batch,
-        T2::Builder: Builder<Output = T2::Batch, Item = ((T2::Key, T2::Val), T2::Time, T2::Diff)>,
-        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::Val, T2::Diff)>) + 'static,
+        T2::Builder:
+            Builder<Output = T2::Batch, Item = ((T2::KeyOwned, T2::ValOwned), T2::Time, T2::Diff)>,
+        L2: FnMut(&K, &[(&V, R)], &mut Vec<(T2::ValOwned, T2::Diff)>) + 'static,
         Arranged<G, TraceAgent<T1>>: ArrangementSize,
         Arranged<G, TraceAgent<T2>>: ArrangementSize,
     {

--- a/src/compute/src/render/join/delta_join.rs
+++ b/src/compute/src/render/join/delta_join.rs
@@ -422,7 +422,15 @@ fn build_halfjoin<G, Tr, CF, K, V>(
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
-    Tr: TraceReader<Time = G::Timestamp, Key = K, Val = V, Diff = Diff> + Clone + 'static,
+    Tr: for<'a> TraceReader<
+            Time = G::Timestamp,
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V,
+            ValOwned = V,
+            Diff = Diff,
+        > + Clone
+        + 'static,
     K: ExchangeData + FromRowByTypes + Hashable + IntoRowByTypes,
     V: ExchangeData + IntoRowByTypes,
     CF: Fn(&G::Timestamp, &G::Timestamp) -> bool + 'static,
@@ -610,7 +618,9 @@ fn build_update_stream<G, Tr, K, V>(
 where
     G: Scope,
     G::Timestamp: crate::render::RenderTimestamp,
-    Tr: TraceReader<Time = G::Timestamp, Key = K, Val = V, Diff = Diff> + Clone + 'static,
+    Tr: for<'a> TraceReader<Time = G::Timestamp, Key<'a> = &'a K, Val<'a> = &'a V, Diff = Diff>
+        + Clone
+        + 'static,
     K: Columnation + ExchangeData + FromRowByTypes + Hashable + IntoRowByTypes,
     V: Columnation + ExchangeData + IntoRowByTypes,
 {

--- a/src/compute/src/render/join/linear_join.rs
+++ b/src/compute/src/render/join/linear_join.rs
@@ -82,9 +82,25 @@ impl LinearJoinSpec {
     where
         G: Scope,
         G::Timestamp: Lattice,
-        Tr1: TraceReader<Key = K, Val = V1, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-        Tr2: TraceReader<Key = K, Val = V2, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-        L: FnMut(&Tr1::Key, &Tr1::Val, &Tr2::Val) -> I + 'static,
+        Tr1: for<'a> TraceReader<
+                Key<'a> = &'a K,
+                KeyOwned = K,
+                Val<'a> = &'a V1,
+                ValOwned = V1,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + Clone
+            + 'static,
+        Tr2: for<'a> TraceReader<
+                Key<'a> = &'a K,
+                KeyOwned = K,
+                Val<'a> = &'a V2,
+                ValOwned = V2,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + Clone
+            + 'static,
+        L: FnMut(Tr1::Key<'_>, Tr1::Val<'_>, Tr2::Val<'_>) -> I + 'static,
         I: IntoIterator,
         I::Item: Data,
         K: Data,
@@ -410,8 +426,24 @@ where
     )
     where
         S: Scope<Timestamp = G::Timestamp>,
-        Tr1: TraceReader<Key = K, Val = V1, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-        Tr2: TraceReader<Key = K, Val = V2, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
+        Tr1: for<'a> TraceReader<
+                Key<'a> = &'a K,
+                KeyOwned = K,
+                Val<'a> = &'a V1,
+                ValOwned = V1,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + Clone
+            + 'static,
+        Tr2: for<'a> TraceReader<
+                Key<'a> = &'a K,
+                KeyOwned = K,
+                Val<'a> = &'a V2,
+                ValOwned = V2,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + Clone
+            + 'static,
         K: Data + IntoRowByTypes,
         V1: Data + IntoRowByTypes,
         V2: Data + IntoRowByTypes,

--- a/src/compute/src/render/join/mz_join_core.rs
+++ b/src/compute/src/render/join/mz_join_core.rs
@@ -74,9 +74,25 @@ pub(super) fn mz_join_core<G, Tr1, Tr2, L, I, K, V1, V2, YFn>(
 where
     G: Scope,
     G::Timestamp: Lattice,
-    Tr1: TraceReader<Key = K, Val = V1, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    Tr2: TraceReader<Key = K, Val = V2, Time = G::Timestamp, Diff = Diff> + Clone + 'static,
-    L: FnMut(&Tr1::Key, &Tr1::Val, &Tr2::Val) -> I + 'static,
+    Tr1: for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V1,
+            ValOwned = V1,
+            Time = G::Timestamp,
+            Diff = Diff,
+        > + Clone
+        + 'static,
+    Tr2: for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V2,
+            ValOwned = V2,
+            Time = G::Timestamp,
+            Diff = Diff,
+        > + Clone
+        + 'static,
+    L: FnMut(Tr1::Key<'_>, Tr1::Val<'_>, Tr2::Val<'_>) -> I + 'static,
     I: IntoIterator,
     I::Item: Data,
     K: Data,
@@ -389,8 +405,22 @@ where
 struct Deferred<T, C1, C2, D, K, V1, V2>
 where
     T: Timestamp,
-    C1: Cursor<Key = K, Val = V1, Time = T, Diff = Diff>,
-    C2: Cursor<Key = K, Val = V2, Time = T, Diff = Diff>,
+    C1: for<'a> Cursor<
+        Key<'a> = &'a K,
+        KeyOwned = K,
+        Val<'a> = &'a V1,
+        ValOwned = V1,
+        Time = T,
+        Diff = Diff,
+    >,
+    C2: for<'a> Cursor<
+        Key<'a> = &'a K,
+        KeyOwned = K,
+        Val<'a> = &'a V2,
+        ValOwned = V2,
+        Time = T,
+        Diff = Diff,
+    >,
 {
     cursor1: C1,
     storage1: C1::Storage,
@@ -404,8 +434,22 @@ where
 impl<T, C1, C2, D, K, V1, V2> Deferred<T, C1, C2, D, K, V1, V2>
 where
     T: Timestamp + Lattice,
-    C1: Cursor<Key = K, Val = V1, Time = T, Diff = Diff>,
-    C2: Cursor<Key = K, Val = V2, Time = T, Diff = Diff>,
+    C1: for<'a> Cursor<
+        Key<'a> = &'a K,
+        KeyOwned = K,
+        Val<'a> = &'a V1,
+        ValOwned = V1,
+        Time = T,
+        Diff = Diff,
+    >,
+    C2: for<'a> Cursor<
+        Key<'a> = &'a K,
+        KeyOwned = K,
+        Val<'a> = &'a V2,
+        ValOwned = V2,
+        Time = T,
+        Diff = Diff,
+    >,
     D: Data,
     K: Data,
     V1: Data,
@@ -442,7 +486,7 @@ where
         work: &mut usize,
     ) where
         I: IntoIterator<Item = D>,
-        L: FnMut(&C1::Key, &C1::Val, &C2::Val) -> I,
+        L: FnMut(C1::Key<'_>, C1::Val<'_>, C2::Val<'_>) -> I,
         YFn: Fn(usize) -> bool,
     {
         let meet = self.capability.time();

--- a/src/compute/src/render/reduce.rs
+++ b/src/compute/src/render/reduce.rs
@@ -466,7 +466,15 @@ where
     )
     where
         S: Scope<Timestamp = G::Timestamp>,
-        Tr: Trace + TraceReader<Key = Row, Val = V, Time = G::Timestamp, Diff = Diff> + 'static,
+        Tr: Trace
+            + for<'a> TraceReader<
+                Key<'a> = &'a Row,
+                KeyOwned = Row,
+                Val<'a> = &'a V,
+                ValOwned = V,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = ((Row, V), G::Timestamp, Diff)>,
         V: Columnation + Default + ExchangeData + IntoRowByTypes,
@@ -679,8 +687,14 @@ where
         S: Scope<Timestamp = G::Timestamp>,
         V: MaybeValidatingRow<(), String>,
         Tr: Trace
-            + TraceReader<Key = (Row, Row), Val = V, Time = G::Timestamp, Diff = Diff>
-            + 'static,
+            + for<'a> TraceReader<
+                Key<'a> = &'a (Row, Row),
+                KeyOwned = (Row, Row),
+                Val<'a> = &'a V,
+                ValOwned = V,
+                Time = G::Timestamp,
+                Diff = Diff,
+            > + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = (((Row, Row), V), G::Timestamp, Diff)>,
         Arranged<S, TraceAgent<Tr>>: ArrangementSize,

--- a/src/compute/src/render/threshold.rs
+++ b/src/compute/src/render/threshold.rs
@@ -39,9 +39,17 @@ fn threshold_arrangement<G, Tr, K, V, T, R, L>(
 where
     G: Scope,
     G::Timestamp: Lattice + Refines<T> + Columnation,
-    Tr: Trace + TraceReader<Key = K, Val = V, Time = G::Timestamp, Diff = Diff> + 'static,
-    Tr::Key: Columnation + Data,
-    Tr::Val: Columnation + Data,
+    Tr: Trace
+        + for<'a> TraceReader<
+            Key<'a> = &'a K,
+            KeyOwned = K,
+            Val<'a> = &'a V,
+            ValOwned = V,
+            Time = G::Timestamp,
+            Diff = Diff,
+        > + 'static,
+    Tr::KeyOwned: Columnation + Data,
+    Tr::ValOwned: Columnation + Data,
     Tr::Batch: Batch,
     Tr::Batcher: Batcher<Item = ((K, V), G::Timestamp, Diff)>,
     T: Timestamp + Lattice,

--- a/src/interchange/src/envelopes.rs
+++ b/src/interchange/src/envelopes.rs
@@ -36,7 +36,13 @@ pub fn combine_at_timestamp<G: Scope, Tr>(
 ) -> Collection<G, (Option<Row>, Vec<DiffPair<Row>>), Diff>
 where
     G::Timestamp: Lattice + Copy,
-    Tr: Clone + TraceReader<Key = Option<Row>, Val = Row, Time = G::Timestamp, Diff = Diff>,
+    Tr: Clone
+        + for<'a> TraceReader<
+            Key<'a> = &'a Option<Row>,
+            Val<'a> = &'a Row,
+            Time = G::Timestamp,
+            Diff = Diff,
+        >,
     Tr::Batch: Batch,
 {
     let mut rows_buf = vec![];
@@ -60,7 +66,8 @@ where
                             while cursor.val_valid(&batch) {
                                 let v = cursor.val(&batch);
                                 cursor.map_times(&batch, |&t, &diff| {
-                                    let update = (t, v, usize::cast_from(diff.unsigned_abs()));
+                                    let update =
+                                        (t, v.clone(), usize::cast_from(diff.unsigned_abs()));
                                     if diff < 0 {
                                         befores.push(update);
                                     } else {

--- a/src/timely-util/src/operator.rs
+++ b/src/timely-util/src/operator.rs
@@ -232,7 +232,9 @@ where
         D1: differential_dataflow::ExchangeData + Hash,
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice,
-        Tr: Trace + TraceReader<Key = D1, Val = (), Time = G::Timestamp, Diff = R> + 'static,
+        Tr: Trace
+            + for<'a> TraceReader<Key<'a> = &'a D1, Val<'a> = &'a (), Time = G::Timestamp, Diff = R>
+            + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
         Tr::Builder:
@@ -548,7 +550,9 @@ where
         D1: differential_dataflow::ExchangeData + Hash,
         R: Semigroup + differential_dataflow::ExchangeData,
         G::Timestamp: Lattice + Ord,
-        Tr: Trace + TraceReader<Key = D1, Val = (), Time = G::Timestamp, Diff = R> + 'static,
+        Tr: Trace
+            + for<'a> TraceReader<Key<'a> = &'a D1, Val<'a> = &'a (), Time = G::Timestamp, Diff = R>
+            + 'static,
         Tr::Batch: Batch,
         Tr::Batcher: Batcher<Item = ((D1, ()), G::Timestamp, R), Time = G::Timestamp>,
         Tr::Builder:


### PR DESCRIPTION
Update our dependency on Differential to support GATs. At the moment, it's not using any of the features exposed by GATs, just making it compatible.

### Motivation

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
