### PR TITLE
doc: document ALTER CONNECTION...(SET|RESET|DROP)

### DIFF
--- a/doc/user/content/sql/alter-connection.md
+++ b/doc/user/content/sql/alter-connection.md
@@ -1,23 +1,49 @@
 ---
 title: "ALTER CONNECTION"
-description: "`ALTER CONNECTION` rotates the key pairs associated with an SSH tunnel connection."
+description: "`ALTER CONNECTION` changes the connection's configuration"
 menu:
-  main:
-    parent: 'commands'
+    main:
+        parent: "commands"
 ---
 
-`ALTER CONNECTION` rotates the key pairs associated with an
-[SSH tunnel connection].
+`ALTER CONNECTION` can:
+
+-   Modify the connection's parameters, such as the hostname to which it points.
+-   Rotate the key pairs associated with an [SSH tunnel connection].
 
 ## Syntax
 
 {{< diagram "alter-connection.svg" >}}
 
-Field   | Use
---------|-----
-_name_  | The identifier of the connection you want to alter.
+| Field                     | Use                                                 |
+| ------------------------- | --------------------------------------------------- |
+| _name_                    | The identifier of the connection you want to alter. |
+| **SET**...                | Sets the option to the specified value.             |
+| **DROP**..., **RESET**... | Resets the specified option to its default value.   |
+| **ROTATE KEYS**           | Rotate the key pairs.                               |
+
+#### `WITH` options
+
+| Field      | Value     | Description                                                                                                                                                       |
+| ---------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `VALIDATE` | `boolean` | Whether [connection validation](/sql/create-connection#connection-validation) should be performed. Not available with **ROTATE KEYS**.<br><br>Defaults to `true`. |
 
 ## Description
+
+### `SET`, `RESET`, `DROP`
+
+These subcommands let you change a connection's parameters.
+
+-   **RESET** and **DROP** are synonyms and will return the parameter to its
+    original state. For instance, if the connection has a default port, **DROP**
+    will return it to the default value.
+-   All provided changes are applied atomically.
+-   The same parameter cannot have multiple modifications.
+
+For the available parameters for each type of connection, see [`CREATE
+CONNECTION`](/sql/create-connection).
+
+### `ROTATE KEYS`
 
 The `ROTATE KEYS` command can be used to change the key pairs associated with
 an [SSH tunnel connection] without causing downtime.
@@ -36,8 +62,8 @@ a new public key.
 After executing `ROTATE KEYS`, you should update your SSH bastion server with
 the new public keys:
 
-  * Remove the public key that was formely in the `public_key_1` column.
-  * Add the new public key from the `public_key_2` column.
+-   Remove the public key that was formely in the `public_key_1` column.
+-   Add the new public key from the `public_key_2` column.
 
 Throughout the entire process, the SSH bastion server is configured to permit
 authentication from at least one of the keys that Materialize will authenticate
@@ -52,12 +78,12 @@ be unable to authenticate with the bastion server.
 
 The privileges required to execute this statement are:
 
-- Ownership of the connection.
+-   Ownership of the connection.
 
 ## Related pages
 
-- [`CREATE CONNECTION`](/sql/create-connection/)
-- [`SHOW CONNECTIONS`](/sql/show-connections)
+-   [`CREATE CONNECTION`](/sql/create-connection/)
+-   [`SHOW CONNECTIONS`](/sql/show-connections)
 
 [SSH tunnel connection]: /sql/create-connection/#ssh-tunnel
 [`mz_ssh_tunnel_connections`]: /sql/system-catalog/mz_catalog/#mz_ssh_tunnel_connections

--- a/doc/user/layouts/partials/sql-grammar/alter-connection.svg
+++ b/doc/user/layouts/partials/sql-grammar/alter-connection.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="575" height="135">
+<svg xmlns="http://www.w3.org/2000/svg" width="509" height="469">
    <polygon points="9 17 1 13 1 21"/>
    <polygon points="17 17 9 13 9 21"/>
    <rect x="31" y="3" width="66" height="32" rx="10"/>
@@ -28,24 +28,135 @@
    <rect x="399" y="3" width="56" height="32"/>
    <rect x="397" y="1" width="56" height="32" class="nonterminal"/>
    <text class="nonterminal" x="407" y="21">name</text>
-   <rect x="475" y="3" width="78" height="32" rx="10"/>
-   <rect x="473"
-         y="1"
+   <rect x="85" y="145" width="46" height="32" rx="10"/>
+   <rect x="83"
+         y="143"
+         width="46"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="93" y="163">SET</text>
+   <rect x="151" y="145" width="26" height="32" rx="10"/>
+   <rect x="149"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="159" y="163">(</text>
+   <rect x="197" y="145" width="62" height="32"/>
+   <rect x="195" y="143" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="205" y="163">option</text>
+   <rect x="279" y="145" width="28" height="32" rx="10"/>
+   <rect x="277"
+         y="143"
+         width="28"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="287" y="163">=</text>
+   <rect x="327" y="145" width="54" height="32"/>
+   <rect x="325" y="143" width="54" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="335" y="163">value</text>
+   <rect x="105" y="189" width="60" height="32" rx="10"/>
+   <rect x="103"
+         y="187"
+         width="60"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="207">DROP</text>
+   <rect x="105" y="233" width="64" height="32" rx="10"/>
+   <rect x="103"
+         y="231"
+         width="64"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="113" y="251">RESET</text>
+   <rect x="209" y="189" width="26" height="32" rx="10"/>
+   <rect x="207"
+         y="187"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="217" y="207">(</text>
+   <rect x="255" y="189" width="62" height="32"/>
+   <rect x="253" y="187" width="62" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="263" y="207">option</text>
+   <rect x="421" y="145" width="26" height="32" rx="10"/>
+   <rect x="419"
+         y="143"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="429" y="163">)</text>
+   <rect x="65" y="101" width="24" height="32" rx="10"/>
+   <rect x="63"
+         y="99"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="73" y="119">,</text>
+   <rect x="45" y="277" width="78" height="32" rx="10"/>
+   <rect x="43"
+         y="275"
          width="78"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="483" y="21">ROTATE</text>
-   <rect x="489" y="101" width="58" height="32" rx="10"/>
-   <rect x="487"
-         y="99"
+   <text class="terminal" x="53" y="295">ROTATE</text>
+   <rect x="143" y="277" width="58" height="32" rx="10"/>
+   <rect x="141"
+         y="275"
          width="58"
          height="32"
          class="terminal"
          rx="10"/>
-   <text class="terminal" x="497" y="119">KEYS</text>
+   <text class="terminal" x="151" y="295">KEYS</text>
+   <rect x="125" y="419" width="58" height="32" rx="10"/>
+   <rect x="123"
+         y="417"
+         width="58"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="133" y="437">WITH</text>
+   <rect x="223" y="387" width="26" height="32" rx="10"/>
+   <rect x="221"
+         y="385"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="231" y="405">(</text>
+   <rect x="289" y="387" width="48" height="32"/>
+   <rect x="287" y="385" width="48" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="297" y="405">field</text>
+   <rect x="357" y="387" width="38" height="32"/>
+   <rect x="355" y="385" width="38" height="32" class="nonterminal"/>
+   <text class="nonterminal" x="365" y="405">val</text>
+   <rect x="289" y="343" width="24" height="32" rx="10"/>
+   <rect x="287"
+         y="341"
+         width="24"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="297" y="361">,</text>
+   <rect x="435" y="387" width="26" height="32" rx="10"/>
+   <rect x="433"
+         y="385"
+         width="26"
+         height="32"
+         class="terminal"
+         rx="10"/>
+   <text class="terminal" x="443" y="405">)</text>
    <path class="line"
-         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m56 0 h10 m0 0 h10 m78 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-108 98 l2 0 m2 0 l2 0 m2 0 l2 0 m2 0 h10 m58 0 h10 m3 0 h-3"/>
-   <polygon points="565 115 573 111 573 119"/>
-   <polygon points="565 115 557 111 557 119"/>
+         d="m17 17 h2 m0 0 h10 m66 0 h10 m0 0 h10 m116 0 h10 m20 0 h10 m0 0 h96 m-126 0 h20 m106 0 h20 m-146 0 q10 0 10 10 m126 0 q0 -10 10 -10 m-136 10 v12 m126 0 v-12 m-126 12 q0 10 10 10 m106 0 q10 0 10 -10 m-116 10 h10 m86 0 h10 m20 -32 h10 m56 0 h10 m2 0 l2 0 m2 0 l2 0 m2 0 l2 0 m-474 142 l2 0 m2 0 l2 0 m2 0 l2 0 m62 0 h10 m46 0 h10 m0 0 h10 m26 0 h10 m0 0 h10 m62 0 h10 m0 0 h10 m28 0 h10 m0 0 h10 m54 0 h10 m-336 0 h20 m316 0 h20 m-356 0 q10 0 10 10 m336 0 q0 -10 10 -10 m-346 10 v24 m336 0 v-24 m-336 24 q0 10 10 10 m316 0 q10 0 10 -10 m-306 10 h10 m60 0 h10 m0 0 h4 m-104 0 h20 m84 0 h20 m-124 0 q10 0 10 10 m104 0 q0 -10 10 -10 m-114 10 v24 m104 0 v-24 m-104 24 q0 10 10 10 m84 0 q10 0 10 -10 m-94 10 h10 m64 0 h10 m20 -44 h10 m26 0 h10 m0 0 h10 m62 0 h10 m0 0 h64 m20 -44 h10 m26 0 h10 m-422 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m402 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-402 0 h10 m24 0 h10 m0 0 h358 m-442 44 h20 m442 0 h20 m-482 0 q10 0 10 10 m462 0 q0 -10 10 -10 m-472 10 v112 m462 0 v-112 m-462 112 q0 10 10 10 m442 0 q10 0 10 -10 m-452 10 h10 m78 0 h10 m0 0 h10 m58 0 h10 m0 0 h266 m22 -132 l2 0 m2 0 l2 0 m2 0 l2 0 m-446 242 l2 0 m2 0 l2 0 m2 0 l2 0 m42 0 h10 m0 0 h68 m-98 0 h20 m78 0 h20 m-118 0 q10 0 10 10 m98 0 q0 -10 10 -10 m-108 10 v12 m98 0 v-12 m-98 12 q0 10 10 10 m78 0 q10 0 10 -10 m-88 10 h10 m58 0 h10 m20 -32 h10 m26 0 h10 m20 0 h10 m48 0 h10 m0 0 h10 m38 0 h10 m-146 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m126 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-126 0 h10 m24 0 h10 m0 0 h82 m20 44 h10 m26 0 h10 m-396 0 h20 m376 0 h20 m-416 0 q10 0 10 10 m396 0 q0 -10 10 -10 m-406 10 v46 m396 0 v-46 m-396 46 q0 10 10 10 m376 0 q10 0 10 -10 m-386 10 h10 m0 0 h366 m23 -66 h-3"/>
+   <polygon points="499 401 507 397 507 405"/>
+   <polygon points="499 401 491 397 491 405"/>
 </svg>

--- a/doc/user/sql-grammar/sql-grammar.bnf
+++ b/doc/user/sql-grammar/sql-grammar.bnf
@@ -4,7 +4,21 @@ alter_cluster_set ::=
 alter_cluster_reset ::=
   'ALTER' 'CLUSTER' name 'RESET' '(' (cluster_option_name)* ')'
 alter_connection ::=
-  'ALTER' 'CONNECTION' 'IF EXISTS'? name 'ROTATE' 'KEYS'
+  'ALTER' 'CONNECTION' 'IF EXISTS'? name
+    (
+      (
+        'SET' '(' option '=' value ')'
+        | ('DROP' | 'RESET') '(' option ')'
+      )
+      ( ','
+        (
+          'SET' '(' option '=' value ')'
+          | ('DROP' | 'RESET') '(' option ')'
+        )
+      ) *
+      | 'ROTATE' 'KEYS'
+    )
+    ( 'WITH'? '(' field val ( ',' field val )* ')' )?
 alter_default_privileges ::=
   'ALTER' 'DEFAULT' 'PRIVILEGES' 'FOR' (( 'ROLE' | 'USER' ) target_role (',' target_role)* | 'ALL' 'ROLES' ) ( 'IN' 'SCHEMA' schema_name (',' schema_name)* | 'IN' 'DATABASE' database_name (',' database_name)* )? ( abbreviated_grant | abbreviated_revoke )
 abbreviated_grant ::=


### PR DESCRIPTION
My autoformatter might have wrought more havoc than intended. Pushing this up as-is.

@morsapaes What autoformatter do you use/suggest?

Fixes #17620.

### Motivation

This PR adds a known-desirable feature. Document `ALTER CONNECTION`.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
