### PR TITLE
catalog: Update name and comment of PersistHandle

### DIFF
--- a/src/catalog/src/durable.rs
+++ b/src/catalog/src/durable.rs
@@ -22,7 +22,7 @@ use mz_stash::DebugStashFactory;
 use crate::durable::debug::{DebugCatalogState, Trace};
 pub use crate::durable::error::{CatalogError, DurableCatalogError};
 pub use crate::durable::impls::persist::metrics::Metrics;
-use crate::durable::impls::persist::PersistHandle;
+use crate::durable::impls::persist::UnopenedPersistCatalogState;
 use crate::durable::impls::shadow::OpenableShadowCatalogState;
 use crate::durable::impls::stash::{OpenableConnection, TestOpenableConnection};
 pub use crate::durable::impls::stash::{
@@ -282,8 +282,8 @@ pub async fn persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,
     metrics: Arc<Metrics>,
-) -> PersistHandle {
-    PersistHandle::new(persist_client, organization_id, metrics).await
+) -> UnopenedPersistCatalogState {
+    UnopenedPersistCatalogState::new(persist_client, organization_id, metrics).await
 }
 
 /// Creates an openable durable catalog state implemented using persist that is meant to be used in
@@ -291,7 +291,7 @@ pub async fn persist_backed_catalog_state(
 pub async fn test_persist_backed_catalog_state(
     persist_client: PersistClient,
     organization_id: Uuid,
-) -> PersistHandle {
+) -> UnopenedPersistCatalogState {
     let metrics = Arc::new(Metrics::new(&MetricsRegistry::new()));
     persist_backed_catalog_state(persist_client, organization_id, metrics).await
 }

--- a/src/catalog/src/durable/debug.rs
+++ b/src/catalog/src/durable/debug.rs
@@ -16,7 +16,7 @@ use serde::{Deserialize, Serialize};
 use serde_plain::{derive_display_from_serialize, derive_fromstr_from_deserialize};
 
 use crate::durable;
-use crate::durable::impls::persist::{PersistHandle, StateUpdateKind};
+use crate::durable::impls::persist::{StateUpdateKind, UnopenedPersistCatalogState};
 use crate::durable::objects::serialization::proto;
 use crate::durable::{
     CatalogError, AUDIT_LOG_COLLECTION, CLUSTER_COLLECTION,
@@ -359,7 +359,7 @@ impl Trace {
 
 pub enum DebugCatalogState {
     Stash(Stash),
-    Persist(PersistHandle),
+    Persist(UnopenedPersistCatalogState),
 }
 
 impl DebugCatalogState {

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -73,7 +73,7 @@ enum Mode {
 /// A Handle to an unopened catalog stored in persist. The unopened catalog can serve `Config` data
 /// or the current epoch. All other catalog data may be un-migrated and should not be read until the
 /// catalog has been opened. The [`UnopenedPersistCatalogState`] is responsible for opening the
-/// catalog, see [`DurableCatalogState::open`] for more details.
+/// catalog, see [`OpenableDurableCatalogState::open`] for more details.
 ///
 /// Production users should call [`Self::expire`] before dropping a [`UnopenedPersistCatalogState`]
 /// so that it can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.

--- a/src/catalog/src/durable/impls/persist.rs
+++ b/src/catalog/src/durable/impls/persist.rs
@@ -70,12 +70,15 @@ enum Mode {
     Writable,
 }
 
-/// Handles and metadata needed to interact with persist.
+/// A Handle to an unopened catalog stored in persist. The unopened catalog can serve `Config` data
+/// or the current epoch. All other catalog data may be un-migrated and should not be read until the
+/// catalog has been opened. The [`UnopenedPersistCatalogState`] is responsible for opening the
+/// catalog, see [`DurableCatalogState::open`] for more details.
 ///
-/// Production users should call [`Self::expire`] before dropping a [`PersistHandle`] so that it
-/// can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.
+/// Production users should call [`Self::expire`] before dropping a [`UnopenedPersistCatalogState`]
+/// so that it can expire its leases. If/when rust gets AsyncDrop, this will be done automatically.
 #[derive(Debug)]
-pub struct PersistHandle {
+pub struct UnopenedPersistCatalogState {
     /// Write handle to persist.
     write_handle: WriteHandle<StateUpdateKindBinary, (), Timestamp, Diff>,
     /// Read handle to persist.
@@ -90,7 +93,7 @@ pub struct PersistHandle {
     metrics: Arc<Metrics>,
 }
 
-impl PersistHandle {
+impl UnopenedPersistCatalogState {
     /// Deterministically generate the a ID for the given `organization_id` and `seed`.
     fn shard_id(organization_id: Uuid, seed: usize) -> ShardId {
         let hash = sha2::Sha256::digest(format!("{organization_id}{seed}")).to_vec();
@@ -99,13 +102,13 @@ impl PersistHandle {
         ShardId::from_str(&format!("s{uuid}")).expect("known to be valid")
     }
 
-    /// Create a new [`PersistHandle`] to the catalog state associated with `organization_id`.
+    /// Create a new [`UnopenedPersistCatalogState`] to the catalog state associated with `organization_id`.
     #[tracing::instrument(level = "debug", skip(persist_client))]
     pub(crate) async fn new(
         persist_client: PersistClient,
         organization_id: Uuid,
         metrics: Arc<Metrics>,
-    ) -> PersistHandle {
+    ) -> UnopenedPersistCatalogState {
         const SEED: usize = 1;
         let shard_id = Self::shard_id(organization_id, SEED);
         debug!(?shard_id, "new persist backed catalog state");
@@ -118,7 +121,7 @@ impl PersistHandle {
             )
             .await
             .expect("invalid usage");
-        PersistHandle {
+        UnopenedPersistCatalogState {
             write_handle,
             read_handle,
             persist_client,
@@ -467,7 +470,7 @@ impl PersistHandle {
 }
 
 #[async_trait]
-impl OpenableDurableCatalogState for PersistHandle {
+impl OpenableDurableCatalogState for UnopenedPersistCatalogState {
     #[tracing::instrument(level = "debug", skip(self))]
     async fn open_savepoint(
         mut self: Box<Self>,
@@ -1257,7 +1260,7 @@ impl Trace {
     }
 }
 
-impl PersistHandle {
+impl UnopenedPersistCatalogState {
     /// Manually update value of `key` in collection `T` to `value`.
     #[tracing::instrument(level = "info", skip(self))]
     pub(crate) async fn debug_edit<T: Collection>(

--- a/src/catalog/src/durable/upgrade.rs
+++ b/src/catalog/src/durable/upgrade.rs
@@ -182,7 +182,7 @@ pub(crate) mod persist {
     use crate::durable::impls::persist::state_update::{
         IntoStateUpdateKindBinary, StateUpdateKindBinary,
     };
-    use crate::durable::impls::persist::{PersistHandle, StateUpdate, Timestamp};
+    use crate::durable::impls::persist::{StateUpdate, Timestamp, UnopenedPersistCatalogState};
     use crate::durable::upgrade::{
         CATALOG_VERSION, FUTURE_VERSION, MIN_CATALOG_VERSION, TOO_OLD_VERSION,
     };
@@ -235,7 +235,7 @@ pub(crate) mod persist {
 
     #[tracing::instrument(name = "persist::upgrade", level = "debug", skip_all)]
     pub(crate) async fn upgrade(
-        persist_handle: &mut PersistHandle,
+        persist_handle: &mut UnopenedPersistCatalogState,
         mut upper: Timestamp,
     ) -> Result<Timestamp, DurableCatalogError> {
         soft_assert_ne!(
@@ -257,7 +257,7 @@ pub(crate) mod persist {
         }
 
         fn run_upgrade(
-            _persist_handle: &mut PersistHandle,
+            _persist_handle: &mut UnopenedPersistCatalogState,
             upper: Timestamp,
             version: u64,
         ) -> Result<(u64, Timestamp), DurableCatalogError> {


### PR DESCRIPTION
This commit updates the name of PersistHandle and the surrounding comments to more accurately convey what it is used for. It used to be a wrapper struct around both a read and write handle, hence the name PersistHandle. Now it is used exclusively for pre-open bootstrap catalog reading and opening a catalog, hence the name UnopenedPersistCatalogState.

### Motivation
This PR refactors existing code.

### Checklist

- [X] This PR has adequate test coverage / QA involvement has been duly considered.
- [X] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [X] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [X] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [X] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - There are no user-facing behavior changes.
