### PR TITLE
ci: reenable checks-backup-rollback

### DIFF
--- a/ci/nightly/pipeline.template.yml
+++ b/ci/nightly/pipeline.template.yml
@@ -466,7 +466,6 @@ steps:
 
       - id: checks-backup-rollback
         label: "Checks + backup + rollback to previous"
-        skip: "Requires #18628 to be fixed"
         timeout_in_minutes: 60
         artifact_paths: junit_*.xml
         agents:


### PR DESCRIPTION
Reenabling this check if https://github.com/MaterializeInc/materialize/issues/18628 is fixed

Seen in https://buildkite.com/materialize/nightlies/builds/5519#018c40ba-e402-4b47-80ac-54950f59e583.

Nightly: https://buildkite.com/materialize/nightlies/builds/5520