### PR TITLE
catalog: report progress sources as running

### DIFF
--- a/src/catalog/src/builtin.rs
+++ b/src/catalog/src/builtin.rs
@@ -2520,9 +2520,14 @@ SELECT
     occurred_at as last_status_change_at,
     -- TODO(parkmycar): Report status of webhook source once #20036 is closed.
     CASE
-        WHEN mz_sources.type = 'webhook' THEN 'running'
-        ELSE coalesce(status, 'created')
-    END status,
+      WHEN
+            mz_sources.type = 'webhook'
+              OR
+            mz_sources.type = 'progress'
+          THEN 'running'
+        ELSE COALESCE(status, 'created')
+      END
+      AS status,
     error,
     details
 FROM mz_sources

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -304,6 +304,9 @@ types_table           subsource <null>  <null>
 utf8_table            subsource <null>  <null>
 таблица               subsource <null>  <null>
 
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'mz_source_progress';
+running
+
 > SELECT lsn > 0 FROM mz_source_progress
 true
 

--- a/test/testdrive/kafka-progress.td
+++ b/test/testdrive/kafka-progress.td
@@ -23,6 +23,9 @@ one
 > SELECT * from data
 one
 
+> SELECT status FROM mz_internal.mz_source_statuses WHERE name = 'data_progress';
+running
+
 # Ensure that we can select from automatically generated remap collection
 > SELECT partition::text, "offset" FROM data_progress
 [0,0] 1


### PR DESCRIPTION
Progress subsources only reported as 'created' because they are not hooked up to any form of health operator.

Instead of synthesizing the 'created' status for them, we could instead synthesize the 'running' status to make their statuses align with other sources.

Coincidentally, this is the same approach taken for webhook sources, so there is some prior art in this space.

### Motivation

This PR adds a known-desirable feature. I've had folks mention this as confusing to me, though I don't think it ever made it into a ticket.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
