### PR TITLE
storage: postgres status UX

### DIFF
--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -311,16 +311,12 @@ where
 
                 let statuses: &mut Vec<_> = statuses_by_idx.entry(*output_index).or_default();
 
-                let mut status = HealthStatusMessage {
+                let status = HealthStatusMessage {
                     index: *output_index,
                     namespace: C::STATUS_NAMESPACE.clone(),
                     update: status,
                 };
                 if statuses.last() != Some(&status) {
-                    statuses.push(status.clone());
-                    // The global status contains the most recent update of the subsources
-
-                    status.index = 0;
                     statuses.push(status);
                 }
 

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -324,6 +324,13 @@ INSERT INTO table_a VALUES (3);
 ! SELECT * FROM table_a;
 contains:incompatible schema change
 
+> SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
+true
+
+# Subsource errors not propagated to primary source
+> SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+true
+
 > ALTER SOURCE mz_source DROP SUBSOURCE table_a;
 
 > ALTER SOURCE mz_source ADD SUBSOURCE table_a;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -304,6 +304,27 @@ types_table           subsource <null>  <null>
 utf8_table            subsource <null>  <null>
 таблица               subsource <null>  <null>
 
+> SELECT name, status FROM mz_internal.mz_source_statuses
+array_types_table     running
+conflict_table        running
+create                running
+escaped_text_table    running
+large_text            running
+multipart_pk          running
+mz_source             running
+mz_source_progress    starting
+nonpk_table           running
+nulls_table           running
+pk_table              running
+"space table"         running
+trailing_space_nopk   running
+trailing_space_pk     running
+"\"literal_quotes\""  running
+types_table           running
+utf8_table            running
+таблица               running
+
+
 > SELECT lsn > 0 FROM mz_source_progress
 true
 


### PR DESCRIPTION
Just a few small things that have bugged me about subsource statuses in PG. If anyone finds these distasteful glad to abandon them as I don't think they're likely to affect users in prod (though possibly create confusion when users are in the trial stage).

### Motivation

 This PR refactors existing code.

### Tips for reviewer

Commit-by-commit.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
