### PR TITLE
Fix assert when a scalar window func is given args

### DIFF
--- a/test/sqllogictest/window_funcs.slt
+++ b/test/sqllogictest/window_funcs.slt
@@ -402,6 +402,11 @@ c
 
 # rank and dense_rank
 
+query error db error: ERROR: function rank has 0 parameters, but was called with 1
+WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
+SELECT rank(x) OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t
+ORDER BY dense_rank;
+
 query IIT
 WITH t (x) AS (VALUES ('a'), ('b'), ('c'))
 SELECT rank() OVER (ORDER BY x), dense_rank() OVER (ORDER BY x), x FROM t


### PR DESCRIPTION
There was a wrong assert in planning when a scalar window function is called with more than zero arguments. (All scalar window functions have 0 parameters.) Instead of an assert panic, we'll now print a helpful error msg.

### Motivation

  * This PR fixes a recognized bug: https://github.com/MaterializeInc/materialize/issues/23743

### Tips for reviewer


### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
