### PR TITLE
storage: do not propagate subsource statuses to primary source

### DIFF
--- a/misc/python/materialize/checks/all_checks/source_errors.py
+++ b/misc/python/materialize/checks/all_checks/source_errors.py
@@ -92,13 +92,15 @@ class SourceErrors(Check):
         return Testdrive(
             dedent(
                 """
-                > SELECT status, error ~* 'publication .+ does not exist'
-                  FROM mz_internal.mz_source_statuses
-                  WHERE name LIKE 'source_errors_source%'
-                  AND type != 'subsource'
-                  AND type != 'progress';
-                stalled true
-                stalled true
+                > SELECT bool_and(error ~* 'publication .+ does not exist')
+                    FROM mz_internal.mz_source_statuses
+                    WHERE
+                    name
+                    IN (
+                    SELECT name FROM (SHOW SUBSOURCES ON source_errors_sourceA WHERE type = 'subsource')
+                    UNION (SELECT name FROM (SHOW SUBSOURCES ON source_errors_sourceB WHERE type = 'subsource'))
+                    );
+                true
                 """
             )
         )

--- a/src/sql/src/pure.rs
+++ b/src/sql/src/pure.rs
@@ -23,6 +23,7 @@ use mz_ore::error::ErrorExt;
 use mz_ore::iter::IteratorExt;
 use mz_ore::str::StrExt;
 use mz_postgres_util::replication::WalLevel;
+use mz_postgres_util::PostgresError;
 use mz_proto::RustType;
 use mz_repr::{strconv, GlobalId};
 use mz_sql_parser::ast::display::AstDisplay;
@@ -611,7 +612,8 @@ async fn purify_create_source(
                 &publication,
                 None,
             )
-            .await?;
+            .await
+            .map_err(PostgresError::from)?;
 
             if publication_tables.is_empty() {
                 Err(PgSourcePurificationError::EmptyPublication(
@@ -1014,7 +1016,8 @@ async fn purify_alter_source(
         &pg_source_connection.publication,
         None,
     )
-    .await?;
+    .await
+    .map_err(PostgresError::from)?;
 
     if publication_tables.is_empty() {
         Err(PgSourcePurificationError::EmptyPublication(

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -225,24 +225,6 @@ pub(crate) fn render<G: Scope<Timestamp = MzOffset>>(
                 "replication metadata",
                 &context.ssh_tunnel_manager,
             ).await?;
-            if let Err(err) = ensure_publication_exists(&client, &connection.publication).await? {
-                // If the publication gets deleted there is nothing else to do. These errors
-                // are not retractable.
-                for &oid in table_info.keys() {
-                    // We must emit this error at a definite LSN which ideally
-                    // would be the LSN at which the `DROP PUBLICATION` action
-                    // was written to in the upstream database. Unfortunately we
-                    // don't have a way to learn that LSN and so we must choose
-                    // an LSN out of thin air that is guaranteed to not
-                    // invalidate the definite decisions previously made by this
-                    // operator. We therefore always pick `u64::MAX`, which will
-                    // (in practice) never conflict any previously revealed
-                    // portions of the TVC.
-                    let update = ((oid, Err(err.clone())), MzOffset::from(u64::MAX), 1);
-                    data_output.give(&data_cap_set[0], update).await;
-                }
-                return Ok(());
-            }
 
             let stream_result = raw_stream(
                 &config,
@@ -392,6 +374,12 @@ async fn raw_stream<'a>(
     >,
     TransientError,
 > {
+    if let Err(err) = ensure_publication_exists(&metadata_client, publication).await? {
+        // If the publication gets deleted there is nothing else to do. These errors
+        // are not retractable.
+        return Ok(Err(err));
+    }
+
     // Skip the timeline ID check for sources without a known timeline ID
     // (sources created before the timeline ID was added to the source details)
     if let Some(expected_timeline_id) = timeline_id {

--- a/src/storage/src/source/postgres/replication.rs
+++ b/src/storage/src/source/postgres/replication.rs
@@ -78,6 +78,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use bytes::Bytes;
 use differential_dataflow::{AsCollection, Collection};
 use futures::{future, future::select, FutureExt, Stream as AsyncStream, StreamExt, TryStreamExt};
+use mz_postgres_util::PostgresError;
 use once_cell::sync::Lazy;
 use postgres_protocol::message::backend::{
     LogicalReplicationMessage, ReplicationMessage, TupleData,
@@ -548,7 +549,8 @@ fn extract_transaction<'a>(
                             publication,
                             Some(rel_id),
                         )
-                        .await?;
+                        .await
+                        .map_err(PostgresError::from)?;
                         let upstream_info = upstream_info.into_iter().map(|t| (t.oid, t)).collect();
 
                         if let Err(err) = verify_schema(rel_id, expected_desc, &upstream_info) {

--- a/src/storage/src/source/source_reader_pipeline.rs
+++ b/src/storage/src/source/source_reader_pipeline.rs
@@ -311,16 +311,12 @@ where
 
                 let statuses: &mut Vec<_> = statuses_by_idx.entry(*output_index).or_default();
 
-                let mut status = HealthStatusMessage {
+                let status = HealthStatusMessage {
                     index: *output_index,
                     namespace: C::STATUS_NAMESPACE.clone(),
                     update: status,
                 };
                 if statuses.last() != Some(&status) {
-                    statuses.push(status.clone());
-                    // The global status contains the most recent update of the subsources
-
-                    status.index = 0;
                     statuses.push(status);
                 }
 

--- a/test/pg-cdc/alter-source.td
+++ b/test/pg-cdc/alter-source.td
@@ -324,6 +324,13 @@ INSERT INTO table_a VALUES (3);
 ! SELECT * FROM table_a;
 contains:incompatible schema change
 
+> SELECT error ~~ '%incompatible schema change%' FROM mz_internal.mz_source_statuses WHERE name = 'table_a';
+true
+
+# Subsource errors not propagated to primary source
+> SELECT error IS NULL FROM mz_internal.mz_source_statuses WHERE name = 'mz_source';
+true
+
 > ALTER SOURCE mz_source DROP SUBSOURCE table_a;
 
 > ALTER SOURCE mz_source ADD SUBSOURCE table_a;

--- a/test/pg-cdc/pg-cdc.td
+++ b/test/pg-cdc/pg-cdc.td
@@ -732,12 +732,11 @@ DROP PUBLICATION mz_source;
 DROP PUBLICATION mz_source_narrow;
 INSERT INTO pk_table VALUES (99999);
 
-# todo: we're purifying Postgres view names incorrectly, fix that and this error!
-# should be "materialize.public.pk_table"
-
-> SELECT error FROM mz_internal.mz_source_statuses where name in ('enum_source', 'mz_source');
-"postgres: publication \"mz_source\" does not exist"
-"postgres: publication \"mz_source\" does not exist"
+# Ensure that all subsources have error
+> SELECT bool_and(error ~* 'publication .+ does not exist')
+  FROM mz_internal.mz_source_statuses
+  WHERE id IN ( SELECT id FROM mz_sources WHERE type = 'subsource' );
+true
 
 > DROP SOURCE enum_source CASCADE;
 > DROP SOURCE "mz_source" CASCADE;

--- a/test/ssh-connection/pg-source-after-ssh-restart.td
+++ b/test/ssh-connection/pg-source-after-ssh-restart.td
@@ -21,7 +21,11 @@ INSERT INTO t1 VALUES (3);
 2
 3
 
-> SELECT status FROM mz_internal.mz_source_statuses st
-  JOIN mz_sources s ON st.id = s.id
-  WHERE s.name = 'mz_source'
-running
+> SELECT bool_and(error IS NULL)
+  FROM mz_internal.mz_source_statuses
+  WHERE
+      name
+      IN (
+      SELECT name FROM (SHOW SUBSOURCES ON mz_source WHERE type = 'subsource')
+      );
+true


### PR DESCRIPTION
If a PG subsource encountered a definitie error the error message was propagated to the primary source's status.

Instead, the relationship should only occur in the other direction where primary source statuses (such as transient errors) should be duplicated to subsources, which already occurs.

<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

This PR refactors existing code.

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
