### PR TITLE
docs: Move temporal filter pushdown to public preview

### DIFF
--- a/doc/user/content/sql/functions/pushdown.md
+++ b/doc/user/content/sql/functions/pushdown.md
@@ -6,9 +6,9 @@ menu:
     parent: 'sql-functions'
 ---
 
-{{< private-preview >}}
+{{< public-preview >}}
 [Temporal filter pushdown](/transform-data/patterns/temporal-filters/#temporal-filter-pushdown)
-{{</ private-preview >}}
+{{</ public-preview >}}
 
 `try_parse_monotonic_iso8601_timestamp` parses a subset of [ISO 8601]
 timestamps that matches the 24 character length output

--- a/src/sql/src/session/vars.rs
+++ b/src/sql/src/session/vars.rs
@@ -1847,7 +1847,7 @@ feature_flags!(
     {
         name: enable_mfp_pushdown_explain,
         desc: "`filter_pushdown` explain",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },
@@ -1952,7 +1952,7 @@ feature_flags!(
     {
         name: enable_try_parse_monotonic_iso8601_timestamp,
         desc: "the try_parse_monotonic_iso8601_timestamp function",
-        default: false,
+        default: true,
         internal: true,
         enable_for_item_parsing: true,
     },


### PR DESCRIPTION
This PR updates the docs to denote that temporal filter pushdown is in public preview, as discussed [here](https://materializeinc.slack.com/archives/C01CFKM1QRF/p1701898914764279).

### Motivation

Move feature to public preview

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Moves the temporal filter pushdown feature to public preview.
