### PR TITLE
persist-txn: sort by original ts instead of compacted one in txn cache

### DIFF
--- a/src/persist-txn/src/lib.rs
+++ b/src/persist-txn/src/lib.rs
@@ -315,6 +315,13 @@ impl TxnsEntry {
             TxnsEntry::Append(data_id, _, _) => data_id,
         }
     }
+
+    fn ts<T: Codec64>(&self) -> T {
+        match self {
+            TxnsEntry::Register(_, ts) => T::decode(*ts),
+            TxnsEntry::Append(_, ts, _) => T::decode(*ts),
+        }
+    }
 }
 
 /// An abstraction over the encoding format of [TxnsEntry].


### PR DESCRIPTION
This was a bug introduced when we added support for keeping the original timestamps around.

Touches https://github.com/MaterializeInc/materialize/issues/22173
Touches https://github.com/MaterializeInc/materialize/issues/22801

### Motivation

  * This PR fixes a previously unreported bug.

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
