### PR TITLE
lsp: remove duplicates on completions

### DIFF
--- a/src/lsp-server/src/backend.rs
+++ b/src/lsp-server/src/backend.rs
@@ -17,7 +17,7 @@
 // of which can be found in the LICENSE file at the root of this repository.
 
 use ::serde::Deserialize;
-use mz_ore::collections::HashMap;
+use mz_ore::collections::{HashMap, HashSet};
 use mz_sql_lexer::keywords::Keyword;
 use mz_sql_lexer::lexer::{self, Token};
 use mz_sql_parser::ast::{statement_kind_label_value, Raw, Statement};
@@ -600,57 +600,50 @@ impl Backend {
     /// and avoid having to rebuild on every [LanguageServer::completion] call.
     fn build_completion_items(&self, schema: Schema) -> Completions {
         // Build SELECT completion items:
+        let mut select_set: HashSet<&String> = HashSet::new();
+        let mut from_set: HashSet<&String> = HashSet::new();
         let mut select_completions = Vec::new();
         let mut from_completions = Vec::new();
 
         schema.objects.iter().for_each(|object| {
             // Columns
             object.columns.iter().for_each(|column| {
-                select_completions.push(CompletionItem {
-                    label: column.name.to_string(),
+                if !select_set.contains(&column.name) {
+                    select_set.insert(&column.name);
+                    select_completions.push(CompletionItem {
+                        label: column.name.to_string(),
+                        label_details: None,
+                        kind: Some(CompletionItemKind::FIELD),
+                        detail: None,
+                        documentation: None,
+                        deprecated: Some(false),
+                        ..Default::default()
+                    });
+                }
+            });
+
+            // Objects
+            if !from_set.contains(&object.name) {
+                from_set.insert(&object.name);
+                from_completions.push(CompletionItem {
+                    label: object.name.to_string(),
                     label_details: Some(CompletionItemLabelDetails {
-                        detail: Some(column.typ.to_string()),
+                        detail: Some(object.typ.to_string()),
                         description: None,
                     }),
-                    kind: Some(CompletionItemKind::FIELD),
-                    detail: Some(
-                        format!(
-                            "From {}.{}.{} ({:?})",
-                            schema.database, schema.schema, object.name, object.typ
-                        )
-                        .to_string(),
-                    ),
+                    kind: match object.typ {
+                        ObjectType::View => Some(CompletionItemKind::ENUM_MEMBER),
+                        ObjectType::MaterializedView => Some(CompletionItemKind::ENUM),
+                        ObjectType::Source => Some(CompletionItemKind::CLASS),
+                        ObjectType::Sink => Some(CompletionItemKind::CLASS),
+                        ObjectType::Table => Some(CompletionItemKind::CONSTANT),
+                    },
+                    detail: None,
                     documentation: None,
                     deprecated: Some(false),
                     ..Default::default()
                 });
-            });
-
-            // Objects
-            from_completions.push(CompletionItem {
-                label: object.name.to_string(),
-                label_details: Some(CompletionItemLabelDetails {
-                    detail: Some(object.typ.to_string()),
-                    description: None,
-                }),
-                kind: match object.typ {
-                    ObjectType::View => Some(CompletionItemKind::ENUM_MEMBER),
-                    ObjectType::MaterializedView => Some(CompletionItemKind::ENUM),
-                    ObjectType::Source => Some(CompletionItemKind::CLASS),
-                    ObjectType::Sink => Some(CompletionItemKind::CLASS),
-                    ObjectType::Table => Some(CompletionItemKind::CONSTANT),
-                },
-                detail: Some(
-                    format!(
-                        "Represents {}.{}.{} ({:?})",
-                        schema.database, schema.schema, object.name, object.typ
-                    )
-                    .to_string(),
-                ),
-                documentation: None,
-                deprecated: Some(false),
-                ..Default::default()
-            });
+            }
         });
 
         Completions {


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation

Simple PR. This PR filters duplicated items for completion.

The LSP suggests all available item names for completion. It is super invasive as an experience. Some column names can appear many times, such as `id`, and one is enough.

<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]

  * This PR adds a feature that has not yet been specified.

    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
