### PR TITLE
docs: Add example for handling webhook batch requests

### DIFF
--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -254,6 +254,25 @@ If the feature is enabled, when casting from `text` to `timestamp` you should pr
 
 {{< /note >}}
 
+### Handling batch events
+
+The application pushing events to your webhook source, may batch multiple events into a single
+HTTP request. You can automatically expand this batch of requests into separate rows, using a
+[`MATERIALIZED VIEW`](/sql/create-materialized-view/) and the [`jsonb_array_elements`](/sql/types/jsonb/#functions)
+function.
+
+```sql
+-- Webhook source that parses request bodies as JSON.
+CREATE SOURCE webhook_source_json_batch IN CLUSTER my_cluster FROM WEBHOOK
+  BODY FORMAT JSON
+  INCLUDE HEADERS
+
+-- Materialized view which expands the JSON array into separate rows.
+CREATE MATERIALIZED VIEW expanded_batch_request IN CLUSTER my_compute_cluster AS (
+  SELECT jsonb_array_elements(body), headers FROM webhook_source_json_batch
+)
+```
+
 ## Request limits
 
 Webhook sources apply the following limits to received requests:

--- a/doc/user/content/sql/create-source/webhook.md
+++ b/doc/user/content/sql/create-source/webhook.md
@@ -256,7 +256,7 @@ If the feature is enabled, when casting from `text` to `timestamp` you should pr
 
 ### Handling batch events
 
-The application pushing events to your webhook source, may batch multiple events into a single
+The application pushing events to your webhook source may batch multiple events into a single
 HTTP request. You can automatically expand this batch of requests into separate rows, using a
 [`MATERIALIZED VIEW`](/sql/create-materialized-view/) and the [`jsonb_array_elements`](/sql/types/jsonb/#functions)
 function.
@@ -265,12 +265,12 @@ function.
 -- Webhook source that parses request bodies as JSON.
 CREATE SOURCE webhook_source_json_batch IN CLUSTER my_cluster FROM WEBHOOK
   BODY FORMAT JSON
-  INCLUDE HEADERS
+  INCLUDE HEADERS;
 
 -- Materialized view which expands the JSON array into separate rows.
 CREATE MATERIALIZED VIEW expanded_batch_request IN CLUSTER my_compute_cluster AS (
   SELECT jsonb_array_elements(body), headers FROM webhook_source_json_batch
-)
+);
 ```
 
 ## Request limits

--- a/test/testdrive/webhook.td
+++ b/test/testdrive/webhook.td
@@ -11,6 +11,8 @@
 
 > CREATE CLUSTER webhook_cluster REPLICAS (r1 (SIZE '1'));
 
+> CREATE CLUSTER webhook_compute REPLICAS (r1 (SIZE '1'));
+
 > CREATE SOURCE webhook_text IN CLUSTER webhook_cluster FROM WEBHOOK
   BODY FORMAT TEXT;
 
@@ -318,6 +320,42 @@ this_will_work
 > SELECT body FROM webhook_with_time_based_rejection
 this_will_work
 
+# Unnest batch requests.
+
+> CREATE SOURCE webhook_for_batch_events IN CLUSTER webhook_cluster FROM WEBHOOK
+  BODY FORMAT JSON
+
+$ webhook-append name=webhook_for_batch_events
+[
+  { "event_id": 1 },
+  { "event_id": 2 },
+  { "event_id": 3 },
+  { "event_id": 4 }
+]
+
+> CREATE MATERIALIZED VIEW webhook_for_batch_events_flattened (body)
+  IN CLUSTER webhook_compute
+  AS (
+    SELECT jsonb_array_elements(body) as body FROM webhook_for_batch_events
+  );
+
+> SELECT body FROM webhook_for_batch_events_flattened
+"{\"event_id\":1}"
+"{\"event_id\":2}"
+"{\"event_id\":3}"
+"{\"event_id\":4}"
+
+$ webhook-append name=webhook_for_batch_events
+[
+  { "event_id": 5 },
+  { "event_id": 6 },
+  { "event_id": 7 },
+  { "event_id": 8 }
+]
+
+> SELECT COUNT(*) FROM webhook_for_batch_events_flattened
+8
+
 # Dropping a webhook source should drop the underlying persist shards.
 
 $ set-from-sql var=webhook-source-id
@@ -333,3 +371,5 @@ SELECT id FROM mz_sources WHERE name = 'webhook_bytes';
 
 # Cleanup.
 > DROP CLUSTER webhook_cluster CASCADE;
+
+> DROP CLUSTER webhook_compute CASCADE;


### PR DESCRIPTION
This PR adds an example to our docs of how to handle batch requests in a webhook source, using `jsonb_array_elements(...)` function.

### Motivation

There are users that need to increase their throughput for webhook sources, an easy way to do that is to batch requests. We want to add docs to help them get this setup.

### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [x] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - Adds docs for handling batch requests with webhooks
