### PR TITLE
[persist] Many little tombstones

### DIFF
--- a/src/persist-client/src/internal/apply.rs
+++ b/src/persist-client/src/internal/apply.rs
@@ -427,6 +427,7 @@ where
     ) -> Result<NextState<K, V, T, D, R>, (SeqNo, E)> {
         let is_write = cmd.name == metrics.cmds.compare_and_append.name;
         let is_rollup = cmd.name == metrics.cmds.add_rollup.name;
+        let is_become_tombstone = cmd.name == metrics.cmds.become_tombstone.name;
 
         let expected = state.seqno;
         let was_tombstone_before = state.collections.is_tombstone();
@@ -448,7 +449,7 @@ where
         // TODO: Even better would be to write the rollup in the
         // tombstone transition so it's a single terminal state
         // transition, but it'll be tricky to get right.
-        if was_tombstone_before && !is_rollup {
+        if was_tombstone_before && !(is_rollup || is_become_tombstone) {
             panic!(
                 "cmd {} unexpectedly tried to commit a new state on a tombstone: {:?}",
                 cmd.name, state

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -186,18 +186,18 @@ v20 false
 
 finalize
 ----
-v21 ok
+v25 ok
 
 is-finalized
 ----
-v21 true
+v25 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
-v21 ok
-v22 ok
+v25 ok
+v26 ok
 
 perform-maintenance
 ----
@@ -209,8 +209,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v21 batches= rollups=v1
-seqno=v22 batches= rollups=v1,v21
+seqno=v25 batches= rollups=v1
+seqno=v26 batches= rollups=v1,v25
 
 blob-scan-batches
 ----
@@ -235,7 +235,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v22 ok
+v26 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -247,7 +247,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v22 ok
+v26 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -256,45 +256,45 @@ v22 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v22 []
+v26 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v22 ok
+v26 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v22 0 []
+v26 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v22 1 []
+v26 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v22 ok
+v26 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v22 []
+v26 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v22 []
+v26 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v22 ok
+v26 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v22 []
+v26 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v22 0 []
+v26 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v22 ok
+v26 ok

--- a/src/persist-client/tests/machine/empty_since
+++ b/src/persist-client/tests/machine/empty_since
@@ -186,18 +186,18 @@ v20 false
 
 finalize
 ----
-v25 ok
+v24 ok
 
 is-finalized
 ----
-v25 true
+v24 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
+v24 ok
 v25 ok
-v26 ok
 
 perform-maintenance
 ----
@@ -209,8 +209,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v25 batches= rollups=v1
-seqno=v26 batches= rollups=v1,v25
+seqno=v24 batches= rollups=v1
+seqno=v25 batches= rollups=v1,v24
 
 blob-scan-batches
 ----
@@ -235,7 +235,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v26 ok
+v25 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -247,7 +247,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v26 ok
+v25 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -256,45 +256,45 @@ v26 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v26 []
+v25 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v26 ok
+v25 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v26 0 []
+v25 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v26 1 []
+v25 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v26 ok
+v25 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v26 []
+v25 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v26 []
+v25 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v26 ok
+v25 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v26 []
+v25 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v26 0 []
+v25 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v26 ok
+v25 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -156,19 +156,19 @@ v14 false
 
 finalize
 ----
-v18 ok
+v17 ok
 
 is-finalized
 ----
-v18 true
+v17 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
+v17 ok
+v17 ok
 v18 ok
-v18 ok
-v19 ok
 
 perform-maintenance
 ----
@@ -180,8 +180,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v18 batches= rollups=v1
-seqno=v19 batches= rollups=v1,v18
+seqno=v17 batches= rollups=v1
+seqno=v18 batches= rollups=v1,v17
 
 blob-scan-batches
 ----
@@ -206,7 +206,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v19 ok
+v18 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -218,7 +218,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v19 ok
+v18 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -227,45 +227,45 @@ v19 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v19 []
+v18 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v19 ok
+v18 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v19 0 []
+v18 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v19 1 []
+v18 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v19 ok
+v18 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v19 []
+v18 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v19 []
+v18 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v19 ok
+v18 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v19 []
+v18 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v19 0 []
+v18 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v19 ok
+v18 ok

--- a/src/persist-client/tests/machine/empty_upper
+++ b/src/persist-client/tests/machine/empty_upper
@@ -156,19 +156,19 @@ v14 false
 
 finalize
 ----
-v15 ok
+v18 ok
 
 is-finalized
 ----
-v15 true
+v18 true
 
 # Run maintenance a few times to make sure it converges (because maintenance
 # like GC can result in followup maintenance)
 perform-maintenance
 ----
-v15 ok
-v15 ok
-v16 ok
+v18 ok
+v18 ok
+v19 ok
 
 perform-maintenance
 ----
@@ -180,8 +180,8 @@ perform-maintenance
 
 consensus-scan from_seqno=v0
 ----
-seqno=v15 batches= rollups=v1
-seqno=v16 batches= rollups=v1,v15
+seqno=v18 batches= rollups=v1
+seqno=v19 batches= rollups=v1,v18
 
 blob-scan-batches
 ----
@@ -206,7 +206,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w11111111-1111-1111-1111-111111111111
 ----
-v16 ok
+v19 ok
 
 # Perhaps counter-intuitively, we can "register" a new writer. This doesn't
 # actually register and produce a new SeqNo, but there's (intentionally) no
@@ -218,7 +218,7 @@ error: Upper(Antichain { elements: [] })
 
 expire-writer writer_id=w44444444-4444-4444-4444-444444444444
 ----
-v16 ok
+v19 ok
 
 # Similarly, downgrade_since, as well as all the other reader operations, works
 # for an existing reader. As an odd side effect, CaDS works even when the token
@@ -227,45 +227,45 @@ v16 ok
 # NB: Critically, none of these create a new seqno.
 downgrade-since since=4 reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v16 []
+v19 []
 
 expire-leased-reader reader_id=r22222222-2222-2222-2222-222222222222
 ----
-v16 ok
+v19 ok
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v16 0 []
+v19 0 []
 
 compare-and-downgrade-since expect_opaque=1 opaque=1 since=5 reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v16 1 []
+v19 1 []
 
 expire-critical-reader reader_id=c22222222-2222-2222-2222-222222222222
 ----
-v16 ok
+v19 ok
 
 # And ditto we can "register" both reader types and do the same ops.
 register-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v16 []
+v19 []
 
 downgrade-since since=4 reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v16 []
+v19 []
 
 expire-leased-reader reader_id=r55555555-5555-5555-5555-555555555555
 ----
-v16 ok
+v19 ok
 
 register-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v16 []
+v19 []
 
 compare-and-downgrade-since expect_opaque=0 opaque=0 since=4 reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v16 0 []
+v19 0 []
 
 expire-critical-reader reader_id=c55555555-5555-5555-5555-555555555555
 ----
-v16 ok
+v19 ok


### PR DESCRIPTION
This splits the Persist-shard-tombstoning process across many state transitions. This should avoid having a single very-large state transition when a shard is finalized.

### Motivation

See https://github.com/MaterializeInc/accounts/issues/20 for motivation, and https://github.com/MaterializeInc/materialize/pull/23435 for the first batch of changes and some context.

### Tips for reviewer

I think this is okay because:
1. If replacing a single batch is too heavy, we have bigger problems than finalization. (Lots of things require rewriting a batch.)
2. Spine should ensure that we have a reasonable number of batches, so this shouldn't be _too_ many state transitions.

If we're worried about (1), we may have to think about splitting really large hollow batches out into their own blobs. (We've already discussed this, but it might become more urgent.) If we're worried about (2), I could probably do multiple smallish hollow batches in one go instead of doing them one at a time. (I'm not super worried about it, but that could reasonably happen in this PR if you prefer it!)

### Checklist

- [x] This PR has adequate test coverage / QA involvement has been duly considered.
- [x] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
