### PR TITLE
mzcompose: Wait for containers to exit when killed

### DIFF
--- a/test/pubsub-disruption/mzcompose.py
+++ b/test/pubsub-disruption/mzcompose.py
@@ -61,8 +61,8 @@ disruptions = [
     # docker compose pause has become unreliable recently
     Disruption(
         name="sigstop-pubsub",
-        breakage=lambda c: c.kill("toxiproxy", signal="SIGSTOP"),
-        fixage=lambda c: c.kill("toxiproxy", signal="SIGCONT"),
+        breakage=lambda c: c.kill("toxiproxy", signal="SIGSTOP", wait=False),
+        fixage=lambda c: c.kill("toxiproxy", signal="SIGCONT", wait=False),
     ),
 ]
 

--- a/test/source-sink-errors/mzcompose.py
+++ b/test/source-sink-errors/mzcompose.py
@@ -474,9 +474,9 @@ disruptions: list[Disruption] = [
     # ),
     KafkaDisruption(
         name="sigstop-redpanda",
-        breakage=lambda c, _: c.kill("redpanda", signal="SIGSTOP"),
+        breakage=lambda c, _: c.kill("redpanda", signal="SIGSTOP", wait=False),
         expected_error="OperationTimedOut|BrokerTransportFailure|transaction",
-        fixage=lambda c, _: c.kill("redpanda", signal="SIGCONT"),
+        fixage=lambda c, _: c.kill("redpanda", signal="SIGCONT", wait=False),
     ),
     KafkaDisruption(
         name="kill-redpanda",


### PR DESCRIPTION
`docker kill` delivers a SIGKILL signal, which may be delivered asynchronously, causing race conditions.

To prevent that, wait for the container to exit after performing a kill.

### Motivation

Nightly was failing attempting to start a previously-killed-but-not-entirely storaged.