### PR TITLE
Add WASM workspace awareness to bin/gen-lints.

### DIFF
--- a/misc/python/materialize/cli/gen-lints.py
+++ b/misc/python/materialize/cli/gen-lints.py
@@ -189,32 +189,39 @@ def main() -> None:
         "// END LINT CONFIG\n",
     ]
 
-    metadata = json.loads(
-        subprocess.check_output(
-            ["cargo", "metadata", "--no-deps", "--format-version=1"]
+    for workspace_root in (".", "misc/wasm"):
+        metadata = json.loads(
+            subprocess.check_output(
+                [
+                    "cargo",
+                    "metadata",
+                    "--no-deps",
+                    "--format-version=1",
+                    f"--manifest-path={workspace_root}/Cargo.toml",
+                ]
+            )
         )
-    )
-    target_srcs = (
-        Path(target["src_path"])
-        for package in metadata["packages"]
-        for target in package["targets"]
-    )
+        target_srcs = (
+            Path(target["src_path"])
+            for package in metadata["packages"]
+            for target in package["targets"]
+        )
 
-    for src in target_srcs:
-        contents = src.read_text().splitlines(keepends=True)
-        try:
-            # Overwrite existing lint configuration block.
-            start = contents.index(lint_config[0])
-            end = contents.index(lint_config[-1])
-            contents[start : end + 1] = lint_config
-        except ValueError:
-            # No existing lint configuration block. Add a new one after the
-            # copyright header.
-            start = 0
-            while start < len(contents) and contents[start].startswith("//"):
-                start += 1
-            contents[start : start + 1] = ["\n", *lint_config, "\n"]
-        src.write_text("".join(contents))
+        for src in target_srcs:
+            contents = src.read_text().splitlines(keepends=True)
+            try:
+                # Overwrite existing lint configuration block.
+                start = contents.index(lint_config[0])
+                end = contents.index(lint_config[-1])
+                contents[start : end + 1] = lint_config
+            except ValueError:
+                # No existing lint configuration block. Add a new one after the
+                # copyright header.
+                start = 0
+                while start < len(contents) and contents[start].startswith("//"):
+                    start += 1
+                contents[start : start + 1] = ["\n", *lint_config, "\n"]
+            src.write_text("".join(contents))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Describe the contents of the PR briefly but completely.

If you write detailed commit messages, it is acceptable to copy/paste them
here, or write "see commit messages for details." If there is only one commit
in the PR, GitHub will have already added its commit message above.
-->

### Motivation
  * This PR adds a feature that has not yet been specified.

WASM crates were not visible to the gen-lints script since they're not included in the root workspace. Add awareness of the WASM workspace to the script.
<!--
Which of the following best describes the motivation behind this PR?

  * This PR fixes a recognized bug.

    [Ensure issue is linked somewhere.]

  * This PR adds a known-desirable feature.

    [Ensure issue is linked somewhere.]

  * This PR fixes a previously unreported bug.

    [Describe the bug in detail, as if you were filing a bug report.]



    [Write a brief specification for the feature, including justification
     for its inclusion in Materialize, as if you were writing the original
     feature specification.]

   * This PR refactors existing code.

    [Describe what was wrong with the existing code, if it is not obvious.]
-->

### Tips for reviewer

<!--
Leave some tips for your reviewer, like:

    * The diff is much smaller if viewed with whitespace hidden.
    * [Some function/module/file] deserves extra attention.
    * [Some function/module/file] is pure code movement and only needs a skim.

Delete this section if no tips.
-->



### Checklist

- [ ] This PR has adequate test coverage / QA involvement has been duly considered.
- [ ] This PR has an associated up-to-date [design doc](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/README.md), is a design doc ([template](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/design/00000000_template.md)), or is sufficiently small to not require a design.
  <!-- Reference the design in the description. -->
- [ ] If this PR evolves [an existing `$T ⇔ Proto$T` mapping](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/command-and-response-binary-encoding.md) (possibly in a backwards-incompatible way), then it is tagged with a `T-proto` label.
- [ ] If this PR will require changes to cloud orchestration or tests, there is a companion cloud PR to account for those changes that is tagged with the release-blocker label ([example](https://github.com/MaterializeInc/cloud/pull/5021)).
  <!-- Ask in #team-cloud on Slack if you need help preparing the cloud PR. -->
- [ ] This PR includes the following [user-facing behavior changes](https://github.com/MaterializeInc/materialize/blob/main/doc/developer/guide-changes.md#what-changes-require-a-release-note):
  - <!-- Add release notes here or explicitly state that there are no user-facing behavior changes. -->
