### PR TITLE
postgres consistency: enrich encode characteristics to let ignore match on regexp_split_to_array

### DIFF
--- a/misc/python/materialize/output_consistency/input_data/operations/bytea_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/bytea_operations_provider.py
@@ -8,6 +8,9 @@
 # by the Apache License, Version 2.0.
 
 from materialize.mz_version import MzVersion
+from materialize.output_consistency.expression.expression_characteristics import (
+    ExpressionCharacteristics,
+)
 from materialize.output_consistency.input_data.params.bytea_operation_param import (
     ByteaOperationParam,
 )
@@ -72,13 +75,16 @@ BYTEA_OPERATION_TYPES.append(
     )
 )
 
-BYTEA_OPERATION_TYPES.append(
-    DbFunction(
-        "encode",
-        [ByteaOperationParam(), TEXT_FORMAT_PARAM],
-        TextReturnTypeSpec(),
-    )
+encode_function = DbFunction(
+    "encode",
+    [ByteaOperationParam(), TEXT_FORMAT_PARAM],
+    TextReturnTypeSpec(),
 )
+# encode may introduce new lines
+encode_function.added_characteristics.add(
+    ExpressionCharacteristics.TEXT_WITH_SPECIAL_SPACE_CHARS
+)
+BYTEA_OPERATION_TYPES.append(encode_function)
 
 BYTEA_OPERATION_TYPES.append(
     DbFunction(

--- a/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
+++ b/misc/python/materialize/output_consistency/input_data/operations/text_operations_provider.py
@@ -224,9 +224,11 @@ class LpadFunction(DbFunction):
     ) -> set[ExpressionCharacteristics]:
         length_arg = args[1]
         if isinstance(length_arg, EnumConstant) and length_arg.value == "0":
-            return {ExpressionCharacteristics.TEXT_EMPTY}
+            return {
+                ExpressionCharacteristics.TEXT_EMPTY
+            } | super().derive_characteristics(args)
 
-        return set()
+        return super().derive_characteristics(args)
 
 
 TEXT_OPERATION_TYPES.append(LpadFunction())

--- a/misc/python/materialize/output_consistency/operation/operation.py
+++ b/misc/python/materialize/output_consistency/operation/operation.py
@@ -63,6 +63,7 @@ class DbOperationOrFunction:
         self.is_enabled = is_enabled
         self.is_pg_compatible = is_pg_compatible
         self.since_mz_version = since_mz_version
+        self.added_characteristics: set[ExpressionCharacteristics] = set()
 
     def to_pattern(self, args_count: int) -> str:
         raise NotImplementedError
@@ -80,8 +81,7 @@ class DbOperationOrFunction:
     def derive_characteristics(
         self, args: list[Expression]
     ) -> set[ExpressionCharacteristics]:
-        # a non-trivial implementation will be helpful for nested expressions
-        return set()
+        return self.added_characteristics
 
     def __str__(self) -> str:
         raise NotImplementedError


### PR DESCRIPTION
This addresses the failure in https://buildkite.com/materialize/nightlies/builds/5537#018c458c-1bf5-4ed6-9e59-4f4c1256e71a.